### PR TITLE
feat(vscode): explain when a free model promotion ends

### DIFF
--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -1,6 +1,7 @@
 import {
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	isClineFreeModelLimitMessage,
+	isClineModelNotFoundMessage,
 	isClineNotSubscribedMessage,
 	isClineOrgIndividualInferenceSubscriptionMessage,
 	isClinePassLimitMessage,
@@ -18,6 +19,37 @@ export enum ClineErrorType {
 	OrgClinePassRestriction = "orgClinePassRestriction",
 	ClinePassLimit = "clinePassLimit",
 	ClineFreeModelLimit = "clineFreeModelLimit",
+	ClineFreePromotionEnded = "clineFreePromotionEnded",
+}
+
+const CLINE_FREE_MODEL_PREFIX = "cline-free/"
+
+// A retired free model reports model-not-found: once a promotion ends the
+// cline-free/ id is dropped from the catalog while the user's selection still
+// points at it. Matching is text based because the SDK path strips the
+// provider's HTTP status, and the model-id gate keeps ordinary model-not-found
+// errors on their generic path. Mirrors the CLI's detection in
+// apps/cli/src/utils/cline-pass-errors.ts.
+const MODEL_NOT_FOUND_PATTERN = /\bmodel\b[^.,;:]*\b(not[ _]?found|does not exist|no such model|unknown model)\b/i
+
+// Providers nest the reason at different depths ("model not found" can arrive
+// as the message, as details.message, or only inside the raw response body), so
+// the retired-model check scans the whole serialized error too.
+function stringifyErrorDetails(details: unknown): string | undefined {
+	try {
+		return JSON.stringify(details)
+	} catch {
+		return undefined
+	}
+}
+
+function isRetiredFreeModelError(modelId: string | undefined, ...messages: (string | undefined)[]): boolean {
+	if (!modelId?.startsWith(CLINE_FREE_MODEL_PREFIX)) {
+		return false
+	}
+	return messages.some((message) =>
+		message ? isClineModelNotFoundMessage(message) || MODEL_NOT_FOUND_PATTERN.test(message) : false,
+	)
 }
 
 interface ErrorDetails {
@@ -192,6 +224,13 @@ export class ClineError extends Error {
 			(rawMessage ? isClineFreeModelLimitMessage(rawMessage) : false)
 		) {
 			return ClineErrorType.ClineFreeModelLimit
+		}
+
+		// Must precede the auth check below: the API answers 404 for a retired
+		// free model, which the status range would otherwise read as an auth
+		// failure and render as a useless "click Retry" prompt.
+		if (isRetiredFreeModelError(err.modelId, detailMessage, rawMessage, stringifyErrorDetails(err._error))) {
+			return ClineErrorType.ClineFreePromotionEnded
 		}
 
 		if (

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -71,5 +71,38 @@ describe("ClineError", () => {
 
 			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreeModelLimit)
 		})
+
+		it("should classify model-not-found on a free model as an ended promotion", () => {
+			const err = new ClineError("Error 404: model not found", "cline-free/glm-5.2")
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should classify an ended promotion ahead of the 404 auth status range", () => {
+			const err = new ClineError({ message: "model not found", status: 404 }, "cline-free/glm-5.2")
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should find the not-found reason nested in the error body", () => {
+			const err = new ClineError(
+				{ message: "Not Found", error: { message: "The model does not exist" } },
+				"cline-free/glm-5.2",
+			)
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should leave model-not-found on non-free models to the generic path", () => {
+			const err = new ClineError({ message: "model not found", status: 404 }, "z-ai/glm-5.2")
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.Auth)
+		})
+
+		it("should not treat other free model failures as an ended promotion", () => {
+			const err = new ClineError({ message: "Internal server error", status: 500 }, "cline-free/glm-5.2")
+
+			;(ClineError.getErrorType(err) === undefined).should.be.true()
+		})
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreeModelLimitError.tsx
@@ -1,20 +1,12 @@
-import { openAiModelInfoSafeDefaults } from "@shared/api"
-import { CommitModelSelectionRequest } from "@shared/proto/cline/models"
-import type { Mode } from "@shared/storage/types"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
-import { useMemo, useState } from "react"
-import { getModeSpecificFields } from "@/components/settings/utils/providerUtils"
-import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useProviderModels } from "@/hooks/useProviderModels"
-import { ModelsServiceClient } from "@/services/grpc-client"
+import { useSwitchToPaidClineModel } from "@/hooks/useSwitchToPaidClineModel"
 
 interface ClineFreeModelLimitErrorProps {
 	message: string
+	/** The cline-free/<slug> model selected for the current mode. */
+	modelId?: string
 }
 
-const CLINE_PROVIDER_ID = "cline"
-const CLINE_FREE_MODEL_PREFIX = "cline-free/"
 const FREE_MODEL_LIMIT_RETRY_MARKER = "try again in "
 
 function extractFreeModelLimitResetTime(message: string): string | undefined {
@@ -28,98 +20,10 @@ function extractFreeModelLimitResetTime(message: string): string | undefined {
 	return resetTime || undefined
 }
 
-// Free model ids are cline-free/<model-slug>; their paid counterpart is the
-// catalog model with the same slug under its lab prefix (e.g.
-// cline-free/deepseek-v4-flash -> deepseek/deepseek-v4-flash).
-function findPaidModelId(freeModelId: string | undefined, clineModelIds: string[]): string | undefined {
-	if (!freeModelId?.startsWith(CLINE_FREE_MODEL_PREFIX)) {
-		return undefined
-	}
-
-	const modelSlug = freeModelId.slice(CLINE_FREE_MODEL_PREFIX.length)
-	if (!modelSlug) {
-		return undefined
-	}
-
-	return clineModelIds.find(
-		(modelId) => !modelId.startsWith(CLINE_FREE_MODEL_PREFIX) && (modelId === modelSlug || modelId.endsWith(`/${modelSlug}`)),
-	)
-}
-
-const ClineFreeModelLimitError = ({ message }: ClineFreeModelLimitErrorProps) => {
-	const { apiConfiguration, mode } = useExtensionState()
-	const { models: clineModels } = useProviderModels(CLINE_PROVIDER_ID)
-	const { handleModeFieldsChange } = useApiConfigurationHandlers()
-	const [isSwitching, setIsSwitching] = useState(false)
-	const [didSwitch, setDidSwitch] = useState(false)
-	const [switchError, setSwitchError] = useState<string | undefined>()
+const ClineFreeModelLimitError = ({ message, modelId }: ClineFreeModelLimitErrorProps) => {
+	const { paidModelId, isSwitching, didSwitch, switchError, switchToPaidModel } = useSwitchToPaidClineModel(modelId)
 
 	const resetTime = extractFreeModelLimitResetTime(message)
-	const currentMode: Mode = mode ?? "act"
-	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
-	// Free models are selectable on both the cline and cline-pass providers, so
-	// read the model id from whichever provider is currently selected.
-	const selectedFreeModelId =
-		modeFields.apiProvider === "cline-pass"
-			? modeFields.clinePassModelId
-			: modeFields.apiProvider === CLINE_PROVIDER_ID
-				? modeFields.clineModelId
-				: undefined
-	const paidModelId = useMemo(
-		() => findPaidModelId(selectedFreeModelId, Object.keys(clineModels ?? {})),
-		[selectedFreeModelId, clineModels],
-	)
-
-	const handleSwitchToPaidModel = async () => {
-		if (!paidModelId) {
-			return
-		}
-		setIsSwitching(true)
-		setSwitchError(undefined)
-		try {
-			const modelInfo = clineModels?.[paidModelId] ?? {
-				...openAiModelInfoSafeDefaults,
-				name: paidModelId,
-			}
-
-			await ModelsServiceClient.commitModelSelection(
-				CommitModelSelectionRequest.create({
-					providerId: CLINE_PROVIDER_ID,
-					mode: currentMode,
-					modelId: paidModelId,
-				}),
-			)
-
-			await handleModeFieldsChange(
-				{
-					apiProvider: {
-						plan: "planModeApiProvider",
-						act: "actModeApiProvider",
-					},
-					clineModelId: {
-						plan: "planModeClineModelId",
-						act: "actModeClineModelId",
-					},
-					clineModelInfo: {
-						plan: "planModeClineModelInfo",
-						act: "actModeClineModelInfo",
-					},
-				},
-				{
-					apiProvider: CLINE_PROVIDER_ID,
-					clineModelId: paidModelId,
-					clineModelInfo: modelInfo,
-				},
-				currentMode,
-			)
-			setDidSwitch(true)
-		} catch (error) {
-			console.error("Failed to switch to the paid model:", error)
-			setSwitchError(`Failed to switch model. Select ${paidModelId} in API Configuration settings.`)
-		} finally {
-			setIsSwitching(false)
-		}
-	}
 
 	return (
 		<div
@@ -141,7 +45,7 @@ const ClineFreeModelLimitError = ({ message }: ClineFreeModelLimitErrorProps) =>
 						appearance="primary"
 						className="w-full mt-3"
 						disabled={isSwitching || didSwitch}
-						onClick={handleSwitchToPaidModel}>
+						onClick={switchToPaidModel}>
 						{isSwitching
 							? "Switching..."
 							: didSwitch

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
@@ -1,0 +1,63 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useSwitchToPaidClineModel } from "@/hooks/useSwitchToPaidClineModel"
+import { getFreeModelLabel } from "@/utils/clineFreeModels"
+
+interface ClineFreePromotionEndedErrorProps {
+	/** The retired cline-free/<slug> model still selected for the current mode. */
+	modelId?: string
+}
+
+/**
+ * Shown when a free model promotion ends: the cline-free/ id is pulled from the
+ * catalog and the API answers model-not-found. Unlike the daily limit there is
+ * nothing to wait for, so the card only offers ways off the model.
+ */
+const ClineFreePromotionEndedError = ({ modelId }: ClineFreePromotionEndedErrorProps) => {
+	const { navigateToSettingsModelPicker } = useExtensionState()
+	const { paidModelId, isSwitching, didSwitch, switchError, switchToPaidModel } = useSwitchToPaidClineModel(modelId)
+
+	const modelLabel = getFreeModelLabel(modelId)
+
+	return (
+		<div
+			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
+			data-testid="cline-free-promotion-ended-error">
+			<div className="text-error mb-2">Free model promotion ended</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
+				The free promotion for {modelLabel ?? "this model"} has ended and it is no longer available.
+			</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">Select another model to continue.</div>
+			{paidModelId && (
+				<div className="text-(--vscode-descriptionForeground) text-xs mt-2 wrap-anywhere">
+					You can keep using the same model ({paidModelId}) with usage-based billing.
+				</div>
+			)}
+			{paidModelId && (
+				<VSCodeButton
+					appearance="primary"
+					className="w-full mt-3"
+					disabled={isSwitching || didSwitch}
+					onClick={switchToPaidModel}>
+					{isSwitching
+						? "Switching..."
+						: didSwitch
+							? "Switched to Usage-Based billing"
+							: "Switch to Usage-Based billing"}
+				</VSCodeButton>
+			)}
+			<VSCodeButton
+				appearance={paidModelId ? "secondary" : "primary"}
+				className="w-full mt-2"
+				onClick={() => navigateToSettingsModelPicker({ targetSection: "api-config" })}>
+				Choose another model
+			</VSCodeButton>
+			{didSwitch && (
+				<div className="text-(--vscode-descriptionForeground) text-xs mt-2">Retry the request after switching.</div>
+			)}
+			{switchError && <div className="text-error text-xs mt-2">{switchError}</div>}
+		</div>
+	)
+}
+
+export default ClineFreePromotionEndedError

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -23,6 +23,8 @@ vi.mock("@/context/ClineAuthContext", () => ({
 	handleSignOut: vi.fn(),
 }))
 
+const mockNavigateToSettingsModelPicker = vi.hoisted(() => vi.fn())
+
 vi.mock("@/context/ExtensionStateContext", () => ({
 	useExtensionState: () => ({
 		apiConfiguration: mockApiConfiguration,
@@ -30,6 +32,7 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 		providerModelsByProvider: {},
 		startProviderModelsRequest: vi.fn(),
 		applyProviderModelsResponse: vi.fn(),
+		navigateToSettingsModelPicker: mockNavigateToSettingsModelPicker,
 	}),
 }))
 
@@ -67,6 +70,7 @@ vi.mock("../../../../src/services/error/ClineError", () => ({
 		OrgClinePassRestriction: "orgClinePassRestriction",
 		ClinePassLimit: "clinePassLimit",
 		ClineFreeModelLimit: "clineFreeModelLimit",
+		ClineFreePromotionEnded: "clineFreePromotionEnded",
 		QuotaExceeded: "quotaExceeded",
 	},
 }))
@@ -333,6 +337,31 @@ describe("ErrorRow", () => {
 			expect(screen.queryByText(limitMessage)).not.toBeInTheDocument()
 			expect(screen.queryByText(/deepseek-v4-flash/i)).not.toBeInTheDocument()
 			expect(screen.queryByText(/Switch to Usage-Based billing/i)).not.toBeInTheDocument()
+		})
+
+		it("renders an ended free promotion with a way off the retired model", async () => {
+			const notFoundMessage = "Error 404: model not found"
+			const mockClineError = {
+				message: notFoundMessage,
+				isErrorType: vi.fn((type) => type === "clineFreePromotionEnded"),
+				providerId: "cline-pass",
+				_error: { message: notFoundMessage },
+			}
+
+			mockApiConfiguration.actModeClinePassModelId = "cline-free/glm-5.2"
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow apiRequestFailedMessage={notFoundMessage} errorType="error" message={mockMessage} />)
+
+			expect(screen.getByTestId("cline-free-promotion-ended-error")).toBeInTheDocument()
+			expect(screen.getByText(/The free promotion for glm-5.2 has ended/)).toBeInTheDocument()
+			expect(screen.queryByText(notFoundMessage)).not.toBeInTheDocument()
+
+			fireEvent.click(screen.getByText("Choose another model"))
+			expect(mockNavigateToSettingsModelPicker).toHaveBeenCalledWith({ targetSection: "api-config" })
+
+			mockApiConfiguration.actModeClinePassModelId = "cline-pass/test-act-model"
 		})
 
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
@@ -2,6 +2,7 @@ import type { ClineMessage } from "@shared/ExtensionMessage"
 import { memo } from "react"
 import { ClineAuthStatus } from "@/components/account/ClineAuthStatus"
 import ClineFreeModelLimitError from "@/components/chat/ClineFreeModelLimitError"
+import ClineFreePromotionEndedError from "@/components/chat/ClineFreePromotionEndedError"
 import ClinePassLimitError from "@/components/chat/ClinePassLimitError"
 import CreditLimitError from "@/components/chat/CreditLimitError"
 import EntitlementError from "@/components/chat/EntitlementError"
@@ -9,6 +10,8 @@ import OrgClinePassRestrictionError from "@/components/chat/OrgClinePassRestrict
 import SpendLimitError from "@/components/chat/SpendLimitError"
 import { Button } from "@/components/ui/button"
 import { useClineAuth, useClineSignIn } from "@/context/ClineAuthContext"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { getSelectedClineModelId } from "@/utils/clineFreeModels"
 import { ClineError, ClineErrorType } from "../../../../src/services/error/ClineError"
 
 const _errorColor = "var(--vscode-errorForeground)"
@@ -22,9 +25,15 @@ interface ErrorRowProps {
 
 const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStreamingFailedMessage }: ErrorRowProps) => {
 	const { clineUser } = useClineAuth()
+	const { apiConfiguration, mode } = useExtensionState()
 	const rawApiError = apiRequestFailedMessage || apiReqStreamingFailedMessage
 
 	const { isLoginLoading, authStatusMessage, handleSignIn } = useClineSignIn()
+
+	// The error payload carries no model id (the SDK path reduces it to plain
+	// text), so classification of model-scoped errors reads the selection the
+	// request was made with.
+	const selectedClineModelId = getSelectedClineModelId(apiConfiguration, mode ?? "act")
 
 	const renderErrorContent = () => {
 		switch (errorType) {
@@ -33,7 +42,7 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 				// Handle API request errors with special error parsing
 				if (rawApiError) {
 					// FIXME: ClineError parsing should not be applied to non-Cline providers, but it seems we're using clineErrorMessage below in the default error display
-					const clineError = ClineError.parse(rawApiError)
+					const clineError = ClineError.parse(rawApiError, selectedClineModelId)
 					const errorMessage = clineError?._error?.message || clineError?.message || rawApiError
 					const requestId = clineError?._error?.request_id
 					const providerId = clineError?.providerId || clineError?._error?.providerId
@@ -87,7 +96,11 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 
 					if (clineError?.isErrorType(ClineErrorType.ClineFreeModelLimit)) {
 						const detailMessage = clineError?._error?.details?.message || errorMessage
-						return <ClineFreeModelLimitError message={detailMessage} />
+						return <ClineFreeModelLimitError message={detailMessage} modelId={selectedClineModelId} />
+					}
+
+					if (clineError?.isErrorType(ClineErrorType.ClineFreePromotionEnded)) {
+						return <ClineFreePromotionEndedError modelId={selectedClineModelId} />
 					}
 
 					if (clineError?.isErrorType(ClineErrorType.RateLimit)) {

--- a/apps/vscode/webview-ui/src/hooks/useSwitchToPaidClineModel.ts
+++ b/apps/vscode/webview-ui/src/hooks/useSwitchToPaidClineModel.ts
@@ -1,0 +1,79 @@
+import { openAiModelInfoSafeDefaults } from "@shared/api"
+import { CommitModelSelectionRequest } from "@shared/proto/cline/models"
+import type { Mode } from "@shared/storage/types"
+import { useMemo, useState } from "react"
+import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useProviderModels } from "@/hooks/useProviderModels"
+import { ModelsServiceClient } from "@/services/grpc-client"
+import { CLINE_PROVIDER_ID, findPaidModelId } from "@/utils/clineFreeModels"
+
+/**
+ * Moves the selection from a Cline free model to its usage-billed twin on the
+ * cline provider. Shared by the free-model error cards, which both need the
+ * same "the free tier is gone, here is the paid same-model" escape hatch.
+ */
+export function useSwitchToPaidClineModel(freeModelId: string | undefined) {
+	const { mode } = useExtensionState()
+	const { models: clineModels } = useProviderModels(CLINE_PROVIDER_ID)
+	const { handleModeFieldsChange } = useApiConfigurationHandlers()
+	const [isSwitching, setIsSwitching] = useState(false)
+	const [didSwitch, setDidSwitch] = useState(false)
+	const [switchError, setSwitchError] = useState<string | undefined>()
+
+	const currentMode: Mode = mode ?? "act"
+	const paidModelId = useMemo(() => findPaidModelId(freeModelId, Object.keys(clineModels ?? {})), [freeModelId, clineModels])
+
+	const switchToPaidModel = async () => {
+		if (!paidModelId) {
+			return
+		}
+		setIsSwitching(true)
+		setSwitchError(undefined)
+		try {
+			const modelInfo = clineModels?.[paidModelId] ?? {
+				...openAiModelInfoSafeDefaults,
+				name: paidModelId,
+			}
+
+			await ModelsServiceClient.commitModelSelection(
+				CommitModelSelectionRequest.create({
+					providerId: CLINE_PROVIDER_ID,
+					mode: currentMode,
+					modelId: paidModelId,
+				}),
+			)
+
+			await handleModeFieldsChange(
+				{
+					apiProvider: {
+						plan: "planModeApiProvider",
+						act: "actModeApiProvider",
+					},
+					clineModelId: {
+						plan: "planModeClineModelId",
+						act: "actModeClineModelId",
+					},
+					clineModelInfo: {
+						plan: "planModeClineModelInfo",
+						act: "actModeClineModelInfo",
+					},
+				},
+				{
+					apiProvider: CLINE_PROVIDER_ID,
+					clineModelId: paidModelId,
+					clineModelInfo: modelInfo,
+				},
+				currentMode,
+			)
+			setDidSwitch(true)
+		} catch (error) {
+			console.error("Failed to switch to the paid model:", error)
+			setSwitchError(`Failed to switch model. Select ${paidModelId} in API Configuration settings.`)
+		} finally {
+			setIsSwitching(false)
+		}
+	}
+
+	return { paidModelId, isSwitching, didSwitch, switchError, switchToPaidModel }
+}

--- a/apps/vscode/webview-ui/src/utils/clineFreeModels.ts
+++ b/apps/vscode/webview-ui/src/utils/clineFreeModels.ts
@@ -1,0 +1,58 @@
+import type { ApiConfiguration } from "@shared/api"
+import type { Mode } from "@shared/storage/types"
+import { getModeSpecificFields } from "@/components/settings/utils/providerUtils"
+
+export const CLINE_PROVIDER_ID = "cline"
+export const CLINE_PASS_PROVIDER_ID = "cline-pass"
+export const CLINE_FREE_MODEL_PREFIX = "cline-free/"
+
+export function isClineFreeModelId(modelId: string | undefined): boolean {
+	return modelId?.startsWith(CLINE_FREE_MODEL_PREFIX) ?? false
+}
+
+/**
+ * The model id selected for `mode`, when the active provider is one of the two
+ * that serve Cline free models. Free models are selectable on both the cline
+ * and cline-pass providers, so read the id from whichever one is selected.
+ */
+export function getSelectedClineModelId(apiConfiguration: ApiConfiguration | undefined, mode: Mode): string | undefined {
+	const modeFields = getModeSpecificFields(apiConfiguration, mode)
+	if (modeFields.apiProvider === CLINE_PASS_PROVIDER_ID) {
+		return modeFields.clinePassModelId
+	}
+	if (modeFields.apiProvider === CLINE_PROVIDER_ID) {
+		return modeFields.clineModelId
+	}
+	return undefined
+}
+
+/**
+ * Free model ids are cline-free/<model-slug>; their paid counterpart is the
+ * catalog model with the same slug under its lab prefix (e.g.
+ * cline-free/deepseek-v4-flash -> deepseek/deepseek-v4-flash).
+ */
+export function findPaidModelId(freeModelId: string | undefined, clineModelIds: string[]): string | undefined {
+	if (!isClineFreeModelId(freeModelId)) {
+		return undefined
+	}
+
+	const modelSlug = freeModelId?.slice(CLINE_FREE_MODEL_PREFIX.length)
+	if (!modelSlug) {
+		return undefined
+	}
+
+	return clineModelIds.find(
+		(modelId) => !isClineFreeModelId(modelId) && (modelId === modelSlug || modelId.endsWith(`/${modelSlug}`)),
+	)
+}
+
+/**
+ * Human-readable label for a free model id, used when the model has already
+ * been pulled from the catalog and no display name is available anymore.
+ */
+export function getFreeModelLabel(freeModelId: string | undefined): string | undefined {
+	if (!isClineFreeModelId(freeModelId)) {
+		return undefined
+	}
+	return freeModelId?.slice(CLINE_FREE_MODEL_PREFIX.length) || undefined
+}


### PR DESCRIPTION
### Related Issue

**Issue:** n/a — follow-up to #12593 (Cline free UX), which shipped the promotion-ended notice to the CLI but not the extension.

### Description

We're ending the free GLM promo (`cline-free/glm-5.2`, selectable on both the `cline` and `cline-pass` providers). When a promotion ends the id is dropped from the recommended-models payload, but users keep the id in their persisted selection — so their next request answers **model not found**.

The CLI has handled this since #12593:

```
Free model promotion ended
The free promotion for this model has ended and it is no longer available.
Select another model to continue.
Open the model selector with /model.
```

The extension got only the *daily limit* card out of that PR, never the promotion-ended path. So today:

- **SDK extension:** `describeModelNotFoundError` appends generic text — *"This model may be retired or unavailable on your account. Switch to a different model in API Configuration settings, then retry."* — rendered as raw red error text. Truthful, but it never mentions the free promotion and offers no action.
- **Legacy extension** (ported separately, see below): worse — the 404 lands in `getErrorType`'s `status > 400 && status < 429` auth range, so `ErrorRow` renders literally just `(Click "Retry" below)`. No message, no reason, and retry can never succeed.

This PR adds the extension equivalent of the CLI card.

#### How it's detected

New `ClineErrorType.ClineFreePromotionEnded`, matched on a model-not-found message **gated on the selected model id carrying the `cline-free/` prefix** — the same gate the CLI uses in `apps/cli/src/utils/cline-pass-errors.ts`. Without that gate every ordinary model-not-found error would get free-promo copy; with it, they keep their generic path.

Two non-obvious bits:

1. **The check has to precede the auth-status check.** A retired model answers 404, which is inside the `> 400 && < 429` range that `getErrorType` reads as auth. Put the new branch after it and the auth classification wins every time.

2. **The error payload has no model id to gate on.** On the SDK path `reshapeErrorForWebview` reduces the error to plain text before it reaches the webview, so `providerId`/`modelId` don't survive. `ClineError.parse()` already accepts a modelId — `ErrorRow` now passes the selection the request was actually made with (read from the mode-specific fields, since free models are selectable on both `cline` and `cline-pass`). That also matches how the CLI does it: it gates on `config.modelId`, not on anything in the error.

The matcher ORs the shared `isClineModelNotFoundMessage` helper with the broader `\bmodel\b[^.,;:]*\b(not found|does not exist|no such model|unknown model)\b` pattern already used by `describeModelNotFoundError`, and additionally scans the serialized error — providers nest the reason at different depths (top-level `message`, `details.message`, or only inside the raw body), and the SDK path can hand us `{"error":{"message":"model not found"}}` whose stringified form is `[object Object]` at the top level.

#### What the card offers

Unlike the daily limit there is nothing to wait for, so the card only offers ways *off* the model:

- **Switch to Usage-Based billing** when the catalog has the paid twin. For GLM that resolves to `z-ai/glm-5.2` — note the static catalog has no paid GLM under the `cline` provider, so this comes from the live provider list; if a retired model has no twin the button is simply absent.
- **Choose another model**, which opens the settings model picker via `navigateToSettingsModelPicker({ targetSection: "api-config" })`. This is the surface the CLI's "open the model selector with /model" maps to.

The switch-to-paid-twin flow was ~80 lines inside `ClineFreeModelLimitError`; it's now a shared `useSwitchToPaidClineModel` hook that both cards use, so this PR is close to net-neutral on line count.

#### Note on retries

Main is unaffected — retries live in the SDK provider layer, and 404 isn't retryable there. The legacy port *did* need retry-skip changes, because being misclassified as `Auth` was what had been keeping these errors out of the auto-retry paths. That's handled in the companion PR.

### Test Procedure

- `bun test src/services/error/__tests__/ClineError.test.ts` — 14 pass. New cases cover: model-not-found on a `cline-free/` id classifies as the new type; it wins over the 404 auth range; the reason is found when nested in the error body; model-not-found on a **non-free** id still classifies as `Auth` (i.e. no behavior change for everyone else); and an unrelated 500 on a free model stays unclassified.
- `vitest run src/components/chat/ErrorRow.test.tsx` — 20 pass. New case renders the card for a `cline-free/glm-5.2` selection, asserts the raw backend message is replaced, and asserts the *Choose another model* button routes to the model picker. The pre-existing paid-twin test still passes, which is what verifies the `useSwitchToPaidClineModel` extraction didn't change the daily-limit card's behavior.
- `tsc --noEmit` clean for both `apps/vscode` and `apps/vscode/webview-ui`.

What could break: the risk is over-matching, i.e. a normal model-not-found on a paid model getting free-promo copy. The `cline-free/` gate makes that impossible, and there's a test pinning it. Second risk is `ErrorRow` now calling `useExtensionState()` — it's already inside the provider everywhere it renders (the child error cards have always called it), and the full ErrorRow suite passes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

**Legacy port:** #12969 — same feature for the legacy-extension branch, which is where the overwhelming majority of stable users are today. Worth landing both before the promo actually ends.

**Separate follow-up, not fixed here:** both `ClineModelPicker` and `ClinePassProvider` treat an *empty* free-model list from the recommended-models endpoint as "unavailable" and fall back to the hardcoded `CLINE_RECOMMENDED_MODELS_FALLBACK.free` (`kwaipilot/kat-coder-pro`, `arcee-ai/trinity-large-preview:free`). If GLM is the last free model, the Free tab will keep advertising two stale ids after the promo ends. Happy to fix that in a follow-up — it needs a product call on whether an empty list should hide the tab.
