### PR TITLE
ci(ui): publish @cline/ui fixes

### DIFF
--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -102,7 +102,6 @@ jobs:
       !endsWith(github.actor, '[bot]')
     needs: quality
     runs-on: ubuntu-latest
-    environment: Publish
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### Related Issue

None — CI chore.

### Description

Our other two npm publishers already work the way this one now does: `sdk-publish.yml` and `cli-publish.yml` both have `id-token: write` and no `environment:`, and they run straight through once dispatched.

#### The npm half of this change

This is the part worth knowing about, because the workflow edit alone would have **broken publishing**.

npm's trusted publisher registration optionally pins an environment, and ours was registered with one:

**This is already live on npm**, done before this PR was opened. Order matters and it's asymmetric: an unconstrained npm config happily accepts a token that *does* carry an environment claim, so relaxing npm first leaves no window where publishing is broken. Doing it the other way around would have.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — no code changed; CI workflow only
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CI configuration.

### Additional Notes

The npm re-registration is already applied, so this can merge whenever. The first `@cline/ui` dispatch after merge is the real smoke test — if it 4xxs at the publish step, the trusted publisher config is the place to look.
