### PR TITLE
docs: correct the cline-core log paths per client

### DIFF
--- a/apps/vscode/src/shared/net.ts
+++ b/apps/vscode/src/shared/net.ts
@@ -78,8 +78,10 @@
  *
  * 1. Verify proxy env vars: `echo $http_proxy $https_proxy`
  * 2. Check certificates: `echo $NODE_EXTRA_CA_CERTS` (should point to PEM file)
- * 3. View logs: Check ~/.cline/cline-core-service.log for network-related
- *    failures.
+ * 3. View logs: check for network-related failures in ~/.cline/data/logs/cline.log
+ *    (CLI, override with CLINE_LOG_PATH). If the hub is involved, also check
+ *    ~/.cline/data/logs/hub-daemon.log. In JetBrains, check the per-project
+ *    ~/.cline/logs/cline-core-<project>-<hash>.log.
  * 4. Test connection: Use `curl -x host:port` etc. to isolate proxy
  *    configuration versus client issues.
  *

--- a/docs/troubleshooting/networking-and-proxies.mdx
+++ b/docs/troubleshooting/networking-and-proxies.mdx
@@ -202,8 +202,18 @@ curl.exe -vv https://api.anthropic.com
 
 Use `--cacert $NODE_EXTRA_CA_CERTS` to specify a certificate if necessary.
 
-Next, check ~/.cline/cline-core-service.log (CLI, JetBrains) for log messages
-confirming your proxy configuration and any network-related errors.
+Next, check the logs for messages confirming your proxy configuration and any
+network-related errors. The location differs by client:
+
+- **CLI**: `~/.cline/data/logs/cline.log` (override with `CLINE_LOG_PATH`). If the
+  hub is involved, `~/.cline/data/logs/hub-daemon.log` covers the daemon itself.
+- **JetBrains IDEs**: `~/.cline/logs/cline-core-<project>-<hash>.log`. The plugin
+  runs one cline-core per open project and gives each its own file, so pick the
+  one named after the project you're debugging. Each run appends and is preceded
+  by a `cline-core start` line, so the output from before a restart is still
+  there — which is where to look if cline-core keeps restarting. To find the file
+  without guessing the hash, use **Help → Find Action…** and run "Show Cline
+  Logs".
 
 ## Common Proxy Patterns
 


### PR DESCRIPTION
### Related Issue

No issue — documentation correction following a JetBrains plugin change
(https://github.com/cline/intellij-plugin/pull/1095). Related tracker items:
[CLINE-646](https://linear.app/cline-bot/issue/CLINE-646) and
[CLINE-65](https://linear.app/cline-bot/issue/CLINE-65).

### Description

The proxy troubleshooting page told users to check
`~/.cline/cline-core-service.log` and named both the CLI and JetBrains as writers
of it. Neither is right any more, and the CLI half was never right.

**What actually writes what** (verified against the tree and with `lsof`, not
transcribed from commit messages):

- Nothing in `sdk/` or `apps/cli/` writes `cline-core-service.log`, on `main` or
  on `legacy-extension`. The only references anywhere are
  `apps/vscode/scripts/runclinecore.sh`, this page, and the `net.ts` comment.
- Its real production writer was the **JetBrains plugin** — which is why the page
  named JetBrains. `lsof` on a machine with two IDEs open showed two cline-core
  processes holding fds 1 and 2 on that one file, which is the bug the plugin PR
  fixes.
- The CLI's runtime log is `~/.cline/data/logs/cline.log` (`CLINE_LOG_PATH`, per
  `apps/cli/README.md`); `cline doctor` resolves `~/.cline/data/logs/<name>.log`.
  The hub daemon writes `~/.cline/data/logs/hub-daemon.log`.

So this is not a path replacement — the two clients were never writing the same
file, and each needs its own line. Anyone following the old instruction on either
client lands on a file that is stale but looks plausible, which is the worst
version of a wrong path.

The JetBrains entry also mentions that runs append behind a `cline-core start`
marker, so output from before a restart survives — worth pointing at, because a
restart loop is exactly when people come looking — and points at the "Show Cline
Logs" action, since the file name contains a hash a user cannot derive by hand.

Same correction applied to the duplicate instruction in `net.ts`'s doc comment
(the only copy of that file in the repo, and its comment block explicitly covers
JetBrains and CLI).

### Test Procedure

Prose and comment changes only; no code paths touched.

- Grepped the whole repo on both lines for `cline-core-service` to establish who
  writes it; used `lsof` on the live file to identify the actual writer rather
  than inferring from code.
- Confirmed the CLI path from `apps/cli/README.md` (`CLINE_LOG_PATH`) and
  `apps/cli/src/commands/doctor.ts`, and the hub path from
  `sdk/packages/core/src/hub/daemon/index.ts`.
- Confirmed `resolveClineDataDir()` is `<clineDir>/data`, so the SDK's log dir is
  `~/.cline/data/logs` — distinct from the plugin's `~/.cline/logs`, which is
  `LOG_DIR`-relative. Easy to conflate; they are different directories.
- Verified the new JetBrains path against a real sandbox run of the plugin PR,
  not against its description.
- Both edited files fall outside the formatter's scope — `bun run format` / `lint`
  cover `sdk/`, `apps/cli/`, `apps/cline-hub/`, `apps/examples/` only. Line
  wrapping matches the surrounding text.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Targets `main` (SDK line). The JetBrains change this documents is SDK-only, so
there is no `legacy-extension` counterpart to mirror here — though note the same
stale paragraph exists on `legacy-extension`'s copy of this page if we care about
correcting it there too.

One thing noticed and deliberately not changed:
`apps/vscode/scripts/runclinecore.sh` sets
`LOG_FILE=~/.cline/cline-core-service.log`. It is now the *only* thing that
writes that file, which is precisely why the plugin PR leaves the stale file
alone rather than cleaning it up. Renaming it there is a dev-harness change and
belongs in its own PR — happy to split it off.
