### PR TITLE
fix(telemetry): attribute agent.run sdk.error events to the active model

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -2419,7 +2419,11 @@ describe("AgentRuntime sdk.error reporting", () => {
 				},
 			],
 		]);
-		const runtime = new AgentRuntime({ model, telemetry });
+		const runtime = new AgentRuntime({
+			model,
+			telemetry,
+			messageModelInfo: { id: "claude-fable-5", provider: "anthropic" },
+		});
 
 		const result = await runtime.run("Hi");
 
@@ -2431,6 +2435,11 @@ describe("AgentRuntime sdk.error reporting", () => {
 			operation: "agent.run",
 			handled: false,
 			error_message: "backend unavailable",
+			// Model attribution must survive into the event so the warehouse
+			// can answer "which models are hitting this" (dbt coalesces
+			// providerId/modelId into inference_provider/inference_model).
+			providerId: "anthropic",
+			modelId: "claude-fable-5",
 		});
 	});
 

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1849,7 +1849,11 @@ export class AgentRuntime {
 						error: event.error,
 						severity: "error",
 						handled: false,
-						context: metadata as TelemetryProperties,
+						context: {
+							...(metadata as TelemetryProperties),
+							providerId: this.getTelemetryProviderId(),
+							modelId: this.getTelemetryModelId(),
+						},
 					});
 				}
 				break;

--- a/sdk/packages/shared/src/services/telemetry.test.ts
+++ b/sdk/packages/shared/src/services/telemetry.test.ts
@@ -99,6 +99,28 @@ describe("SDK error telemetry", () => {
 			}),
 		});
 	});
+
+	it("drops undefined context values instead of exporting them", () => {
+		const telemetry = {
+			capture: vi.fn(),
+		};
+
+		captureSdkError(telemetry as never, {
+			component: "agents",
+			operation: "agent.run",
+			error: new Error("boom"),
+			context: {
+				sessionId: "s1",
+				providerId: undefined,
+				modelId: undefined,
+			},
+		});
+
+		const properties = telemetry.capture.mock.calls[0]?.[0]?.properties ?? {};
+		expect(properties).toMatchObject({ sessionId: "s1" });
+		expect("providerId" in properties).toBe(false);
+		expect("modelId" in properties).toBe(false);
+	});
 });
 
 describe("SDK error rate limiting", () => {

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -326,14 +326,16 @@ export function captureSdkError(
 export function buildSdkErrorProperties(
 	input: CaptureSdkErrorInput,
 ): TelemetryProperties {
-	return {
+	// Strip undefined values (matching the other capture helpers here) — the
+	// OTel adapter would otherwise export them as literal "undefined" strings.
+	return stripUndefinedTelemetryProperties({
 		...(input.context ?? {}),
 		component: input.component,
 		operation: input.operation,
 		severity: input.severity ?? "error",
 		handled: input.handled ?? true,
 		...normalizeSdkError(input.error, input.messageLimit, input.errorMessage),
-	};
+	});
 }
 
 function stripUndefinedTelemetryProperties(


### PR DESCRIPTION
### Related Issue

Follow-up from Renee's dash-19 review of the extension-migration A/B rollout: `sdk.error` sub-categories ("Model returned empty response", "Model reached the maximum output token limit...", socket errors) showed no model/provider attribution, so we couldn't answer "which models are suffering from these?"

### Description

**The gap.** Of ~83k `sdk.error` events over the last 7 days, ~35k carry no model attribution. The warehouse side is fine — dbt's `silver_error_events_daily` already coalesces `providerId`/`modelId` into `inference_provider`/`inference_model` — the problem is that some events are *captured* without model context at the source. After splitting the unattributed volume by component, the fixable chunk is `agents` / `agent.run`: the run-death report in `AgentRuntime.emit` passes `context: metadata`, and `buildEventMetadata` carries agentId/runId/iteration but not the model. (The other unattributed bulk is hub/infra errors — `core / hub.runtime_host.capability_request` — which genuinely have no model.)

This capture site is exactly the one that owns failures the model layer didn't self-report (custom `AgentModel`s that flatten errors into `finish` events, and loop-originated failures) — which is why the empty-response / max-output-token classes land here without attribution while `provider.stream` errors from `@cline/llms` attribute fine.

**The fix.** The runtime already resolves the active model for telemetry (`getTelemetryProviderId()` / `getTelemetryModelId()`, used by the reasoning-tokens capture) — the `agent.run` capture now spreads them into the event context under the same `providerId`/`modelId` keys the llms-layer captures use, so dbt's existing coalesce picks them up with no warehouse changes.

### Test Procedure

- `tsc --noEmit` clean on `sdk/packages/agents`.
- Extended the existing "reports exactly one sdk.error for custom models that do not record their own telemetry" test: runtime constructed with `messageModelInfo`, asserts `providerId`/`modelId` land on the event. Full `agent-runtime.test.ts` suite: 55/55.
- Field verification after ship: the blank-model share of `sdk.error` where `component='agents'` should drop to ~zero; dash 19's deep-dive table (question 221) then attributes the empty-response / max-output-token / socket classes by model.
