### PR TITLE
fix(desktop): plugin package names

### DIFF
--- a/apps/cline-hub/src/webview/src/components/views/settings/extensions-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/settings/extensions-view.tsx
@@ -774,7 +774,7 @@ export function CustomizationSectionView({
 	const pluginToolsByPluginKey = useMemo(() => {
 		const grouped = new Map<string, ToolItem[]>();
 		for (const tool of pluginTools) {
-			const key = `${tool.pluginName ?? ""}:${tool.path ?? ""}`;
+			const key = tool.path ?? "";
 			const existing = grouped.get(key) ?? [];
 			existing.push(tool);
 			grouped.set(key, existing);
@@ -937,9 +937,7 @@ export function CustomizationSectionView({
 					{plugin.path}
 				</p>
 				<div className="mt-3 ml-7 flex flex-col gap-2">
-					{(
-						pluginToolsByPluginKey.get(`${plugin.name}:${plugin.path}`) ?? []
-					).map((tool) => {
+					{(pluginToolsByPluginKey.get(plugin.path) ?? []).map((tool) => {
 						const isToggling = togglingToolIds.has(tool.id);
 						return (
 							<div
@@ -970,8 +968,7 @@ export function CustomizationSectionView({
 							</div>
 						);
 					})}
-					{(pluginToolsByPluginKey.get(`${plugin.name}:${plugin.path}`)
-						?.length ?? 0) === 0 && (
+					{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) === 0 && (
 						<p className="text-xs text-muted-foreground">
 							No plugin tools found.
 						</p>
@@ -1013,8 +1010,7 @@ export function CustomizationSectionView({
 	);
 
 	const renderPluginMatchedDetails = (plugin: PluginItem) => {
-		const pluginTools =
-			pluginToolsByPluginKey.get(`${plugin.name}:${plugin.path}`) ?? [];
+		const pluginTools = pluginToolsByPluginKey.get(plugin.path) ?? [];
 		if (pluginTools.length === 0) {
 			return null;
 		}
@@ -1151,11 +1147,7 @@ export function CustomizationSectionView({
 							renderMatchedControls: () =>
 								renderPluginMatchedControls(item.plugin),
 							renderMatchedDetails:
-								(
-									pluginToolsByPluginKey.get(
-										`${item.plugin.name}:${item.plugin.path}`,
-									) ?? []
-								).length > 0
+								(pluginToolsByPluginKey.get(item.plugin.path) ?? []).length > 0
 									? () => renderPluginMatchedDetails(item.plugin)
 									: undefined,
 							renderMatchedMeta: () => renderPluginMatchedMeta(item.plugin),
@@ -1504,45 +1496,42 @@ export function CustomizationSectionView({
 										{plugin.path}
 									</p>
 									<div className="mt-3 ml-7 flex flex-col gap-2">
-										{(
-											pluginToolsByPluginKey.get(
-												`${plugin.name}:${plugin.path}`,
-											) ?? []
-										).map((tool) => {
-											const isToggling = togglingToolIds.has(tool.id);
-											return (
-												<div
-													key={tool.id}
-													className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-												>
-													<div className="min-w-0">
-														<p className="text-xs font-medium text-foreground">
-															{tool.name}
-														</p>
-														<p className="text-xs text-muted-foreground">
-															{tool.description?.trim() ||
-																"No description available."}
-														</p>
+										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
+											(tool) => {
+												const isToggling = togglingToolIds.has(tool.id);
+												return (
+													<div
+														key={tool.id}
+														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="text-xs font-medium text-foreground">
+																{tool.name}
+															</p>
+															<p className="text-xs text-muted-foreground">
+																{tool.description?.trim() ||
+																	"No description available."}
+															</p>
+														</div>
+														<div className="flex items-center gap-2">
+															<span className="text-xs text-muted-foreground">
+																{tool.enabled ? "Enabled" : "Disabled"}
+															</span>
+															<Switch
+																checked={tool.enabled}
+																onCheckedChange={() => {
+																	void setToolEnabled(tool);
+																}}
+																disabled={isToggling || !plugin.enabled}
+																aria-label={`Toggle ${tool.name}`}
+															/>
+														</div>
 													</div>
-													<div className="flex items-center gap-2">
-														<span className="text-xs text-muted-foreground">
-															{tool.enabled ? "Enabled" : "Disabled"}
-														</span>
-														<Switch
-															checked={tool.enabled}
-															onCheckedChange={() => {
-																void setToolEnabled(tool);
-															}}
-															disabled={isToggling || !plugin.enabled}
-															aria-label={`Toggle ${tool.name}`}
-														/>
-													</div>
-												</div>
-											);
-										})}
-										{(pluginToolsByPluginKey.get(
-											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
+												);
+											},
+										)}
+										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
+											0 && (
 											<p className="text-xs text-muted-foreground">
 												No plugin tools found.
 											</p>
@@ -1589,45 +1578,42 @@ export function CustomizationSectionView({
 										{plugin.path}
 									</p>
 									<div className="mt-3 ml-7 flex flex-col gap-2">
-										{(
-											pluginToolsByPluginKey.get(
-												`${plugin.name}:${plugin.path}`,
-											) ?? []
-										).map((tool) => {
-											const isToggling = togglingToolIds.has(tool.id);
-											return (
-												<div
-													key={tool.id}
-													className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-												>
-													<div className="min-w-0">
-														<p className="text-xs font-medium text-foreground">
-															{tool.name}
-														</p>
-														<p className="text-xs text-muted-foreground">
-															{tool.description?.trim() ||
-																"No description available."}
-														</p>
+										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
+											(tool) => {
+												const isToggling = togglingToolIds.has(tool.id);
+												return (
+													<div
+														key={tool.id}
+														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="text-xs font-medium text-foreground">
+																{tool.name}
+															</p>
+															<p className="text-xs text-muted-foreground">
+																{tool.description?.trim() ||
+																	"No description available."}
+															</p>
+														</div>
+														<div className="flex items-center gap-2">
+															<span className="text-xs text-muted-foreground">
+																{tool.enabled ? "Enabled" : "Disabled"}
+															</span>
+															<Switch
+																checked={tool.enabled}
+																onCheckedChange={() => {
+																	void setToolEnabled(tool);
+																}}
+																disabled={isToggling || !plugin.enabled}
+																aria-label={`Toggle ${tool.name}`}
+															/>
+														</div>
 													</div>
-													<div className="flex items-center gap-2">
-														<span className="text-xs text-muted-foreground">
-															{tool.enabled ? "Enabled" : "Disabled"}
-														</span>
-														<Switch
-															checked={tool.enabled}
-															onCheckedChange={() => {
-																void setToolEnabled(tool);
-															}}
-															disabled={isToggling || !plugin.enabled}
-															aria-label={`Toggle ${tool.name}`}
-														/>
-													</div>
-												</div>
-											);
-										})}
-										{(pluginToolsByPluginKey.get(
-											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
+												);
+											},
+										)}
+										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
+											0 && (
 											<p className="text-xs text-muted-foreground">
 												No plugin tools found.
 											</p>

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -7,7 +7,15 @@ import {
 	statSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, extname, isAbsolute, join } from "node:path";
+import {
+	basename,
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 import { promisify } from "node:util";
 import type {
 	ClineAccountActionRequest,
@@ -88,6 +96,45 @@ import { readSessionHooks } from "./session-data/artifacts";
 import { normalizeSessionTitle } from "./session-data/common";
 import { discoverChatSessions } from "./session-data/discovery";
 import { readSessionMessages } from "./session-data/messages";
+
+function readPackageName(packageJsonPath: string): string | undefined {
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+			name?: unknown;
+		};
+		return typeof packageJson.name === "string" && packageJson.name.trim()
+			? packageJson.name.trim()
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isPathWithin(parentPath: string, childPath: string): boolean {
+	const relativePath = relative(resolve(parentPath), resolve(childPath));
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
+}
+
+function getPluginDisplayName(filePath: string, searchRoot: string): string {
+	let current = dirname(filePath);
+	const root = resolve(searchRoot);
+	while (isPathWithin(root, current)) {
+		const packageName = readPackageName(join(current, "package.json"));
+		if (packageName) {
+			return packageName;
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+	return basename(filePath, extname(filePath));
+}
+
 import { searchWorkspaceFiles } from "./session-data/search";
 import type {
 	ChatSessionCommandRequest,
@@ -830,7 +877,7 @@ async function listUserInstructionConfigs(
 						continue;
 					}
 					pluginsByPath.set(filePath, {
-						name: basename(filePath, extname(filePath)),
+						name: getPluginDisplayName(filePath, directory),
 						path: filePath,
 						enabled: !disabledPlugins.has(filePath),
 					});

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -776,7 +776,7 @@ export function CustomizationSectionView({
 	const pluginToolsByPluginKey = useMemo(() => {
 		const grouped = new Map<string, ToolItem[]>();
 		for (const tool of pluginTools) {
-			const key = `${tool.pluginName ?? ""}:${tool.path ?? ""}`;
+			const key = tool.path ?? "";
 			const existing = grouped.get(key) ?? [];
 			existing.push(tool);
 			grouped.set(key, existing);
@@ -951,9 +951,7 @@ export function CustomizationSectionView({
 					{plugin.path}
 				</p>
 				<div className="mt-3 ml-7 flex flex-col gap-2">
-					{(
-						pluginToolsByPluginKey.get(`${plugin.name}:${plugin.path}`) ?? []
-					).map((tool) => {
+					{(pluginToolsByPluginKey.get(plugin.path) ?? []).map((tool) => {
 						const isToggling = togglingToolIds.has(tool.id);
 						return (
 							<div
@@ -984,8 +982,7 @@ export function CustomizationSectionView({
 							</div>
 						);
 					})}
-					{(pluginToolsByPluginKey.get(`${plugin.name}:${plugin.path}`)
-						?.length ?? 0) === 0 && (
+					{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) === 0 && (
 						<p className="text-xs text-muted-foreground">
 							No plugin tools found.
 						</p>
@@ -1421,45 +1418,42 @@ export function CustomizationSectionView({
 										{plugin.path}
 									</p>
 									<div className="mt-3 ml-7 flex flex-col gap-2">
-										{(
-											pluginToolsByPluginKey.get(
-												`${plugin.name}:${plugin.path}`,
-											) ?? []
-										).map((tool) => {
-											const isToggling = togglingToolIds.has(tool.id);
-											return (
-												<div
-													key={tool.id}
-													className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-												>
-													<div className="min-w-0">
-														<p className="text-xs font-medium text-foreground">
-															{tool.name}
-														</p>
-														<p className="text-xs text-muted-foreground">
-															{tool.description?.trim() ||
-																"No description available."}
-														</p>
+										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
+											(tool) => {
+												const isToggling = togglingToolIds.has(tool.id);
+												return (
+													<div
+														key={tool.id}
+														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="text-xs font-medium text-foreground">
+																{tool.name}
+															</p>
+															<p className="text-xs text-muted-foreground">
+																{tool.description?.trim() ||
+																	"No description available."}
+															</p>
+														</div>
+														<div className="flex items-center gap-2">
+															<span className="text-xs text-muted-foreground">
+																{tool.enabled ? "Enabled" : "Disabled"}
+															</span>
+															<Switch
+																checked={tool.enabled}
+																onCheckedChange={() => {
+																	void setToolEnabled(tool);
+																}}
+																disabled={isToggling || !plugin.enabled}
+																aria-label={`Toggle ${tool.name}`}
+															/>
+														</div>
 													</div>
-													<div className="flex items-center gap-2">
-														<span className="text-xs text-muted-foreground">
-															{tool.enabled ? "Enabled" : "Disabled"}
-														</span>
-														<Switch
-															checked={tool.enabled}
-															onCheckedChange={() => {
-																void setToolEnabled(tool);
-															}}
-															disabled={isToggling || !plugin.enabled}
-															aria-label={`Toggle ${tool.name}`}
-														/>
-													</div>
-												</div>
-											);
-										})}
-										{(pluginToolsByPluginKey.get(
-											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
+												);
+											},
+										)}
+										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
+											0 && (
 											<p className="text-xs text-muted-foreground">
 												No plugin tools found.
 											</p>
@@ -1506,45 +1500,42 @@ export function CustomizationSectionView({
 										{plugin.path}
 									</p>
 									<div className="mt-3 ml-7 flex flex-col gap-2">
-										{(
-											pluginToolsByPluginKey.get(
-												`${plugin.name}:${plugin.path}`,
-											) ?? []
-										).map((tool) => {
-											const isToggling = togglingToolIds.has(tool.id);
-											return (
-												<div
-													key={tool.id}
-													className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-												>
-													<div className="min-w-0">
-														<p className="text-xs font-medium text-foreground">
-															{tool.name}
-														</p>
-														<p className="text-xs text-muted-foreground">
-															{tool.description?.trim() ||
-																"No description available."}
-														</p>
+										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
+											(tool) => {
+												const isToggling = togglingToolIds.has(tool.id);
+												return (
+													<div
+														key={tool.id}
+														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
+													>
+														<div className="min-w-0">
+															<p className="text-xs font-medium text-foreground">
+																{tool.name}
+															</p>
+															<p className="text-xs text-muted-foreground">
+																{tool.description?.trim() ||
+																	"No description available."}
+															</p>
+														</div>
+														<div className="flex items-center gap-2">
+															<span className="text-xs text-muted-foreground">
+																{tool.enabled ? "Enabled" : "Disabled"}
+															</span>
+															<Switch
+																checked={tool.enabled}
+																onCheckedChange={() => {
+																	void setToolEnabled(tool);
+																}}
+																disabled={isToggling || !plugin.enabled}
+																aria-label={`Toggle ${tool.name}`}
+															/>
+														</div>
 													</div>
-													<div className="flex items-center gap-2">
-														<span className="text-xs text-muted-foreground">
-															{tool.enabled ? "Enabled" : "Disabled"}
-														</span>
-														<Switch
-															checked={tool.enabled}
-															onCheckedChange={() => {
-																void setToolEnabled(tool);
-															}}
-															disabled={isToggling || !plugin.enabled}
-															aria-label={`Toggle ${tool.name}`}
-														/>
-													</div>
-												</div>
-											);
-										})}
-										{(pluginToolsByPluginKey.get(
-											`${plugin.name}:${plugin.path}`,
-										)?.length ?? 0) === 0 && (
+												);
+											},
+										)}
+										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
+											0 && (
 											<p className="text-xs text-muted-foreground">
 												No plugin tools found.
 											</p>


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Root cause:

- The desktop sidecar derived plugin names from the entry filename, so package plugins using index.ts appeared as “index.”
- Plugin tools used the exported plugin name.
- The UI matched plugins and tools using both name and path, so the mismatched names prevented tools from appearing.

Changes:

- Package plugins now use the nearest package.json name.
- Tools are associated with plugins by canonical plugin path.
- Applied the same robust path matching to the mirrored Cline Hub view.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

After

<img width="1222" height="964" alt="image" src="https://github.com/user-attachments/assets/108d7d5a-50b3-40e2-a8f4-66a1d257b875" />

Before

<img width="1202" height="942" alt="image" src="https://github.com/user-attachments/assets/4bbaa4c8-5f7d-4726-849d-d7b83b8ba2ca" />


### Additional Notes

<!-- Add any additional notes for reviewers -->
