### PR TITLE
fix(vscode): show Authenticate button when MCP OAuth token refresh fails mid-session

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -580,8 +580,14 @@ export class McpHub {
 						Logger.error(`Transport error for "${name}":`, error)
 						const connection = this.findConnection(name, source)
 						if (connection) {
-							connection.server.status = "disconnected"
-							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
+							if (error instanceof UnauthorizedError) {
+								// auth() returned 'REDIRECT' mid-session: tokens were cleared and
+								// re-authorization is required. Mirror the connectToServer catch path.
+								this.markConnectionUnauthenticated(connection)
+							} else {
+								connection.server.status = "disconnected"
+								this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
+							}
 						}
 						// onerror's promise is discarded, so a rejection here
 						// would surface as an unhandled rejection
@@ -678,24 +684,7 @@ export class McpHub {
 			} catch (error) {
 				if (error instanceof UnauthorizedError) {
 					// Server requires OAuth authentication
-					Logger.log(`Server "${name}" requires OAuth authentication`)
-					const unauthConnection: McpConnection = {
-						server: {
-							name,
-							config: JSON.stringify(config),
-							status: "disconnected",
-							disabled: false,
-							oauthRequired: true,
-							oauthAuthStatus: "unauthenticated",
-							error: "This MCP server requires authentication to get started.",
-						},
-						client,
-						transport,
-						authProvider, // CRITICAL: Keep authProvider so it's available when user authenticates!
-					}
-					// Replace the connection with unauthenticated version
-					this.connections = this.connections.filter((conn) => conn.server.name !== name)
-					this.connections.push(unauthConnection)
+					this.markConnectionUnauthenticated(connection)
 					await this.notifyWebviewOfServerChanges()
 					return // Don't throw, just mark as needs auth
 				}
@@ -816,6 +805,26 @@ export class McpHub {
 	private appendErrorMessage(connection: McpConnection, error: string) {
 		const newError = connection.server.error ? `${connection.server.error}\n${error}` : error
 		connection.server.error = newError //.slice(0, 800)
+	}
+
+	private markConnectionUnauthenticated(connection: McpConnection): void {
+		Logger.log(`Server "${connection.server.name}" requires OAuth authentication`)
+		const unauthConnection: McpConnection = {
+			server: {
+				name: connection.server.name,
+				config: connection.server.config,
+				status: "disconnected",
+				disabled: false,
+				oauthRequired: true,
+				oauthAuthStatus: "unauthenticated",
+				error: "This MCP server requires authentication to get started.",
+			},
+			client: connection.client,
+			transport: connection.transport,
+			authProvider: connection.authProvider,
+		}
+		this.connections = this.connections.filter((conn) => conn.server.name !== connection.server.name)
+		this.connections.push(unauthConnection)
 	}
 
 	/**


### PR DESCRIPTION
### Description

When the SSE transport's `onerror` fires with an `UnauthorizedError` (the MCP SDK exhausted re-auth and called `redirectToAuthorization`), the connection is now marked unauthenticated so the UI shows the `Authenticate` button instead of `Retry connection`.

Refactors the duplicate unauthenticated-connection construction into a shared `markConnectionUnauthenticated()` helper used by both the `onerror` handler and the `connectToServer` catch block.

### Test Procedure

Prerequisites: An MCP server that supports OAuth 2.0 with token refresh configured and a working OAuth setup.

1. Authenticate successfully — confirm the server shows as connected and tools are available.
2. Wait until both the access token and the refresh token have expired (refresh tokens typically have a lifetime of hours to days — check the server's configuration).
3. Trigger a reconnect — either disable/re-enable the server or wait for Cline to send an MCP request.
4. Expected: The server shows the `Authenticate` button.
    Before fix: The server showed `Retry connection`, and clicking it looped without ever showing `Authenticate`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
