### PR TITLE
fix(agents): circuit-break assistant text loops without tool calls

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -46,9 +46,17 @@ import {
 	trimNonEmpty,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
+import {
+	inspectAssistantTextLoop,
+	TEXT_LOOP_ABORT_MESSAGE,
+	TEXT_LOOP_RECOVERY_GUIDANCE,
+} from "./text-loop-detection";
 
 const MAX_TOKENS_INCOMPLETE_TURN_MESSAGE =
 	"Model reached the maximum output token limit before completing the turn";
+
+/** How often (in chars of accumulated text) to re-check for text loops mid-stream. */
+const TEXT_LOOP_CHECK_EVERY_CHARS = 400;
 
 /**
  * Terminal message when a context-window overflow cannot be recovered because
@@ -696,7 +704,7 @@ export class AgentRuntime {
 					iteration: this.state.iteration,
 				});
 
-				const { message, finishReason } =
+				const { message, finishReason, textLoopAborted } =
 					await this.generateAssistantMessageWithOverflowRecovery();
 				if (finishReason === "aborted") {
 					throw this.normalizeAbortError();
@@ -743,6 +751,31 @@ export class AgentRuntime {
 						iteration: this.state.iteration,
 						toolCallCount: 0,
 					});
+					const assistantText = textFromMessage(message);
+					const textLoop = inspectAssistantTextLoop(assistantText);
+					if (
+						textLoopAborted ||
+						textLoop.kind === "hard" ||
+						textLoop.kind === "soft"
+					) {
+						this.config.logger?.log("Assistant text loop without tools", {
+							agentId: this.state.agentId,
+							runId: this.state.runId,
+							iteration: this.state.iteration,
+							kind: textLoopAborted ? "hard" : textLoop.kind,
+							reason: textLoop.reason ?? this.state.lastError,
+							textLength: assistantText.length,
+							textLoopAborted,
+						});
+						await this.addUserReminderMessage(
+							`${TEXT_LOOP_RECOVERY_GUIDANCE}\nDetected: ${
+								textLoop.reason ??
+								this.state.lastError ??
+								TEXT_LOOP_ABORT_MESSAGE
+							}`,
+						);
+						continue;
+					}
 					const completionReminderMessages =
 						this.getCompletionReminderMessages();
 					if (completionReminderMessages.length > 0) {
@@ -891,6 +924,7 @@ export class AgentRuntime {
 	private async generateAssistantMessageWithOverflowRecovery(): Promise<{
 		message: AgentMessage;
 		finishReason: AgentModelFinishReason;
+		textLoopAborted?: boolean;
 	}> {
 		const first = await this.generateAssistantMessage();
 		if (!this.isRecoverableOverflowTurn(first)) {
@@ -953,6 +987,7 @@ export class AgentRuntime {
 	}): Promise<{
 		message: AgentMessage;
 		finishReason: AgentModelFinishReason;
+		textLoopAborted?: boolean;
 	}> {
 		const usageBeforeModel = cloneUsage(this.state.usage);
 		const modelRequestMetadata = omitUndefinedValues({
@@ -1051,8 +1086,10 @@ export class AgentRuntime {
 		let finishReason: AgentModelFinishReason = "stop";
 		let accumulatedText = "";
 		let accumulatedReasoning = "";
+		let lastTextLoopCheckAt = 0;
+		let textLoopAborted = false;
 
-		for await (const event of stream) {
+		stream: for await (const event of stream) {
 			this.throwIfAborted();
 			switch (event.type) {
 				case "text-delta": {
@@ -1073,6 +1110,40 @@ export class AgentRuntime {
 						text: event.text,
 						accumulatedText,
 					});
+					if (
+						accumulatedText.length - lastTextLoopCheckAt >=
+						TEXT_LOOP_CHECK_EVERY_CHARS
+					) {
+						lastTextLoopCheckAt = accumulatedText.length;
+						const loop = inspectAssistantTextLoop(accumulatedText);
+						if (loop.kind === "hard") {
+							textLoopAborted = true;
+							finishReason = "stop";
+							this.state.lastError =
+								loop.reason ?? TEXT_LOOP_ABORT_MESSAGE;
+							this.config.logger?.log(
+								"Aborting model stream due to assistant text loop",
+								{
+									agentId: this.state.agentId,
+									runId: this.state.runId,
+									iteration: this.state.iteration,
+									reason: loop.reason,
+									textLength: accumulatedText.length,
+								},
+							);
+							// Truncate trailing spam so history stays usable.
+							for (const item of sequence) {
+								if (
+									item.type === "part" &&
+									item.part.type === "text" &&
+									item.part.text.length > 2_500
+								) {
+									item.part.text = `${item.part.text.slice(0, 2_000)}\n\n[${TEXT_LOOP_ABORT_MESSAGE}]`;
+								}
+							}
+							break stream;
+						}
+					}
 					break;
 				}
 				case "reasoning-delta": {
@@ -1245,7 +1316,7 @@ export class AgentRuntime {
 			this.applyStopControl(control);
 		}
 
-		return { message, finishReason };
+		return { message, finishReason, textLoopAborted };
 	}
 
 	private async *openTaskLifecycleStream(

--- a/sdk/packages/agents/src/index.ts
+++ b/sdk/packages/agents/src/index.ts
@@ -55,3 +55,13 @@ export {
 	createAgent,
 	createAgentRuntime,
 } from "./agent-runtime";
+export {
+	countLetMe,
+	inspectAssistantTextLoop,
+	TEXT_LOOP_ABORT_MESSAGE,
+	TEXT_LOOP_RECOVERY_GUIDANCE,
+} from "./text-loop-detection";
+export type {
+	TextLoopConfig,
+	TextLoopVerdict,
+} from "./text-loop-detection";

--- a/sdk/packages/agents/src/text-loop-detection.test.ts
+++ b/sdk/packages/agents/src/text-loop-detection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+	countLetMe,
+	inspectAssistantTextLoop,
+	normalizeLoopLine,
+	trailingRepeatedLineRun,
+	trailingSameTokenRun,
+} from "./text-loop-detection";
+
+describe("text-loop-detection", () => {
+	it("normalizes lines for comparison", () => {
+		expect(normalizeLoopLine("  Let me update the themepack.  ")).toBe(
+			"let me update the themepack",
+		);
+	});
+
+	it("counts let-me phrases", () => {
+		const text = "Let me check.\nLet me inspect.\nOkay let me look now.";
+		expect(countLetMe(text)).toBe(3);
+	});
+
+	it("detects trailing repeated intent lines as hard", () => {
+		const line =
+			"Let me check the Cline settings and logs now for the tool calling issue.";
+		const text = Array.from({ length: 30 }, () => line).join("\n");
+		const verdict = inspectAssistantTextLoop(text);
+		expect(verdict.kind).toBe("hard");
+		expect(verdict.letMeCount).toBeGreaterThanOrEqual(24);
+		expect(trailingRepeatedLineRun(text).count).toBeGreaterThanOrEqual(16);
+	});
+
+	it("detects Read. token spam as hard", () => {
+		const text = Array.from({ length: 50 }, () => "Read.").join("\n");
+		const verdict = inspectAssistantTextLoop(text);
+		expect(verdict.kind).toBe("hard");
+		expect(trailingSameTokenRun(text).count).toBeGreaterThanOrEqual(40);
+	});
+
+	it("allows normal assistant prose", () => {
+		const text = [
+			"Batch is queued. Next I will validate the CSV and update the graph.",
+			"Validation passed for all 8 candidates.",
+			"Graph update completed with AST-only refresh.",
+			"Ready for your submit decision.",
+		].join("\n");
+		expect(inspectAssistantTextLoop(text).kind).toBe("ok");
+	});
+
+	it("soft-flags moderate let-me density before hard threshold", () => {
+		const lines = Array.from(
+			{ length: 14 },
+			(_, i) => `Let me verify step ${i} of the pipeline status now.`,
+		);
+		const text = lines.join("\n");
+		const verdict = inspectAssistantTextLoop(text, {
+			minCharsForHard: 50_000,
+		});
+		expect(verdict.kind).toBe("soft");
+	});
+});

--- a/sdk/packages/agents/src/text-loop-detection.ts
+++ b/sdk/packages/agents/src/text-loop-detection.ts
@@ -1,0 +1,242 @@
+/**
+ * Detects degenerate assistant text loops where the model streams repeated
+ * "I'm about to…" / single-token spam instead of emitting tool calls.
+ *
+ * Observed with DeepSeek V4 Flash (Cline Pass) on long sessions: 100k+ char
+ * turns of near-identical "Let me …" lines with zero tool_use.
+ */
+
+export interface TextLoopConfig {
+	/** Consecutive near-duplicate lines before soft warning. Default 8. */
+	softRepeatedLines: number;
+	/** Consecutive near-duplicate lines before hard stop. Default 16. */
+	hardRepeatedLines: number;
+	/** "Let me" / "let me" count soft threshold. Default 12. */
+	softLetMeCount: number;
+	/** "Let me" / "let me" count hard threshold. Default 24. */
+	hardLetMeCount: number;
+	/** Repeated identical short token soft threshold. Default 20. */
+	softSameToken: number;
+	/** Repeated identical short token hard threshold. Default 40. */
+	hardSameToken: number;
+	/** Minimum accumulated chars before hard checks apply. Default 1500. */
+	minCharsForHard: number;
+}
+
+export interface TextLoopVerdict {
+	kind: "ok" | "soft" | "hard";
+	reason?: string;
+	repeatedLines?: number;
+	letMeCount?: number;
+	sameTokenCount?: number;
+}
+
+const DEFAULT_CONFIG: TextLoopConfig = {
+	softRepeatedLines: 8,
+	hardRepeatedLines: 16,
+	softLetMeCount: 12,
+	hardLetMeCount: 24,
+	softSameToken: 20,
+	hardSameToken: 40,
+	minCharsForHard: 1500,
+};
+
+const LET_ME_RE = /\blet me\b/gi;
+const SHORT_TOKEN_RE = /^[A-Za-z][A-Za-z0-9_-]{0,24}[.!]?\s*$/;
+
+export function normalizeLoopLine(line: string): string {
+	return line
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, " ")
+		.replace(/[.!…]+$/g, "");
+}
+
+export function countLetMe(text: string): number {
+	const matches = text.match(LET_ME_RE);
+	return matches?.length ?? 0;
+}
+
+/**
+ * Longest trailing run of near-duplicate non-empty lines.
+ */
+export function trailingRepeatedLineRun(text: string): {
+	count: number;
+	sample: string;
+} {
+	const lines = text
+		.split(/\r?\n/)
+		.map((line) => normalizeLoopLine(line))
+		.filter((line) => line.length > 0);
+	if (lines.length === 0) {
+		return { count: 0, sample: "" };
+	}
+	const sample = lines[lines.length - 1] ?? "";
+	if (sample.length < 8) {
+		// Very short lines handled by same-token detector.
+		return { count: 0, sample };
+	}
+	let count = 1;
+	for (let i = lines.length - 2; i >= 0; i -= 1) {
+		const prev = lines[i] ?? "";
+		if (prev === sample || isNearDuplicate(prev, sample)) {
+			count += 1;
+		} else {
+			break;
+		}
+	}
+	return { count, sample };
+}
+
+/**
+ * Longest trailing run of identical short tokens (e.g. "Read." spam).
+ */
+export function trailingSameTokenRun(text: string): {
+	count: number;
+	sample: string;
+} {
+	const lines = text
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	if (lines.length === 0) {
+		return { count: 0, sample: "" };
+	}
+	const sample = lines[lines.length - 1] ?? "";
+	if (!SHORT_TOKEN_RE.test(sample)) {
+		return { count: 0, sample: "" };
+	}
+	const normalized = normalizeLoopLine(sample);
+	let count = 1;
+	for (let i = lines.length - 2; i >= 0; i -= 1) {
+		if (normalizeLoopLine(lines[i] ?? "") === normalized) {
+			count += 1;
+		} else {
+			break;
+		}
+	}
+	return { count, sample };
+}
+
+function isNearDuplicate(a: string, b: string): boolean {
+	if (a === b) return true;
+	if (a.length < 12 || b.length < 12) return false;
+	// Prefix collapse: "let me update the themepack doc" vs "... doc and clean up"
+	const shorter = a.length <= b.length ? a : b;
+	const longer = a.length <= b.length ? b : a;
+	if (longer.startsWith(shorter) && shorter.length / longer.length >= 0.7) {
+		return true;
+	}
+	// Shared stem of first 6 words
+	const aw = a.split(" ").slice(0, 6).join(" ");
+	const bw = b.split(" ").slice(0, 6).join(" ");
+	return aw.length >= 16 && aw === bw;
+}
+
+export function inspectAssistantTextLoop(
+	text: string,
+	config: Partial<TextLoopConfig> = {},
+): TextLoopVerdict {
+	const cfg: TextLoopConfig = { ...DEFAULT_CONFIG, ...config };
+	if (!text || text.length < 200) {
+		return { kind: "ok" };
+	}
+
+	const letMeCount = countLetMe(text);
+	const repeated = trailingRepeatedLineRun(text);
+	const sameToken = trailingSameTokenRun(text);
+
+	// Same-token spam is unambiguous even in short buffers.
+	if (sameToken.count >= cfg.hardSameToken) {
+		return {
+			kind: "hard",
+			reason: describeLoop({
+				repeated,
+				letMeCount,
+				sameToken,
+				level: "hard",
+			}),
+			repeatedLines: repeated.count,
+			letMeCount,
+			sameTokenCount: sameToken.count,
+		};
+	}
+
+	const hardEligible = text.length >= cfg.minCharsForHard;
+	if (
+		hardEligible &&
+		(repeated.count >= cfg.hardRepeatedLines ||
+			letMeCount >= cfg.hardLetMeCount)
+	) {
+		return {
+			kind: "hard",
+			reason: describeLoop({
+				repeated,
+				letMeCount,
+				sameToken,
+				level: "hard",
+			}),
+			repeatedLines: repeated.count,
+			letMeCount,
+			sameTokenCount: sameToken.count,
+		};
+	}
+
+	if (
+		repeated.count >= cfg.softRepeatedLines ||
+		letMeCount >= cfg.softLetMeCount ||
+		sameToken.count >= cfg.softSameToken
+	) {
+		return {
+			kind: "soft",
+			reason: describeLoop({
+				repeated,
+				letMeCount,
+				sameToken,
+				level: "soft",
+			}),
+			repeatedLines: repeated.count,
+			letMeCount,
+			sameTokenCount: sameToken.count,
+		};
+	}
+
+	return {
+		kind: "ok",
+		repeatedLines: repeated.count,
+		letMeCount,
+		sameTokenCount: sameToken.count,
+	};
+}
+
+function describeLoop(input: {
+	repeated: { count: number; sample: string };
+	letMeCount: number;
+	sameToken: { count: number; sample: string };
+	level: "soft" | "hard";
+}): string {
+	const parts: string[] = [];
+	if (input.repeated.count > 0) {
+		parts.push(
+			`${input.repeated.count} repeated lines (e.g. "${input.repeated.sample.slice(0, 60)}")`,
+		);
+	}
+	if (input.letMeCount > 0) {
+		parts.push(`${input.letMeCount}× "let me"`);
+	}
+	if (input.sameToken.count > 0) {
+		parts.push(
+			`${input.sameToken.count}× token "${input.sameToken.sample}"`,
+		);
+	}
+	return `Assistant text ${input.level} loop detected: ${parts.join("; ")}`;
+}
+
+export const TEXT_LOOP_RECOVERY_GUIDANCE = [
+	"[SYSTEM] You entered a text-only loop (repeated 'Let me…' / identical lines) without emitting a tool call.",
+	"Stop narrating intent. Immediately call exactly one concrete tool (run_commands, read_files, editor, etc.) to make progress.",
+	"Do not repeat prior sentences. Do not apologize. Tool call now.",
+].join(" ");
+
+export const TEXT_LOOP_ABORT_MESSAGE =
+	"Stopped streaming: assistant text loop detected (repeated intent text with no tool call).";


### PR DESCRIPTION
## Summary
- Adds mid-stream + end-of-turn detection for degenerate assistant text loops (repeated `Let me…` / identical short tokens) that emit **zero** `tool_use`.
- On hard detect: abort the model stream early, truncate spam in history, inject a system recovery nudge requiring a concrete tool call instead of completing as text-only.
- Covers the CLI failure mode reported in https://github.com/cline/cline/issues/13041 (Cline Pass `deepseek-v4-flash` + `xhigh` on long sessions). Related: #11328, #12963.

## Why
Existing `LoopDetectionTracker` only watches **identical tool calls**. This bug never calls a tool — it streams 100k+ chars of intent narration until the user aborts. `--retries` / mistake limits never fire because the stream is treated as valid assistant text.

## Test plan
- [x] `bun -F @cline/agents test src/text-loop-detection.test.ts` (6/6)
- [x] `bun run build:sdk`
- [ ] Manual: long ACT session on `cline-pass/deepseek-v4-flash` — confirm text-loop aborts and forces a tool call instead of unbounded `Let me…` spam
- [ ] Confirm normal short prose answers still complete without false positives

Fixes #13041

Made with [Cursor](https://cursor.com)