### PR TITLE
fix(llms): use configured fetch for Vertex ADC refreshes

### DIFF
--- a/sdk/packages/llms/src/providers/vendors/vertex.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/vertex.test.ts
@@ -51,9 +51,14 @@ describe("createVertexProviderModule", () => {
 				project: "test-project",
 				location: "global",
 				apiKey: undefined,
-				googleAuthOptions: {
+				googleAuthOptions: expect.objectContaining({
 					projectId: "test-project",
-				},
+					clientOptions: {
+						transporterOptions: {
+							fetchImplementation: globalThis.fetch,
+						},
+					},
+				}),
 				fetch: expect.any(Function),
 			}),
 		);
@@ -77,9 +82,9 @@ describe("createVertexProviderModule", () => {
 			expect.objectContaining({
 				project: "nested-project",
 				location: "europe-west4",
-				googleAuthOptions: {
+				googleAuthOptions: expect.objectContaining({
 					projectId: "nested-project",
-				},
+				}),
 			}),
 		);
 	});
@@ -116,9 +121,45 @@ describe("createVertexProviderModule", () => {
 			expect.objectContaining({
 				project: "test-project",
 				location: "us-east5",
+				googleAuthOptions: expect.objectContaining({
+					projectId: "test-project",
+					clientOptions: {
+						transporterOptions: {
+							fetchImplementation: globalThis.fetch,
+						},
+					},
+				}),
 			}),
 		);
 		expect(createVertexMock).not.toHaveBeenCalled();
+	});
+
+	it("passes a configured fetch to Vertex requests and the ADC refresh transport", async () => {
+		const customFetch = vi.fn() as unknown as typeof fetch;
+
+		await createVertexProviderModule(
+			config({
+				fetch: customFetch,
+				options: {
+					project: "test-project",
+					location: "global",
+				},
+			}),
+			context("claude-sonnet-4-5@20250929"),
+		);
+
+		expect(createVertexAnthropicMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				fetch: customFetch,
+				googleAuthOptions: expect.objectContaining({
+					clientOptions: {
+						transporterOptions: {
+							fetchImplementation: customFetch,
+						},
+					},
+				}),
+			}),
+		);
 	});
 });
 

--- a/sdk/packages/llms/src/providers/vendors/vertex.ts
+++ b/sdk/packages/llms/src/providers/vendors/vertex.ts
@@ -8,6 +8,25 @@ import { ensureFetch, resolveApiKey } from "../http";
 import { isClaudeModelId } from "../model-facts";
 import type { ProviderFactoryResult } from "./types";
 
+type VertexProviderSettings = NonNullable<Parameters<typeof createVertex>[0]>;
+type VertexGoogleAuthOptions = NonNullable<
+	VertexProviderSettings["googleAuthOptions"]
+>;
+
+function createGoogleAuthOptions(
+	projectId: string | undefined,
+	fetchImplementation: typeof fetch,
+): VertexGoogleAuthOptions {
+	return {
+		...(projectId ? { projectId } : {}),
+		clientOptions: {
+			transporterOptions: {
+				fetchImplementation,
+			},
+		},
+	};
+}
+
 function readStringOption(
 	options: Record<string, unknown> | undefined,
 	key: string,
@@ -49,11 +68,13 @@ export async function createVertexProviderModule(
 		"us-central1";
 	const googleAuthProjectId = project || undefined;
 	const fetch = ensureFetch(config.fetch);
+	const googleAuthOptions = createGoogleAuthOptions(googleAuthProjectId, fetch);
 
 	if (isClaudeModelId(context.model.id)) {
 		const provider = createVertexAnthropic({
 			project,
 			location,
+			googleAuthOptions,
 			baseURL: config.baseUrl,
 			headers: config.headers,
 			fetch,
@@ -65,11 +86,7 @@ export async function createVertexProviderModule(
 		project,
 		location,
 		apiKey: googleAuthProjectId ? undefined : await resolveApiKey(config),
-		googleAuthOptions: googleAuthProjectId
-			? {
-					projectId: googleAuthProjectId,
-				}
-			: undefined,
+		googleAuthOptions: googleAuthProjectId ? googleAuthOptions : undefined,
 		baseURL: config.baseUrl,
 		headers: config.headers,
 		fetch,


### PR DESCRIPTION
### Related Issue

**Issue:** #12981

Closes #12981

### Description

Vertex requests in the CLI could intermittently fail during Application Default Credentials token refresh with:

```text
Error: $ is not a function. (In '$(Z.url,Q)', '$' is undefined)
```

OpenTUI creates a browser-like `window` object without `window.fetch`. Gaxios therefore selected an undefined fetch implementation while `google-auth-library` refreshed an ADC token. The Vertex provider already supplied a valid fetch implementation for model requests, but not for the authentication transport.

This change passes the same ensured fetch implementation through `googleAuthOptions.clientOptions.transporterOptions.fetchImplementation` for both Vertex Gemini and Vertex Anthropic authentication. Gemini API-key express mode remains unchanged.

### Test Procedure

- Built CLI 3.0.50 without the patch and reproduced the exact `$ is not a function` error in the interactive TUI using Vertex with ADC.
- Rebuilt the same native CLI with the patch and confirmed Vertex Gemini 2.5 Flash returned `VERTEX_OK` in the interactive TUI.
- Confirmed a Fable request passed the previously failing authentication stage and reached Vertex. Vertex then returned a separate `403` because the test project has not enabled Fable's partner-model terms and prompt-response sharing.
- Verified Gemini API-key express mode still omits `googleAuthOptions`.
- Ran `bun run build:sdk`.
- Ran `bun -F @cline/llms test` — 608 passed, 4 skipped.
- Ran `bun -F @cline/llms typecheck`.
- Ran targeted Biome checks on both changed files and `git diff --check` — passed.
- Ran `bun run lint` — passed with existing warnings. `bun run format` reports pre-existing formatting drift in files outside this PR; both changed files pass the targeted formatter check.
- Ran `bun -F @cline/cli build:platforms:single` and its native binary smoke test.
- Built and typechecked the VS Code extension, ran its unit suite — 1,060 passed — and activated it in an isolated development host.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is an authentication transport fix without UI changes.

### Additional Notes

Fable itself did not produce a model response because the Google Cloud project requires separate partner-model consent. The successful Vertex Gemini request confirms the CLI authentication fix works with an enabled Vertex model. No Google Cloud settings were changed during testing.

The live regression test covered local ADC. Metadata-only ADC on GCE performs an earlier metadata-discovery request through a separate Gaxios instance and was not covered by this test.
