### PR TITLE
fix: support max reasoning effort in UI and CLI

### DIFF
--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -33,7 +33,7 @@ export function addRootOptions(cmd: Command): Command {
 			.option("-c, --cwd <path>", "Working directory")
 			.option(
 				"--thinking <level>",
-				"Set reasoning effort: none|low|medium|high|xhigh. Bare --thinking uses medium; omitted leaves provider default.",
+				"Set reasoning effort: none|low|medium|high|xhigh|max. Bare --thinking uses medium; omitted leaves provider default.",
 			)
 			.option("--compaction <mode>", CLI_COMPACTION_MODE_OPTION_DESCRIPTION)
 			.option(
@@ -178,7 +178,8 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 			effort === "low" ||
 			effort === "medium" ||
 			effort === "high" ||
-			effort === "xhigh"
+			effort === "xhigh" ||
+			effort === "max"
 		) {
 			result.thinkingExplicitlySet = true;
 			if (effort === "none") {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -743,7 +743,7 @@ export async function runCli(): Promise<void> {
 
 	if (args.invalidThinkingLevel) {
 		writeErr(
-			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "low", "medium", "high", or "xhigh")`,
+			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "low", "medium", "high", "xhigh", or "max")`,
 		);
 		process.exitCode = 1;
 		return;

--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -171,6 +171,13 @@ describe("parseArgs", () => {
 		expect(parsed.reasoningEffort).toBe("high");
 	});
 
+	it("parses --thinking max", () => {
+		const parsed = parseArgs(["--thinking", "max"]);
+		expect(parsed.thinking).toBe(true);
+		expect(parsed.reasoningEffort).toBe("max");
+		expect(parsed.invalidThinkingLevel).toBeUndefined();
+	});
+
 	it("parses --thinking none as disabled", () => {
 		const parsed = parseArgs(["--thinking", "none"]);
 		expect(parsed.thinking).toBe(false);

--- a/apps/cli/src/utils/reasoning.test.ts
+++ b/apps/cli/src/utils/reasoning.test.ts
@@ -39,6 +39,19 @@ describe("resolveCliReasoning", () => {
 		});
 	});
 
+	it("preserves explicit max reasoning effort", () => {
+		expect(
+			resolveCliReasoning({
+				thinking: true,
+				thinkingExplicitlySet: true,
+				reasoningEffort: "max",
+			}),
+		).toEqual({
+			thinking: true,
+			reasoningEffort: "max",
+		});
+	});
+
 	it("uses persisted disabled reasoning when --thinking is unset", () => {
 		expect(
 			resolveCliReasoning({

--- a/apps/cli/src/utils/reasoning.ts
+++ b/apps/cli/src/utils/reasoning.ts
@@ -8,6 +8,7 @@ const ACTIVE_REASONING_EFFORTS = new Set<ActiveCliReasoningEffort>([
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ]);
 
 export interface ResolveCliReasoningInput {

--- a/apps/vscode/src/core/controller/state/reasoningEffort.test.ts
+++ b/apps/vscode/src/core/controller/state/reasoningEffort.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { normalizeOpenaiReasoningEffort, OPENAI_REASONING_EFFORT_OPTIONS } from "@/shared/storage/types"
+
+describe("normalizeOpenaiReasoningEffort", () => {
+	it("includes max in the selectable effort options", () => {
+		expect(OPENAI_REASONING_EFFORT_OPTIONS).toContain("max")
+	})
+
+	it("preserves max reasoning effort", () => {
+		expect(normalizeOpenaiReasoningEffort("max")).toBe("max")
+	})
+
+	it("normalizes uppercase max reasoning effort", () => {
+		expect(normalizeOpenaiReasoningEffort("MAX")).toBe("max")
+	})
+})

--- a/apps/vscode/src/shared/storage/types.ts
+++ b/apps/vscode/src/shared/storage/types.ts
@@ -1,4 +1,4 @@
-export const OPENAI_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const
+export const OPENAI_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh", "max"] as const
 
 export type OpenaiReasoningEffort = (typeof OPENAI_REASONING_EFFORT_OPTIONS)[number]
 


### PR DESCRIPTION
### Related Issue

**Issue:** #12947

### Description

Adds `max` to the shared VS Code reasoning-effort options and the CLI's accepted active efforts. The CLI parser, validation message, and help text now advertise and preserve the same value, allowing providers whose model catalog supports `max` to receive it instead of capping user selection at `xhigh`.

### Test Procedure

- Ran the focused CLI unit suites for argument parsing, help construction, and reasoning resolution: 48 tests passed.
- Ran the VS Code reasoning-effort regression suite: 3 tests passed, including selectable-option and normalization coverage for `max`.
- Ran Biome checks on all changed TypeScript files and `git diff --check`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Focused tests and formatting checks pass. The complete `bun test` suite was not run because the isolated controller workspace does not have the repository's required Bun 1.3.13 dependency environment installed.

### Screenshots

Not included. The change extends the existing data-driven selector with one additional option; the focused regression test verifies that `max` is present in the selector's default option source.

### Additional Notes

The downstream SDK already supports and normalizes `max`, so this change is limited to the two runtime gates that previously excluded it. Model-specific dynamic filtering is intentionally out of scope.
