### PR TITLE
fix(vscode): omit images for text-only OpenRouter models

### DIFF
--- a/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/apps/vscode/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "mocha"
 import "should"
 import type { ModelInfo } from "@shared/api"
 import sinon from "sinon"
-import { createOpenRouterStream } from "../openrouter-stream"
+import { createOpenRouterStream, IMAGE_UNSUPPORTED_PLACEHOLDER } from "../openrouter-stream"
 
 describe("createOpenRouterStream", () => {
 	const createAsyncIterable = () => ({
@@ -28,6 +28,80 @@ describe("createOpenRouterStream", () => {
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,
+	})
+
+	const image = {
+		type: "image" as const,
+		source: { type: "base64" as const, media_type: "image/png" as const, data: "aW1hZ2U=" },
+	}
+
+	it("replaces historical user and tool-result images for known text-only models", async () => {
+		const { client, create } = createClient()
+		const messages = [
+			{ role: "user", content: [{ type: "text", text: "look" }, image] },
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "tool_1", content: [{ type: "text", text: "read" }, image] }],
+			},
+		] as any
+		const snapshot = structuredClone(messages)
+
+		await createOpenRouterStream(client as any, "system prompt", messages, {
+			id: "deepseek/deepseek-v4-flash",
+			info: { ...createModelInfo(8_192), supportsImages: false },
+		})
+
+		const serialized = JSON.stringify(create.firstCall.args[0].messages)
+		serialized.includes("image_url").should.be.false()
+		serialized.includes(image.source.data).should.be.false()
+		serialized.includes(IMAGE_UNSUPPORTED_PLACEHOLDER).should.be.true()
+		messages.should.deepEqual(snapshot)
+	})
+
+	it("keeps images for image-capable and unknown models", async () => {
+		for (const supportsImages of [true, undefined]) {
+			const { client, create } = createClient()
+
+			await createOpenRouterStream(
+				client as any,
+				"system prompt",
+				[{ role: "user", content: [image] }] as any,
+				{
+					id: "openai/gpt-4o",
+					info: { ...createModelInfo(8_192), supportsImages },
+				},
+			)
+
+			const serialized = JSON.stringify(create.firstCall.args[0].messages)
+			serialized.includes("image_url").should.be.true()
+			serialized.includes(image.source.data).should.be.true()
+			serialized.includes(IMAGE_UNSUPPORTED_PLACEHOLDER).should.be.false()
+		}
+	})
+
+	it("preserves substituted tool-result context for known text-only R1 models", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(
+			client as any,
+			"system prompt",
+			[
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "tool_1", content: [{ type: "text", text: "read" }, image] }],
+				},
+			] as any,
+			{
+				id: "deepseek/deepseek-r1",
+				info: { ...createModelInfo(8_192), supportsImages: false },
+			},
+		)
+
+		const serialized = JSON.stringify(create.firstCall.args[0].messages)
+		serialized.includes("read").should.be.true()
+		serialized.includes(IMAGE_UNSUPPORTED_PLACEHOLDER).should.be.true()
+		serialized.includes("image_url").should.be.false()
+		serialized.includes(image.source.data).should.be.false()
 	})
 
 	it("caps Gemini Flash OpenRouter requests to 8192 max_tokens", async () => {

--- a/apps/vscode/src/core/api/transform/openrouter-stream.ts
+++ b/apps/vscode/src/core/api/transform/openrouter-stream.ts
@@ -27,6 +27,8 @@ import { convertToOpenAiMessages, sanitizeGeminiMessages } from "./openai-format
 import { convertToR1Format } from "./r1-format"
 import { getOpenAIToolParams } from "./tool-call-processor"
 
+export const IMAGE_UNSUPPORTED_PLACEHOLDER = "[image omitted: model does not support image input]"
+
 const openRouterExplicitCacheControlModelIds = new Set([
 	"deepseek/deepseek-v3.2",
 	"qwen/qwen-plus",
@@ -43,6 +45,34 @@ function needsExplicitCacheControl(modelId: string): boolean {
 	)
 }
 
+function replaceUnsupportedImages(messages: Anthropic.Messages.MessageParam[]): Anthropic.Messages.MessageParam[] {
+	return messages.map((message) => {
+		if (typeof message.content === "string") {
+			return message
+		}
+
+		return {
+			...message,
+			content: message.content.map((part) => {
+				if (part.type === "image") {
+					return { type: "text", text: IMAGE_UNSUPPORTED_PLACEHOLDER }
+				}
+				if (part.type !== "tool_result" || !Array.isArray(part.content)) {
+					return part
+				}
+				return {
+					...part,
+					content: part.content.map((resultPart) =>
+						resultPart.type === "image"
+							? { type: "text" as const, text: IMAGE_UNSUPPORTED_PLACEHOLDER }
+							: resultPart,
+					),
+				}
+			}),
+		}
+	})
+}
+
 export async function createOpenRouterStream(
 	client: OpenAI,
 	systemPrompt: string,
@@ -54,10 +84,15 @@ export async function createOpenRouterStream(
 	tools?: Array<ChatCompletionTool>,
 	enableParallelToolCalling?: boolean,
 ) {
+	// Capability changes take effect at the next request. Sanitize a request
+	// snapshot so model switches cannot send images already stored in history,
+	// while preserving that history for a later image-capable model.
+	const requestMessages = model.info.supportsImages === false ? replaceUnsupportedImages(messages) : messages
+
 	// Convert Anthropic messages to OpenAI format
 	let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 		{ role: "system", content: systemPrompt },
-		...convertToOpenAiMessages(messages),
+		...convertToOpenAiMessages(requestMessages),
 	]
 
 	const isClaude1m =
@@ -127,7 +162,7 @@ export async function createOpenRouterStream(
 		// Recommended values from DeepSeek
 		temperature = 0.7
 		topP = 0.95
-		openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
+		openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...requestMessages])
 	}
 	if (model.id.startsWith("google/gemini-3")) {
 		// Recommended value from google

--- a/apps/vscode/src/core/api/transform/r1-format.ts
+++ b/apps/vscode/src/core/api/transform/r1-format.ts
@@ -102,6 +102,13 @@ export function convertToR1Format(
 					if (part.type === "text") {
 						textParts.push(part.text);
 					}
+					if (part.type === "tool_result") {
+						if (typeof part.content === "string") {
+							textParts.push(part.content);
+						} else if (Array.isArray(part.content)) {
+							textParts.push(...part.content.filter((resultPart) => resultPart.type === "text").map((resultPart) => resultPart.text));
+						}
+					}
 					if (part.type === "image") {
 						hasImages = true;
 						imageParts.push({


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Classic Cline avoids producing most new images for text-only models, but images can remain in stored history after a model switch or resumed task. OpenRouter then rejects the complete request before selecting a provider.

This change applies the selected model's image-input capability at final OpenRouter request construction, shared by both the direct OpenRouter and Cline handlers. For models explicitly marked `supportsImages: false`, direct and tool-result images are replaced with placeholder text in an immutable request snapshot. Image-capable models and models with unknown metadata retain the existing behavior.

The R1 formatter now preserves textual tool-result content so substituted image notices and surrounding tool context survive DeepSeek R1 conversion.

### Test Procedure

```bash
cd apps/vscode
TS_NODE_TRANSPILE_ONLY=1 bun run test:unit -- --grep "createOpenRouterStream"
```

Result: 14 passing tests, covering direct images, nested tool-result images, R1 conversion, image-capable models, unknown metadata, history immutability, and existing OpenRouter request behavior.

```bash
cd apps/vscode
bunx tsc --noEmit
```

The changed files are type-clean. The branch-wide command currently stops on an unrelated pre-existing stale directive at `src/core/api/providers/openrouter.ts:157` (`TS2578: Unused '@ts-expect-error' directive`).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stored conversation history is not mutated. Capability changes take effect on the next OpenRouter request.
