### PR TITLE
fix(llms): keep explicit reasoning disable on the wire for openai-compatible providers

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
@@ -47,6 +47,19 @@ describe("resolvePortableReasoning", () => {
 		).toBe("none");
 	});
 
+	it("leaves explicit disable to native rules for openai-compatible providers", () => {
+		// @ai-sdk/openai-compatible drops the portable "none" on the floor,
+		// so the disable intent must stay on the request for provider-option
+		// rules (e.g. DeepSeek thinking.type="disabled") to encode natively.
+		for (const providerId of ["deepseek", "fireworks", "groq", "xai"]) {
+			const disable = { ...request({ enabled: false }), providerId };
+			expect(resolvePortableReasoning(disable)).toBeUndefined();
+			expect(withoutPortableReasoning(disable).reasoning).toEqual({
+				enabled: false,
+			});
+		}
+	});
+
 	it("removes conflicting controls from native disable requests", () => {
 		const normalized = withoutPortableReasoning({
 			...request({ enabled: false, effort: "high", budgetTokens: 12_000 }),

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -3,19 +3,25 @@ import type { CallSettings } from "ai";
 
 export type AiSdkReasoning = NonNullable<CallSettings["reasoning"]>;
 
-const PORTABLE_REASONING_PROVIDERS = new Set([
+/**
+ * Providers whose AI SDK package maps the full portable scale, including the
+ * explicit-disable value "none". Providers routed through
+ * `@ai-sdk/openai-compatible` (deepseek, fireworks, groq, xai, ...) are
+ * deliberately absent: that package forwards effort levels as
+ * `reasoning_effort` but silently drops "none", so an explicit disable would
+ * vanish from the wire. Their disable requests must keep riding the native
+ * provider-option rules (e.g. DeepSeek `thinking.type = "disabled"`,
+ * Fireworks `reasoning_effort: "none"`).
+ */
+const PORTABLE_REASONING_DISABLE_PROVIDERS = new Set([
 	"anthropic",
 	"bedrock",
-	"deepseek",
-	"fireworks",
 	"gemini",
 	"google",
-	"groq",
-	"openai-native",
-	"openai-codex",
 	"ollama",
+	"openai-codex",
+	"openai-native",
 	"vertex",
-	"xai",
 ]);
 
 const NON_PORTABLE_REASONING_PROVIDERS = new Set([
@@ -34,9 +40,10 @@ export function resolvePortableReasoning(
 	if (!reasoning) {
 		return undefined;
 	}
-	const fullySupported = PORTABLE_REASONING_PROVIDERS.has(request.providerId);
 	if (reasoning.enabled === false) {
-		return fullySupported ? "none" : undefined;
+		return PORTABLE_REASONING_DISABLE_PROVIDERS.has(request.providerId)
+			? "none"
+			: undefined;
 	}
 	if (typeof reasoning.budgetTokens === "number") {
 		return undefined;

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -297,22 +297,26 @@ const fireworksReasoningRule: ProviderOptionRule = {
 	id: "provider.fireworks.reasoning-budget",
 	phase: "provider-reasoning",
 	description:
-		"Fireworks uses its native thinking object for exact token budgets.",
+		"Fireworks uses its native thinking object for exact token budgets and reasoning_effort 'none' for explicit disable (which @ai-sdk/openai-compatible cannot express portably).",
 	applies: (input) =>
 		input.request.providerId === "fireworks" &&
-		typeof input.request.reasoning?.budgetTokens === "number",
+		(typeof input.request.reasoning?.budgetTokens === "number" ||
+			input.request.reasoning?.enabled === false),
 	suppresses: { genericThinking: true },
 	build: (input) => {
 		const reasoning = input.request.reasoning;
 		return buildProviderAndAliasPatch({
 			providerId: input.request.providerId,
 			providerOptionsKey: input.providerOptionsKey,
-			bucketOptions: {
-				thinking: {
-					type: "enabled",
-					budget_tokens: reasoning?.budgetTokens,
-				},
-			},
+			bucketOptions:
+				typeof reasoning?.budgetTokens === "number"
+					? {
+							thinking: {
+								type: "enabled",
+								budget_tokens: reasoning.budgetTokens,
+							},
+						}
+					: { reasoningEffort: "none" },
 		});
 	},
 };


### PR DESCRIPTION
### Related Issue

Follow-up to #12946 (portable reasoning resolution), which already shipped in SDK 0.0.71 / CLI 3.0.51.

### Description

#### Problem

Since #12946, explicitly disabling reasoning on DeepSeek, Fireworks, Groq, and xAI sends **nothing** on the wire — the model keeps thinking at its server default and the user's "off" is silently ignored.

#### Root cause

`PORTABLE_REASONING_PROVIDERS` listed these providers as fully supporting the AI SDK's portable reasoning option, but they are routed through `@ai-sdk/openai-compatible`, which forwards effort levels as `reasoning_effort` yet silently drops the explicit-disable value (`isCustomReasoning(reasoning) && reasoning !== "none" ? reasoning : void 0`). Because the disable resolved "portably", `withoutPortableReasoning` also stripped it from the request before provider-option rules ran — so the native disable encodings (DeepSeek `thinking: {type: "disabled"}`, Fireworks `reasoning_effort: "none"`) became unreachable.

#### Changes

- Restrict the set to providers whose AI SDK package can actually express `"none"` (anthropic, bedrock, google/gemini/vertex, ollama, openai-native, openai-codex) and rename it to `PORTABLE_REASONING_DISABLE_PROVIDERS` — it only ever governed the disable branch. Disable requests on the openai-compatible family stay on the request, so the existing native rules encode them again.
- Restore the `reasoning_effort: "none"` branch in the Fireworks rule (covers non-DeepSeek Fireworks models; DeepSeek-family models are covered by the existing family rule).
- Add a unit test pinning that disable resolves natively (not portably) for these providers.

Notably, the provider-options suite already documented these exact contracts ("direct deepseek reasoning disable -> thinking.type=disabled", "maps Fireworks off to its supported wire shape"), but its runner short-circuits whenever the portable path resolves, so those expectations had silently become dead code. With this fix they execute again and pass **unchanged** — no test expectations needed rewriting.

Explicit disable on Anthropic/Gemini/Ollama (the improvement that shipped with #12946) is untouched, as is every effort/enable/budget path.

### Test Procedure

- `bun -F @cline/llms test` — 610 passed, including the reactivated disable contracts.
- `bun -F @cline/shared test` (326), `bun -F @cline/agents test` (63), `bun -F @cline/cli test:unit` (1116), `bun run types` — all green. `@cline/core test:unit` shows only the known cloud-VM git artifact plus a git-heavy checkpoint flake that passes in isolation (identical on unmodified `main`).
- **Wire capture against real provider packages**: pointed the real gateway at local mock servers across 9 provider/model targets × 6 reasoning intents (54 cases) on three builds — pre-#12946, current `main`, and this branch. Exactly the two disable cases change versus `main`, both restored byte-for-byte to the pre-#12946 request bodies; the other 52 cases are identical to `main`:

```
CASE: deepseek :: deepseek-v4-flash :: enabled_false
  pre-change : {"thinking":{"type":"disabled"},"max_tokens":32000}
  prod (now) : {"max_tokens":32000}
  this PR    : {"thinking":{"type":"disabled"},"max_tokens":32000}   <- same as pre-change

CASE: fireworks :: accounts/fireworks/models/deepseek-v4-flash-0731 :: enabled_false
  pre-change : {"reasoning_effort":"none","thinking":{"type":"disabled"},"max_tokens":32000}
  prod (now) : {"max_tokens":32000}
  this PR    : {"reasoning_effort":"none","thinking":{"type":"disabled"},"max_tokens":32000}   <- same as pre-change
```