### PR TITLE
security: raise fast-uri override to >=3.1.5 (the #12749 floor is now one version short), add ip-address floor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -355,7 +355,7 @@
     },
     "apps/vscode": {
       "name": "claude-dev",
-      "version": "4.1.3",
+      "version": "4.1.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.37.0",
         "@bufbuild/protobuf": "^2.2.5",
@@ -785,7 +785,8 @@
     "@sap-cloud-sdk/util": "4.6.0",
     "axios": "1.18.0",
     "diff": "8.0.4",
-    "fast-uri": ">=3.1.4",
+    "fast-uri": ">=3.1.5 <4",
+    "ip-address": ">=10.3.1 <11",
     "js-yaml": "^4.1.1",
     "mermaid": "11.16.0",
     "protobufjs": "7.6.5",
@@ -3377,7 +3378,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -3649,7 +3650,7 @@
 
     "intl-messageformat": ["intl-messageformat@10.7.18", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/fast-memoize": "2.2.7", "@formatjs/icu-messageformat-parser": "2.11.4", "tslib": "^2.8.0" } }, "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g=="],
 
-    "ip-address": ["ip-address@10.2.2", "", {}, "sha512-aNJVEVdXTr/g5+N2VCLo+CTrFLo/Y+9rx9RC5BpxPtf7NEknmzY+UQvMO8Fjni5KFmDaHJieL8HCMJKjJXsTgg=="],
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -5179,8 +5180,6 @@
 
     "@jerome-benoit/sap-ai-provider/@ai-sdk/provider": ["@ai-sdk/provider@3.0.14", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA=="],
 
-    "@jerome-benoit/sap-ai-provider/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.40", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw=="],
-
     "@jerome-benoit/sap-ai-provider/ai": ["ai@6.0.235", "", { "dependencies": { "@ai-sdk/gateway": "3.0.157", "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.40", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A=="],
 
     "@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
@@ -5652,8 +5651,6 @@
     "@vscode/vsce/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ai-sdk-provider-opencode-sdk/@ai-sdk/provider": ["@ai-sdk/provider@3.0.14", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA=="],
-
-    "ai-sdk-provider-opencode-sdk/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.40", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     },
     "overrides": {
         "axios": "1.18.0",
-        "fast-uri": ">=3.1.4",
+        "fast-uri": ">=3.1.5 <4",
+        "ip-address": ">=10.3.1 <11",
         "@ai-sdk/provider-utils": ">=4.0.0",
         "undici@>=6.0.0 <7.0.0": "6.28.0",
         "@opentui/core": "0.4.3",


### PR DESCRIPTION
## Summary

Two-line override correction. Both packages are reachable in shipped code (`apps/vscode`), and both were tiered **T2** in this week's review — real dependencies whose advisory preconditions we don't currently meet, so this is hygiene rather than an emergency.

## Why this exists one week after #12749

#12749 added `"fast-uri": ">=3.1.4"` as a workspace override. That was the correct floor when written. **CVE-2026-18446** (GHSA-7p8r-x3mc-p8w7, host confusion via a backslash authority introducer) has been published since, and is fixed in **3.1.5**.

The root `bun.lock` was resolving *exactly* 3.1.4 — and doing so **because of** our override. Meanwhile `docs/package-lock.json`, which the override doesn't touch, had already floated to 3.1.5 on its own.

That is the general failure mode worth noting: **a floor pin silently becomes a ceiling the moment a new advisory lands on the pinned line.** Every override we set is a standing commitment to re-check it each run, and the VMP run now does exactly that.

## Changes

| Package | Before | After | Advisory |
|---|---|---|---|
| `fast-uri` | 3.1.4 | **3.1.5** | CVE-2026-18446, AIKIDO-2026-236835 |
| `ip-address` | 10.2.2 | **10.4.0** | CVE-2026-69192 |

`ip-address` is new — reachable via `apps/vscode` → `puppeteer-core` → `proxy-agent` → `socks-proxy-agent` → `socks`. The advisory is an `Address4` leading-zero parser differential that matters for SSRF guards built on its classifiers; cline has none, hence T2 rather than T1.

Both floors are capped to the fixed major (`<4`, `<11`) per the VMP convention, so a future major can't resolve in untested. Lockfile diff is 13 lines; `bun install --lockfile-only --ignore-scripts`.

## Findings closed

`CVE-2026-18446`, `AIKIDO-2026-236835` (almost certainly Aikido's pre-CVE duplicate of the same issue — same package, same version, detected 4 days earlier), `CVE-2026-69192`.

## To finish (owner)

- [ ] CI green (both are patch/minor bumps within the existing ranges — no API surface change expected)
- [ ] Mark ready for review

## Provenance

Produced automatically by the compliance VMP automation, 2026-08-06 run — see the [exploitability index](https://github.com/cline/compliance-automation/blob/main/Artifacts/VMP/03-exploitability-index-20260806a.md) and [PR worklist](https://github.com/cline/compliance-automation/blob/main/Artifacts/VMP/04-condensed-pr-worklist-20260806a.md) for file:line evidence.