### PR TITLE
Fix CLI hanging on "Thinking..." forever when the model stream stalls

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -261,6 +261,161 @@ describe("AgentRuntime", () => {
 		expect(prepareTurn.mock.calls[1]?.[0].overflowRecovery).toBe(true);
 	});
 
+	it("retries a turn whose model stream stalled and completes on the retry", async () => {
+		const stallEvent: AgentModelEvent = {
+			type: "finish",
+			reason: "error",
+			error: "Model stream stalled: Chunk timeout of 120000ms exceeded",
+			errorClass: "stream_stalled",
+		};
+		const model = new ScriptedModel([
+			() => [{ type: "reasoning-delta", text: "The user wants" }, stallEvent],
+			() => [
+				{ type: "text-delta", text: "recovered" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const statusNotices: Array<{ message: string; metadata?: unknown }> = [];
+		const runtime = new AgentRuntime({ model });
+		runtime.subscribe((event) => {
+			if (event.type === "status-notice") {
+				statusNotices.push({
+					message: event.message,
+					metadata: event.metadata,
+				});
+			}
+		});
+
+		vi.useFakeTimers();
+		try {
+			const pending = runtime.run("Hi");
+			await vi.advanceTimersByTimeAsync(30_000);
+			const result = await pending;
+
+			expect(result.status).toBe("completed");
+			expect(result.outputText).toBe("recovered");
+			expect(model.requests).toHaveLength(2);
+			// The stalled attempt's partial reasoning is not committed.
+			expect(
+				result.messages.some((message) =>
+					message.content.some(
+						(part) =>
+							part.type === "reasoning" && part.text.includes("The user wants"),
+					),
+				),
+			).toBe(false);
+			expect(statusNotices).toContainEqual(
+				expect.objectContaining({
+					message: expect.stringContaining("stream stalled — retrying"),
+					metadata: expect.objectContaining({
+						kind: "stream_stall_recovery",
+					}),
+				}),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("fails the run after exhausting stall retries", async () => {
+		const stallStep = () =>
+			[
+				{
+					type: "finish",
+					reason: "error",
+					error: "Model stream stalled: First chunk timeout of 180000ms exceeded",
+					errorClass: "stream_stalled",
+				} as AgentModelEvent,
+			] as const;
+		const model = new ScriptedModel([stallStep, stallStep, stallStep]);
+		const statusNotices: string[] = [];
+		const runtime = new AgentRuntime({ model });
+		runtime.subscribe((event) => {
+			if (event.type === "status-notice") {
+				statusNotices.push(event.message);
+			}
+		});
+
+		vi.useFakeTimers();
+		try {
+			const pending = runtime.run("Hi");
+			await vi.advanceTimersByTimeAsync(60_000);
+			const result = await pending;
+
+			// 1 initial attempt + MAX_STREAM_STALL_RETRIES retries.
+			expect(model.requests).toHaveLength(3);
+			expect(statusNotices).toHaveLength(2);
+			expect(result.status).toBe("failed");
+			expect(result.error?.message).toContain("Model stream stalled");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not retry a stalled turn that already produced a tool call", async () => {
+		// An errored stream that produced tool calls proceeds through the
+		// normal loop (executing the partial work) instead of being retried —
+		// a retry would discard the tool call the model already committed to.
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_1",
+					toolName: "echo",
+					input: { text: "hi" },
+					inputText: '{"text":"hi"}',
+				},
+				{
+					type: "finish",
+					reason: "error",
+					error: "Model stream stalled: Chunk timeout of 120000ms exceeded",
+					errorClass: "stream_stalled",
+				},
+			],
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const statusNotices: string[] = [];
+		const runtime = new AgentRuntime({ model, tools: [createEchoTool()] });
+		runtime.subscribe((event) => {
+			if (event.type === "status-notice") {
+				statusNotices.push(event.message);
+			}
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(model.requests).toHaveLength(2);
+		expect(statusNotices).toHaveLength(0);
+	});
+
+	it("does not retry a stalled turn after the run was aborted", async () => {
+		let abortRuntime: (() => void) | undefined;
+		const model = new ScriptedModel([
+			() => {
+				abortRuntime?.();
+				return [
+					{
+						type: "finish",
+						reason: "error",
+						error: "Model stream stalled: Chunk timeout of 120000ms exceeded",
+						errorClass: "stream_stalled",
+					} as AgentModelEvent,
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({ model });
+		abortRuntime = () => runtime.abort("user cancelled");
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("aborted");
+		expect(model.requests).toHaveLength(1);
+	});
+
 	it("does not treat an unrelated stream failure as an overflow", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -323,7 +323,8 @@ describe("AgentRuntime", () => {
 				{
 					type: "finish",
 					reason: "error",
-					error: "Model stream stalled: First chunk timeout of 180000ms exceeded",
+					error:
+						"Model stream stalled: First chunk timeout of 180000ms exceeded",
 					errorClass: "stream_stalled",
 				} as AgentModelEvent,
 			] as const;

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -705,8 +705,8 @@ export class AgentRuntime {
 					iteration: this.state.iteration,
 				});
 
-			const { message, finishReason } =
-				await this.generateAssistantMessageWithRecovery();
+				const { message, finishReason } =
+					await this.generateAssistantMessageWithRecovery();
 				if (finishReason === "aborted") {
 					throw this.normalizeAbortError();
 				}

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -72,6 +72,15 @@ export const CONTEXT_WINDOW_OVERFLOW_RECOVERY_FAILED_MESSAGE =
 export const CONTEXT_WINDOW_OVERFLOW_NO_RECOVERY_MESSAGE =
 	"The conversation exceeds the model's context window. Compact the conversation, start a new session, or switch to a model with a larger context window.";
 
+/**
+ * Retries for a turn whose model stream stalled (the provider connection
+ * went silent and the model layer's stall watchdog aborted it — error class
+ * `stream_stalled`). The stalled attempt produced no committed state, so
+ * re-running the request is safe; a fresh connection usually succeeds.
+ */
+const MAX_STREAM_STALL_RETRIES = 2;
+const STREAM_STALL_RETRY_BASE_DELAY_MS = 2_000;
+
 /** Thrown when overflow recovery cannot proceed; carries the terminal text. */
 class ContextWindowOverflowError extends Error {
 	constructor(message: string, providerError: string | undefined) {
@@ -696,8 +705,8 @@ export class AgentRuntime {
 					iteration: this.state.iteration,
 				});
 
-				const { message, finishReason } =
-					await this.generateAssistantMessageWithOverflowRecovery();
+			const { message, finishReason } =
+				await this.generateAssistantMessageWithRecovery();
 				if (finishReason === "aborted") {
 					throw this.normalizeAbortError();
 				}
@@ -880,6 +889,77 @@ export class AgentRuntime {
 		for (const hook of this.hooks.afterRun) {
 			await hook({ snapshot: this.snapshot(), result });
 		}
+	}
+
+	/**
+	 * Run a model turn with both recovery layers: context-overflow recovery
+	 * (below) and stalled-stream retries. A turn that failed because the
+	 * provider stream went silent (`stream_stalled`, raised by the model
+	 * layer's stall watchdog) committed nothing, so it is retried up to
+	 * {@link MAX_STREAM_STALL_RETRIES} times with a short backoff instead of
+	 * failing the whole run. Turns that stalled *after* producing tool calls
+	 * are not retried — the normal loop executes that partial work (matching
+	 * the errored-stream behavior in `execute`).
+	 */
+	private async generateAssistantMessageWithRecovery(): Promise<{
+		message: AgentMessage;
+		finishReason: AgentModelFinishReason;
+	}> {
+		for (let attempt = 0; ; attempt++) {
+			const turn = await this.generateAssistantMessageWithOverflowRecovery();
+			const stalled =
+				turn.finishReason === "error" &&
+				this.state.lastErrorClass === "stream_stalled" &&
+				!turn.message.content.some((part) => part.type === "tool-call");
+			if (
+				!stalled ||
+				attempt >= MAX_STREAM_STALL_RETRIES ||
+				this.abortController?.signal.aborted
+			) {
+				return turn;
+			}
+			const providerError = this.state.lastError;
+			this.config.logger?.log?.("Model stream stalled; retrying turn", {
+				severity: "warn",
+				iteration: this.state.iteration,
+				attempt: attempt + 1,
+				maxAttempts: MAX_STREAM_STALL_RETRIES,
+				providerError,
+			});
+			await this.emit({
+				type: "status-notice",
+				snapshot: this.snapshot(),
+				message: `model stream stalled — retrying (attempt ${attempt + 1}/${MAX_STREAM_STALL_RETRIES})`,
+				metadata: {
+					kind: "stream_stall_recovery",
+					reason: "stream_stall_recovery",
+					phase: "started",
+					iteration: this.state.iteration,
+					providerError,
+				},
+			});
+			await this.waitBeforeStallRetry(
+				STREAM_STALL_RETRY_BASE_DELAY_MS * (attempt + 1),
+			);
+			this.throwIfAborted();
+		}
+	}
+
+	/** Backoff between stall retries that wakes up immediately on abort. */
+	private async waitBeforeStallRetry(delayMs: number): Promise<void> {
+		const signal = this.abortController?.signal;
+		if (signal?.aborted) {
+			return;
+		}
+		await new Promise<void>((resolve) => {
+			const finish = () => {
+				clearTimeout(timer);
+				signal?.removeEventListener("abort", finish);
+				resolve();
+			};
+			const timer = setTimeout(finish, delayMs);
+			signal?.addEventListener("abort", finish, { once: true });
+		});
 	}
 
 	/**

--- a/sdk/packages/llms/src/providers/ai-sdk.stream-stall.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.stream-stall.test.ts
@@ -1,0 +1,315 @@
+import type {
+	AgentModelEvent,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+	createOpenAICompatibleProvider,
+	DEFAULT_STREAM_CHUNK_TIMEOUT_MS,
+	DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
+	resolveStreamStallTimeouts,
+} from "./ai-sdk";
+
+/**
+ * Stream-stall watchdog tests (ENG: CLI hangs on "Thinking..." forever).
+ *
+ * A provider stream that stops delivering chunks while keeping the
+ * connection open (half-open TCP, dead proxy hop — observed with hosted
+ * gateway providers on long reasoning turns) used to hang the agent turn
+ * forever: no timeout existed anywhere on the streaming path, so the CLI
+ * showed a permanent "Thinking..." spinner until the process was killed.
+ *
+ * These tests drive the real adapter + real `ai` package with a fake wire
+ * response that stalls at various points, and prove the watchdog turns the
+ * silent hang into a `finish { reason: "error", errorClass:
+ * "stream_stalled" }` the agent loop can retry.
+ */
+
+const encoder = new TextEncoder();
+
+const chunk = (delta: unknown, finish: string | null = null) =>
+	`data: ${JSON.stringify({
+		id: "cmpl-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "test-model",
+		choices: [{ index: 0, delta, finish_reason: finish }],
+	})}\n\n`;
+
+/**
+ * A fetch whose SSE body emits `prefix` and then stalls forever. Mirrors
+ * real fetch semantics: when the request's abort signal fires, the pending
+ * body read rejects with the signal's reason (the watchdog's TimeoutError).
+ */
+function stallingFetch(prefix: string[]) {
+	return vi.fn(async (_url: unknown, init?: RequestInit) => {
+		const signal = init?.signal ?? undefined;
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const part of prefix) {
+					controller.enqueue(encoder.encode(part));
+				}
+				signal?.addEventListener(
+					"abort",
+					() => {
+						try {
+							controller.error(
+								signal.reason ?? new DOMException("aborted", "AbortError"),
+							);
+						} catch {
+							// stream already errored/closed
+						}
+					},
+					{ once: true },
+				);
+			},
+		});
+		return new Response(stream, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	});
+}
+
+function completingFetch(body: string) {
+	return vi.fn(
+		async () =>
+			new Response(body, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+	);
+}
+
+async function collect(
+	iterable: AsyncIterable<AgentModelEvent>,
+): Promise<AgentModelEvent[]> {
+	const events: AgentModelEvent[] = [];
+	for await (const event of iterable) {
+		events.push(event);
+	}
+	return events;
+}
+
+function streamRequest(
+	overrides: Partial<GatewayStreamRequest> = {},
+): GatewayStreamRequest {
+	return {
+		providerId: "cline",
+		modelId: "test-model",
+		messages: [
+			{
+				id: "msg_user",
+				role: "user",
+				content: [{ type: "text", text: "do the thing" }],
+				createdAt: new Date(),
+			},
+		],
+		tools: [],
+		...overrides,
+	} as unknown as GatewayStreamRequest;
+}
+
+function providerContext(config: Record<string, unknown>) {
+	const model = { id: "test-model", providerId: "cline", name: "test-model" };
+	return {
+		provider: {
+			id: "cline",
+			name: "cline",
+			defaultModelId: "test-model",
+			models: [model],
+		},
+		model,
+		config,
+	} as unknown as GatewayProviderContext;
+}
+
+async function runStream(input: {
+	fetch: ReturnType<typeof vi.fn>;
+	timeoutMs?: number;
+	request?: GatewayStreamRequest;
+}) {
+	const config = {
+		providerId: "cline",
+		apiKey: "test-key",
+		baseUrl: "http://fake.local/v1",
+		timeoutMs: input.timeoutMs,
+		fetch: input.fetch as unknown as typeof fetch,
+	};
+	const provider = await createOpenAICompatibleProvider(config);
+	return collect(
+		await provider.stream(
+			input.request ?? streamRequest(),
+			providerContext(config),
+		),
+	);
+}
+
+function finishEvent(events: AgentModelEvent[]) {
+	const finishes = events.filter((event) => event.type === "finish");
+	expect(finishes).toHaveLength(1);
+	return finishes[0] as Extract<AgentModelEvent, { type: "finish" }>;
+}
+
+describe("resolveStreamStallTimeouts", () => {
+	it("applies the global defaults when nothing is configured", () => {
+		expect(resolveStreamStallTimeouts({}, {})).toEqual({
+			firstChunkMs: DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
+			chunkMs: DEFAULT_STREAM_CHUNK_TIMEOUT_MS,
+		});
+	});
+
+	it("prefers the request apiTimeoutMs over everything else", () => {
+		expect(
+			resolveStreamStallTimeouts(
+				{ apiTimeoutMs: 600_000 },
+				{ timeoutMs: 30_000 },
+				{ firstChunkMs: 1, chunkMs: 1 },
+			),
+		).toEqual({ firstChunkMs: 600_000, chunkMs: 600_000 });
+	});
+
+	it("falls back to the provider config timeoutMs", () => {
+		expect(
+			resolveStreamStallTimeouts({}, { timeoutMs: 45_000 }),
+		).toEqual({ firstChunkMs: 45_000, chunkMs: 45_000 });
+	});
+
+	it("uses vendor fallbacks below config overrides", () => {
+		expect(
+			resolveStreamStallTimeouts(
+				{},
+				{},
+				{ firstChunkMs: 300_000, chunkMs: 300_000 },
+			),
+		).toEqual({ firstChunkMs: 300_000, chunkMs: 300_000 });
+	});
+
+	it("lets a vendor opt out entirely", () => {
+		expect(resolveStreamStallTimeouts({}, {}, false)).toBeUndefined();
+	});
+
+	it("ignores non-positive and non-finite overrides", () => {
+		expect(
+			resolveStreamStallTimeouts(
+				{ apiTimeoutMs: 0 },
+				{ timeoutMs: Number.NaN },
+			),
+		).toEqual({
+			firstChunkMs: DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
+			chunkMs: DEFAULT_STREAM_CHUNK_TIMEOUT_MS,
+		});
+	});
+});
+
+describe("stream-stall watchdog (openai-compatible wire format)", () => {
+	it("fails a turn whose stream stalls mid-reasoning", async () => {
+		const events = await runStream({
+			fetch: stallingFetch([
+				chunk({ role: "assistant" }),
+				chunk({ reasoning_content: "The user wants" }),
+			]),
+			timeoutMs: 150,
+		});
+
+		expect(
+			events.some(
+				(event) =>
+					event.type === "reasoning-delta" &&
+					event.text.includes("The user wants"),
+			),
+		).toBe(true);
+		const finish = finishEvent(events);
+		expect(finish.reason).toBe("error");
+		expect(finish.errorClass).toBe("stream_stalled");
+		expect(finish.error).toMatch(/stalled/i);
+		expect(finish.error).toMatch(/timeout/i);
+	});
+
+	it("fails a turn whose stream never produces a first chunk", async () => {
+		const events = await runStream({
+			fetch: stallingFetch([]),
+			timeoutMs: 150,
+		});
+
+		const finish = finishEvent(events);
+		expect(finish.reason).toBe("error");
+		expect(finish.errorClass).toBe("stream_stalled");
+		expect(finish.error).toMatch(/first chunk timeout/i);
+	});
+
+	it("fails a turn whose stream stalls mid-text", async () => {
+		const events = await runStream({
+			fetch: stallingFetch([
+				chunk({ role: "assistant" }),
+				chunk({ content: "Let me start working on th" }),
+			]),
+			timeoutMs: 150,
+		});
+
+		const finish = finishEvent(events);
+		expect(finish.reason).toBe("error");
+		expect(finish.errorClass).toBe("stream_stalled");
+	});
+
+	it("honors the request-level apiTimeoutMs override", async () => {
+		const events = await runStream({
+			fetch: stallingFetch([chunk({ role: "assistant" })]),
+			// Provider config would wait far longer; the request override
+			// must win so agent-level apiTimeoutMs works end to end.
+			timeoutMs: 60_000,
+			request: streamRequest({ apiTimeoutMs: 150 }),
+		});
+
+		const finish = finishEvent(events);
+		expect(finish.reason).toBe("error");
+		expect(finish.errorClass).toBe("stream_stalled");
+	});
+
+	it("never classifies a caller abort as stream_stalled", async () => {
+		const controller = new AbortController();
+		const fetchMock = stallingFetch([
+			chunk({ role: "assistant" }),
+			chunk({ content: "partial" }),
+		]);
+		const pending = runStream({
+			fetch: fetchMock,
+			timeoutMs: 60_000,
+			request: streamRequest({ signal: controller.signal }),
+		});
+		// Let the stream start, then cancel like the user pressing Esc.
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		controller.abort();
+		const events = await pending;
+
+		// A caller abort may still surface as a generic finish error (the
+		// usage promise rejects — pre-existing behavior the agent loop
+		// ignores because its own signal is aborted), but it must never be
+		// classified as a stall, or the runtime would retry a turn the user
+		// intentionally cancelled.
+		const finish = finishEvent(events);
+		expect(finish.errorClass).not.toBe("stream_stalled");
+		expect(finish.error ?? "").not.toMatch(/stalled/i);
+	});
+
+	it("does not interfere with a healthy turn", async () => {
+		const events = await runStream({
+			fetch: completingFetch(
+				chunk({ role: "assistant" }) +
+					chunk({ content: "hello" }) +
+					chunk({}, "stop") +
+					"data: [DONE]\n\n",
+			),
+			timeoutMs: 5_000,
+		});
+
+		const finish = finishEvent(events);
+		expect(finish.reason).toBe("stop");
+		expect(
+			events.some(
+				(event) => event.type === "text-delta" && event.text === "hello",
+			),
+		).toBe(true);
+	});
+});

--- a/sdk/packages/llms/src/providers/ai-sdk.stream-stall.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.stream-stall.test.ts
@@ -171,9 +171,10 @@ describe("resolveStreamStallTimeouts", () => {
 	});
 
 	it("falls back to the provider config timeoutMs", () => {
-		expect(
-			resolveStreamStallTimeouts({}, { timeoutMs: 45_000 }),
-		).toEqual({ firstChunkMs: 45_000, chunkMs: 45_000 });
+		expect(resolveStreamStallTimeouts({}, { timeoutMs: 45_000 })).toEqual({
+			firstChunkMs: 45_000,
+			chunkMs: 45_000,
+		});
 	});
 
 	it("uses vendor fallbacks below config overrides", () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -1163,9 +1163,12 @@ async function* emitAiSdkEvents(
 					// surface it as a stream error so the turn fails visibly
 					// (and can be retried) instead of being accepted truncated.
 					if (!request.signal?.aborted) {
+						// The reason is the watchdog's DOMException serialized as
+						// "TimeoutError: Chunk timeout of Nms exceeded" — drop the
+						// error-name prefix, the message already says "timeout".
 						const reason =
 							typeof part.reason === "string" && part.reason.trim().length > 0
-								? part.reason.trim()
+								? part.reason.trim().replace(/^TimeoutError:\s*/, "")
 								: "stream aborted without a reason";
 						const message = `Model stream stalled: ${reason}`;
 						const reported = captureSdkError(context.telemetry, {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -81,6 +81,61 @@ export function buildAiSdkStreamConfig(
 	};
 }
 
+/**
+ * Default bound on the wait for the first content chunk of a model turn.
+ * Generous because hosted reasoning models can queue and process large
+ * prompts for a while before emitting anything.
+ */
+export const DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS = 180_000;
+
+/**
+ * Default bound on the silence between content chunks once a turn has
+ * started streaming. Providers emit deltas continuously while generating;
+ * a multi-minute gap with zero output almost always means the connection
+ * died without the socket closing (half-open TCP, dead proxy hop).
+ */
+export const DEFAULT_STREAM_CHUNK_TIMEOUT_MS = 120_000;
+
+function positiveTimeoutMs(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? Math.floor(value)
+		: undefined;
+}
+
+/**
+ * Resolve the stream-stall watchdog passed to the AI SDK's `timeout` option.
+ * Without it, a provider stream that stops delivering chunks while keeping
+ * the connection open hangs the agent turn forever — the user sees a
+ * permanent "Thinking..." spinner and has to kill the process (ENG report:
+ * frequent with long reasoning turns routed through gateway providers).
+ *
+ * Precedence: request `apiTimeoutMs` (agent config) > provider config
+ * `timeoutMs` > vendor `stallTimeouts` fallback > global defaults. Vendors
+ * can return `stallTimeouts: false` to opt out entirely.
+ */
+export function resolveStreamStallTimeouts(
+	request: Pick<GatewayStreamRequest, "apiTimeoutMs">,
+	config: Pick<GatewayResolvedProviderConfig, "timeoutMs">,
+	vendorFallback?: ProviderFactoryResult["stallTimeouts"],
+): { firstChunkMs: number; chunkMs: number } | undefined {
+	if (vendorFallback === false) {
+		return undefined;
+	}
+	const override =
+		positiveTimeoutMs(request.apiTimeoutMs) ??
+		positiveTimeoutMs(config.timeoutMs);
+	return {
+		firstChunkMs:
+			override ??
+			positiveTimeoutMs(vendorFallback?.firstChunkMs) ??
+			DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
+		chunkMs:
+			override ??
+			positiveTimeoutMs(vendorFallback?.chunkMs) ??
+			DEFAULT_STREAM_CHUNK_TIMEOUT_MS,
+	};
+}
+
 function buildAiSdkRequestMessages(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
@@ -1099,7 +1154,38 @@ async function* emitAiSdkEvents(
 				}
 
 				if (part.type === "abort") {
-					// abort
+					// The AI SDK emits `abort` both for caller-requested
+					// cancellation and for its internal stall watchdog (the
+					// `timeout` option wired in `createAiSdkProvider`). Caller
+					// aborts keep the silent-finish behavior — the agent loop
+					// already handles them via its own abort signal. A watchdog
+					// abort means the provider connection went silent mid-turn:
+					// surface it as a stream error so the turn fails visibly
+					// (and can be retried) instead of being accepted truncated.
+					if (!request.signal?.aborted) {
+						const reason =
+							typeof part.reason === "string" && part.reason.trim().length > 0
+								? part.reason.trim()
+								: "stream aborted without a reason";
+						const message = `Model stream stalled: ${reason}`;
+						const reported = captureSdkError(context.telemetry, {
+							component: "llms",
+							operation: "provider.stream",
+							error: new Error(message),
+							errorMessage: message,
+							severity: "error",
+							handled: true,
+							context: {
+								providerId: request.providerId,
+								modelId: request.modelId,
+							},
+						});
+						streamError = {
+							message,
+							errorClass: "stream_stalled",
+							reported,
+						};
+					}
 					break;
 				}
 			}
@@ -1303,6 +1389,11 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				const requestConfig = provider.buildStreamConfig
 					? provider.buildStreamConfig(request, context)
 					: buildAiSdkStreamConfig(request, context);
+				const stallTimeouts = resolveStreamStallTimeouts(
+					request,
+					config,
+					provider.stallTimeouts,
+				);
 				recordProviderRequestCapture({
 					stage: "ai_sdk_prompt",
 					request,
@@ -1324,6 +1415,11 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					...(useSystemOption ? { system: systemPrompt } : {}),
 					...(tools ? { tools } : {}),
 					abortSignal: request.signal,
+					// Stall watchdog: bounds the wait for the first content chunk
+					// and the silence between chunks so a dead provider stream
+					// fails the turn instead of hanging it forever. Fires as an
+					// `abort` stream part handled in `emitAiSdkEvents`.
+					...(stallTimeouts ? { timeout: stallTimeouts } : {}),
 					experimental_repairToolCall: repairMalformedToolCall as never,
 					experimental_telemetry: {
 						isEnabled: langfuse,

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -926,7 +926,10 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		defaultModelId: "",
 		apiKeyEnv: ["LMSTUDIO_API_KEY"],
 		modelsProviderId: "lmstudio",
-		defaults: { baseUrl: "http://localhost:1234/v1" },
+		// Local inference goes silent for minutes during model load and
+		// prompt processing; widen the stream-stall watchdog accordingly
+		// (same allowance as the Ollama vendor default).
+		defaults: { baseUrl: "http://localhost:1234/v1", timeoutMs: 300_000 },
 		modelsSourceUrl: "http://localhost:1234/v1/models",
 	},
 	{

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1154,8 +1154,9 @@ export function resolveProviderApiLineBaseUrl(
 	if (!isProviderApiLine(apiLine)) {
 		return undefined;
 	}
-	return API_LINE_BASE_URLS_BY_PROVIDER_ID.get(normalizeProviderId(providerId))
-		?.[apiLine];
+	return API_LINE_BASE_URLS_BY_PROVIDER_ID.get(
+		normalizeProviderId(providerId),
+	)?.[apiLine];
 }
 
 function getModels(spec: BuiltinSpec): Record<string, ModelInfo> {

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -170,6 +170,10 @@ class GatewayModelAdapter implements AgentModel {
 				legacyReasoning,
 				requestedReasoning,
 			),
+			apiTimeoutMs:
+				typeof request.options?.apiTimeoutMs === "number"
+					? request.options.apiTimeoutMs
+					: undefined,
 			signal: request.signal ?? this.defaults?.signal,
 		});
 	}

--- a/sdk/packages/llms/src/providers/vendors/ollama.ts
+++ b/sdk/packages/llms/src/providers/vendors/ollama.ts
@@ -154,5 +154,13 @@ export async function createOllamaProviderModule(
 				model: provider.chat(modelId),
 				middleware: splitToolImagesMiddleware,
 			}),
+		// Local backends legitimately go silent for minutes (model load,
+		// prompt processing on CPU), so widen the central stall watchdog to
+		// the same allowance as the response-start timeout above. Explicit
+		// request/provider `timeoutMs` overrides still win.
+		stallTimeouts: {
+			firstChunkMs: OLLAMA_DEFAULT_TIMEOUT_MS,
+			chunkMs: OLLAMA_DEFAULT_TIMEOUT_MS,
+		},
 	};
 }

--- a/sdk/packages/llms/src/providers/vendors/types.ts
+++ b/sdk/packages/llms/src/providers/vendors/types.ts
@@ -17,6 +17,16 @@ export interface ProviderFactoryResult {
 	 * unset for the defaults.
 	 */
 	retryEmptyResponses?: false | Omit<RetryEmptyResponseOptions, "logger">;
+	/**
+	 * Vendor fallback for the stream-stall watchdog applied at the central
+	 * composition point in `ai-sdk.ts`. A stalled provider stream (an open
+	 * connection that stops delivering chunks) otherwise hangs the agent turn
+	 * forever. Request- and provider-config overrides always win; this field
+	 * only replaces the global defaults — e.g. local backends (Ollama) allow
+	 * longer silences for model loading and prompt processing. Set `false` to
+	 * opt a vendor out entirely.
+	 */
+	stallTimeouts?: false | { firstChunkMs?: number; chunkMs?: number };
 	buildStreamConfig?: (
 		request: GatewayStreamRequest,
 		context: GatewayProviderContext,

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -243,7 +243,10 @@ export type AgentModelFinishReason =
  * runtime's recovery policy and telemetry (`error_class`). Extend with new
  * classes (auth, rate_limit, billing, ...) as consumers need them.
  */
-export type ProviderErrorClass = "context_window_exceeded" | "unknown";
+export type ProviderErrorClass =
+	| "context_window_exceeded"
+	| "stream_stalled"
+	| "unknown";
 
 export type AgentModelEvent =
 	| { type: "text-delta"; text: string }

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -187,6 +187,14 @@ export interface GatewayStreamRequest {
 		effort?: ReasoningEffort;
 		budgetTokens?: number;
 	};
+	/**
+	 * Caller override for the stream-stall watchdog (`AgentConfig.apiTimeoutMs`
+	 * reaches the gateway through this field). Bounds both the wait for the
+	 * first content chunk and the silence between chunks; when unset the
+	 * provider config's `timeoutMs`, vendor defaults, and finally the global
+	 * stall defaults apply. See `resolveStreamStallTimeouts` in `@cline/llms`.
+	 */
+	apiTimeoutMs?: number;
 	signal?: AbortSignal;
 }
 


### PR DESCRIPTION
### Related Issue

User report: "It stops work midway a lot of times, and then just says 'thinking,' at which point I have to kill the terminal and restart the session - happened 5+ times." (observed with Kimi K3 via the Cline usage-based provider)

### Description

**Root cause.** The model streaming path had no timeout of any kind. When a provider stream stops delivering chunks while keeping the connection open (half-open TCP, dead proxy hop — the Cline provider proxies to OpenRouter/Moonshot, so there are several hops that can die silently), the `for await` over the stream blocks forever:

- `streamText` was called without the AI SDK's `timeout` option (`ai-sdk.ts`), so there was no first-chunk or inter-chunk bound (only Ollama had a response-*start* timeout, and it never covered the body).
- The hub's `session.send_input` command deliberately has no timeout, so the turn promise never settles.
- The TUI's `isStreaming`/reasoning-entry state is only cleared by a content/done/error event — none ever arrives, hence the permanent "Thinking..." spinner. This is especially visible with reasoning models like Kimi K3 whose turns spend a long time in the reasoning phase.

Reproduced deterministically by pointing the real `cline` provider (`CLINE_API_BASE_URL`) at a mock SSE backend that streams a few reasoning deltas and then goes silent: the TUI stays on "Thinking..." forever (verified for 60+ seconds; only Esc or killing the terminal gets out, and a `finish` was never produced).

**Fix (three layers):**

1. **Stall watchdog (`@cline/llms`)** — `streamText` now gets `timeout: { firstChunkMs, chunkMs }` via the new `resolveStreamStallTimeouts()`. Defaults: 180s to first content chunk, 120s max silence between chunks. Precedence: request `apiTimeoutMs` (agent config) > provider config `timeoutMs` > vendor fallback > defaults. Ollama and LM Studio widen to 300s because local backends legitimately go silent during model load / prompt processing (Ollama's existing response-start semantics are preserved).
2. **Honest failure instead of silent truncation (`@cline/llms`)** — the AI SDK surfaces a watchdog abort as an `abort` stream part, which `emitAiSdkEvents` previously swallowed as a normal finish (that would have accepted a truncated turn as complete). A watchdog abort (abort part without the caller's signal being aborted) now produces `finish { reason: "error", errorClass: "stream_stalled" }` with a clear message, and is reported to telemetry so stall frequency is measurable. Caller aborts (Esc) keep their existing behavior and are never classified as stalls.
3. **Automatic retry (`@cline/agents`)** — a turn that failed with `stream_stalled` and produced no tool calls is retried up to 2 times with 2s/4s backoff and a visible status notice ("model stream stalled — retrying (attempt N/2)"). The stalled attempt committed nothing, so the retry is safe; turns that stalled *after* emitting tool calls keep the existing errored-stream behavior of executing the partial work. Retries wake immediately on abort.

Also wired up `AgentConfig.apiTimeoutMs` end to end (`GatewayStreamRequest.apiTimeoutMs`) — it was declared, defaulted, and set by callers (e.g. agent teams set 10 minutes for teammates) but consumed by nothing.

Worst case a user now waits ~3 minutes and then sees an actionable error with the input usable again — and transient stalls self-heal invisibly. Because the fix is in the shared model layer, it covers the CLI (local and hub backends), the VS Code extension, and the SDK.

### Test Procedure

- **New unit tests, `@cline/llms`** (`ai-sdk.stream-stall.test.ts`, 12 tests): drives the real adapter + real `ai` package with a fake SSE wire that stalls mid-reasoning / mid-text / before the first chunk; asserts `stream_stalled` error finishes, timeout precedence (request > provider config > vendor > defaults), vendor opt-out, that caller aborts are never classified as stalls, and that healthy streams are untouched.
- **New unit tests, `@cline/agents`** (4 tests): stalled turn retried and completes; run fails after exhausting retries (3 total attempts, 2 notices); tool-call-carrying stalled turn not retried; aborted run not retried.
- **Full suites**: `@cline/shared` 325 ✓, `@cline/llms` 604 ✓, `@cline/agents` 67 ✓, `@cline/cli` unit 1107 ✓, `@cline/core` unit 1732 ✓ (2 pre-existing environment failures: the documented `workspace-manifest` cloud-VM git artifact and flaky checkpoint hook timeouts, both unrelated). `bun run types` ✓, biome ✓ on changed files.
- **End-to-end TUI verification (tuistory)**: ran the real interactive CLI against a mock stalled Cline backend with an 8s provider `timeout`:
  - *Before the fix*: permanent "Thinking..." spinner, task hung indefinitely (see first screenshot).
  - *After the fix*: stall detected, two visible retries, then a clear error with the input usable again (second screenshot); and with a backend that stalls once then recovers, the retry rescued the task with no user intervention.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before — stream stalls mid-reasoning and the TUI hangs on "Thinking..." forever:

(attach: before_fix_stuck_thinking_forever.png)

After — stall detected (8s test timeout), two automatic retries with visible notices, then a clear actionable error and a usable prompt:

(attach: after_fix_stall_retries_then_clear_error.png)

### Additional Notes

- The watchdog only counts *content* chunks; Cline's tools carry no `execute` callbacks, so each `streamText` call is a single model step and tool execution time can never trip the inter-chunk timer.
- Stalls are now measurable in telemetry (`sdk.error` with `error_class: stream_stalled`), which should confirm how often this was happening in the wild.