### PR TITLE
fix(telemetry): dedupe sdk.error across layers and rate-limit repeated failures

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -2332,7 +2332,7 @@ describe("AgentRuntime sdk.error reporting", () => {
 			.filter((call) => call.event === SDK_ERROR_TELEMETRY_EVENT);
 	}
 
-	it("does not re-report model stream failures the model layer already owns", async () => {
+	it("does not re-report a failure the model layer marked as reported", async () => {
 		const { telemetry, capture } = createTelemetryMock();
 		const model = new ScriptedModel([
 			() => [
@@ -2340,6 +2340,7 @@ describe("AgentRuntime sdk.error reporting", () => {
 					type: "finish",
 					reason: "error",
 					error: "Upstream returned HTTP 429",
+					errorReported: true,
 				},
 			],
 		]);
@@ -2353,6 +2354,35 @@ describe("AgentRuntime sdk.error reporting", () => {
 		expect(capture).toHaveBeenCalledWith(
 			expect.objectContaining({ event: "agent.run-failed" }),
 		);
+	});
+
+	it("reports exactly one sdk.error for custom models that do not record their own telemetry", async () => {
+		const { telemetry, capture } = createTelemetryMock();
+		// A custom `AgentModel` flattens its failure into the finish event and
+		// never calls `captureSdkError`; without `errorReported` the run loop
+		// must own the report.
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "backend unavailable",
+				},
+			],
+		]);
+		const runtime = new AgentRuntime({ model, telemetry });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		const events = sdkErrorEvents(capture);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.properties).toMatchObject({
+			component: "agents",
+			operation: "agent.run",
+			handled: false,
+			error_message: "backend unavailable",
+		});
 	});
 
 	it("still reports failures that originate in the run loop itself", async () => {

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -9,14 +9,20 @@ import type {
 } from "@cline/shared";
 import {
 	AGENT_UNEXPECTED_REASONING_TOKENS_EVENT,
+	resetSdkErrorRateLimiterForTests,
+	SDK_ERROR_TELEMETRY_EVENT,
 	TASK_CANCELLED_EVENT,
 	TASK_FIRST_CHUNK_RECEIVED_EVENT,
 	TASK_PROVIDER_REQUEST_STARTED_EVENT,
 	TASK_PROVIDER_STREAM_FAILED_EVENT,
 	TASK_PROVIDER_STREAM_STARTED_EVENT,
 } from "@cline/shared";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentRuntime } from "./index";
+
+beforeEach(() => {
+	resetSdkErrorRateLimiterForTests();
+});
 
 class ScriptedModel implements AgentModel {
 	public readonly requests: AgentModelRequest[] = [];
@@ -2315,6 +2321,58 @@ describe("AgentRuntime", () => {
 			inputTokens: 200,
 			outputTokens: 40,
 			totalCost: 1.0,
+		});
+	});
+});
+
+describe("AgentRuntime sdk.error reporting", () => {
+	function sdkErrorEvents(capture: ReturnType<typeof vi.fn>) {
+		return capture.mock.calls
+			.map(([call]) => call as { event: string; properties?: unknown })
+			.filter((call) => call.event === SDK_ERROR_TELEMETRY_EVENT);
+	}
+
+	it("does not re-report model stream failures the model layer already owns", async () => {
+		const { telemetry, capture } = createTelemetryMock();
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "finish",
+					reason: "error",
+					error: "Upstream returned HTTP 429",
+				},
+			],
+		]);
+		const runtime = new AgentRuntime({ model, telemetry });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		expect(sdkErrorEvents(capture)).toHaveLength(0);
+		// The structured lifecycle event still records the failure.
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({ event: "agent.run-failed" }),
+		);
+	});
+
+	it("still reports failures that originate in the run loop itself", async () => {
+		const { telemetry, capture } = createTelemetryMock();
+		// An empty response is a loop-originated failure no model layer saw.
+		const model = new ScriptedModel([
+			() => [{ type: "finish", reason: "stop" }],
+		]);
+		const runtime = new AgentRuntime({ model, telemetry });
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("failed");
+		const events = sdkErrorEvents(capture);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.properties).toMatchObject({
+			component: "agents",
+			operation: "agent.run",
+			handled: false,
+			error_message: "Model returned empty response",
 		});
 	});
 });

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1797,14 +1797,22 @@ export class AgentRuntime {
 					...metadata,
 					error: event.error,
 				});
-				captureSdkError(this.config.telemetry, {
-					component: "agents",
-					operation: "agent.run",
-					error: event.error,
-					severity: "error",
-					handled: false,
-					context: metadata as TelemetryProperties,
-				});
+				// `errorClass` is derived only when the run failed on a model
+				// stream error (see the guard in `execute`'s catch), and the
+				// model layer reports those at its own error boundary
+				// (`provider.stream`) — re-reporting them here exactly doubled
+				// `sdk.error` volume. Report only failures that originate in
+				// the run loop itself.
+				if (event.errorClass === undefined) {
+					captureSdkError(this.config.telemetry, {
+						component: "agents",
+						operation: "agent.run",
+						error: event.error,
+						severity: "error",
+						handled: false,
+						context: metadata as TelemetryProperties,
+					});
+				}
 				break;
 			default:
 				this.config.logger?.debug?.("Agent event", metadata);

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -459,6 +459,13 @@ export class AgentRuntime {
 		usage: cloneUsage(DEFAULT_USAGE),
 		lastError: undefined as string | undefined,
 		lastErrorClass: undefined as ProviderErrorClass | undefined,
+		/**
+		 * Whether the model layer already recorded `sdk.error` telemetry for
+		 * `lastError` (from `errorReported` on the stream's `finish` event).
+		 * Custom `AgentModel` implementations that do not record their own
+		 * telemetry leave this false, so their failures still get reported.
+		 */
+		lastErrorReported: false,
 	};
 	/** One automatic overflow-recovery attempt per run. */
 	private overflowRecoveryAttempted = false;
@@ -538,6 +545,7 @@ export class AgentRuntime {
 		this.state.usage = cloneUsage(DEFAULT_USAGE);
 		this.state.lastError = undefined;
 		this.state.lastErrorClass = undefined;
+		this.state.lastErrorReported = false;
 		this.state.messages = cloneMessages(messages);
 		this.config = {
 			...this.config,
@@ -651,6 +659,7 @@ export class AgentRuntime {
 		this.state.pendingToolCalls = [];
 		this.state.lastError = undefined;
 		this.state.lastErrorClass = undefined;
+		this.state.lastErrorReported = false;
 		this.state.usage = cloneUsage(DEFAULT_USAGE);
 		this.overflowRecoveryAttempted = false;
 
@@ -805,9 +814,15 @@ export class AgentRuntime {
 					: normalized.message === this.state.lastError
 						? this.state.lastErrorClass
 						: undefined;
+			// Same guard: the model layer's telemetry only covers this failure
+			// if the run failed on that exact recorded error.
+			const errorAlreadyReported =
+				normalized.message === this.state.lastError &&
+				this.state.lastErrorReported;
 			this.state.status = status;
 			this.state.lastError = normalized.message;
 			this.state.lastErrorClass = errorClass;
+			this.state.lastErrorReported = errorAlreadyReported;
 			const lastAssistantMessage = this.findLastAssistantMessage();
 			const result: AgentRunResult = {
 				agentId: this.state.agentId,
@@ -1142,6 +1157,7 @@ export class AgentRuntime {
 						// stays eligible for overflow recovery.
 						this.state.lastErrorClass =
 							event.errorClass ?? classifyProviderError(event.error);
+						this.state.lastErrorReported = event.errorReported === true;
 					}
 					break;
 				}
@@ -1797,13 +1813,14 @@ export class AgentRuntime {
 					...metadata,
 					error: event.error,
 				});
-				// `errorClass` is derived only when the run failed on a model
-				// stream error (see the guard in `execute`'s catch), and the
-				// model layer reports those at its own error boundary
-				// (`provider.stream`) — re-reporting them here exactly doubled
-				// `sdk.error` volume. Report only failures that originate in
-				// the run loop itself.
-				if (event.errorClass === undefined) {
+				// Failures the model layer already recorded at its own error
+				// boundary (`provider.stream`, carried across the stream's
+				// string-flattening boundary as `finish.errorReported`) must not
+				// be re-reported here — that exactly doubled `sdk.error` volume.
+				// Everything else still reports: loop-originated failures, and
+				// failures from model implementations that do not record their
+				// own telemetry.
+				if (!this.state.lastErrorReported) {
 					captureSdkError(this.config.telemetry, {
 						component: "agents",
 						operation: "agent.run",

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -919,6 +919,12 @@ function extractGoogleThoughtMetadata(
 interface CapturedStreamError {
 	message: string;
 	errorClass: ProviderErrorClass;
+	/**
+	 * This layer already recorded `sdk.error` telemetry for the failure.
+	 * Forwarded as `errorReported` on the `finish` event so the agent loop
+	 * does not report the same failure a second time.
+	 */
+	reported?: boolean;
 }
 
 function captureStreamError(error: unknown): CapturedStreamError {
@@ -1102,6 +1108,7 @@ async function* emitAiSdkEvents(
 		reason: streamError ? "error" : mapFinishReason(finishReason, sawToolCalls),
 		error: streamError?.message,
 		errorClass: streamError?.errorClass,
+		errorReported: streamError?.reported,
 	};
 }
 
@@ -1261,7 +1268,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 								severity: "error",
 							});
 						}
-						captureSdkError(context.telemetry, {
+						captured.reported = captureSdkError(context.telemetry, {
 							component: "llms",
 							operation: "provider.stream",
 							error: streamError,
@@ -1308,7 +1315,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 						severity: "error",
 					});
 				}
-				captureSdkError(context.telemetry, {
+				const reported = captureSdkError(context.telemetry, {
 					component: "llms",
 					operation: "provider.create_or_stream",
 					error,
@@ -1326,6 +1333,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					reason: "error",
 					error: msg,
 					errorClass: captured.errorClass,
+					errorReported: reported || captured.reported,
 				};
 			}
 		},

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -14,6 +14,7 @@ import {
 	estimateRequestInputTokens,
 	type GatewayModelHandleOptions,
 	type ITelemetryService,
+	resetSdkErrorRateLimiterForTests,
 } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeModelsDevProviderModels } from "../catalog/catalog-live";
@@ -227,6 +228,7 @@ function readCaptureRecords(dir: string): Array<Record<string, unknown>> {
 
 describe("sdk-gateway", () => {
 	beforeEach(() => {
+		resetSdkErrorRateLimiterForTests();
 		streamTextSpy.mockReset();
 		openaiCompatibleFactorySpy.mockReset();
 		openaiCompatibleSpy.mockReset();
@@ -803,6 +805,106 @@ describe("sdk-gateway", () => {
 				error_status: 400,
 			}),
 		});
+	});
+
+	it("marks the finish event as reported so the agent loop skips the same failure", async () => {
+		const rawError = Object.assign(new Error("Upstream returned HTTP 429"), {
+			statusCode: 429,
+		});
+		streamTextSpy.mockImplementation(
+			(input: { onError?: (event: { error: unknown }) => void }) => {
+				input.onError?.({ error: rawError });
+				return {
+					fullStream: makeStreamParts([{ type: "error", error: rawError }]),
+				};
+			},
+		);
+		const { telemetry, capture } = createTelemetryMock();
+		const gateway = createGateway({
+			telemetry,
+			providerConfigs: [{ providerId: "openai-native", apiKey: "test" }],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "openai-native",
+				modelId: "gpt-5-mini",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(events.at(-1)).toMatchObject({
+			type: "finish",
+			reason: "error",
+			error: "Upstream returned HTTP 429",
+			errorReported: true,
+		});
+		const sdkErrors = capture.mock.calls.filter(
+			([call]) => (call as { event: string }).event === "sdk.error",
+		);
+		expect(sdkErrors).toHaveLength(1);
+	});
+
+	it("does not mark the finish event as reported when telemetry is unavailable", async () => {
+		const rawError = Object.assign(new Error("Upstream returned HTTP 429"), {
+			statusCode: 429,
+		});
+		streamTextSpy.mockImplementation(
+			(input: { onError?: (event: { error: unknown }) => void }) => {
+				input.onError?.({ error: rawError });
+				return {
+					fullStream: makeStreamParts([{ type: "error", error: rawError }]),
+				};
+			},
+		);
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openai-native", apiKey: "test" }],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "openai-native",
+				modelId: "gpt-5-mini",
+				messages: baseMessages,
+			}),
+		);
+
+		const finish = events.at(-1) as { errorReported?: boolean };
+		expect(finish.errorReported).not.toBe(true);
+	});
+
+	it("rate-limits identical stream failures per process", async () => {
+		const { telemetry, capture } = createTelemetryMock();
+		const gateway = createGateway({
+			telemetry,
+			providerConfigs: [{ providerId: "openai-native", apiKey: "test" }],
+		});
+
+		for (let i = 0; i < 20; i++) {
+			const rawError = Object.assign(new Error("Upstream returned HTTP 429"), {
+				statusCode: 429,
+			});
+			streamTextSpy.mockImplementation(
+				(input: { onError?: (event: { error: unknown }) => void }) => {
+					input.onError?.({ error: rawError });
+					return {
+						fullStream: makeStreamParts([{ type: "error", error: rawError }]),
+					};
+				},
+			);
+			await collect(
+				await gateway.stream({
+					providerId: "openai-native",
+					modelId: "gpt-5-mini",
+					messages: baseMessages,
+				}),
+			);
+		}
+
+		const sdkErrors = capture.mock.calls.filter(
+			([call]) => (call as { event: string }).event === "sdk.error",
+		);
+		expect(sdkErrors).toHaveLength(5);
 	});
 
 	it("records the extracted cause when provider creation fails through a generic wrapper", async () => {

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -271,6 +271,15 @@ export type AgentModelEvent =
 			reason: AgentModelFinishReason;
 			error?: string;
 			errorClass?: ProviderErrorClass;
+			/**
+			 * The model layer already recorded `sdk.error` telemetry for this
+			 * failure at its own error boundary. `error` is a flattened string,
+			 * so this bit carries reporting ownership across the boundary: the
+			 * agent loop skips re-reporting when it is set, and still reports
+			 * failures from model implementations that do not record their own
+			 * telemetry.
+			 */
+			errorReported?: boolean;
 	  };
 
 export interface AgentModel {

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -413,6 +413,7 @@ export {
 	captureSdkError,
 	captureTaskLifecycleEvent,
 	normalizeSdkError,
+	resetSdkErrorRateLimiterForTests,
 	SDK_ERROR_TELEMETRY_EVENT,
 	TASK_CANCELLED_EVENT,
 	TASK_FIRST_CHUNK_RECEIVED_EVENT,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -471,6 +471,7 @@ export {
 	captureSdkError,
 	captureTaskLifecycleEvent,
 	normalizeSdkError,
+	resetSdkErrorRateLimiterForTests,
 	SDK_ERROR_TELEMETRY_EVENT,
 	TASK_CANCELLED_EVENT,
 	TASK_FIRST_CHUNK_RECEIVED_EVENT,

--- a/sdk/packages/shared/src/services/telemetry.test.ts
+++ b/sdk/packages/shared/src/services/telemetry.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	captureSdkError,
 	normalizeSdkError,
+	resetSdkErrorRateLimiterForTests,
+	SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+	SDK_ERROR_RATE_LIMIT_WINDOW_MS,
 	SDK_ERROR_TELEMETRY_EVENT,
 } from "./telemetry";
+
+beforeEach(() => {
+	resetSdkErrorRateLimiterForTests();
+});
 
 describe("SDK error telemetry", () => {
 	it("normalizes unknown errors with sanitized, bounded messages", () => {
@@ -91,5 +98,87 @@ describe("SDK error telemetry", () => {
 				sessionId: "s1",
 			}),
 		});
+	});
+});
+
+describe("SDK error rate limiting", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function captureRepeatedly(count: number, message: (i: number) => string) {
+		const capture = vi.fn();
+		for (let i = 0; i < count; i++) {
+			captureSdkError({ capture } as never, {
+				component: "llms",
+				operation: "provider.stream",
+				error: new Error(message(i)),
+			});
+		}
+		return capture;
+	}
+
+	it("emits the first N identical failures per window, then suppresses", () => {
+		const capture = captureRepeatedly(100, () => "Upstream returned HTTP 429");
+
+		expect(capture).toHaveBeenCalledTimes(SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW);
+	});
+
+	it("does not suppress distinct failures", () => {
+		const capture = captureRepeatedly(10, (i) => `distinct ${"x".repeat(i)}`);
+
+		expect(capture).toHaveBeenCalledTimes(10);
+	});
+
+	it("coalesces messages that differ only by numbers", () => {
+		const capture = captureRepeatedly(
+			100,
+			(i) => `run failed at iteration ${i}`,
+		);
+
+		expect(capture).toHaveBeenCalledTimes(SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW);
+	});
+
+	it("carries suppressed_count onto the next emission after the window rolls over", () => {
+		vi.useFakeTimers();
+		const capture = captureRepeatedly(
+			SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW + 7,
+			() => "Upstream returned HTTP 429",
+		);
+		expect(capture).toHaveBeenCalledTimes(SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW);
+
+		vi.advanceTimersByTime(SDK_ERROR_RATE_LIMIT_WINDOW_MS);
+		captureSdkError({ capture } as never, {
+			component: "llms",
+			operation: "provider.stream",
+			error: new Error("Upstream returned HTTP 429"),
+		});
+
+		expect(capture).toHaveBeenLastCalledWith({
+			event: SDK_ERROR_TELEMETRY_EVENT,
+			properties: expect.objectContaining({
+				error_message: "Upstream returned HTTP 429",
+				suppressed_count: 7,
+			}),
+		});
+	});
+
+	it("keeps a 12-hour hot loop bounded to dozens of events", () => {
+		vi.useFakeTimers();
+		const capture = vi.fn();
+
+		// One identical failure every 10 seconds for 12 hours.
+		for (let i = 0; i < (12 * SDK_ERROR_RATE_LIMIT_WINDOW_MS) / 10_000; i++) {
+			captureSdkError({ capture } as never, {
+				component: "llms",
+				operation: "provider.stream",
+				error: new Error("Upstream returned HTTP 429"),
+			});
+			vi.advanceTimersByTime(10_000);
+		}
+
+		expect(capture).toHaveBeenCalledTimes(
+			12 * SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+		);
 	});
 });

--- a/sdk/packages/shared/src/services/telemetry.test.ts
+++ b/sdk/packages/shared/src/services/telemetry.test.ts
@@ -139,6 +139,68 @@ describe("SDK error rate limiting", () => {
 		expect(capture).toHaveBeenCalledTimes(SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW);
 	});
 
+	it("keeps failures with distinct error_status on separate budgets", () => {
+		const capture = vi.fn();
+		for (const status of [429, 401]) {
+			for (let i = 0; i < 100; i++) {
+				captureSdkError({ capture } as never, {
+					component: "llms",
+					operation: "provider.stream",
+					error: Object.assign(new Error(`Upstream returned HTTP ${status}`), {
+						status,
+					}),
+				});
+			}
+		}
+
+		// A hot rate-limit loop must not consume the auth failure's budget.
+		expect(capture).toHaveBeenCalledTimes(
+			2 * SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+		);
+		const statuses = capture.mock.calls.map(
+			([call]) => call.properties.error_status,
+		);
+		expect(statuses.filter((status) => status === 429)).toHaveLength(
+			SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+		);
+		expect(statuses.filter((status) => status === 401)).toHaveLength(
+			SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+		);
+	});
+
+	it("keeps failures with distinct error_code on separate budgets", () => {
+		const capture = vi.fn();
+		for (const code of ["rate_limit_error", "authentication_error"]) {
+			for (let i = 0; i < 100; i++) {
+				captureSdkError({ capture } as never, {
+					component: "llms",
+					operation: "provider.stream",
+					error: Object.assign(new Error("request rejected"), { code }),
+				});
+			}
+		}
+
+		expect(capture).toHaveBeenCalledTimes(
+			2 * SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW,
+		);
+	});
+
+	it("returns whether the failure was recorded", () => {
+		const capture = vi.fn();
+		const input = {
+			component: "llms",
+			operation: "provider.stream",
+			error: new Error("boom"),
+		} as const;
+
+		expect(captureSdkError(undefined, input)).toBe(false);
+		expect(captureSdkError({ capture } as never, input)).toBe(true);
+		// Rate-limit-suppressed failures still count as recorded.
+		for (let i = 0; i < 100; i++) {
+			expect(captureSdkError({ capture } as never, input)).toBe(true);
+		}
+	});
+
 	it("carries suppressed_count onto the next emission after the window rolls over", () => {
 		vi.useFakeTimers();
 		const capture = captureRepeatedly(

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -166,16 +166,23 @@ interface SdkErrorWindow {
 
 const sdkErrorWindows = new Map<string, SdkErrorWindow>();
 
-/** Clear per-process `sdk.error` rate-limit state (test isolation). */
+/**
+ * Clear per-process `sdk.error` rate-limit state (test isolation).
+ *
+ * @internal Exported only so package test suites can isolate the
+ * process-wide suppression state between tests; not a supported runtime API.
+ */
 export function resetSdkErrorRateLimiterForTests(): void {
 	sdkErrorWindows.clear();
 }
 
 /**
- * One key per distinct failure. The message is normalized (digit runs
- * collapsed, whitespace folded, case-insensitive, bounded) so messages that
- * differ only by counters or ids — `"iteration 14"` vs `"iteration 99"` —
- * coalesce instead of each getting a fresh budget.
+ * One key per distinct failure. Structured discriminators (`error_status`,
+ * `error_code`) participate in the key so an HTTP 429 and an HTTP 401 never
+ * share a budget, while the message is normalized (digit runs collapsed,
+ * whitespace folded, case-insensitive, bounded) so messages that differ only
+ * by counters or ids — `"iteration 14"` vs `"iteration 99"` — coalesce
+ * instead of each getting a fresh budget.
  */
 function sdkErrorRateLimitKey(
 	event: string,
@@ -190,6 +197,8 @@ function sdkErrorRateLimitKey(
 		properties.component,
 		properties.operation,
 		properties.error_type,
+		properties.error_code ?? "",
+		properties.error_status ?? "",
 		message
 			.replace(/\d+/g, "#")
 			.replace(/\s+/g, " ")
@@ -274,12 +283,23 @@ export function captureTaskLifecycleEvent(
 	});
 }
 
+/**
+ * Report an SDK error, subject to the per-process volume cap on identical
+ * failures described above.
+ *
+ * Returns `true` when the failure is recorded — emitted, or counted toward
+ * `suppressed_count` by the volume cap — and `false` when telemetry is
+ * unavailable. Reporters that sit on a layer boundary forward the return
+ * value (see `errorReported` on the model stream's `finish` event) so outer
+ * layers know the failure is already accounted for and one underlying
+ * failure produces one event, not one per layer it propagates through.
+ */
 export function captureSdkError(
 	telemetry: ITelemetryService | undefined,
 	input: CaptureSdkErrorInput,
-): void {
+): boolean {
 	if (!telemetry) {
-		return;
+		return false;
 	}
 	const event = input.event ?? SDK_ERROR_TELEMETRY_EVENT;
 	const properties = buildSdkErrorProperties(input);
@@ -287,7 +307,7 @@ export function captureSdkError(
 	try {
 		const decision = admitSdkError(sdkErrorRateLimitKey(event, properties));
 		if (!decision.emit) {
-			return;
+			return true;
 		}
 		suppressed = decision.suppressed;
 	} catch {
@@ -300,6 +320,7 @@ export function captureSdkError(
 				? { ...properties, suppressed_count: suppressed }
 				: properties,
 	});
+	return true;
 }
 
 export function buildSdkErrorProperties(

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -143,6 +143,87 @@ export interface ITelemetryService {
 
 export const SDK_ERROR_TELEMETRY_EVENT = "sdk.error";
 
+// `sdk.error` is a diagnostic firehose: a process stuck in a retry loop
+// (e.g. an unattended agent re-hitting a rate-limited provider) can emit the
+// same failure thousands of times and drown the signal. Identical failures
+// are therefore capped per process: the first few per hour emit normally,
+// the rest are only counted, and the count surfaces as `suppressed_count` on
+// the next emission once the window rolls over — a hot loop stays visible
+// without flooding. State is in-memory only and the cap never throws.
+
+/** Identical `sdk.error` emissions allowed per key per window. */
+export const SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW = 5;
+/** Suppression window for identical `sdk.error` emissions. */
+export const SDK_ERROR_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+/** Bound on distinct failure keys tracked; the oldest key is evicted. */
+const SDK_ERROR_RATE_LIMIT_MAX_TRACKED_KEYS = 512;
+
+interface SdkErrorWindow {
+	startMs: number;
+	emitted: number;
+	suppressed: number;
+}
+
+const sdkErrorWindows = new Map<string, SdkErrorWindow>();
+
+/** Clear per-process `sdk.error` rate-limit state (test isolation). */
+export function resetSdkErrorRateLimiterForTests(): void {
+	sdkErrorWindows.clear();
+}
+
+/**
+ * One key per distinct failure. The message is normalized (digit runs
+ * collapsed, whitespace folded, case-insensitive, bounded) so messages that
+ * differ only by counters or ids — `"iteration 14"` vs `"iteration 99"` —
+ * coalesce instead of each getting a fresh budget.
+ */
+function sdkErrorRateLimitKey(
+	event: string,
+	properties: TelemetryProperties,
+): string {
+	const message =
+		typeof properties.error_message === "string"
+			? properties.error_message
+			: "";
+	return [
+		event,
+		properties.component,
+		properties.operation,
+		properties.error_type,
+		message
+			.replace(/\d+/g, "#")
+			.replace(/\s+/g, " ")
+			.trim()
+			.toLowerCase()
+			.slice(0, 256),
+	].join("\u0000");
+}
+
+function admitSdkError(key: string): { emit: boolean; suppressed: number } {
+	const now = Date.now();
+	const window = sdkErrorWindows.get(key);
+	if (window && now - window.startMs < SDK_ERROR_RATE_LIMIT_WINDOW_MS) {
+		if (window.emitted < SDK_ERROR_RATE_LIMIT_MAX_PER_WINDOW) {
+			window.emitted += 1;
+			return { emit: true, suppressed: 0 };
+		}
+		window.suppressed += 1;
+		return { emit: false, suppressed: window.suppressed };
+	}
+	// New key or expired window: emit, carrying forward the count of
+	// emissions suppressed in the previous window.
+	const suppressed = window?.suppressed ?? 0;
+	sdkErrorWindows.delete(key);
+	if (sdkErrorWindows.size >= SDK_ERROR_RATE_LIMIT_MAX_TRACKED_KEYS) {
+		const oldest = sdkErrorWindows.keys().next();
+		if (!oldest.done) {
+			sdkErrorWindows.delete(oldest.value);
+		}
+	}
+	sdkErrorWindows.set(key, { startMs: now, emitted: 1, suppressed: 0 });
+	return { emit: true, suppressed };
+}
+
 export function captureAgentUnexpectedReasoningTokens(
 	telemetry: ITelemetryService | undefined,
 	input: CaptureAgentUnexpectedReasoningTokensInput,
@@ -200,9 +281,24 @@ export function captureSdkError(
 	if (!telemetry) {
 		return;
 	}
+	const event = input.event ?? SDK_ERROR_TELEMETRY_EVENT;
+	const properties = buildSdkErrorProperties(input);
+	let suppressed = 0;
+	try {
+		const decision = admitSdkError(sdkErrorRateLimitKey(event, properties));
+		if (!decision.emit) {
+			return;
+		}
+		suppressed = decision.suppressed;
+	} catch {
+		// The volume cap must never block error reporting.
+	}
 	telemetry.capture({
-		event: input.event ?? SDK_ERROR_TELEMETRY_EVENT,
-		properties: buildSdkErrorProperties(input),
+		event,
+		properties:
+			suppressed > 0
+				? { ...properties, suppressed_count: suppressed }
+				: properties,
 	});
 }
 


### PR DESCRIPTION
### Related Issue

Telemetry-quality fix driven by production `sdk.error` analysis (2026-08-02→03): 300,973 events from 1,686 CLI users in 24h, the top 10 machines producing 70% of volume, and every provider failure emitted at least twice — the `llms`/`provider.stream` (`handled: true`) and `agents`/`agent.run` (`handled: false`) counts match exactly (6,567/6,427 × `Unauthorized…`; 5,147 × 2 × `Upstream returned HTTP 429` from one machine's unattended retry loop).

### Description

Two root causes, two small changes:

**1. Two layers reported the same failure.** The model layer reports provider failures at its own error boundary, where it still holds the structured error; the agent loop then re-reported the same failure verbatim when the run failed on it. Reporting ownership is now an explicit signal: `captureSdkError` returns whether the failure was recorded, the model layer forwards that across the stream's string-flattening boundary as `errorReported` on the `finish` event, and the run loop skips only failures marked reported. Loop-originated failures (empty response, max-iterations) and failures from custom `AgentModel` implementations that never record their own telemetry still produce exactly one `sdk.error` from the run loop (regression-tested).

**2. Retry loops emitted without bound.** `captureSdkError` now caps identical failures per process: 5 per hour per `(event, component, operation, error_type, error_code, error_status, normalized message)`. The structured `error_status`/`error_code` participate in the key so an HTTP 429 hot loop can never consume an HTTP 401's budget, while digit runs in the message are collapsed so counters and ids coalesce. Beyond the cap, emissions are counted rather than sent, and the count surfaces as `suppressed_count` on the next emission after the window rolls over — a 12-hour hot loop produces dozens of events instead of ten thousand while staying visible. State is one bounded in-memory map; the cap never blocks reporting.

Schema compatibility: event name and all existing attributes are unchanged; `suppressed_count` is the only additive event field, and `errorReported` is an additive optional field on the model stream contract.

### Test Procedure

- **Unit tests** (in this PR): first-5-then-suppress; distinct failures unsuppressed; distinct `error_status`/`error_code` on separate budgets; digit-coalescing keys; `suppressed_count` carried across window rollover (fake timers); a simulated 12-hour hot loop bounded to 60 events; `errorReported` set by the real provider path (and not set without telemetry); the agent loop skipping reported failures while still emitting `agent.run-failed`; exactly one `sdk.error` for custom models that don't record their own telemetry; loop-originated failures still reported.
- **End-to-end 429 loop**: drove the real stack (gateway → openai-compatible ai-sdk provider → real HTTP fetch → `AgentRuntime`) against a local always-429 endpoint in an unattended run loop with a capturing telemetry service.
  - Baseline (`main`, 60s): 10 failed runs / 30 upstream 429s → **20 `sdk.error` events**, the exact production `provider.stream` + `agent.run` pair per failure, growing without bound.
  - This branch (60s): 10 failed runs / 30 upstream 429s → **5 `sdk.error` events**, all from the model layer, zero duplicates.
- **Suites**: `@cline/shared` 304, `@cline/llms` 518, `@cline/agents` 61, `@cline/core` 1555, `@cline/cli` 1023 — passing (`@cline/core` shows only the documented `workspace-manifest` cloud-VM git artifact plus a checkpoint-test flake reproduced identically on pristine `main`). `bun run types` clean across all packages; changed files pass `biome check`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

- **Review follow-ups addressed** (second commit): reporting ownership is explicit (`errorReported`) rather than inferred from `errorClass`, with the requested custom-model regression expecting exactly one `sdk.error`; the limiter key includes `error_status`/`error_code`; `resetSdkErrorRateLimiterForTests` is tagged `@internal` — it stays re-exported because package test suites can only reach it through the package entry point.
- **Expected telemetry effect (dashboard owners, please note):** CLI `sdk.error` daily volume should drop roughly an order of magnitude (~300K → tens of thousands) when this ships, with no loss of distinct-user/distinct-error information — dedup removes the redundant second copy of each failure and the cap only collapses identical repeats from one process (summarized via `suppressed_count`). Annotate the change date if this event is charted.
- **Follow-up observation (not addressed here):** the second-largest signal in the same window — `Unauthorized: Please make sure you're using the latest version…` from ~235 distinct CLI users on old versions (3.0.24 seen) — is a real, widespread failure that was buried under the loop spam and deserves its own investigation.