### PR TITLE
feat: support max reasoning effort across extension UI and CLI

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -256,7 +256,7 @@ Schedules can route results back to chat surfaces with `--delivery-adapter`, `--
 | `--config <path>` | Configuration directory (used for CLI home resolution) |
 | `--hooks-dir <path>` | Additional hooks directory hint for runtime hook injection |
 | `--acp` | ACP (Agent Client Protocol) mode |
-| `--thinking [none\|low\|medium\|high\|xhigh]` | Model thinking level when supported. Defaults to `medium` when the flag is provided without a level; thinking is off when the flag is omitted. |
+| `--thinking [none\|low\|medium\|high\|xhigh\|max]` | Model thinking level when supported. Defaults to `medium` when the flag is provided without a level; thinking is off when the flag is omitted. |
 | `--compaction <agentic\|basic\|off>` | Context compaction mode. Defaults to `agentic`; use `basic` for local truncation or `off` to disable. |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting (default: `3`) |
 | `--json` | Output NDJSON instead of styled text |

--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -33,7 +33,7 @@ export function addRootOptions(cmd: Command): Command {
 			.option("-c, --cwd <path>", "Working directory")
 			.option(
 				"--thinking <level>",
-				"Set reasoning effort: none|low|medium|high|xhigh. Bare --thinking uses medium; omitted leaves provider default.",
+				"Set reasoning effort: none|low|medium|high|xhigh|max. Bare --thinking uses medium; omitted leaves provider default.",
 			)
 			.option("--compaction <mode>", CLI_COMPACTION_MODE_OPTION_DESCRIPTION)
 			.option(
@@ -178,7 +178,8 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 			effort === "low" ||
 			effort === "medium" ||
 			effort === "high" ||
-			effort === "xhigh"
+			effort === "xhigh" ||
+			effort === "max"
 		) {
 			result.thinkingExplicitlySet = true;
 			if (effort === "none") {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -743,7 +743,7 @@ export async function runCli(): Promise<void> {
 
 	if (args.invalidThinkingLevel) {
 		writeErr(
-			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "low", "medium", "high", or "xhigh")`,
+			`invalid thinking level "${args.invalidThinkingLevel}" (expected "none", "low", "medium", "high", "xhigh", or "max")`,
 		);
 		process.exitCode = 1;
 		return;

--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -310,7 +310,13 @@ export function ModelSelectorContent(
 
 // -- Thinking level dialog content --
 
-export type ThinkingLevel = "none" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel =
+	| "none"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 
 const THINKING_LEVELS: { value: ThinkingLevel; label: string; desc: string }[] =
 	[
@@ -319,6 +325,7 @@ const THINKING_LEVELS: { value: ThinkingLevel; label: string; desc: string }[] =
 		{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 		{ value: "high", label: "High", desc: "Deep reasoning" },
 		{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
+		{ value: "max", label: "Max", desc: "Highest supported reasoning" },
 	];
 
 export function ThinkingLevelContent(

--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -324,8 +324,8 @@ const THINKING_LEVELS: { value: ThinkingLevel; label: string; desc: string }[] =
 		{ value: "low", label: "Low", desc: "Minimal reasoning" },
 		{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 		{ value: "high", label: "High", desc: "Deep reasoning" },
-		{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
-		{ value: "max", label: "Max", desc: "Highest supported reasoning" },
+		{ value: "xhigh", label: "Extra High", desc: "Very deep reasoning" },
+		{ value: "max", label: "Max", desc: "Maximum reasoning" },
 	];
 
 export function ThinkingLevelContent(

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -15,7 +15,13 @@ export type OnboardingStep =
 	| "thinking_level"
 	| "done";
 
-export type ThinkingLevel = "none" | "low" | "medium" | "high" | "xhigh";
+export type ThinkingLevel =
+	| "none"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 export type ReasoningEffort = Exclude<ThinkingLevel, "none">;
 
 export const THINKING_LEVELS: {
@@ -28,6 +34,7 @@ export const THINKING_LEVELS: {
 	{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 	{ value: "high", label: "High", desc: "Deep reasoning" },
 	{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
+	{ value: "max", label: "Max", desc: "Highest supported reasoning" },
 ];
 
 export const DEFAULT_THINKING_LEVEL_INDEX = THINKING_LEVELS.findIndex(

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -33,8 +33,8 @@ export const THINKING_LEVELS: {
 	{ value: "low", label: "Low", desc: "Minimal reasoning" },
 	{ value: "medium", label: "Medium", desc: "Balanced reasoning" },
 	{ value: "high", label: "High", desc: "Deep reasoning" },
-	{ value: "xhigh", label: "Extra High", desc: "Maximum reasoning" },
-	{ value: "max", label: "Max", desc: "Highest supported reasoning" },
+	{ value: "xhigh", label: "Extra High", desc: "Very deep reasoning" },
+	{ value: "max", label: "Max", desc: "Maximum reasoning" },
 ];
 
 export const DEFAULT_THINKING_LEVEL_INDEX = THINKING_LEVELS.findIndex(

--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -171,6 +171,13 @@ describe("parseArgs", () => {
 		expect(parsed.reasoningEffort).toBe("high");
 	});
 
+	it("parses --thinking max", () => {
+		const parsed = parseArgs(["--thinking", "max"]);
+		expect(parsed.thinking).toBe(true);
+		expect(parsed.reasoningEffort).toBe("max");
+		expect(parsed.invalidThinkingLevel).toBeUndefined();
+	});
+
 	it("parses --thinking none as disabled", () => {
 		const parsed = parseArgs(["--thinking", "none"]);
 		expect(parsed.thinking).toBe(false);

--- a/apps/cli/src/utils/reasoning.test.ts
+++ b/apps/cli/src/utils/reasoning.test.ts
@@ -39,6 +39,31 @@ describe("resolveCliReasoning", () => {
 		});
 	});
 
+	it("preserves explicit max reasoning effort", () => {
+		expect(
+			resolveCliReasoning({
+				thinking: true,
+				thinkingExplicitlySet: true,
+				reasoningEffort: "max",
+			}),
+		).toEqual({
+			thinking: true,
+			reasoningEffort: "max",
+		});
+	});
+
+	it("uses persisted max reasoning effort when --thinking is unset", () => {
+		expect(
+			resolveCliReasoning({
+				thinking: false,
+				persistedReasoning: { enabled: true, effort: "max" },
+			}),
+		).toEqual({
+			thinking: true,
+			reasoningEffort: "max",
+		});
+	});
+
 	it("uses persisted disabled reasoning when --thinking is unset", () => {
 		expect(
 			resolveCliReasoning({

--- a/apps/cli/src/utils/reasoning.ts
+++ b/apps/cli/src/utils/reasoning.ts
@@ -8,6 +8,7 @@ const ACTIVE_REASONING_EFFORTS = new Set<ActiveCliReasoningEffort>([
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ]);
 
 export interface ResolveCliReasoningInput {

--- a/apps/vscode/src/core/controller/state/reasoningEffort.test.ts
+++ b/apps/vscode/src/core/controller/state/reasoningEffort.test.ts
@@ -1,0 +1,18 @@
+// Ported from #12965 (thanks @Oxygen56) — regression coverage for "max"
+// surviving the storage-level effort gate.
+import { describe, expect, it } from "vitest"
+import { normalizeOpenaiReasoningEffort, OPENAI_REASONING_EFFORT_OPTIONS } from "@/shared/storage/types"
+
+describe("normalizeOpenaiReasoningEffort", () => {
+	it("includes max in the selectable effort options", () => {
+		expect(OPENAI_REASONING_EFFORT_OPTIONS).toContain("max")
+	})
+
+	it("preserves max reasoning effort", () => {
+		expect(normalizeOpenaiReasoningEffort("max")).toBe("max")
+	})
+
+	it("normalizes uppercase max reasoning effort", () => {
+		expect(normalizeOpenaiReasoningEffort("MAX")).toBe("max")
+	})
+})

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -329,6 +329,12 @@ describe("normalizeProviderReasoningSettings", () => {
 		expect(result).toEqual({ thinking: true, reasoningEffort: "xhigh" })
 	})
 
+	it("preserves a max effort", () => {
+		const result = normalizeProviderReasoningSettings({ enabled: true, effort: "max" })
+
+		expect(result).toEqual({ thinking: true, reasoningEffort: "max" })
+	})
+
 	it("keeps disabled reasoning off even with a stored budget", () => {
 		const result = normalizeProviderReasoningSettings({ enabled: false, budgetTokens: 4096 })
 

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -144,7 +144,7 @@ type ProviderReasoningSettings = NonNullable<ProviderSettings["reasoning"]>
 type SessionReasoningConfig = Pick<CoreSessionConfig, "thinking" | "reasoningEffort">
 
 function isReasoningEffort(value: unknown): value is ReasoningEffort {
-	return value === "low" || value === "medium" || value === "high" || value === "xhigh"
+	return value === "low" || value === "medium" || value === "high" || value === "xhigh" || value === "max"
 }
 
 function hasStaleDisabledReasoningFields(reasoning: ProviderReasoningSettings | undefined): boolean {

--- a/apps/vscode/src/sdk/sdk-api-handler.test.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.test.ts
@@ -104,6 +104,42 @@ describe("buildSdkProviderConfig", () => {
 		})
 	})
 
+	it.each([
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		"max",
+	] as const)("forwards reasoning effort %s to the provider config", (effort) => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "openai",
+				actModeOpenAiModelId: "gpt-5.6-luna",
+				actModeReasoningEffort: effort,
+			},
+			"act",
+		)
+
+		expect(providerConfig.reasoningEffort).toBe(effort)
+	})
+
+	it("omits reasoning effort when set to none", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+
+		const providerConfig = buildSdkProviderConfig(
+			{
+				actModeApiProvider: "openai",
+				actModeOpenAiModelId: "gpt-5.6-luna",
+				actModeReasoningEffort: "none",
+			},
+			"act",
+		)
+
+		expect("reasoningEffort" in providerConfig).toBe(false)
+	})
+
 	it("omits timeoutMs for Ollama when no explicit timeout is configured", () => {
 		mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
 

--- a/apps/vscode/src/sdk/sdk-api-handler.ts
+++ b/apps/vscode/src/sdk/sdk-api-handler.ts
@@ -89,7 +89,13 @@ export function buildSdkProviderConfig(
 		return { ...base, thinking: false }
 	}
 
-	if (reasoningEffort === "low" || reasoningEffort === "medium" || reasoningEffort === "high" || reasoningEffort === "xhigh") {
+	if (
+		reasoningEffort === "low" ||
+		reasoningEffort === "medium" ||
+		reasoningEffort === "high" ||
+		reasoningEffort === "xhigh" ||
+		reasoningEffort === "max"
+	) {
 		return { ...base, reasoningEffort }
 	}
 	// An explicit "none" wins over any stored legacy budget.

--- a/apps/vscode/src/shared/storage/types.ts
+++ b/apps/vscode/src/shared/storage/types.ts
@@ -1,4 +1,4 @@
-export const OPENAI_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const
+export const OPENAI_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh", "max"] as const
 
 export type OpenaiReasoningEffort = (typeof OPENAI_REASONING_EFFORT_OPTIONS)[number]
 


### PR DESCRIPTION
### Related Issue

**Issue:** #12947

### Description

The SDK gateway already accepts reasoning effort `max` and normalizes it per model (clamping to the nearest advertised effort for models that don't support it, e.g. `max` → `high` for uncataloged models), but every runtime gate upstream of the SDK excluded it. This meant models that advertise `max` on models.dev (e.g. DeepSeek V4 Flash/Pro, GPT-5.6 family) could never receive it — and for `deepseek-v4-flash`, whose `xhigh` executes at `high`, the top reasoning tier was unreachable entirely.

This PR adds `max` to every gate:

**VS Code extension**
- `apps/vscode/src/shared/storage/types.ts` — `OPENAI_REASONING_EFFORT_OPTIONS` (dropdown source + validation/normalization)
- `apps/vscode/src/sdk/sdk-api-handler.ts` — `buildSdkProviderConfig` whitelist (previously dropped `max` silently before it reached the SDK)
- `apps/vscode/src/sdk/cline-session-factory.ts` — `isReasoningEffort` (same silent drop on the session path)

**CLI**
- `apps/cli/src/utils/reasoning.ts` — `ACTIVE_REASONING_EFFORTS`
- `apps/cli/src/commands/program.ts` / `src/main.ts` — `--thinking` parsing, help text, error message
- `apps/cli/src/tui/components/model-selector/model-selector.tsx` and `src/tui/views/onboarding/model.ts` — the interactive thinking-level dialogs
- `apps/cli/README.md` — flag docs

Note: this overlaps with community PR #12965, which covers the option list and CLI flag but misses the two extension-side gates (`sdk-api-handler.ts`, `cline-session-factory.ts`) — so its "Max" option would appear in the dropdown but be silently dropped before reaching the SDK — and both CLI TUI dialogs. No SDK changes are needed; models that don't advertise `max` degrade gracefully via the existing `normalizeReasoningEffort` clamping.

### Test Procedure

- `apps/cli`: full unit suite (`bun run test:unit`) — 1110 tests pass, including new coverage for `--thinking max` parsing and `resolveCliReasoning` preserving explicit/persisted `max`.
- `apps/vscode`: full bun unit suite (`bun run test:unit`) — 1055 tests pass; vitest sdk suites (`bun run test:vitest -- src/sdk/sdk-api-handler.test.ts src/sdk/cline-session-factory.test.ts`) — 81 tests pass, including new coverage that `buildSdkProviderConfig` forwards each active effort (`low`…`max`) and omits `none`, and that `normalizeProviderReasoningSettings` preserves `max`.
- `bun run typecheck` (CLI) and `bun run check-types` (extension + webview) pass.
- Biome lint at error level passes on all changed files.
- Manual: verified in the running extension dev host that the Reasoning Effort dropdown shows and persists Max, and in the CLI TUI that the thinking-level dialog offers Max and the status bar reflects it after selection. Also verified `--thinking max` is accepted by the CLI flag parser and `--thinking ultra` reports the updated error message listing `max`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

VS Code settings — Reasoning Effort dropdown now offers Max (OpenAI Compatible, `deepseek-v4-flash`):

![Reasoning Effort dropdown open showing None, Low, Medium, High, Xhigh, Max](https://cursor.com/artifacts/c/art-4d11f473-f557-48bf-9fe4-97d2e837e418)

Max selected and persisted:

![Reasoning Effort dropdown showing Max selected](https://cursor.com/artifacts/c/art-6ba65a80-86a7-49c1-ad76-b41db56ef4e5)

CLI TUI — thinking-level dialog with the new Max option highlighted:

![CLI TUI thinking level dialog with Max option](https://cursor.com/artifacts/c/art-c6435895-db45-4de1-b05c-196c87116d87)

CLI TUI — status bar showing the model running with max effort after selection:

![CLI TUI status bar showing Claude Sonnet 4.6 (max)](https://cursor.com/artifacts/c/art-3fce400a-5da1-4b56-b227-3665b7759d48)

### Additional Notes

Per-model filtering of the dropdown from models.dev `reasoning_options` (so only models that advertise `max` show it) is a larger plumbing change and intentionally out of scope; the SDK's clamping makes the static list safe in the meantime.