### PR TITLE
Fix LiteLLM provider routing through chat completions

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -719,7 +719,6 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "LiteLLM",
 		description: "Self-hosted LLM proxy",
 		family: "openai-compatible",
-		protocol: "openai-responses",
 		popular: 40,
 		capabilities: ["prompt-cache"],
 		defaultModelId: "gpt-5.4",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	createOpenAICompatibleProvider,
-	createOpenAIProvider,
 	createSapAiCoreProvider,
 } from "./ai-sdk";
 import { BUILTIN_PROVIDER_REGISTRATIONS } from "./builtins-runtime";
@@ -147,19 +146,19 @@ describe("provider-ids", () => {
 		});
 	});
 
-	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
+	it("routes LiteLLM through the OpenAI-compatible provider factory", async () => {
 		const provider = await getProvider("litellm");
 		expect(provider).toMatchObject({
 			id: "litellm",
-			protocol: "openai-responses",
-			client: "openai",
+			protocol: "openai-chat",
+			client: "openai-compatible",
 		});
 
 		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
 			(item) => item.manifest.id === "litellm",
 		);
 		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
-			createProvider: createOpenAIProvider,
+			createProvider: createOpenAICompatibleProvider,
 		});
 	});
 


### PR DESCRIPTION
## Summary
- remove the `openai-responses` protocol override from the LiteLLM provider spec
- LiteLLM now inherits the `openai-compatible` family default (`openai-chat`)
- routes through `/v1/chat/completions` instead of `/v1/responses`
- works against Chat-Completions-only gateways on both the CLI and Next extension bundle

Fixes #13003

## Testing
- `bun -F @cline/llms test -- src/providers/ids.test.ts` (10 passed)
- `bun -F @cline/llms test -- src/providers/builtins.test.ts` (15 passed)
- `bun run typecheck` is blocked by the pre-existing SAP provider type error in `sdk/packages/llms/src/providers/vendors/community.ts:361`