### PR TITLE
chore(telemetry): drop capture defs @cline/core owns, keep agent identity on late tool events

### DIFF
--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -83,8 +83,8 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			remoteLogSpy.resetHistory()
 			localLogSpy.resetHistory()
 
-			remoteService.captureTaskCreated("task-remote", "openai")
-			localService.captureTaskCreated("task-local", "openai")
+			remoteService.captureButtonClick("test-button", "task-remote")
+			localService.captureButtonClick("test-button", "task-local")
 
 			assert.ok(remoteLogSpy.calledOnce, "remote service should emit an event")
 			assert.ok(localLogSpy.calledOnce, "local service should emit an event")
@@ -131,7 +131,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 
 					service = await TelemetryService.create()
 					logSpy.resetHistory()
-					service.captureTaskCreated("task-123", "openai")
+					service.captureButtonClick("test-button", "task-123")
 
 					assert.ok(logSpy.calledOnce, `service should emit an event (${hostVersion.clineType})`)
 					assert.strictEqual(logSpy.firstCall.args[1]?.host_plugin_version, expectedHostPluginVersion)
@@ -140,29 +140,6 @@ describe("Telemetry system is abstracted and can easily switch between providers
 					await service?.dispose()
 				}
 			}
-		})
-
-		it("should include remote workspace metadata on workspace.initialized events", async () => {
-			const noOpProvider = new NoOpTelemetryProvider()
-			const logSpy = sinon.spy(noOpProvider, "log")
-			const telemetryService = new TelemetryService([noOpProvider], {
-				...MOCK_METADATA,
-				is_remote_workspace: true,
-			})
-
-			logSpy.resetHistory()
-			telemetryService.captureWorkspaceInitialized(1, ["Git"], 123, false)
-
-			assert.ok(logSpy.calledOnce, "workspace.initialized should be emitted once")
-			const [eventName, properties] = logSpy.firstCall.args
-			assert.strictEqual(eventName, "workspace.initialized")
-			assert.ok(properties, "workspace.initialized properties should be defined")
-			assert.strictEqual(properties.is_remote_workspace, true)
-			assert.strictEqual(properties.root_count, 1)
-			assert.deepStrictEqual(properties.vcs_types, ["Git"])
-
-			logSpy.restore()
-			await noOpProvider.dispose()
 		})
 
 		it("should include correct metadata with telemetry events", async () => {
@@ -179,21 +156,20 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			logSpy.resetHistory()
 
 			// Test that metadata is included in events
-			telemetryService.captureTaskCreated("task-456", "openai")
+			telemetryService.captureButtonClick("test-button", "task-456")
 
 			// Verify that log was called with correct arguments
 			assert.ok(logSpy.calledOnce, "Log should be called once")
 			const [eventName, properties] = logSpy.firstCall.args
-			assert.strictEqual(eventName, "task.created", "Event name should be task.created")
+			assert.strictEqual(eventName, "ui.button_clicked", "Event name should be ui.button_clicked")
 			assert.deepStrictEqual(
 				properties,
 				{
+					button: "test-button",
 					ulid: "task-456",
-					apiProvider: "openai",
-					openAiCompatibleDomain: undefined,
 					...MOCK_METADATA,
 				},
-				"Task created event should include only the expected metadata properties",
+				"Button clicked event should include only the expected metadata properties",
 			)
 
 			// Test identify includes metadata
@@ -205,9 +181,14 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			assert.deepStrictEqual(metadata, MOCK_METADATA, "Identify user should include only the expected metadata properties")
 
 			// Test org attributes are included in standard attributes (metrics)
-			telemetryService.captureToolUsage("task-456", "write_to_file", "gpt-4", "openai", false, true)
+			telemetryService.captureProviderApiError({
+				ulid: "task-456",
+				model: "gpt-4",
+				errorMessage: "boom",
+				provider: "openai",
+			})
 
-			assert.ok(recordCounterSpy.called, "recordCounter should be called for tool usage")
+			assert.ok(recordCounterSpy.called, "recordCounter should be called for provider API errors")
 			const recordCounterArgs = recordCounterSpy.firstCall.args
 			const recordCounterAttributes = recordCounterArgs[2] as Record<string, unknown>
 			assert.strictEqual(recordCounterAttributes.organization_id, "org-123")
@@ -245,7 +226,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			logSpy2.resetHistory()
 
 			// Test that events are sent to both providers
-			telemetryService.captureTaskCreated("multi-task-123", "anthropic")
+			telemetryService.captureButtonClick("multi-test-button", "multi-task-123")
 
 			// Verify both providers received the event
 			assert.ok(logSpy1.calledOnce, "First provider should receive the event")
@@ -255,13 +236,12 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const [eventName1, properties1] = logSpy1.firstCall.args
 			const [eventName2, properties2] = logSpy2.firstCall.args
 
-			assert.strictEqual(eventName1, "task.created", "First provider should receive correct event name")
-			assert.strictEqual(eventName2, "task.created", "Second provider should receive correct event name")
+			assert.strictEqual(eventName1, "ui.button_clicked", "First provider should receive correct event name")
+			assert.strictEqual(eventName2, "ui.button_clicked", "Second provider should receive correct event name")
 
 			const expectedProperties = {
+				button: "multi-test-button",
 				ulid: "multi-task-123",
-				apiProvider: "anthropic",
-				openAiCompatibleDomain: undefined,
 				...MOCK_METADATA,
 			}
 			assert.deepStrictEqual(properties1, expectedProperties, "First provider should receive correct properties")
@@ -295,10 +275,9 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const posthogTelemetryService = new TelemetryService([posthogProvider], MOCK_METADATA)
 
 			// Test various telemetry methods
-			posthogTelemetryService.captureTaskCreated("task-123", "anthropic")
+			posthogTelemetryService.captureButtonClick("test-button", "task-123")
 			posthogTelemetryService.identifyAccount(MOCK_USER_INFO)
-			posthogTelemetryService.captureTaskCompleted("task-123")
-			posthogTelemetryService.captureModelSelected("claude-3", "anthropic", "task-123")
+			posthogTelemetryService.captureTaskFeedback("task-123", "thumbs_up")
 
 			// Test provider methods directly
 			posthogProvider.log("test_event", { test: "property" })
@@ -323,11 +302,15 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const noOpTelemetryService = new TelemetryService([noOpProvider], MOCK_METADATA)
 
 			// Test various telemetry methods - should all be no-ops
-			noOpTelemetryService.captureTaskCreated("task-789", "google")
+			noOpTelemetryService.captureButtonClick("test-button", "task-789")
 			noOpTelemetryService.identifyAccount(MOCK_USER_INFO)
-			noOpTelemetryService.captureTaskCompleted("task-789")
-			noOpTelemetryService.captureModelSelected("gpt-4", "openai", "task-789")
-			noOpTelemetryService.captureToolUsage("task-789", "write_to_file", "gpt-4", "openai", false, true)
+			noOpTelemetryService.captureTaskFeedback("task-789", "thumbs_up")
+			noOpTelemetryService.captureProviderApiError({
+				ulid: "task-789",
+				model: "gpt-4",
+				errorMessage: "boom",
+				provider: "openai",
+			})
 
 			// Test provider methods directly
 			noOpProvider.log("test_event", { test: "property" })
@@ -378,7 +361,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 
 			// Should handle all operations safely
 			const telemetryService = new TelemetryService([unsupportedProvider], MOCK_METADATA)
-			telemetryService.captureTaskCreated("task-456", "test")
+			telemetryService.captureButtonClick("test-button", "task-456")
 			telemetryService.identifyAccount(MOCK_USER_INFO)
 
 			await unsupportedProvider.dispose()
@@ -531,7 +514,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const providers = await TelemetryProviderFactory.createProviders()
 			let telemetryService = new TelemetryService(providers, MOCK_METADATA)
 
-			telemetryService.captureTaskCreated("task-switch-1", "anthropic")
+			telemetryService.captureButtonClick("test-button", "task-switch-1")
 			console.log("Captured event with available providers")
 
 			await Promise.all(providers.map((p) => p.dispose()))
@@ -540,7 +523,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const noOpProvider = new NoOpTelemetryProvider()
 			telemetryService = new TelemetryService([noOpProvider], MOCK_METADATA)
 
-			telemetryService.captureTaskCreated("task-switch-2", "openai")
+			telemetryService.captureButtonClick("test-button", "task-switch-2")
 			console.log("Captured event with No-Op provider")
 
 			// Verify different behaviors
@@ -589,46 +572,6 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			await noOpProvider.dispose()
 		})
 
-		it("should capture subagent execution events correctly", async () => {
-			const noOpProvider = new NoOpTelemetryProvider()
-			const logSpy = sinon.spy(noOpProvider, "log")
-			const telemetryService = new TelemetryService([noOpProvider], MOCK_METADATA)
-
-			// Reset spy to ignore constructor events
-			logSpy.resetHistory()
-
-			// Test successful subagent execution
-			telemetryService.captureSubagentExecution("task-123", 1500, 25, true)
-
-			assert.ok(logSpy.calledOnce, "Log should be called once for successful execution")
-			const [eventName1, properties1] = logSpy.firstCall.args
-			assert.ok(properties1, "Properties should be defined")
-			assert.strictEqual(eventName1, "task.subagent_completed", "Event should be subagent_completed when successful")
-			assert.strictEqual(properties1.ulid, "task-123", "Properties should include task ULID")
-			assert.strictEqual(properties1.durationMs, 1500, "Properties should include duration")
-			assert.strictEqual(properties1.outputLines, 25, "Properties should include output line count")
-			assert.strictEqual(properties1.success, true, "Properties should include success status")
-			assert.ok(properties1.timestamp, "Properties should include timestamp")
-
-			// Reset spy for next test
-			logSpy.resetHistory()
-
-			// Test failed subagent execution
-			telemetryService.captureSubagentExecution("task-456", 3200, 150, false)
-
-			assert.ok(logSpy.calledOnce, "Log should be called once for failed execution")
-			const [eventName2, properties2] = logSpy.firstCall.args
-			assert.ok(properties2, "Properties should be defined")
-			assert.strictEqual(eventName2, "task.subagent_started", "Event should be subagent_started when failed")
-			assert.strictEqual(properties2.ulid, "task-456", "Properties should include task ULID")
-			assert.strictEqual(properties2.durationMs, 3200, "Properties should include duration")
-			assert.strictEqual(properties2.outputLines, 150, "Properties should include output line count")
-			assert.strictEqual(properties2.success, false, "Properties should include success status")
-
-			logSpy.restore()
-			await noOpProvider.dispose()
-		})
-
 		it("should respect subagents telemetry category settings", async () => {
 			const noOpProvider = new NoOpTelemetryProvider()
 			const logSpy = sinon.spy(noOpProvider, "log")
@@ -647,48 +590,6 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			// Test that events are captured when category is enabled
 			telemetryService.captureSubagentToggle(true)
 			assert.ok(logSpy.calledOnce, "Event should be captured when category is enabled")
-
-			// Reset spy
-			logSpy.resetHistory()
-
-			// Test that events are captured for execution
-			telemetryService.captureSubagentExecution("task-789", 2000, 10, true)
-			assert.ok(logSpy.calledOnce, "Execution event should be captured when category is enabled")
-
-			logSpy.restore()
-			await noOpProvider.dispose()
-		})
-	})
-
-	describe("Skills Telemetry", () => {
-		it("should capture skill used events correctly", async () => {
-			const noOpProvider = new NoOpTelemetryProvider()
-			const logSpy = sinon.spy(noOpProvider, "log")
-			const telemetryService = new TelemetryService([noOpProvider], MOCK_METADATA)
-
-			logSpy.resetHistory()
-
-			telemetryService.captureSkillUsed({
-				ulid: "task-123",
-				skillName: "my-skill",
-				skillSource: "global",
-				skillsAvailableGlobal: 2,
-				skillsAvailableProject: 3,
-				provider: "cline",
-				modelId: "anthropic/claude-sonnet-4.5",
-			})
-
-			assert.ok(logSpy.calledOnce, "Log should be called once")
-			const [eventName, properties] = logSpy.firstCall.args
-			assert.strictEqual(eventName, "task.skill_used", "Event name should be task.skill_used")
-			assert.ok(properties, "Properties should be defined")
-			assert.strictEqual(properties.ulid, "task-123", "Properties should include task ULID")
-			assert.strictEqual(properties.skillName, "my-skill", "Properties should include skillName")
-			assert.strictEqual(properties.skillSource, "global", "Properties should include skillSource")
-			assert.strictEqual(properties.skillsAvailableGlobal, 2, "Properties should include global skill count")
-			assert.strictEqual(properties.skillsAvailableProject, 3, "Properties should include project skill count")
-			assert.strictEqual(properties.provider, "cline", "Properties should include provider")
-			assert.strictEqual(properties.modelId, "anthropic/claude-sonnet-4.5", "Properties should include modelId")
 
 			logSpy.restore()
 			await noOpProvider.dispose()

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1,6 +1,5 @@
 import { HostProvider } from "@hosts/host-provider"
 import type { BrowserSettings } from "@shared/BrowserSettings"
-import { ApiFormat, apiFormatToJSON } from "@shared/proto/cline/models"
 import { ShowMessageType } from "@shared/proto/host/window"
 import type { TaskFeedbackType } from "@shared/WebviewMessage"
 import * as os from "os"
@@ -129,18 +128,6 @@ export type TelemetryMetadata = {
 }
 
 /**
- * Token usage data shared across telemetry capture methods.
- * Used by both `captureTokenUsage` and `captureConversationTurnEvent`.
- */
-export interface TokenUsage {
-	tokensIn?: number
-	tokensOut?: number
-	cacheWriteTokens?: number
-	cacheReadTokens?: number
-	totalCost?: number
-}
-
-/**
  * Maximum length for error messages to prevent excessive data
  */
 const MAX_ERROR_MESSAGE_LENGTH = 500
@@ -167,8 +154,6 @@ export class TelemetryService {
 		organization_name: string
 		member_id: string
 	} | null = null
-	private taskTurnCounts = new Map<string, number>()
-	private taskToolCallCounts = new Map<string, number>()
 	private taskErrorCounts = new Map<string, number>()
 	public static readonly METRICS = {
 		TASK: {
@@ -252,67 +237,37 @@ export class TelemetryService {
 		// Task-related events for tracking conversation and execution flow
 
 		USER: {
-			OPT_OUT: "user.opt_out",
 			OPT_IN: "user.opt_in",
 			TELEMETRY_ENABLED: "user.telemetry_enabled",
 			EXTENSION_ACTIVATED: "user.extension_activated",
 			EXTENSION_STORAGE_ERROR: "user.extension_storage_error",
-			AUTH_STARTED: "user.auth_started",
-			AUTH_SUCCEEDED: "user.auth_succeeded",
-			AUTH_FAILED: "user.auth_failed",
 			AUTH_LOGGED_OUT: "user.auth_logged_out",
 			ONBOARDING_PROGRESS: "user.onboarding_progress",
 		},
 		// Workspace-related events for multi-root support
 		WORKSPACE: {
-			// Track workspace initialization
-			INITIALIZED: "workspace.initialized",
-			// Track VCS detection
-			VCS_DETECTED: "workspace.vcs_detected",
 			// Track multi-root checkpoint operations
 			MULTI_ROOT_CHECKPOINT: "workspace.multi_root_checkpoint",
-			// Track workspace resolution
-			PATH_RESOLVED: "workspace.path_resolved",
 		},
 		TASK: {
-			// Tracks when a new task/conversation is started
-			CREATED: "task.created",
-			// Tracks when a task is reopened
-			RESTARTED: "task.restarted",
-			// Tracks when a task is finished, with acceptance or rejection status
-			COMPLETED: "task.completed",
 			// Tracks user feedback on completed tasks
 			FEEDBACK: "task.feedback",
-			// Tracks when a message is sent in a conversation
-			CONVERSATION_TURN: "task.conversation_turn",
-			// Tracks token consumption for cost and usage analysis
-			TOKEN_USAGE: "task.tokens",
-			// Tracks switches between plan and act modes
-			MODE_SWITCH: "task.mode",
 			// Tracks when users select an option from AI-generated followup questions
 			OPTION_SELECTED: "task.option_selected",
 			// Tracks when users type a custom response instead of selecting an option from AI-generated followup questions
 			OPTIONS_IGNORED: "task.options_ignored",
 			// Tracks checkpoint lifecycle actions.
 			CHECKPOINT_USED: "task.checkpoint_used",
-			// Tracks when tools (like file operations, commands) are used
-			TOOL_USED: "task.tool_used",
 			// Tracks when MCP tools are used
 			MCP_TOOL_CALLED: "task.mcp_tool_called",
-			// Tracks when a historical task is loaded from storage
-			HISTORICAL_LOADED: "task.historical_loaded",
 			// Tracks legacy VS Code task history migration into SDK sessions
 			LEGACY_TASK_MIGRATION: "task.legacy_task_migration",
-			// Tracks when the retry button is clicked for failed operations
-			RETRY_CLICKED: "task.retry_clicked",
 			// Tracks when the browser tool is started
 			BROWSER_TOOL_START: "task.browser_tool_start",
 			// Tracks when the browser tool is completed
 			BROWSER_TOOL_END: "task.browser_tool_end",
 			// Tracks when browser errors occur
 			BROWSER_ERROR: "task.browser_error",
-			// Tracks Gemini API specific performance metrics
-			GEMINI_API_PERFORMANCE: "task.gemini_api_performance",
 			// Tracks when API providers return errors
 			PROVIDER_API_ERROR: "task.provider_api_error",
 			// Tracks when users enable the focus chain feature
@@ -329,8 +284,6 @@ export class TelemetryService {
 			FOCUS_CHAIN_LIST_OPENED: "task.focus_chain_list_opened",
 			// Tracks when users save and write to the focus chain markdown file
 			FOCUS_CHAIN_LIST_WRITTEN: "task.focus_chain_list_written",
-			// Tracks when the context window is auto-condensed with the summarize_task tool call
-			AUTO_COMPACT: "task.summarize_task",
 			// Tracks when slash commands or workflows are activated
 			SLASH_COMMAND_USED: "task.slash_command_used",
 			// Tracks when a feature is toggled on/off
@@ -357,15 +310,9 @@ export class TelemetryService {
 			// CLI Subagents telemetry events
 			SUBAGENT_ENABLED: "task.subagent_enabled",
 			SUBAGENT_DISABLED: "task.subagent_disabled",
-			SUBAGENT_STARTED: "task.subagent_started",
-			SUBAGENT_COMPLETED: "task.subagent_completed",
-			// Skills telemetry events
-			SKILL_USED: "task.skill_used",
 		},
 		// UI interaction events for tracking user engagement
 		UI: {
-			// Tracks when a different model is selected
-			MODEL_SELECTED: "ui.model_selected",
 			// Tracks when users use the "favorite" button in the model picker
 			MODEL_FAVORITE_TOGGLED: "ui.model_favorite_toggled",
 			// Tracks when a button is clicked
@@ -376,19 +323,9 @@ export class TelemetryService {
 			NEW_TASK_CLICKED: "ui.new_task_clicked",
 			// Tracks when the user submits chat composer content
 			PROMPT_SUBMITTED: "ui.prompt_submitted",
-			// Tracks when the rules menu button is clicked
-			RULES_MENU_OPENED: "ui.rules_menu_opened",
 		},
 		// Hooks-related events for tracking hook execution
 		HOOKS: {
-			// Tracks when hooks feature is enabled
-			ENABLED: "hooks.enabled",
-			// Tracks when hooks feature is disabled
-			DISABLED: "hooks.disabled",
-			// Tracks when a hook requests task cancellation
-			CANCEL_REQUESTED: "hooks.cancel_requested",
-			// Tracks when a hook modifies context
-			CONTEXT_MODIFIED: "hooks.context_modified",
 			// Tracks when hook discovery completes
 			DISCOVERY_COMPLETED: "hooks.discovery_completed",
 		},
@@ -400,10 +337,6 @@ export class TelemetryService {
 			CREATED: "worktree.created",
 			// Tracks when a worktree merge is attempted
 			MERGE_ATTEMPTED: "worktree.merge_attempted",
-		},
-		HOST: {
-			// Tracks events detected from the host environment
-			DETECTED: "host.detected",
 		},
 	}
 
@@ -480,13 +413,21 @@ export class TelemetryService {
 	}
 
 	/**
-	 * Captures when a user explicitly opts out of telemetry.
-	 * Uses captureRequired to ensure the event is sent before telemetry is disabled.
-	 * Should only be called on explicit user action, not on init/sync.
+	 * NOTE — SDK-line telemetry parity gap. This method and several others in
+	 * this file have no caller on this line but are called on
+	 * `legacy-extension`. They are kept, not deleted: the signals they emit
+	 * originate in this bundle (webview UI, VS Code storage, host terminal,
+	 * checkpoints, focus chain, legacy-task migration), so @cline/core cannot
+	 * emit them and the missing piece is a call site here. Tracked in
+	 * https://linear.app/cline-bot/issue/ENG-2401
+	 *
+	 * Anything whose event @cline/core already emits was deleted instead: a
+	 * second capture path for a core-owned event is how the
+	 * task.provider_api_error double-emission happened (cline/cline#12820).
+	 *
+	 * So: do not "clean up" an uncalled capture method here as dead code
+	 * without checking `legacy-extension` for callers first.
 	 */
-	public captureUserOptOut(): void {
-		this.captureRequired(TelemetryService.EVENTS.USER.OPT_OUT, {})
-	}
 
 	/**
 	 * Captures when a user explicitly opts back into telemetry.
@@ -620,8 +561,6 @@ export class TelemetryService {
 	}
 
 	private resetTaskAggregates(ulid: string): void {
-		this.taskTurnCounts.delete(ulid)
-		this.taskToolCallCounts.delete(ulid)
 		this.taskErrorCounts.delete(ulid)
 	}
 
@@ -657,45 +596,6 @@ export class TelemetryService {
 						? errorMessage.substring(0, MAX_ERROR_MESSAGE_LENGTH) + "..."
 						: errorMessage,
 				eventName,
-			},
-		})
-	}
-
-	/**
-	 * Records when authentication flow is started
-	 * @param provider The authentication provider being used
-	 */
-	public captureAuthStarted(provider?: string) {
-		this.capture({
-			event: TelemetryService.EVENTS.USER.AUTH_STARTED,
-			properties: {
-				provider,
-			},
-		})
-	}
-
-	/**
-	 * Records when authentication flow succeeds
-	 * @param provider The authentication provider that was used
-	 */
-	public captureAuthSucceeded(provider?: string) {
-		this.capture({
-			event: TelemetryService.EVENTS.USER.AUTH_SUCCEEDED,
-			properties: {
-				provider,
-			},
-		})
-	}
-
-	/**
-	 * Records when authentication flow fails
-	 * @param provider The authentication provider that was used
-	 */
-	public captureAuthFailed(provider?: string) {
-		this.capture({
-			event: TelemetryService.EVENTS.USER.AUTH_FAILED,
-			properties: {
-				provider,
 			},
 		})
 	}
@@ -751,276 +651,6 @@ export class TelemetryService {
 
 	// Task events
 	/**
-	 * Records when a new task/conversation is started
-	 * @param ulid Unique identifier for the new task
-	 * @param apiProvider Optional API provider
-	 * @param openAiCompatibleDomain Optional domain for OpenAI Compatible providers (e.g., "api.example.com")
-	 */
-	public captureTaskCreated(ulid: string, apiProvider?: string, openAiCompatibleDomain?: string) {
-		this.resetTaskAggregates(ulid)
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.CREATED,
-			properties: { ulid, apiProvider, openAiCompatibleDomain },
-		})
-	}
-
-	/**
-	 * Records when a task/conversation is restarted
-	 * @param ulid Unique identifier for the new task
-	 * @param apiProvider Optional API provider
-	 * @param openAiCompatibleDomain Optional domain for OpenAI Compatible providers (e.g., "api.example.com")
-	 */
-	public captureTaskRestarted(ulid: string, apiProvider?: string, openAiCompatibleDomain?: string) {
-		this.resetTaskAggregates(ulid)
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.RESTARTED,
-			properties: { ulid, apiProvider, openAiCompatibleDomain },
-		})
-	}
-
-	/**
-	 * Records when cline calls the task completion_result tool signifying that cline is done with the task
-	 * @param ulid Unique identifier for the task
-	 */
-	public captureTaskCompleted(
-		ulid: string,
-		args?: {
-			provider?: string
-			modelId?: string
-			apiFormat?: ApiFormat
-			timeToFirstTokenMs?: number
-			durationMs?: number
-			mode: Mode
-		},
-	) {
-		const apiFormatName = args?.apiFormat !== undefined ? apiFormatToJSON(args.apiFormat) : undefined
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.COMPLETED,
-			properties: {
-				ulid,
-				provider: args?.provider,
-				modelId: args?.modelId,
-				apiFormat: args?.apiFormat,
-				apiFormatName,
-				timeToFirstTokenMs: args?.timeToFirstTokenMs,
-				durationMs: args?.durationMs,
-				mode: args?.mode,
-			},
-		})
-
-		if (Number.isFinite(args?.timeToFirstTokenMs)) {
-			this.recordHistogram(TelemetryService.METRICS.API.TTFT_SECONDS, (args?.timeToFirstTokenMs ?? 0) / 1000, {
-				ulid,
-				provider: args?.provider,
-				model: args?.modelId,
-				apiFormat: apiFormatName,
-				mode: args?.mode,
-			})
-		}
-
-		if (Number.isFinite(args?.durationMs)) {
-			this.recordHistogram(TelemetryService.METRICS.API.DURATION_SECONDS, (args?.durationMs ?? 0) / 1000, {
-				ulid,
-				provider: args?.provider,
-				model: args?.modelId,
-				apiFormat: apiFormatName,
-				scope: "task",
-				mode: args?.mode,
-			})
-		}
-
-		this.resetTaskAggregates(ulid)
-	}
-
-	/**
-	 * Captures that a message was sent, and includes the API provider and model used
-	 * @param ulid Unique identifier for the task
-	 * @param provider The API provider (e.g., OpenAI, Anthropic)
-	 * @param model The specific model used (e.g., GPT-4, Claude)
-	 * @param source The source of the message ("user" | "model"). Used to track message patterns and identify when users need to correct the model's responses.
-	 * @param mode The mode in which the conversation turn occurred ("plan" or "act")
-	 * @param tokenUsage Optional token usage data
-	 */
-	public captureConversationTurnEvent(
-		ulid: string,
-		provider = "unknown",
-		model = "unknown",
-		source: "user" | "assistant",
-		mode: Mode,
-		tokenUsage: TokenUsage = {},
-		isNativeToolCall?: boolean,
-	) {
-		// Ensure required parameters are provided
-		if (!ulid || !provider || !model || !source) {
-			Logger.warn("TelemetryService: Missing required parameters for message capture")
-			return
-		}
-
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.CONVERSATION_TURN,
-			properties: {
-				ulid,
-				provider,
-				model,
-				source,
-				mode,
-				timestamp: new Date().toISOString(), // Add timestamp for message sequencing
-				...tokenUsage,
-				isNativeToolCall,
-			},
-		})
-
-		const turnCount = this.incrementTaskCounter(this.taskTurnCounts, ulid)
-
-		const turnAttributes = { ulid, provider, model, source, mode }
-		this.recordCounter(TelemetryService.METRICS.TASK.TURNS_TOTAL, 1, turnAttributes)
-		this.recordHistogram(TelemetryService.METRICS.TASK.TURNS_PER_TASK, turnCount, turnAttributes)
-
-		if (Number.isFinite(tokenUsage.cacheWriteTokens)) {
-			const cacheWriteTokens = tokenUsage.cacheWriteTokens ?? 0
-			this.recordCounter(TelemetryService.METRICS.CACHE.WRITE_TOTAL, cacheWriteTokens, {
-				ulid,
-				provider,
-				model,
-				mode,
-			})
-			this.recordHistogram(TelemetryService.METRICS.CACHE.WRITE_PER_EVENT, cacheWriteTokens, {
-				ulid,
-				provider,
-				model,
-				mode,
-			})
-		}
-
-		if (Number.isFinite(tokenUsage.cacheReadTokens)) {
-			const cacheReadTokens = tokenUsage.cacheReadTokens ?? 0
-			this.recordCounter(TelemetryService.METRICS.CACHE.READ_TOTAL, cacheReadTokens, {
-				ulid,
-				provider,
-				model,
-				mode,
-			})
-			this.recordHistogram(TelemetryService.METRICS.CACHE.READ_PER_EVENT, cacheReadTokens, {
-				ulid,
-				provider,
-				model,
-				mode,
-			})
-		}
-
-		if (Number.isFinite(tokenUsage.totalCost)) {
-			const totalCost = tokenUsage.totalCost ?? 0
-			const costAttributes = { ulid, provider, model, mode, currency: "USD" }
-			this.recordCounter(TelemetryService.METRICS.TASK.COST_TOTAL, totalCost, costAttributes)
-			this.recordHistogram(TelemetryService.METRICS.TASK.COST_PER_EVENT, totalCost, costAttributes)
-		}
-	}
-
-	/**
-	 * Records token usage metrics for cost tracking and usage analysis
-	 * @param ulid Unique identifier for the task
-	 * @param tokensIn Number of input tokens consumed
-	 * @param tokensOut Number of output tokens generated
-	 * @param provider The API provider identifier (e.g. "anthropic", "openai", "cline")
-	 * @param model The model used for token calculation
-	 */
-	public captureTokenUsage(
-		ulid: string,
-		tokensIn: number,
-		tokensOut: number,
-		provider: string,
-		model: string,
-		options?: TokenUsage,
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.TOKEN_USAGE,
-			properties: {
-				ulid,
-				tokensIn,
-				tokensOut,
-				provider,
-				model,
-				...options,
-			},
-		})
-
-		const attributes = { ulid, provider, model }
-
-		if (Number.isFinite(tokensIn)) {
-			const value = tokensIn ?? 0
-			this.recordCounter(TelemetryService.METRICS.TASK.TOKENS_INPUT_TOTAL, value, attributes)
-			this.recordHistogram(TelemetryService.METRICS.TASK.TOKENS_INPUT_PER_RESPONSE, value, attributes)
-		}
-
-		if (Number.isFinite(tokensOut)) {
-			const value = tokensOut ?? 0
-			this.recordCounter(TelemetryService.METRICS.TASK.TOKENS_OUTPUT_TOTAL, value, attributes)
-			this.recordHistogram(TelemetryService.METRICS.TASK.TOKENS_OUTPUT_PER_RESPONSE, value, attributes)
-		}
-
-		if (Number.isFinite(options?.cacheWriteTokens)) {
-			const cacheWriteTokens = options!.cacheWriteTokens ?? 0
-			this.recordCounter(TelemetryService.METRICS.CACHE.WRITE_TOTAL, cacheWriteTokens, attributes)
-			this.recordHistogram(TelemetryService.METRICS.CACHE.WRITE_PER_EVENT, cacheWriteTokens, attributes)
-		}
-
-		if (Number.isFinite(options?.cacheReadTokens)) {
-			const cacheReadTokens = options!.cacheReadTokens ?? 0
-			this.recordCounter(TelemetryService.METRICS.CACHE.READ_TOTAL, cacheReadTokens, attributes)
-			this.recordHistogram(TelemetryService.METRICS.CACHE.READ_PER_EVENT, cacheReadTokens, attributes)
-		}
-
-		if (Number.isFinite(options?.totalCost)) {
-			const totalCost = options!.totalCost ?? 0
-			const costAttributes = { ...attributes, currency: "USD" }
-			this.recordCounter(TelemetryService.METRICS.TASK.COST_TOTAL, totalCost, costAttributes)
-			this.recordHistogram(TelemetryService.METRICS.TASK.COST_PER_EVENT, totalCost, costAttributes)
-		}
-	}
-
-	/**
-	 * Records when a task switches between plan and act modes
-	 * @param ulid Unique identifier for the task
-	 * @param mode The mode being switched to (plan or act)
-	 */
-	public captureModeSwitch(ulid: string, mode: Mode) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.MODE_SWITCH,
-			properties: {
-				ulid,
-				mode,
-			},
-		})
-	}
-
-	/**
-	 * Records when context summarization is triggered due to context window pressure
-	 * @param ulid Unique identifier for the task
-	 * @param modelId The model that triggered summarization
-	 * @param provider The API provider being used
-	 * @param currentTokens Total tokens in context window when summarization was triggered
-	 * @param maxContextWindow Maximum context window size for the model
-	 */
-	public captureSummarizeTask(
-		ulid: string,
-		modelId: string,
-		provider: string,
-		currentTokens: number,
-		maxContextWindow: number,
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.AUTO_COMPACT,
-			properties: {
-				ulid,
-				modelId,
-				provider,
-				currentTokens,
-				maxContextWindow,
-			},
-		})
-	}
-
-	/**
 	 * Records user feedback on completed tasks
 	 * @param ulid Unique identifier for the task
 	 * @param feedbackType The type of feedback ("thumbs_up" or "thumbs_down")
@@ -1041,99 +671,6 @@ export class TelemetryService {
 	}
 
 	// Tool events
-	/**
-	 * Records when a tool is used during task execution
-	 * @param ulid Unique identifier for the task
-	 * @param tool Name of the tool being used
-	 * @param modelId The model ID being used
-	 * @param provider The API provider being used
-	 * @param autoApproved Whether the tool was auto-approved based on settings
-	 * @param success Whether the tool execution was successful
-	 * @param workspaceContext Optional workspace context for multi-root workspace tracking
-	 */
-	public captureToolUsage(
-		ulid: string,
-		tool: string,
-		modelId: string,
-		provider: string,
-		autoApproved: boolean,
-		success: boolean,
-		workspaceContext?: {
-			isMultiRootEnabled: boolean
-			usedWorkspaceHint: boolean
-			resolvedToNonPrimary: boolean
-			resolutionMethod: "hint" | "primary_fallback" | "path_detection"
-		},
-		isNativeToolCall = false,
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.TOOL_USED,
-			properties: {
-				ulid,
-				tool,
-				autoApproved,
-				success,
-				modelId,
-				provider,
-				// Workspace context (optional)
-				...(workspaceContext && {
-					workspace_multi_root_enabled: workspaceContext.isMultiRootEnabled,
-					workspace_hint_used: workspaceContext.usedWorkspaceHint,
-					workspace_resolved_non_primary: workspaceContext.resolvedToNonPrimary,
-					workspace_resolution_method: workspaceContext.resolutionMethod,
-				}),
-				isNativeToolCall,
-			},
-		})
-
-		const toolAttributes = {
-			ulid,
-			tool,
-			model: modelId,
-			success,
-			autoApproved,
-		}
-		const toolCallCount = this.incrementTaskCounter(this.taskToolCallCounts, ulid)
-		this.recordCounter(TelemetryService.METRICS.TOOLS.CALLS_TOTAL, 1, toolAttributes)
-		this.recordHistogram(TelemetryService.METRICS.TOOLS.CALLS_PER_TASK, toolCallCount, toolAttributes)
-	}
-
-	public captureSkillUsed(args: {
-		ulid: string
-		skillName: string
-		skillSource: "global" | "project"
-		skillsAvailableGlobal: number
-		skillsAvailableProject: number
-		provider?: string
-		modelId?: string
-	}): void {
-		if (!this.isCategoryEnabled("skills")) {
-			return
-		}
-
-		if (!args.ulid || !args.skillName) {
-			return
-		}
-
-		const skillsAvailableGlobal = Math.max(0, args.skillsAvailableGlobal)
-		const skillsAvailableProject = Math.max(0, args.skillsAvailableProject)
-
-		const properties = {
-			ulid: args.ulid,
-			skillName: args.skillName,
-			skillSource: args.skillSource,
-			skillsAvailableGlobal,
-			skillsAvailableProject,
-			provider: args.provider,
-			modelId: args.modelId,
-		}
-
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.SKILL_USED,
-			properties,
-		})
-	}
-
 	/**
 	 * Records when an MCP tool is called.
 	 * This telemetry event is designed to monitor the usage and performance of MCP tools
@@ -1187,23 +724,6 @@ export class TelemetryService {
 				ulid,
 				action,
 				durationMs,
-			},
-		})
-	}
-
-	/**
-	 * Records when a different model is selected for use
-	 * @param model Name of the selected model
-	 * @param provider Provider of the selected model
-	 * @param ulid Optional task identifier if model was selected during a task
-	 */
-	public captureModelSelected(model: string, provider: string, ulid?: string) {
-		this.capture({
-			event: TelemetryService.EVENTS.UI.MODEL_SELECTED,
-			properties: {
-				model,
-				provider,
-				ulid,
 			},
 		})
 	}
@@ -1326,66 +846,6 @@ export class TelemetryService {
 				mode,
 			},
 		})
-	}
-
-	/**
-	 * Captures Gemini API performance metrics.
-	 * @param ulid Unique identifier for the task
-	 * @param modelId Specific Gemini model ID
-	 * @param data Performance data including TTFT, durations, token counts, cache stats, and API success status
-	 */
-	public captureGeminiApiPerformance(
-		ulid: string,
-		modelId: string,
-		data: {
-			ttftSec?: number
-			totalDurationSec?: number
-			promptTokens: number
-			outputTokens: number
-			cacheReadTokens: number
-			cacheHit: boolean
-			cacheHitPercentage?: number
-			apiSuccess: boolean
-			apiError?: string
-			throughputTokensPerSec?: number
-		},
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.TASK.GEMINI_API_PERFORMANCE,
-			properties: {
-				ulid,
-				modelId,
-				...data,
-			},
-		})
-
-		if (typeof data.ttftSec === "number") {
-			this.recordHistogram(TelemetryService.METRICS.API.TTFT_SECONDS, data.ttftSec, {
-				ulid,
-				model: modelId,
-				provider: "gemini",
-			})
-		}
-
-		if (typeof data.totalDurationSec === "number") {
-			this.recordHistogram(TelemetryService.METRICS.API.DURATION_SECONDS, data.totalDurationSec, {
-				ulid,
-				model: modelId,
-				provider: "gemini",
-			})
-		}
-
-		if (typeof data.throughputTokensPerSec === "number") {
-			this.recordHistogram(TelemetryService.METRICS.API.THROUGHPUT_TOKENS_PER_SECOND, data.throughputTokensPerSec, {
-				ulid,
-				model: modelId,
-				provider: "gemini",
-			})
-		}
-
-		if (data.cacheHit) {
-			this.recordCounter(TelemetryService.METRICS.CACHE.HITS_TOTAL, 1, { ulid, model: modelId, provider: "gemini" })
-		}
 	}
 
 	/**
@@ -1726,16 +1186,6 @@ export class TelemetryService {
 		})
 	}
 
-	/**
-	 * Records when the rules menu button is clicked to open the rules/workflows modal
-	 */
-	public captureRulesMenuOpened() {
-		this.capture({
-			event: TelemetryService.EVENTS.UI.RULES_MENU_OPENED,
-			properties: {},
-		})
-	}
-
 	// Terminal telemetry methods
 
 	/**
@@ -1855,42 +1305,6 @@ export class TelemetryService {
 	// Workspace telemetry methods
 
 	/**
-	 * Records when workspace is initialized
-	 * @param rootCount Number of workspace roots
-	 * @param vcsTypes Array of VCS types detected
-	 * @param initDurationMs Time taken to initialize in milliseconds
-	 * @param featureFlagEnabled Whether multi-root feature flag is enabled
-	 */
-	public captureWorkspaceInitialized(
-		rootCount: number,
-		vcsTypes: string[],
-		initDurationMs?: number,
-		featureFlagEnabled?: boolean,
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.WORKSPACE.INITIALIZED,
-			properties: {
-				root_count: rootCount,
-				vcs_types: vcsTypes,
-				is_multi_root: rootCount > 1,
-				has_git: vcsTypes.includes("Git"),
-				has_mercurial: vcsTypes.includes("Mercurial"),
-				init_duration_ms: initDurationMs,
-				feature_flag_enabled: featureFlagEnabled,
-			},
-		})
-
-		const isMultiRoot = rootCount > 1
-		this.recordGauge("cline.workspace.active_roots", rootCount, {
-			is_multi_root: isMultiRoot,
-		})
-		// Retire the previous series to avoid leaking gauge entries when the flag flips.
-		this.recordGauge("cline.workspace.active_roots", null, {
-			is_multi_root: !isMultiRoot,
-		})
-	}
-
-	/**
 	 * Records multi-root checkpoint operations
 	 * @param ulid Task identifier
 	 * @param action Type of checkpoint action
@@ -1917,39 +1331,6 @@ export class TelemetryService {
 				failure_count: failureCount,
 				success_rate: rootCount > 0 ? successCount / rootCount : 0,
 				duration_ms: durationMs,
-			},
-		})
-	}
-
-	/**
-	 * Records workspace path resolution events
-	 * @param ulid Unique identifier for the task
-	 * @param context The component/handler where resolution occurred
-	 * @param resolutionType Type of resolution performed
-	 * @param hintType Type of workspace hint provided (if any)
-	 * @param resolutionSuccess Whether the resolution was successful
-	 * @param targetWorkspaceIndex Index of the resolved workspace (0=primary, 1=secondary, etc.)
-	 * @param isMultiRootEnabled Whether multi-root mode is enabled
-	 */
-	public captureWorkspacePathResolved(
-		ulid: string,
-		context: string,
-		resolutionType: "hint_provided" | "fallback_to_primary" | "cross_workspace_search",
-		hintType?: "workspace_name" | "workspace_path" | "invalid",
-		resolutionSuccess?: boolean,
-		targetWorkspaceIndex?: number,
-		isMultiRootEnabled?: boolean,
-	) {
-		this.capture({
-			event: TelemetryService.EVENTS.WORKSPACE.PATH_RESOLVED,
-			properties: {
-				ulid,
-				context,
-				resolution_type: resolutionType,
-				hint_type: hintType,
-				resolution_success: resolutionSuccess,
-				target_workspace_index: targetWorkspaceIndex,
-				is_multi_root_enabled: isMultiRootEnabled,
 			},
 		})
 	}
@@ -2173,30 +1554,6 @@ export class TelemetryService {
 			event: enabled ? TelemetryService.EVENTS.TASK.SUBAGENT_ENABLED : TelemetryService.EVENTS.TASK.SUBAGENT_DISABLED,
 			properties: {
 				enabled,
-				timestamp: new Date().toISOString(),
-			},
-		})
-	}
-
-	/**
-	 * Records when a CLI subagent is executed
-	 * @param ulid Unique identifier for the task
-	 * @param durationMs Duration of the subagent execution in milliseconds
-	 * @param outputLines Number of lines of output produced by the subagent
-	 * @param success Whether the subagent execution was successful
-	 */
-	public captureSubagentExecution(ulid: string, durationMs: number, outputLines: number, success: boolean) {
-		if (!this.isCategoryEnabled("subagents")) {
-			return
-		}
-
-		this.capture({
-			event: success ? TelemetryService.EVENTS.TASK.SUBAGENT_COMPLETED : TelemetryService.EVENTS.TASK.SUBAGENT_STARTED,
-			properties: {
-				ulid,
-				durationMs,
-				outputLines,
-				success,
 				timestamp: new Date().toISOString(),
 			},
 		})
@@ -2451,16 +1808,6 @@ export class TelemetryService {
 		if (args.filesMoved) {
 			this.recordCounter(TelemetryService.METRICS.AI_OUTPUT.REJECTED_FILES_MOVED, args.filesMoved, attrs)
 		}
-	}
-
-	public captureHostEvent(name: string, content: string) {
-		this.capture({
-			event: TelemetryService.EVENTS.HOST.DETECTED,
-			properties: {
-				name,
-				content,
-			},
-		})
 	}
 
 	/**

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -1,5 +1,4 @@
 import { describe, it } from "bun:test"
-import { ApiFormat } from "@shared/proto/cline/models"
 import * as assert from "assert"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE } from "../../../sdk/provider-failure-telemetry"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
@@ -88,11 +87,17 @@ describe("TelemetryService metrics", () => {
 			extension_variant: "next",
 		})
 
-		service.captureTaskCreated("task-rollout", "anthropic")
-		service.captureTokenUsage("task-rollout", 120, 80, "anthropic", "model-a")
+		service.captureProviderApiError({
+			ulid: "task-rollout",
+			model: "model-a",
+			errorMessage: "boom",
+			provider: "anthropic",
+		})
 
-		const taskEvent = provider.logs.find((entry) => entry.event === "task.created")
-		assert.strictEqual(taskEvent?.properties?.extension_variant, "next")
+		const errorEvent = provider.logs.find((entry) => entry.event === "task.provider_api_error")
+		assert.strictEqual(errorEvent?.properties?.extension_variant, "next")
+		assert.ok(provider.counters.length > 0)
+		assert.ok(provider.histograms.length > 0)
 		for (const entry of [...provider.counters, ...provider.histograms]) {
 			assert.strictEqual(entry.attributes.extension_variant, "next")
 		}
@@ -137,315 +142,48 @@ describe("TelemetryService metrics", () => {
 		)
 	})
 
-	it("captureTokenUsage emits token counters and histograms", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureTokenUsage("task-1", 120, 80, "anthropic", "model-a")
-
-		assert.deepStrictEqual(
-			provider.counters.map((entry) => entry.name),
-			[TelemetryService.METRICS.TASK.TOKENS_INPUT_TOTAL, TelemetryService.METRICS.TASK.TOKENS_OUTPUT_TOTAL],
-		)
-		assert.deepStrictEqual(
-			provider.histograms.map((entry) => entry.name),
-			[TelemetryService.METRICS.TASK.TOKENS_INPUT_PER_RESPONSE, TelemetryService.METRICS.TASK.TOKENS_OUTPUT_PER_RESPONSE],
-		)
-		;[...provider.counters, ...provider.histograms].forEach((entry) => {
-			assert.strictEqual(entry.attributes.ulid, "task-1")
-			assert.strictEqual(entry.attributes.provider, "anthropic")
-			assert.strictEqual(entry.attributes.model, "model-a")
-			assert.strictEqual(entry.attributes.extension_version, "test")
-		})
-	})
-
-	it("captureTokenUsage emits cache and cost metrics when options provided", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureTokenUsage("task-1", 120, 80, "anthropic", "model-a", {
-			cacheWriteTokens: 50,
-			cacheReadTokens: 30,
-			totalCost: 0.42,
-		})
-
-		assert.deepStrictEqual(
-			provider.counters.map((entry) => entry.name),
-			[
-				TelemetryService.METRICS.TASK.TOKENS_INPUT_TOTAL,
-				TelemetryService.METRICS.TASK.TOKENS_OUTPUT_TOTAL,
-				TelemetryService.METRICS.CACHE.WRITE_TOTAL,
-				TelemetryService.METRICS.CACHE.READ_TOTAL,
-				TelemetryService.METRICS.TASK.COST_TOTAL,
-			],
-		)
-		assert.deepStrictEqual(
-			provider.histograms.map((entry) => entry.name),
-			[
-				TelemetryService.METRICS.TASK.TOKENS_INPUT_PER_RESPONSE,
-				TelemetryService.METRICS.TASK.TOKENS_OUTPUT_PER_RESPONSE,
-				TelemetryService.METRICS.CACHE.WRITE_PER_EVENT,
-				TelemetryService.METRICS.CACHE.READ_PER_EVENT,
-				TelemetryService.METRICS.TASK.COST_PER_EVENT,
-			],
-		)
-		const cacheWriteCounter = provider.counters.find((entry) => entry.name === TelemetryService.METRICS.CACHE.WRITE_TOTAL)
-		assert.ok(cacheWriteCounter)
-		assert.strictEqual(cacheWriteCounter?.value, 50)
-		assert.strictEqual(cacheWriteCounter?.attributes.ulid, "task-1")
-		assert.strictEqual(cacheWriteCounter?.attributes.model, "model-a")
-
-		const cacheReadCounter = provider.counters.find((entry) => entry.name === TelemetryService.METRICS.CACHE.READ_TOTAL)
-		assert.ok(cacheReadCounter)
-		assert.strictEqual(cacheReadCounter?.value, 30)
-
-		const costCounter = provider.counters.find((entry) => entry.name === TelemetryService.METRICS.TASK.COST_TOTAL)
-		assert.ok(costCounter)
-		assert.strictEqual(costCounter?.value, 0.42)
-		assert.strictEqual(costCounter?.attributes.ulid, "task-1")
-		assert.strictEqual(costCounter?.attributes.model, "model-a")
-		assert.strictEqual(costCounter?.attributes.currency, "USD")
-
-		const cacheWriteHist = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.CACHE.WRITE_PER_EVENT)
-		assert.ok(cacheWriteHist)
-		assert.strictEqual(cacheWriteHist?.value, 50)
-
-		const cacheReadHist = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.CACHE.READ_PER_EVENT)
-		assert.ok(cacheReadHist)
-		assert.strictEqual(cacheReadHist?.value, 30)
-
-		const costHist = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.TASK.COST_PER_EVENT)
-		assert.ok(costHist)
-		assert.strictEqual(costHist?.value, 0.42)
-	})
-
-	it("captureTokenUsage skips cache/cost metrics when options fields are undefined", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureTokenUsage("task-1", 120, 80, "anthropic", "model-a", {})
-
-		assert.deepStrictEqual(
-			provider.counters.map((entry) => entry.name),
-			[TelemetryService.METRICS.TASK.TOKENS_INPUT_TOTAL, TelemetryService.METRICS.TASK.TOKENS_OUTPUT_TOTAL],
-		)
-		assert.deepStrictEqual(
-			provider.histograms.map((entry) => entry.name),
-			[TelemetryService.METRICS.TASK.TOKENS_INPUT_PER_RESPONSE, TelemetryService.METRICS.TASK.TOKENS_OUTPUT_PER_RESPONSE],
-		)
-	})
-
-	it("captureTokenUsage includes options in event properties", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureTokenUsage("task-1", 120, 80, "anthropic", "model-a", {
-			cacheWriteTokens: 50,
-			cacheReadTokens: 30,
-			totalCost: 0.42,
-		})
-
-		const tokenEvent = provider.logs.find((entry) => entry.event === "task.tokens")
-		assert.ok(tokenEvent)
-		assert.strictEqual(tokenEvent?.properties?.provider, "anthropic")
-		assert.strictEqual(tokenEvent?.properties?.model, "model-a")
-		assert.strictEqual(tokenEvent?.properties?.cacheWriteTokens, 50)
-		assert.strictEqual(tokenEvent?.properties?.cacheReadTokens, 30)
-		assert.strictEqual(tokenEvent?.properties?.totalCost, 0.42)
-	})
-
 	it("metrics include is_remote_workspace in standard attributes", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider, { is_remote_workspace: true })
 
-		service.captureTokenUsage("task-remote", 120, 80, "anthropic", "model-a")
+		service.captureProviderApiError({
+			ulid: "task-remote",
+			model: "model-a",
+			errorMessage: "boom",
+			provider: "anthropic",
+		})
 
 		assert.ok(provider.counters.length > 0)
 		assert.strictEqual(provider.counters[0].attributes.is_remote_workspace, true)
 		assert.strictEqual(provider.histograms[0].attributes.is_remote_workspace, true)
 	})
 
-	it("captureConversationTurnEvent emits counters with cache and cost", () => {
+	it("captureLegacyTaskMigrationBacklog records pending and migrated gauges", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)
-		service.identifyAccount({ id: "user-1" } as any)
 
-		service.captureConversationTurnEvent("task-2", "openai", "gpt-4", "assistant", "plan", {
-			tokensIn: 150,
-			tokensOut: 200,
-			cacheWriteTokens: 40,
-			cacheReadTokens: 20,
-			totalCost: 1.23,
+		service.captureLegacyTaskMigrationBacklog({
+			pendingLegacyTaskCount: 4,
+			migratedSdkTaskCount: 7,
+			visibleSdkTaskCount: 9,
+			visibleTaskCount: 13,
 		})
 
-		assert.deepStrictEqual(
-			provider.counters.map((entry) => entry.name),
-			[
-				TelemetryService.METRICS.TASK.TURNS_TOTAL,
-				TelemetryService.METRICS.CACHE.WRITE_TOTAL,
-				TelemetryService.METRICS.CACHE.READ_TOTAL,
-				TelemetryService.METRICS.TASK.COST_TOTAL,
-			],
-		)
-		const costEntry = provider.counters.find((entry) => entry.name === "cline.cost.total")
-		assert.ok(costEntry)
-		assert.strictEqual(costEntry?.attributes.ulid, "task-2")
-		assert.strictEqual(costEntry?.attributes.provider, "openai")
-		assert.strictEqual(costEntry?.attributes.model, "gpt-4")
-		assert.strictEqual(costEntry?.attributes.mode, "plan")
-		assert.strictEqual(costEntry?.attributes.currency, "USD")
-		assert.deepStrictEqual(
-			provider.histograms.map((entry) => entry.name),
-			[
-				TelemetryService.METRICS.TASK.TURNS_PER_TASK,
-				TelemetryService.METRICS.CACHE.WRITE_PER_EVENT,
-				TelemetryService.METRICS.CACHE.READ_PER_EVENT,
-				TelemetryService.METRICS.TASK.COST_PER_EVENT,
-			],
-		)
-		const turnEntry = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.TASK.TURNS_PER_TASK)
-		assert.ok(turnEntry)
-		assert.strictEqual(turnEntry?.value, 1)
-		assert.strictEqual(turnEntry?.attributes.ulid, "task-2")
-		assert.strictEqual(turnEntry?.attributes.provider, "openai")
-		assert.strictEqual(turnEntry?.attributes.model, "gpt-4")
-		assert.strictEqual(turnEntry?.attributes.source, "assistant")
-		assert.strictEqual(turnEntry?.attributes.mode, "plan")
-	})
+		const pendingSeries = provider.gauges.get(TelemetryService.METRICS.MIGRATION.LEGACY_TASK_PENDING_COUNT)
+		assert.ok(pendingSeries)
+		const [pendingEntry] = Array.from(pendingSeries.values())
+		assert.strictEqual(pendingEntry.value, 4)
+		assert.strictEqual(pendingEntry.attributes.migration_type, "legacy_task_to_sdk_session")
 
-	it("captureWorkspaceInitialized emits gauge and retires previous series", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
+		const migratedSeries = provider.gauges.get(TelemetryService.METRICS.MIGRATION.LEGACY_TASK_MIGRATED_COUNT)
+		assert.ok(migratedSeries)
+		const [migratedEntry] = Array.from(migratedSeries.values())
+		assert.strictEqual(migratedEntry.value, 7)
 
-		service.captureWorkspaceInitialized(3, ["Git"], 500)
-		const initialSeries = provider.gauges.get("cline.workspace.active_roots")
-		assert.ok(initialSeries)
-		assert.strictEqual(initialSeries.size, 1)
-		const [initialEntry] = Array.from(initialSeries.values())
-		assert.strictEqual(initialEntry.value, 3)
-		assert.strictEqual(initialEntry.attributes.is_multi_root, true)
-		assert.strictEqual(initialEntry.attributes.extension_version, "test")
-
-		service.captureWorkspaceInitialized(1, ["Git"], 200)
-		const updatedSeries = provider.gauges.get("cline.workspace.active_roots")
-		assert.ok(updatedSeries)
-		assert.strictEqual(updatedSeries.size, 1)
-		const [updatedEntry] = Array.from(updatedSeries.values())
-		assert.strictEqual(updatedEntry.value, 1)
-		assert.strictEqual(updatedEntry.attributes.is_multi_root, false)
-	})
-
-	it("captureProviderApiError increments error counter", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureProviderApiError({
-			ulid: "task-3",
-			model: "claude",
-			errorMessage: "boom",
-			provider: "anthropic",
-			errorStatus: 500,
-			errorType: PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR,
-			failurePhase: PROVIDER_FAILURE_PHASE.STREAMING,
-		})
-
-		assert.strictEqual(provider.counters.length, 1)
-		const entry = provider.counters[0]
-		assert.strictEqual(entry.name, TelemetryService.METRICS.ERRORS.TOTAL)
-		assert.strictEqual(entry.value, 1)
-		assert.strictEqual(entry.attributes.ulid, "task-3")
-		assert.strictEqual(entry.attributes.provider, "anthropic")
-		assert.strictEqual(entry.attributes.model, "claude")
-		assert.strictEqual(entry.attributes.error_status, 500)
-		assert.strictEqual(entry.attributes.error_type, PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR)
-		assert.strictEqual(entry.attributes.failure_phase, PROVIDER_FAILURE_PHASE.STREAMING)
-		assert.strictEqual(provider.histograms.length, 1)
-		const errorHistogram = provider.histograms[0]
-		assert.strictEqual(errorHistogram.name, TelemetryService.METRICS.ERRORS.PER_TASK)
-		assert.strictEqual(errorHistogram.value, 1)
-		assert.strictEqual(errorHistogram.attributes.ulid, "task-3")
-		assert.strictEqual(errorHistogram.attributes.provider, "anthropic")
-		assert.strictEqual(errorHistogram.attributes.model, "claude")
-		assert.strictEqual(errorHistogram.attributes.error_status, 500)
-		assert.strictEqual(errorHistogram.attributes.error_type, PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR)
-		assert.strictEqual(errorHistogram.attributes.failure_phase, PROVIDER_FAILURE_PHASE.STREAMING)
-	})
-
-	it("captureTaskCompleted records completion payload with TTFT and duration histograms", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureTaskCompleted("task-4", {
-			provider: "openai-native",
-			modelId: "gpt-5",
-			apiFormat: ApiFormat.OPENAI_RESPONSES,
-			timeToFirstTokenMs: 350,
-			durationMs: 2100,
-			mode: "act",
-		})
-
-		const completionEvent = provider.logs.find((entry) => entry.event === "task.completed")
-		assert.ok(completionEvent)
-		assert.ok(completionEvent?.properties)
-		assert.strictEqual(completionEvent?.properties?.ulid, "task-4")
-		assert.strictEqual(completionEvent?.properties?.provider, "openai-native")
-		assert.strictEqual(completionEvent?.properties?.modelId, "gpt-5")
-		assert.strictEqual(completionEvent?.properties?.apiFormat, ApiFormat.OPENAI_RESPONSES)
-		assert.strictEqual(completionEvent?.properties?.apiFormatName, "OPENAI_RESPONSES")
-		assert.strictEqual(completionEvent?.properties?.timeToFirstTokenMs, 350)
-		assert.strictEqual(completionEvent?.properties?.durationMs, 2100)
-
-		const ttftMetric = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.API.TTFT_SECONDS)
-		assert.ok(ttftMetric)
-		assert.strictEqual(ttftMetric?.value, 0.35)
-		assert.strictEqual(ttftMetric?.attributes.ulid, "task-4")
-		assert.strictEqual(ttftMetric?.attributes.provider, "openai-native")
-		assert.strictEqual(ttftMetric?.attributes.model, "gpt-5")
-		assert.strictEqual(ttftMetric?.attributes.apiFormat, "OPENAI_RESPONSES")
-
-		const durationMetric = provider.histograms.find((entry) => entry.name === TelemetryService.METRICS.API.DURATION_SECONDS)
-		assert.ok(durationMetric)
-		assert.strictEqual(durationMetric?.value, 2.1)
-		assert.strictEqual(durationMetric?.attributes.scope, "task")
-	})
-
-	it("captureGrpcResponseSize records histogram with correct name, value, and attributes", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureGrpcResponseSize(123456, "cline.StateService", "subscribeToState")
-
-		assert.strictEqual(provider.histograms.length, 1)
-		const entry = provider.histograms[0]
-		assert.strictEqual(entry.name, TelemetryService.METRICS.GRPC.RESPONSE_SIZE_BYTES)
-		assert.strictEqual(entry.value, 123456)
-		assert.strictEqual(entry.attributes.service, "cline.StateService")
-		assert.strictEqual(entry.attributes.method, "subscribeToState")
-		assert.strictEqual(entry.description, "Size of gRPC response messages in bytes")
-		// Should not have request_id when not provided
-		assert.strictEqual(entry.attributes.request_id, undefined)
-	})
-
-	it("captureGrpcResponseSize includes request_id when provided", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureGrpcResponseSize(5000, "cline.StateService", "subscribeToState", "req-42")
-
-		assert.strictEqual(provider.histograms.length, 1)
-		const entry = provider.histograms[0]
-		assert.strictEqual(entry.attributes.request_id, "req-42")
-	})
-
-	it("captureGrpcResponseSize includes standard metadata attributes", () => {
-		const provider = new FakeProvider()
-		const service = createTelemetryService(provider)
-
-		service.captureGrpcResponseSize(1000, "cline.StateService", "subscribeToState")
-
-		const entry = provider.histograms[0]
-		assert.strictEqual(entry.attributes.extension_version, "test")
-		assert.strictEqual(entry.attributes.platform, "test-platform")
+		const backlogEvent = provider.logs.find((entry) => entry.event === "task.legacy_task_migration")
+		assert.ok(backlogEvent)
+		assert.strictEqual(backlogEvent?.properties?.outcome, "backlog")
+		assert.strictEqual(backlogEvent?.properties?.pendingLegacyTaskCount, 4)
 	})
 
 	it("captureLegacyTaskMigration emits event and migration metrics", () => {
@@ -489,5 +227,80 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(provider.histograms[0].value, 0.25)
 		assert.strictEqual(provider.histograms[0].attributes.migration_type, "legacy_task_to_sdk_session")
 		assert.strictEqual(provider.histograms[0].attributes.reason, "migrated")
+	})
+
+	it("captureProviderApiError increments error counter", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureProviderApiError({
+			ulid: "task-3",
+			model: "claude",
+			errorMessage: "boom",
+			provider: "anthropic",
+			errorStatus: 500,
+			errorType: PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR,
+			failurePhase: PROVIDER_FAILURE_PHASE.STREAMING,
+		})
+
+		assert.strictEqual(provider.counters.length, 1)
+		const entry = provider.counters[0]
+		assert.strictEqual(entry.name, TelemetryService.METRICS.ERRORS.TOTAL)
+		assert.strictEqual(entry.value, 1)
+		assert.strictEqual(entry.attributes.ulid, "task-3")
+		assert.strictEqual(entry.attributes.provider, "anthropic")
+		assert.strictEqual(entry.attributes.model, "claude")
+		assert.strictEqual(entry.attributes.error_status, 500)
+		assert.strictEqual(entry.attributes.error_type, PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR)
+		assert.strictEqual(entry.attributes.failure_phase, PROVIDER_FAILURE_PHASE.STREAMING)
+		assert.strictEqual(provider.histograms.length, 1)
+		const errorHistogram = provider.histograms[0]
+		assert.strictEqual(errorHistogram.name, TelemetryService.METRICS.ERRORS.PER_TASK)
+		assert.strictEqual(errorHistogram.value, 1)
+		assert.strictEqual(errorHistogram.attributes.ulid, "task-3")
+		assert.strictEqual(errorHistogram.attributes.provider, "anthropic")
+		assert.strictEqual(errorHistogram.attributes.model, "claude")
+		assert.strictEqual(errorHistogram.attributes.error_status, 500)
+		assert.strictEqual(errorHistogram.attributes.error_type, PROVIDER_FAILURE_ERROR_TYPE.SDK_AGENT_DONE_ERROR)
+		assert.strictEqual(errorHistogram.attributes.failure_phase, PROVIDER_FAILURE_PHASE.STREAMING)
+	})
+
+	it("captureGrpcResponseSize records histogram with correct name, value, and attributes", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(123456, "cline.StateService", "subscribeToState")
+
+		assert.strictEqual(provider.histograms.length, 1)
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.name, TelemetryService.METRICS.GRPC.RESPONSE_SIZE_BYTES)
+		assert.strictEqual(entry.value, 123456)
+		assert.strictEqual(entry.attributes.service, "cline.StateService")
+		assert.strictEqual(entry.attributes.method, "subscribeToState")
+		assert.strictEqual(entry.description, "Size of gRPC response messages in bytes")
+		// Should not have request_id when not provided
+		assert.strictEqual(entry.attributes.request_id, undefined)
+	})
+
+	it("captureGrpcResponseSize includes request_id when provided", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(5000, "cline.StateService", "subscribeToState", "req-42")
+
+		assert.strictEqual(provider.histograms.length, 1)
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.attributes.request_id, "req-42")
+	})
+
+	it("captureGrpcResponseSize includes standard metadata attributes", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(1000, "cline.StateService", "subscribeToState")
+
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.attributes.extension_version, "test")
+		assert.strictEqual(entry.attributes.platform, "test-platform")
 	})
 })

--- a/sdk/packages/core/src/runtime/host/local/agent-event-bridge.test.ts
+++ b/sdk/packages/core/src/runtime/host/local/agent-event-bridge.test.ts
@@ -1,6 +1,11 @@
+import type { AgentEvent } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
+import type { CoreSessionConfig } from "../../../types/config";
 import type { ActiveSession } from "../../../types/session";
-import { AgentEventBridge, type AgentEventBridgeDeps } from "./agent-event-bridge";
+import {
+	AgentEventBridge,
+	type AgentEventBridgeDeps,
+} from "./agent-event-bridge";
 
 function createTelemetryStub() {
 	return {
@@ -12,7 +17,9 @@ function createTelemetryStub() {
 	};
 }
 
-function createBridge(telemetry: ReturnType<typeof createTelemetryStub> | undefined) {
+function createBridge(
+	telemetry: ReturnType<typeof createTelemetryStub> | undefined,
+) {
 	const session = telemetry
 		? ({ config: { telemetry } } as unknown as ActiveSession)
 		: undefined;
@@ -21,6 +28,99 @@ function createBridge(telemetry: ReturnType<typeof createTelemetryStub> | undefi
 	} as unknown as AgentEventBridgeDeps;
 	return new AgentEventBridge(deps);
 }
+
+describe("AgentEventBridge.dispatchAgentEvent", () => {
+	function createDispatchFixture() {
+		const telemetry = createTelemetryStub();
+		const config = {
+			telemetry,
+			providerId: "cline",
+			modelId: "model-a",
+			mode: "act",
+		} as unknown as CoreSessionConfig;
+		const session = {
+			config,
+			agent: {
+				getAgentId: () => "agent-1",
+				getConversationId: () => "conv-1",
+			},
+			runtime: {},
+		} as unknown as ActiveSession;
+		const sessions = new Map<string, ActiveSession>([["session-1", session]]);
+		const deps = {
+			getSession: (sessionId: string) => sessions.get(sessionId),
+			usageBySession: new Map(),
+			aggregateUsageBySession: new Map(),
+			emit: vi.fn(),
+			persistMessages: vi.fn(),
+		} as unknown as AgentEventBridgeDeps;
+		return { telemetry, config, sessions, bridge: new AgentEventBridge(deps) };
+	}
+
+	const toolEvent = {
+		type: "content_end",
+		contentType: "tool",
+		toolName: "run_commands",
+	} as unknown as AgentEvent;
+
+	function toolUsedProperties(
+		telemetry: ReturnType<typeof createTelemetryStub>,
+	) {
+		const call = telemetry.capture.mock.calls.find(
+			([arg]) => arg.event === "task.tool_used",
+		);
+		expect(call).toBeDefined();
+		return call?.[0].properties as Record<string, unknown>;
+	}
+
+	it("stamps root agent identity on tool events while the session is registered", () => {
+		const { telemetry, config, bridge } = createDispatchFixture();
+
+		bridge.dispatchAgentEvent("session-1", config, toolEvent);
+
+		expect(toolUsedProperties(telemetry)).toMatchObject({
+			ulid: "session-1",
+			tool: "run_commands",
+			agentId: "agent-1",
+			agentKind: "root",
+			isSubagent: false,
+			conversationId: "conv-1",
+		});
+	});
+
+	it("keeps the last known identity for events dispatched after the session was deregistered", () => {
+		const { telemetry, config, sessions, bridge } = createDispatchFixture();
+
+		// A live event records the identity snapshot...
+		bridge.dispatchAgentEvent("session-1", config, toolEvent);
+		telemetry.capture.mockClear();
+
+		// ...then teardown removes the session from the map while the agent's
+		// run is still draining (sessions.delete precedes shutdown completion).
+		sessions.delete("session-1");
+		bridge.dispatchAgentEvent("session-1", config, toolEvent);
+
+		expect(toolUsedProperties(telemetry)).toMatchObject({
+			ulid: "session-1",
+			tool: "run_commands",
+			agentId: "agent-1",
+			agentKind: "root",
+			isSubagent: false,
+			conversationId: "conv-1",
+		});
+	});
+
+	it("emits without identity when a session was never registered (no snapshot to reuse)", () => {
+		const { telemetry, config, bridge } = createDispatchFixture();
+
+		bridge.dispatchAgentEvent("session-unknown", config, toolEvent);
+
+		const properties = toolUsedProperties(telemetry);
+		expect(properties.ulid).toBe("session-unknown");
+		expect(properties.agentId).toBeUndefined();
+		expect(properties.agentKind).toBeUndefined();
+	});
+});
 
 describe("AgentEventBridge.handlePluginTelemetry", () => {
 	it("routes plugin capture calls into the session telemetry service", () => {

--- a/sdk/packages/core/src/runtime/host/local/agent-event-bridge.ts
+++ b/sdk/packages/core/src/runtime/host/local/agent-event-bridge.ts
@@ -7,6 +7,7 @@ import type {
 import type { TeamEvent } from "../../../extensions/tools/team";
 import {
 	type AgentEventContext,
+	type AgentTelemetryContextOverrides,
 	buildTelemetryAgentIdentity,
 	extractAgentEventMetadata,
 	handleAgentEvent,
@@ -39,6 +40,20 @@ export interface AgentEventBridgeDeps {
 export class AgentEventBridge {
 	constructor(private readonly deps: AgentEventBridgeDeps) {}
 
+	/**
+	 * Last agent identity stamped on each session's events while the session
+	 * was still registered. A session's agent can keep emitting after the host
+	 * removes it from the sessions map (teardown deletes the entry before the
+	 * run fully drains), and without this snapshot those late events reach
+	 * telemetry with no agent identity at all. Bounded FIFO so a long-lived
+	 * host doesn't accumulate entries forever.
+	 */
+	private readonly lastKnownIdentityBySession = new Map<
+		string,
+		AgentTelemetryContextOverrides
+	>();
+	private static readonly MAX_IDENTITY_SNAPSHOTS = 512;
+
 	dispatchAgentEvent(
 		sessionId: string,
 		config: CoreSessionConfig,
@@ -59,20 +74,50 @@ export class AgentEventBridge {
 			!!liveSession &&
 			(!eventMetadata.agentId ||
 				eventMetadata.agentId === readAgentId(liveSession.agent));
-		handleAgentEvent(
-			ctx,
-			event,
-			isRootAgentEvent
-				? {
-						isPrimaryAgentEvent: true,
-						agentId: readAgentId(liveSession.agent),
-						conversationId: liveSession.agent.getConversationId(),
-						...(liveSession?.runtime.teamRuntime
-							? { teamRole: "lead" as const }
-							: {}),
-					}
-				: { isPrimaryAgentEvent: false },
-		);
+		if (isRootAgentEvent) {
+			const identity: AgentTelemetryContextOverrides = {
+				agentId: readAgentId(liveSession.agent),
+				conversationId: liveSession.agent.getConversationId(),
+				...(liveSession?.runtime.teamRuntime
+					? { teamRole: "lead" as const }
+					: {}),
+			};
+			this.rememberSessionIdentity(sessionId, identity);
+			handleAgentEvent(ctx, event, {
+				...identity,
+				isPrimaryAgentEvent: true,
+			});
+			return;
+		}
+		handleAgentEvent(ctx, event, {
+			// Session-map miss: the session was already deregistered but its
+			// agent is still emitting. Reuse the identity captured while it was
+			// live so task.tool_used and friends keep their agentId/agentKind
+			// attributes. When the session IS live this is a non-root
+			// (sub-agent) event carrying its own metadata, so no fallback is
+			// applied.
+			...(liveSession ? {} : this.lastKnownIdentityBySession.get(sessionId)),
+			isPrimaryAgentEvent: false,
+		});
+	}
+
+	private rememberSessionIdentity(
+		sessionId: string,
+		identity: AgentTelemetryContextOverrides,
+	): void {
+		// Delete-then-set keeps insertion order acting as least-recently-updated
+		// for the FIFO eviction below.
+		this.lastKnownIdentityBySession.delete(sessionId);
+		this.lastKnownIdentityBySession.set(sessionId, identity);
+		if (
+			this.lastKnownIdentityBySession.size >
+			AgentEventBridge.MAX_IDENTITY_SNAPSHOTS
+		) {
+			const oldest = this.lastKnownIdentityBySession.keys().next().value;
+			if (oldest !== undefined) {
+				this.lastKnownIdentityBySession.delete(oldest);
+			}
+		}
 	}
 
 	async handleTeamEvent(


### PR DESCRIPTION
### Related Issue

No public issue. Two internal telemetry changes: the first continues the sweep started in #12818 (which removed `captureDiffEditFailure` / `captureWorkspaceInitError` after the `task.provider_api_error` double-emission fixed in #12820); the second comes from a ClickHouse query on `otel.otel_logs`.

The SDK-parity gap this PR surfaces is tracked separately in [ENG-2401](https://linear.app/cline-bot/issue/ENG-2401).

### Description

Neither change alters which events are emitted or their counts on the SDK line: one removes duplicate capture paths, the other adds missing attributes.

**1. `chore(telemetry)`: remove capture defs that `@cline/core` owns**

`apps/vscode/src/services/telemetry/TelemetryService.ts` still carries event constants and public capture methods inherited from the legacy architecture. Note this file is **not** VS-Code-only — `apps/vscode` also compiles into the `cline-core.js` that the JetBrains plugin runs (`compile-standalone`), so it's the shared cline-core bundle layer for both IDEs.

Where `@cline/core` emits the same event, a bundle-layer twin is a **second capture path on the same telemetry service** — exactly how the `task.provider_api_error` double-emission happened. Those are what this removes.

**Removed (20) — safe because the signal is covered elsewhere on the SDK line:**

<details>
<summary>15 — <code>@cline/core</code> emits the same signal today</summary>

`captureTaskCreated`, `captureTaskRestarted`, `captureTaskCompleted`, `captureConversationTurnEvent`, `captureTokenUsage`, `captureModeSwitch`, `captureToolUsage`, `captureSkillUsed`, `captureSubagentExecution`, `captureAuthStarted`, `captureAuthSucceeded`, `captureAuthFailed`, `captureUserOptOut`, `captureWorkspaceInitialized`, `captureSummarizeTask`

Each has a live emitter in `sdk/packages/core/src/services/telemetry/core-events.ts` that is actually called from a core code path — verified individually, not just by the constant existing. Two worth spelling out:

- **`captureUserOptOut`** looks host-triggered, but the SDK line routes the *bundle layer's* opt-out through core: `SdkController.updateTelemetrySetting` → `setTelemetryOptOutGlobally(…, { telemetry })` → `writeGlobalSettings` → `captureTelemetryOptOut` → `captureRequired("user.opt_out")`. Core gets handed this layer's telemetry handle, so `user.opt_out` does fire — and keeping the local method would be a genuine double-emission risk.
- **`captureSummarizeTask`** wasn't dropped, it was renamed: core replaced `task.summarize_task` with `task.compaction_executed` / `_skipped` / `_budget_emergency`.

</details>

<details>
<summary>3 — obsolete on both architecture lines (zero callers on <code>main</code> <em>and</em> <code>legacy-extension</code>)</summary>

`captureModelSelected`, `captureRulesMenuOpened`, `captureHostEvent`

`ui.model_selected` isn't lost: the `model_selected` signal survives as an action string on `captureOnboardingProgress` (kept, 7 callers) — see `OnboardingView.tsx`.

</details>

<details>
<summary>2 — trigger moved into core/sdk, so this layer can no longer observe them</summary>

- `captureWorkspacePathResolved` — core already owns `workspace.path_resolved` (it defines `captureWorkspacePathResolved` but doesn't call it yet). Restoring the bundle-layer twin would plant the same double-emission hazard the moment core wires it, so the fix belongs in core.
- `captureGeminiApiPerformance` — providers live in core now, so this layer can't compute Gemini timings. Core's generic provider-timing events supersede it.

</details>

**Deliberately kept (18) — no caller here, but a live caller on `legacy-extension`:**

`captureUserOptIn`, `captureExtensionStorageError`, `captureOptionSelected`, `captureOptionsIgnored`, `captureCheckpointUsage`, `captureFocusChainToggle`, `captureFocusChainProgressFirst`, `captureFocusChainProgressUpdate`, `captureFocusChainIncompleteOnCompletion`, `captureFocusChainListWritten`, `captureTerminalHang`, `captureMultiRootCheckpoint`, `captureWorkspaceSearchPattern`, `captureAiOutputAccepted`, `captureAiOutputRejected`, `captureSlashCommandUsed`, `captureTaskInitialization`, `captureLegacyTaskMigration`

These are **not** dead code, and the distinction is the whole point of this PR. "No callers" has more than one cause, and only some of them mean "delete":

| Why is it uncalled? | What to do |
|---|---|
| Core emits the same signal now | **Delete** — a duplicate path is the hazard |
| Obsolete / renamed away on both lines | **Delete** |
| Trigger moved into core/sdk | **Delete here**, implement in core if wanted |
| It was wired on legacy and never ported to SDK | **Keep** — this layer is the only place it can live |

Every one of the 18 falls in that last row. Their signals originate in this bundle — webview UI, VS Code storage, host terminal, checkpoints, focus chain, legacy-task migration — so `@cline/core` structurally cannot emit them; the missing piece is a call site on this line. Deleting them wouldn't cause a regression (the gap already exists on `main`) but it would erase the last marker of one, for signals core can't restore. Several look genuinely valuable — `task.ai_output.accepted`/`rejected` (AI-output acceptance rates), per-task legacy-migration outcomes, terminal-hang. Porting them is tracked in [ENG-2401](https://linear.app/cline-bot/issue/ENG-2401), and there's a comment on the first of them recording the criterion so they don't get "cleaned up" later.

The sibling pattern is the tell: `captureTerminalExecution` (8 callers), `captureTerminalOutputFailure` (2) and `captureTerminalUserIntervention` (2) all fire from `VscodeTerminalProcess`, but `captureTerminalHang` has none — same subsystem, same file. Likewise `captureFocusChainListOpened` fires while the other five focus-chain methods don't, and `captureLegacyTaskMigrationBacklog` fires while the per-task `captureLegacyTaskMigration` doesn't.

Also removed: `EVENTS` constants referenced only by the 20; constants already orphaned before this PR (`HISTORICAL_LOADED`, `RETRY_CLICKED`, `VCS_DETECTED`, `HOOKS.ENABLED`/`DISABLED`/`CANCEL_REQUESTED`/`CONTEXT_MODIFIED` — `EVENTS` is `private`, so these are provably unreachable); the unused `TokenUsage` interface; and the `taskTurnCounts`/`taskToolCallCounts` maps, which only deleted methods wrote to. `METRICS`, `TelemetryCategory` (including `skills`) and `TerminalHangStage` are untouched.

**2. `fix(telemetry)`: keep agent identity on events dispatched after session teardown**

Empirically (2026-08-04, `otel.otel_logs`, `extension_variant='next'`, 48h): 229,016 `task.tool_used` rows carry `agentId`, but **285 do not** — concentrated in long-running tools (`run_commands`, `editor`, `read_files`).

One emitter produces that event in core (`captureToolUsage` from `handleAgentEvent`), spreading `...agentIdentity` from `buildTelemetryAgentIdentity`. Why it returns `undefined`:

- `AgentEvent` metadata never carries `agentId` in production — the producers in `runtime/orchestration/runtime-event-adapter.ts` don't set it. So `AgentEventBridge.dispatchAgentEvent` resolves identity *solely* from the live-session map, and its `isRootAgentEvent` check effectively reduces to "is the session still registered?".
- Teardown deletes the map entry **before** the run drains: `dispose` / `stopSession` → `releaseSessionRuntime` can skip `agent.shutdown()` entirely (it's inside `if (session.artifacts)`) or have it throw (it only awaits the run when an abort was requested first), and that throw is swallowed by `recordCleanupError`. The event subscription is never removed.
- Late tool events therefore hit the map-miss branch, which passed `{ isPrimaryAgentEvent: false }` and no identity → `buildTelemetryAgentIdentity` returns `undefined` → `...agentIdentity` spreads nothing.

The 0.12% rate and tool distribution both match a teardown-window race rather than a systematic gap.

Fix: the bridge snapshots the identity it stamps while a session is registered (bounded FIFO, 512 entries) and reuses it **only** on a map miss. Post-teardown events now carry `agentId`, `agentKind: "root"`, `isSubagent: false`, `conversationId`. Purely additive: with a live session, or for a genuine sub-agent event carrying its own metadata, emitted properties are byte-identical. `isPrimaryAgentEvent: false` is preserved on the fallback path so usage bucketing is untouched (and unreachable there anyway).

Two things found while tracing but deliberately **not** changed, since both would alter attribute *values* on existing events: while a session is live, sub-agent and team-member tool events are stamped with the **root** agent's identity (event metadata carries no `agentId` to distinguish them); and `hub/server/handlers/connector-handlers.ts` emits `task.tool_used` with no identity by construction (its tool names aren't in the observed set, so it isn't the 285).

**Why now**

Nothing here fixes something a user can see, so it sits behind the user-facing SDK queue on urgency. It's still worth landing ahead of that, for reasons that get worse with time rather than better:

- **It disarms loaded guns.** Every core-owned twin left in place is a callable API for an event core already emits. Wiring one up doesn't fail loudly — it silently double-counts, and you make decisions on the bad number. That has already happened once (#12820).
- **It removes a trap.** With ~38 uncalled capture methods in one file, "no callers ⇒ dead" looks like a safe inference and is wrong for 18 of them. The comment on `captureUserOptIn` records the criterion so the next sweep doesn't repeat it.
- **The evidence is cheap today and won't stay that way.** Telling "core took over this signal" apart from "this was never ported" depends on `legacy-extension` being a live branch to grep. When legacy retires, that distinction becomes archaeology.
- **Low interference.** The chore half changes no emissions on the SDK line, touches no protos, and doesn't affect the JetBrains plugin, so it can't destabilise anything currently in flight. The fix half is additive (attributes gained; no event added, removed or renamed).

The cost is reviewer attention on a ~1,000-line deletion. The `legacy-extension` caller counts above are meant to make that mechanical — check the criterion and spot-check, rather than reasoning about each method.

### Test Procedure

- **core**: `bun run test:unit` → **1,559 passed, 14 skipped, 0 failed**; `bun tsc -p tsconfig.dev.json --noEmit` clean.
- **New coverage** for the fix in `runtime/host/local/agent-event-bridge.test.ts` (3 tests, matching that file's existing stub/`describe` style; it had no coverage of `dispatchAgentEvent` before): identity stamped while registered; identity **survives dispatch after deregistration** (the previously-empty path — fails before the fix); never-registered session still emits, without identity and without throwing.
- **apps/vscode**: `bunx tsc --noEmit` clean against freshly built SDK packages (`bun --production -F './sdk/packages/*' build`) after `bun run protos`. `TelemetryService.metrics.test.ts` 10/10 (`bun test`), `sdk/sdk-task-history.test.ts` 38/38 (vitest). `bun run compile-tests` succeeds, so the mocha-based `TelemetryService.test.ts` compiles.
- **Lint/format**: biome with each package's own config over every changed file.
- **Verifying the delete/keep split** — the risk is deleting something still needed. Each of the 38 candidates was checked against three independent things: live callers on `main` (excluding tests and the definition), whether `@cline/core` both *defines and calls* an equivalent, and **live callers on `legacy-extension`** (the control group that shows *why* a count is zero). After the change I re-swept all 20 removed names repo-wide (zero hits) and verified `EVENTS` has exactly 49 constants defined and 49 referenced — no dead, none broken. I also confirmed nothing uses dynamic dispatch through the `telemetryService` Proxy (`telemetryService[name]`), which a static grep would have missed.
- **Cross-host / proto checks**: since this file also compiles into the JetBrains cline-core, I grepped the `cline/intellij-plugin` repo for all 38 method names and every removed event-name string — **zero hits**. No proto surface changes either: `git diff --stat origin/main..HEAD -- '*.proto' 'apps/vscode/proto/**'` is empty (`TelemetryService` is internal TypeScript, not a proto service), and the telemetry-adjacent RPCs `cline.StateService.updateTelemetrySetting` and `host.EnvService.getTelemetrySettings` keep their handlers and consumers.
- **Known local gap**: the extension-host (mocha) suite can't run on my machine — `vscode-test` downloads VS Code 1.131.0, whose macOS binary is now `Visual Studio Code.app/Contents/MacOS/Code`, while the pinned `@vscode/test-electron` spawns `.../MacOS/Electron` → `ENOENT`. Pre-existing and affects **every** extension-host test. `TelemetryService.test.ts` is verified via `tsc --noEmit` + `compile-tests`, and every method it calls is runtime-covered by the bun/vitest suites. Worth confirming against CI.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore — **not checked deliberately**: two related telemetry changes in two self-contained commits. Happy to split; they touch disjoint trees (`apps/vscode` vs `sdk/packages/core`) and review cleanly commit-by-commit as-is.
-   [x] Tests are passing and code is formatted and linted — with the one documented exception in Test Procedure (the extension-host suite can't run locally for a pre-existing, unrelated reason).
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes — telemetry only.

### Additional Notes

Review order: the `chore` commit is a mechanical deletion best skimmed for "did this have a caller I missed?" (the `legacy-extension` counts in the table above are the fastest way to check); the `fix` commit is ~40 lines of real logic plus tests and deserves the closer read.

The neutral-verification question for the fix is whether reusing a cached identity after deregistration can misattribute an event. It can't within a session id: the snapshot is keyed by session id, only ever written from that session's own live root-agent events, and only read when the session is absent from the map (so there's no live agent to disagree with). The bound is a safety valve for a long-lived host, not a correctness mechanism.

**Follow-ups, not in this PR:** the 18 kept methods are tracked in [ENG-2401](https://linear.app/cline-bot/issue/ENG-2401), together with the two core-side items (`workspace.path_resolved`, already defined in core but never called; and Gemini/provider performance telemetry). Separately, this PR leaves a handful of `METRICS` entries orphaned (`TASK.TURNS_*`, `TASK.TOKENS_*`, `TOOLS.*`) now that core owns those events; I left `METRICS` untouched rather than widen the diff.
