### PR TITLE
fix(cli): harden tool input/output formatters against malformed payloads

### DIFF
--- a/apps/cli/src/tui/utils/hydrate-messages.test.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages.test.ts
@@ -135,6 +135,35 @@ describe("hydrateSessionMessages", () => {
 		]);
 	});
 
+	// Regression test for https://github.com/cline/cline/issues/13036:
+	// persisted sessions with malformed tool inputs must stay resumable.
+	it("hydrates tool calls with malformed inputs without throwing", () => {
+		const messages = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool-1",
+						name: "run_commands",
+						input: { command: null },
+					},
+				],
+			},
+		] as Message[];
+
+		expect(hydrateSessionMessages(messages)).toEqual([
+			{
+				kind: "tool_call",
+				toolName: "run_commands",
+				inputSummary: "",
+				rawInput: { command: null },
+				streaming: false,
+				mode: undefined,
+			},
+		]);
+	});
+
 	it("leaves mode undefined for transcripts without user_input wrappers", () => {
 		const messages = [
 			{ role: "user", content: "plain old message" },

--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -392,6 +392,19 @@ describe("format helpers", () => {
 		);
 	});
 
+	it("keeps valid empty-string args in structured command summaries", () => {
+		expect(
+			formatToolInput("run_commands", {
+				commands: [{ command: "grep", args: ["", "pattern", "file.txt"] }],
+			}),
+		).toBe("grep  pattern file.txt");
+		expect(
+			formatToolInput("run_commands", {
+				commands: [{ command: "git", args: [null, "status", undefined] }],
+			}),
+		).toBe("git status");
+	});
+
 	it("skips null entries in run_commands command arrays", () => {
 		expect(
 			formatToolInput("run_commands", { commands: [null, "echo hi"] }),

--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -10,6 +10,7 @@ import {
 	isCliHookPayload,
 	normalizeAutoApproveArgs,
 	parseArgs,
+	truncate,
 } from "./helpers";
 
 type EnvSnapshot = {
@@ -373,6 +374,60 @@ describe("format helpers", () => {
 			]),
 		).toBe("first (+2 more)");
 		expect(formatToolOutput(null)).toBe("");
+	});
+
+	// Regression tests for https://github.com/cline/cline/issues/13036:
+	// malformed tool inputs crossing the model/tool boundary must never
+	// throw from display-only formatters.
+	it("does not crash on run_commands with a null command", () => {
+		expect(formatToolInput("run_commands", { command: null })).toBe("");
+	});
+
+	it("does not crash on run_commands with a non-string command", () => {
+		expect(formatToolInput("run_commands", { command: { nested: true } })).toBe(
+			'{"nested":true}',
+		);
+		expect(formatToolInput("run_commands", { commands: { command: 42 } })).toBe(
+			"42",
+		);
+	});
+
+	it("skips null entries in run_commands command arrays", () => {
+		expect(
+			formatToolInput("run_commands", { commands: [null, "echo hi"] }),
+		).toBe("echo hi");
+		expect(formatToolInput("run_commands", [undefined, "echo hi"])).toBe(
+			"echo hi",
+		);
+	});
+
+	it("does not crash on fetch_web_content with malformed requests", () => {
+		expect(
+			formatToolInput("fetch_web_content", {
+				requests: [null, { url: "https://example.com" }, { url: 42 }, "raw"],
+			}),
+		).toBe("https://example.com, 42");
+	});
+
+	it("falls back to an empty summary for unserializable inputs", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+		expect(formatToolInput("unknown_tool", circular)).toBe("");
+		expect(formatToolOutput(circular)).toBe("");
+		expect(
+			formatToolInput("unknown_tool", {
+				toJSON() {
+					throw new Error("boom");
+				},
+			}),
+		).toBe("");
+	});
+
+	it("truncates non-string values without throwing", () => {
+		expect(truncate(null, 10)).toBe("");
+		expect(truncate(undefined, 10)).toBe("");
+		expect(truncate(42, 10)).toBe("42");
+		expect(truncate({ nested: true }, 60)).toBe('{"nested":true}');
 	});
 });
 

--- a/apps/cli/src/utils/helpers.ts
+++ b/apps/cli/src/utils/helpers.ts
@@ -98,8 +98,12 @@ export function formatStructuredCommand(cmd: unknown): string {
 	if (cmd && typeof cmd === "object" && "command" in cmd) {
 		const structured = cmd as { command?: unknown; args?: unknown };
 		const command = toDisplayString(structured.command);
+		// Drop only nullish entries: they carry no display value, while an
+		// empty string is a valid argv entry that must stay in the summary.
 		const args = Array.isArray(structured.args)
-			? structured.args.map(toDisplayString).filter(Boolean)
+			? structured.args
+					.filter((arg) => arg !== null && arg !== undefined)
+					.map(toDisplayString)
 			: [];
 		if (args.length === 0) {
 			return command;

--- a/apps/cli/src/utils/helpers.ts
+++ b/apps/cli/src/utils/helpers.ts
@@ -53,8 +53,38 @@ export function resolveWorkspaceRoot(cwd: string): string {
 	return cwd;
 }
 
-export function truncate(str: string, maxLen: number): string {
-	const oneLine = str.replace(/\n/g, " ").trim();
+function safeJsonStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Normalizes an untrusted runtime value into a display string without ever
+ * throwing. Tool inputs/outputs cross the model/tool boundary, so they may
+ * not match their TypeScript annotations (e.g. `{ command: null }`).
+ */
+export function toDisplayString(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	if (value === null || value === undefined) {
+		return "";
+	}
+	if (typeof value === "object") {
+		return safeJsonStringify(value);
+	}
+	try {
+		return String(value);
+	} catch {
+		return "";
+	}
+}
+
+export function truncate(value: unknown, maxLen: number): string {
+	const oneLine = toDisplayString(value).replace(/\n/g, " ").trim();
 	if (oneLine.length <= maxLen) {
 		return oneLine;
 	}
@@ -66,14 +96,17 @@ export function formatStructuredCommand(cmd: unknown): string {
 		return cmd;
 	}
 	if (cmd && typeof cmd === "object" && "command" in cmd) {
-		const structured = cmd as { command: string; args?: unknown };
-		const args = Array.isArray(structured.args) ? structured.args : [];
+		const structured = cmd as { command?: unknown; args?: unknown };
+		const command = toDisplayString(structured.command);
+		const args = Array.isArray(structured.args)
+			? structured.args.map(toDisplayString).filter(Boolean)
+			: [];
 		if (args.length === 0) {
-			return structured.command;
+			return command;
 		}
-		return `${structured.command} ${args.join(" ")}`;
+		return `${command} ${args.join(" ")}`;
 	}
-	return String(cmd);
+	return toDisplayString(cmd);
 }
 
 function summarizeRunCommandsInput(input: unknown): string {
@@ -82,14 +115,17 @@ function summarizeRunCommandsInput(input: unknown): string {
 	}
 
 	if (Array.isArray(input)) {
-		return input.map(formatStructuredCommand).join("; ");
+		return input.map(formatStructuredCommand).filter(Boolean).join("; ");
 	}
 
 	if (input && typeof input === "object") {
 		const obj = input as Record<string, unknown>;
 		if (obj.commands !== undefined) {
 			if (Array.isArray(obj.commands)) {
-				return obj.commands.map(formatStructuredCommand).join("; ");
+				return obj.commands
+					.map(formatStructuredCommand)
+					.filter(Boolean)
+					.join("; ");
 			}
 			return formatStructuredCommand(obj.commands);
 		}
@@ -157,7 +193,11 @@ export function formatToolInput(toolName: string, input: unknown): string {
 			if (Array.isArray(obj.requests)) {
 				return truncate(
 					obj.requests
-						.map((r) => r.url)
+						.map((r) =>
+							r && typeof r === "object" && "url" in r
+								? toDisplayString((r as { url?: unknown }).url)
+								: "",
+						)
 						.filter(Boolean)
 						.join(", "),
 					120,
@@ -286,7 +326,7 @@ export function formatToolInput(toolName: string, input: unknown): string {
 			return "list";
 	}
 
-	return truncate(JSON.stringify(input), 60);
+	return truncate(input, 60);
 }
 
 export function formatToolOutput(output: unknown): string {
@@ -330,10 +370,10 @@ export function formatToolOutput(output: unknown): string {
 								)
 								.filter(Boolean)
 								.join(" ") || "Successfully read image"
-						: String(result ?? "");
+						: toDisplayString(result);
 					return truncate(resultStr, 80);
 				}
-				return truncate(JSON.stringify(item), 80);
+				return truncate(item, 80);
 			})
 			.filter((s) => s.length > 0);
 
@@ -346,7 +386,7 @@ export function formatToolOutput(output: unknown): string {
 		return `${results[0]} (+${results.length - 1} more)`;
 	}
 
-	return truncate(JSON.stringify(output), 100);
+	return truncate(output, 100);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
### Related Issue

**Issue:** #13036

### Description

The CLI TUI crashes with `.replace is not a function` (minified: `O.replace is not a function`) when a tool call carries an input that does not match its TypeScript annotation, e.g. `run_commands` with `{ command: null }` or `{ command: { nested: true } }`. Because session hydration replays persisted `tool_use` inputs through the same `formatToolInput()` helper, a session containing such a payload also becomes non-resumable from `cline history` with the same error.

Root cause: `truncate()` in `apps/cli/src/utils/helpers.ts` called `str.replace()` assuming a runtime string, and `formatStructuredCommand()` returned `structured.command` verbatim regardless of its actual type. Tool inputs cross the runtime/model boundary, so the display-only formatters must treat them as untrusted data.

Changes, all confined to `apps/cli`:

- `truncate()` now accepts `unknown` and normalizes through a new `toDisplayString()` helper: strings pass through, `null`/`undefined` become empty, objects are safely JSON-stringified (circular structures and throwing `toJSON()` degrade to an empty string instead of throwing).
- `formatStructuredCommand()` normalizes non-string `command` values and structured args instead of returning them verbatim; `null`/`undefined` entries in command arrays are skipped rather than rendered.
- The `fetch_web_content` summary tolerates malformed entries in `requests` (null entries, non-string `url`).
- The `JSON.stringify` fallbacks in `formatToolInput()` and `formatToolOutput()` now go through the safe stringify path, so unserializable payloads can no longer throw.

This hardens both crash sites reported in the issue: the live event path (`use-agent-events.ts` / `events.ts`) and persisted-session hydration (`hydrate-messages.ts`), which both funnel into these helpers.

### Test Procedure

- Reproduced the exact crash from the issue against unmodified code: `formatToolInput("run_commands", { command: null })` throws `null is not an object (evaluating 'str.replace')`. With this fix it returns `""`, and `{ command: { nested: true } }` returns `{"nested":true}`:

```text
$ git stash && bun -e '... formatToolInput("run_commands", { command: null }) ...'
CRASH: null is not an object (evaluating 'str.replace')

$ git stash pop && bun -e '...'
run_commands {command:null} -> ""
run_commands {command:{nested:true}} -> "{\"nested\":true}"
```

- Added regression tests in `helpers.test.ts` for null/non-string commands, null entries in command arrays, malformed `fetch_web_content` requests, circular / `toJSON`-throwing payloads in both `formatToolInput` and `formatToolOutput`, and non-string values passed to `truncate`.
- Added a hydration regression test in `hydrate-messages.test.ts` proving a persisted transcript with `{ command: null }` tool input hydrates without throwing (the non-resumable-session case).
- Full CLI unit suite passes: 132 files, 1123 tests. `tsc --noEmit` and `biome check` on the changed files are clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend/formatter change; evidence is the before/after repro output and the test run in the Test Procedure section.

### Additional Notes

The malformed-input display convention follows the issue's suggestion: unknown values are normalized before newline replacement/truncation, and the fallback serialization path never throws. A separate Git-related process-abort path mentioned in the issue logs is intentionally out of scope, matching the reporter's scoping.