### PR TITLE
refactor(telemetry): unify telemetry transport and settings gating in the SDK bundle

### DIFF
--- a/.changeset/unify-telemetry-transport-gating.md
+++ b/.changeset/unify-telemetry-transport-gating.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Unify telemetry transport and settings gating: all telemetry in the extension now flows through one shared set of exporters and one settings checkpoint. Runtime `CLINE_OTEL_*` configuration (the documented enterprise/self-hosted override) now applies to all telemetry in the process — previously part of it only honored build-time configuration and ignored the runtime variables.

--- a/apps/vscode/.env.example
+++ b/apps/vscode/.env.example
@@ -22,67 +22,78 @@ ERROR_SERVICE_API_KEY=your-posthog-error-tracking-api-key
 # OpenTelemetry provides flexible telemetry collection with multiple export options
 # Can run alongside PostHog or independently
 # Primary focus: Logs (events), with optional metrics support
+#
+# Two env-var families with distinct roles (both pipelines share one config):
+# - OTEL_*        build-time only: always inlined into the bundle by esbuild
+#                 (set them in the shell that runs the build, e.g. the publish
+#                 workflow). Values in .env have NO effect on OTEL_* because
+#                 .env is only loaded at runtime.
+# - CLINE_OTEL_*  runtime only: read live from the environment in every build,
+#                 so this is the family to use here for local debugging.
+#                 NOTE: a CLINE_OTEL_* collector currently exports telemetry
+#                 even if you opted out of Cline telemetry (deliberate debug
+#                 escape hatch; see services/telemetry/telemetry-policy.ts).
 
-# Enable OpenTelemetry (set to 1 to enable)
-# OTEL_TELEMETRY_ENABLED=1
+# Enable OpenTelemetry at runtime (set to "true" to enable)
+# CLINE_OTEL_TELEMETRY_ENABLED=true
 
 # Exporters: "console" for local debugging, "otlp" for remote collector
 # Logs are the primary signal (recommended)
-# OTEL_LOGS_EXPORTER=console
-# OTEL_METRICS_EXPORTER=otlp
+# CLINE_OTEL_LOGS_EXPORTER=console
+# CLINE_OTEL_METRICS_EXPORTER=otlp
 
 # OTLP Protocol: "grpc", "http/json", or "http/protobuf"
-# OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+# CLINE_OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 # OTLP Endpoint (without /v1/logs or /v1/metrics path - auto-appended)
 # For gRPC: use "localhost:4317" (no http:// prefix)
 # For HTTP: use "http://localhost:4318"
-# OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+# CLINE_OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 
 # OTLP Headers (for authentication, e.g., bearer tokens)
-# OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token-here
+# CLINE_OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token-here
 
 # Use insecure gRPC connections (for local testing only, NOT for production)
-# OTEL_EXPORTER_OTLP_INSECURE=true
+# CLINE_OTEL_EXPORTER_OTLP_INSECURE=true
 
 # Metric export interval in milliseconds (default: 60000)
-# OTEL_METRIC_EXPORT_INTERVAL=10000
+# CLINE_OTEL_METRIC_EXPORT_INTERVAL=10000
 
 # Batch configuration for logs (optional)
-# OTEL_LOG_BATCH_SIZE=512              # Max logs per batch (default: 512)
-# OTEL_LOG_BATCH_TIMEOUT=5000          # Max wait time in ms (default: 5000)
-# OTEL_LOG_MAX_QUEUE_SIZE=2048         # Max queue size (default: 2048)
+# CLINE_OTEL_LOG_BATCH_SIZE=512        # Max logs per batch (default: 512)
+# CLINE_OTEL_LOG_BATCH_TIMEOUT=5000    # Max wait time in ms (default: 5000)
+# CLINE_OTEL_LOG_MAX_QUEUE_SIZE=2048   # Max queue size (default: 2048)
 
 # Enable detailed export diagnostics (for debugging)
 # TEL_DEBUG_DIAGNOSTICS=true
 
 # Advanced: Separate endpoints for metrics and logs (optional)
-# OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
-# OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://metrics.example.com:4318
-# OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc
-# OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=logs.example.com:4317
+# CLINE_OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
+# CLINE_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://metrics.example.com:4318
+# CLINE_OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc
+# CLINE_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=logs.example.com:4317
 
 # Example configurations:
 #
 # Console debugging (logs only):
-#   OTEL_TELEMETRY_ENABLED=true
-#   OTEL_LOGS_EXPORTER=console
+#   CLINE_OTEL_TELEMETRY_ENABLED=true
+#   CLINE_OTEL_LOGS_EXPORTER=console
 #   TEL_DEBUG_DIAGNOSTICS=true
 #
 # OTLP with gRPC (insecure, for local testing):
-#   OTEL_TELEMETRY_ENABLED=true
-#   OTEL_LOGS_EXPORTER=otlp
-#   OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-#   OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
-#   OTEL_EXPORTER_OTLP_INSECURE=true
-#   OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token
+#   CLINE_OTEL_TELEMETRY_ENABLED=true
+#   CLINE_OTEL_LOGS_EXPORTER=otlp
+#   CLINE_OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+#   CLINE_OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+#   CLINE_OTEL_EXPORTER_OTLP_INSECURE=true
+#   CLINE_OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token
 #
-# OTLP with HTTP/JSON (production):
-#   OTEL_TELEMETRY_ENABLED=true
-#   OTEL_LOGS_EXPORTER=otlp
-#   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com
-#   OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token
+# OTLP with HTTP/JSON:
+#   CLINE_OTEL_TELEMETRY_ENABLED=true
+#   CLINE_OTEL_LOGS_EXPORTER=otlp
+#   CLINE_OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+#   CLINE_OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com
+#   CLINE_OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token
 
 # ============================================================================
 # OBJECT STORE CONFIGURATION

--- a/apps/vscode/esbuild.mjs
+++ b/apps/vscode/esbuild.mjs
@@ -109,28 +109,23 @@ if (process.env.ERROR_SERVICE_API_KEY) {
 	buildEnvVars["process.env.ERROR_SERVICE_API_KEY"] = JSON.stringify(process.env.ERROR_SERVICE_API_KEY)
 }
 
-// OpenTelemetry configuration (injected at build time from GitHub secrets)
-// These provide production defaults that can be overridden at runtime via environment variables
-if (process.env.OTEL_TELEMETRY_ENABLED) {
-	buildEnvVars["process.env.OTEL_TELEMETRY_ENABLED"] = JSON.stringify(process.env.OTEL_TELEMETRY_ENABLED)
-}
-if (process.env.OTEL_LOGS_EXPORTER) {
-	buildEnvVars["process.env.OTEL_LOGS_EXPORTER"] = JSON.stringify(process.env.OTEL_LOGS_EXPORTER)
-}
-if (process.env.OTEL_METRICS_EXPORTER) {
-	buildEnvVars["process.env.OTEL_METRICS_EXPORTER"] = JSON.stringify(process.env.OTEL_METRICS_EXPORTER)
-}
-if (process.env.OTEL_EXPORTER_OTLP_PROTOCOL) {
-	buildEnvVars["process.env.OTEL_EXPORTER_OTLP_PROTOCOL"] = JSON.stringify(process.env.OTEL_EXPORTER_OTLP_PROTOCOL)
-}
-if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
-	buildEnvVars["process.env.OTEL_EXPORTER_OTLP_ENDPOINT"] = JSON.stringify(process.env.OTEL_EXPORTER_OTLP_ENDPOINT)
-}
-if (process.env.OTEL_EXPORTER_OTLP_HEADERS) {
-	buildEnvVars["process.env.OTEL_EXPORTER_OTLP_HEADERS"] = JSON.stringify(process.env.OTEL_EXPORTER_OTLP_HEADERS)
-}
-if (process.env.OTEL_METRIC_EXPORT_INTERVAL) {
-	buildEnvVars["process.env.OTEL_METRIC_EXPORT_INTERVAL"] = JSON.stringify(process.env.OTEL_METRIC_EXPORT_INTERVAL)
+// OpenTelemetry build-time configuration (injected from GitHub secrets in the
+// publish workflows). The OTEL_* family is strictly build-time: every variable
+// is ALWAYS inlined — as "" when unset — so dev and prod bundles have identical
+// semantics and a user's runtime OTEL_* environment can never leak into either
+// pipeline. Runtime overrides/debugging use the CLINE_OTEL_* family, which is
+// read live from the environment (see shared/services/config/otel-config.ts).
+for (const otelVar of [
+	"OTEL_TELEMETRY_ENABLED",
+	"OTEL_LOGS_EXPORTER",
+	"OTEL_METRICS_EXPORTER",
+	"OTEL_TRACES_EXPORTER",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_HEADERS",
+	"OTEL_METRIC_EXPORT_INTERVAL",
+]) {
+	buildEnvVars[`process.env.${otelVar}`] = JSON.stringify(process.env[otelVar] || "")
 }
 // Base configuration shared between extension and standalone builds
 const baseConfig = {

--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -16,7 +16,9 @@ import { ErrorService } from "./services/error"
 import { featureFlagsService } from "./services/feature-flags"
 import { getDistinctId } from "./services/logging/distinctId"
 import { telemetryService } from "./services/telemetry"
+import { disposeSharedOtelClients } from "./services/telemetry/otel-clients"
 import { PostHogClientProvider } from "./services/telemetry/providers/posthog/PostHogClientProvider"
+import { disposeTelemetryPolicy } from "./services/telemetry/telemetry-policy"
 import { ClineTempManager } from "./services/temp"
 import { ShowMessageType } from "./shared/proto/host/window"
 import { syncWorker } from "./shared/services/worker/sync"
@@ -169,6 +171,10 @@ export async function tearDown(): Promise<void> {
 		AgentConfigLoader.getInstance()?.dispose()
 		PostHogClientProvider.getInstance().dispose()
 		telemetryService.dispose()
+		// Both telemetry pipelines write through the shared OTel clients; shut
+		// them down (flushing pending batches) after the services stop capturing.
+		await disposeSharedOtelClients()
+		disposeTelemetryPolicy()
 		ErrorService.get().dispose()
 		featureFlagsService.dispose()
 		// Dispose all webview instances

--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -171,10 +171,6 @@ export async function tearDown(): Promise<void> {
 		AgentConfigLoader.getInstance()?.dispose()
 		PostHogClientProvider.getInstance().dispose()
 		telemetryService.dispose()
-		// Both telemetry pipelines write through the shared OTel clients; shut
-		// them down (flushing pending batches) after the services stop capturing.
-		await disposeSharedOtelClients()
-		disposeTelemetryPolicy()
 		ErrorService.get().dispose()
 		featureFlagsService.dispose()
 		// Dispose all webview instances
@@ -188,6 +184,15 @@ export async function tearDown(): Promise<void> {
 		HookDiscoveryCache.getInstance().dispose()
 		// Stop periodic temp file cleanup
 		ClineTempManager.stopPeriodicCleanup()
+
+		// Shut the shared OpenTelemetry clients down LAST: both telemetry
+		// pipelines export through them, so the exporters have to outlive every
+		// capture site. In particular the SDK pipeline is torn down inside
+		// WebviewProvider.disposeAllInstances() above and still emits while doing
+		// so (session end, the deferred telemetry.provider_created), so shutting
+		// the clients down any earlier silently drops those records.
+		await disposeSharedOtelClients()
+		disposeTelemetryPolicy()
 	} finally {
 		try {
 			await StateManager.get().flushPendingState()

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -1,16 +1,17 @@
 import type { ConfiguredTelemetryHandle, ITelemetryService } from "@cline/core"
 import type { Mock } from "vitest"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetTelemetryPolicyForTests } from "@/services/telemetry/telemetry-policy"
 import { Setting } from "@/shared/proto/index.host"
 
-const coreTelemetryMocks = vi.hoisted(() => ({
-	createConfig: vi.fn((config: Record<string, unknown>) => config),
-	createHandle: vi.fn(),
+const otelClientMocks = vi.hoisted(() => ({
+	clients: [] as unknown[],
+	flush: vi.fn(async () => {}),
 }))
 
-vi.mock("@cline/core", () => ({
-	createClineTelemetryServiceConfig: coreTelemetryMocks.createConfig,
-	createConfiguredTelemetryHandle: coreTelemetryMocks.createHandle,
+vi.mock("@/services/telemetry/otel-clients", () => ({
+	getSharedOtelClients: () => otelClientMocks.clients,
+	flushSharedOtelClients: otelClientMocks.flush,
 }))
 
 const telemetryState = vi.hoisted(() => ({
@@ -59,8 +60,39 @@ vi.mock("@/hosts/host-provider", () => ({
 
 import { createVscodeSdkTelemetryHandle, VscodeTelemetryPolicyService } from "./sdk-telemetry"
 
-describe("VscodeTelemetryPolicyService", () => {
+interface EmittedRecord {
+	body: string
+	attributes: Record<string, unknown>
+}
+
+function createFakeSharedClient(overrides: { id?: string; bypassUserSettings?: boolean } = {}) {
+	const emitted: EmittedRecord[] = []
+	const client = {
+		meterProvider: null,
+		loggerProvider: {
+			getLogger: () => ({
+				emit: (record: EmittedRecord) => {
+					emitted.push(record)
+				},
+			}),
+			forceFlush: vi.fn(async () => {}),
+			shutdown: vi.fn(async () => {}),
+		},
+	}
+	return {
+		emitted,
+		shared: {
+			id: overrides.id ?? "build-time",
+			client,
+			config: { enabled: true, logsExporter: "otlp", otlpProtocol: "http/json", otlpEndpoint: "https://collector.example" },
+			bypassUserSettings: overrides.bypassUserSettings ?? false,
+		},
+	}
+}
+
+describe("createVscodeSdkTelemetryHandle (shared-stack construction)", () => {
 	beforeEach(() => {
+		resetTelemetryPolicyForTests()
 		telemetryState.clineTelemetrySetting = "unset"
 		telemetryState.hostSetting = Setting.ENABLED
 		telemetryState.hostVersion = {
@@ -72,8 +104,8 @@ describe("VscodeTelemetryPolicyService", () => {
 		telemetryState.hostVersionGate = undefined
 		telemetryState.subscribeCallback = undefined
 		telemetryState.unsubscribe.mockReset()
-		coreTelemetryMocks.createConfig.mockClear()
-		coreTelemetryMocks.createHandle.mockReset()
+		otelClientMocks.clients = []
+		otelClientMocks.flush.mockClear()
 		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "")
 	})
 
@@ -81,73 +113,153 @@ describe("VscodeTelemetryPolicyService", () => {
 		vi.unstubAllEnvs()
 	})
 
-	it("constructs the handle with unknown host identity fallbacks", () => {
-		// The policy service overrides these from getHostVersion before any event is
-		// emitted; "unknown" must survive a failed lookup instead of a VSCode mislabel.
-		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+	it("exports events through the shared clients with resolved host identity metadata", async () => {
+		const { emitted, shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
 
-		createVscodeSdkTelemetryHandle()
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
 
-		expect(coreTelemetryMocks.createConfig).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({
-					cline_type: "unknown",
-					platform: "unknown",
-					platform_version: "unknown",
-				}),
-			}),
-		)
+		handle.telemetry.capture({ event: "session.started", properties: { sessionId: "s1" } })
+
+		const event = emitted.find((record) => record.body === "session.started")
+		expect(event).toBeDefined()
+		expect(event?.attributes).toMatchObject({
+			sessionId: "s1",
+			cline_type: "VSCode Extension",
+			platform: "VS Code",
+			platform_version: "1.103.0",
+		})
 	})
 
-	it("defers the provider_created event so it carries resolved host identity", () => {
-		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+	it("keeps the unknown host identity fallbacks when the host version lookup fails", async () => {
+		// "unknown" must survive a failed lookup instead of a VSCode mislabel.
+		telemetryState.hostVersionError = new Error("host bridge unavailable")
+		const { emitted, shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
 
-		createVscodeSdkTelemetryHandle()
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
 
-		expect(coreTelemetryMocks.createHandle).toHaveBeenCalledWith(
-			expect.objectContaining({
-				deferProviderCreatedEvent: true,
-			}),
-		)
+		handle.telemetry.capture({ event: "session.started" })
+
+		const event = emitted.find((record) => record.body === "session.started")
+		expect(event?.attributes).toMatchObject({
+			cline_type: "unknown",
+			platform: "unknown",
+			platform_version: "unknown",
+		})
 	})
 
-	it("adds rollout metadata as SDK common properties", () => {
+	it("emits provider_created once, after the host identity metadata is applied", async () => {
+		const { emitted, shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
+
+		createVscodeSdkTelemetryHandle()
+		await settlePromises()
+
+		const providerCreated = emitted.filter((record) => record.body === "telemetry.provider_created")
+		expect(providerCreated).toHaveLength(1)
+		expect(providerCreated[0].attributes).toMatchObject({
+			provider: "opentelemetry",
+			enabled: true,
+			cline_type: "VSCode Extension",
+			_required: true,
+		})
+	})
+
+	it("omits provider_created when no shared clients are configured", async () => {
+		otelClientMocks.clients = []
+
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
+
+		// Zero destinations: the handle reports disabled and nothing throws.
+		expect(handle.telemetry.isEnabled()).toBe(false)
+	})
+
+	it("adds rollout metadata as SDK common properties", async () => {
 		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "next")
-		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+		const { emitted, shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
 
-		createVscodeSdkTelemetryHandle()
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
+		handle.telemetry.capture({ event: "session.started" })
 
-		expect(coreTelemetryMocks.createHandle).toHaveBeenCalledWith(
-			expect.objectContaining({
-				commonProperties: {
-					extension_variant: "next",
-				},
-			}),
-		)
+		const event = emitted.find((record) => record.body === "session.started")
+		expect(event?.attributes).toMatchObject({ extension_variant: "next" })
 	})
 
-	it("omits SDK rollout common properties from ordinary builds", () => {
-		coreTelemetryMocks.createHandle.mockReturnValue(createHandle())
+	it("gates each destination by its own bypass flag when the user opts out", async () => {
+		telemetryState.clineTelemetrySetting = "disabled"
+		const prod = createFakeSharedClient({ id: "build-time", bypassUserSettings: false })
+		const runtime = createFakeSharedClient({ id: "runtime-env", bypassUserSettings: true })
+		otelClientMocks.clients = [prod.shared, runtime.shared]
 
-		createVscodeSdkTelemetryHandle()
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
 
-		expect(coreTelemetryMocks.createHandle).toHaveBeenCalledWith(
-			expect.objectContaining({
-				commonProperties: {},
-			}),
-		)
+		handle.telemetry.capture({ event: "task.created" })
+
+		expect(prod.emitted.filter((record) => record.body === "task.created")).toHaveLength(0)
+		expect(runtime.emitted.filter((record) => record.body === "task.created")).toHaveLength(1)
 	})
 
-	it("drops ordinary events until the async host telemetry setting resolves", () => {
+	it("flushes the shared clients instead of shutting them down on dispose", async () => {
+		const { shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
+
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
+		await handle.dispose()
+
+		expect(otelClientMocks.flush).toHaveBeenCalled()
+		expect(shared.client.loggerProvider.shutdown).not.toHaveBeenCalled()
+	})
+})
+
+describe("VscodeTelemetryPolicyService", () => {
+	beforeEach(() => {
+		resetTelemetryPolicyForTests()
+		telemetryState.clineTelemetrySetting = "unset"
+		telemetryState.hostSetting = Setting.ENABLED
+		telemetryState.hostVersion = {
+			platform: "VS Code",
+			version: "1.103.0",
+			clineType: "VSCode Extension",
+		}
+		telemetryState.hostVersionError = undefined
+		telemetryState.hostVersionGate = undefined
+		telemetryState.subscribeCallback = undefined
+		telemetryState.unsubscribe.mockReset()
+		otelClientMocks.clients = []
+		otelClientMocks.flush.mockClear()
+		vi.stubEnv("CLINE_ROLLOUT_VARIANT", "")
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it("drops every event until the host identity metadata resolves", () => {
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 
 		service.capture({ event: "session.started" })
+		service.captureRequired("user.opt_out")
+		service.recordCounter("cline.turns.total", 1)
 
 		expect(handle.telemetry.capture).not.toHaveBeenCalled()
+		expect(handle.telemetry.captureRequired).not.toHaveBeenCalled()
+		expect(handle.telemetry.recordCounter).not.toHaveBeenCalled()
 	})
 
-	it("allows ordinary events when host telemetry is enabled and Cline telemetry is not disabled", async () => {
+	it("forwards ordinary events once metadata is ready; destinations gate on the shared policy", async () => {
+		// Even with the user opted out, ordinary events reach the handle so a
+		// bypass-enabled destination (runtime env collector) can still export
+		// them — exactly like the classic pipeline's providers.
+		telemetryState.clineTelemetrySetting = "disabled"
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
@@ -157,58 +269,64 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "session.started", properties: { sessionId: "s1" } })
 	})
 
-	it("drops ordinary events when Cline telemetry is disabled but allows required events while host telemetry is enabled", async () => {
+	it("reports isEnabled false when the user opted out even though events are forwarded", async () => {
 		telemetryState.clineTelemetrySetting = "disabled"
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
 
-		service.capture({ event: "task.created" })
+		expect(service.isEnabled()).toBe(false)
+	})
+
+	it("allows required events while host telemetry is enabled and the user opted out", async () => {
+		telemetryState.clineTelemetrySetting = "disabled"
+		const handle = createHandle()
+		const service = new VscodeTelemetryPolicyService(handle)
+		await settlePromises()
+
 		service.captureRequired("user.opt_out", { explicit: true })
 
-		expect(handle.telemetry.capture).not.toHaveBeenCalled()
 		expect(handle.telemetry.captureRequired).toHaveBeenCalledWith("user.opt_out", { explicit: true })
 	})
 
-	it("drops ordinary and required events when host telemetry is disabled", async () => {
+	it("drops required events when host telemetry is disabled", async () => {
 		telemetryState.hostSetting = Setting.DISABLED
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
 
-		service.capture({ event: "task.created" })
 		service.captureRequired("user.opt_out")
 
-		expect(handle.telemetry.capture).not.toHaveBeenCalled()
 		expect(handle.telemetry.captureRequired).not.toHaveBeenCalled()
 	})
 
-	it("uses host telemetry subscription updates for later events", async () => {
+	it("uses host telemetry subscription updates for later required events", async () => {
 		telemetryState.hostSetting = Setting.DISABLED
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
 
-		service.capture({ event: "task.created" })
+		service.captureRequired("user.opt_out")
 		telemetryState.subscribeCallback?.({ isEnabled: Setting.ENABLED })
-		// Subscription updates apply asynchronously, after host metadata resolution.
 		await settlePromises()
-		service.capture({ event: "task.created" })
+		service.captureRequired("user.opt_out")
 
-		expect(handle.telemetry.capture).toHaveBeenCalledTimes(1)
+		expect(handle.telemetry.captureRequired).toHaveBeenCalledTimes(1)
 	})
 
-	it("gates metrics with the same ordinary/required policy", async () => {
-		telemetryState.clineTelemetrySetting = "disabled"
+	it("gates metrics with the required policy and forwards ordinary metrics once ready", async () => {
+		telemetryState.hostSetting = Setting.DISABLED
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
 
+		// Ordinary metrics are forwarded (destination adapters gate them);
+		// required metrics still need the host setting.
 		service.recordCounter("ordinary", 1)
 		service.recordCounter("required", 1, undefined, undefined, true)
 
 		expect(handle.telemetry.recordCounter).toHaveBeenCalledTimes(1)
-		expect(handle.telemetry.recordCounter).toHaveBeenCalledWith("required", 1, undefined, undefined, true)
+		expect(handle.telemetry.recordCounter).toHaveBeenCalledWith("ordinary", 1, undefined, undefined, false)
 	})
 
 	it("applies the full host identity metadata before enabling events", async () => {
@@ -279,8 +397,7 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.telemetry.capture).toHaveBeenCalledWith({ event: "task.created" })
 	})
 
-	it("holds subscription-driven gate opens until the host identity is applied", async () => {
-		telemetryState.hostSetting = Setting.DISABLED
+	it("holds events until the host identity is applied even when the host setting is already enabled", async () => {
 		let releaseHostVersion!: () => void
 		telemetryState.hostVersionGate = new Promise((resolve) => {
 			releaseHostVersion = resolve
@@ -289,8 +406,6 @@ describe("VscodeTelemetryPolicyService", () => {
 		const service = new VscodeTelemetryPolicyService(handle)
 		await settlePromises()
 
-		telemetryState.subscribeCallback?.({ isEnabled: Setting.ENABLED })
-		await settlePromises()
 		service.capture({ event: "task.created" })
 		expect(handle.telemetry.capture).not.toHaveBeenCalled()
 		expect(handle.emitProviderCreated).not.toHaveBeenCalled()
@@ -324,7 +439,7 @@ describe("VscodeTelemetryPolicyService", () => {
 		expect(handle.emitProviderCreated).toHaveBeenCalledTimes(1)
 	})
 
-	it("always forwards metadata mutators and cleans up on dispose", async () => {
+	it("always forwards metadata mutators and disposes the handle", async () => {
 		const handle = createHandle()
 		const service = new VscodeTelemetryPolicyService(handle)
 
@@ -332,7 +447,6 @@ describe("VscodeTelemetryPolicyService", () => {
 		await service.dispose()
 
 		expect(handle.telemetry.updateCommonProperties).toHaveBeenCalledWith({ member_id: "member-1" })
-		expect(telemetryState.unsubscribe).toHaveBeenCalled()
 		expect(handle.dispose).toHaveBeenCalled()
 	})
 })

--- a/apps/vscode/src/sdk/sdk-telemetry.test.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.test.ts
@@ -132,6 +132,29 @@ describe("createVscodeSdkTelemetryHandle (shared-stack construction)", () => {
 		})
 	})
 
+	it("exports through the real @cline/core adapter, not a test double", async () => {
+		// Pins that the vitest @cline/core alias re-exports the shipped
+		// OpenTelemetryAdapter rather than a hand-written copy: attribute
+		// flattening (nested -> dot notation, arrays -> JSON) is behavior only the
+		// real adapter has, so this fails if the alias ever regresses to a stub.
+		const { emitted, shared } = createFakeSharedClient()
+		otelClientMocks.clients = [shared]
+
+		const handle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
+
+		handle.telemetry.capture({
+			event: "session.started",
+			properties: { nested: { depth: 2 }, list: [1, 2] },
+		})
+
+		const event = emitted.find((record) => record.body === "session.started")
+		expect(event?.attributes).toMatchObject({
+			"nested.depth": 2,
+			list: "[1,2]",
+		})
+	})
+
 	it("keeps the unknown host identity fallbacks when the host version lookup fails", async () => {
 		// "unknown" must survive a failed lookup instead of a VSCode mislabel.
 		telemetryState.hostVersionError = new Error("host bridge unavailable")

--- a/apps/vscode/src/sdk/sdk-telemetry.ts
+++ b/apps/vscode/src/sdk/sdk-telemetry.ts
@@ -1,18 +1,24 @@
 import {
 	type ConfiguredTelemetryHandle,
-	createClineTelemetryServiceConfig,
-	createConfiguredTelemetryHandle,
+	TelemetryService as CoreTelemetryService,
+	createClineTelemetryServiceMetadata,
 	type ITelemetryService,
+	OpenTelemetryAdapter,
+	resolveCoreDistinctId,
 	type TelemetryMetadata,
 	type TelemetryProperties,
 } from "@cline/core"
 import * as os from "os"
-import { StateManager } from "@/core/storage/StateManager"
 import { HostProvider } from "@/hosts/host-provider"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getDistinctId } from "@/services/logging/distinctId"
+import { flushSharedOtelClients, getSharedOtelClients, type SharedOtelClient } from "@/services/telemetry/otel-clients"
 import { getRolloutTelemetryMetadata } from "@/services/telemetry/rollout-metadata"
-import { Setting } from "@/shared/proto/index.host"
+import {
+	ensureTelemetryPolicyInitialized,
+	isHostTelemetryEnabled,
+	isTelemetryExportAllowed,
+} from "@/services/telemetry/telemetry-policy"
 import { Logger } from "@/shared/services/Logger"
 
 export interface VscodeSdkTelemetryHandle {
@@ -26,34 +32,8 @@ export interface CreateVscodeSdkTelemetryHandleOptions {
 	metadata?: Partial<TelemetryMetadata>
 }
 
-type TelemetrySettingsEvent = { isEnabled: Setting }
-
 export function createVscodeSdkTelemetryHandle(options: CreateVscodeSdkTelemetryHandleOptions = {}): VscodeSdkTelemetryHandle {
-	const sdkHandle =
-		options.telemetryHandle ??
-		createConfiguredTelemetryHandle({
-			...createClineTelemetryServiceConfig({
-				metadata: {
-					extension_version: ExtensionRegistryInfo.version,
-					// VscodeTelemetryPolicyService replaces these with the authoritative
-					// getHostVersion values before any event is emitted. "unknown" surfaces
-					// a failed host version lookup instead of mislabeling the host as VSCode.
-					cline_type: "unknown",
-					platform: "unknown",
-					platform_version: "unknown",
-					os_type: process.platform,
-					os_version: os.version(),
-					is_dev: process.env.IS_DEV,
-					...options.metadata,
-				},
-			}),
-			commonProperties: getRolloutTelemetryMetadata(),
-			distinctId: getDistinctId() || undefined,
-			// telemetry.provider_created is otherwise captured during construction,
-			// before the host identity resolves; VscodeTelemetryPolicyService emits
-			// it once the getHostVersion metadata has been applied.
-			deferProviderCreatedEvent: true,
-		})
+	const sdkHandle = options.telemetryHandle ?? createSharedStackTelemetryHandle(options.metadata)
 
 	const telemetry = new VscodeTelemetryPolicyService(sdkHandle)
 	return {
@@ -63,12 +43,108 @@ export function createVscodeSdkTelemetryHandle(options: CreateVscodeSdkTelemetry
 	}
 }
 
+/**
+ * Builds the SDK telemetry handle on top of the process's shared OpenTelemetry
+ * clients (see {@link getSharedOtelClients}) instead of a second, private
+ * exporter stack. One adapter is bound per shared client, each gated by the
+ * shared telemetry policy with that destination's bypass flag — so the SDK
+ * pipeline and the classic host pipeline always agree, per destination, on
+ * whether an event exports (ENG-2397).
+ */
+function createSharedStackTelemetryHandle(metadataOverrides: Partial<TelemetryMetadata> = {}): ConfiguredTelemetryHandle {
+	// The adapters' enabled closures read the shared policy state; start
+	// resolving it now so the host setting is known as early as possible.
+	void ensureTelemetryPolicyInitialized()
+
+	const metadata = createClineTelemetryServiceMetadata({
+		extension_version: ExtensionRegistryInfo.version,
+		// VscodeTelemetryPolicyService replaces these with the authoritative
+		// getHostVersion values before any event is emitted. "unknown" surfaces
+		// a failed host version lookup instead of mislabeling the host as VSCode.
+		cline_type: "unknown",
+		platform: "unknown",
+		platform_version: "unknown",
+		os_type: process.platform,
+		os_version: os.version(),
+		is_dev: process.env.IS_DEV,
+		...metadataOverrides,
+	})
+
+	const clients = getSharedOtelClients()
+	const adapters = clients.map(
+		({ client, bypassUserSettings }) =>
+			new OpenTelemetryAdapter({
+				metadata,
+				meterProvider: client.meterProvider,
+				loggerProvider: client.loggerProvider,
+				enabled: () => isTelemetryExportAllowed(bypassUserSettings),
+				// The shared clients are owned by the process-wide registry
+				// (disposed during extension teardown), not this handle.
+				ownsProviders: false,
+			}),
+	)
+
+	const telemetry = new CoreTelemetryService({
+		adapters,
+		metadata,
+		distinctId: resolveCoreDistinctId(getDistinctId() || undefined),
+		commonProperties: getRolloutTelemetryMetadata(),
+	})
+
+	const flush = async (): Promise<void> => {
+		try {
+			await flushSharedOtelClients()
+		} catch {
+			// best-effort flush; swallow to avoid blocking shutdown paths
+		}
+	}
+
+	const dispose = async (): Promise<void> => {
+		// The adapters do not own the shared clients, so this releases only the
+		// handle; the client registry shuts the exporters down at teardown.
+		await Promise.allSettled([telemetry.dispose(), flush()])
+	}
+
+	return {
+		telemetry,
+		flush,
+		dispose,
+		// telemetry.provider_created is emitted by VscodeTelemetryPolicyService
+		// once the host identity metadata has been applied (mirrors the
+		// deferProviderCreatedEvent flow the private stack used).
+		...(clients.length > 0 ? { emitProviderCreated: () => emitProviderCreated(telemetry, clients) } : {}),
+	}
+}
+
+/**
+ * Emits the same `telemetry.provider_created` event (name and attribute keys)
+ * that `createOpenTelemetryTelemetryService` in @cline/core emits, describing
+ * the primary shared destination this handle exports through.
+ */
+function emitProviderCreated(telemetry: ITelemetryService, clients: SharedOtelClient[]): void {
+	const primary = clients[0]
+	telemetry.captureRequired("telemetry.provider_created", {
+		provider: "opentelemetry",
+		enabled: true,
+		logsExporter: primary.config.logsExporter,
+		metricsExporter: primary.config.metricsExporter,
+		tracesExporter: undefined,
+		otlpProtocol: primary.config.otlpProtocol,
+		hasOtlpEndpoint: Boolean(primary.config.otlpEndpoint),
+		serviceName: undefined,
+		serviceVersion: undefined,
+	})
+}
+
 export class VscodeTelemetryPolicyService implements ITelemetryService {
-	private hostTelemetryEnabled = false
 	private disposed = false
-	private unsubscribeHostTelemetrySettings?: () => void
-	private receivedHostSubscriptionUpdate = false
 	private providerCreatedEmitted = false
+	/**
+	 * No event may be emitted before the authoritative host identity metadata is
+	 * applied; per-destination export decisions past this gate belong to the
+	 * shared telemetry policy (via the handle's adapters).
+	 */
+	private hostMetadataReady = false
 
 	constructor(private readonly handle: ConfiguredTelemetryHandle) {
 		this.initializeHostTelemetryState()
@@ -99,9 +175,11 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	}
 
 	capture(input: { event: string; properties?: TelemetryProperties }): void {
-		if (!this.isOrdinaryTelemetryAllowed()) {
+		if (!this.hostMetadataReady) {
 			return
 		}
+		// Per-destination gating (host + user settings, bypass flags) happens in
+		// the handle's adapters via the shared telemetry policy.
 		this.handle.telemetry.capture(input)
 	}
 
@@ -149,8 +227,6 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 			return
 		}
 		this.disposed = true
-		this.unsubscribeHostTelemetrySettings?.()
-		this.unsubscribeHostTelemetrySettings = undefined
 		// If the host-version lookup is still pending, emit the deferred
 		// provider_created now (with the construction-time fallback identity, as the
 		// undeferred event always did) so disposal never swallows the required event.
@@ -167,48 +243,19 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 	}
 
 	private initializeHostTelemetryState(): void {
-		// Resolve host-derived metadata first and only then let events flow: the gate
-		// below (and every subscription update) waits on this promise, so no event —
+		// The shared policy module owns the host telemetry setting (fetch +
+		// subscription); this service only sequences metadata: resolve the
+		// host-derived identity first and only then let events flow, so no event —
 		// including the deferred provider_created — is emitted before the host
 		// identity metadata is in place. Never rejects: resolveHostMetadata catches.
-		const hostMetadataApplied = this.resolveHostMetadata().then((hostMetadata) => {
+		void ensureTelemetryPolicyInitialized()
+		this.resolveHostMetadata().then((hostMetadata) => {
 			if (Object.keys(hostMetadata).length > 0) {
 				this.handle.telemetry.updateMetadata(hostMetadata)
 			}
+			this.hostMetadataReady = true
 			this.emitProviderCreatedOnce()
 		})
-
-		Promise.all([hostMetadataApplied, HostProvider.env.getTelemetrySettings({})])
-			.then(([, settings]) => {
-				// A subscription event is always newer than the initial fetch; don't
-				// let a slow fetch overwrite a setting change that already arrived.
-				if (!this.receivedHostSubscriptionUpdate) {
-					this.applyHostTelemetrySetting(settings.isEnabled)
-				}
-			})
-			.catch((error) => {
-				Logger.warn("[SdkTelemetry] Failed to read host telemetry setting; keeping SDK telemetry disabled", error)
-			})
-
-		try {
-			this.unsubscribeHostTelemetrySettings = HostProvider.env.subscribeToTelemetrySettings(
-				{},
-				{
-					onResponse: (event: TelemetrySettingsEvent) => {
-						this.receivedHostSubscriptionUpdate = true
-						// Chain on the metadata promise so a setting flip cannot open the
-						// gate while the host identity is still resolving. Chained callbacks
-						// run in attach order, so multiple updates apply in arrival order.
-						hostMetadataApplied.then(() => this.applyHostTelemetrySetting(event.isEnabled))
-					},
-					onError: (error: Error) => {
-						Logger.warn("[SdkTelemetry] Host telemetry subscription failed; keeping last known state", error)
-					},
-				},
-			)
-		} catch (error) {
-			Logger.warn("[SdkTelemetry] Failed to subscribe to host telemetry changes", error)
-		}
 	}
 
 	// Mirrors the classic TelemetryService.create() mapping of GetHostVersionResponse
@@ -229,19 +276,15 @@ export class VscodeTelemetryPolicyService implements ITelemetryService {
 		}
 	}
 
-	private applyHostTelemetrySetting(setting: Setting): void {
-		this.hostTelemetryEnabled = setting === Setting.ENABLED || setting === Setting.UNSUPPORTED
-	}
-
 	private isOrdinaryTelemetryAllowed(): boolean {
-		return this.hostTelemetryEnabled && StateManager.get().getGlobalSettingsKey("telemetrySetting") !== "disabled"
+		return this.hostMetadataReady && isTelemetryExportAllowed(false)
 	}
 
 	private isRequiredTelemetryAllowed(): boolean {
-		return this.hostTelemetryEnabled
+		return this.hostMetadataReady && isHostTelemetryEnabled()
 	}
 
 	private isMetricAllowed(required: boolean): boolean {
-		return required ? this.isRequiredTelemetryAllowed() : this.isOrdinaryTelemetryAllowed()
+		return required ? this.isRequiredTelemetryAllowed() : this.hostMetadataReady
 	}
 }

--- a/apps/vscode/src/services/telemetry/TelemetryProviderFactory.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryProviderFactory.ts
@@ -1,30 +1,24 @@
 import { ClineEndpoint } from "@/config"
-import {
-	getValidOpenTelemetryConfig,
-	getValidRuntimeOpenTelemetryConfig,
-	OpenTelemetryClientValidConfig,
-} from "@/shared/services/config/otel-config"
 import { isPostHogConfigValid, posthogConfig } from "@/shared/services/config/posthog-config"
 import { Logger } from "@/shared/services/Logger"
+import { getSharedOtelClients, type SharedOtelClient } from "./otel-clients"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "./providers/ITelemetryProvider"
-import { OpenTelemetryClientProvider } from "./providers/opentelemetry/OpenTelemetryClientProvider"
 import { OpenTelemetryTelemetryProvider } from "./providers/opentelemetry/OpenTelemetryTelemetryProvider"
 import { PostHogClientProvider } from "./providers/posthog/PostHogClientProvider"
 import { PostHogTelemetryProvider } from "./providers/posthog/PostHogTelemetryProvider"
+import { ensureTelemetryPolicyInitialized } from "./telemetry-policy"
 
 /**
  * Configuration for telemetry providers
  */
 export type TelemetryProviderConfig =
 	| { type: "posthog"; apiKey?: string; host?: string }
-	/** OpenTelemetry collector
-	 * @param config - Config for this specific collector
-	 * @param bypassUserSettings - When true, telemetry is sent regardless of the user's Cline telemetry opt-in/opt-out settings.
-	 * This is used for:
-	 * 	- User-controlled collectors configured via environment variables (e.g., CLINE_OTEL_TELEMETRY_ENABLED).
-	 * 	- Organization-controlled collectors configured via remote config.
+	/** OpenTelemetry collector backed by one of the process's shared clients
+	 * (see {@link getSharedOtelClients}); the client carries its own
+	 * bypassUserSettings policy flag. The SDK telemetry handle exports through
+	 * the same clients, so both pipelines share one exporter per destination.
 	 */
-	| { type: "opentelemetry"; config: OpenTelemetryClientValidConfig; bypassUserSettings: boolean }
+	| { type: "opentelemetry"; client: SharedOtelClient }
 	| { type: "no-op" }
 
 /**
@@ -37,6 +31,10 @@ export class TelemetryProviderFactory {
 	 * Supports dual tracking during transition period
 	 */
 	public static async createProviders(): Promise<ITelemetryProvider[]> {
+		// All providers gate on the shared policy state; make sure the host
+		// setting is resolved before the first capture, like the per-provider
+		// initialize() fetches used to guarantee.
+		await ensureTelemetryPolicyInitialized()
 		const configs = TelemetryProviderFactory.getDefaultConfigs()
 		const providers: ITelemetryProvider[] = []
 
@@ -73,14 +71,10 @@ export class TelemetryProviderFactory {
 				return new NoOpTelemetryProvider()
 			}
 			case "opentelemetry": {
-				const otelConfig = config.config
-				if (!otelConfig) {
-					return new NoOpTelemetryProvider()
-				}
-				const client = new OpenTelemetryClientProvider(otelConfig)
+				const { client, bypassUserSettings } = config.client
 				if (client.meterProvider || client.loggerProvider) {
 					return await new OpenTelemetryTelemetryProvider(client.meterProvider, client.loggerProvider, {
-						bypassUserSettings: config.bypassUserSettings,
+						bypassUserSettings,
 					}).initialize()
 				}
 				Logger.info("TelemetryProviderFactory: OpenTelemetry providers not available")
@@ -106,26 +100,11 @@ export class TelemetryProviderFactory {
 			configs.push({ type: "posthog", ...posthogConfig })
 		}
 
-		// Skip build-time OTEL in selfHosted mode - enterprise customers should not send telemetry to Cline's collector
-		// Note: Runtime env OTEL and remote config OTEL are still allowed (user/org explicitly configured them)
-		const otelConfig = getValidOpenTelemetryConfig()
-		if (!ClineEndpoint.isSelfHosted() && otelConfig) {
-			configs.push({
-				type: "opentelemetry",
-				config: otelConfig,
-				bypassUserSettings: false,
-			})
-		}
-
-		const runtimeOtelConfig = getValidRuntimeOpenTelemetryConfig()
-		if (runtimeOtelConfig) {
-			configs.push({
-				type: "opentelemetry",
-				config: runtimeOtelConfig,
-				// If the user has `CLINE_OTEL_TELEMETRY_ENABLED` in his environment, enable
-				// OTEL regardless of his Cline telemetry settings
-				bypassUserSettings: true,
-			})
+		// The shared clients carry the self-hosted build-time skip and the
+		// runtime-env bypass policy; the SDK telemetry handle consumes the
+		// same registry.
+		for (const client of getSharedOtelClients()) {
+			configs.push({ type: "opentelemetry", client })
 		}
 
 		return configs.length > 0 ? configs : [{ type: "no-op" }]

--- a/apps/vscode/src/services/telemetry/TelemetryService.test.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.test.ts
@@ -8,13 +8,14 @@
  */
 
 import * as assert from "assert"
-import { after, before, describe, it } from "mocha"
+import { after, afterEach, before, beforeEach, describe, it } from "mocha"
 import * as sinon from "sinon"
 import { ClineEndpoint } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
 import * as otelConfigModule from "@/shared/services/config/otel-config"
 import * as posthogConfigModule from "@/shared/services/config/posthog-config"
 import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
+import { resetSharedOtelClientsForTests } from "./otel-clients"
 import { NoOpTelemetryProvider, TelemetryProviderFactory } from "./TelemetryProviderFactory"
 import { TelemetryMetadata, TelemetryService } from "./TelemetryService"
 
@@ -369,6 +370,15 @@ describe("Telemetry system is abstracted and can easily switch between providers
 	})
 
 	describe("Factory Configuration", () => {
+		// The shared OTel client registry caches per process; each test stubs a
+		// different config source, so reset the cache around every test.
+		beforeEach(() => {
+			resetSharedOtelClientsForTests()
+		})
+		afterEach(() => {
+			resetSharedOtelClientsForTests()
+		})
+
 		it("should return default configurations", () => {
 			// Mock PostHog config validation to return true for this test
 			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(true)
@@ -492,10 +502,10 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			const hasOtel = configs.some((c) => c.type === "opentelemetry")
 			assert.strictEqual(hasOtel, true, "Should include runtime env OTEL configuration even in selfHosted mode")
 
-			// Verify it has bypassUserSettings: true
+			// Verify the shared client carries bypassUserSettings: true
 			const otelConfig = configs.find((c) => c.type === "opentelemetry")
 			assert.strictEqual(
-				(otelConfig as any).bypassUserSettings,
+				otelConfig?.type === "opentelemetry" ? otelConfig.client.bypassUserSettings : undefined,
 				true,
 				"Runtime env OTEL should have bypassUserSettings: true",
 			)

--- a/apps/vscode/src/services/telemetry/__tests__/telemetry-pipeline-parity.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/telemetry-pipeline-parity.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression test for ENG-2397: the VS Code bundle runs two telemetry pipelines
+ * (the classic host TelemetryService providers and the SDK handle), which used
+ * to apply their settings checks and transport config independently.
+ *
+ * The invariant under test: for EVERY destination (shared OTel client) and
+ * EVERY policy state (host setting x user setting), the classic pipeline and
+ * the SDK pipeline agree on whether an ordinary event exports. Configuration
+ * must affect all telemetry in the process uniformly — never one pipeline.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Setting } from "@/shared/proto/index.host"
+
+const telemetryState = vi.hoisted(() => ({
+	clineTelemetrySetting: "unset" as string | undefined,
+	hostSetting: 1,
+}))
+
+vi.mock("@/core/storage/StateManager", () => ({
+	StateManager: {
+		get: () => ({
+			getGlobalSettingsKey: (key: string) =>
+				key === "telemetrySetting" ? telemetryState.clineTelemetrySetting : undefined,
+		}),
+	},
+}))
+
+vi.mock("@/hosts/host-provider", () => ({
+	HostProvider: {
+		env: {
+			getTelemetrySettings: vi.fn(async () => ({ isEnabled: telemetryState.hostSetting })),
+			getHostVersion: vi.fn(async () => ({
+				platform: "VS Code",
+				version: "1.103.0",
+				clineType: "VSCode Extension",
+			})),
+			subscribeToTelemetrySettings: vi.fn(() => () => {}),
+		},
+	},
+}))
+
+const otelClientMocks = vi.hoisted(() => ({
+	clients: [] as unknown[],
+}))
+
+vi.mock("@/services/telemetry/otel-clients", () => ({
+	getSharedOtelClients: () => otelClientMocks.clients,
+	flushSharedOtelClients: vi.fn(async () => {}),
+}))
+
+import { createVscodeSdkTelemetryHandle } from "@/sdk/sdk-telemetry"
+import { OpenTelemetryTelemetryProvider } from "../providers/opentelemetry/OpenTelemetryTelemetryProvider"
+import { RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT, resetTelemetryPolicyForTests } from "../telemetry-policy"
+
+interface EmittedRecord {
+	body: string
+	attributes: Record<string, unknown>
+}
+
+interface FakeDestination {
+	id: string
+	bypassUserSettings: boolean
+	emitted: EmittedRecord[]
+	shared: {
+		id: string
+		client: { meterProvider: null; loggerProvider: { getLogger(name: string): { emit(record: EmittedRecord): void } } }
+		config: Record<string, unknown>
+		bypassUserSettings: boolean
+	}
+}
+
+function createDestination(id: string, bypassUserSettings: boolean): FakeDestination {
+	const emitted: EmittedRecord[] = []
+	return {
+		id,
+		bypassUserSettings,
+		emitted,
+		shared: {
+			id,
+			client: {
+				meterProvider: null,
+				loggerProvider: {
+					getLogger: () => ({
+						emit: (record: EmittedRecord) => {
+							emitted.push(record)
+						},
+					}),
+				},
+			},
+			config: { enabled: true, logsExporter: "otlp", otlpEndpoint: "https://collector.example" },
+			bypassUserSettings,
+		},
+	}
+}
+
+function countEvents(destination: FakeDestination, event: string): number {
+	return destination.emitted.filter((record) => record.body === event).length
+}
+
+async function settlePromises(): Promise<void> {
+	for (let i = 0; i < 6; i++) {
+		await Promise.resolve()
+	}
+}
+
+describe("telemetry pipeline parity (ENG-2397 double-export regression)", () => {
+	beforeEach(() => {
+		resetTelemetryPolicyForTests()
+		telemetryState.clineTelemetrySetting = "unset"
+		telemetryState.hostSetting = Setting.ENABLED
+		otelClientMocks.clients = []
+	})
+
+	const policyStates = [
+		{ name: "host enabled, user opted in", host: Setting.ENABLED, user: "unset" },
+		{ name: "host enabled, user opted out", host: Setting.ENABLED, user: "disabled" },
+		{ name: "host disabled, user opted in", host: Setting.DISABLED, user: "unset" },
+		{ name: "host disabled, user opted out", host: Setting.DISABLED, user: "disabled" },
+	] as const
+
+	for (const policy of policyStates) {
+		it(`exports ordinary events to the same destinations from both pipelines (${policy.name})`, async () => {
+			telemetryState.hostSetting = policy.host
+			telemetryState.clineTelemetrySetting = policy.user
+
+			// The same two destinations the production factory builds: the
+			// build-time (prod) collector and a runtime CLINE_OTEL_* collector.
+			const destinations = [
+				createDestination("build-time", false),
+				createDestination("runtime-env", RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT),
+			]
+			otelClientMocks.clients = destinations.map((destination) => destination.shared)
+
+			// Classic pipeline: one provider per shared client, exactly as
+			// TelemetryProviderFactory.createProvider wires them.
+			const classicProviders = await Promise.all(
+				destinations.map((destination) =>
+					new OpenTelemetryTelemetryProvider(null, destination.shared.client.loggerProvider as never, {
+						name: `classic-${destination.id}`,
+						bypassUserSettings: destination.bypassUserSettings,
+					}).initialize(),
+				),
+			)
+
+			// SDK pipeline: the handle binds one adapter per shared client.
+			const sdkHandle = createVscodeSdkTelemetryHandle()
+			await settlePromises()
+
+			for (const provider of classicProviders) {
+				provider.log("classic.event", { source: "classic" })
+			}
+			sdkHandle.telemetry.capture({ event: "sdk.event", properties: { source: "sdk" } })
+
+			for (const destination of destinations) {
+				const classicCount = countEvents(destination, "classic.event")
+				const sdkCount = countEvents(destination, "sdk.event")
+				expect(
+					{ destination: destination.id, classic: classicCount, sdk: sdkCount },
+					`pipelines must agree on destination "${destination.id}" under "${policy.name}"`,
+				).toEqual({ destination: destination.id, classic: classicCount, sdk: classicCount })
+			}
+
+			// The bypass destination is the only one allowed to export when the
+			// policy denies ordinary telemetry — and then it must receive BOTH
+			// pipelines' events (the pre-unification bug exported only classic).
+			const ordinaryAllowed = policy.host === Setting.ENABLED && policy.user !== "disabled"
+			for (const destination of destinations) {
+				const expected = ordinaryAllowed || destination.bypassUserSettings ? 1 : 0
+				expect(countEvents(destination, "classic.event")).toBe(expected)
+				expect(countEvents(destination, "sdk.event")).toBe(expected)
+			}
+		})
+	}
+
+	it("required events reach every destination from both pipelines while host telemetry is enabled", async () => {
+		telemetryState.clineTelemetrySetting = "disabled"
+
+		const destinations = [
+			createDestination("build-time", false),
+			createDestination("runtime-env", RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT),
+		]
+		otelClientMocks.clients = destinations.map((destination) => destination.shared)
+
+		const classicProviders = await Promise.all(
+			destinations.map((destination) =>
+				new OpenTelemetryTelemetryProvider(null, destination.shared.client.loggerProvider as never, {
+					name: `classic-${destination.id}`,
+					bypassUserSettings: destination.bypassUserSettings,
+				}).initialize(),
+			),
+		)
+		const sdkHandle = createVscodeSdkTelemetryHandle()
+		await settlePromises()
+
+		for (const provider of classicProviders) {
+			provider.logRequired("classic.required")
+		}
+		sdkHandle.telemetry.captureRequired("sdk.required")
+
+		for (const destination of destinations) {
+			expect(countEvents(destination, "classic.required")).toBe(1)
+			expect(countEvents(destination, "sdk.required")).toBe(1)
+		}
+	})
+})

--- a/apps/vscode/src/services/telemetry/otel-clients.ts
+++ b/apps/vscode/src/services/telemetry/otel-clients.ts
@@ -1,0 +1,109 @@
+import { ClineEndpoint } from "@/config"
+import {
+	getValidOpenTelemetryConfig,
+	getValidRuntimeOpenTelemetryConfig,
+	type OpenTelemetryClientValidConfig,
+} from "@/shared/services/config/otel-config"
+import { Logger } from "@/shared/services/Logger"
+import { OpenTelemetryClientProvider } from "./providers/opentelemetry/OpenTelemetryClientProvider"
+import { RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT } from "./telemetry-policy"
+
+/**
+ * The process's shared OpenTelemetry clients (ENG-2397).
+ *
+ * Both telemetry pipelines — the classic host TelemetryService providers and the
+ * SDK handle's adapters — export through the clients in this registry, so each
+ * configured destination has exactly one exporter, one batcher, and one
+ * connection pool per process, and runtime env configuration affects all
+ * telemetry uniformly instead of only the classic half.
+ */
+export interface SharedOtelClient {
+	/** Which config source produced this client. */
+	readonly id: "build-time" | "runtime-env"
+	readonly client: OpenTelemetryClientProvider
+	readonly config: OpenTelemetryClientValidConfig
+	/** See {@link RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT}. */
+	readonly bypassUserSettings: boolean
+}
+
+let sharedClients: SharedOtelClient[] | null = null
+
+/**
+ * Lazily constructs the process's OpenTelemetry clients from the unified config:
+ * - "build-time": `OTEL_*` values inlined into the bundle at build time
+ *   (production collector defaults; skipped in self-hosted deployments).
+ * - "runtime-env": `CLINE_OTEL_*` environment variables read live at runtime
+ *   (user-controlled debugging/override collector).
+ */
+export function getSharedOtelClients(): SharedOtelClient[] {
+	if (sharedClients) {
+		return sharedClients
+	}
+
+	const clients: SharedOtelClient[] = []
+
+	// Skip build-time OTEL in selfHosted mode - enterprise customers should not
+	// send telemetry to Cline's collector. Runtime env OTEL (and remote config
+	// OTEL) are still allowed: the user/org explicitly configured them.
+	const buildTimeConfig = getValidOpenTelemetryConfig()
+	if (!ClineEndpoint.isSelfHosted() && buildTimeConfig) {
+		try {
+			clients.push({
+				id: "build-time",
+				client: new OpenTelemetryClientProvider(buildTimeConfig),
+				config: buildTimeConfig,
+				bypassUserSettings: false,
+			})
+		} catch (error) {
+			Logger.error("[OTEL] Failed to create build-time OpenTelemetry client", error)
+		}
+	}
+
+	const runtimeEnvConfig = getValidRuntimeOpenTelemetryConfig()
+	if (runtimeEnvConfig) {
+		try {
+			clients.push({
+				id: "runtime-env",
+				client: new OpenTelemetryClientProvider(runtimeEnvConfig),
+				config: runtimeEnvConfig,
+				bypassUserSettings: RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT,
+			})
+		} catch (error) {
+			Logger.error("[OTEL] Failed to create runtime-env OpenTelemetry client", error)
+		}
+	}
+
+	sharedClients = clients
+	return sharedClients
+}
+
+/** Best-effort flush of every shared client's pending batches. */
+export async function flushSharedOtelClients(): Promise<void> {
+	if (!sharedClients) {
+		return
+	}
+	await Promise.allSettled(
+		sharedClients.flatMap(({ client }) => [
+			client.meterProvider?.forceFlush() ?? Promise.resolve(),
+			client.loggerProvider?.forceFlush() ?? Promise.resolve(),
+		]),
+	)
+}
+
+/**
+ * Shuts down every shared client (flushing pending batches). Called from
+ * extension teardown, after both pipelines have stopped capturing.
+ */
+export async function disposeSharedOtelClients(): Promise<void> {
+	if (!sharedClients) {
+		return
+	}
+	const clients = sharedClients
+	sharedClients = null
+	await Promise.allSettled(clients.map(({ client }) => client.dispose()))
+}
+
+/** Test-only: reset module state between test cases (does not shut down clients). */
+export function resetSharedOtelClientsForTests(): void {
+	sharedClients = null
+}

--- a/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
+++ b/apps/vscode/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
@@ -2,13 +2,15 @@ import { Meter } from "@opentelemetry/api"
 import type { Logger as OTELLogger } from "@opentelemetry/api-logs"
 import { LoggerProvider } from "@opentelemetry/sdk-logs"
 import { MeterProvider } from "@opentelemetry/sdk-metrics"
-import { StateManager } from "@/core/storage/StateManager"
-import { HostProvider } from "@/hosts/host-provider"
-import { getErrorLevelFromString } from "@/services/error"
 import { getDistinctId, setDistinctId } from "@/services/logging/distinctId"
-import { Setting } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
 import type { ClineAccountUserInfo } from "../../../auth/AuthService"
+import {
+	ensureTelemetryPolicyInitialized,
+	getHostTelemetryLevel,
+	isHostTelemetryEnabled,
+	isTelemetryExportAllowed,
+} from "../../telemetry-policy"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../ITelemetryProvider"
 
 /**
@@ -18,7 +20,6 @@ import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from 
 export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	private meter: Meter | null = null
 	private logger: OTELLogger | null = null
-	private telemetrySettings: TelemetrySettings
 	private userAttributes: Record<string, string> = {}
 	// Lazy instrument caches for metrics
 	private counters = new Map<string, ReturnType<Meter["createCounter"]>>()
@@ -39,12 +40,6 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	) {
 		this.name = name || "OpenTelemetryProvider"
 		this.bypassUserSettings = bypassUserSettings
-
-		// Initialize telemetry settings
-		this.telemetrySettings = {
-			hostEnabled: true,
-			level: "all",
-		}
 
 		if (meterProvider) {
 			this.meter = meterProvider.getMeter("cline")
@@ -69,24 +64,9 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 			return this
 		}
 
-		// Listen for host telemetry changes
-		HostProvider.env.subscribeToTelemetrySettings(
-			{},
-			{
-				onResponse: (event: { isEnabled: Setting }) => {
-					const hostEnabled = event.isEnabled === Setting.ENABLED || event.isEnabled === Setting.UNSUPPORTED
-					this.telemetrySettings.hostEnabled = hostEnabled
-				},
-			},
-		)
-
-		// Check host-specific telemetry setting (e.g. VS Code setting)
-		const hostSettings = await HostProvider.env.getTelemetrySettings({})
-		if (hostSettings.isEnabled === Setting.DISABLED) {
-			this.telemetrySettings.hostEnabled = false
-		}
-
-		this.telemetrySettings.level = await this.getTelemetryLevel()
+		// Host telemetry state (and the settings subscription) live in the shared
+		// policy module, which is the single opt-out checkpoint for the process.
+		await ensureTelemetryPolicyInitialized()
 		return this
 	}
 
@@ -95,12 +75,13 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	}
 
 	public log(event: string, properties?: TelemetryProperties): void {
-		if (!this.isEnabled() || this.telemetrySettings.level === "off") {
+		const level = this.getEffectiveLevel()
+		if (!this.isEnabled() || level === "off") {
 			return
 		}
 
 		// Filter events based on telemetry level
-		if (this.telemetrySettings.level === "error") {
+		if (level === "error") {
 			if (!event.includes("error")) {
 				return
 			}
@@ -189,14 +170,14 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	}
 
 	public isEnabled(): boolean {
-		return (
-			this.bypassUserSettings ||
-			(StateManager.get().getGlobalSettingsKey("telemetrySetting") !== "disabled" && this.telemetrySettings.hostEnabled)
-		)
+		return isTelemetryExportAllowed(this.bypassUserSettings)
 	}
 
 	public getSettings(): TelemetrySettings {
-		return { ...this.telemetrySettings }
+		return {
+			hostEnabled: isHostTelemetryEnabled(),
+			level: this.getEffectiveLevel(),
+		}
 	}
 
 	/**
@@ -329,18 +310,11 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	}
 
 	/**
-	 * Get the current telemetry level from VS Code settings
+	 * The telemetry level this destination applies: collectors that bypass user
+	 * settings ignore the host level; the rest use the shared policy state.
 	 */
-	private async getTelemetryLevel(): Promise<TelemetrySettings["level"]> {
-		if (this.bypassUserSettings) {
-			return "all"
-		}
-
-		const hostSettings = await HostProvider.env.getTelemetrySettings({})
-		if (hostSettings.isEnabled === Setting.DISABLED) {
-			return "off"
-		}
-		return getErrorLevelFromString(hostSettings.errorLevel)
+	private getEffectiveLevel(): TelemetrySettings["level"] {
+		return this.bypassUserSettings ? "all" : getHostTelemetryLevel()
 	}
 
 	/**

--- a/apps/vscode/src/services/telemetry/providers/posthog/PostHogTelemetryProvider.ts
+++ b/apps/vscode/src/services/telemetry/providers/posthog/PostHogTelemetryProvider.ts
@@ -1,13 +1,16 @@
 import { PostHog } from "posthog-node"
-import { StateManager } from "@/core/storage/StateManager"
-import { HostProvider } from "@/hosts/host-provider"
-import { getErrorLevelFromString } from "@/services/error"
 import { getDistinctId, setDistinctId } from "@/services/logging/distinctId"
 import { fetch } from "@/shared/net"
-import { Setting } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
 import { posthogConfig } from "../../../../shared/services/config/posthog-config"
 import type { ClineAccountUserInfo } from "../../../auth/AuthService"
+import {
+	ensureTelemetryPolicyInitialized,
+	getHostTelemetryLevel,
+	isHostTelemetryEnabled,
+	isTelemetryExportAllowed,
+	isUserTelemetryOptedIn,
+} from "../../telemetry-policy"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../ITelemetryProvider"
 /**
  * PostHog implementation of the telemetry provider interface
@@ -15,7 +18,6 @@ import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from 
  */
 export class PostHogTelemetryProvider implements ITelemetryProvider {
 	private client: PostHog
-	private telemetrySettings: TelemetrySettings
 	private isSharedClient: boolean
 	private optInCache: boolean
 
@@ -38,32 +40,12 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 			})
 		}
 
-		// Initialize telemetry settings
 		this.optInCache = true
-		this.telemetrySettings = {
-			hostEnabled: true,
-			level: "all",
-		}
 	}
 	public async initialize(): Promise<PostHogTelemetryProvider> {
-		// Listen for host telemetry changes
-		HostProvider.env.subscribeToTelemetrySettings(
-			{},
-			{
-				onResponse: (event: { isEnabled: Setting }) => {
-					const hostEnabled = event.isEnabled === Setting.ENABLED || event.isEnabled === Setting.UNSUPPORTED
-					this.telemetrySettings.hostEnabled = hostEnabled
-				},
-			},
-		)
-
-		// Check host-specific telemetry setting (e.g. VS Code setting)
-		const hostSettings = await HostProvider.env.getTelemetrySettings({})
-		if (hostSettings.isEnabled === Setting.DISABLED) {
-			this.telemetrySettings.hostEnabled = false
-		}
-
-		this.telemetrySettings.level = await this.getTelemetryLevel()
+		// Host telemetry state (and the settings subscription) live in the shared
+		// policy module, which is the single opt-out checkpoint for the process.
+		await ensureTelemetryPolicyInitialized()
 		return this
 	}
 
@@ -72,12 +54,13 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 	}
 
 	public log(event: string, properties?: TelemetryProperties): void {
-		if (!this.isEnabled() || this.telemetrySettings.level === "off") {
+		const level = getHostTelemetryLevel()
+		if (!this.isEnabled() || level === "off") {
 			return
 		}
 
 		// Filter events based on telemetry level
-		if (this.telemetrySettings.level === "error") {
+		if (level === "error") {
 			if (!event.includes("error")) {
 				return
 			}
@@ -120,7 +103,7 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 	}
 
 	public isEnabled(): boolean {
-		const isOptedIn = StateManager.get().getGlobalSettingsKey("telemetrySetting") !== "disabled"
+		const isOptedIn = isUserTelemetryOptedIn()
 		const wasOptedIn = this.optInCache
 		try {
 			if (isOptedIn && !wasOptedIn) {
@@ -134,11 +117,14 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 		}
 		this.optInCache = isOptedIn
 
-		return isOptedIn && this.telemetrySettings.hostEnabled
+		return isTelemetryExportAllowed(false)
 	}
 
 	public getSettings(): TelemetrySettings {
-		return { ...this.telemetrySettings }
+		return {
+			hostEnabled: isHostTelemetryEnabled(),
+			level: getHostTelemetryLevel(),
+		}
 	}
 
 	/**
@@ -210,16 +196,5 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 				Logger.error("Error shutting down PostHog client:", error)
 			}
 		}
-	}
-
-	/**
-	 * Get the current telemetry level from VS Code settings
-	 */
-	private async getTelemetryLevel(): Promise<TelemetrySettings["level"]> {
-		const hostSettings = await HostProvider.env.getTelemetrySettings({})
-		if (hostSettings.isEnabled === Setting.DISABLED) {
-			return "off"
-		}
-		return getErrorLevelFromString(hostSettings.errorLevel)
 	}
 }

--- a/apps/vscode/src/services/telemetry/telemetry-policy.ts
+++ b/apps/vscode/src/services/telemetry/telemetry-policy.ts
@@ -1,0 +1,141 @@
+import { StateManager } from "@/core/storage/StateManager"
+import { HostProvider } from "@/hosts/host-provider"
+import { getErrorLevelFromString } from "@/services/error"
+import { Setting } from "@/shared/proto/index.host"
+import { Logger } from "@/shared/services/Logger"
+
+/**
+ * Single telemetry opt-out policy for the whole process.
+ *
+ * Every telemetry destination — the classic host providers (PostHog, OpenTelemetry)
+ * and the SDK handle's adapters — must derive its export decision from
+ * {@link isTelemetryExportAllowed} so the process cannot simultaneously honor and
+ * ignore the user's telemetry choice (ENG-2397).
+ */
+
+/**
+ * Policy: telemetry destinations that the user (via `CLINE_OTEL_*` environment
+ * variables) or an organization (via remote config) explicitly configured export
+ * telemetry even when the user's Cline telemetry setting or the host (IDE)
+ * telemetry setting is off.
+ *
+ * Rationale: the collector was deliberately configured by the party receiving the
+ * data — the user's opt-out governs Cline's collection, not a collector the
+ * user/org pointed at themselves. This is documented behavior:
+ * https://docs.cline.bot/enterprise-solutions/monitoring/opentelemetry_override
+ * ("Environment variable configuration bypasses user telemetry settings").
+ * This constant preserves the classic pipeline's long-standing behavior and now
+ * applies uniformly to SDK-handle telemetry too. Removing the bypass means
+ * changing that documented contract, not just flipping this to false.
+ */
+export const RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT = true
+
+type HostTelemetryLevel = "all" | "off" | "error" | "crash"
+
+interface HostTelemetryState {
+	enabled: boolean
+	level: HostTelemetryLevel
+	/** A subscription event is always newer than the initial fetch; don't let a slow fetch clobber it. */
+	receivedSubscriptionUpdate: boolean
+}
+
+// Until the initial fetch resolves, treat host telemetry as disabled so nothing
+// exports before the host's choice is known (matches the previous SDK-pipeline
+// behavior; the classic factory awaits initialization before creating providers).
+const state: HostTelemetryState = {
+	enabled: false,
+	level: "all",
+	receivedSubscriptionUpdate: false,
+}
+
+let initPromise: Promise<void> | null = null
+let unsubscribeHostTelemetrySettings: (() => void) | undefined
+
+function applyHostTelemetrySetting(setting: Setting): void {
+	state.enabled = setting === Setting.ENABLED || setting === Setting.UNSUPPORTED
+}
+
+/**
+ * Starts the single host-telemetry-settings subscription and performs the initial
+ * fetch. Idempotent; safe to call from every consumer. Never rejects — on failure
+ * the host state stays at its safe default (disabled).
+ */
+export function ensureTelemetryPolicyInitialized(): Promise<void> {
+	if (!initPromise) {
+		initPromise = initializeHostTelemetryState()
+	}
+	return initPromise
+}
+
+async function initializeHostTelemetryState(): Promise<void> {
+	try {
+		unsubscribeHostTelemetrySettings = HostProvider.env.subscribeToTelemetrySettings(
+			{},
+			{
+				onResponse: (event: { isEnabled: Setting }) => {
+					state.receivedSubscriptionUpdate = true
+					applyHostTelemetrySetting(event.isEnabled)
+				},
+				onError: (error: Error) => {
+					Logger.warn("[TelemetryPolicy] Host telemetry subscription failed; keeping last known state", error)
+				},
+			},
+		)
+	} catch (error) {
+		Logger.warn("[TelemetryPolicy] Failed to subscribe to host telemetry changes", error)
+	}
+
+	try {
+		const settings = await HostProvider.env.getTelemetrySettings({})
+		if (!state.receivedSubscriptionUpdate) {
+			applyHostTelemetrySetting(settings.isEnabled)
+		}
+		state.level = settings.isEnabled === Setting.DISABLED ? "off" : (getErrorLevelFromString(settings.errorLevel) ?? "all")
+	} catch (error) {
+		Logger.warn("[TelemetryPolicy] Failed to read host telemetry setting; keeping telemetry disabled", error)
+	}
+}
+
+/** Whether the host (IDE) telemetry setting currently allows telemetry. */
+export function isHostTelemetryEnabled(): boolean {
+	return state.enabled
+}
+
+/**
+ * The host's telemetry level from the initial settings fetch ("all" | "off" |
+ * "error" | "crash"). Destinations that bypass user settings ignore this.
+ */
+export function getHostTelemetryLevel(): HostTelemetryLevel {
+	return state.level
+}
+
+/** Whether the user's Cline telemetry setting allows telemetry. */
+export function isUserTelemetryOptedIn(): boolean {
+	return StateManager.get().getGlobalSettingsKey("telemetrySetting") !== "disabled"
+}
+
+/**
+ * The process-wide opt-out checkpoint for ordinary (non-required) telemetry.
+ *
+ * @param bypassUserSettings true only for destinations explicitly configured by
+ * the receiving party (runtime `CLINE_OTEL_*` env collectors, remote-config org
+ * collectors) — see {@link RUNTIME_ENV_OTEL_BYPASSES_USER_OPT_OUT}.
+ */
+export function isTelemetryExportAllowed(bypassUserSettings: boolean): boolean {
+	return bypassUserSettings || (state.enabled && isUserTelemetryOptedIn())
+}
+
+/** Tears down the host-settings subscription. Called from extension teardown. */
+export function disposeTelemetryPolicy(): void {
+	unsubscribeHostTelemetrySettings?.()
+	unsubscribeHostTelemetrySettings = undefined
+}
+
+/** Test-only: reset module state between test cases. */
+export function resetTelemetryPolicyForTests(): void {
+	disposeTelemetryPolicy()
+	initPromise = null
+	state.enabled = false
+	state.level = "all"
+	state.receivedSubscriptionUpdate = false
+}

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs"
 import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { createFileReadExecutor } from "../../../../sdk/packages/core/src/extensions/tools/executors/file-read"
+import type { ITelemetryAdapter } from "../../../../sdk/packages/core/src/services/telemetry/ITelemetryAdapter"
 
 export interface OAuthCredentials {
 	accessToken?: string
@@ -319,135 +320,18 @@ export function resolveCoreDistinctId(distinctId?: string): string {
 	return distinctId ?? "stub-core-distinct-id"
 }
 
-export interface ITelemetryAdapter {
-	readonly name: string
-	emit(event: string, properties?: TelemetryProperties): void
-	emitRequired(event: string, properties?: TelemetryProperties): void
-	recordCounter(name: string, value: number, attributes?: TelemetryProperties, description?: string, required?: boolean): void
-	recordHistogram(name: string, value: number, attributes?: TelemetryProperties, description?: string, required?: boolean): void
-	recordGauge(
-		name: string,
-		value: number | null,
-		attributes?: TelemetryProperties,
-		description?: string,
-		required?: boolean,
-	): void
-	isEnabled(): boolean
-	setDistinctId(distinctId?: string): void
-	setCommonProperties(properties: TelemetryProperties): void
-	updateCommonProperties(properties: TelemetryProperties): void
-	flush(): Promise<void>
-	dispose(): Promise<void>
-}
-
-export interface OpenTelemetryAdapterOptions {
-	readonly metadata: TelemetryMetadata
-	readonly meterProvider?: { getMeter(name: string): unknown; forceFlush?(): Promise<void>; shutdown?(): Promise<void> } | null
-	readonly loggerProvider?: {
-		getLogger(name: string): { emit(record: Record<string, unknown>): void }
-		forceFlush?(): Promise<void>
-		shutdown?(): Promise<void>
-	} | null
-	readonly name?: string
-	readonly enabled?: boolean | (() => boolean)
-	readonly distinctId?: string
-	readonly commonProperties?: TelemetryProperties
-	readonly ownsProviders?: boolean
-}
-
-/**
- * Behavior-faithful stub of @cline/core's OpenTelemetryAdapter: same enabled
- * gating (`emit` gated, `emitRequired` not) and the same attribute merge order,
- * minus metric instruments and property flattening.
- */
-export class OpenTelemetryAdapter implements ITelemetryAdapter {
-	readonly name: string
-	private readonly metadata: TelemetryMetadata
-	private readonly logger: { emit(record: Record<string, unknown>): void } | null
-	private readonly enabled: boolean | (() => boolean)
-	private readonly ownsProviders: boolean
-	private readonly meterProvider?: OpenTelemetryAdapterOptions["meterProvider"]
-	private readonly loggerProvider?: OpenTelemetryAdapterOptions["loggerProvider"]
-	private distinctId?: string
-	private commonProperties: TelemetryProperties
-
-	constructor(options: OpenTelemetryAdapterOptions) {
-		this.name = options.name ?? "OpenTelemetryAdapter"
-		this.metadata = { ...options.metadata }
-		this.meterProvider = options.meterProvider
-		this.loggerProvider = options.loggerProvider
-		this.logger = options.loggerProvider?.getLogger("cline") ?? null
-		this.enabled = options.enabled ?? true
-		this.ownsProviders = options.ownsProviders ?? true
-		this.distinctId = options.distinctId
-		this.commonProperties = { ...(options.commonProperties ?? {}) }
-	}
-
-	isEnabled(): boolean {
-		return typeof this.enabled === "function" ? this.enabled() : this.enabled
-	}
-
-	emit(event: string, properties?: TelemetryProperties): void {
-		if (!this.isEnabled()) {
-			return
-		}
-		this.emitLog(event, properties, false)
-	}
-
-	emitRequired(event: string, properties?: TelemetryProperties): void {
-		this.emitLog(event, properties, true)
-	}
-
-	recordCounter(_name: string, _value: number, _attributes?: TelemetryProperties, _description?: string, _required = false) {}
-	recordHistogram(_name: string, _value: number, _attributes?: TelemetryProperties, _description?: string, _required = false) {}
-	recordGauge(
-		_name: string,
-		_value: number | null,
-		_attributes?: TelemetryProperties,
-		_description?: string,
-		_required = false,
-	) {}
-
-	setDistinctId(distinctId?: string): void {
-		this.distinctId = distinctId
-	}
-
-	setCommonProperties(properties: TelemetryProperties): void {
-		this.commonProperties = { ...properties }
-	}
-
-	updateCommonProperties(properties: TelemetryProperties): void {
-		this.commonProperties = { ...this.commonProperties, ...properties }
-	}
-
-	async flush(): Promise<void> {
-		await Promise.all([this.meterProvider?.forceFlush?.(), this.loggerProvider?.forceFlush?.()])
-	}
-
-	async dispose(): Promise<void> {
-		if (!this.ownsProviders) {
-			return
-		}
-		await Promise.all([this.meterProvider?.shutdown?.(), this.loggerProvider?.shutdown?.()])
-	}
-
-	private emitLog(event: string, properties: TelemetryProperties | undefined, required: boolean): void {
-		if (!this.logger) {
-			return
-		}
-		this.logger.emit({
-			severityText: "INFO",
-			body: event,
-			attributes: {
-				...this.commonProperties,
-				...this.metadata,
-				...properties,
-				...(this.distinctId ? { distinct_id: this.distinctId } : {}),
-				...(required ? { _required: true } : {}),
-			},
-		})
-	}
-}
+// Real OpenTelemetryAdapter, re-exported from the sdk source (same pattern as the
+// executors above) so the telemetry parity suite asserts the adapter's actual
+// enabled-gating rather than a copy that could silently drift from it. Safe to
+// pull in: OpenTelemetryAdapter's own imports are all type-only, so it brings no
+// runtime dependencies with it.
+export type { ITelemetryAdapter }
+export {
+	OpenTelemetryAdapter,
+	type OpenTelemetryAdapterOptions,
+	type TelemetryLoggerProviderLike,
+	type TelemetryMeterProviderLike,
+} from "../../../../sdk/packages/core/src/services/telemetry/OpenTelemetryAdapter"
 
 export interface TelemetryServiceOptions {
 	adapters?: ITelemetryAdapter[]

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -300,6 +300,263 @@ export function createConfiguredTelemetryHandle(): ConfiguredTelemetryHandle {
 	}
 }
 
+export function createClineTelemetryServiceMetadata(overrides: Partial<TelemetryMetadata> = {}): TelemetryMetadata {
+	// Mirrors @cline/shared createClineTelemetryServiceMetadata defaults.
+	return {
+		extension_version: "unknown",
+		cline_type: "unknown",
+		platform: "terminal",
+		platform_version: process?.version || "unknown",
+		os_type: process?.platform || "unknown",
+		os_version: process?.platform === "win32" ? (process?.env?.OS ?? "unknown") : "unknown",
+		...overrides,
+	}
+}
+
+export function resolveCoreDistinctId(distinctId?: string): string {
+	// The real implementation falls back to a persisted machine id; tests only
+	// need the pass-through behavior for an explicitly provided id.
+	return distinctId ?? "stub-core-distinct-id"
+}
+
+export interface ITelemetryAdapter {
+	readonly name: string
+	emit(event: string, properties?: TelemetryProperties): void
+	emitRequired(event: string, properties?: TelemetryProperties): void
+	recordCounter(name: string, value: number, attributes?: TelemetryProperties, description?: string, required?: boolean): void
+	recordHistogram(name: string, value: number, attributes?: TelemetryProperties, description?: string, required?: boolean): void
+	recordGauge(
+		name: string,
+		value: number | null,
+		attributes?: TelemetryProperties,
+		description?: string,
+		required?: boolean,
+	): void
+	isEnabled(): boolean
+	setDistinctId(distinctId?: string): void
+	setCommonProperties(properties: TelemetryProperties): void
+	updateCommonProperties(properties: TelemetryProperties): void
+	flush(): Promise<void>
+	dispose(): Promise<void>
+}
+
+export interface OpenTelemetryAdapterOptions {
+	readonly metadata: TelemetryMetadata
+	readonly meterProvider?: { getMeter(name: string): unknown; forceFlush?(): Promise<void>; shutdown?(): Promise<void> } | null
+	readonly loggerProvider?: {
+		getLogger(name: string): { emit(record: Record<string, unknown>): void }
+		forceFlush?(): Promise<void>
+		shutdown?(): Promise<void>
+	} | null
+	readonly name?: string
+	readonly enabled?: boolean | (() => boolean)
+	readonly distinctId?: string
+	readonly commonProperties?: TelemetryProperties
+	readonly ownsProviders?: boolean
+}
+
+/**
+ * Behavior-faithful stub of @cline/core's OpenTelemetryAdapter: same enabled
+ * gating (`emit` gated, `emitRequired` not) and the same attribute merge order,
+ * minus metric instruments and property flattening.
+ */
+export class OpenTelemetryAdapter implements ITelemetryAdapter {
+	readonly name: string
+	private readonly metadata: TelemetryMetadata
+	private readonly logger: { emit(record: Record<string, unknown>): void } | null
+	private readonly enabled: boolean | (() => boolean)
+	private readonly ownsProviders: boolean
+	private readonly meterProvider?: OpenTelemetryAdapterOptions["meterProvider"]
+	private readonly loggerProvider?: OpenTelemetryAdapterOptions["loggerProvider"]
+	private distinctId?: string
+	private commonProperties: TelemetryProperties
+
+	constructor(options: OpenTelemetryAdapterOptions) {
+		this.name = options.name ?? "OpenTelemetryAdapter"
+		this.metadata = { ...options.metadata }
+		this.meterProvider = options.meterProvider
+		this.loggerProvider = options.loggerProvider
+		this.logger = options.loggerProvider?.getLogger("cline") ?? null
+		this.enabled = options.enabled ?? true
+		this.ownsProviders = options.ownsProviders ?? true
+		this.distinctId = options.distinctId
+		this.commonProperties = { ...(options.commonProperties ?? {}) }
+	}
+
+	isEnabled(): boolean {
+		return typeof this.enabled === "function" ? this.enabled() : this.enabled
+	}
+
+	emit(event: string, properties?: TelemetryProperties): void {
+		if (!this.isEnabled()) {
+			return
+		}
+		this.emitLog(event, properties, false)
+	}
+
+	emitRequired(event: string, properties?: TelemetryProperties): void {
+		this.emitLog(event, properties, true)
+	}
+
+	recordCounter(_name: string, _value: number, _attributes?: TelemetryProperties, _description?: string, _required = false) {}
+	recordHistogram(_name: string, _value: number, _attributes?: TelemetryProperties, _description?: string, _required = false) {}
+	recordGauge(
+		_name: string,
+		_value: number | null,
+		_attributes?: TelemetryProperties,
+		_description?: string,
+		_required = false,
+	) {}
+
+	setDistinctId(distinctId?: string): void {
+		this.distinctId = distinctId
+	}
+
+	setCommonProperties(properties: TelemetryProperties): void {
+		this.commonProperties = { ...properties }
+	}
+
+	updateCommonProperties(properties: TelemetryProperties): void {
+		this.commonProperties = { ...this.commonProperties, ...properties }
+	}
+
+	async flush(): Promise<void> {
+		await Promise.all([this.meterProvider?.forceFlush?.(), this.loggerProvider?.forceFlush?.()])
+	}
+
+	async dispose(): Promise<void> {
+		if (!this.ownsProviders) {
+			return
+		}
+		await Promise.all([this.meterProvider?.shutdown?.(), this.loggerProvider?.shutdown?.()])
+	}
+
+	private emitLog(event: string, properties: TelemetryProperties | undefined, required: boolean): void {
+		if (!this.logger) {
+			return
+		}
+		this.logger.emit({
+			severityText: "INFO",
+			body: event,
+			attributes: {
+				...this.commonProperties,
+				...this.metadata,
+				...properties,
+				...(this.distinctId ? { distinct_id: this.distinctId } : {}),
+				...(required ? { _required: true } : {}),
+			},
+		})
+	}
+}
+
+export interface TelemetryServiceOptions {
+	adapters?: ITelemetryAdapter[]
+	metadata?: Partial<TelemetryMetadata>
+	distinctId?: string
+	deviceId?: string
+	commonProperties?: TelemetryProperties
+}
+
+/** Behavior-faithful stub of @cline/core's TelemetryService (adapter fan-out + attribute merging). */
+export class TelemetryService implements ITelemetryService {
+	private adapters: ITelemetryAdapter[]
+	private metadata: Partial<TelemetryMetadata>
+	private distinctId?: string
+	private readonly deviceId: string
+	private commonProperties: TelemetryProperties
+
+	constructor(options: TelemetryServiceOptions = {}) {
+		this.adapters = [...(options.adapters ?? [])]
+		this.metadata = { ...(options.metadata ?? {}) }
+		this.distinctId = options.distinctId
+		this.deviceId = options.deviceId ?? "stub-core-device-id"
+		this.commonProperties = { ...(options.commonProperties ?? {}) }
+	}
+
+	setDistinctId(distinctId?: string): void {
+		this.distinctId = distinctId
+	}
+
+	setMetadata(metadata: Partial<TelemetryMetadata>): void {
+		this.metadata = { ...metadata }
+	}
+
+	updateMetadata(metadata: Partial<TelemetryMetadata>): void {
+		this.metadata = { ...this.metadata, ...metadata }
+	}
+
+	setCommonProperties(properties: TelemetryProperties): void {
+		this.commonProperties = { ...properties }
+	}
+
+	updateCommonProperties(properties: TelemetryProperties): void {
+		this.commonProperties = { ...this.commonProperties, ...properties }
+	}
+
+	isEnabled(): boolean {
+		return this.adapters.some((adapter) => adapter.isEnabled())
+	}
+
+	capture(input: { event: string; properties?: TelemetryProperties }): void {
+		const properties = this.buildAttributes(input.properties)
+		for (const adapter of this.adapters) {
+			adapter.emit(input.event, properties)
+		}
+	}
+
+	captureRequired(event: string, properties?: TelemetryProperties): void {
+		const merged = this.buildAttributes(properties)
+		for (const adapter of this.adapters) {
+			adapter.emitRequired(event, merged)
+		}
+	}
+
+	recordCounter(name: string, value: number, attributes?: TelemetryProperties, description?: string, required = false): void {
+		const merged = this.buildAttributes(attributes)
+		for (const adapter of this.adapters) {
+			adapter.recordCounter(name, value, merged, description, required)
+		}
+	}
+
+	recordHistogram(name: string, value: number, attributes?: TelemetryProperties, description?: string, required = false): void {
+		const merged = this.buildAttributes(attributes)
+		for (const adapter of this.adapters) {
+			adapter.recordHistogram(name, value, merged, description, required)
+		}
+	}
+
+	recordGauge(
+		name: string,
+		value: number | null,
+		attributes?: TelemetryProperties,
+		description?: string,
+		required = false,
+	): void {
+		const merged = this.buildAttributes(attributes)
+		for (const adapter of this.adapters) {
+			adapter.recordGauge(name, value, merged, description, required)
+		}
+	}
+
+	async flush(): Promise<void> {
+		await Promise.all(this.adapters.map((adapter) => adapter.flush()))
+	}
+
+	async dispose(): Promise<void> {
+		await Promise.all(this.adapters.map((adapter) => adapter.dispose()))
+	}
+
+	private buildAttributes(properties?: TelemetryProperties): TelemetryProperties {
+		return {
+			...this.commonProperties,
+			...properties,
+			...this.metadata,
+			...(this.distinctId ? { distinct_id: this.distinctId } : {}),
+			device_id: this.deviceId,
+		}
+	}
+}
+
 interface ProviderSettingsState {
 	providers: Record<string, Record<string, unknown>>
 	lastUsedProvider?: string

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
 			"src/core/controller/state/**/*.test.ts",
 			"src/core/controller/slash/**/*.test.ts",
 			"src/services/mcp/__tests__/settingsLock.test.ts",
+			"src/services/telemetry/__tests__/telemetry-pipeline-parity.test.ts",
 			"src/shared/model-catalog/provider-helpers.test.ts",
 			"src/core/controller/models/__tests__/providerCatalogHandlers.test.ts",
 			"src/core/controller/models/__tests__/providerSwitchNormalization.test.ts",

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -706,8 +706,12 @@ export {
 	type SqliteTeamStoreOptions,
 } from "./services/storage/team-store";
 export {
+	OpenTelemetryAdapter,
+	type OpenTelemetryAdapterOptions,
 	resolveCoreDeviceId,
 	resolveCoreDistinctId,
+	type TelemetryLoggerProviderLike,
+	type TelemetryMeterProviderLike,
 } from "./services/telemetry";
 export type {
 	CaptureAgentUnexpectedReasoningTokensInput,

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryAdapter.test.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryAdapter.test.ts
@@ -142,6 +142,29 @@ describe("OpenTelemetryAdapter", () => {
 			expect(shutdown).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	it("does not shut down providers it does not own", async () => {
+		const forceFlush = vi.fn().mockResolvedValue(undefined);
+		const shutdown = vi.fn().mockResolvedValue(undefined);
+
+		const adapter = new OpenTelemetryAdapter({
+			metadata: makeMetadata(),
+			// Shared providers (e.g. the VS Code extension's process-wide OTel
+			// clients): dispose must leave shutdown to the provider owner.
+			ownsProviders: false,
+			meterProvider: {
+				getMeter: () => ({}) as never,
+				forceFlush,
+				shutdown,
+			},
+		});
+
+		await adapter.flush();
+		await adapter.dispose();
+
+		expect(forceFlush).toHaveBeenCalledTimes(1);
+		expect(shutdown).not.toHaveBeenCalled();
+	});
 });
 
 function makeMetadata() {

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryAdapter.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryAdapter.ts
@@ -1,7 +1,5 @@
 import type { Meter } from "@opentelemetry/api";
 import type { Logger as OpenTelemetryLogger } from "@opentelemetry/api-logs";
-import type { LoggerProvider } from "@opentelemetry/sdk-logs";
-import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type {
 	ITelemetryAdapter,
 	TelemetryMetadata,
@@ -11,14 +9,40 @@ import type {
 
 type FlatTelemetryAttributes = Record<string, string | number | boolean>;
 
+/**
+ * The subset of an SDK MeterProvider/LoggerProvider this adapter actually
+ * uses. Structural on purpose: hosts may bind the adapter to providers built
+ * by a different @opentelemetry/sdk-* release line than the one @cline/core
+ * compiles against (e.g. the VS Code extension's shared telemetry clients),
+ * and these entry points have been stable across those releases.
+ */
+export interface TelemetryMeterProviderLike {
+	getMeter(name: string, version?: string): Meter;
+	forceFlush?(): Promise<void>;
+	shutdown?(): Promise<void>;
+}
+
+export interface TelemetryLoggerProviderLike {
+	getLogger(name: string, version?: string): OpenTelemetryLogger;
+	forceFlush?(): Promise<void>;
+	shutdown?(): Promise<void>;
+}
+
 export interface OpenTelemetryAdapterOptions {
 	readonly metadata: TelemetryMetadata;
-	readonly meterProvider?: MeterProvider | null;
-	readonly loggerProvider?: LoggerProvider | null;
+	readonly meterProvider?: TelemetryMeterProviderLike | null;
+	readonly loggerProvider?: TelemetryLoggerProviderLike | null;
 	readonly name?: string;
 	readonly enabled?: boolean | (() => boolean);
 	readonly distinctId?: string;
 	readonly commonProperties?: TelemetryProperties;
+	/**
+	 * Whether disposing this adapter shuts down the meter/logger providers.
+	 * Defaults to true. Hosts that bind an adapter to providers shared with
+	 * another pipeline (e.g. the VS Code extension writing through the host
+	 * telemetry stack) pass false so the provider owner controls shutdown.
+	 */
+	readonly ownsProviders?: boolean;
 }
 
 export class OpenTelemetryAdapter implements ITelemetryAdapter {
@@ -40,14 +64,16 @@ export class OpenTelemetryAdapter implements ITelemetryAdapter {
 		string,
 		Map<string, { value: number; attributes?: TelemetryProperties }>
 	>();
-	private readonly meterProvider?: MeterProvider | null;
-	private readonly loggerProvider?: LoggerProvider | null;
+	private readonly meterProvider?: TelemetryMeterProviderLike | null;
+	private readonly loggerProvider?: TelemetryLoggerProviderLike | null;
+	private readonly ownsProviders: boolean;
 
 	constructor(options: OpenTelemetryAdapterOptions) {
 		this.name = options.name ?? "OpenTelemetryAdapter";
 		this.metadata = { ...options.metadata };
 		this.meterProvider = options.meterProvider;
 		this.loggerProvider = options.loggerProvider;
+		this.ownsProviders = options.ownsProviders ?? true;
 		this.meter = options.meterProvider?.getMeter("cline") ?? null;
 		this.logger = options.loggerProvider?.getLogger("cline") ?? null;
 		this.enabled = options.enabled ?? true;
@@ -198,6 +224,9 @@ export class OpenTelemetryAdapter implements ITelemetryAdapter {
 	}
 
 	async dispose(): Promise<void> {
+		if (!this.ownsProviders) {
+			return;
+		}
 		await Promise.all([
 			this.meterProvider?.shutdown?.(),
 			this.loggerProvider?.shutdown?.(),

--- a/sdk/packages/core/src/services/telemetry/index.ts
+++ b/sdk/packages/core/src/services/telemetry/index.ts
@@ -11,6 +11,8 @@ export type {
 export {
 	OpenTelemetryAdapter,
 	type OpenTelemetryAdapterOptions,
+	type TelemetryLoggerProviderLike,
+	type TelemetryMeterProviderLike,
 } from "./OpenTelemetryAdapter";
 export {
 	type ConfiguredTelemetryHandle,


### PR DESCRIPTION
Part of [ENG-2397](https://linear.app/cline-bot/issue/ENG-2397/unify-the-two-telemetry-policy-gates-and-transport-configs-in-the-sdk).

The VS Code SDK bundle ran two parallel telemetry stacks — the host `TelemetryService` providers and the SDK handle — each constructing its own OTel exporters, reading its own config source, and applying its own settings checks. This consolidates them.

Before/after architecture diagram (visible to org members): https://claude.ai/code/artifact/27d9f6d6-c3f8-4780-9bba-c488d5614831

## Changes

- **`services/telemetry/otel-clients.ts` (new):** shared OTel client registry. Both the host provider factory and the SDK handle export through the same clients, so each configured destination has one exporter, one batcher, and one connection pool per process (previously two of each).
- **`services/telemetry/telemetry-policy.ts` (new):** single policy module. One host-settings subscription/fetch (previously one per provider) and one shared predicate that every destination — host providers, PostHog, SDK adapters — consults, so all telemetry in the process follows the same settings consistently. The [documented enterprise override behavior](https://docs.cline.bot/enterprise-solutions/monitoring/opentelemetry_override) of explicitly-configured `CLINE_OTEL_*` collectors is preserved and expressed as one constant.
- **`sdk/sdk-telemetry.ts`:** the SDK handle binds one `@cline/core` `OpenTelemetryAdapter` per shared client instead of building its own exporter stack. `VscodeTelemetryPolicyService` keeps the host-identity-metadata ordering guarantee (no event before `getHostVersion` metadata is applied; deferred `telemetry.provider_created` unchanged in name and keys).
- **`esbuild.mjs` / `.env.example`:** one config source with the same semantics in dev and prod builds: `OTEL_*` is build-time only (always inlined), `CLINE_OTEL_*` is runtime only (read live). `.env.example` updated — use `CLINE_OTEL_*` for local telemetry debugging.
- **`@cline/core`:** `OpenTelemetryAdapter` accepts structural provider types and an `ownsProviders` flag (default unchanged) so a host can bind it to clients whose lifecycle it doesn't own.

Event names, attribute keys, which layer emits which event, and the ordinary/required gating semantics are unchanged (event ownership is a separate ticket, ENG-2396).

## Behavior notes

- Runtime `CLINE_OTEL_*` configuration now applies to **all** telemetry in the process; previously the SDK-handle pipeline only used build-time config and ignored the runtime family. (Docs follow-up tracked in ENG-2397: mention this on the enterprise OpenTelemetry override page.)
- The SDK pipeline's events flow through the host stack's exporters — same destinations and config as before, shared connection pool.
- The core-level global opt-out file check at handle construction is replaced by the live synced setting, i.e. re-evaluated per capture instead of frozen at construction.
- If the host-settings fetch fails, providers now start in the disabled state instead of being dropped entirely.

## Tests

- New `telemetry-pipeline-parity.test.ts`: for every destination and every settings combination, both pipelines must agree on whether an event exports.
- Reworked `sdk-telemetry.test.ts` for the shared-stack construction; new core test for `ownsProviders`.
- Full apps/vscode vitest suite, touched-area bun tests, core telemetry suite, `tsc --noEmit`, sdk package builds, and biome on changed files — all green (re-verified after rebasing onto latest `main`).

## After merge

Nightly picks this up automatically on its next scheduled build. Since telemetry regressions have no user-visible symptom — the signal that would surface one is the thing that would be broken — this wants a deliberate event-volume check a few days in, before the stable A/B bundle is dispatched. Query, baselines, and expected failure signatures are on the Linear ticket.
