### PR TITLE
feat(vscode): explain when a free model promotion ends

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -300,7 +300,13 @@ export class Controller {
 			() => this.lastKnownWorkspaceRoot,
 			// Model backing the active turn — lets error reshaping recognize
 			// retired cline-free/ models (the error payload itself never names one).
-			() => this.getSessionModelId() ?? this.getTaskModelId(),
+			// The task shim is preferred over session-start metadata: a mid-task
+			// model-only switch updates the running session's model in place
+			// (updateActiveSessionModel) and refreshes the shim, but never touches
+			// startConfig/manifest, which would otherwise report the stale model.
+			// The shim starts as "unknown" (filtered out by getTaskModelId), so
+			// fresh sessions still resolve through their start metadata.
+			() => this.getTaskModelId() ?? this.getSessionModelId(),
 		)
 		// Warm the synchronous workspace-root snapshot used for display-path
 		// relativization (getWorkspaceRoot never rejects — it falls back internally).

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -298,6 +298,9 @@ export class Controller {
 			() => this.getActiveProviderId(),
 			() => (this.stateManager.getGlobalSettingsKey("mode") === "plan" ? "plan" : "act"),
 			() => this.lastKnownWorkspaceRoot,
+			// Model backing the active turn — lets error reshaping recognize
+			// retired cline-free/ models (the error payload itself never names one).
+			() => this.getSessionModelId() ?? this.getTaskModelId(),
 		)
 		// Warm the synchronous workspace-root snapshot used for display-path
 		// relativization (getWorkspaceRoot never rejects — it falls back internally).

--- a/apps/vscode/src/sdk/free-promotion-ended.test.ts
+++ b/apps/vscode/src/sdk/free-promotion-ended.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { ClineError, ClineErrorType } from "../services/error/ClineError"
+import { reshapeErrorForWebview } from "./message-translator"
+
+// Once a free promotion ends the cline-free/ model is removed from the catalog
+// and the backend answers "model not found". These tests pin the host-side
+// detection that turns that answer into the webview's promotion-ended card.
+describe("reshapeErrorForWebview - free promotion ended", () => {
+	it("stamps the promotion-ended code when a cline-free model answers model-not-found", () => {
+		const payload = reshapeErrorForWebview({ message: "Error 404: Model not found" }, "cline", "cline-free/glm-5")
+
+		const parsed = JSON.parse(payload)
+		expect(parsed.code).toBe("cline_free_promotion_ended")
+		expect(parsed.modelId).toBe("cline-free/glm-5")
+		expect(parsed.providerId).toBe("cline")
+		expect(parsed.details?.code).toBe("cline_free_promotion_ended")
+	})
+
+	it("keeps the selected provider id, so cline-pass selections stay attributed", () => {
+		const payload = reshapeErrorForWebview({ message: "Model not found" }, "cline-pass", "cline-free/glm-5")
+
+		expect(JSON.parse(payload).providerId).toBe("cline-pass")
+	})
+
+	it("round-trips into the webview's ClineFreePromotionEnded classification", () => {
+		const payload = reshapeErrorForWebview({ message: "Error 404: Model not found" }, "cline", "cline-free/glm-5")
+
+		const clineError = ClineError.parse(payload)
+		expect(clineError && ClineError.getErrorType(clineError)).toBe(ClineErrorType.ClineFreePromotionEnded)
+	})
+
+	it("leaves model-not-found for a paid model on the generic guidance path", () => {
+		const payload = reshapeErrorForWebview({ message: "Model not found" }, "cline", "deepseek/deepseek-v4-flash")
+
+		expect(payload).toBe(
+			"Model not found This model may be retired or unavailable on your account. Switch to a different model in API Configuration settings, then retry.",
+		)
+	})
+
+	it("leaves model-not-found on the generic guidance path when the model id is unknown", () => {
+		const payload = reshapeErrorForWebview({ message: "Model not found" }, "cline")
+
+		expect(payload).toContain("This model may be retired or unavailable")
+	})
+
+	it("does not touch unrelated errors from a cline-free model", () => {
+		expect(reshapeErrorForWebview({ message: "socket hang up" }, "cline", "cline-free/glm-5")).toBe("socket hang up")
+	})
+})

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -46,6 +46,7 @@ import type {
 import { Logger } from "@shared/services/Logger"
 import * as path from "path"
 import { arePathsEqual, getDesktopDir } from "@/utils/path"
+import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage } from "../services/error/ClineError"
 import { MessageIdMinter } from "./message-id-minter"
 import { describeMissingCredentialError } from "./provider-credential-error"
 import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
@@ -152,6 +153,7 @@ export class MessageTranslatorState {
 		private readonly getActiveProviderId?: () => string | undefined,
 		private readonly getUiMode?: () => "plan" | "act" | "yolo" | undefined,
 		private readonly getCwd?: () => string | undefined,
+		private readonly getActiveModelId?: () => string | undefined,
 	) {
 		this.minter = minter
 	}
@@ -159,6 +161,11 @@ export class MessageTranslatorState {
 	/** Provider backing the active turn, if the host can supply it. */
 	activeProviderId(): string | undefined {
 		return this.getActiveProviderId?.()
+	}
+
+	/** Model backing the active turn, if the host can supply it. */
+	activeModelId(): string | undefined {
+		return this.getActiveModelId?.()
 	}
 
 	/**
@@ -1909,7 +1916,7 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 			// `code: "insufficient_credits"`). We try to reshape it into the
 			// ClineError-serialized format the webview expects so that ErrorRow
 			// can render the correct UI (Buy Credits button, etc.).
-			const errorPayload = reshapeErrorForWebview(event.error, state.activeProviderId())
+			const errorPayload = reshapeErrorForWebview(event.error, state.activeProviderId(), state.activeModelId())
 
 			// Emit an api_req_started with streamingFailedMessage so the
 			// RequestStartRow renders the error via ErrorRow. This replaces
@@ -2530,13 +2537,34 @@ function describeModelNotFoundError(rawMessage: string): string | undefined {
  * ErrorRow expects (`code`, `providerId`, `details`), extracting structured
  * info from the error message when present and falling back to raw text.
  */
-export function reshapeErrorForWebview(error: { message?: string; status?: number; code?: string }, providerId?: string): string {
+export function reshapeErrorForWebview(
+	error: { message?: string; status?: number; code?: string },
+	providerId?: string,
+	modelId?: string,
+): string {
 	// The ClineError-JSON branches below are cline-provider flows (balance,
 	// spend limit), so "cline" stays their fallback id. The missing-credential
 	// message instead gets the raw value: defaulting there would name the wrong
 	// provider when the active provider id is unknown.
 	const clineErrorProviderId = providerId ?? "cline"
 	const rawMessage = error.message ?? "Unknown error"
+
+	// A retired cline-free/ model answers "model not found" once its free
+	// promotion ends and the id is removed from the catalog. Stamp the payload
+	// with a dedicated code so the webview renders the promotion-ended card
+	// instead of the generic model-not-found guidance below.
+	if (isClineFreePromotionEndedMessage(rawMessage, modelId)) {
+		return JSON.stringify({
+			message: rawMessage,
+			code: CLINE_FREE_PROMOTION_ENDED_ERROR_CODE,
+			providerId: clineErrorProviderId,
+			modelId,
+			details: {
+				code: CLINE_FREE_PROMOTION_ENDED_ERROR_CODE,
+				message: rawMessage,
+			},
+		})
+	}
 
 	// Try to extract structured error info from the error message.
 	// The SDK often wraps API error JSON in the Error.message field.

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -1,6 +1,7 @@
 import {
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	isClineFreeModelLimitMessage,
+	isClineModelNotFoundMessage,
 	isClineNotSubscribedMessage,
 	isClineOrgIndividualInferenceSubscriptionMessage,
 	isClinePassLimitMessage,
@@ -18,6 +19,24 @@ export enum ClineErrorType {
 	OrgClinePassRestriction = "orgClinePassRestriction",
 	ClinePassLimit = "clinePassLimit",
 	ClineFreeModelLimit = "clineFreeModelLimit",
+	ClineFreePromotionEnded = "clineFreePromotionEnded",
+}
+
+export const CLINE_FREE_MODEL_ID_PREFIX = "cline-free/"
+/** Error code stamped by the host when it detects a retired free model (see message-translator). */
+export const CLINE_FREE_PROMOTION_ENDED_ERROR_CODE = "cline_free_promotion_ended"
+
+/**
+ * Detects a request against a retired free model: once a promotion ends the
+ * cline-free/ model is removed from the catalog and the backend answers "model
+ * not found". The modelId gate keeps ordinary model-not-found errors on their
+ * generic path. Mirrors the CLI's detection in apps/cli/src/utils/cline-pass-errors.ts.
+ */
+export function isClineFreePromotionEndedMessage(message: string, modelId?: string): boolean {
+	if (!modelId?.toLowerCase().startsWith(CLINE_FREE_MODEL_ID_PREFIX)) {
+		return false
+	}
+	return isClineModelNotFoundMessage(message)
 }
 
 interface ErrorDetails {
@@ -199,6 +218,18 @@ export class ClineError extends Error {
 			(rawMessage ? isClinePassLimitMessage(rawMessage) : false)
 		) {
 			return ClineErrorType.ClinePassLimit
+		}
+
+		// Retired free models must be classified before the auth branch: the
+		// backend's model-not-found answer is a 404, which falls inside the
+		// generic 401-428 auth-status range below.
+		if (
+			code === CLINE_FREE_PROMOTION_ENDED_ERROR_CODE ||
+			details?.code === CLINE_FREE_PROMOTION_ENDED_ERROR_CODE ||
+			(detailMessage ? isClineFreePromotionEndedMessage(detailMessage, err.modelId) : false) ||
+			(rawMessage ? isClineFreePromotionEndedMessage(rawMessage, err.modelId) : false)
+		) {
+			return ClineErrorType.ClineFreePromotionEnded
 		}
 
 		// Check auth errors

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -71,5 +71,45 @@ describe("ClineError", () => {
 
 			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreeModelLimit)
 		})
+
+		it("should classify the host-stamped promotion-ended code as ClineFreePromotionEnded", () => {
+			// reshapeErrorForWebview stamps this code when the active model is a
+			// retired cline-free/ id (see message-translator).
+			const err = new ClineError({
+				message: "Model not found",
+				code: "cline_free_promotion_ended",
+			})
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should classify model-not-found for a cline-free model as ClineFreePromotionEnded", () => {
+			const err = new ClineError({ message: "Error 404: Model not found" }, "cline-free/glm-5")
+
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should prefer ClineFreePromotionEnded over Auth for a 404 with a cline-free model", () => {
+			// A 404 falls inside the generic 401-428 auth-status range; the
+			// promotion-ended classification must win.
+			const err = new ClineError({ message: "Error 404: Model not found", status: 404 }, "cline-free/glm-5")
+
+			const result = ClineError.getErrorType(err)
+			result!.should.equal(ClineErrorType.ClineFreePromotionEnded)
+		})
+
+		it("should keep model-not-found for a non-free model on the generic path", () => {
+			const err = new ClineError({ message: "Error 404: Model not found", status: 404 }, "deepseek/deepseek-v4-flash")
+
+			const result = ClineError.getErrorType(err)
+			;(result !== ClineErrorType.ClineFreePromotionEnded).should.be.true()
+		})
+
+		it("should not classify unrelated cline-free errors as ClineFreePromotionEnded", () => {
+			const err = new ClineError({ message: "Network error: socket hang up" }, "cline-free/glm-5")
+
+			const result = ClineError.getErrorType(err)
+			;(result !== ClineErrorType.ClineFreePromotionEnded).should.be.true()
+		})
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
@@ -1,0 +1,30 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+
+// Shown when a request targets a retired cline-free/ model: once its free
+// promotion ends the model is removed from the catalog and the backend answers
+// "model not found". Mirrors the CLI's "Free model promotion ended" banner,
+// with the CLI's "/model" hint replaced by a button into the model picker.
+const ClineFreePromotionEndedError = () => {
+	const { navigateToSettingsModelPicker } = useExtensionState()
+
+	return (
+		<div
+			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
+			data-testid="cline-free-promotion-ended-error">
+			<div className="text-error mb-2">Free model promotion ended</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
+				The free promotion for this model has ended and it is no longer available.
+			</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">Select another model to continue.</div>
+			<VSCodeButton
+				appearance="primary"
+				className="w-full mt-3"
+				onClick={() => navigateToSettingsModelPicker({ targetSection: "api-config" })}>
+				Select a Model
+			</VSCodeButton>
+		</div>
+	)
+}
+
+export default ClineFreePromotionEndedError

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -5,6 +5,7 @@ import ErrorRow from "./ErrorRow"
 
 const mockSetUserOrganization = vi.hoisted(() => vi.fn())
 const mockUpdateApiConfigurationProto = vi.hoisted(() => vi.fn())
+const mockNavigateToSettingsModelPicker = vi.hoisted(() => vi.fn())
 const mockApiConfiguration = vi.hoisted(() => ({
 	planModeApiProvider: "cline-pass",
 	actModeApiProvider: "cline-pass",
@@ -30,6 +31,7 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 		providerModelsByProvider: {},
 		startProviderModelsRequest: vi.fn(),
 		applyProviderModelsResponse: vi.fn(),
+		navigateToSettingsModelPicker: mockNavigateToSettingsModelPicker,
 	}),
 }))
 
@@ -67,6 +69,7 @@ vi.mock("../../../../src/services/error/ClineError", () => ({
 		OrgClinePassRestriction: "orgClinePassRestriction",
 		ClinePassLimit: "clinePassLimit",
 		ClineFreeModelLimit: "clineFreeModelLimit",
+		ClineFreePromotionEnded: "clineFreePromotionEnded",
 		QuotaExceeded: "quotaExceeded",
 	},
 }))
@@ -333,6 +336,31 @@ describe("ErrorRow", () => {
 			expect(screen.queryByText(limitMessage)).not.toBeInTheDocument()
 			expect(screen.queryByText(/deepseek-v4-flash/i)).not.toBeInTheDocument()
 			expect(screen.queryByText(/Switch to Usage-Based billing/i)).not.toBeInTheDocument()
+		})
+
+		it("renders the promotion-ended card with a route into the model picker", async () => {
+			const rawMessage = "Error 404: Model not found"
+			const mockClineError = {
+				message: rawMessage,
+				isErrorType: vi.fn((type) => type === "clineFreePromotionEnded"),
+				providerId: "cline",
+				modelId: "cline-free/glm-5",
+				_error: { message: rawMessage },
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow apiRequestFailedMessage={rawMessage} errorType="error" message={mockMessage} />)
+
+			expect(screen.getByTestId("cline-free-promotion-ended-error")).toBeInTheDocument()
+			expect(screen.getByText("Free model promotion ended")).toBeInTheDocument()
+			expect(screen.getByText(/no longer available/)).toBeInTheDocument()
+			// The raw backend message is replaced by the dedicated copy.
+			expect(screen.queryByText(rawMessage)).not.toBeInTheDocument()
+
+			fireEvent.click(screen.getByText("Select a Model"))
+			expect(mockNavigateToSettingsModelPicker).toHaveBeenCalledWith({ targetSection: "api-config" })
 		})
 
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
@@ -2,6 +2,7 @@ import type { ClineMessage } from "@shared/ExtensionMessage"
 import { memo } from "react"
 import { ClineAuthStatus } from "@/components/account/ClineAuthStatus"
 import ClineFreeModelLimitError from "@/components/chat/ClineFreeModelLimitError"
+import ClineFreePromotionEndedError from "@/components/chat/ClineFreePromotionEndedError"
 import ClinePassLimitError from "@/components/chat/ClinePassLimitError"
 import CreditLimitError from "@/components/chat/CreditLimitError"
 import EntitlementError from "@/components/chat/EntitlementError"
@@ -88,6 +89,13 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 					if (clineError?.isErrorType(ClineErrorType.ClineFreeModelLimit)) {
 						const detailMessage = clineError?._error?.details?.message || errorMessage
 						return <ClineFreeModelLimitError message={detailMessage} />
+					}
+
+					// A retired free model answers model-not-found once its promotion
+					// ends — dedicated copy plus a route into the model picker,
+					// since retrying the deleted model can never succeed.
+					if (clineError?.isErrorType(ClineErrorType.ClineFreePromotionEnded)) {
+						return <ClineFreePromotionEndedError />
 					}
 
 					if (clineError?.isErrorType(ClineErrorType.RateLimit)) {


### PR DESCRIPTION
### Related Issue

N/A — part of winding down the free GLM promotion on the `cline`/`cline-pass` providers. CLI counterpart shipped in #12593; legacy-extension counterpart is the sibling PR targeting `legacy-extension`.

### Description

**The problem.** When a free model promotion ends, the `cline-free/<slug>` model id is deleted from the catalog and the backend answers **404 "model not found"** to any request still pointed at it. Users who had the free model selected get no explanation of what happened. The CLI has shown a dedicated banner for this since #12593:

```
Free model promotion ended
The free promotion for this model has ended and it is no longer available.
Select another model to continue.
Open the model selector with /model.
```

The extension had nothing equivalent. The SDK error path rewrote the answer into generic model-not-found guidance ("This model may be retired or unavailable on your account…") with no dedicated UI and no route into the model picker — and if the error ever arrives with a status attached, a 404 falls inside `ClineError.getErrorType()`'s generic 401–428 auth-status range and renders as an auth error.

**The fix.** Detect the case on the host, where the model id is known, and give it a first-class error type + card:

- `MessageTranslatorState` gains an optional `getActiveModelId` source (wired from `SdkController` as `getSessionModelId() ?? getTaskModelId()`). This is the key enabling piece: the SDK strips HTTP status upstream and the error payload never names the model, so nothing downstream could previously tell a retired free model apart from any other 404.
- `reshapeErrorForWebview` now takes that model id. When the message is a model-not-found **and** the model id carries the `cline-free/` prefix, it synthesizes ClineError JSON stamped with `code: "cline_free_promotion_ended"` (mirroring how the balance/spend-limit reshaping works). Every other model-not-found keeps the existing generic guidance path — the prefix gate keeps ordinary 404s untouched.
- `ClineErrorType.ClineFreePromotionEnded` classifies on that code (with a message+modelId fallback via the shared `isClineModelNotFoundMessage` from `@cline/llms`), placed **before** the auth branch since 404 ∈ (400, 429).
- `ErrorRow` renders a new `ClineFreePromotionEndedError` card: CLI-parity copy plus a **Select a Model** button that calls `navigateToSettingsModelPicker({ targetSection: "api-config" })` — the extension's equivalent of the CLI's "/model" hint.

**Decisions / non-obvious bits:**

- Detection matches the CLI exactly (`apps/cli/src/utils/cline-pass-errors.ts`): `cline-free/` model-id prefix + `isClineModelNotFoundMessage`. Text-based because the provider's HTTP status is stripped upstream, same reason `describeModelNotFoundError` matches on text.
- No auto-retry work needed on this bundle: the AI SDK provider layer only retries retryable statuses (429/5xx), so the 404 surfaces immediately. (The legacy sibling PR *does* need skip-list changes because the legacy task loop has its own 3-attempt backoff.)
- The card is deliberately minimal — copy + picker button. The daily-free-limit card's one-click "switch to the paid twin" flow could be added here too (the paid `glm-5` stays in the catalog after the promo ends); left out to keep this PR small, easy follow-up if we want the conversion nudge.
- `providerId` is passed through untouched, so a `cline-pass` selection stays attributed to `cline-pass` in the payload.

### Test Procedure

- New `apps/vscode/src/sdk/free-promotion-ended.test.ts` (vitest): reshaping stamps code/modelId/providerId for `cline-free/` + model-not-found; keeps paid-model and unknown-model 404s on the generic-guidance path; leaves unrelated cline-free errors untouched; and a round-trip test proving the reshaped payload classifies as `ClineFreePromotionEnded` through the same `ClineError.parse` the webview uses.
- `ClineError.test.ts` (bun): code-based and message+modelId-based classification, 404-beats-auth precedence, prefix gate, unrelated-error negative.
- `ErrorRow.test.tsx` (vitest): renders the card, hides the raw backend message, and the button fires `navigateToSettingsModelPicker({ targetSection: "api-config" })`.
- Full runs: both touched vitest files ✓, bun ClineError suite ✓, webview ErrorRow suite ✓, `tsc --noEmit` clean for both the extension and webview projects, biome clean on touched files.
- Regression thinking: the reshape change is a pure-add early return gated on a model-id prefix that can only come from the Cline catalog, so non-Cline providers and ordinary 404s can't hit it; the classification change sits after all existing specific types and before the auth fall-through, so no existing classification moves.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The card mirrors the existing daily-free-limit card's layout:

> **Free model promotion ended**
> The free promotion for this model has ended and it is no longer available.
> Select another model to continue.
> **[ Select a Model ]**

### Additional Notes

Ships to users via the next stable combined VSIX together with the legacy sibling PR — both bundles need the card since the rollout flag governs which one a stable install runs.
