### PR TITLE
fix: task with attachments not resetting on "New Task" click

### DIFF
--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -53,8 +53,18 @@ describe("SdkTaskStartCoordinator", () => {
 		expect(options.taskHistory.updateTaskHistoryItem).toHaveBeenCalledWith(
 			expect.objectContaining({ id: sessionId, task: "hello @file", modelId: "model" }),
 		)
+		// Attachments must be on the authoritative task message so the webview's
+		// optimistic pending copy (which carries them) gets confirmed and cleared.
 		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[expect.objectContaining({ type: "say", say: "task", text: "hello @file" })],
+			[
+				expect.objectContaining({
+					type: "say",
+					say: "task",
+					text: "hello @file",
+					images: ["image.png"],
+					files: ["a.ts"],
+				}),
+			],
 			{ type: "status", payload: { sessionId, status: "running" } },
 		)
 		expect(options.postStateToWebview).toHaveBeenCalledTimes(2)
@@ -74,6 +84,17 @@ describe("SdkTaskStartCoordinator", () => {
 			["image.png"],
 			["a.ts"],
 		)
+	})
+
+	it("omits images/files from the task message when the task has no attachments", async () => {
+		const { coordinator, options } = makeCoordinator()
+
+		await coordinator.initTask("plain text task")
+
+		const [emitted] = options.messages.appendAndEmit.mock.calls[0][0] as [Record<string, unknown>]
+		expect(emitted).toMatchObject({ type: "say", say: "task", text: "plain text task" })
+		expect(emitted).not.toHaveProperty("images")
+		expect(emitted).not.toHaveProperty("files")
 	})
 
 	it("emits a Cline auth error instead of starting when the cline provider has no token", async () => {

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -121,7 +121,7 @@ export class SdkTaskStartCoordinator {
 			})
 
 			const task = this.createAndSetTask(taskSessionId)
-			this.emitInitialTaskMessage(taskSessionId, prompt ?? "")
+			this.emitInitialTaskMessage(taskSessionId, prompt ?? "", images, files)
 
 			// The turn phase was already set to "streaming" (in SdkController.initTask), but the
 			// webview only learns the phase through a full state post. Ship one now, in parallel
@@ -230,12 +230,19 @@ export class SdkTaskStartCoordinator {
 		return task
 	}
 
-	private emitInitialTaskMessage(sessionId: string, task: string): void {
+	private emitInitialTaskMessage(sessionId: string, task: string, images?: string[], files?: string[]): void {
+		// Attachments must ride on the authoritative task message: the webview's
+		// optimistic pending copy is only cleared once an identical message (text
+		// AND images/files) arrives from the extension. Omitting them left the
+		// optimistic message unconfirmed forever, so it was re-injected into the
+		// transcript even after "New Task" cleared it (#12924).
 		const taskMessage: ClineMessage = {
 			ts: Date.now(),
 			type: "say",
 			say: "task",
 			text: task,
+			...(images?.length ? { images } : {}),
+			...(files?.length ? { files } : {}),
 			partial: false,
 		}
 		this.options.messages.appendAndEmit([taskMessage], {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 // gRPC clients: record which RPC the send path chose.
 const newTask = vi.fn().mockResolvedValue(undefined)
 const askResponse = vi.fn().mockResolvedValue(undefined)
+const clearTask = vi.fn().mockResolvedValue(undefined)
 const condense = vi.fn().mockResolvedValue(undefined)
 const trackIntent = vi.fn().mockResolvedValue(undefined)
 
@@ -13,7 +14,7 @@ vi.mock("@/services/grpc-client", () => ({
 	TaskServiceClient: {
 		newTask: (req: unknown) => newTask(req),
 		askResponse: (req: unknown) => askResponse(req),
-		clearTask: vi.fn().mockResolvedValue(undefined),
+		clearTask: (req: unknown) => clearTask(req),
 	},
 	SlashServiceClient: {
 		condense: (req: unknown) => condense(req),
@@ -100,6 +101,8 @@ describe("useMessageHandlers — send routing", () => {
 		newTask.mockResolvedValue(undefined)
 		askResponse.mockReset()
 		askResponse.mockResolvedValue(undefined)
+		clearTask.mockReset()
+		clearTask.mockResolvedValue(undefined)
 		condense.mockReset()
 		condense.mockResolvedValue(undefined)
 		trackIntent.mockReset()
@@ -626,6 +629,30 @@ describe("useMessageHandlers — send routing", () => {
 		const pendingResponse = setPendingResponse.mock.calls[0][0]
 		const rollbackResponse = setPendingResponse.mock.calls.at(-1)?.[0]
 		expect(rollbackResponse(pendingResponse)).toBeUndefined()
+	})
+
+	it("startNewTask drops any unconfirmed optimistic message so it cannot be re-injected after clearTask", async () => {
+		mockTurnState = { phase: "streaming", seq: 2 }
+		const streamingConversation: ClineMessage[] = [
+			{ ts: 1, type: "say", say: "task", text: "task with attachment" },
+			{ ts: 2, type: "say", say: "text", text: "working", partial: true },
+		]
+		const setPendingUserMessage = vi.fn()
+		const setPendingResponse = vi.fn()
+		const { result } = renderHook(() =>
+			useMessageHandlers(
+				streamingConversation,
+				makeChatState(streamingConversation, { setPendingUserMessage, setPendingResponse }),
+			),
+		)
+
+		await act(async () => {
+			await result.current.startNewTask()
+		})
+
+		expect(clearTask).toHaveBeenCalledTimes(1)
+		expect(setPendingUserMessage).toHaveBeenCalledWith(undefined)
+		expect(setPendingResponse).toHaveBeenCalledWith(undefined)
 	})
 
 	// The webview does not gate sends on provider usability: submission always

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -335,8 +335,14 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 			}),
 		).catch((error) => console.error("Failed to track new task click:", error))
 		setActiveQuote(null)
+		// Drop any unconfirmed optimistic message: if it lingered past an explicit
+		// New Task, withPendingUserMessage would re-inject the old task (and its
+		// attachments) into the freshly cleared transcript, leaving the chat stuck
+		// on the previous task (#12924).
+		setPendingUserMessage(undefined)
+		setPendingResponse(undefined)
 		await TaskServiceClient.clearTask(EmptyRequest.create({}))
-	}, [messages.length, setActiveQuote])
+	}, [messages.length, setActiveQuote, setPendingUserMessage, setPendingResponse])
 
 	// Clear input state helper
 	const clearInputState = useCallback(() => {


### PR DESCRIPTION
### Related Issue

**Issue:** #12924

### Description

In Cline Next, a task started with a file or image attachment could never be reset: clicking "New Task" (while the response streams, or any time after) left the chat stuck on the old task and its attachment until the IDE was restarted.

**Root cause:** when a new task is submitted, the webview immediately renders an optimistic `say:"task"` message that carries the user's `images`/`files`, and only removes it once an identical authoritative message arrives from the extension (`sameOptimisticMessage` compares text and attachments). `emitInitialTaskMessage` in `sdk-task-start-coordinator.ts` emitted the task message with text only, so the optimistic copy was never confirmed for tasks with attachments. `withPendingUserMessage` then kept re-injecting the stale optimistic message into the transcript, so even after `clearTask` emptied the messages, the chat view still saw a "task" and never returned to the welcome state.

**Fix:**
- Extension: include `images`/`files` on the authoritative initial task message so the webview's optimistic pending copy is confirmed and cleared as designed (this also makes the persisted transcript carry the attachments, matching legacy behavior).
- Webview (defensive): `startNewTask` now drops any unconfirmed optimistic message and pending-response loader before calling `clearTask`, so an explicit "New Task" click always yields a clean slate even if confirmation ever diverges again.

### Test Procedure

- Updated `sdk-task-start-coordinator.test.ts`: the emitted task message must carry the task's `images`/`files`, and must omit the keys when there are no attachments.
- Added a `useMessageHandlers` test: `startNewTask` clears `pendingUserMessage`/`pendingResponse` and calls `clearTask`.
- Full suites pass: `bun run test:unit` (1061), `bun run test:vitest` (1003), webview `bun run test` (412). `bun run lint` and `bun run format` are clean.
- Manually reproduced the issue's exact steps in a dev extension host against a local mock streaming provider: new task with a pasted image → click "New Task" mid-stream. On `main` the task stays stuck with the attachment; with this fix the chat resets to the welcome screen immediately and stays reset.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (on `main`): "New Task" was clicked while the response streamed — the task with the image attachment stays stuck and never resets:

![Before fix: task stuck after New Task click](https://cursor.com/artifacts/c/art-cc26fe32-e91d-4a4a-a31d-4d250b3d0c2c)

After (this fix): the same scenario — task with a pasted image attachment, response streaming:

![After fix: task with image attachment streaming](https://cursor.com/artifacts/c/art-a47c0cff-2797-4f86-a0e3-6543b4dd72af)

Clicking "New Task" mid-stream now resets the chat to a clean welcome state immediately (and it stays reset):

![After fix: chat reset to welcome after New Task click](https://cursor.com/artifacts/c/art-95bdffa2-f856-4b28-9aa9-97525c2b733e)

### Additional Notes

The video in the issue shows the same repro; the mock provider used here just streams a slow canned response so there is a long mid-stream window to click "New Task" in.