### PR TITLE
fix(llms): flatten top-level tool schema unions with required preservation

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -262,3 +262,152 @@ describe("repairMalformedToolCall", () => {
 		expect(repaired).toBeNull();
 	});
 });
+
+describe("ai-sdk adapter tool schema normalization", () => {
+	// Drives the real adapter with a capturing fetch and returns the tool
+	// parameters exactly as they would be serialized onto the wire.
+	async function captureNormalizedToolParameters(
+		inputSchema: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		let capturedBody: Record<string, unknown> | undefined;
+		const config = {
+			providerId: "openai-compatible",
+			apiKey: "test-key",
+			baseUrl: "http://fake.local/v1",
+			fetch: (async (_input: unknown, init?: { body?: unknown }) => {
+				capturedBody = JSON.parse(String(init?.body ?? "{}"));
+				return new Response("data: [DONE]\n\n", {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}) as unknown as typeof fetch,
+		};
+		const provider = await createOpenAICompatibleProvider(config);
+		const model = {
+			id: "test-model",
+			providerId: "openai-compatible",
+			name: "test-model",
+		};
+		const context = {
+			provider: {
+				id: "openai-compatible",
+				name: "OpenAI Compatible",
+				defaultModelId: "test-model",
+				models: [model],
+			},
+			model,
+			config,
+		} as unknown as GatewayProviderContext;
+		const unionTool: AgentToolDefinition = {
+			name: "lookup_entity",
+			description: "Look up an entity by id or by name.",
+			inputSchema,
+		};
+		const request = {
+			providerId: "openai-compatible",
+			modelId: "test-model",
+			messages: [
+				{
+					id: "msg_user",
+					role: "user",
+					content: [{ type: "text", text: "do the thing" }],
+					createdAt: new Date(),
+				},
+			],
+			tools: [unionTool],
+		} as unknown as GatewayStreamRequest;
+
+		for await (const _event of await provider.stream(request, context)) {
+			// Drain the stream so the request is fully issued.
+		}
+
+		const requestTools = capturedBody?.tools as Array<{
+			function: { name: string; parameters: Record<string, unknown> };
+		}>;
+		return requestTools[0].function.parameters;
+	}
+
+	it("flattens top-level anyOf unions before sending tools to the provider", async () => {
+		// MCP servers commonly advertise tools whose input schema is a union of
+		// object shapes. Anthropic — and several providers OpenRouter fans out
+		// to — reject any input_schema with oneOf/allOf/anyOf at the top level,
+		// failing the whole request with "tools.N.custom.input_schema:
+		// input_schema does not support oneOf, allOf, or anyOf at the top
+		// level". Branch-required fields disagree here, so none survive.
+		const parameters = await captureNormalizedToolParameters({
+			anyOf: [
+				{
+					type: "object",
+					properties: { id: { type: "string" } },
+					required: ["id"],
+				},
+				{
+					type: "object",
+					properties: { name: { type: "string" } },
+					required: ["name"],
+				},
+			],
+		});
+		expect(parameters).toEqual({
+			type: "object",
+			properties: {
+				id: { type: "string" },
+				name: { type: "string" },
+			},
+		});
+	});
+
+	it("keeps properties required by every anyOf branch as required", async () => {
+		// The input matches ONE branch, so a property is only truly required
+		// when all branches require it.
+		const parameters = await captureNormalizedToolParameters({
+			anyOf: [
+				{
+					type: "object",
+					properties: { id: { type: "string" }, scope: { type: "string" } },
+					required: ["id", "scope"],
+				},
+				{
+					type: "object",
+					properties: { name: { type: "string" }, scope: { type: "string" } },
+					required: ["name", "scope"],
+				},
+			],
+		});
+		expect(parameters).toEqual({
+			type: "object",
+			properties: {
+				id: { type: "string" },
+				scope: { type: "string" },
+				name: { type: "string" },
+			},
+			required: ["scope"],
+		});
+	});
+
+	it("merges required constraints from all allOf branches", async () => {
+		// allOf branches ALL apply, so requirements placed in a separate
+		// branch from the properties must still be advertised as required.
+		const parameters = await captureNormalizedToolParameters({
+			allOf: [
+				{
+					type: "object",
+					properties: {
+						query: { type: "string" },
+						limit: { type: "number" },
+					},
+				},
+				{ required: ["query"] },
+				{ required: ["limit"] },
+			],
+		});
+		expect(parameters).toEqual({
+			type: "object",
+			properties: {
+				query: { type: "string" },
+				limit: { type: "number" },
+			},
+			required: ["query", "limit"],
+		});
+	});
+});

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -477,6 +477,63 @@ export async function repairMalformedToolCall<T extends RepairableToolCall>({
 function normalizeAiSdkToolInputSchema(
 	inputSchema: Record<string, unknown>,
 ): Record<string, unknown> {
+	// Anthropic (and several providers OpenRouter fans out to) rejects any
+	// tool input_schema with oneOf/allOf/anyOf at the top level, failing the
+	// whole request. MCP servers commonly advertise unions of object shapes,
+	// so merge each branch's properties into a single object schema and drop
+	// the union keyword. Tools still validate their real input shapes in
+	// execute().
+	for (const key of ["oneOf", "anyOf", "allOf"] as const) {
+		const branches = inputSchema[key];
+		if (!Array.isArray(branches) || branches.length === 0) {
+			continue;
+		}
+		const { [key]: _union, ...rest } = inputSchema;
+		const properties: Record<string, unknown> = {
+			...(rest.properties as Record<string, unknown> | undefined),
+		};
+		const requiredPerBranch: string[][] = [];
+		for (const branch of branches) {
+			if (branch && typeof branch === "object") {
+				const branchRecord = branch as Record<string, unknown>;
+				Object.assign(properties, branchRecord.properties);
+				requiredPerBranch.push(
+					Array.isArray(branchRecord.required)
+						? branchRecord.required.filter(
+								(entry): entry is string => typeof entry === "string",
+							)
+						: [],
+				);
+			}
+		}
+		// allOf: every branch applies, so require the union of branch
+		// requirements. anyOf/oneOf: the input matches one branch, so only
+		// properties required by every branch are truly required.
+		const branchRequired =
+			key === "allOf"
+				? [...new Set(requiredPerBranch.flat())]
+				: requiredPerBranch.length > 0
+					? requiredPerBranch.reduce((common, current) =>
+							common.filter((entry) => current.includes(entry)),
+						)
+					: [];
+		const required = [
+			...new Set([
+				...(Array.isArray(rest.required)
+					? rest.required.filter(
+							(entry): entry is string => typeof entry === "string",
+						)
+					: []),
+				...branchRequired,
+			]),
+		];
+		return normalizeAiSdkToolInputSchema({
+			...rest,
+			properties,
+			...(required.length > 0 ? { required } : {}),
+		});
+	}
+
 	if (inputSchema.type === "object") {
 		return inputSchema;
 	}


### PR DESCRIPTION
### Related Issue

Final form of #12948 (reverted in #12950), now including the `required`-field preservation that addressed the Greptile P1 follow-up. Alternative to #12944.

Internal bug report: CLI turns fail with

```
tools.5.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

whenever an MCP server advertises a tool with a top-level union schema.

### Description

Anthropic — and several providers OpenRouter fans out to — rejects any tool whose `input_schema` has `oneOf`, `allOf`, or `anyOf` at the top level, even alongside `type: "object"`. The whole request 400s, so a single such tool bricks every turn. MCP servers commonly advertise tools whose input schema is a top-level union of object shapes (the natural output of a Zod/TypeBox union); Cline previously forwarded the union as-is, only adding `type: "object"` beside it. This is a longstanding latent bug, not an AI SDK 7 regression — the identical repro fails on the pre-upgrade commit (`ai@6.0.144`).

Fix, all in `normalizeAiSdkToolInputSchema` in `@cline/llms`: when a tool schema has a top-level `oneOf`/`anyOf`/`allOf`, merge each branch's `properties` into a single flat object schema and drop the union keyword, preserving `required` semantics:

- `allOf`: every branch applies, so the **union** of branch `required` fields is kept.
- `anyOf`/`oneOf`: the input matches one branch, so only properties required by **every** branch stay required (intersection); fields the branches disagree on remain optional.
- Top-level `required` entries next to the union keyword are preserved in both cases.

Applied unconditionally at the AI SDK provider boundary, so it covers every tool source (builtin, MCP, plugin, hand-written) and every provider path. This mirrors opencode's approach (`ToolSchemaProjection.openAI` flattens top-level unions unconditionally on its OpenAI-compatible wire); our version additionally preserves `required`, which opencode drops. Flattening is advertisement-only — tools still validate their real input shapes inside `execute()`, matching the adapter's existing design of leaving schema validation to the tools themselves.

### Test Procedure

**Reproduced the exact bug first** (on `main`): registered a minimal stdio MCP server advertising a tool whose `inputSchema` is a top-level `anyOf` of two object shapes, ran the CLI against `anthropic/claude-sonnet-4.6` via OpenRouter. The turn failed with `Provider returned error` and the log shows the exact reported message. Wire capture (`CLINE_CAPTURE_WIRE`) confirmed the tool went out as `{"type":"object","anyOf":[...]}`.

**Verified the fix end-to-end**: same setup after the change — the request succeeds, the wire capture shows the tool advertised as a flat object schema with zero top-level unions, and the model successfully *calls* the MCP tool through the flattened schema and reports its result (`entity found: demo`). Also verified interactively in the TUI.

**Unit tests**: three regression tests driving the real OpenAI-compatible adapter with a capturing fetch, asserting on the serialized request body: basic `anyOf` flattening, `anyOf` with a property required by every branch (stays required), and `allOf` with `required` split across branches (the Greptile P1 case — advertises `required: ["query", "limit"]`). `@cline/llms`: 595 tests pass.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Wire-captured schema for the MCP tool after the fix (was `{"type":"object","anyOf":[...]}` before):

```json
{
  "type": "object",
  "properties": {
    "id": { "type": "string", "description": "Entity id" },
    "name": { "type": "string", "description": "Entity name" }
  }
}
```

End-to-end tool call on this branch:

```
[union-schema-server__lookup_entity] {"name":"demo"}
   ⎿ {"content":[{"type":"text","text":"entity found: demo"}]}
The lookup returned a simple confirmation: the entity named **"demo"** was found.
```

### Additional Notes

The only remaining known simplification: conflicting property definitions across branches resolve last-wins rather than emitting a nested `anyOf`. That has no failure mode beyond slightly less precise advertisement (opencode has the same behavior), so it is left out to keep the change minimal.