### PR TITLE
fix(llms): parse Kimi tool markers into tool calls

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -225,6 +225,73 @@ describe("ai-sdk adapter malformed tool calls", () => {
 	});
 });
 
+function sseTextContent(content: string, finish: string | null = "stop"): string {
+	const chunk = (delta: unknown, finishReason: string | null = null) =>
+		`data: ${JSON.stringify({
+			id: "cmpl-1",
+			object: "chat.completion.chunk",
+			created: 1,
+			model: "test-model",
+			choices: [{ index: 0, delta, finish_reason: finishReason }],
+		})}\n\n`;
+	return (
+		chunk({ role: "assistant", content }) +
+		chunk({}, finish) +
+		"data: [DONE]\n\n"
+	);
+}
+
+describe("ai-sdk adapter Kimi tool markers", () => {
+	it("translates Kimi content markers into tool-call-delta and hides them from text", async () => {
+		const markers =
+			"I'll read that.\n" +
+			"<|tool_calls_section_begin|>" +
+			"<|tool_call_begin|>functions.read_files:0" +
+			"<|tool_call_argument_begin|>" +
+			'{"files":[{"path":"/tmp/a.txt"}]}' +
+			"<|tool_call_end|>" +
+			"<|tool_calls_section_end|>";
+
+		const events = await streamToolCallEvents(sseTextContent(markers), [
+			READ_FILES_TOOL,
+		]);
+
+		const text = events
+			.filter((e) => e.type === "text-delta")
+			.map((e) => (e.type === "text-delta" ? e.text : ""))
+			.join("");
+		expect(text).toBe("I'll read that.\n");
+		expect(text).not.toContain("<|tool_");
+
+		expect(findToolInput(events)).toEqual({
+			files: [{ path: "/tmp/a.txt" }],
+		});
+		const toolEvent = events.find((e) => e.type === "tool-call-delta");
+		expect(toolEvent).toMatchObject({
+			type: "tool-call-delta",
+			toolCallId: "functions.read_files:0",
+			toolName: "read_files",
+		});
+
+		const finish = events.find((e) => e.type === "finish");
+		expect(finish).toMatchObject({ type: "finish", reason: "tool-calls" });
+	});
+
+	it("still passes native OpenAI tool_calls through when markers are absent", async () => {
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", '{"commands": ["pwd"]}'),
+			[RUN_COMMANDS_TOOL],
+		);
+		expect(findToolInput(events)).toEqual({ commands: ["pwd"] });
+		expect(
+			events
+				.filter((e) => e.type === "text-delta")
+				.map((e) => (e.type === "text-delta" ? e.text : ""))
+				.join(""),
+		).toBe("");
+	});
+});
+
 describe("repairMalformedToolCall", () => {
 	const toolCall = (input: string) => ({
 		toolCallId: "call_1",

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -45,6 +45,10 @@ import {
 import { nanoid } from "nanoid";
 import { classifyProviderError } from "./error-classification";
 import { extractErrorMessage } from "./format";
+import {
+	type KimiMarkerEvent,
+	KimiToolMarkerTranslator,
+} from "./kimi-tool-markers";
 import { createRetryEmptyResponseMiddleware } from "./middleware/retry-empty-response";
 import {
 	isAnthropicCompatibleModel,
@@ -1307,6 +1311,39 @@ async function* emitAiSdkEvents(
 	const projectedModelToolResults = new Map<string, ProjectedModelToolResult>();
 	const pendingProjectedModelToolOutputs = new Map<string, unknown>();
 	const projectedModelToolErrors = new Map<string, string>();
+	// Kimi (Together / Moonshot / openai-compatible) may put tool requests in
+	// plain content markers instead of delta.tool_calls. Translate those into
+	// tool-call-delta and never forward the raw markers as chat text.
+	const kimiMarkers = new KimiToolMarkerTranslator();
+
+	const emitKimiMarkerEvents = function* (
+		events: Iterable<KimiMarkerEvent>,
+	): Generator<AgentModelEvent> {
+		for (const event of events) {
+			if (event.type === "text") {
+				if (event.text) {
+					sawVisibleContent = true;
+					yield { type: "text-delta", text: event.text };
+				}
+				continue;
+			}
+			sawToolCalls = true;
+			sawVisibleContent = true;
+			emittedToolCallIds.add(event.toolCallId);
+			yield {
+				type: "tool-call-delta",
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				input: event.input,
+				inputText: event.inputText,
+				metadata: buildToolCallMetadata({
+					metadata: { toolSourceDialect: "kimi-markers" },
+					request,
+					context,
+				}),
+			};
+		}
+	};
 
 	try {
 		if (stream.fullStream) {
@@ -1317,8 +1354,7 @@ async function* emitAiSdkEvents(
 						(part.text as string | undefined) ??
 						(part.delta as string | undefined);
 					if (text) {
-						sawVisibleContent = true;
-						yield { type: "text-delta", text };
+						yield* emitKimiMarkerEvents(kimiMarkers.push(text));
 					}
 					continue;
 				}
@@ -1593,10 +1629,12 @@ async function* emitAiSdkEvents(
 					break;
 				}
 			}
+			yield* emitKimiMarkerEvents(kimiMarkers.flush());
 		} else if (stream.textStream) {
 			for await (const text of stream.textStream) {
-				yield { type: "text-delta", text };
+				yield* emitKimiMarkerEvents(kimiMarkers.push(text));
 			}
+			yield* emitKimiMarkerEvents(kimiMarkers.flush());
 		}
 	} catch (error) {
 		// Prefer the real provider error from onError over the generic

--- a/sdk/packages/llms/src/providers/kimi-tool-markers.test.ts
+++ b/sdk/packages/llms/src/providers/kimi-tool-markers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+	KIMI_TOOL_CALL_ARGUMENT_BEGIN,
+	KIMI_TOOL_CALL_BEGIN,
+	KIMI_TOOL_CALL_END,
+	KIMI_TOOL_SECTION_BEGIN,
+	KIMI_TOOL_SECTION_END,
+	KimiToolMarkerTranslator,
+	longestPartialMarkerSuffix,
+	parseKimiToolCallBody,
+	toolNameFromKimiToolId,
+} from "./kimi-tool-markers";
+
+function sectionWithCall(toolId: string, args: string): string {
+	return (
+		KIMI_TOOL_SECTION_BEGIN +
+		KIMI_TOOL_CALL_BEGIN +
+		toolId +
+		KIMI_TOOL_CALL_ARGUMENT_BEGIN +
+		args +
+		KIMI_TOOL_CALL_END +
+		KIMI_TOOL_SECTION_END
+	);
+}
+
+function collect(translator: KimiToolMarkerTranslator, chunks: string[]) {
+	const events = [];
+	for (const chunk of chunks) {
+		for (const event of translator.push(chunk)) {
+			events.push(event);
+		}
+	}
+	for (const event of translator.flush()) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("kimi-tool-markers helpers", () => {
+	it("extracts the function name from a Kimi tool id", () => {
+		expect(toolNameFromKimiToolId("functions.read_file:0")).toBe("read_file");
+		expect(toolNameFromKimiToolId("functions.list_files:12")).toBe("list_files");
+		expect(toolNameFromKimiToolId("read_file:0")).toBe("read_file");
+	});
+
+	it("parses a tool-call body into name + arguments", () => {
+		const parsed = parseKimiToolCallBody(
+			`functions.read_file:0${KIMI_TOOL_CALL_ARGUMENT_BEGIN}{"path":"a.ts"}`,
+		);
+		expect(parsed).toEqual({
+			toolCallId: "functions.read_file:0",
+			toolName: "read_file",
+			inputText: '{"path":"a.ts"}',
+			input: { path: "a.ts" },
+		});
+	});
+
+	it("holds a partial marker suffix so mid-token chunks do not leak", () => {
+		expect(longestPartialMarkerSuffix("hello")).toBe(0);
+		expect(longestPartialMarkerSuffix("say <|")).toBe(2);
+		expect(longestPartialMarkerSuffix("say <|tool_call_")).toBe(
+			"<|tool_call_".length,
+		);
+	});
+});
+
+describe("KimiToolMarkerTranslator", () => {
+	it("passes plain text through unchanged", () => {
+		const events = collect(new KimiToolMarkerTranslator(), [
+			"Hello ",
+			"world",
+		]);
+		const text = events
+			.filter((e) => e.type === "text")
+			.map((e) => (e.type === "text" ? e.text : ""))
+			.join("");
+		expect(text).toBe("Hello world");
+		expect(events.every((e) => e.type === "text")).toBe(true);
+	});
+
+	it("converts a complete marker section into a tool call and drops markers", () => {
+		const events = collect(new KimiToolMarkerTranslator(), [
+			"Before\n" +
+				sectionWithCall("functions.read_file:0", '{"path":"foo.ts"}') +
+				"\nAfter",
+		]);
+		expect(events).toEqual([
+			{ type: "text", text: "Before\n" },
+			{
+				type: "tool-call",
+				toolCallId: "functions.read_file:0",
+				toolName: "read_file",
+				inputText: '{"path":"foo.ts"}',
+				input: { path: "foo.ts" },
+			},
+			{ type: "text", text: "\nAfter" },
+		]);
+	});
+
+	it("handles markers split across many tiny stream chunks", () => {
+		const full = sectionWithCall(
+			"functions.list_files:1",
+			'{"path":"."}',
+		);
+		const chunks = full.split("").map((c) => c);
+		const events = collect(new KimiToolMarkerTranslator(), chunks);
+		expect(events).toEqual([
+			{
+				type: "tool-call",
+				toolCallId: "functions.list_files:1",
+				toolName: "list_files",
+				inputText: '{"path":"."}',
+				input: { path: "." },
+			},
+		]);
+	});
+
+	it("supports multiple tool calls in one section", () => {
+		const text =
+			KIMI_TOOL_SECTION_BEGIN +
+			KIMI_TOOL_CALL_BEGIN +
+			"functions.a:0" +
+			KIMI_TOOL_CALL_ARGUMENT_BEGIN +
+			'{"x":1}' +
+			KIMI_TOOL_CALL_END +
+			KIMI_TOOL_CALL_BEGIN +
+			"functions.b:1" +
+			KIMI_TOOL_CALL_ARGUMENT_BEGIN +
+			'{"y":2}' +
+			KIMI_TOOL_CALL_END +
+			KIMI_TOOL_SECTION_END;
+		const events = collect(new KimiToolMarkerTranslator(), [text]);
+		expect(events.map((e) => (e.type === "tool-call" ? e.toolName : e))).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("does not emit raw marker text when the stream ends mid-section", () => {
+		const events = collect(new KimiToolMarkerTranslator(), [
+			`${KIMI_TOOL_SECTION_BEGIN}${KIMI_TOOL_CALL_BEGIN}functions.x:0`,
+		]);
+		expect(events).toEqual([]);
+	});
+});

--- a/sdk/packages/llms/src/providers/kimi-tool-markers.ts
+++ b/sdk/packages/llms/src/providers/kimi-tool-markers.ts
@@ -1,0 +1,235 @@
+/**
+ * Translate Kimi / Moonshot plain-text tool markers into structured tool calls.
+ *
+ * Models such as Kimi K2.x (including via Together) often emit tool requests as
+ * content markers instead of OpenAI-style `delta.tool_calls`:
+ *
+ * ```
+ * <|tool_calls_section_begin|>
+ * <|tool_call_begin|>functions.read_file:0
+ * <|tool_call_argument_begin|>{"path":"foo.ts"}
+ * <|tool_call_end|>
+ * <|tool_calls_section_end|>
+ * ```
+ *
+ * Without a translator those markers leak into chat text and never execute.
+ * This module streams text through a small state machine that strips markers
+ * and yields complete tool calls (same shape Cline already executes).
+ *
+ * Format reference: Moonshot tool_call_guidance + vLLM kimi_k2_tool_parser.
+ */
+
+export const KIMI_TOOL_SECTION_BEGIN = "<|tool_calls_section_begin|>";
+export const KIMI_TOOL_SECTION_END = "<|tool_calls_section_end|>";
+export const KIMI_TOOL_CALL_BEGIN = "<|tool_call_begin|>";
+export const KIMI_TOOL_CALL_END = "<|tool_call_end|>";
+export const KIMI_TOOL_CALL_ARGUMENT_BEGIN = "<|tool_call_argument_begin|>";
+
+const ALL_MARKERS = [
+	KIMI_TOOL_SECTION_BEGIN,
+	KIMI_TOOL_SECTION_END,
+	KIMI_TOOL_CALL_BEGIN,
+	KIMI_TOOL_CALL_END,
+	KIMI_TOOL_CALL_ARGUMENT_BEGIN,
+] as const;
+
+/** True when text contains (or may be starting) a Kimi tool marker. */
+export function looksLikeKimiToolMarkup(text: string): boolean {
+	if (text.includes("<|tool_")) {
+		return true;
+	}
+	// Hold partial prefixes of `<|…` so streaming chunks do not leak mid-token.
+	return longestPartialMarkerSuffix(text) > 0;
+}
+
+/**
+ * How many trailing characters of `text` are a proper prefix of a known marker
+ * (but not a full marker). Used so we do not emit a partial `<|tool_…` into chat.
+ */
+export function longestPartialMarkerSuffix(text: string): number {
+	let hold = 0;
+	const maxLen = Math.min(
+		text.length,
+		Math.max(...ALL_MARKERS.map((m) => m.length)) - 1,
+	);
+	for (let n = 1; n <= maxLen; n++) {
+		const suffix = text.slice(-n);
+		if (ALL_MARKERS.some((m) => m.startsWith(suffix) && m !== suffix)) {
+			hold = n;
+		}
+	}
+	return hold;
+}
+
+export type KimiMarkerEvent =
+	| { type: "text"; text: string }
+	| {
+			type: "tool-call";
+			toolCallId: string;
+			toolName: string;
+			inputText: string;
+			input?: unknown;
+	  };
+
+/**
+ * Extract the function name from a Kimi tool id such as `functions.read_file:0`.
+ * Falls back to the raw id when the shape is unexpected.
+ */
+export function toolNameFromKimiToolId(toolCallId: string): string {
+	const trimmed = toolCallId.trim();
+	const match = /^functions\.(.+):(\d+)$/.exec(trimmed);
+	if (match) {
+		return match[1];
+	}
+	// Tolerate missing `functions.` prefix: `read_file:0`
+	const loose = /^(.+):(\d+)$/.exec(trimmed);
+	if (loose) {
+		return loose[1];
+	}
+	return trimmed || "tool";
+}
+
+function tryParseJson(text: string): unknown | undefined {
+	const trimmed = text.trim();
+	if (!trimmed) {
+		return {};
+	}
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Parse one tool-call body (text between begin/end markers):
+ * `functions.name:0<|tool_call_argument_begin|>{...}`
+ */
+export function parseKimiToolCallBody(
+	body: string,
+): Omit<Extract<KimiMarkerEvent, { type: "tool-call" }>, "type"> | undefined {
+	const sep = body.indexOf(KIMI_TOOL_CALL_ARGUMENT_BEGIN);
+	if (sep === -1) {
+		return undefined;
+	}
+	const toolCallId = body.slice(0, sep).trim();
+	const inputText = body.slice(sep + KIMI_TOOL_CALL_ARGUMENT_BEGIN.length).trim();
+	if (!toolCallId) {
+		return undefined;
+	}
+	const input = tryParseJson(inputText);
+	return {
+		toolCallId,
+		toolName: toolNameFromKimiToolId(toolCallId),
+		inputText,
+		...(input !== undefined ? { input } : {}),
+	};
+}
+
+/**
+ * Streaming translator: feed text deltas, get safe text + structured tool calls.
+ * Call {@link KimiToolMarkerTranslator.flush} when the model stream ends.
+ */
+export class KimiToolMarkerTranslator {
+	private buffer = "";
+	/** True while inside a section begin…end, or after a bare call begin. */
+	private inToolRegion = false;
+
+	*push(text: string): Generator<KimiMarkerEvent> {
+		if (!text) {
+			return;
+		}
+		this.buffer += text;
+		yield* this.drain(false);
+	}
+
+	*flush(): Generator<KimiMarkerEvent> {
+		yield* this.drain(true);
+	}
+
+	private *drain(final: boolean): Generator<KimiMarkerEvent> {
+		while (true) {
+			if (!this.inToolRegion) {
+				const sectionBegin = this.buffer.indexOf(KIMI_TOOL_SECTION_BEGIN);
+				const callBegin = this.buffer.indexOf(KIMI_TOOL_CALL_BEGIN);
+
+				let enterAt = -1;
+				let enterLen = 0;
+				if (sectionBegin !== -1 && (callBegin === -1 || sectionBegin <= callBegin)) {
+					enterAt = sectionBegin;
+					enterLen = KIMI_TOOL_SECTION_BEGIN.length;
+				} else if (callBegin !== -1) {
+					enterAt = callBegin;
+					enterLen = 0; // keep call begin in buffer for parse loop
+				}
+
+				if (enterAt === -1) {
+					const hold = final ? 0 : longestPartialMarkerSuffix(this.buffer);
+					const emitLen = this.buffer.length - hold;
+					if (emitLen > 0) {
+						yield { type: "text", text: this.buffer.slice(0, emitLen) };
+						this.buffer = this.buffer.slice(emitLen);
+					} else if (final && this.buffer.length > 0) {
+						// Incomplete marker at EOS — drop it so it never reaches chat.
+						this.buffer = "";
+					}
+					return;
+				}
+
+				if (enterAt > 0) {
+					yield { type: "text", text: this.buffer.slice(0, enterAt) };
+				}
+				this.buffer = this.buffer.slice(enterAt + enterLen);
+				this.inToolRegion = true;
+				continue;
+			}
+
+			// Inside tool region: emit complete calls; exit on section end.
+			const sectionEnd = this.buffer.indexOf(KIMI_TOOL_SECTION_END);
+			const callBegin = this.buffer.indexOf(KIMI_TOOL_CALL_BEGIN);
+
+			if (callBegin === -1) {
+				if (sectionEnd !== -1) {
+					this.buffer = this.buffer.slice(
+						sectionEnd + KIMI_TOOL_SECTION_END.length,
+					);
+					this.inToolRegion = false;
+					continue;
+				}
+				if (final) {
+					// Incomplete region — discard residual marker junk.
+					this.buffer = "";
+					this.inToolRegion = false;
+				}
+				return;
+			}
+
+			// If section end comes before the next call, close the region first
+			// (shouldn't normally happen mid-call, but keeps state sane).
+			if (sectionEnd !== -1 && sectionEnd < callBegin) {
+				this.buffer = this.buffer.slice(
+					sectionEnd + KIMI_TOOL_SECTION_END.length,
+				);
+				this.inToolRegion = false;
+				continue;
+			}
+
+			const afterBegin = callBegin + KIMI_TOOL_CALL_BEGIN.length;
+			const callEnd = this.buffer.indexOf(KIMI_TOOL_CALL_END, afterBegin);
+			if (callEnd === -1) {
+				if (final) {
+					this.buffer = "";
+					this.inToolRegion = false;
+				}
+				return;
+			}
+
+			const body = this.buffer.slice(afterBegin, callEnd);
+			const parsed = parseKimiToolCallBody(body);
+			if (parsed) {
+				yield { type: "tool-call", ...parsed };
+			}
+			this.buffer = this.buffer.slice(callEnd + KIMI_TOOL_CALL_END.length);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Translate Kimi/Moonshot plain-text tool markers (`<|tool_calls_section_begin|>` / `<|tool_call_begin|>` / …) into normal `tool-call-delta` events in the AI SDK stream adapter
- Strip those markers from chat text so they never leak into the UI
- Leave existing native OpenAI-style `tool_calls` unchanged

Fixes #12979

Related: #12385, #12482, #12963

## Context

Together + `moonshotai/Kimi-K2.7-Code` (and similar Kimi hosts) often emit tool requests as content markers instead of `delta.tool_calls`. Cline only executes structured tool calls, so YOLO Act fails after consecutive mistakes while raw markers appear in chat.

## Test plan

- [x] Unit tests for streaming marker parser (`kimi-tool-markers.test.ts`)
- [x] Adapter integration tests with fake OpenAI-compatible SSE (`ai-sdk.tool-calls.test.ts`)
- [x] Confirm native `tool_calls` still pass when markers are absent
- [x] Manual smoke (VS Code + local VSIX): Together + `moonshotai/Kimi-K2.7-Code`, Act + YOLO on — tools run, no `<|tool_…|>` in UI