### PR TITLE
fix(cli): guard tool input formatting against malformed runtime values

### DIFF
--- a/apps/cli/src/tui/utils/hydrate-messages-malformed-tool-input.test.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages-malformed-tool-input.test.ts
@@ -1,0 +1,33 @@
+import type { Message } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { hydrateSessionMessages } from "./hydrate-messages";
+
+describe("hydrateSessionMessages malformed tool input regression", () => {
+	it("keeps a persisted run_commands call resumable when command is null", () => {
+		const messages = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool-null-command",
+						name: "run_commands",
+						input: { command: null },
+					},
+				],
+			},
+		] as unknown as Message[];
+
+		expect(() => hydrateSessionMessages(messages)).not.toThrow();
+
+		const hydrated = hydrateSessionMessages(messages);
+		expect(hydrated).toHaveLength(1);
+		expect(hydrated[0]).toMatchObject({
+			kind: "tool_call",
+			toolName: "run_commands",
+			inputSummary: "",
+			rawInput: { command: null },
+			streaming: false,
+		});
+	});
+});

--- a/apps/cli/src/utils/helpers.ts
+++ b/apps/cli/src/utils/helpers.ts
@@ -61,19 +61,46 @@ export function truncate(str: string, maxLen: number): string {
 	return `${oneLine.slice(0, maxLen - 3)}...`;
 }
 
+function stringifyForDisplay(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	if (value === null || value === undefined) {
+		return "";
+	}
+
+	try {
+		const serialized = JSON.stringify(value);
+		if (typeof serialized === "string") {
+			return serialized;
+		}
+	} catch {
+		// Fall through to best-effort string conversion.
+	}
+
+	try {
+		return String(value);
+	} catch {
+		return "";
+	}
+}
+
 export function formatStructuredCommand(cmd: unknown): string {
 	if (typeof cmd === "string") {
 		return cmd;
 	}
 	if (cmd && typeof cmd === "object" && "command" in cmd) {
-		const structured = cmd as { command: string; args?: unknown };
-		const args = Array.isArray(structured.args) ? structured.args : [];
+		const structured = cmd as { command: unknown; args?: unknown };
+		const command = stringifyForDisplay(structured.command);
+		const args = Array.isArray(structured.args)
+			? structured.args.map(stringifyForDisplay)
+			: [];
 		if (args.length === 0) {
-			return structured.command;
+			return command;
 		}
-		return `${structured.command} ${args.join(" ")}`;
+		return [command, ...args].filter(Boolean).join(" ");
 	}
-	return String(cmd);
+	return stringifyForDisplay(cmd);
 }
 
 function summarizeRunCommandsInput(input: unknown): string {
@@ -286,7 +313,7 @@ export function formatToolInput(toolName: string, input: unknown): string {
 			return "list";
 	}
 
-	return truncate(JSON.stringify(input), 60);
+	return truncate(stringifyForDisplay(input), 60);
 }
 
 export function formatToolOutput(output: unknown): string {
@@ -333,7 +360,7 @@ export function formatToolOutput(output: unknown): string {
 						: String(result ?? "");
 					return truncate(resultStr, 80);
 				}
-				return truncate(JSON.stringify(item), 80);
+				return truncate(stringifyForDisplay(item), 80);
 			})
 			.filter((s) => s.length > 0);
 
@@ -346,7 +373,7 @@ export function formatToolOutput(output: unknown): string {
 		return `${results[0]} (+${results.length - 1} more)`;
 	}
 
-	return truncate(JSON.stringify(output), 100);
+	return truncate(stringifyForDisplay(output), 100);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/cli/src/utils/tool-input-formatting-regression.test.ts
+++ b/apps/cli/src/utils/tool-input-formatting-regression.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatToolInput, formatToolOutput } from "./helpers";
+
+describe("tool input formatting regressions", () => {
+	it("does not throw for a structured command with a null command", () => {
+		expect(() =>
+			formatToolInput("run_commands", { command: null }),
+		).not.toThrow();
+		expect(formatToolInput("run_commands", { command: null })).toBe("");
+	});
+
+	it("stringifies unexpected structured command values", () => {
+		expect(
+			formatToolInput("run_commands", {
+				command: { nested: true },
+				args: [null, "status"],
+			}),
+		).toBe('{"nested":true} status');
+	});
+
+	it("falls back safely when tool input cannot be JSON serialized", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+
+		expect(() => formatToolInput("unknown_tool", circular)).not.toThrow();
+		expect(formatToolInput("unknown_tool", circular)).toBe("[object Object]");
+	});
+
+	it("falls back safely when tool output cannot be JSON serialized", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+
+		expect(() => formatToolOutput(circular)).not.toThrow();
+		expect(formatToolOutput(circular)).toBe("[object Object]");
+	});
+});


### PR DESCRIPTION
Fixes #13036

## Summary

Harden CLI tool-call display formatting so unexpected runtime values cannot crash the interactive TUI or make a persisted session non-resumable.

## Root cause

`formatStructuredCommand()` trusted the TypeScript shape of `run_commands` input at runtime and could return `structured.command` directly even when it was not actually a string. A persisted payload such as:

```ts
{ command: null }
```

could therefore flow through:

```text
formatToolInput("run_commands", input)
→ summarizeRunCommandsInput(input)
→ formatStructuredCommand(input)
→ null
→ truncate(null, 120)
→ null.replace(...)
→ TypeError
```

The same formatter is used while hydrating persisted messages, so a malformed tool-use payload can reproduce the crash when resuming the affected session.

The generic tool input/output fallbacks also called `JSON.stringify()` and passed the result directly to `truncate()`, which is unsafe when serialization returns `undefined` or throws (for example, circular values).

## Changes

- add a best-effort display-string conversion helper for unknown runtime values
- make structured command formatting validate/serialize `command` and `args` values instead of trusting the compile-time type
- use the safe display conversion for generic tool input/output fallbacks
- add regression coverage for null/object command values and unserializable input/output
- add a hydration regression test for a persisted `run_commands` tool use with `command: null`

## Validation

Run on Windows with Bun 4.1.10:

- `bun run test:unit -- src/utils/tool-input-formatting-regression.test.ts src/tui/utils/hydrate-messages-malformed-tool-input.test.ts` — 5/5 tests passed
- `bun run typecheck` — passed
- `bun run test:unit -- src/utils/helpers.test.ts src/tui/utils/hydrate-messages.test.ts` — 44/44 tests passed
- `git diff --cached --check` — passed
- pre-commit gitleaks scan — no leaks found

The deterministic `{ command: null }` reproduction demonstrates the unsafe formatter boundary and matching error class; it is not intended to claim that the original production session payload has been recovered exactly.