### PR TITLE
fix(llms): preserve model capability knowledge

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -757,6 +757,20 @@ describe("buildSessionConfig", () => {
 		expect((config as any).maxTokensPerTurn).toBe(4_096)
 	})
 
+	it("keeps sparse OpenAI Compatible capability metadata unknown", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "custom-model",
+			openAiApiKey: "openai-compatible-key",
+			actModeOpenAiModelInfo: { supportsPromptCache: false },
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["custom-model"]
+
+		expect(knownModel?.capabilities).toBeUndefined()
+	})
+
 	it("uses OpenAI Compatible overrides from models.json for runtime request settings", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openai",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -752,6 +752,7 @@ describe("buildSessionConfig", () => {
 		// the top level (manual compaction budgets).
 		expect(config.knownModels).toBeDefined()
 		expect((config.providerConfig as any).knownModels).toBeDefined()
+		expect((config.providerConfig as any).knownModels["custom-reasoner"].capabilities).toEqual([])
 		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
 		expect((config as any).maxTokensPerTurn).toBe(4_096)
 	})

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -269,7 +269,7 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 		...(maxTokens !== undefined ? { maxTokens } : {}),
 		...(contextWindow !== undefined ? { contextWindow } : {}),
 		...(maxInputTokens !== undefined ? { maxInputTokens } : {}),
-		...(capabilities.size > 0 ? { capabilities: [...capabilities] } : {}),
+		capabilities: [...capabilities],
 		...(apiFormat !== undefined ? { apiFormat } : {}),
 		...(temperature !== undefined ? { temperature } : {}),
 		...(hasPricing

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -239,6 +239,11 @@ function resolveOpenAiCompatibleMaxTokens(config: ApiConfiguration | undefined, 
 
 function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 	const modelInfo = selection.modelInfo
+	const hasCapabilityMetadata =
+		selection.overrides?.capabilities !== undefined ||
+		modelInfo.supportsImages !== undefined ||
+		modelInfo.supportsReasoning !== undefined ||
+		selection.overrides?.supportsAttachments !== undefined
 	const capabilities = new Set<NonNullable<SdkModelInfo["capabilities"]>[number]>(
 		(selection.overrides?.capabilities ?? []) as NonNullable<SdkModelInfo["capabilities"]>,
 	)
@@ -269,7 +274,7 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 		...(maxTokens !== undefined ? { maxTokens } : {}),
 		...(contextWindow !== undefined ? { contextWindow } : {}),
 		...(maxInputTokens !== undefined ? { maxInputTokens } : {}),
-		capabilities: [...capabilities],
+		...(hasCapabilityMetadata ? { capabilities: [...capabilities] } : {}),
 		...(apiFormat !== undefined ? { apiFormat } : {}),
 		...(temperature !== undefined ? { temperature } : {}),
 		...(hasPricing

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -221,6 +221,23 @@ describe("createProviderConfigStore", () => {
 		})
 	})
 
+	it("preserves an explicit empty capability override", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openrouter")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "text-only-model",
+			overrides: { capabilities: [] },
+		})
+
+		expect(mocks.getModelsFile().providers.openrouter?.models?.["text-only-model"]).toMatchObject({
+			capabilities: [],
+		})
+		expect(store.readSelection(providerId, "act")?.overrides?.capabilities).toEqual([])
+	})
+
 	it("round-trips generic provider selections using the in-process modelInfo envelope", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1003,4 +1003,18 @@ describe("createProviderConfigStore", () => {
 		// the SDK's writeModelsFileSync enforces.
 		expect(() => StoredModelEntrySchema.parse(entry)).not.toThrow()
 	})
+
+	it("preserves an explicitly empty capability set", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		store.commitSelection(providerId, "act", {
+			providerId,
+			modelId: "text-only-model",
+			overrides: { capabilities: [] },
+		})
+
+		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["text-only-model"]?.capabilities).toEqual([])
+	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -1003,18 +1003,4 @@ describe("createProviderConfigStore", () => {
 		// the SDK's writeModelsFileSync enforces.
 		expect(() => StoredModelEntrySchema.parse(entry)).not.toThrow()
 	})
-
-	it("preserves an explicitly empty capability set", async () => {
-		const { createProviderConfigStore } = await import("./store")
-		const store = createProviderConfigStore()
-		const providerId = parseProviderId("openai")
-
-		store.commitSelection(providerId, "act", {
-			providerId,
-			modelId: "text-only-model",
-			overrides: { capabilities: [] },
-		})
-
-		expect(mocks.getModelsFile().providers["openai-compatible"]?.models?.["text-only-model"]?.capabilities).toEqual([])
-	})
 })

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -204,7 +204,7 @@ function toStoredCapabilities(capabilities: readonly string[] | undefined): Stor
 			next.add(parsed.data)
 		}
 	}
-	return next.size > 0 ? [...next] : undefined
+	return next.size > 0 || capabilities.length === 0 ? [...next] : undefined
 }
 
 function toStoredApiFormat(apiFormat: ModelInfo["apiFormat"]): StoredModelEntry["apiFormat"] | undefined {

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -204,7 +204,12 @@ function toStoredCapabilities(capabilities: readonly string[] | undefined): Stor
 			next.add(parsed.data)
 		}
 	}
-	return next.size > 0 ? [...next] : undefined
+	if (next.size > 0) {
+		return [...next]
+	}
+	// Preserve an explicitly empty capability set, but continue dropping a
+	// non-empty user list when every entry failed schema validation.
+	return capabilities.length === 0 ? [] : undefined
 }
 
 function toStoredApiFormat(apiFormat: ModelInfo["apiFormat"]): StoredModelEntry["apiFormat"] | undefined {

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -204,7 +204,7 @@ function toStoredCapabilities(capabilities: readonly string[] | undefined): Stor
 			next.add(parsed.data)
 		}
 	}
-	return next.size > 0 || capabilities.length === 0 ? [...next] : undefined
+	return next.size > 0 ? [...next] : undefined
 }
 
 function toStoredApiFormat(apiFormat: ModelInfo["apiFormat"]): StoredModelEntry["apiFormat"] | undefined {

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -13,13 +13,17 @@ const gatewayMock = vi.hoisted(() => {
 	};
 });
 
-vi.mock("@cline/llms", () => ({
-	createGateway: gatewayMock.createGateway,
-	MODEL_COLLECTIONS_BY_PROVIDER_ID: {},
-	hasRegisteredHandler: gatewayMock.hasRegisteredHandler,
-	createHandlerAsync: gatewayMock.createHandlerAsync,
-	normalizeProviderId: (id: string) => id,
-}));
+vi.mock("@cline/llms", async (importOriginal) => {
+	const original = await importOriginal<typeof import("@cline/llms")>();
+	return {
+		createGateway: gatewayMock.createGateway,
+		MODEL_COLLECTIONS_BY_PROVIDER_ID: {},
+		hasRegisteredHandler: gatewayMock.hasRegisteredHandler,
+		createHandlerAsync: gatewayMock.createHandlerAsync,
+		normalizeProviderId: (id: string) => id,
+		toGatewayModelCapabilities: original.toGatewayModelCapabilities,
+	};
+});
 
 describe("createAgentModelFromConfig", () => {
 	beforeEach(() => {

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -4,6 +4,7 @@ import {
 	hasRegisteredHandler,
 	MODEL_COLLECTIONS_BY_PROVIDER_ID,
 	normalizeProviderId,
+	toGatewayModelCapabilities,
 } from "@cline/llms";
 import type {
 	AgentConfig,
@@ -128,36 +129,6 @@ export function resolveKnownModelsFromConfig(
 	};
 }
 
-function toGatewayCapabilities(
-	capabilities: ModelInfo["capabilities"],
-): GatewayModelDefinition["capabilities"] {
-	if (!capabilities?.length) {
-		return undefined;
-	}
-
-	const mapped = new Set<
-		NonNullable<GatewayModelDefinition["capabilities"]>[number]
-	>();
-	for (const capability of capabilities) {
-		switch (capability) {
-			case "tools":
-			case "reasoning":
-			case "prompt-cache":
-			case "images":
-				mapped.add(capability);
-				break;
-			case "structured_output":
-				mapped.add("structured-output");
-				break;
-			default:
-				mapped.add("text");
-		}
-	}
-
-	mapped.add("text");
-	return [...mapped];
-}
-
 function toGatewayConfiguredModel(
 	id: string,
 	model: ModelInfo,
@@ -169,7 +140,7 @@ function toGatewayConfiguredModel(
 		contextWindow: model.contextWindow,
 		maxInputTokens: model.maxInputTokens,
 		maxOutputTokens: model.maxTokens,
-		capabilities: toGatewayCapabilities(model.capabilities),
+		capabilities: toGatewayModelCapabilities(model.capabilities),
 		reasoningOptions: model.reasoningOptions,
 		metadata: {
 			family: model.family,

--- a/sdk/packages/core/src/services/providers/local-provider-registry.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-registry.ts
@@ -308,6 +308,12 @@ function toStoredModelInfo(
 	model: StoredModelEntry | undefined,
 	fallbackCapabilities?: ModelInfo["capabilities"],
 ): ModelInfo {
+	const hasCapabilityMetadata =
+		model?.capabilities !== undefined ||
+		fallbackCapabilities !== undefined ||
+		model?.supportsVision !== undefined ||
+		model?.supportsAttachments !== undefined ||
+		model?.supportsReasoning !== undefined;
 	const capabilities = new Set<ModelCapability>(
 		model?.capabilities ?? fallbackCapabilities ?? [],
 	);
@@ -340,7 +346,7 @@ function toStoredModelInfo(
 		...(model?.maxInputTokens !== undefined
 			? { maxInputTokens: model.maxInputTokens }
 			: {}),
-		...(capabilities.size > 0 ? { capabilities: [...capabilities] } : {}),
+		...(hasCapabilityMetadata ? { capabilities: [...capabilities] } : {}),
 		...(model?.temperature !== undefined
 			? { temperature: model.temperature }
 			: {}),
@@ -427,7 +433,7 @@ export function registerProviderSettingsProvider(
 	const generatedModels = getGeneratedModelsForProvider(providerId);
 	const modelCapabilities = toModelCapabilities(settings.capabilities);
 	const fallbackCapabilities =
-		modelCapabilities.length > 0 ? modelCapabilities : undefined;
+		settings.capabilities !== undefined ? modelCapabilities : undefined;
 	const modelId = settings.model?.trim();
 	const models: Record<string, ModelInfo> = {
 		...generatedModels,
@@ -500,8 +506,9 @@ export function registerCustomProvider(
 		registerCustomModels(providerId, storedModels);
 		return;
 	}
+	const provider = entry.provider;
 
-	const modelCapabilities = toModelCapabilities(entry.provider.capabilities);
+	const modelCapabilities = toModelCapabilities(provider.capabilities);
 	const modelEntries = Object.entries(storedModels)
 		.map(([modelKey, model]) => ({
 			id: model.id?.trim() || modelKey.trim(),
@@ -509,10 +516,10 @@ export function registerCustomProvider(
 		}))
 		.filter(({ id }) => id.length > 0);
 	const defaultModelId =
-		entry.provider.defaultModelId?.trim() || modelEntries[0]?.id || "default";
-	const protocol = resolveProviderProtocol(entry.provider.protocol, undefined);
+		provider.defaultModelId?.trim() || modelEntries[0]?.id || "default";
+	const protocol = resolveProviderProtocol(provider.protocol, undefined);
 	const client = resolveProviderClient(
-		entry.provider.client,
+		provider.client,
 		protocol,
 		undefined,
 	);
@@ -523,7 +530,9 @@ export function registerCustomProvider(
 				...toStoredModelInfo(
 					id,
 					model,
-					modelCapabilities.length > 0 ? modelCapabilities : undefined,
+					provider.capabilities !== undefined
+						? modelCapabilities
+						: undefined,
 				),
 				status: "active" as const,
 			},
@@ -533,13 +542,13 @@ export function registerCustomProvider(
 	LlmsModels.registerProvider({
 		provider: {
 			id: providerId,
-			name: entry.provider.name.trim() || titleCaseFromId(providerId),
+			name: provider.name.trim() || titleCaseFromId(providerId),
 			protocol,
 			client,
-			baseUrl: entry.provider.baseUrl,
-			modelsSourceUrl: entry.provider.modelsSourceUrl,
+			baseUrl: provider.baseUrl,
+			modelsSourceUrl: provider.modelsSourceUrl,
 			defaultModelId,
-			capabilities: toProviderCapabilities(entry.provider.capabilities),
+			capabilities: toProviderCapabilities(provider.capabilities),
 			source: "file",
 		},
 		models: normalizedModels,

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -175,6 +175,29 @@ describe("models registry parsing", () => {
 		expect(model).not.toHaveProperty("temperature");
 	});
 
+	it("preserves an explicitly empty model capability set", async () => {
+		const entry = parseModelsFile({
+			version: 1,
+			providers: {
+				"text-only-provider": {
+					provider: {
+						name: "Text Only Provider",
+						baseUrl: "https://text-only.example.invalid/v1",
+					},
+					models: { alpha: { capabilities: [] } },
+				},
+			},
+		}).providers["text-only-provider"];
+		if (!entry) {
+			throw new Error("expected parsed provider entry");
+		}
+
+		registerCustomProvider("text-only-provider", entry);
+
+		const models = await LlmsModels.getModelsForProvider("text-only-provider");
+		expect(models.alpha?.capabilities).toEqual([]);
+	});
+
 	it("skips malformed provider entries while preserving valid providers", () => {
 		expect(
 			parseModelsFile({

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -101,6 +101,7 @@ export {
 } from "./providers/billing";
 export type * from "./providers/gateway";
 export { createGateway, DefaultGateway } from "./providers/gateway";
+export { toGatewayModelCapabilities } from "./providers/model-capabilities";
 export { resolveProviderModelCatalogKeys } from "./providers/provider-keys";
 export {
 	type OpenAICodexRequestHeaderContext,

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1,6 +1,5 @@
 import {
 	CLINE_DEFAULT_MODEL_ID,
-	type GatewayModelCapability,
 	type GatewayModelDefinition,
 	type GatewayProviderManifest,
 	type GatewayProviderMetadata,
@@ -1198,7 +1197,7 @@ export function toManifest(spec: BuiltinSpec): GatewayProviderManifest {
 						id: collection.provider.defaultModelId || "default",
 						name: collection.provider.defaultModelId || "Default",
 						providerId: spec.id,
-						capabilities: ["text"] as GatewayModelCapability[],
+						capabilities: ["text"] as const,
 					},
 				];
 

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -35,6 +35,7 @@ import {
 	isClineOrgIndividualInferenceSubscriptionMessage,
 } from "./errors";
 import { normalizeProviderId } from "./ids";
+import { toGatewayModelCapabilities } from "./model-capabilities";
 import { filterOpenAICodexModels } from "./openai-codex-models";
 import { GENERATED_PROVIDER_SPECS } from "./providers.generated";
 import {
@@ -441,26 +442,6 @@ function modelInfoToGateway(
 	providerId: string,
 	info: ModelInfo,
 ): GatewayModelDefinition {
-	const capabilities = new Set<GatewayModelCapability>(["text"]);
-	for (const cap of info.capabilities ?? []) {
-		switch (cap) {
-			case "tools":
-				capabilities.add("tools");
-				break;
-			case "reasoning":
-				capabilities.add("reasoning");
-				break;
-			case "prompt-cache":
-				capabilities.add("prompt-cache");
-				break;
-			case "images":
-				capabilities.add("images");
-				break;
-			case "structured_output":
-				capabilities.add("structured-output");
-				break;
-		}
-	}
 	const metadata: Record<string, JsonValue | undefined> = {};
 	if (info.family) {
 		metadata.family = info.family;
@@ -485,7 +466,7 @@ function modelInfoToGateway(
 		contextWindow: info.contextWindow,
 		maxInputTokens: info.maxInputTokens,
 		maxOutputTokens: info.maxTokens,
-		capabilities: [...capabilities],
+		capabilities: toGatewayModelCapabilities(info.capabilities),
 		reasoningOptions: info.reasoningOptions,
 		metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
 	};

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -28,6 +28,7 @@ import {
 } from "./ai-sdk";
 import { BUILTIN_PROVIDER_REGISTRATIONS } from "./builtins-runtime";
 import { createGateway } from "./gateway";
+import { toGatewayModelCapabilities } from "./model-capabilities";
 import {
 	getProviderCollection,
 	getProviderCollectionSync,
@@ -51,45 +52,6 @@ const BUILTIN_PROVIDER_MAP = new Map(
 	]),
 );
 
-function toGatewayCapabilities(
-	capabilities: readonly string[] | undefined,
-): GatewayModelDefinition["capabilities"] {
-	if (!capabilities?.length) {
-		return undefined;
-	}
-
-	const mapped = new Set<
-		NonNullable<GatewayModelDefinition["capabilities"]>[number]
-	>();
-	for (const capability of capabilities) {
-		switch (capability) {
-			case "tools":
-			case "reasoning":
-			case "prompt-cache":
-			case "images":
-			case "audio":
-				mapped.add(capability);
-				break;
-			case "files":
-			case "streaming":
-			case "temperature":
-			case "reasoning-effort":
-			case "computer-use":
-			case "global-endpoint":
-				mapped.add("text");
-				break;
-			case "structured_output":
-				mapped.add("structured-output");
-				break;
-			default:
-				mapped.add("text");
-		}
-	}
-
-	mapped.add("text");
-	return [...mapped];
-}
-
 function toGatewayModelDefinition(
 	providerId: string,
 	model: ModelInfo,
@@ -102,7 +64,7 @@ function toGatewayModelDefinition(
 		contextWindow: model.contextWindow,
 		maxInputTokens: model.maxInputTokens,
 		maxOutputTokens: model.maxTokens,
-		capabilities: toGatewayCapabilities(model.capabilities),
+		capabilities: toGatewayModelCapabilities(model.capabilities),
 		reasoningOptions: model.reasoningOptions,
 		metadata: {
 			family: model.family,

--- a/sdk/packages/llms/src/providers/model-capabilities.test.ts
+++ b/sdk/packages/llms/src/providers/model-capabilities.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { toGatewayModelCapabilities } from "./model-capabilities";
+
+describe("toGatewayModelCapabilities", () => {
+	it.each([
+		["unknown", undefined, undefined],
+		["known empty", [], ["text"]],
+		["known text-only", ["tools", "reasoning"], ["text", "tools", "reasoning"]],
+		["image-capable", ["images"], ["text", "images"]],
+	] as const)("preserves %s capability knowledge", (_case, input, expected) => {
+		expect(toGatewayModelCapabilities(input)).toEqual(expected);
+	});
+});

--- a/sdk/packages/llms/src/providers/model-capabilities.ts
+++ b/sdk/packages/llms/src/providers/model-capabilities.ts
@@ -1,4 +1,4 @@
-import type { GatewayModelDefinition, ModelInfo } from "@cline/shared";
+import type { GatewayModelCapabilities, ModelInfo } from "@cline/shared";
 
 /**
  * Converts catalog capabilities into gateway capabilities without erasing
@@ -9,14 +9,12 @@ import type { GatewayModelDefinition, ModelInfo } from "@cline/shared";
  */
 export function toGatewayModelCapabilities(
 	capabilities: ModelInfo["capabilities"],
-): GatewayModelDefinition["capabilities"] {
+): GatewayModelCapabilities | undefined {
 	if (capabilities === undefined) {
 		return undefined;
 	}
 
-	const mapped = new Set<
-		NonNullable<GatewayModelDefinition["capabilities"]>[number]
-	>(["text"]);
+	const mapped = new Set<Exclude<GatewayModelCapabilities[number], "text">>();
 	for (const capability of capabilities) {
 		switch (capability) {
 			case "tools":
@@ -31,5 +29,5 @@ export function toGatewayModelCapabilities(
 		}
 	}
 
-	return [...mapped];
+	return ["text", ...mapped];
 }

--- a/sdk/packages/llms/src/providers/model-capabilities.ts
+++ b/sdk/packages/llms/src/providers/model-capabilities.ts
@@ -1,0 +1,35 @@
+import type { GatewayModelDefinition, ModelInfo } from "@cline/shared";
+
+/**
+ * Converts catalog capabilities into gateway capabilities without erasing
+ * whether the catalog supplied capability metadata. Gateway models always
+ * accept text; an absent result means the model's other capabilities are
+ * unknown, while `["text"]` means they are known to include no other mapped
+ * capability.
+ */
+export function toGatewayModelCapabilities(
+	capabilities: ModelInfo["capabilities"],
+): GatewayModelDefinition["capabilities"] {
+	if (capabilities === undefined) {
+		return undefined;
+	}
+
+	const mapped = new Set<
+		NonNullable<GatewayModelDefinition["capabilities"]>[number]
+	>(["text"]);
+	for (const capability of capabilities) {
+		switch (capability) {
+			case "tools":
+			case "reasoning":
+			case "prompt-cache":
+			case "images":
+				mapped.add(capability);
+				break;
+			case "structured_output":
+				mapped.add("structured-output");
+				break;
+		}
+	}
+
+	return [...mapped];
+}

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -36,6 +36,11 @@ export type GatewayModelCapability =
 	| "audio"
 	| "structured-output";
 
+export type GatewayModelCapabilities = readonly [
+	"text",
+	...Exclude<GatewayModelCapability, "text">[],
+];
+
 export type GatewayPromptCacheStrategy = "anthropic-automatic";
 export const USAGE_COST_DISPLAYS = ["show", "hide", "subscription"] as const;
 export type GatewayUsageCostDisplay = (typeof USAGE_COST_DISPLAYS)[number];
@@ -104,7 +109,7 @@ export interface GatewayModelDefinition {
 	contextWindow?: number;
 	maxInputTokens?: number;
 	maxOutputTokens?: number;
-	capabilities?: readonly GatewayModelCapability[];
+	capabilities?: GatewayModelCapabilities;
 	reasoningOptions?: readonly ModelReasoningOption[];
 	metadata?: Record<string, JsonValue | undefined>;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Model capability metadata distinguishes unknown capability knowledge from a known capability set. Several SDK and VS Code conversion boundaries inferred knowledge from array length, allowing known text-only metadata to become unknown and fail open for image input.

This change preserves capability knowledge through VS Code model selection, full model metadata in `models.json`, custom-provider registration, and gateway configuration. One shared translator now serves every ModelInfo-to-gateway path.

The gateway contract is deliberately stronger than the source catalog contract:

- omitted gateway capabilities mean capability knowledge is unavailable;
- present gateway capabilities are a non-empty tuple beginning with `text`;
- a source catalog's known empty optional-feature set therefore translates to `[text]`;
- sparse VS Code metadata remains unknown instead of being inferred as text-only.

Empty per-model override arrays still normalize away because override capability arrays are additive and an empty array performs no operation.

### Test Procedure

```bash
bun run build:sdk
bun -F @cline/llms test -- src/providers/model-capabilities.test.ts src/providers/builtins.test.ts src/providers/compat.test.ts
bun -F @cline/core test:unit -- src/services/llms/handler-factory.test.ts src/services/providers/local-provider-service.test.ts
cd apps/vscode && bun run test:vitest -- src/sdk/model-catalog/store.test.ts
cd apps/vscode && bun run test:vitest -- src/sdk/cline-session-factory.test.ts -t "OpenAI Compatible capability metadata|passes OpenAI Compatible max output"
bun -F @cline/llms typecheck
bun -F @cline/core typecheck
cd apps/vscode && bunx tsc --noEmit
cd apps/vscode && bun run check-types:compat
cd apps/vscode/webview-ui && bunx tsc --noEmit
```

All commands pass locally.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The request formatter continues to fail open only when capability metadata is genuinely unavailable. Stored conversation history and the version-1 `models.json` format are unchanged.
