### PR TITLE
Fix silently repaired truncated tool-call JSON

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -176,7 +176,7 @@ describe("ai-sdk adapter malformed tool calls", () => {
 		expect(findToolInput(events)).toEqual({ commands: ["ls", "pwd"] });
 	});
 
-	it("repairs truncated JSON arguments", async () => {
+	it("repairs unclosed container brackets with complete string values", async () => {
 		const events = await streamToolCallEvents(
 			sseToolCall("read_files", '{"files": [{"path": "/tmp/a.txt"}]'),
 			[READ_FILES_TOOL],
@@ -184,6 +184,16 @@ describe("ai-sdk adapter malformed tool calls", () => {
 
 		expect(findParseError(events)).toBeUndefined();
 		expect(findToolInput(events)).toEqual({ files: [{ path: "/tmp/a.txt" }] });
+	});
+
+	it("surfaces parse error for truncated JSON with unterminated string value", async () => {
+		const truncated = '{"commands": ["npm install';
+		const events = await streamToolCallEvents(
+			sseToolCall("run_commands", truncated),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toContain("Invalid input");
 	});
 
 	it("repairs single-quoted JSON arguments", async () => {
@@ -222,12 +232,21 @@ describe("repairMalformedToolCall", () => {
 		input,
 	});
 
-	it("repairs truncated JSON", async () => {
+	it("repairs unclosed containers (brackets/braces) with complete string values", async () => {
 		const repaired = await repairMalformedToolCall({
 			toolCall: toolCall('{"commands": ["ls"'),
 			error: new Error("JSON parsing failed"),
 		});
 		expect(repaired?.input).toBe('{"commands":["ls"]}');
+	});
+
+	it("returns null for unterminated string values in truncated JSON", async () => {
+		const truncated = '{"commands": ["npm install ';
+		const repaired = await repairMalformedToolCall({
+			toolCall: toolCall(truncated),
+			error: new Error("JSON parsing failed"),
+		});
+		expect(repaired).toBeNull();
 	});
 
 	it("repairs single-quoted JSON", async () => {

--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -27,6 +27,24 @@ describe("parseJsonStream", () => {
 		expect(parseJsonStream(truncated)).toBe(truncated);
 	});
 
+	it("repairs bare-object values with literal double quotes", () => {
+		expect(parseJsonStream('{"commands": echo \'it"s fine\'}')).toEqual({
+			commands: "echo 'it\"s fine'",
+		});
+	});
+
+	it("repairs bare-object values with unbalanced double quotes in shell commands", () => {
+		expect(parseJsonStream('{"commands": grep -c " file.txt}')).toEqual({
+			commands: 'grep -c " file.txt',
+		});
+	});
+
+	it("repairs single-quoted JSON with double-quote characters inside values", () => {
+		expect(parseJsonStream("{'commands': ['grep \" foo']}")).toEqual({
+			commands: ['grep " foo'],
+		});
+	});
+
 	it("repairs unclosed containers with complete string values", () => {
 		expect(parseJsonStream('{"commands": ["ls"')).toEqual({
 			commands: ["ls"],

--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -27,6 +27,11 @@ describe("parseJsonStream", () => {
 		expect(parseJsonStream(truncated)).toBe(truncated);
 	});
 
+	it("repairs Python-style literals into typed JSON values", () => {
+		expect(parseJsonStream('{"flag": True}')).toEqual({ flag: true });
+		expect(parseJsonStream('{"flag": None}')).toEqual({ flag: null });
+	});
+
 	it("repairs bare-object values with literal double quotes", () => {
 		expect(parseJsonStream('{"commands": echo \'it"s fine\'}')).toEqual({
 			commands: "echo 'it\"s fine'",

--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -11,6 +11,33 @@ describe("parseJsonStream", () => {
 				'find /Users/beatrix/dev/sdk -name "user-instruction-config-loader.ts" -o -name "rules.ts" | head -20',
 		});
 	});
+
+	it("repairs single-quoted JSON", () => {
+		expect(parseJsonStream("{'commands': ['ls']}")).toEqual({
+			commands: ["ls"],
+		});
+	});
+
+	it("repairs valid JSON with trailing commas", () => {
+		expect(parseJsonStream('{"name": "test",}')).toEqual({ name: "test" });
+	});
+
+	it("rejects truncated JSON with an unterminated string", () => {
+		const truncated = '{"path":"cfg.yml","content":"production:\\n  host: db';
+		expect(parseJsonStream(truncated)).toBe(truncated);
+	});
+
+	it("repairs unclosed containers with complete string values", () => {
+		expect(parseJsonStream('{"commands": ["ls"')).toEqual({
+			commands: ["ls"],
+		});
+	});
+
+	it("returns already-valid JSON unchanged", () => {
+		expect(parseJsonStream('{"commands": ["ls"]}')).toEqual({
+			commands: ["ls"],
+		});
+	});
 });
 
 describe("normalizeJsonLikeStringsForSchema", () => {

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -1,5 +1,32 @@
 import { jsonrepair } from "jsonrepair";
 
+/**
+ * Returns true when the text contains an unterminated string value,
+ * meaning repair would close it with a synthetic quote and produce a
+ * plausible but incorrect value. This guards against truncated tool-call
+ * arguments being silently repaired into valid-looking JSON whose values
+ * are cut off mid-content.
+ */
+function hasUnterminatedString(text: string): boolean {
+	let inString = false;
+	let escapeNext = false;
+	for (let i = 0; i < text.length; i += 1) {
+		const ch = text[i];
+		if (escapeNext) {
+			escapeNext = false;
+			continue;
+		}
+		if (ch === "\\") {
+			escapeNext = true;
+			continue;
+		}
+		if (ch === '"') {
+			inString = !inString;
+		}
+	}
+	return inString;
+}
+
 const BARE_OBJECT_RE = /^\{\s*"([A-Za-z0-9_.$-]+)"\s*:\s*([\s\S]+?)\s*\}$/;
 /**
  * Attempt to repair `{"key": some unquoted value}` by wrapping the value in quotes.
@@ -32,28 +59,35 @@ function repairBareObjectValue(
 	return JSON.parse(`{"${key}":${JSON.stringify(value)}}`);
 }
 
-/** Parse strategies applied in order — first success wins. */
-const strategies: Array<(text: string) => unknown> = [
-	(text) => JSON.parse(text),
-	(text) => JSON.parse(jsonrepair(text)),
-	repairBareObjectValue,
-];
-
 export function parseJsonStream(input: unknown): unknown {
 	if (typeof input !== "string") return input;
 
 	const text = input.trimStart();
 	if (text[0] !== "{" && text[0] !== "[") return input;
 
-	for (const strategy of strategies) {
-		try {
-			const result = strategy(text);
-			if (result !== undefined) return result;
-		} catch {
-			// strategy failed — try next
-		}
+	// Always attempt a straight parse first — this is the common path.
+	try {
+		return JSON.parse(text);
+	} catch {
+		// Not valid JSON — attempt repair below.
 	}
-	return input;
+
+	// If the text has an unterminated string literal the content was almost
+	// certainly cut off mid-value (e.g. the model hit max_tokens while
+	// writing a file-contents argument). Repairing this would close the
+	// string with a synthetic quote and produce a valid-looking but wrong
+	// value. Reject it instead so the error propagates naturally.
+	if (hasUnterminatedString(text)) {
+		return input;
+	}
+
+	try {
+		return JSON.parse(jsonrepair(text));
+	} catch {
+		// jsonrepair failed — try the last strategy below.
+	}
+
+	return repairBareObjectValue(text) ?? input;
 }
 
 export function safeJsonStringify(input: unknown): string {

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -80,30 +80,25 @@ export function parseJsonStream(input: unknown): unknown {
 		// Not valid JSON — attempt repair below.
 	}
 
-	// bare-object repair wraps the value verbatim through JSON.stringify
-	// and cannot invent a string terminator; try it first.
-	const bare = repairBareObjectValue(text);
-	if (bare !== undefined) {
-		return bare;
-	}
-
 	// If the text has an unterminated string literal the content was almost
 	// certainly cut off mid-value (e.g. the model hit max_tokens while
 	// writing a file-contents argument). Repairing this with jsonrepair
 	// would close the string with a synthetic quote and produce a
-	// valid-looking but wrong value. Reject it instead so the error
-	// propagates naturally.
-	if (hasUnterminatedString(text)) {
-		return input;
+	// valid-looking but wrong value. Skip jsonrepair so the error
+	// propagates naturally. jsonrepair stays ahead of bare-object repair
+	// because both can handle bare non-string tokens (True, None) and only
+	// jsonrepair maps them to their typed JSON equivalents.
+	if (!hasUnterminatedString(text)) {
+		try {
+			return JSON.parse(jsonrepair(text));
+		} catch {
+			// jsonrepair failed — try bare-object repair below.
+		}
 	}
 
-	try {
-		return JSON.parse(jsonrepair(text));
-	} catch {
-		// jsonrepair failed — return original for the caller to handle.
-	}
-
-	return input;
+	// Last resort: wraps the value verbatim through JSON.stringify and
+	// cannot invent a string terminator, so it needs no truncation guard.
+	return repairBareObjectValue(text) ?? input;
 }
 
 export function safeJsonStringify(input: unknown): string {

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -6,9 +6,15 @@ import { jsonrepair } from "jsonrepair";
  * plausible but incorrect value. This guards against truncated tool-call
  * arguments being silently repaired into valid-looking JSON whose values
  * are cut off mid-content.
+ *
+ * Tracks both double-quoted and single-quoted strings so literal quotes
+ * inside the opposite delimiter style do not trigger false positives
+ * (e.g. a bare-object value like `{"commands": grep -c " file.txt}` or
+ * a single-quoted payload like `{'commands': ['grep " foo']}`).
  */
 function hasUnterminatedString(text: string): boolean {
-	let inString = false;
+	let inDouble = false;
+	let inSingle = false;
 	let escapeNext = false;
 	for (let i = 0; i < text.length; i += 1) {
 		const ch = text[i];
@@ -20,11 +26,13 @@ function hasUnterminatedString(text: string): boolean {
 			escapeNext = true;
 			continue;
 		}
-		if (ch === '"') {
-			inString = !inString;
+		if (!inSingle && ch === '"') {
+			inDouble = !inDouble;
+		} else if (!inDouble && ch === "'") {
+			inSingle = !inSingle;
 		}
 	}
-	return inString;
+	return inDouble || inSingle;
 }
 
 const BARE_OBJECT_RE = /^\{\s*"([A-Za-z0-9_.$-]+)"\s*:\s*([\s\S]+?)\s*\}$/;
@@ -72,11 +80,19 @@ export function parseJsonStream(input: unknown): unknown {
 		// Not valid JSON — attempt repair below.
 	}
 
+	// bare-object repair wraps the value verbatim through JSON.stringify
+	// and cannot invent a string terminator; try it first.
+	const bare = repairBareObjectValue(text);
+	if (bare !== undefined) {
+		return bare;
+	}
+
 	// If the text has an unterminated string literal the content was almost
 	// certainly cut off mid-value (e.g. the model hit max_tokens while
-	// writing a file-contents argument). Repairing this would close the
-	// string with a synthetic quote and produce a valid-looking but wrong
-	// value. Reject it instead so the error propagates naturally.
+	// writing a file-contents argument). Repairing this with jsonrepair
+	// would close the string with a synthetic quote and produce a
+	// valid-looking but wrong value. Reject it instead so the error
+	// propagates naturally.
 	if (hasUnterminatedString(text)) {
 		return input;
 	}
@@ -84,10 +100,10 @@ export function parseJsonStream(input: unknown): unknown {
 	try {
 		return JSON.parse(jsonrepair(text));
 	} catch {
-		// jsonrepair failed — try the last strategy below.
+		// jsonrepair failed — return original for the caller to handle.
 	}
 
-	return repairBareObjectValue(text) ?? input;
+	return input;
 }
 
 export function safeJsonStringify(input: unknown): string {


### PR DESCRIPTION
## Summary
- add `hasUnterminatedString()` detection in `parseJsonStream()`
- reject truncated tool-call arguments whose string values are cut off mid-content
- `jsonrepair` still handles harmless formatting issues (single quotes, trailing commas, unclosed containers)
- regression tests for unterminated string rejection and safe-repair cases

Fixes #13001

## Testing
- `bun -F @cline/shared test -- src/parse/json.test.ts` (9 passed)
- `bun -F @cline/llms test -- src/providers/ai-sdk.tool-calls.test.ts` (13 passed)