### PR TITLE
fix(ci): correct webview coverage file path in coverage_check

### DIFF
--- a/.github/scripts/coverage_check/workflow.py
+++ b/.github/scripts/coverage_check/workflow.py
@@ -275,7 +275,7 @@ def extract_pr_coverage_from_artifacts():
     
     # Check if the coverage files exist
     ext_file_path = "extension_coverage.txt"
-    web_file_path = "webview-ui/webview_coverage.txt"
+    web_file_path = "webview_coverage.txt"
     
     # Extract extension coverage
     log(f"Extracting extension coverage from {ext_file_path}")


### PR DESCRIPTION
# fix(ci): correct webview coverage file path in coverage_check

## Related Issue

N/A (found while investigating a `coverage_check` CI failure)

## Description

`.github/scripts/coverage_check/workflow.py` looks for the PR's webview
coverage report in a path that the script never actually writes to, so
`extract_pr_coverage_from_artifacts()` always fails with:

```
ERROR: PR webview coverage file webview-ui/webview_coverage.txt not found
```

which calls `sys.exit(1)` and fails the whole coverage job.

### Where the file is actually written

`run_webview_coverage()` changes the working directory to `webview-ui/`
before running the coverage command, and passes `run_coverage()` a **relative**
output path of `os.path.join('..', file_path)`:

```python
# workflow.py, run_webview_coverage()
os.chdir('webview-ui')
...
web_cov = run_coverage(
    ["npm", "run", "test:coverage"],
    os.path.join('..', file_path),   # file_path == "webview_coverage.txt"
    "webview"
)
```

`run_coverage()` opens that path with a plain `open(output_file, 'w')`
(`extraction.py`), and this happens *while the process is still inside
`webview-ui/`* — `os.chdir(original_dir)` only runs afterward, in the
`finally` block. So `'../webview_coverage.txt'` resolves relative to
`webview-ui/`, one directory up, i.e. the **repository root**:

```
<repo root>/
├── webview_coverage.txt   <-- this is what actually gets created
└── webview-ui/            <-- cwd at the moment the file is opened
```

That repo-root location is also the one two other places in the codebase
already agree on:

- The 0.0-coverage fallback inside `run_webview_coverage()` itself reads back
  from `file_path` (i.e. `webview_coverage.txt`) *after* `os.chdir(original_dir)`
  has restored the repo root as cwd.
- The test harness in `.github/scripts/tests/coverage_check_test.py` writes
  `webview_coverage.txt` into a flat temp directory, at the same level as
  `extension_coverage.txt` — not nested under a `webview-ui`-equivalent
  subdirectory.

### Where the extractor looks instead

```python
# workflow.py, extract_pr_coverage_from_artifacts()
ext_file_path = "extension_coverage.txt"
web_file_path = "webview-ui/webview_coverage.txt"
```

`ext_file_path` matches its producer (`run_extension_coverage()` writes to
`extension_coverage.txt` directly, no `chdir` involved). `web_file_path` does
not match its producer — it points at a third location
(`<repo root>/webview-ui/webview_coverage.txt`) that no code path in this
script ever writes to. The two sides of this comparison can never be
satisfied at the same time, so this failure is not conditional on test
results, flakiness, or environment — it fails deterministically every run.

## Fix

Align `web_file_path` with the location `run_webview_coverage()` actually
produces (repo root), the same convention already used for
`ext_file_path`:

```diff
-    web_file_path = "webview-ui/webview_coverage.txt"
+    web_file_path = "webview_coverage.txt"
```

Single-line change, `.github/scripts/coverage_check/workflow.py` only.

## Test Procedure

- **Static check**: after the fix, both `ext_file_path` and `web_file_path`
  in `extract_pr_coverage_from_artifacts()` match the paths their respective
  producers (`run_extension_coverage()` / `run_webview_coverage()`) write to.
- **Manual repro**, before and after:

  ```bash
  cd .github/scripts/coverage_check
  python3 - <<'EOF'
  from workflow import extract_pr_coverage_from_artifacts
  open("webview_coverage.txt", "w").write(
      "All files | 50.00 | 40.00 | 30.00 | 50.00 |\n"
  )
  open("extension_coverage.txt", "w").write("Lines : 60.00% ( 100/166 )\n")
  print(extract_pr_coverage_from_artifacts())
  EOF
  ```

  - Before the fix: `SystemExit: 1`, logging
    `ERROR: PR webview coverage file webview-ui/webview_coverage.txt not found`.
  - After the fix: returns `(60.0, 50.0)` as expected.
- **Existing suite**: `.github/scripts/tests/coverage_check_test.py` still
  passes; it exercises `extract_coverage()` directly against files in its own
  temp directory and isn't affected by this path change. (Its `setUpClass`
  regenerates real coverage reports and needs `webview-ui/node_modules`
  bootstrapped locally to run.)

## Type of Change

*    ☑️ 🐛 Bug fix (non-breaking change which fixes an issue)
*    ☐ ✨ New feature (non-breaking change which adds functionality)
*    ☐ 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
*    ☐ ♻️ Refactor Changes
*    ☐ 💅 Cosmetic Changes
*    ☐ 📚 Documentation update
*    ☐ 🏃 Workflow Changes

## Pre-flight Checklist

*    ☑️ Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
*    ☑️ Tests are passing and code is formatted and linted
*    ☑️ I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

## Screenshots

Not applicable; this is a CI script path fix with no UI changes.

## Additional Notes

- **Alternative fix considered**: instead of changing `web_file_path`, we
  could drop the `os.path.join('..', ...)` in `run_webview_coverage()` and
  have it write into `webview-ui/` directly. I went with the repo-root
  convention instead because it's what the extension side, the
  0.0-coverage fallback read inside `run_webview_coverage()`, and the test
  harness all already assume — changing the extractor is the smaller,
  more consistent change. Happy to go the other direction if an
  artifact-upload step elsewhere in CI expects the file under
  `webview-ui/`.
- I couldn't find a workflow file under `.github/workflows/` that currently
  invokes `coverage_check` (e.g. via `python -m coverage_check
  process-workflow`). If it's wired up from a private/internal workflow not
  present in this checkout, this fix should apply there unchanged; if the
  job has simply been dormant, this fix is a prerequisite for turning it back
  on.
