### PR TITLE
ci: stop over-long changelogs from silently dropping release Slack posts

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -206,12 +206,40 @@ jobs:
 
       - name: Get Changelog Entry
         id: changelog
+        env:
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}
         run: |
           # Grab content between the first "## " header and the next one in apps/cli/CHANGELOG.md
           CONTENT=$(awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' apps/cli/CHANGELOG.md)
           echo "content<<EOF" >> $GITHUB_OUTPUT
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+          # Slack section blocks reject text longer than 3000 characters, and the
+          # Slack action logs that rejection WITHOUT failing the step - so an
+          # over-long changelog silently drops the release announcement while the
+          # run stays green (cline@3.0.50 hit this). Post a trimmed copy to Slack
+          # and link out to the full notes. The GitHub release body stays whole.
+          SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+          import os
+          content = os.environ["CONTENT"]
+          more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+          if len(content) <= 3000:
+              print(content, end="")
+          else:
+              budget = 3000 - len(more)
+              kept, used = [], 0
+              for line in content.splitlines(keepends=True):
+                  if used + len(line) > budget:
+                      break
+                  kept.append(line)
+                  used += len(line)
+              body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+              print(body + more, end="")
+          ')
+          echo "slack_content<<SLACK_EOF" >> $GITHUB_OUTPUT
+          echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+          echo "SLACK_EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -248,7 +276,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ${{ toJSON(steps.changelog.outputs.content) }}
+                  text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
               - type: "context"
                 elements:
                   - type: "mrkdwn"

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -506,6 +506,33 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           printf "%s\n" "$CONTENT" > "$RUNNER_TEMP/release-notes.md"
 
+          # Slack section blocks reject text longer than 3000 characters, and the
+          # Slack action logs that rejection WITHOUT failing the step - so an
+          # over-long changelog silently drops the release announcement while the
+          # run stays green. Post a trimmed copy to Slack and link out to the full
+          # notes. The GitHub release body and updater manifest stay whole.
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ needs.validate.outputs.tag }}"
+          SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+          import os
+          content = os.environ["CONTENT"]
+          more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+          if len(content) <= 3000:
+              print(content, end="")
+          else:
+              budget = 3000 - len(more)
+              kept, used = [], 0
+              for line in content.splitlines(keepends=True):
+                  if used + len(line) > budget:
+                      break
+                  kept.append(line)
+                  used += len(line)
+              body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+              print(body + more, end="")
+          ')
+          echo "slack_content<<SLACK_EOF" >> $GITHUB_OUTPUT
+          echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+          echo "SLACK_EOF" >> $GITHUB_OUTPUT
+
       - name: Generate updater manifest
         env:
           VERSION: ${{ needs.validate.outputs.version }}
@@ -621,7 +648,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ${{ toJSON(steps.changelog.outputs.content) }}
+                  text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
               - type: "context"
                 elements:
                   - type: "mrkdwn"

--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -492,6 +492,35 @@ jobs:
                     echo "CHANGELOG_EOF"
                   } >> "$GITHUB_OUTPUT"
 
+                  # Slack section blocks reject text longer than 3000 characters, and
+                  # the Slack action logs that rejection WITHOUT failing the step - so
+                  # an over-long changelog silently drops the release announcement
+                  # while the run stays green. Post a trimmed copy to Slack and link
+                  # out to the full notes. The GitHub release body stays whole.
+                  RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${{ github.event.inputs.version }}"
+                  SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+                  import os
+                  content = os.environ["CONTENT"]
+                  more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+                  if len(content) <= 3000:
+                      print(content, end="")
+                  else:
+                      budget = 3000 - len(more)
+                      kept, used = [], 0
+                      for line in content.splitlines(keepends=True):
+                          if used + len(line) > budget:
+                              break
+                          kept.append(line)
+                          used += len(line)
+                      body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+                      print(body + more, end="")
+                  ')
+                  {
+                    echo "slack_content<<CHANGELOG_EOF"
+                    echo "$SLACK_CONTENT"
+                    echo "CHANGELOG_EOF"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Resolve previous release tag
               id: prev_tag
               if: ${{ !cancelled() && steps.publish_marketplace.outcome == 'success' }}
@@ -547,7 +576,7 @@ jobs:
                       - type: "section"
                         text:
                           type: "mrkdwn"
-                          text: ${{ toJSON(steps.changelog.outputs.content) }}
+                          text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
                       - type: "context"
                         elements:
                           - type: "mrkdwn"

--- a/.github/workflows/ext-vscode-publish-legacy.yml
+++ b/.github/workflows/ext-vscode-publish-legacy.yml
@@ -266,6 +266,33 @@ jobs:
                   echo "$CONTENT" >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT
 
+                  # Slack section blocks reject text longer than 3000 characters, and
+                  # the Slack action logs that rejection WITHOUT failing the step - so
+                  # an over-long changelog silently drops the release announcement
+                  # while the run stays green. Post a trimmed copy to Slack and link
+                  # out to the full notes. The GitHub release body stays whole.
+                  RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ steps.resolve_tag.outputs.tag }}"
+                  SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+                  import os
+                  content = os.environ["CONTENT"]
+                  more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+                  if len(content) <= 3000:
+                      print(content, end="")
+                  else:
+                      budget = 3000 - len(more)
+                      kept, used = [], 0
+                      for line in content.splitlines(keepends=True):
+                          if used + len(line) > budget:
+                              break
+                          kept.append(line)
+                          used += len(line)
+                      body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+                      print(body + more, end="")
+                  ')
+                  echo "slack_content<<SLACK_EOF" >> $GITHUB_OUTPUT
+                  echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+                  echo "SLACK_EOF" >> $GITHUB_OUTPUT
+
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1
               with:
@@ -295,7 +322,7 @@ jobs:
                       - type: "section"
                         text:
                           type: "mrkdwn"
-                          text: ${{ toJSON(steps.changelog.outputs.content) }}
+                          text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
                       - type: "context"
                         elements:
                           - type: "mrkdwn"

--- a/.github/workflows/ext-vscode-publish-stable.yml
+++ b/.github/workflows/ext-vscode-publish-stable.yml
@@ -234,6 +234,33 @@ jobs:
                   echo "$CONTENT" >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT
 
+                  # Slack section blocks reject text longer than 3000 characters, and
+                  # the Slack action logs that rejection WITHOUT failing the step - so
+                  # an over-long changelog silently drops the release announcement
+                  # while the run stays green. Post a trimmed copy to Slack and link
+                  # out to the full notes. The GitHub release body stays whole.
+                  RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ steps.resolve_tag.outputs.tag }}"
+                  SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+                  import os
+                  content = os.environ["CONTENT"]
+                  more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+                  if len(content) <= 3000:
+                      print(content, end="")
+                  else:
+                      budget = 3000 - len(more)
+                      kept, used = [], 0
+                      for line in content.splitlines(keepends=True):
+                          if used + len(line) > budget:
+                              break
+                          kept.append(line)
+                          used += len(line)
+                      body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+                      print(body + more, end="")
+                  ')
+                  echo "slack_content<<SLACK_EOF" >> $GITHUB_OUTPUT
+                  echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+                  echo "SLACK_EOF" >> $GITHUB_OUTPUT
+
             - name: Package and Publish Extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -303,7 +330,7 @@ jobs:
                       - type: "section"
                         text:
                           type: "mrkdwn"
-                          text: ${{ toJSON(steps.changelog.outputs.content) }}
+                          text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
                       - type: "context"
                         elements:
                           - type: "mrkdwn"

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -282,6 +282,33 @@ jobs:
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
+          # Slack section blocks reject text longer than 3000 characters, and the
+          # Slack action logs that rejection WITHOUT failing the step - so an
+          # over-long changelog silently drops the release announcement while the
+          # run stays green. Post a trimmed copy to Slack and link out to the full
+          # notes. The GitHub release body stays whole.
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/sdk/sdk/v${{ steps.version.outputs.version }}"
+          SLACK_CONTENT=$(CONTENT="$CONTENT" RELEASE_URL="$RELEASE_URL" python3 -c '
+          import os
+          content = os.environ["CONTENT"]
+          more = "\n\n… <%s|Read the full release notes>" % os.environ["RELEASE_URL"]
+          if len(content) <= 3000:
+              print(content, end="")
+          else:
+              budget = 3000 - len(more)
+              kept, used = [], 0
+              for line in content.splitlines(keepends=True):
+                  if used + len(line) > budget:
+                      break
+                  kept.append(line)
+                  used += len(line)
+              body = "".join(kept).rstrip() if kept else content[:budget].rstrip()
+              print(body + more, end="")
+          ')
+          echo "slack_content<<${DELIMITER}" >> $GITHUB_OUTPUT
+          echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+          echo "${DELIMITER}" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         if: steps.check_commits.outputs.skip != 'true' && steps.channel.outputs.channel == 'latest'
         uses: softprops/action-gh-release@v1
@@ -333,7 +360,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ${{ toJSON(steps.changelog.outputs.content) }}
+                  text: ${{ toJSON(steps.changelog.outputs.slack_content) }}
               - type: "context"
                 elements:
                   - type: "mrkdwn"


### PR DESCRIPTION
### Related Issue

None — found while cutting the `cline@3.0.50` release today.

### Description

**The `cline@3.0.50` release published to npm, pushed its tag, and created its GitHub release — but never posted to Slack, and the run stayed green.**

Slack's `section` block rejects `text` longer than 3000 characters. Every publish workflow pastes the top changelog section verbatim into a single section block, so an over-long changelog produces:

```
##[error]failed to match all allowed schemas [json-pointer:/blocks/1/text]
##[error]must be less than 3000 characters [json-pointer:/blocks/1/text/text]
```

The critical part: `slackapi/slack-github-action@v3.0.1` logs those as `##[error]` but **does not fail the step**. The step's conclusion was `success`. Nothing turned red, no annotation surfaced on the run summary, and the only way to notice was someone asking "how come the CLI release didn't post to Slack?" — which is exactly how this was found, hours later.

The CLI 3.0.50 section was 3272 characters. For reference, how close the others were to the same cliff at the time:

| Release | Top changelog section | Margin |
| --- | --- | --- |
| CLI 3.0.50 | 3272 | **over by 272** |
| SDK 0.0.70 | 2840 | 160 |
| Extension 4.1.4 | 2649 | 351 |
| Desktop 0.0.9 | 2267 | 733 |

So this wasn't one unlucky workflow. All six publish workflows share the pattern, and the SDK was ~160 characters from silently dropping its announcement too. Any release with a slightly wordier changelog would have hit it.

#### Approach

Each `changelog` step now emits a second output, `slack_content`, next to the existing `content`:

- section fits in 3000 → passed through **byte-identical**
- section is longer → whole lines kept up to a budget of `3000 - len(suffix)`, then `… <release-url|Read the full release notes>` appended

Only the Slack payload switches to `slack_content`. GitHub release bodies, and the desktop updater manifest notes, still receive the complete section — truncation is a Slack display concern and shouldn't degrade the canonical record.

Trimming happens on a line boundary rather than a hard character cut so the message never ends mid-word or mid-markdown-link. There's a fallback to a hard cut for the pathological case of a single first line already exceeding the budget.

#### Why inline rather than a shared script

The obvious cleanup is one `.github/scripts/` helper instead of six copies. That doesn't work here: `ext-vscode-publish-legacy.yml` checks out the `legacy-extension` branch, so a script living on `main` wouldn't exist in its workspace. Keeping each workflow self-contained avoids a cross-branch coupling that would fail only during a legacy hotfix — the worst possible time to discover it.

#### Considered and rejected

- **Dropping `continue-on-error` so a failed post turns the run red.** Doesn't help: the step already reports `success`. The action swallows the failure itself, so there's nothing for `continue-on-error` to act on. Fixing that properly means checking the action's response, which is a larger change than the problem warrants.
- **Splitting long changelogs across multiple section blocks.** More faithful, but Slack caps a message at 50 blocks and long release notes read badly as a wall of text in a channel. A trimmed summary plus a link is the better read.

### Test Procedure

Inline Python inside a YAML block scalar is exactly where indentation bugs hide, and none of this executes until a real release. So rather than eyeballing it, I parsed each workflow, extracted the `changelog` step's actual `run` script, substituted `${{ }}` expressions, and executed it against synthetic changelogs.

**Over-limit input** (~6000 char section) — all six trim correctly and include the link:

| Workflow | `slack_content` | ≤3000 | link |
| --- | --- | --- | --- |
| cli-publish | 2976 | ✅ | ✅ |
| sdk-publish | 2870 | ✅ | ✅ |
| desktop-publish | 2861 | ✅ | ✅ |
| ext-vscode-ab-package | 2862 | ✅ | ✅ |
| ext-vscode-publish-legacy | 2861 | ✅ | ✅ |
| ext-vscode-publish-stable | 2861 | ✅ | ✅ |

**Under-limit input** — all six pass through byte-identical with no link appended, confirming normal releases are unaffected.

**The real regression case**: the actual `cline@3.0.50` changelog section runs 3272 → 2948 characters, cut cleanly at a bullet boundary.

Also verified all six still parse as valid YAML, and that no Slack payload references the raw `content` output anymore.

What could break: the extraction `awk` in each step is untouched, so `content` — which feeds the GitHub release bodies and the desktop updater manifest — is unchanged. The blast radius is limited to the text inside the Slack message. `python3` is present on both the `ubuntu-latest` and `macos-latest` runner images; the desktop `release` job that runs this is on `ubuntu-latest` regardless.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Workflow-only change; nothing ships to users.

Two follow-ups deliberately left out of scope:

1. **The `cline@3.0.50` Slack announcement was never posted and this doesn't backfill it.** Re-dispatching the publish workflow would attempt a republish, so if that post is wanted it should go up by hand.
2. **The silent-success behaviour of the Slack action itself is still there.** This change removes the trigger, not the underlying trap — any other payload validation error (a malformed block, a bad channel id) would still pass silently. Worth revisiting if it bites again.
