### PR TITLE
Slow hero heading verb rotation from 2.6s to 5s

### DIFF
--- a/sdk/packages/ui/components/agent-hero-heading.tsx
+++ b/sdk/packages/ui/components/agent-hero-heading.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 const HERO_VERBS = ["build", "create", "fix", "know"] as const;
-const HERO_CYCLE_MS = 2600;
+const HERO_CYCLE_MS = 5000;
 
 export function AgentHeroHeading() {
 	const [verbIndex, setVerbIndex] = useState(0);

--- a/sdk/packages/ui/tests/agent-hero-heading.test.tsx
+++ b/sdk/packages/ui/tests/agent-hero-heading.test.tsx
@@ -41,7 +41,7 @@ describe("AgentHeroHeading", () => {
 				?.textContent,
 		).toBe("build");
 
-		await act(async () => vi.advanceTimersByTime(2600));
+		await act(async () => vi.advanceTimersByTime(5000));
 
 		expect(
 			container.querySelector(".cline-ui-agent-hero-heading__word")
@@ -54,7 +54,7 @@ describe("AgentHeroHeading", () => {
 		window.matchMedia = vi.fn().mockReturnValue({ matches: false });
 		await renderHeading();
 
-		await act(async () => vi.advanceTimersByTime(2600));
+		await act(async () => vi.advanceTimersByTime(5000));
 
 		expect(
 			container.querySelector(".cline-ui-agent-hero-heading__word")


### PR DESCRIPTION
### Related Issue

N/A — small cosmetic tweak.

### Description

The "What would you like to ___?" hero heading on the desktop app welcome screen cycles its verb (build / create / fix / know) too quickly. This bumps `HERO_CYCLE_MS` in the shared `@cline/ui` `AgentHeroHeading` component from 2600ms to 5000ms so the word rotates at a calmer pace.

### Test Procedure

- Updated the `AgentHeroHeading` vitest timings to match the new interval; `bun -F @cline/ui test` passes (35 tests).
- Ran the desktop app headless (`dev:sidecar` + `dev:web`), opened the welcome screen, and verified the verb now changes at exactly 5-second intervals (observed build → create → fix → know cycling on a screen recording).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

_Screenshot of the welcome screen hero heading is attached in the agent run artifacts (hero_heading_welcome_screen.png) — drag it in here if you'd like it inline._

### Additional Notes

The interval only runs when `prefers-reduced-motion` is not set; that behavior is unchanged.