### PR TITLE
fix(hub): recoverable agent errors must not end the turn in the dashboard

### DIFF
--- a/apps/cline-hub/src/server/agent-events.test.ts
+++ b/apps/cline-hub/src/server/agent-events.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CoreSessionEvent } from "@cline/core";
+import type { HubContext } from "./state";
+
+// agent-events.ts only needs these siblings at runtime; mocking them keeps the
+// test from loading @cline/core (state-payloads imports it at module scope),
+// whose transitive provider deps do not survive vitest's module interop.
+vi.mock("./approvals", () => ({ rejectPendingApprovalsForSession: vi.fn() }));
+vi.mock("./state-payloads", () => ({ broadcastHubState: vi.fn() }));
+
+import { handleSessionEvent } from "./agent-events";
+
+function makeContextWithPeer(sessionId: string): {
+	ctx: HubContext;
+	sent: unknown[];
+} {
+	const sent: unknown[] = [];
+	const ctx = {
+		peers: new Set([{ selectedSessionId: sessionId }]),
+		sessions: new Map(),
+		send: (_peer: unknown, payload: unknown) => sent.push(payload),
+		sendToSelectedPeers(id: string, payload: unknown) {
+			if (id === sessionId) sent.push(payload);
+		},
+	} as unknown as HubContext;
+	return { ctx, sent };
+}
+
+function agentErrorEvent(
+	sessionId: string,
+	recoverable: boolean,
+): CoreSessionEvent {
+	return {
+		type: "agent_event",
+		payload: {
+			sessionId,
+			event: {
+				type: "error",
+				error: new Error(
+					"1 tool call(s) failed: [run_commands] Command not executed",
+				),
+				recoverable,
+				iteration: 1,
+			},
+		},
+	};
+}
+
+describe("handleSessionEvent — agent error events", () => {
+	it("does not forward recoverable errors to peers (in-run notices, not turn outcomes)", () => {
+		const { ctx, sent } = makeContextWithPeer("session-1");
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		handleSessionEvent(ctx, agentErrorEvent("session-1", true));
+
+		expect(sent).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Recoverable agent error"),
+		);
+		warn.mockRestore();
+	});
+
+	it("forwards non-recoverable errors to peers", () => {
+		const { ctx, sent } = makeContextWithPeer("session-1");
+
+		handleSessionEvent(ctx, agentErrorEvent("session-1", false));
+
+		expect(sent).toEqual([
+			{
+				type: "error",
+				text: "1 tool call(s) failed: [run_commands] Command not executed",
+			},
+		]);
+	});
+});

--- a/apps/cline-hub/src/server/agent-events.test.ts
+++ b/apps/cline-hub/src/server/agent-events.test.ts
@@ -47,20 +47,21 @@ function agentErrorEvent(
 }
 
 describe("handleSessionEvent — agent error events", () => {
-	it("does not forward recoverable errors to peers (in-run notices, not turn outcomes)", () => {
+	it("forwards recoverable errors flagged as in-run notices, not turn outcomes", () => {
 		const { ctx, sent } = makeContextWithPeer("session-1");
-		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 		handleSessionEvent(ctx, agentErrorEvent("session-1", true));
 
-		expect(sent).toEqual([]);
-		expect(warn).toHaveBeenCalledWith(
-			expect.stringContaining("Recoverable agent error"),
-		);
-		warn.mockRestore();
+		expect(sent).toEqual([
+			{
+				type: "error",
+				text: "1 tool call(s) failed: [run_commands] Command not executed",
+				recoverable: true,
+			},
+		]);
 	});
 
-	it("forwards non-recoverable errors to peers", () => {
+	it("forwards non-recoverable errors unflagged", () => {
 		const { ctx, sent } = makeContextWithPeer("session-1");
 
 		handleSessionEvent(ctx, agentErrorEvent("session-1", false));
@@ -69,6 +70,7 @@ describe("handleSessionEvent — agent error events", () => {
 			{
 				type: "error",
 				text: "1 tool call(s) failed: [run_commands] Command not executed",
+				recoverable: false,
 			},
 		]);
 	});

--- a/apps/cline-hub/src/server/agent-events.ts
+++ b/apps/cline-hub/src/server/agent-events.ts
@@ -119,6 +119,20 @@ function forwardAgentEvent(
 		return;
 	}
 	if (event.type === "error") {
+		// Recoverable errors are in-run notices, not turn outcomes: the
+		// MistakeTracker emits one for every recorded mistake (e.g. a
+		// plan-mode guard-blocked run_commands call) and the run keeps
+		// going. Forwarding them as `error` made the webview drop out of
+		// the sending state and append an error row mid-turn. Any tool
+		// failure involved is already forwarded inline as a failed
+		// tool_event above; the turn's outcome is decided by how it
+		// actually ends (turn_done / non-recoverable error).
+		if (event.recoverable) {
+			console.warn(
+				`Recoverable agent error (run continues): ${event.error.message}`,
+			);
+			return;
+		}
 		ctx.sendToSelectedPeers(sessionId, {
 			type: "error",
 			text: event.error.message,

--- a/apps/cline-hub/src/server/agent-events.ts
+++ b/apps/cline-hub/src/server/agent-events.ts
@@ -119,23 +119,16 @@ function forwardAgentEvent(
 		return;
 	}
 	if (event.type === "error") {
-		// Recoverable errors are in-run notices, not turn outcomes: the
-		// MistakeTracker emits one for every recorded mistake (e.g. a
-		// plan-mode guard-blocked run_commands call) and the run keeps
-		// going. Forwarding them as `error` made the webview drop out of
-		// the sending state and append an error row mid-turn. Any tool
-		// failure involved is already forwarded inline as a failed
-		// tool_event above; the turn's outcome is decided by how it
-		// actually ends (turn_done / non-recoverable error).
-		if (event.recoverable) {
-			console.warn(
-				`Recoverable agent error (run continues): ${event.error.message}`,
-			);
-			return;
-		}
+		// Forwarded with the recoverable flag intact: recoverable errors are
+		// in-run notices (the MistakeTracker emits one per recorded mistake,
+		// e.g. a plan-mode guard-blocked run_commands call) and the run keeps
+		// going, so it is up to each peer to decide how to render them — the
+		// turn's outcome is decided by how it actually ends (turn_done /
+		// non-recoverable error).
 		ctx.sendToSelectedPeers(sessionId, {
 			type: "error",
 			text: event.error.message,
+			recoverable: event.recoverable,
 		});
 	}
 }

--- a/apps/cline-hub/src/webview-protocol.ts
+++ b/apps/cline-hub/src/webview-protocol.ts
@@ -272,7 +272,13 @@ export type WebviewInboundMessage =
 
 export type WebviewOutboundMessage =
 	| { type: "status"; text: string }
-	| { type: "error"; text: string }
+	/**
+	 * `recoverable: true` marks an in-run notice (e.g. a MistakeTracker
+	 * mistake such as a plan-mode guard-blocked command) — the run continues,
+	 * so peers should not treat it as the turn's outcome. Absent/false means
+	 * a genuine failure.
+	 */
+	| { type: "error"; text: string; recoverable?: boolean }
 	| {
 			type: "desktopCommandResult";
 			id: string;

--- a/apps/cline-hub/src/webview/src/Chat.tsx
+++ b/apps/cline-hub/src/webview/src/Chat.tsx
@@ -807,6 +807,15 @@ export default function Chat({
 					setStatus(message.text);
 					return;
 				case "error":
+					// Recoverable errors are in-run notices (e.g. a plan-mode
+					// guard-blocked command recorded as a model mistake) — the
+					// run continues and any tool failure is already shown on
+					// its tool row, so keep the turn state and transcript
+					// intact. Only genuine failures end the turn.
+					if (message.recoverable) {
+						setStatus(`Recoverable error (run continues): ${message.text}`);
+						return;
+					}
 					setStatus(`Error: ${message.text}`);
 					setSending(false);
 					setHydratingSessionId(undefined);


### PR DESCRIPTION
## Problem

#12953 fixed the VS Code extension and CLI treating *any* agent `error` event as terminal, ignoring the `recoverable` flag. The hub dashboard has the identical bug: `handleSessionEvent` forwards every agent error event to peers as `{ type: "error" }` with no recoverable information, and the webview treats every such message as a turn outcome — it drops out of the sending state, clears the active assistant ref, and appends an `Error: 1 tool call(s) failed: [run_commands] ...` row mid-turn.

The MistakeTracker emits a recoverable error event for every recorded mistake (e.g. a plan-mode guard-blocked `run_commands` call from #12906) while the run continues, so a session that recovers and completes cleanly would still show a failed-looking transcript in the dashboard.

Note (from live verification, see PR discussion): over the detached-daemon transport this is currently **latent** — the hub server's session-event projector doesn't project `error` AgentEvents at all yet — so this fix is parity/future-proofing for when those events flow, plus correctness for any transport that already delivers them.

## Fix

Per review feedback: the server is a relay between agent events and the webview protocol, so it carries no display policy. It forwards every agent error with its flag intact — `{ type: "error"; text; recoverable? }` (`webview-protocol.ts`, backward-compatible optional field) — and each peer decides how to render it:

- **webview** (`Chat.tsx`): `recoverable: true` → transient status line only; the turn state and transcript stay intact (the underlying tool failure is already shown inline on its tool row). Non-recoverable errors keep today's terminal treatment. The turn's outcome stays decided by how it actually ends (`turn_done` / non-recoverable error).

This matches how the CLI gates *display* on the same flag while keeping the information available to every peer (e.g. a future verbose/diagnostics view).

## Testing

- `agent-events.test.ts`: recoverable errors are forwarded flagged `recoverable: true`; non-recoverable forwarded with `recoverable: false`. The test `vi.mock`s the two sibling modules that import `@cline/core` at module scope, so it runs without the heavy provider import chain.
- `bun run typecheck` (server) and the webview `tsc -b` build clean.
- Live end-to-end check against a real hub daemon (isolated `CLINE_HUB_PORT`/`CLINE_HUB_DISCOVERY_PATH`, plan-mode session, guard-blocked `echo hello > file`): guard blocks, model recovers and presents a plan, turn ends `Done (completed)`, no error row in the dashboard.
- Note: `connectors`/`marketplace`/`user-instructions` tests currently fail at import time on any *fresh* checkout for unrelated pre-existing reasons (winston under vitest via the SAP provider chain, and an ajv@6/@8 hoisting mismatch via `@modelcontextprotocol/sdk`). Not addressed here; being tracked separately.