### PR TITLE
fix(llms): normalize tool schema unions

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -390,7 +390,10 @@ function toAiSdkMessages(
 	});
 }
 
-function toAiSdkTools(request: GatewayStreamRequest): ToolSet | undefined {
+function toAiSdkTools(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): ToolSet | undefined {
 	if (!request.tools?.length) {
 		return undefined;
 	}
@@ -400,12 +403,19 @@ function toAiSdkTools(request: GatewayStreamRequest): ToolSet | undefined {
 	// accept common weak-model shapes like a bare string for a string[]
 	// property). Rejecting here would return an error to the model without
 	// the tool's own input handling ever seeing the call.
+	const flattenTopLevelCompositions = isAnthropicCompatibleModel({
+		modelId: request.modelId,
+		family: resolveModelFamily(context),
+	});
 	const tools: ToolSet = {};
 	for (const definition of request.tools) {
 		tools[definition.name] = {
 			description: definition.description,
 			inputSchema: jsonSchema(
-				normalizeAiSdkToolInputSchema(definition.inputSchema),
+				normalizeAiSdkToolInputSchema(
+					definition.inputSchema,
+					flattenTopLevelCompositions,
+				),
 			),
 		};
 	}
@@ -456,12 +466,13 @@ export async function repairMalformedToolCall<T extends RepairableToolCall>({
 
 function normalizeAiSdkToolInputSchema(
 	inputSchema: Record<string, unknown>,
+	flattenTopLevelCompositions: boolean,
 ): Record<string, unknown> {
 	const { oneOf, anyOf, allOf, ...schema } = inputSchema;
 	const compositions = [oneOf, anyOf, allOf].filter(
 		(value): value is Record<string, unknown>[] => Array.isArray(value),
 	);
-	if (compositions.length === 0) {
+	if (!flattenTopLevelCompositions || compositions.length === 0) {
 		return inputSchema.type === "object"
 			? inputSchema
 			: { type: "object", ...inputSchema };
@@ -479,11 +490,16 @@ function normalizeAiSdkToolInputSchema(
 			: [],
 	);
 
-	for (const composition of compositions) {
+	for (const [compositionKind, composition] of [
+		["oneOf", oneOf],
+		["anyOf", anyOf],
+		["allOf", allOf],
+	] as const) {
+		if (!Array.isArray(composition)) continue;
 		for (const branch of composition) {
 			if (!branch || typeof branch !== "object" || Array.isArray(branch))
 				continue;
-			const normalizedBranch = normalizeAiSdkToolInputSchema(branch);
+			const normalizedBranch = normalizeAiSdkToolInputSchema(branch, true);
 			if (
 				normalizedBranch.properties &&
 				typeof normalizedBranch.properties === "object" &&
@@ -493,6 +509,14 @@ function normalizeAiSdkToolInputSchema(
 					properties,
 					normalizedBranch.properties as Record<string, unknown>,
 				);
+			}
+			if (
+				compositionKind === "allOf" &&
+				Array.isArray(normalizedBranch.required)
+			) {
+				for (const key of normalizedBranch.required) {
+					if (typeof key === "string") required.add(key);
+				}
 			}
 		}
 	}
@@ -1249,7 +1273,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				);
 				const tools = providerDisablesExternalToolExecution(context)
 					? undefined
-					: toAiSdkTools(request);
+					: toAiSdkTools(request, context);
 				const systemPrompt = resolveAiSdkSystemPrompt(request);
 				const useSystemOption =
 					typeof systemPrompt === "string" && systemPrompt.trim().length > 0;

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -457,13 +457,51 @@ export async function repairMalformedToolCall<T extends RepairableToolCall>({
 function normalizeAiSdkToolInputSchema(
 	inputSchema: Record<string, unknown>,
 ): Record<string, unknown> {
-	if (inputSchema.type === "object") {
-		return inputSchema;
+	const { oneOf, anyOf, allOf, ...schema } = inputSchema;
+	const compositions = [oneOf, anyOf, allOf].filter(
+		(value): value is Record<string, unknown>[] => Array.isArray(value),
+	);
+	if (compositions.length === 0) {
+		return inputSchema.type === "object"
+			? inputSchema
+			: { type: "object", ...inputSchema };
+	}
+
+	const properties: Record<string, unknown> =
+		schema.properties &&
+		typeof schema.properties === "object" &&
+		!Array.isArray(schema.properties)
+			? { ...(schema.properties as Record<string, unknown>) }
+			: {};
+	const required = new Set(
+		Array.isArray(schema.required)
+			? schema.required.filter((key): key is string => typeof key === "string")
+			: [],
+	);
+
+	for (const composition of compositions) {
+		for (const branch of composition) {
+			if (!branch || typeof branch !== "object" || Array.isArray(branch))
+				continue;
+			const normalizedBranch = normalizeAiSdkToolInputSchema(branch);
+			if (
+				normalizedBranch.properties &&
+				typeof normalizedBranch.properties === "object" &&
+				!Array.isArray(normalizedBranch.properties)
+			) {
+				Object.assign(
+					properties,
+					normalizedBranch.properties as Record<string, unknown>,
+				);
+			}
+		}
 	}
 
 	return {
+		...schema,
 		type: "object",
-		...inputSchema,
+		properties,
+		...(required.size > 0 ? { required: [...required] } : {}),
 	};
 }
 

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2748,6 +2748,60 @@ describe("sdk-gateway", () => {
 		});
 	});
 
+	it("flattens top-level tool schema unions for Anthropic-compatible providers", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "openrouter", apiKey: "test" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "anthropic/claude-sonnet-4.6",
+				messages: baseMessages,
+				tools: [
+					{
+						name: "custom",
+						description: "A tool supplied by an extension",
+						inputSchema: {
+							type: "object",
+							anyOf: [
+								{
+									type: "object",
+									properties: { query: { type: "string" } },
+									required: ["query"],
+								},
+								{
+									type: "object",
+									properties: { id: { type: "string" } },
+									required: ["id"],
+								},
+							],
+						},
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { tools?: Record<string, { inputSchema?: { jsonSchema?: unknown } }> }
+			| undefined;
+		const schema = await call?.tools?.custom.inputSchema?.jsonSchema;
+		expect(schema).toEqual({
+			type: "object",
+			properties: {
+				query: { type: "string" },
+				id: { type: "string" },
+			},
+		});
+		expect(JSON.stringify(schema)).not.toMatch(/"(?:oneOf|anyOf|allOf)"/);
+	});
+
 	it("passes reasoning effort through to Anthropic provider options", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2748,7 +2748,7 @@ describe("sdk-gateway", () => {
 		});
 	});
 
-	it("flattens top-level tool schema unions for Anthropic-compatible providers", async () => {
+	it("flattens top-level tool schema unions for Anthropic-compatible models", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([
 				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
@@ -2800,6 +2800,112 @@ describe("sdk-gateway", () => {
 			},
 		});
 		expect(JSON.stringify(schema)).not.toMatch(/"(?:oneOf|anyOf|allOf)"/);
+	});
+
+	it("preserves top-level tool schema unions for non-Anthropic models", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+		const inputSchema = {
+			type: "object",
+			anyOf: [
+				{
+					type: "object",
+					properties: { query: { type: "string" } },
+					required: ["query"],
+				},
+				{
+					type: "object",
+					properties: { id: { type: "string" } },
+					required: ["id"],
+				},
+			],
+		};
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openai-compatible",
+					apiKey: "test",
+					baseUrl: "https://example.com/v1",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "openai-compatible",
+				modelId: "test-model",
+				messages: baseMessages,
+				tools: [
+					{
+						name: "custom",
+						description: "A tool supplied by an extension",
+						inputSchema,
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { tools?: Record<string, { inputSchema?: { jsonSchema?: unknown } }> }
+			| undefined;
+		expect(await call?.tools?.custom.inputSchema?.jsonSchema).toEqual(
+			inputSchema,
+		);
+	});
+
+	it("preserves required fields while flattening allOf tool schemas", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "anthropic", apiKey: "test" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "anthropic",
+				modelId: "claude-sonnet-4-6",
+				messages: baseMessages,
+				tools: [
+					{
+						name: "custom",
+						description: "A tool supplied by an extension",
+						inputSchema: {
+							type: "object",
+							allOf: [
+								{
+									type: "object",
+									properties: { query: { type: "string" } },
+									required: ["query"],
+								},
+								{
+									type: "object",
+									properties: { limit: { type: "number" } },
+									required: ["limit"],
+								},
+							],
+						},
+					},
+				],
+			}),
+		);
+
+		const call = streamTextSpy.mock.calls.at(-1)?.[0] as
+			| { tools?: Record<string, { inputSchema?: { jsonSchema?: unknown } }> }
+			| undefined;
+		expect(await call?.tools?.custom.inputSchema?.jsonSchema).toEqual({
+			type: "object",
+			properties: {
+				query: { type: "string" },
+				limit: { type: "number" },
+			},
+			required: ["query", "limit"],
+		});
 	});
 
 	it("passes reasoning effort through to Anthropic provider options", async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Prevent OpenRouter requests to Anthropic-compatible models from failing when custom tools use top-level `oneOf`, `anyOf`, or `allOf` schemas.

#### Root cause

Anthropic-compatible providers require tool inputs to have a plain object schema and reject composition keywords at the top level. Cline previously added `type: "object"` without removing those keywords, causing the request to fail before inference.

#### Changes

- Flatten top-level schema compositions into a provider-compatible object.
- Preserve properties declared by each composition branch.
- Retain existing top-level properties and required fields.
- Add regression coverage for custom tools sent through OpenRouter.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. bun run cli
2. confirm anthropic models with cline provider is not returning error

<img width="1025" height="1224" alt="image" src="https://github.com/user-attachments/assets/085ccd6c-e14f-423c-ba1a-d489470cf3cc" />

Before

<img width="2046" height="800" alt="image" src="https://github.com/user-attachments/assets/560e2b3b-290f-4c36-b0f1-cf6594d6a092" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
