### PR TITLE
Fix CLI transcript overlap with chat footer

### DIFF
--- a/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/apps/cli/src/tui/components/chat-message-list.tsx
@@ -90,6 +90,7 @@ export const ChatMessageList = forwardRef<
 		<scrollbox
 			ref={scrollboxRef}
 			flexGrow={1}
+			flexShrink={1}
 			stickyScroll
 			stickyStart="bottom"
 		>


### PR DESCRIPTION
### Related Issue

**Issue:** Closes #12917

### Description

OpenTUI scrollboxes default to `flexShrink: 0`. The chat transcript therefore could retain rows needed by the fixed input and status footer, leaving the last streamed lines hidden until the user scrolled manually in short terminal windows.

This change makes the transcript explicitly shrinkable. Yoga now reserves the footer's rows within the existing column layout while preserving sticky-bottom scrolling.

### Test Procedure

1. Run `bun run typecheck` from `apps/cli`.
2. Run `bun biome check --diagnostic-level=error apps/cli/src/tui/components/chat-message-list.tsx` from the repository root.
3. Open Ghostty 1.3.1 at 19 rows × 118 columns and run `bun run dev` from `apps/cli`.
4. Submit `Reply with exactly 25 numbered lines, each saying LINE N.` and wait for completion without scrolling.
5. Verify line 25 is visible above the input and status footer.

The overlap is timing-sensitive and did not appear in every unfixed Ghostty run. In a matched 22 × 118 run, the unfixed viewport stopped at line 24 until a manual scroll; with this change, line 25 was immediately visible. The screenshots below record separate real-Ghostty unfixed and fixed runs at 19 × 118; both landed correctly and show the tested footer boundary.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Unfixed Ghostty run (19 × 118)**

_BEFORE_SCREENSHOT_

**Fixed Ghostty run (19 × 118)**

_AFTER_SCREENSHOT_
