### PR TITLE
fix(mcp): reduce mid-session agent confusion after remote auth

### DIFF
--- a/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
+++ b/apps/vscode/src/hosts/vscode/__tests__/vscode-to-file-migration.test.ts
@@ -524,6 +524,25 @@ describe("vscode-to-file-migration", () => {
 				path.join(extensionStorage, "settings", "cline_mcp_settings.json"),
 			)
 		})
+
+		it("neutralizes leftover empty legacy MCP settings so agents are not misled", async () => {
+			const mockCtx = createMockVSCodeContext()
+			const extensionStorage = path.join(tempDir, "vscode-global-storage")
+			mockCtx.globalStorageUri.fsPath = extensionStorage
+			const legacyPath = path.join(extensionStorage, "settings", "cline_mcp_settings.json")
+			fs.mkdirSync(path.dirname(legacyPath), { recursive: true })
+			fs.writeFileSync(legacyPath, JSON.stringify({ mcpServers: {} }))
+
+			await exportVSCodeStorageToSharedFiles(mockCtx as any, storageContext)
+
+			const neutralized = JSON.parse(fs.readFileSync(legacyPath, "utf8")) as {
+				mcpServers: Record<string, unknown>
+				_deprecated?: string
+			}
+			neutralized.mcpServers.should.deepEqual({})
+			;(typeof neutralized._deprecated).should.equal("string")
+			neutralized._deprecated!.includes(sharedMcpSettingsPath()).should.be.true()
+		})
 	})
 
 	describe("secrets migration", () => {

--- a/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
+++ b/apps/vscode/src/hosts/vscode/mcp-settings-legacy-migration.ts
@@ -1,11 +1,11 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { getDocumentsPath } from "@/core/storage/documents-path"
 import type * as vscode from "vscode"
+import { getDocumentsPath } from "@/core/storage/documents-path"
 import { updateMcpSettingsFile } from "@/services/mcp/settingsLock"
-import type { StorageContext } from "@/shared/storage/storage-context"
 import { Logger } from "@/shared/services/Logger"
+import type { StorageContext } from "@/shared/storage/storage-context"
 import { getServerAuthHash } from "@/utils/mcpAuth"
 import { arePathsEqual } from "@/utils/path"
 
@@ -264,6 +264,41 @@ export function getSharedMcpSettingsPath(storage: StorageContext): string {
 	return path.join(clineDir, "data", "settings", MCP_SETTINGS_FILE_NAME)
 }
 
+/**
+ * Replace a leftover legacy MCP settings file with a stub that points at the
+ * shared settings path. Agents that still `cat` the old VS Code globalStorage
+ * location otherwise conclude MCP is unconfigured when the real config lives
+ * under ~/.cline/data/settings/.
+ */
+export function buildLegacyMcpSettingsStub(sharedSettingsPath: string): string {
+	return `${JSON.stringify(
+		{
+			_deprecated: `This legacy VS Code MCP settings file is unused. Active settings: ${sharedSettingsPath}`,
+			mcpServers: {},
+		},
+		null,
+		2,
+	)}\n`
+}
+
+export function neutralizeLegacyMcpSettingsFile(legacyPath: string, sharedSettingsPath: string): boolean {
+	if (!existsSync(legacyPath) || arePathsEqual(legacyPath, sharedSettingsPath)) {
+		return false
+	}
+	const stub = buildLegacyMcpSettingsStub(sharedSettingsPath)
+	try {
+		const existing = readFileSync(legacyPath, "utf8")
+		if (existing === stub) {
+			return false
+		}
+	} catch {
+		// Fall through and overwrite unreadable leftovers.
+	}
+	writeFileSync(legacyPath, stub, "utf8")
+	Logger.log(`[Migration] Neutralized legacy MCP settings at ${legacyPath}`)
+	return true
+}
+
 function readMigrationState(storage: StorageContext): JsonRecord {
 	const value = storage.globalState.get(MCP_SETTINGS_MIGRATION_KEY)
 	return isRecord(value) ? value : {}
@@ -372,6 +407,13 @@ export async function migrateLegacyMcpSettings(
 
 	if (result.migrated) {
 		writeMigrationState(storage, { sources: migratedSources })
+	}
+
+	// Always neutralize leftover legacy files (including empty ones that never
+	// contributed servers). Migration copies into the shared path but used to
+	// leave the old file in place, which misleads agents that inspect it.
+	for (const source of await getLegacyMcpSettingsSources(vscodeContext)) {
+		neutralizeLegacyMcpSettingsFile(source.path, sharedSettingsPath)
 	}
 
 	return result

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -394,6 +394,7 @@ export class Controller {
 			// this.mode is assigned later in this constructor; the closure only
 			// runs at send time, long after construction completes.
 			consumeModeSwitchNotice: (sessionId) => this.mode.consumeModeSwitchNotice(sessionId),
+			consumeMcpToolsNotice: (sessionId) => this.mcpTools.consumeMcpToolsNotice(sessionId),
 			onSendComplete: async () => {
 				// Normal flows close their diff sessions inline; anything left here is orphaned.
 				void this.diffEdits.discardAllPreviews("turn complete")
@@ -493,6 +494,7 @@ export class Controller {
 			},
 		})
 		this.mcpTools = new SdkMcpCoordinator({
+			mcpHub: this.mcpHub,
 			stateManager: this.stateManager,
 			sessions: this.sessions,
 			messages: this.messages,

--- a/apps/vscode/src/sdk/sdk-mcp-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-mcp-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
+import type { McpHub } from "@/services/mcp/McpHub"
 import { SdkMcpCoordinator, type SdkMcpCoordinatorOptions } from "./sdk-mcp-coordinator"
 
 vi.mock("@/shared/services/Logger", () => ({
@@ -40,7 +41,6 @@ describe("SdkMcpCoordinator", () => {
 		coordinator.handleToolListChanged()
 
 		await vi.waitFor(() => expect(options.sessions.replaceActiveSession).toHaveBeenCalledOnce())
-		// Reloading tools is silent: only a status transition is emitted, no chat message.
 		expect(options.messages.emitSessionEvents).toHaveBeenCalledWith([], {
 			type: "status",
 			payload: { sessionId: "old-session", status: "running" },
@@ -66,14 +66,33 @@ describe("SdkMcpCoordinator", () => {
 			initialMessages: [{ role: "user", content: "hello" }],
 			disposeReason: "mcpToolRestart",
 		})
-		// Success is silent: only a status transition back to idle, no chat
-		// message or completion banner.
 		expect(options.messages.emitSessionEvents).toHaveBeenCalledWith([], {
 			type: "status",
 			payload: { sessionId: "new-session", status: "idle" },
 		})
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("queues a model-facing MCP tools notice after a successful restart", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator } = makeCoordinator({
+			activeSession,
+			servers: [
+				{
+					name: "bodyspec",
+					status: "connected",
+					tools: [{ name: "list_scan_results" }, { name: "search" }, { name: "fetch" }],
+				},
+			],
+		})
+
+		await coordinator.restartSessionForMcpTools()
+
+		const notice = coordinator.consumeMcpToolsNotice("new-session")
+		expect(notice).toContain("bodyspec: list_scan_results, search, fetch")
+		expect(notice).toContain("Do not diagnose MCP connectivity by reading settings JSON files.")
+		expect(coordinator.consumeMcpToolsNotice("new-session")).toBeNull()
 	})
 
 	it("emits an error message when restart fails", async () => {
@@ -94,6 +113,7 @@ describe("SdkMcpCoordinator", () => {
 			{ type: "status", payload: { sessionId: "old-session", status: "error" } },
 		)
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+		expect(coordinator.consumeMcpToolsNotice("old-session")).toBeNull()
 	})
 })
 
@@ -105,6 +125,9 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		apiKey: "key",
 	}
 	const options = {
+		mcpHub: {
+			getServers: vi.fn(() => input.servers ?? []),
+		} as unknown as McpHub,
 		stateManager: {
 			getGlobalSettingsKey: vi.fn(() => input.mode ?? "act"),
 		} as unknown as StateManager,
@@ -134,6 +157,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 			}),
 		},
 	} as unknown as SdkMcpCoordinatorOptions & {
+		mcpHub: McpHub & { getServers: ReturnType<typeof vi.fn> }
 		stateManager: StateManager & { getGlobalSettingsKey: ReturnType<typeof vi.fn> }
 		sessions: SdkMcpCoordinatorOptions["sessions"] & {
 			getActiveSession: ReturnType<typeof vi.fn>
@@ -159,6 +183,11 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 interface MakeCoordinatorInput {
 	activeSession: ReturnType<typeof makeActiveSession>
 	mode: "act" | "plan"
+	servers: Array<{
+		name: string
+		status?: string
+		tools?: Array<{ name: string }>
+	}>
 }
 
 function makeActiveSession(input: { isRunning?: boolean } = {}) {

--- a/apps/vscode/src/sdk/sdk-mcp-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mcp-coordinator.ts
@@ -1,6 +1,8 @@
+import { summarizeConnectedMcpTools } from "@cline/shared"
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import type { Mode } from "@shared/storage/types"
 import type { StateManager } from "@/core/storage/StateManager"
+import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
@@ -14,6 +16,7 @@ type InitialMessages = StartInput["initialMessages"]
 type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
 
 export interface SdkMcpCoordinatorOptions {
+	mcpHub: McpHub
 	stateManager: StateManager
 	sessions: SdkSessionLifecycle
 	messages: SdkMessageCoordinator
@@ -26,7 +29,23 @@ export interface SdkMcpCoordinatorOptions {
 }
 
 export class SdkMcpCoordinator {
+	/**
+	 * Summary stamped onto the next outbound user prompt after MCP tools change
+	 * mid-session (mirrors mode_notice). Cleared on consume.
+	 */
+	private pendingMcpToolsNotice: string | null = null
+
 	constructor(private readonly options: SdkMcpCoordinatorOptions) {}
+
+	/**
+	 * Returns (and clears) a pending MCP tools-updated notice for the next send.
+	 * Session id is accepted for symmetry with mode notices; tools are global.
+	 */
+	consumeMcpToolsNotice(_sessionId: string): string | null {
+		const notice = this.pendingMcpToolsNotice
+		this.pendingMcpToolsNotice = null
+		return notice
+	}
 
 	handleToolListChanged(): void {
 		Logger.log("[SdkController] MCP tool list changed")
@@ -50,9 +69,9 @@ export class SdkMcpCoordinator {
 
 		Logger.log(`[SdkController] Restarting session ${oldSessionId} for MCP tool changes`)
 
-		// Reloading tools is a silent, behind-the-scenes operation — it should
-		// "just work" without spamming the chat. Emit only the status transition
-		// (no chat message), so toggling several servers doesn't pile up notices.
+		// Reloading tools is mostly silent in the chat UI — emit only the status
+		// transition so toggling several servers doesn't pile up notices. The
+		// model-facing <mcp_tools_notice> is stamped onto the next user send.
 		this.options.messages.emitSessionEvents([], {
 			type: "status",
 			payload: { sessionId: oldSessionId, status: "running" },
@@ -84,8 +103,12 @@ export class SdkMcpCoordinator {
 				)
 			}
 
-			// Silently return the session to idle — no "reloaded successfully"
-			// chat message or completion banner. The reload is transparent.
+			const summary = summarizeConnectedMcpTools(this.options.mcpHub.getServers())
+			if (summary) {
+				this.pendingMcpToolsNotice = summary
+				Logger.log(`[SdkController] Queued MCP tools notice for next send (${summary.split("\n").length} lines)`)
+			}
+
 			this.options.messages.emitSessionEvents([], {
 				type: "status",
 				payload: { sessionId: startResult.sessionId, status: "idle" },

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
@@ -597,6 +597,38 @@ describe("SdkSessionLifecycle", () => {
 		expect(send).toHaveBeenLastCalledWith(expect.objectContaining({ prompt: "and the tests?" }))
 	})
 
+	it("stamps a pending MCP tools notice onto the outbound prompt", async () => {
+		const send = vi.fn().mockResolvedValue(undefined)
+		const sdkHost = makeSdkHost({ send })
+		mockCreateSessionHost.mockResolvedValueOnce(sdkHost)
+		let pending: string | null = "MCP tools were updated and are available now."
+		const consumeMcpToolsNotice = vi.fn((sessionId: string) => {
+			if (sessionId !== "session-123") {
+				return null
+			}
+			const notice = pending
+			pending = null
+			return notice
+		})
+		const lifecycle = makeLifecycle({ consumeMcpToolsNotice })
+		// biome-ignore lint/suspicious/noExplicitAny: focused fake for lifecycle unit test
+		await lifecycle.startNewSession({} as any)
+
+		// biome-ignore lint/suspicious/noExplicitAny: focused fake for lifecycle unit test
+		lifecycle.fireAndForgetSend(sdkHost as any, "session-123", "list my BodySpec scans")
+		await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prompt: "<mcp_tools_notice>MCP tools were updated and are available now.</mcp_tools_notice>\nlist my BodySpec scans",
+			}),
+		)
+
+		// biome-ignore lint/suspicious/noExplicitAny: focused fake for lifecycle unit test
+		lifecycle.fireAndForgetSend(sdkHost as any, "session-123", "again")
+		await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2))
+		expect(send).toHaveBeenLastCalledWith(expect.objectContaining({ prompt: "again" }))
+	})
+
 	it("sends prompts unchanged when no mode-switch notice is pending", async () => {
 		const send = vi.fn().mockResolvedValue(undefined)
 		const sdkHost = makeSdkHost({ send })

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -6,7 +6,7 @@ import type {
 	RestoreResult,
 	StartSessionResult,
 } from "@cline/core"
-import { formatModeSwitchNotice, type ModeSwitchNotice } from "@cline/shared"
+import { formatMcpToolsUpdatedNotice, formatModeSwitchNotice, type ModeSwitchNotice } from "@cline/shared"
 import { StateManager } from "@/core/storage/StateManager"
 import type { VscodeTerminalManager } from "@/hosts/vscode/terminal/VscodeTerminalManager"
 import { McpHub } from "@/services/mcp/McpHub"
@@ -52,6 +52,11 @@ export interface SdkSessionLifecycleOptions {
 	 * message. Consumed exactly once; null when no switch is pending.
 	 */
 	consumeModeSwitchNotice?: (sessionId: string) => ModeSwitchNotice | null
+	/**
+	 * Returns (and clears) a pending MCP tools-updated notice so the next send
+	 * carries <mcp_tools_notice> for the model (hidden from chat display).
+	 */
+	consumeMcpToolsNotice?: (sessionId: string) => string | null
 	onDidBecomeIdle?: () => void
 }
 
@@ -379,14 +384,19 @@ export class SdkSessionLifecycle {
 			Logger.debug(`[SdkController] Ignoring ${label} of superseded send for session: ${sessionId}`)
 			return true
 		}
-		// Mark a preceding user-initiated mode switch on this message so the model
-		// sees exactly when the rules changed, instead of only inferring it from
-		// the user_input mode attribute flipping (mirrors the CLI's
-		// run-interactive stamping). The notice survives prepareTurnInput's
-		// normalizeUserInput sanitize and is hidden from display surfaces by
+		// Mark a preceding user-initiated mode switch / MCP tools update on this
+		// message so the model sees the change. Notices survive prepareTurnInput's
+		// normalizeUserInput sanitize and are hidden from display surfaces by
 		// stripModeNotices.
-		const notice = this.options.consumeModeSwitchNotice?.(sessionId)
-		const noticedPrompt = notice ? `${formatModeSwitchNotice(notice.from, notice.to)}\n${prompt}` : prompt
+		const modeNotice = this.options.consumeModeSwitchNotice?.(sessionId)
+		const mcpToolsNotice = this.options.consumeMcpToolsNotice?.(sessionId)
+		let noticedPrompt = prompt
+		if (modeNotice) {
+			noticedPrompt = `${formatModeSwitchNotice(modeNotice.from, modeNotice.to)}\n${noticedPrompt}`
+		}
+		if (mcpToolsNotice) {
+			noticedPrompt = `${formatMcpToolsUpdatedNotice(mcpToolsNotice)}\n${noticedPrompt}`
+		}
 		this.options.onSendStart?.(sessionId)
 		sdkHost
 			.send({

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -106,6 +106,9 @@ export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExt
 		)
 	}
 
-	Logger.log(`[VscodeRuntimeTools] Prepared ${tools.length} VSCode extra tools`)
+	Logger.log(
+		`[VscodeRuntimeTools] Prepared ${tools.length} VSCode extra tools` +
+			(tools.length > 0 ? `: ${tools.map((tool) => tool.name).join(", ")}` : ""),
+	)
 	return tools
 }

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -291,12 +291,14 @@ export {
 	createModeSwitchNoticeTracker,
 	formatDisplayUserInput,
 	formatFileContentBlock,
+	formatMcpToolsUpdatedNotice,
 	formatModeSwitchNotice,
 	formatUserCommandBlock,
 	formatUserInputBlock,
 	normalizeUserInput,
 	parseUserCommandEnvelope,
 	stripModeNotices,
+	summarizeConnectedMcpTools,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { CLINE_DEFAULT_MODEL_ID } from "./providers/defaults";

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -317,6 +317,7 @@ export {
 	createModeSwitchNoticeTracker,
 	formatDisplayUserInput,
 	formatFileContentBlock,
+	formatMcpToolsUpdatedNotice,
 	formatModeSwitchNotice,
 	formatUserCommandBlock,
 	formatUserInputBlock,
@@ -324,6 +325,7 @@ export {
 	parseUserCommandEnvelope,
 	parseUserInputMode,
 	stripModeNotices,
+	summarizeConnectedMcpTools,
 	xmlTagsRemoval,
 } from "./prompt/format";
 export { CLINE_DEFAULT_MODEL_ID } from "./providers/defaults";

--- a/sdk/packages/shared/src/prompt/format.test.ts
+++ b/sdk/packages/shared/src/prompt/format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	createModeSwitchNoticeTracker,
 	formatDisplayUserInput,
+	formatMcpToolsUpdatedNotice,
 	formatModeSwitchNotice,
 	formatUserCommandBlock,
 	formatUserInputBlock,
@@ -9,6 +10,7 @@ import {
 	parseUserCommandEnvelope,
 	parseUserInputMode,
 	stripModeNotices,
+	summarizeConnectedMcpTools,
 } from "./format";
 
 describe("prompt format helpers", () => {
@@ -62,6 +64,45 @@ describe("prompt format helpers", () => {
 		expect(
 			parseUserInputMode('<user_input mode="warp">hello</user_input>'),
 		).toBeUndefined();
+	});
+
+	it("formats an MCP tools-updated notice", () => {
+		expect(formatMcpToolsUpdatedNotice("MCP tools were updated.")).toBe(
+			"<mcp_tools_notice>MCP tools were updated.</mcp_tools_notice>",
+		);
+	});
+
+	it("summarizes connected MCP tools for the model notice", () => {
+		expect(
+			summarizeConnectedMcpTools([
+				{
+					name: "bodyspec",
+					status: "connected",
+					tools: [{ name: "list_scan_results" }, { name: "search" }],
+				},
+				{ name: "offline", status: "disconnected", tools: [{ name: "x" }] },
+			]),
+		).toBe(
+			[
+				"MCP tools were updated and are available now. Connected servers:",
+				"- bodyspec: list_scan_results, search",
+				"Call these tools directly. Do not diagnose MCP connectivity by reading settings JSON files.",
+			].join("\n"),
+		);
+		expect(summarizeConnectedMcpTools([])).toBeNull();
+	});
+
+	it("hides MCP tools notices from displayed user input", () => {
+		const wrapped = formatUserInputBlock(
+			`${formatMcpToolsUpdatedNotice("MCP tools were updated.")}\nlist my scans`,
+			"act",
+		);
+		expect(formatDisplayUserInput(wrapped)).toBe("list my scans");
+	});
+
+	it("keeps MCP tools notices when normalizing outbound prompts", () => {
+		const prompt = `${formatMcpToolsUpdatedNotice("MCP tools were updated.")}\nlist my scans`;
+		expect(normalizeUserInput(prompt)).toBe(prompt);
 	});
 
 	it("formats a mode switch notice", () => {

--- a/sdk/packages/shared/src/prompt/format.ts
+++ b/sdk/packages/shared/src/prompt/format.ts
@@ -45,6 +45,45 @@ export function formatModeSwitchNotice(
 	return `<mode_notice>The user switched from ${from} mode to ${to} mode before sending this message.</mode_notice>`;
 }
 
+/**
+ * Marks that MCP tools available to the agent changed mid-session (for example
+ * after OAuth completes). Prepended to the next user message so the model
+ * stops trusting earlier "MCP is not configured" turns. Hidden from transcript
+ * display by stripModeNotices.
+ */
+export function formatMcpToolsUpdatedNotice(summary: string): string {
+	return `<mcp_tools_notice>${summary}</mcp_tools_notice>`;
+}
+
+/**
+ * Builds the human/model-facing summary used inside {@link formatMcpToolsUpdatedNotice}.
+ * Returns null when no connected server currently exposes tools.
+ */
+export function summarizeConnectedMcpTools(
+	servers: ReadonlyArray<{
+		name: string;
+		status?: string;
+		tools?: ReadonlyArray<{ name: string }> | null;
+	}>,
+): string | null {
+	const connected = servers.filter(
+		(server) =>
+			server.status === "connected" && (server.tools?.length ?? 0) > 0,
+	);
+	if (connected.length === 0) {
+		return null;
+	}
+	const lines = connected.map((server) => {
+		const toolNames = (server.tools ?? []).map((tool) => tool.name).join(", ");
+		return `- ${server.name}: ${toolNames}`;
+	});
+	return [
+		"MCP tools were updated and are available now. Connected servers:",
+		...lines,
+		"Call these tools directly. Do not diagnose MCP connectivity by reading settings JSON files.",
+	].join("\n");
+}
+
 export type ModeSwitchNotice = {
 	from: "act" | "plan";
 	to: "act" | "plan";
@@ -146,15 +185,19 @@ export function normalizeUserInput(input?: string): string {
 }
 
 /**
- * Removes runtime-generated <mode_notice> elements (content included): they
- * are not user-typed text and must not render as such. Deliberately NOT part
- * of normalizeUserInput -- that function also sanitizes outbound prompts
- * before the host wraps them (prepareTurnInput), and stripping there deletes
- * the notice before the model ever sees it.
+ * Removes runtime-generated notice elements (content included): they are not
+ * user-typed text and must not render as such. Covers <mode_notice> and
+ * <mcp_tools_notice>. Deliberately NOT part of normalizeUserInput -- that
+ * function also sanitizes outbound prompts before the host wraps them
+ * (prepareTurnInput), and stripping there deletes the notice before the model
+ * ever sees it.
  */
 export function stripModeNotices(input?: string): string {
 	if (!input?.trim()) return "";
-	return removeTagElements(input, "mode_notice").trim();
+	return removeTagElements(
+		removeTagElements(input, "mode_notice"),
+		"mcp_tools_notice",
+	).trim();
 }
 
 // indexOf-based rather than a regex: a lazy dot-all pattern re-scans to the


### PR DESCRIPTION
### Related Issue

**Issue:** #13011

### Description

After authenticating a remote MCP server mid-chat, tools are often already loaded into the session, but the agent can still conclude MCP is "not configured."

Two setup issues make that likely:

1. Legacy migration left an empty `cline_mcp_settings.json` under VS Code `globalStorage`. Agents that inspect that old path see `mcpServers: {}` even though the live config is in `~/.cline/data/settings/cline_mcp_settings.json`.
2. Mid-session MCP tool reload is silent. Earlier wrong "not configured" turns stay in chat history with nothing telling the model tools are now available.

This PR does not fix a broken MCP transport. It addresses those setup issues:

- Neutralize leftover legacy settings files with a stub pointing at the shared settings path
- Stamp a hidden `<mcp_tools_notice>` on the next user send after tools change (same pattern as `<mode_notice>`)
- Log prepared MCP tool names for easier debugging

Related: #11671, #11818

### Test Procedure

- Unit tests for legacy-file neutralization, notice formatting/stamping, and coordinator queue/consume (`@cline/shared` format tests; VS Code unit tests for migration, `SdkMcpCoordinator`, and session lifecycle)
- Manual follow-up recommended: local `dev:mcp-oauth-test-server --auto-approve`, authenticate mid-chat, confirm the next turn uses MCP tools without a window reload

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bug fix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend / agent-context behavior)

### Additional Notes

Reproduced with `together:moonshotai/Kimi-K2.7-Code` against BodySpec remote MCP; behavior is model-dependent, but the leftover settings path and silent reload are general.
