### PR TITLE
fix(cli): preserve binary MCP payloads in expanded TUI tool output

### DIFF
--- a/apps/cli/src/tui/components/tool-output.tsx
+++ b/apps/cli/src/tui/components/tool-output.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useTheme } from "../hooks/use-theme";
 import type { ResolvedTheme } from "../themes";
 import { makeUnifiedDiff } from "../utils/diff";
@@ -297,12 +297,6 @@ export function ToolOutput(props: ToolOutputProps) {
 	const { toolName, outputSummary, rawOutput, rawInput, error } = props;
 	const terminalTheme = useTheme();
 	const [errorExpanded, setErrorExpanded] = useState(false);
-	// Extraction can chunk large base64 payloads (MCP images/blobs) into many
-	// lines, so avoid redoing that work on unrelated re-renders.
-	const fullText = useMemo(
-		() => (rawOutput ? extractFullOutputText(rawOutput) : undefined),
-		[rawOutput],
-	);
 
 	if (error) {
 		const presentation = getToolErrorPresentation(error);
@@ -331,6 +325,8 @@ export function ToolOutput(props: ToolOutputProps) {
 
 	if (toolName === "switch_to_act_mode") return null;
 	if (!outputSummary.trim() && !rawOutput) return null;
+
+	const fullText = rawOutput ? extractFullOutputText(rawOutput) : undefined;
 
 	if (isAskTool(toolName)) {
 		const answer = (fullText || outputSummary).trim();

--- a/apps/cli/src/tui/components/tool-output.tsx
+++ b/apps/cli/src/tui/components/tool-output.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTheme } from "../hooks/use-theme";
 import type { ResolvedTheme } from "../themes";
 import { makeUnifiedDiff } from "../utils/diff";
@@ -297,6 +297,12 @@ export function ToolOutput(props: ToolOutputProps) {
 	const { toolName, outputSummary, rawOutput, rawInput, error } = props;
 	const terminalTheme = useTheme();
 	const [errorExpanded, setErrorExpanded] = useState(false);
+	// Extraction can chunk large base64 payloads (MCP images/blobs) into many
+	// lines, so avoid redoing that work on unrelated re-renders.
+	const fullText = useMemo(
+		() => (rawOutput ? extractFullOutputText(rawOutput) : undefined),
+		[rawOutput],
+	);
 
 	if (error) {
 		const presentation = getToolErrorPresentation(error);
@@ -325,8 +331,6 @@ export function ToolOutput(props: ToolOutputProps) {
 
 	if (toolName === "switch_to_act_mode") return null;
 	if (!outputSummary.trim() && !rawOutput) return null;
-
-	const fullText = rawOutput ? extractFullOutputText(rawOutput) : undefined;
 
 	if (isAskTool(toolName)) {
 		const answer = (fullText || outputSummary).trim();

--- a/apps/cli/src/tui/utils/tool-parsing.test.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.test.ts
@@ -48,18 +48,70 @@ describe("extractFullOutputText", () => {
 		expect(extractFullOutputText(raw)).toBe("# Memory\n\nline one\nline two");
 	});
 
-	it("keeps identifying placeholders for non-text blocks in mixed MCP content", () => {
+	it("preserves binary payloads for non-text blocks in mixed MCP content", () => {
 		const raw = {
 			content: [
 				{ type: "text", text: "before" },
-				{ type: "image", data: "...", mimeType: "image/png" },
-				{ type: "resource", resource: { uri: "file:///a.md", blob: "..." } },
+				{ type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+				{
+					type: "resource",
+					resource: { uri: "file:///a.bin", blob: "d29ybGQ=" },
+				},
 				{ type: "resource_link", uri: "file:///b.md", name: "b.md" },
 				{ type: "text", text: "after" },
 			],
 		};
 		expect(extractFullOutputText(raw)).toBe(
-			"before\n[image: image/png]\n[resource: file:///a.md]\n[resource_link: file:///b.md]\nafter",
+			[
+				"before",
+				"[image image/png, 5 B base64]",
+				"aGVsbG8=",
+				"[resource file:///a.bin, 5 B base64]",
+				"d29ybGQ=",
+				"[resource_link: file:///b.md]",
+				"after",
+			].join("\n"),
+		);
+	});
+
+	it("chunks large base64 payloads into fixed-width lines behind a header", () => {
+		const data = "A".repeat(76 * 2 + 10);
+		const raw = {
+			content: [{ type: "image", data, mimeType: "image/jpeg" }],
+		};
+		const result = extractFullOutputText(raw);
+		const lines = result?.split("\n") ?? [];
+
+		expect(lines[0]).toBe("[image image/jpeg, 121 B base64]");
+		expect(lines).toHaveLength(4);
+		expect(lines[1]).toHaveLength(76);
+		expect(lines[2]).toHaveLength(76);
+		expect(lines[3]).toHaveLength(10);
+		expect(lines.slice(1).join("")).toBe(data);
+	});
+
+	it("keeps a metadata-only placeholder for image blocks without data", () => {
+		const raw = {
+			content: [{ type: "image", mimeType: "image/png" }],
+		};
+		expect(extractFullOutputText(raw)).toBe("[image: image/png]");
+	});
+
+	it("includes the mime type in blob-backed resource headers when present", () => {
+		const raw = {
+			content: [
+				{
+					type: "resource",
+					resource: {
+						uri: "file:///a.pdf",
+						mimeType: "application/pdf",
+						blob: "aGVsbG8=",
+					},
+				},
+			],
+		};
+		expect(extractFullOutputText(raw)).toBe(
+			"[resource file:///a.pdf application/pdf, 5 B base64]\naGVsbG8=",
 		);
 	});
 

--- a/apps/cli/src/tui/utils/tool-parsing.test.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.test.ts
@@ -48,71 +48,36 @@ describe("extractFullOutputText", () => {
 		expect(extractFullOutputText(raw)).toBe("# Memory\n\nline one\nline two");
 	});
 
-	it("preserves binary payloads for non-text blocks in mixed MCP content", () => {
+	it("keeps binary payloads behind placeholders in mixed MCP content", () => {
 		const raw = {
 			content: [
 				{ type: "text", text: "before" },
 				{ type: "image", data: "aGVsbG8=", mimeType: "image/png" },
 				{
 					type: "resource",
-					resource: { uri: "file:///a.bin", blob: "d29ybGQ=" },
+					resource: { uri: "file:///a.md", blob: "d29ybGQ=" },
 				},
 				{ type: "resource_link", uri: "file:///b.md", name: "b.md" },
 				{ type: "text", text: "after" },
 			],
 		};
 		expect(extractFullOutputText(raw)).toBe(
-			[
-				"before",
-				"[image image/png, 5 B base64]",
-				"aGVsbG8=",
-				"[resource file:///a.bin, 5 B base64]",
-				"d29ybGQ=",
-				"[resource_link: file:///b.md]",
-				"after",
-			].join("\n"),
+			"before\n[image: image/png]\naGVsbG8=\n[resource: file:///a.md]\nd29ybGQ=\n[resource_link: file:///b.md]\nafter",
 		);
 	});
 
-	it("chunks large base64 payloads into fixed-width lines behind a header", () => {
-		const data = "A".repeat(76 * 2 + 10);
-		const raw = {
-			content: [{ type: "image", data, mimeType: "image/jpeg" }],
-		};
-		const result = extractFullOutputText(raw);
-		const lines = result?.split("\n") ?? [];
-
-		expect(lines[0]).toBe("[image image/jpeg, 121 B base64]");
-		expect(lines).toHaveLength(4);
-		expect(lines[1]).toHaveLength(76);
-		expect(lines[2]).toHaveLength(76);
-		expect(lines[3]).toHaveLength(10);
-		expect(lines.slice(1).join("")).toBe(data);
-	});
-
-	it("keeps a metadata-only placeholder for image blocks without data", () => {
-		const raw = {
-			content: [{ type: "image", mimeType: "image/png" }],
-		};
-		expect(extractFullOutputText(raw)).toBe("[image: image/png]");
-	});
-
-	it("includes the mime type in blob-backed resource headers when present", () => {
+	it("chunks base64 payloads into 76-char lines so collapse stays compact", () => {
 		const raw = {
 			content: [
-				{
-					type: "resource",
-					resource: {
-						uri: "file:///a.pdf",
-						mimeType: "application/pdf",
-						blob: "aGVsbG8=",
-					},
-				},
+				{ type: "image", data: "A".repeat(160), mimeType: "image/png" },
 			],
 		};
-		expect(extractFullOutputText(raw)).toBe(
-			"[resource file:///a.pdf application/pdf, 5 B base64]\naGVsbG8=",
-		);
+		expect(extractFullOutputText(raw)?.split("\n")).toEqual([
+			"[image: image/png]",
+			"A".repeat(76),
+			"A".repeat(76),
+			"A".repeat(8),
+		]);
 	});
 
 	it("extracts embedded resource text from MCP content", () => {

--- a/apps/cli/src/tui/utils/tool-parsing.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.ts
@@ -185,6 +185,31 @@ export function parseSpawnAgentInput(
 	return { task: input.task };
 }
 
+// Standard MIME width. Chunking base64 payloads into fixed-width lines lets
+// GenericOutput's line-based collapse keep the default view compact while the
+// expanded view still contains the complete payload.
+const BASE64_LINE_WIDTH = 76;
+
+function chunkBase64(data: string): string {
+	const lines: string[] = [];
+	for (let i = 0; i < data.length; i += BASE64_LINE_WIDTH) {
+		lines.push(data.slice(i, i + BASE64_LINE_WIDTH));
+	}
+	return lines.join("\n");
+}
+
+function formatBase64Size(data: string): string {
+	const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+	const bytes = Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+	if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${bytes} B`;
+}
+
+function formatBinaryBlock(label: string, data: string): string {
+	return `[${label}, ${formatBase64Size(data)} base64]\n${chunkBase64(data)}`;
+}
+
 export function extractFullOutputText(raw: unknown): string | undefined {
 	if (raw === null || raw === undefined) return undefined;
 	if (typeof raw === "string") return raw;
@@ -216,8 +241,10 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 		// MCP tools return {content: [{type: "text", text}, ...]}. Extract the
 		// text so multi-line results keep real newlines instead of being
 		// JSON-escaped into one giant line that floods the terminal (#13038).
-		// Non-text blocks keep their identifying metadata (resource text/URIs,
-		// mime types) so mixed results are not silently truncated.
+		// Binary blocks (image/audio data, resource blobs) keep their full
+		// base64 payload, chunked into short lines behind a metadata header,
+		// so expanding a mixed result shows the complete tool output without
+		// re-flooding the collapsed view.
 		const content = (raw as { content?: unknown }).content;
 		if (Array.isArray(content)) {
 			const parts = content
@@ -230,8 +257,25 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 						if (typeof part.resource.text === "string") {
 							return part.resource.text;
 						}
-						if (typeof part.resource.uri === "string") {
-							return `[resource: ${part.resource.uri}]`;
+						const uri =
+							typeof part.resource.uri === "string"
+								? part.resource.uri
+								: undefined;
+						const mimeType =
+							typeof part.resource.mimeType === "string"
+								? part.resource.mimeType
+								: undefined;
+						if (
+							typeof part.resource.blob === "string" &&
+							part.resource.blob.length > 0
+						) {
+							const label = ["resource", uri, mimeType]
+								.filter(Boolean)
+								.join(" ");
+							return formatBinaryBlock(label, part.resource.blob);
+						}
+						if (uri) {
+							return `[resource: ${uri}]`;
 						}
 					}
 					if (part.type === "resource_link" && typeof part.uri === "string") {
@@ -241,6 +285,12 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 						(part.type === "image" || part.type === "audio") &&
 						typeof part.mimeType === "string"
 					) {
+						if (typeof part.data === "string" && part.data.length > 0) {
+							return formatBinaryBlock(
+								`${part.type} ${part.mimeType}`,
+								part.data,
+							);
+						}
 						return `[${part.type}: ${part.mimeType}]`;
 					}
 					return typeof part.type === "string" ? `[${part.type}]` : "";

--- a/apps/cli/src/tui/utils/tool-parsing.ts
+++ b/apps/cli/src/tui/utils/tool-parsing.ts
@@ -185,29 +185,10 @@ export function parseSpawnAgentInput(
 	return { task: input.task };
 }
 
-// Standard MIME width. Chunking base64 payloads into fixed-width lines lets
-// GenericOutput's line-based collapse keep the default view compact while the
-// expanded view still contains the complete payload.
-const BASE64_LINE_WIDTH = 76;
-
+// Base64 payloads are one giant line; chunk to MIME width so GenericOutput's
+// line-based collapse stays compact and expand shows the full data.
 function chunkBase64(data: string): string {
-	const lines: string[] = [];
-	for (let i = 0; i < data.length; i += BASE64_LINE_WIDTH) {
-		lines.push(data.slice(i, i + BASE64_LINE_WIDTH));
-	}
-	return lines.join("\n");
-}
-
-function formatBase64Size(data: string): string {
-	const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
-	const bytes = Math.max(0, Math.floor((data.length * 3) / 4) - padding);
-	if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-	if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-	return `${bytes} B`;
-}
-
-function formatBinaryBlock(label: string, data: string): string {
-	return `[${label}, ${formatBase64Size(data)} base64]\n${chunkBase64(data)}`;
+	return data.match(/.{1,76}/g)?.join("\n") ?? data;
 }
 
 export function extractFullOutputText(raw: unknown): string | undefined {
@@ -241,10 +222,8 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 		// MCP tools return {content: [{type: "text", text}, ...]}. Extract the
 		// text so multi-line results keep real newlines instead of being
 		// JSON-escaped into one giant line that floods the terminal (#13038).
-		// Binary blocks (image/audio data, resource blobs) keep their full
-		// base64 payload, chunked into short lines behind a metadata header,
-		// so expanding a mixed result shows the complete tool output without
-		// re-flooding the collapsed view.
+		// Non-text blocks keep their identifying metadata plus their base64
+		// payloads so mixed results are not silently truncated.
 		const content = (raw as { content?: unknown }).content;
 		if (Array.isArray(content)) {
 			const parts = content
@@ -257,25 +236,15 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 						if (typeof part.resource.text === "string") {
 							return part.resource.text;
 						}
-						const uri =
-							typeof part.resource.uri === "string"
-								? part.resource.uri
-								: undefined;
-						const mimeType =
-							typeof part.resource.mimeType === "string"
-								? part.resource.mimeType
-								: undefined;
-						if (
-							typeof part.resource.blob === "string" &&
-							part.resource.blob.length > 0
-						) {
-							const label = ["resource", uri, mimeType]
-								.filter(Boolean)
-								.join(" ");
-							return formatBinaryBlock(label, part.resource.blob);
+						if (typeof part.resource.blob === "string" && part.resource.blob) {
+							const label =
+								typeof part.resource.uri === "string"
+									? `[resource: ${part.resource.uri}]`
+									: "[resource]";
+							return `${label}\n${chunkBase64(part.resource.blob)}`;
 						}
-						if (uri) {
-							return `[resource: ${uri}]`;
+						if (typeof part.resource.uri === "string") {
+							return `[resource: ${part.resource.uri}]`;
 						}
 					}
 					if (part.type === "resource_link" && typeof part.uri === "string") {
@@ -285,11 +254,8 @@ export function extractFullOutputText(raw: unknown): string | undefined {
 						(part.type === "image" || part.type === "audio") &&
 						typeof part.mimeType === "string"
 					) {
-						if (typeof part.data === "string" && part.data.length > 0) {
-							return formatBinaryBlock(
-								`${part.type} ${part.mimeType}`,
-								part.data,
-							);
+						if (typeof part.data === "string" && part.data) {
+							return `[${part.type}: ${part.mimeType}]\n${chunkBase64(part.data)}`;
 						}
 						return `[${part.type}: ${part.mimeType}]`;
 					}


### PR DESCRIPTION
## Problem

Follow-up to #13066, addressing the P1 Greptile surfaced after merge ("Non-text MCP payloads remain hidden"): image/audio blocks and blob-backed resources in MCP results were replaced with bare markers like `[image: image/png]`, so even the expanded TUI output omitted the actual payload.

## Change

Minimal change in `extractFullOutputText`: when an image/audio block has `data` or a resource has a `blob`, append the base64 payload under the existing marker, chunked into 76-char lines. Because the payload becomes real lines, GenericOutput's existing 5-line collapse keeps the default view compact (no regression of the #13038 flood), and click-to-expand now shows the complete result.

## Testing

- Updated the mixed-content unit test and added a chunking test; suite, `tsc --noEmit`, and Biome pass.
- Manually verified in the interactive TUI against a stdio MCP server returning text + PNG + blob resource: collapses to a 5-line preview, expands on click to the full payloads.

Collapsed:

![Collapsed MCP mixed result preview](https://cursor.com/artifacts/c/art-a68ab9a3-3286-4da4-b77a-2c65a83af931)

Expanded on click:

![Expanded MCP mixed result with full payloads](https://cursor.com/artifacts/c/art-09ab16ee-7293-4f73-9a41-f62d61759f14)