### PR TITLE
feat(desktop): add token usage warning colors

### DIFF
--- a/apps/examples/desktop-app/webview/components/ui/button.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/button.tsx
@@ -25,6 +25,7 @@ const buttonVariants = cva(
 					"!h-auto w-full justify-start text-left gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground",
 				sidebarText:
 					"!h-auto justify-start gap-1 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-sidebar-foreground",
+				text: "bg-transparent text-sm font-medium text-muted-foreground hover:text-accent-foreground",
 			},
 			size: {
 				default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -473,7 +473,7 @@ describe("ChatInputBar token ring", () => {
 		).toBeNull();
 	});
 
-	it("fills from input only and sits immediately before the workspace selector", async () => {
+	it("fills from input only and sits immediately after the workspace selector", async () => {
 		const trigger = await renderTokenUsage(
 			{
 				toolCalls: 0,
@@ -490,24 +490,44 @@ describe("ChatInputBar token ring", () => {
 		expect(ring?.classList.contains("size-3.5")).toBe(true);
 		expect(ring?.getAttribute("height")).toBe("22");
 		expect(ring?.getAttribute("width")).toBe("22");
-		const progressCircle = trigger?.querySelector("circle.stroke-primary");
+		const progressCircle = trigger?.querySelector("circle.stroke-orange-500");
 		expect(progressCircle?.getAttribute("stroke-width")).toBe("4");
 		const circumference = 2 * Math.PI * 8.5;
 		expect(
 			Number(progressCircle?.getAttribute("stroke-dashoffset")),
 		).toBeCloseTo(circumference * 0.5);
 
-		const workspaceSelector = container.querySelector("#git-branch-btn");
+		const workspaceSelector = trigger?.parentElement?.querySelector("#git-branch-btn");
 		expect(workspaceSelector).not.toBeNull();
 		expect(trigger?.parentElement?.classList.contains("gap-0")).toBe(true);
 		expect(trigger?.parentElement?.contains(workspaceSelector)).toBe(true);
 		expect(
 			Boolean(
 				trigger?.compareDocumentPosition(workspaceSelector as Node) &
-					Node.DOCUMENT_POSITION_FOLLOWING,
+					Node.DOCUMENT_POSITION_PRECEDING,
 			),
 		).toBe(true);
 		expect(container.textContent).not.toContain("1,500 tokens");
+	});
+
+	it("changes the ring from primary to orange at 50% and red at 75%", async () => {
+		const belowWarning = await renderTokenUsage(
+			{ toolCalls: 0, tokensIn: 499, tokensOut: 0 },
+			1000,
+		);
+		expect(belowWarning?.querySelector("circle.stroke-primary")).not.toBeNull();
+
+		const warning = await renderTokenUsage(
+			{ toolCalls: 0, tokensIn: 500, tokensOut: 0 },
+			1000,
+		);
+		expect(warning?.querySelector("circle.stroke-orange-500")).not.toBeNull();
+
+		const critical = await renderTokenUsage(
+			{ toolCalls: 0, tokensIn: 750, tokensOut: 0 },
+			1000,
+		);
+		expect(critical?.querySelector("circle.stroke-red-500")).not.toBeNull();
 	});
 
 	it("opens only supported usage details on click", async () => {
@@ -526,13 +546,39 @@ describe("ChatInputBar token ring", () => {
 
 		const panel = document.querySelector("#token-usage-panel");
 		expect(panel?.textContent).toContain("Context window500k / 1.0M (50%)");
+		expect(panel?.querySelector(".bg-primary")).not.toBeNull();
 		expect(panel?.textContent).toContain("Output tokens500");
 		expect(panel?.textContent).toContain("Cost$0.014");
 		expect(panel?.textContent).not.toContain("Total");
 		expect(panel?.textContent).not.toContain("usage limit");
 	});
 
-	it("saturates at 100% without switching to a destructive style", async () => {
+	it("changes the popover progress bar to orange above 50% and red above 75%", async () => {
+		const trigger = await renderTokenUsage(
+			{ toolCalls: 0, tokensIn: 501, tokensOut: 0 },
+			1000,
+		);
+		await act(async () => {
+			trigger?.click();
+		});
+		expect(
+			document
+				.querySelector("#token-usage-panel")
+				?.querySelector(".bg-orange-500"),
+		).not.toBeNull();
+
+		await renderTokenUsage(
+			{ toolCalls: 0, tokensIn: 751, tokensOut: 0 },
+			1000,
+		);
+		expect(
+			document
+				.querySelector("#token-usage-panel")
+				?.querySelector(".bg-red-500"),
+		).not.toBeNull();
+	});
+
+	it("saturates at 100% with the critical ring color", async () => {
 		const trigger = await renderTokenUsage(
 			{
 				toolCalls: 0,
@@ -541,8 +587,7 @@ describe("ChatInputBar token ring", () => {
 			},
 			128_000,
 		);
-		const progressCircle = trigger?.querySelector("circle.stroke-primary");
+		const progressCircle = trigger?.querySelector("circle.stroke-red-500");
 		expect(progressCircle?.getAttribute("stroke-dashoffset")).toBe("0");
-		expect(trigger?.querySelector(".stroke-destructive")).toBeNull();
 	});
 });

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -453,7 +453,7 @@ describe("ChatInputBar token ring", () => {
 		return container.querySelector<HTMLButtonElement>("#token-usage");
 	};
 
-	it("waits for input usage and model context metadata", async () => {
+	it("waits for token usage and model context metadata", async () => {
 		expect(
 			await renderTokenUsage({
 				toolCalls: 0,
@@ -461,19 +461,20 @@ describe("ChatInputBar token ring", () => {
 				tokensOut: 0,
 			}),
 		).toBeNull();
-		expect(
-			await renderTokenUsage(
-				{
-					toolCalls: 0,
-					tokensIn: 0,
-					tokensOut: 500,
-				},
-				2000,
-			),
-		).toBeNull();
+		const outputOnly = await renderTokenUsage(
+			{
+				toolCalls: 0,
+				tokensIn: 0,
+				tokensOut: 500,
+			},
+			2000,
+		);
+		expect(outputOnly?.getAttribute("aria-label")).toBe(
+			"Context window: 500 of 2,000 tokens used (25%)",
+		);
 	});
 
-	it("fills from input only and sits immediately after the workspace selector", async () => {
+	it("fills from input and output and sits immediately after the workspace selector", async () => {
 		const trigger = await renderTokenUsage(
 			{
 				toolCalls: 0,
@@ -483,31 +484,36 @@ describe("ChatInputBar token ring", () => {
 			2000,
 		);
 		expect(trigger?.getAttribute("aria-label")).toBe(
-			"Context window: 1,000 of 2,000 input tokens used (50%)",
+			"Context window: 1,500 of 2,000 tokens used (75%)",
 		);
 		expect(trigger?.textContent).toBe("");
 		const ring = trigger?.querySelector("svg");
 		expect(ring?.classList.contains("size-3.5")).toBe(true);
 		expect(ring?.getAttribute("height")).toBe("22");
 		expect(ring?.getAttribute("width")).toBe("22");
-		const progressCircle = trigger?.querySelector("circle.stroke-orange-500");
+		const progressCircle = trigger?.querySelector("circle.stroke-red-500");
 		expect(progressCircle?.getAttribute("stroke-width")).toBe("4");
 		const circumference = 2 * Math.PI * 8.5;
 		expect(
 			Number(progressCircle?.getAttribute("stroke-dashoffset")),
-		).toBeCloseTo(circumference * 0.5);
+		).toBeCloseTo(circumference * 0.25);
 
-		const workspaceSelector = trigger?.parentElement?.querySelector("#git-branch-btn");
-		expect(workspaceSelector).not.toBeNull();
-		expect(trigger?.parentElement?.classList.contains("gap-0")).toBe(true);
-		expect(trigger?.parentElement?.contains(workspaceSelector)).toBe(true);
+		if (!trigger?.parentElement) {
+			throw new Error("Expected token usage trigger group");
+		}
+		const usageGroup = trigger.parentElement;
+		const workspaceSelector = usageGroup.querySelector("#git-branch-btn");
+		if (!workspaceSelector) {
+			throw new Error("Expected workspace selector in token usage group");
+		}
+		expect(usageGroup.classList.contains("gap-0")).toBe(true);
+		expect(usageGroup.contains(workspaceSelector)).toBe(true);
 		expect(
 			Boolean(
-				trigger?.compareDocumentPosition(workspaceSelector as Node) &
+				trigger.compareDocumentPosition(workspaceSelector) &
 					Node.DOCUMENT_POSITION_PRECEDING,
 			),
 		).toBe(true);
-		expect(container.textContent).not.toContain("1,500 tokens");
 	});
 
 	it("changes the ring from primary to orange at 50% and red at 75%", async () => {
@@ -536,6 +542,7 @@ describe("ChatInputBar token ring", () => {
 				toolCalls: 0,
 				tokensIn: 500_000,
 				tokensOut: 500,
+				cacheReadTokens: 125_000,
 				totalCostUsd: 0.0142,
 			},
 			1_000_000,
@@ -545,37 +552,30 @@ describe("ChatInputBar token ring", () => {
 		});
 
 		const panel = document.querySelector("#token-usage-panel");
-		expect(panel?.textContent).toContain("Context window500k / 1.0M (50%)");
-		expect(panel?.querySelector(".bg-primary")).not.toBeNull();
+		expect(panel?.textContent).toContain("Context window500.5k / 1.0M (50%)");
+		expect(panel?.textContent).toContain("Input tokens500,000");
 		expect(panel?.textContent).toContain("Output tokens500");
+		expect(panel?.textContent).toContain("Cached tokens125,000");
 		expect(panel?.textContent).toContain("Cost$0.014");
+		const uncachedSegment = panel?.querySelector<HTMLElement>(
+			'[data-token-kind="uncached-input"]',
+		);
+		const cachedSegment = panel?.querySelector<HTMLElement>(
+			'[data-token-kind="cached-input"]',
+		);
+		const outputSegment = panel?.querySelector<HTMLElement>(
+			'[data-token-kind="output"]',
+		);
+		expect(uncachedSegment?.classList.contains("bg-primary")).toBe(true);
+		expect(uncachedSegment?.style.width).toBe("37.5%");
+		expect(cachedSegment?.classList.contains("bg-primary/60")).toBe(true);
+		expect(cachedSegment?.style.backgroundImage).toContain("linear-gradient");
+		expect(cachedSegment?.style.width).toBe("12.5%");
+		expect(outputSegment?.classList.contains("bg-blue-500")).toBe(true);
+		expect(outputSegment?.style.backgroundImage).toContain("linear-gradient");
+		expect(outputSegment?.style.width).toBe("0.05%");
 		expect(panel?.textContent).not.toContain("Total");
 		expect(panel?.textContent).not.toContain("usage limit");
-	});
-
-	it("changes the popover progress bar to orange above 50% and red above 75%", async () => {
-		const trigger = await renderTokenUsage(
-			{ toolCalls: 0, tokensIn: 501, tokensOut: 0 },
-			1000,
-		);
-		await act(async () => {
-			trigger?.click();
-		});
-		expect(
-			document
-				.querySelector("#token-usage-panel")
-				?.querySelector(".bg-orange-500"),
-		).not.toBeNull();
-
-		await renderTokenUsage(
-			{ toolCalls: 0, tokensIn: 751, tokensOut: 0 },
-			1000,
-		);
-		expect(
-			document
-				.querySelector("#token-usage-panel")
-				?.querySelector(".bg-red-500"),
-		).not.toBeNull();
 	});
 
 	it("saturates at 100% with the critical ring color", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1635,6 +1635,18 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 		1,
 	);
 	const percent = Math.round(ratio * 100);
+	const ringColorClass =
+		ratio >= 0.75
+			? "stroke-red-500"
+			: ratio >= 0.5
+				? "stroke-orange-500"
+				: "stroke-primary";
+	const contextBarColorClass =
+		ratio > 0.75
+			? "bg-red-500"
+			: ratio > 0.5
+				? "bg-orange-500"
+				: "bg-primary";
 	const cost = formatCostUsd(usage.totalCost);
 	const contextUsageLabel = `${formatCompactTokens(usage.tokensIn)} / ${formatCompactTokens(contextWindow)} (${percent}%)`;
 	const radius = 8.5;
@@ -1645,11 +1657,11 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 			<PopoverTrigger asChild>
 				<Button
 					aria-label={`Context window: ${usage.tokensIn.toLocaleString()} of ${contextWindow.toLocaleString()} input tokens used (${percent}%)`}
-					className="size-7 shrink-0 p-0 text-muted-foreground data-[state=open]:bg-accent"
+					className="size-7 shrink-0 p-0 text-muted-foreground data-[state=open]:bg-accent opacity-65 hover:opacity-100"
 					id="token-usage"
 					size="icon-sm"
 					type="button"
-					variant="ghost"
+					variant="text"
 				>
 					<svg
 						aria-hidden="true"
@@ -1667,7 +1679,10 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 							strokeWidth="4"
 						/>
 						<circle
-							className="stroke-primary transition-[stroke-dashoffset] duration-200"
+							className={cn(
+								"transition-[stroke,stroke-dashoffset] duration-200",
+								ringColorClass,
+							)}
 							cx="11"
 							cy="11"
 							fill="none"
@@ -1697,7 +1712,10 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 					<div className="mt-2 h-1 overflow-hidden rounded-full bg-muted">
 						<div
 							aria-hidden="true"
-							className="h-full rounded-full bg-primary transition-[width] duration-200"
+							className={cn(
+								"h-full rounded-full transition-[background-color,width] duration-200",
+								contextBarColorClass,
+							)}
 							style={{ width: `${percent}%` }}
 						/>
 					</div>

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -255,6 +255,7 @@ type ChatInputBarProps = {
 		toolCalls: number;
 		tokensIn: number;
 		tokensOut: number;
+		cacheReadTokens?: number;
 		totalCostUsd?: number;
 	};
 };
@@ -1134,15 +1135,15 @@ export function ChatInputBar({
 			</div>
 
 			{/* Composer settings */}
-			<div className="flex min-w-0 items-center justify-between gap-x-3 gap-y-2 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
+			<div className="flex min-w-0 items-center  justify-between gap-x-3 gap-y-2 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
 				<div className="flex min-w-0 flex-auto flex-wrap items-center gap-2 max-[560px]:flex-nowrap">
 					<button
 						aria-label="Attach files"
-						className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						className="rounded-md p-0 pl-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 						onClick={() => fileInputRef.current?.click()}
 						type="button"
 					>
-						<Paperclip className="h-4 w-4" />
+						<Paperclip className="size-3" />
 					</button>
 					<input
 						accept="*/*"
@@ -1251,6 +1252,7 @@ export function ChatInputBar({
 									contextWindow: modelContextWindow,
 									tokensIn: summary.tokensIn,
 									tokensOut: summary.tokensOut,
+									cacheReadTokens: summary.cacheReadTokens ?? 0,
 									totalCost: summary.totalCostUsd,
 								}}
 							/>
@@ -1619,19 +1621,21 @@ const ModelSelector = memo(function ModelSelector({
 type TokenUsage = {
 	tokensIn: number;
 	tokensOut: number;
+	cacheReadTokens: number;
 	totalCost?: number;
 	contextWindow?: number;
 };
 
-/** Current input context relative to the selected model's context window. */
+/** Current model context relative to the selected model's context window. */
 function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 	const contextWindow = usage.contextWindow;
-	if (usage.tokensIn <= 0 || !contextWindow || contextWindow <= 0) {
+	const totalTokens = usage.tokensIn + usage.tokensOut;
+	if (totalTokens <= 0 || !contextWindow || contextWindow <= 0) {
 		return null;
 	}
 
 	const ratio = Math.min(
-		Math.max(usage.tokensIn / Math.max(contextWindow, 1), 0),
+		Math.max(totalTokens / Math.max(contextWindow, 1), 0),
 		1,
 	);
 	const percent = Math.round(ratio * 100);
@@ -1641,14 +1645,14 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 			: ratio >= 0.5
 				? "stroke-orange-500"
 				: "stroke-primary";
-	const contextBarColorClass =
-		ratio > 0.75
-			? "bg-red-500"
-			: ratio > 0.5
-				? "bg-orange-500"
-				: "bg-primary";
 	const cost = formatCostUsd(usage.totalCost);
-	const contextUsageLabel = `${formatCompactTokens(usage.tokensIn)} / ${formatCompactTokens(contextWindow)} (${percent}%)`;
+	const contextUsageLabel = `${formatCompactTokens(totalTokens)} / ${formatCompactTokens(contextWindow)} (${percent}%)`;
+	const cachedTokens = Math.min(usage.cacheReadTokens, usage.tokensIn);
+	const uncachedInputTokens = Math.max(usage.tokensIn - cachedTokens, 0);
+	const segmentScale =
+		totalTokens > contextWindow ? contextWindow / totalTokens : 1;
+	const segmentWidth = (tokens: number) =>
+		`${(tokens / contextWindow) * segmentScale * 100}%`;
 	const radius = 8.5;
 	const circumference = 2 * Math.PI * radius;
 
@@ -1656,7 +1660,7 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 		<Popover>
 			<PopoverTrigger asChild>
 				<Button
-					aria-label={`Context window: ${usage.tokensIn.toLocaleString()} of ${contextWindow.toLocaleString()} input tokens used (${percent}%)`}
+					aria-label={`Context window: ${totalTokens.toLocaleString()} of ${contextWindow.toLocaleString()} tokens used (${percent}%)`}
 					className="size-7 shrink-0 p-0 text-muted-foreground data-[state=open]:bg-accent opacity-65 hover:opacity-100"
 					id="token-usage"
 					size="icon-sm"
@@ -1709,30 +1713,60 @@ function TokenUsageRing({ usage }: { usage: TokenUsage }) {
 							{contextUsageLabel}
 						</span>
 					</div>
-					<div className="mt-2 h-1 overflow-hidden rounded-full bg-muted">
+					<div className="mt-2 flex h-1 overflow-hidden rounded-full bg-muted">
 						<div
 							aria-hidden="true"
-							className={cn(
-								"h-full rounded-full transition-[background-color,width] duration-200",
-								contextBarColorClass,
-							)}
-							style={{ width: `${percent}%` }}
+							className="h-full shrink-0 bg-primary transition-[width] duration-200"
+							data-token-kind="uncached-input"
+							style={{ width: segmentWidth(uncachedInputTokens) }}
+						/>
+						<div
+							aria-hidden="true"
+							className="h-full shrink-0 bg-primary/60 transition-[background,width] duration-200"
+							data-token-kind="cached-input"
+							style={{
+								backgroundImage:
+									"linear-gradient(to right, var(--primary), color-mix(in srgb, var(--primary) 60%, transparent))",
+								width: segmentWidth(cachedTokens),
+							}}
+						/>
+						<div
+							aria-hidden="true"
+							className="h-full shrink-0 bg-blue-500 transition-[background,width] duration-200"
+							data-token-kind="output"
+							style={{
+								backgroundImage:
+									"linear-gradient(to right, color-mix(in srgb, var(--primary) 60%, transparent), var(--color-blue-500))",
+								width: segmentWidth(usage.tokensOut),
+							}}
 						/>
 					</div>
-				</div>
-				<div className="border-t border-border/70 px-3 py-2.5 text-xs">
-					<div className="flex items-center justify-between gap-4">
-						<span className="text-muted-foreground">Output tokens</span>
-						<span className="font-mono text-foreground">
-							{usage.tokensOut.toLocaleString()}
-						</span>
-					</div>
-					{cost ? (
-						<div className="mt-2 flex items-center justify-between gap-4">
-							<span className="text-muted-foreground">Cost</span>
-							<span className="font-mono text-foreground">{cost}</span>
+					<div className="mt-3 space-y-2 text-xs">
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-muted-foreground">Input tokens</span>
+							<span className="font-mono text-foreground">
+								{usage.tokensIn.toLocaleString()}
+							</span>
 						</div>
-					) : null}
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-muted-foreground">Output tokens</span>
+							<span className="font-mono text-foreground">
+								{usage.tokensOut.toLocaleString()}
+							</span>
+						</div>
+						<div className="flex items-center justify-between gap-4">
+							<span className="text-muted-foreground">Cached tokens</span>
+							<span className="font-mono text-foreground">
+								{usage.cacheReadTokens.toLocaleString()}
+							</span>
+						</div>
+						{cost ? (
+							<div className="flex items-center justify-between gap-4">
+								<span className="text-muted-foreground">Cost</span>
+								<span className="font-mono text-foreground">{cost}</span>
+							</div>
+						) : null}
+					</div>
 				</div>
 			</PopoverContent>
 		</Popover>

--- a/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
@@ -26,6 +26,8 @@ export type ChatUsageEvent = {
 	inputTokens?: number;
 	/** Tokens produced by the latest model request. */
 	outputTokens?: number;
+	/** Input tokens served from the provider's prompt cache. */
+	cacheReadTokens?: number;
 	/** Cost of the latest model request. */
 	cost?: number;
 };

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -574,6 +574,7 @@ describe("useChatSession", () => {
 				chunk: JSON.stringify({
 					inputTokens: 13_000,
 					outputTokens: 700,
+					cacheReadTokens: 4_000,
 					cost: 0.02,
 				}),
 				ts: Date.now(),
@@ -584,6 +585,7 @@ describe("useChatSession", () => {
 		expect(current.summary).toMatchObject({
 			tokensIn: 13_000,
 			tokensOut: 700,
+			cacheReadTokens: 4_000,
 		});
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 	});
@@ -766,6 +768,7 @@ describe("useChatSession", () => {
 							meta: {
 								inputTokens: 24_000,
 								outputTokens: 1_000,
+								cacheReadTokens: 8_000,
 								totalCost: 0.02,
 							},
 						},
@@ -805,6 +808,7 @@ describe("useChatSession", () => {
 		expect(current.summary).toMatchObject({
 			tokensIn: 24_000,
 			tokensOut: 1_000,
+			cacheReadTokens: 8_000,
 		});
 		expect(current.summary.totalCostUsd).toBeCloseTo(0.03);
 	});

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -190,6 +190,7 @@ function updateMessageById(
 type SessionUsageSummary = {
 	tokensIn: number;
 	tokensOut: number;
+	cacheReadTokens: number;
 	totalCostUsd: number;
 };
 
@@ -210,6 +211,7 @@ function summarizeSessionUsage(
 ): SessionUsageSummary | undefined {
 	let tokensIn: number | undefined;
 	let tokensOut: number | undefined;
+	let cacheReadTokens: number | undefined;
 	let totalCostUsd = 0;
 	let hasCost = false;
 
@@ -218,10 +220,12 @@ function summarizeSessionUsage(
 		if (!meta) continue;
 		if (
 			typeof meta.inputTokens === "number" ||
-			typeof meta.outputTokens === "number"
+			typeof meta.outputTokens === "number" ||
+			typeof meta.cacheReadTokens === "number"
 		) {
 			tokensIn = meta.inputTokens ?? 0;
 			tokensOut = meta.outputTokens ?? 0;
+			cacheReadTokens = meta.cacheReadTokens ?? 0;
 		}
 		if (typeof meta.totalCost === "number") {
 			totalCostUsd += meta.totalCost;
@@ -235,6 +239,7 @@ function summarizeSessionUsage(
 	return {
 		tokensIn: tokensIn ?? 0,
 		tokensOut: tokensOut ?? 0,
+		cacheReadTokens: cacheReadTokens ?? 0,
 		totalCostUsd,
 	};
 }
@@ -277,6 +282,7 @@ export function useChatSession() {
 	const [toolCalls, setToolCalls] = useState(0);
 	const [tokensIn, setTokensIn] = useState(0);
 	const [tokensOut, setTokensOut] = useState(0);
+	const [cacheReadTokens, setCacheReadTokens] = useState(0);
 	const [totalCostUsd, setTotalCostUsd] = useState(0);
 	const [fileDiffs, setFileDiffs] = useState<SessionFileDiff[]>([]);
 	const [diffSummary, setDiffSummary] =
@@ -329,6 +335,7 @@ export function useChatSession() {
 	);
 	const persistedTokensIn = persistedUsage?.tokensIn;
 	const persistedTokensOut = persistedUsage?.tokensOut;
+	const persistedCacheReadTokens = persistedUsage?.cacheReadTokens;
 	const persistedTotalCostUsd = persistedUsage?.totalCostUsd;
 	// ---- Ref syncs ----
 
@@ -351,6 +358,7 @@ export function useChatSession() {
 		}
 		setTokensIn(persistedTokensIn);
 		setTokensOut(persistedTokensOut);
+		setCacheReadTokens(persistedCacheReadTokens ?? 0);
 		// Move newly persisted spend out of the live ledger. Multiple queued turns
 		// may finish before their message metadata is hydrated, so this ledger is
 		// session-wide rather than tied only to the currently active turn.
@@ -364,7 +372,12 @@ export function useChatSession() {
 		);
 		lastPersistedCostUsdRef.current = persistedTotalCostUsd;
 		setTotalCostUsd(persistedTotalCostUsd + unpersistedCostUsdRef.current);
-	}, [persistedTokensIn, persistedTokensOut, persistedTotalCostUsd]);
+	}, [
+		persistedTokensIn,
+		persistedTokensOut,
+		persistedCacheReadTokens,
+		persistedTotalCostUsd,
+	]);
 	useEffect(() => {
 		promptsInQueueRef.current = promptsInQueue;
 	}, [promptsInQueue]);
@@ -408,6 +421,7 @@ export function useChatSession() {
 		setToolCalls(0);
 		setTokensIn(0);
 		setTokensOut(0);
+		setCacheReadTokens(0);
 		setTotalCostUsd(0);
 		setFileDiffs([]);
 		setDiffSummary(EMPTY_DIFF_SUMMARY);
@@ -1006,6 +1020,9 @@ export function useChatSession() {
 				}
 				if (typeof usage.outputTokens === "number") {
 					setTokensOut(usage.outputTokens);
+				}
+				if (typeof usage.cacheReadTokens === "number") {
+					setCacheReadTokens(usage.cacheReadTokens);
 				}
 				const cost = usage.cost;
 				if (typeof cost === "number") {
@@ -1634,6 +1651,11 @@ export function useChatSession() {
 				if (typeof outputTokens === "number") {
 					setTokensOut(outputTokens);
 				}
+				const resultCacheReadTokens =
+					result?.usage?.cacheReadTokens ?? result?.cacheReadTokens;
+				if (typeof resultCacheReadTokens === "number") {
+					setCacheReadTokens(resultCacheReadTokens);
+				}
 				const totalCost =
 					typeof result?.usage?.totalCost === "number"
 						? result.usage.totalCost
@@ -1652,6 +1674,7 @@ export function useChatSession() {
 					assistantMessageId &&
 					(typeof inputTokens === "number" ||
 						typeof outputTokens === "number" ||
+						typeof resultCacheReadTokens === "number" ||
 						typeof totalCost === "number")
 				) {
 					setMessages((prev) =>
@@ -1667,6 +1690,10 @@ export function useChatSession() {
 									typeof outputTokens === "number"
 										? outputTokens
 										: msg.meta?.outputTokens,
+								cacheReadTokens:
+									typeof resultCacheReadTokens === "number"
+										? resultCacheReadTokens
+										: msg.meta?.cacheReadTokens,
 								totalCost:
 									typeof totalCost === "number"
 										? totalCost
@@ -2173,6 +2200,7 @@ export function useChatSession() {
 			toolCalls,
 			tokensIn,
 			tokensOut,
+			cacheReadTokens,
 			totalCostUsd,
 			additions: diffSummary.additions,
 			deletions: diffSummary.deletions,
@@ -2182,6 +2210,7 @@ export function useChatSession() {
 			diffSummary.deletions,
 			tokensIn,
 			tokensOut,
+			cacheReadTokens,
 			totalCostUsd,
 			toolCalls,
 		],

--- a/apps/examples/desktop-app/webview/lib/chat-schema.ts
+++ b/apps/examples/desktop-app/webview/lib/chat-schema.ts
@@ -69,6 +69,7 @@ export const ChatMessageSchema = z.object({
 			reason: z.string().optional(),
 			inputTokens: z.number().int().nonnegative().optional(),
 			outputTokens: z.number().int().nonnegative().optional(),
+			cacheReadTokens: z.number().int().nonnegative().optional(),
 			totalCost: z.number().nonnegative().optional(),
 			providerId: z.string().optional(),
 			modelId: z.string().optional(),


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->


Improve the desktop chat context-window indicator with cached-token reporting and a segmented usage visualization.

The backend emitted cached-token usage, but the webview discarded it. The context indicator also only counted input tokens and displayed a single-color progress bar, making it difficult to understand how the context window was being consumed.


- Preserve cached-token metrics from live events, completed turns, and restored sessions
- Calculate context usage from input and output tokens
- Display input, output, cached tokens, and cost in the popover
- Split the progress bar into:
  - Primary: uncached input
  - 60% primary: cached input
  - Blue: output
- Add gradients between segments for smoother visual transitions
- Keep warning colors on the usage ring at elevated context levels
- Add and update tests for token hydration, combined usage, segment sizing, colors, and accessibility labels


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->


- Focused chat input tests pass (9 tests)
- Desktop app typecheck passes

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

> 75%

<img width="373" height="186" alt="image" src="https://github.com/user-attachments/assets/889ecfaa-0733-4f94-b2e1-b3a2ef66299f" />

< 50%
<img width="360" height="192" alt="image" src="https://github.com/user-attachments/assets/24c386b1-144f-4b53-a7e2-e159465ffde4" />

<img width="346" height="207" alt="image" src="https://github.com/user-attachments/assets/fb198219-7e83-4617-a70f-607e2e16df10" />



### Additional Notes

<!-- Add any additional notes for reviewers -->
