### PR TITLE
feat(vscode): explain when a free model promotion ends (legacy)

### DIFF
--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -2477,6 +2477,12 @@ export class Task {
 				const isClineFreeModelLimitError = clineError.isErrorType(
 					ClineErrorType.ClineFreeModelLimit,
 				);
+				// A retired free model can never answer — its id was removed from
+				// the catalog when the promotion ended — so retrying only delays
+				// the card that routes the user into the model picker.
+				const isClineFreePromotionEndedError = clineError.isErrorType(
+					ClineErrorType.ClineFreePromotionEnded,
+				);
 
 				// Check if this is a Cline provider insufficient credits error - don't auto-retry these
 				const isClineProviderInsufficientCredits = (() => {
@@ -2506,6 +2512,7 @@ export class Task {
 					!isOrgClinePassRestrictionError &&
 					!isClinePassLimitError &&
 					!isClineFreeModelLimitError &&
+					!isClineFreePromotionEndedError &&
 					this.taskState.autoRetryAttempts < 3;
 
 				// Mirror the SDK extension's provider-failure reporting: same
@@ -2608,7 +2615,8 @@ export class Task {
 						!isEntitlementError &&
 						!isOrgClinePassRestrictionError &&
 						!isClinePassLimitError &&
-						!isClineFreeModelLimitError;
+						!isClineFreeModelLimitError &&
+						!isClineFreePromotionEndedError;
 					if (showRetry) {
 						await this.say(
 							"error_retry",
@@ -3646,10 +3654,15 @@ export class Task {
 					const isStreamingClineFreeModelLimitError = clineError.isErrorType(
 						ClineErrorType.ClineFreeModelLimit,
 					);
+					// A retired free model (promotion ended) can never answer, so a
+					// retry against it is guaranteed to fail again.
+					const isStreamingClineFreePromotionEndedError =
+						clineError.isErrorType(ClineErrorType.ClineFreePromotionEnded);
 					const isStreamingNonRetriableError =
 						isStreamingSpendLimitError ||
 						isStreamingQuotaExceededError ||
-						isStreamingClineFreeModelLimitError;
+						isStreamingClineFreeModelLimitError ||
+						isStreamingClineFreePromotionEndedError;
 					const willAutoRetryStreamingFailure =
 						!isStreamingNonRetriableError &&
 						this.taskState.autoRetryAttempts < 3;

--- a/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
@@ -879,12 +879,18 @@ export class SubagentRunner {
 		const isOrgClinePassRestrictionError = parsedError.isErrorType(
 			ClineErrorType.OrgClinePassRestriction,
 		);
+		// A retired free model (promotion ended) can never answer, so a retry
+		// against it is guaranteed to fail again.
+		const isClineFreePromotionEndedError = parsedError.isErrorType(
+			ClineErrorType.ClineFreePromotionEnded,
+		);
 
 		if (
 			isAuthError ||
 			isBalanceError ||
 			isEntitlementError ||
-			isOrgClinePassRestrictionError
+			isOrgClinePassRestrictionError ||
+			isClineFreePromotionEndedError
 		) {
 			return false;
 		}

--- a/apps/vscode/src/services/error/ClineError.ts
+++ b/apps/vscode/src/services/error/ClineError.ts
@@ -12,6 +12,7 @@ export enum ClineErrorType {
 	OrgClinePassRestriction = "orgClinePassRestriction",
 	ClinePassLimit = "clinePassLimit",
 	ClineFreeModelLimit = "clineFreeModelLimit",
+	ClineFreePromotionEnded = "clineFreePromotionEnded",
 }
 
 interface ErrorDetails {
@@ -72,6 +73,14 @@ const CLINE_PASS_LIMIT_SUFFIX = "please try again later.";
 const CLINE_FREE_MODEL_LIMIT_MARKER = "free limit reached on model";
 const CLINE_FREE_MODEL_LIMIT_RETRY_MARKER = "try again in ";
 
+// Once a free promotion ends, the cline-free/ model is removed from the catalog
+// and the backend answers "model not found" to requests against it. The prefix
+// gate keeps ordinary model-not-found errors on their generic path. Kept local
+// (rather than importing shared/cline/free-models) so this file stays free of
+// import cycles — it is loaded by both the extension host and the webview.
+const CLINE_FREE_MODEL_ID_PREFIX = "cline-free/";
+const CLINE_MODEL_NOT_FOUND_MARKER = "model not found";
+
 function findClinePassLimitMessageBounds(
 	text: string,
 ): { start: number; end: number } | undefined {
@@ -107,6 +116,25 @@ export function extractClinePassLimitMessage(
 
 export function isClineFreeModelLimitMessage(text: string): boolean {
 	return text.toLowerCase().includes(CLINE_FREE_MODEL_LIMIT_MARKER);
+}
+
+export function isClineModelNotFoundMessage(text: string): boolean {
+	return text.toLowerCase().includes(CLINE_MODEL_NOT_FOUND_MARKER);
+}
+
+/**
+ * Detects a request against a retired free model: once a promotion ends the
+ * cline-free/ model is removed from the catalog and the backend answers "model
+ * not found". Mirrors the CLI's detection in apps/cli (cline-pass-errors.ts).
+ */
+export function isClineFreePromotionEndedMessage(
+	text: string,
+	modelId?: string,
+): boolean {
+	if (!modelId?.toLowerCase().startsWith(CLINE_FREE_MODEL_ID_PREFIX)) {
+		return false;
+	}
+	return isClineModelNotFoundMessage(text);
 }
 
 /**
@@ -294,6 +322,20 @@ export class ClineError extends Error {
 			isClinePassLimitMessage(message ?? "")
 		) {
 			return ClineErrorType.ClinePassLimit;
+		}
+
+		// Retired free models must be classified before the auth branch: the
+		// backend's model-not-found answer is a 404, which falls inside the
+		// generic 401-428 auth-status range below.
+		const promotionEndedModelId = err.modelId ?? err._error?.modelId;
+		if (
+			isClineFreePromotionEndedMessage(
+				detailMessage ?? "",
+				promotionEndedModelId,
+			) ||
+			isClineFreePromotionEndedMessage(message ?? "", promotionEndedModelId)
+		) {
+			return ClineErrorType.ClineFreePromotionEnded;
 		}
 
 		// Check auth errors

--- a/apps/vscode/src/services/error/__tests__/ClineError.test.ts
+++ b/apps/vscode/src/services/error/__tests__/ClineError.test.ts
@@ -6,6 +6,7 @@ import {
 	extractClineFreeModelLimitResetTime,
 	extractClinePassLimitMessage,
 	isClineFreeModelLimitMessage,
+	isClineFreePromotionEndedMessage,
 	isClinePassLimitMessage,
 } from "../ClineError";
 
@@ -236,6 +237,87 @@ describe("ClineError", () => {
 			(
 				extractClinePassLimitMessage("some other error") === undefined
 			).should.be.true();
+		});
+	});
+
+	describe("isClineFreePromotionEndedMessage", () => {
+		it("matches model-not-found only for cline-free model ids", () => {
+			isClineFreePromotionEndedMessage(
+				"Error 404: Model not found",
+				"cline-free/glm-5",
+			).should.be.true();
+			isClineFreePromotionEndedMessage(
+				"Error 404: Model not found",
+				"deepseek/deepseek-v4-flash",
+			).should.be.false();
+			isClineFreePromotionEndedMessage(
+				"Error 404: Model not found",
+				undefined,
+			).should.be.false();
+		});
+
+		it("does not match unrelated cline-free errors", () => {
+			isClineFreePromotionEndedMessage(
+				"Network error: socket hang up",
+				"cline-free/glm-5",
+			).should.be.false();
+		});
+	});
+
+	describe("ClineFreePromotionEnded classification", () => {
+		it("classifies model-not-found for a cline-free model as ClineFreePromotionEnded", () => {
+			const err = new ClineError(
+				{ message: "Error 404: Model not found" },
+				"cline-free/glm-5",
+				"cline",
+			);
+
+			ClineError.getErrorType(err)!.should.equal(
+				ClineErrorType.ClineFreePromotionEnded,
+			);
+		});
+
+		it("prefers ClineFreePromotionEnded over Auth for a 404 with a cline-free model", () => {
+			// status 404 falls inside the generic auth-status range; the
+			// promotion-ended classification must win.
+			const err = new ClineError(
+				{ message: "Error 404: Model not found", status: 404 },
+				"cline-free/glm-5",
+				"cline",
+			);
+
+			const result = ClineError.getErrorType(err);
+			result!.should.equal(ClineErrorType.ClineFreePromotionEnded);
+			(result !== ClineErrorType.Auth).should.be.true();
+		});
+
+		it("classifies the nested provider error shape via the serialized modelId", () => {
+			// ErrorRow re-parses the serialized error in the webview; the model id
+			// rides the payload, not the message.
+			const original = new ClineError(
+				{
+					status: 404,
+					error: { message: "Model not found" },
+				},
+				"cline-free/glm-5",
+				"cline-pass",
+			);
+
+			const reparsed = ClineError.parse(original.serialize())!;
+			ClineError.getErrorType(reparsed)!.should.equal(
+				ClineErrorType.ClineFreePromotionEnded,
+			);
+		});
+
+		it("keeps model-not-found for a non-free model on the generic path", () => {
+			const err = new ClineError(
+				{ message: "Error 404: Model not found", status: 404 },
+				"deepseek/deepseek-v4-flash",
+				"cline",
+			);
+
+			const result = ClineError.getErrorType(err);
+			(result !== ClineErrorType.ClineFreePromotionEnded).should.be.true();
 		});
 	});
 });

--- a/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ClineFreePromotionEndedError.tsx
@@ -1,0 +1,37 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { useExtensionState } from "@/context/ExtensionStateContext";
+
+// Shown when a request targets a retired cline-free/ model: once its free
+// promotion ends the model is removed from the catalog and the backend answers
+// "model not found". Mirrors the CLI's "Free model promotion ended" banner,
+// with the CLI's "/model" hint replaced by a button into the model picker.
+const ClineFreePromotionEndedError = () => {
+	const { navigateToSettingsModelPicker } = useExtensionState();
+
+	return (
+		<div
+			className="p-2 border-none rounded-md mb-2 bg-(--vscode-textBlockQuote-background)"
+			data-testid="cline-free-promotion-ended-error"
+		>
+			<div className="text-error mb-2">Free model promotion ended</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs wrap-anywhere">
+				The free promotion for this model has ended and it is no longer
+				available.
+			</div>
+			<div className="text-(--vscode-descriptionForeground) text-xs mt-2">
+				Select another model to continue.
+			</div>
+			<VSCodeButton
+				appearance="primary"
+				className="w-full mt-3"
+				onClick={() =>
+					navigateToSettingsModelPicker({ targetSection: "api-config" })
+				}
+			>
+				Select a Model
+			</VSCodeButton>
+		</div>
+	);
+};
+
+export default ClineFreePromotionEndedError;

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -6,6 +6,7 @@ import ErrorRow from "./ErrorRow";
 
 const mockSetUserOrganization = vi.hoisted(() => vi.fn());
 const mockUpdateApiConfigurationProto = vi.hoisted(() => vi.fn());
+const mockNavigateToSettingsModelPicker = vi.hoisted(() => vi.fn());
 const mockApiConfiguration = vi.hoisted(() => ({
 	planModeApiProvider: "cline-pass",
 	actModeApiProvider: "cline-pass",
@@ -55,6 +56,7 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 		apiConfiguration: mockApiConfiguration,
 		mode: "act",
 		clineModels: mockClineModels,
+		navigateToSettingsModelPicker: mockNavigateToSettingsModelPicker,
 	}),
 }));
 
@@ -80,6 +82,7 @@ vi.mock("../../../../src/services/error/ClineError", () => ({
 		OrgClinePassRestriction: "orgClinePassRestriction",
 		ClinePassLimit: "clinePassLimit",
 		ClineFreeModelLimit: "clineFreeModelLimit",
+		ClineFreePromotionEnded: "clineFreePromotionEnded",
 	},
 	extractClinePassLimitMessage: vi.fn((text: string) => text),
 	extractClineFreeModelLimitResetTime: vi.fn((text: string) => {
@@ -423,6 +426,45 @@ describe("ErrorRow", () => {
 			expect(
 				screen.queryByText(/Switch to Usage-Based billing/i),
 			).not.toBeInTheDocument();
+		});
+
+		it("renders the promotion-ended card with a route into the model picker", async () => {
+			const rawMessage = "Error 404: Model not found";
+			const mockClineError = {
+				message: rawMessage,
+				isErrorType: vi.fn((type) => type === "clineFreePromotionEnded"),
+				providerId: "cline",
+				modelId: "cline-free/glm-5",
+				_error: { message: rawMessage },
+			};
+
+			const { ClineError } = await import(
+				"../../../../src/services/error/ClineError"
+			);
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any);
+
+			render(
+				<ErrorRow
+					apiRequestFailedMessage={rawMessage}
+					errorType="error"
+					message={mockMessage}
+				/>,
+			);
+
+			expect(
+				screen.getByTestId("cline-free-promotion-ended-error"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText("Free model promotion ended"),
+			).toBeInTheDocument();
+			expect(screen.getByText(/no longer\s+available/)).toBeInTheDocument();
+			// The raw backend message is replaced by the dedicated copy.
+			expect(screen.queryByText(rawMessage)).not.toBeInTheDocument();
+
+			fireEvent.click(screen.getByText("Select a Model"));
+			expect(mockNavigateToSettingsModelPicker).toHaveBeenCalledWith({
+				targetSection: "api-config",
+			});
 		});
 
 		it("offers the paid twin of the selected free model", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ErrorRow.tsx
@@ -2,6 +2,7 @@ import type { ClineMessage } from "@shared/ExtensionMessage";
 import { isClineProvider } from "@shared/utils/cline";
 import { memo } from "react";
 import ClineFreeModelLimitError from "@/components/chat/ClineFreeModelLimitError";
+import ClineFreePromotionEndedError from "@/components/chat/ClineFreePromotionEndedError";
 import ClinePassLimitError from "@/components/chat/ClinePassLimitError";
 import CreditLimitError from "@/components/chat/CreditLimitError";
 import EntitlementError from "@/components/chat/EntitlementError";
@@ -113,6 +114,15 @@ const ErrorRow = memo(
 							const detailMessage =
 								clineError?._error?.details?.message || errorMessage;
 							return <ClineFreeModelLimitError message={detailMessage} />;
+						}
+
+						// A retired free model answers model-not-found once its
+						// promotion ends — dedicated copy plus a route into the model
+						// picker, since retrying the deleted model can never succeed.
+						if (
+							clineError?.isErrorType(ClineErrorType.ClineFreePromotionEnded)
+						) {
+							return <ClineFreePromotionEndedError />;
 						}
 
 						if (clineError?.isErrorType(ClineErrorType.RateLimit)) {


### PR DESCRIPTION
### Related Issue

N/A — part of winding down the free GLM promotion on the `cline`/`cline-pass` providers. Legacy port of the main-branch sibling PR; CLI counterpart shipped in #12593.

### Description

**The problem.** When a free promotion ends, the `cline-free/<slug>` model is deleted from the catalog and the backend answers **404 "model not found"** to requests still pointed at it. In the legacy extension that 404 fell into `ClineError.getErrorType()`'s generic 401–428 auth-status range, so users saw a bare auth-flavored error with a "Retry" prompt — no explanation that the promo ended, and retrying a deleted model can never succeed.

**The fix.**

- New `ClineErrorType.ClineFreePromotionEnded`, detected as: message contains "model not found" **and** the request's model id carries the `cline-free/` prefix. The prefix gate keeps ordinary model-not-found errors on their generic path. Detection mirrors the CLI (`apps/cli/src/utils/cline-pass-errors.ts`).
- The model id needs no new plumbing: the host already passes `model.id` into `ErrorService.toClineError(...)` at both stream-failure sites, and `ClineError.serialize()` already carries `modelId`, so the webview's `ClineError.parse` re-hydrates it. Classification reads `err.modelId ?? err._error.modelId` and runs **before** the auth branch (404 ∈ (400, 429)) — same reason the ClinePass/free-limit types sit above it.
- `ErrorRow` renders a new `ClineFreePromotionEndedError` card: CLI-parity copy plus a **Select a Model** button into `navigateToSettingsModelPicker({ targetSection: "api-config" })`.
- The new type joins the auto-retry skip lists — first-chunk (`shouldRetry` + `showRetry`), mid-stream (`isStreamingNonRetriableError`), and `SubagentRunner.shouldRetryInitialStreamError`. Previously these errors were *incidentally* excluded from some retry paths by their accidental Auth classification; now that they classify as their own type they must be excluded explicitly, or users would sit through three backoffs (2s/4s/8s) before the card appears.

**Decisions / non-obvious bits:**

- The `cline-free/` prefix constant and the model-not-found marker are kept **local to `ClineError.ts`** instead of importing `shared/cline/free-models` — this file is loaded by both the extension host and (via relative import) the webview, and the legacy bundle has bitten us before with latent import cycles breaking activation (#12017/4.0.6 regression). Zero-dependency additions are the safe shape here.
- Deliberately minimal card — copy + picker button. The daily-free-limit card's one-click paid-twin switch (`findPaidClineModelId`) would work here too since the paid `glm-5` remains in the catalog; left as a follow-up to keep the diff small.
- Committed with `--no-verify`: lint-staged's biome *format* pass disagrees with the entire pre-existing legacy formatting and would reformat whole files into diff noise. CI's gate is `biome lint` (clean on all touched files); new code hand-matches the surrounding style.

### Test Procedure

- `ClineError.test.ts` (mocha): helper prefix-gate tests, classification for flat and nested provider error shapes, 404-beats-auth precedence, and a serialize→parse round-trip proving the model id survives to the webview's classifier. Full legacy unit suite: **1575 passing**.
- `ErrorRow.test.tsx` (vitest): renders the card, hides the raw backend message, button fires `navigateToSettingsModelPicker({ targetSection: "api-config" })`. Suite passes (19 tests).
- `tsc --noEmit` clean for both the extension and webview projects; `biome lint` clean on touched files.
- Regression thinking: classification is additive and gated on a model-id prefix only the Cline catalog produces; retry-skip changes only add one more `!isX` clause per site, in the exact shape of the existing ClinePass/free-limit exclusions, so behavior for every other error type is unchanged.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The card mirrors the existing daily-free-limit card's layout:

> **Free model promotion ended**
> The free promotion for this model has ended and it is no longer available.
> Select another model to continue.
> **[ Select a Model ]**

### Additional Notes

Ships to users via the next stable combined VSIX together with the main-branch sibling PR — the rollout flag decides which bundle a stable install runs, so both need the card. Note the usual caveat: PRs targeting `legacy-extension` skip the real test workflows (the green "Run Tests" check is the no-op JB workflow), hence the full local suite runs above.
