### PR TITLE
fix(core): stop daemon leak

### DIFF
--- a/apps/cli/src/connectors/adapters/slack.ts
+++ b/apps/cli/src/connectors/adapters/slack.ts
@@ -1305,7 +1305,14 @@ class SlackConnector extends ConnectorBase<
 		await bot.shutdown();
 		userInstructionService.stop();
 		client.close();
-		this.removeStateFile(statePath);
+		// Only when this process still owns the record: a replacement connector may
+		// have claimed the same state path while this one was running.
+		this.removeStateFileIfOwnedBy(
+			statePath,
+			process.pid,
+			(path) => this.readConnectorState(path),
+			(state) => state.pid,
+		);
 		return 0;
 	}
 }

--- a/apps/cli/src/connectors/base.test.ts
+++ b/apps/cli/src/connectors/base.test.ts
@@ -155,6 +155,76 @@ describe("ConnectorBase background launch", () => {
 		);
 	});
 
+	it("keeps a state file that another instance has claimed", async () => {
+		// Two connectors share one state path. If the exiting one deletes a record
+		// naming the other, the survivor keeps serving but vanishes from doctor and
+		// can no longer be stopped by name.
+		const connector = new TestConnector();
+		const removeStateFile = vi.spyOn(
+			connector as unknown as { removeStateFile: (path: string) => void },
+			"removeStateFile",
+		);
+
+		const removed = (
+			connector as unknown as {
+				removeStateFileIfOwnedBy: (
+					statePath: string,
+					pid: number,
+					readState: (path: string) => { pid: number } | undefined,
+					getPid: (state: { pid: number }) => number,
+				) => boolean;
+			}
+		).removeStateFileIfOwnedBy(
+			"/tmp/test-connector.json",
+			111,
+			() => ({ pid: 222 }),
+			(state) => state.pid,
+		);
+
+		expect(removed).toBe(false);
+		expect(removeStateFile).not.toHaveBeenCalled();
+	});
+
+	it("removes its own state file on the way out", async () => {
+		const connector = new TestConnector();
+		const removeStateFile = vi.spyOn(
+			connector as unknown as { removeStateFile: (path: string) => void },
+			"removeStateFile",
+		);
+
+		const helper = (
+			connector as unknown as {
+				removeStateFileIfOwnedBy: (
+					statePath: string,
+					pid: number,
+					readState: (path: string) => { pid: number } | undefined,
+					getPid: (state: { pid: number }) => number,
+				) => boolean;
+			}
+		).removeStateFileIfOwnedBy;
+
+		expect(
+			helper.call(
+				connector,
+				"/tmp/test-connector.json",
+				111,
+				() => ({ pid: 111 }),
+				(state: { pid: number }) => state.pid,
+			),
+		).toBe(true);
+		// An already-absent record is nothing to protect.
+		expect(
+			helper.call(
+				connector,
+				"/tmp/test-connector.json",
+				111,
+				() => undefined,
+				(state: { pid: number }) => state.pid,
+			),
+		).toBe(true);
+		expect(removeStateFile).toHaveBeenCalledTimes(2);
+	});
+
 	it("returns a distinct result when a connector is already running", async () => {
 		await expect(
 			new TestConnector().runBackground(io, {

--- a/apps/cli/src/connectors/base.ts
+++ b/apps/cli/src/connectors/base.ts
@@ -251,6 +251,29 @@ export abstract class ConnectorBase<Options, State>
 		removeFile(statePath);
 	}
 
+	/**
+	 * Remove the state file only while it still describes `pid`.
+	 *
+	 * Every instance of a connector shares one state path, so an exiting process
+	 * must not delete a record another process has since claimed. When it does,
+	 * the surviving connector keeps serving its platform but disappears from
+	 * `doctor`, `connect --stop` can no longer find it, and the hub cannot adopt
+	 * it — a live bot that no tooling can see.
+	 */
+	protected removeStateFileIfOwnedBy(
+		statePath: string,
+		pid: number,
+		readState: (path: string) => State | undefined,
+		getPid: (state: State) => number,
+	): boolean {
+		const state = readState(statePath);
+		if (state && getPid(state) !== pid) {
+			return false;
+		}
+		this.removeStateFile(statePath);
+		return true;
+	}
+
 	protected removeStaleState(
 		statePath: string,
 		readState: (path: string) => State | undefined,

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -13,6 +13,10 @@ import {
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
 import { startHubWebSocketServer } from "../server";
+import {
+	armHubDaemonShutdownWatchdog,
+	HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
+} from "./shutdown-watchdog";
 import { createHubDaemonTelemetry } from "./telemetry";
 
 initVcr(process.env.CLINE_VCR);
@@ -118,6 +122,18 @@ async function main(): Promise<void> {
 	setActiveConnectorSupervisor(supervisor);
 
 	const shutdown = async (): Promise<void> => {
+		// server.close() can stall forever (Bun never resolves it once a WebSocket
+		// upgrade happened), and with signal handlers installed nothing else will
+		// end the process — so the exit must not depend on the graceful path.
+		armHubDaemonShutdownWatchdog({
+			deadlineMs: HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
+			exitCode: 0,
+			onTimeout: () => {
+				process.stderr.write(
+					"[hub-daemon] graceful shutdown stalled; forcing exit\n",
+				);
+			},
+		});
 		// Stop supervising but leave the connectors running: they are detached on
 		// purpose so a hub restart does not disconnect Slack/Telegram, and the next
 		// hub adopts them from their state files.
@@ -134,6 +150,15 @@ async function main(): Promise<void> {
 			return;
 		}
 		fatalShutdownStarted = true;
+		armHubDaemonShutdownWatchdog({
+			deadlineMs: HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
+			exitCode: 1,
+			onTimeout: () => {
+				process.stderr.write(
+					`[hub-daemon] shutdown after ${label} stalled; forcing exit\n`,
+				);
+			},
+		});
 		const message =
 			error instanceof Error ? error.stack || error.message : String(error);
 		process.stderr.write(`[hub-daemon] ${label}: ${message}\n`);

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -17,7 +17,7 @@ const {
 	resolveClineDataDir,
 	resolveHubBuildId,
 	writeHubDiscovery,
-	hubProcessStartMatchesReport,
+	killHubProcessBoundToReport,
 	CLINE_RUN_AS_HUB_DAEMON_ENV,
 } = vi.hoisted(() => ({
 	spawn: vi.fn(() => ({ unref: vi.fn() })),
@@ -43,7 +43,7 @@ const {
 	resolveClineDataDir: vi.fn(() => "/tmp/cline-data"),
 	resolveHubBuildId: vi.fn(() => "current-build"),
 	writeHubDiscovery: vi.fn(),
-	hubProcessStartMatchesReport: vi.fn(() => true),
+	killHubProcessBoundToReport: vi.fn(() => "killed"),
 	CLINE_RUN_AS_HUB_DAEMON_ENV: "CLINE_RUN_AS_HUB_DAEMON",
 }));
 
@@ -95,7 +95,7 @@ vi.mock("../discovery", () => ({
 }));
 
 vi.mock("./process-identity", () => ({
-	hubProcessStartMatchesReport,
+	killHubProcessBoundToReport,
 }));
 
 describe("ensureDetachedHubServer", () => {
@@ -118,8 +118,8 @@ describe("ensureDetachedHubServer", () => {
 		requestHubShutdown.mockReset();
 		requestHubShutdown.mockResolvedValue(true);
 		readHubDiscovery.mockReset();
-		hubProcessStartMatchesReport.mockReset();
-		hubProcessStartMatchesReport.mockReturnValue(true);
+		killHubProcessBoundToReport.mockReset();
+		killHubProcessBoundToReport.mockReturnValue("killed");
 		vi.stubGlobal("fetch", fetchMock);
 	});
 
@@ -353,7 +353,6 @@ describe("ensureDetachedHubServer", () => {
 			await vi.runAllTimersAsync();
 
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
-			expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
 			// The identity probe must ask for /version. `/health` omits the pid and
 			// `/status` needs a token, so any other route makes this guard
 			// unsatisfiable against a real server however the mock is shaped.
@@ -361,12 +360,14 @@ describe("ensureDetachedHubServer", () => {
 				"ws://127.0.0.1:25463/hub",
 				expect.objectContaining({ endpoint: "version" }),
 			);
-			// The pid must also be bound to the reporting process via its /proc
-			// start time, using the startedAt the hub itself served.
-			expect(hubProcessStartMatchesReport).toHaveBeenCalledWith(
+			// The force-kill goes through the identity-bound path (SIGSTOP →
+			// verify /proc start time against the startedAt the hub itself
+			// served → SIGKILL), never through a bare process.kill.
+			expect(killHubProcessBoundToReport).toHaveBeenCalledWith(
 				12345,
 				"2026-08-06T16:15:00.000Z",
 			);
+			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();
@@ -375,9 +376,10 @@ describe("ensureDetachedHubServer", () => {
 
 	it("does not force-kill when the pid's process is younger than the hub's report", async () => {
 		// The P1 race: the daemon can die between answering /version and the
-		// kill, and the OS can hand its pid to a bystander. The /proc start-time
-		// check re-reads identity at the last instant, so a recycled pid —
-		// necessarily younger than the report it did not write — is spared.
+		// kill, and the OS can hand its pid to a bystander. The bound kill
+		// freezes the pid, verifies /proc identity while it cannot exit, and
+		// spares (SIGCONT) a recycled pid — necessarily younger than the
+		// report it did not write.
 		vi.useFakeTimers();
 		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 		try {
@@ -393,13 +395,17 @@ describe("ensureDetachedHubServer", () => {
 				pid: 12345,
 				startedAt: "2026-08-06T16:15:00.000Z",
 			});
-			hubProcessStartMatchesReport.mockReturnValue(false);
+			killHubProcessBoundToReport.mockReturnValue("spared");
 
 			const { prewarmDetachedHubServer } = await import(".");
 			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
 			await vi.runAllTimersAsync();
 
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(killHubProcessBoundToReport).toHaveBeenCalledWith(
+				12345,
+				"2026-08-06T16:15:00.000Z",
+			);
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
@@ -433,6 +439,8 @@ describe("ensureDetachedHubServer", () => {
 
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
+			// A pid the serving hub does not claim never reaches the bound kill.
+			expect(killHubProcessBoundToReport).not.toHaveBeenCalled();
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -330,7 +330,68 @@ describe("ensureDetachedHubServer", () => {
 				authToken: "",
 				pid: 12345,
 			});
-			// Still answering after SIGTERM: the hub never retires.
+			// Still answering after SIGTERM, and it reports the same pid, so the
+			// process we are about to force really does own this hub.
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				pid: 12345,
+			});
+
+			const { prewarmDetachedHubServer } = await import(".");
+			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
+			await vi.runAllTimersAsync();
+
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
+		} finally {
+			kill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not force-kill a pid the responding hub does not claim", async () => {
+		// A discovery record outlives its daemon and the OS recycles pids, so the
+		// recorded pid can belong to an unrelated process while a different daemon
+		// answers at that URL. SIGKILL there would kill a bystander outright.
+		vi.useFakeTimers();
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "",
+				pid: 12345,
+			});
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				// A different daemon owns the port now.
+				pid: 99999,
+			});
+
+			const { prewarmDetachedHubServer } = await import(".");
+			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
+			await vi.runAllTimersAsync();
+
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
+		} finally {
+			kill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not force-kill when the hub is too old to report a pid", async () => {
+		vi.useFakeTimers();
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "",
+				pid: 12345,
+			});
 			probeHubServer.mockResolvedValue({
 				url: "ws://127.0.0.1:25463/hub",
 				protocolVersion: "v1",
@@ -341,8 +402,8 @@ describe("ensureDetachedHubServer", () => {
 			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
 			await vi.runAllTimersAsync();
 
-			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
-			expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
+			// Leaking a daemon beats killing an unidentified process.
+			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -17,6 +17,7 @@ const {
 	resolveClineDataDir,
 	resolveHubBuildId,
 	writeHubDiscovery,
+	hubProcessStartMatchesReport,
 	CLINE_RUN_AS_HUB_DAEMON_ENV,
 } = vi.hoisted(() => ({
 	spawn: vi.fn(() => ({ unref: vi.fn() })),
@@ -42,6 +43,7 @@ const {
 	resolveClineDataDir: vi.fn(() => "/tmp/cline-data"),
 	resolveHubBuildId: vi.fn(() => "current-build"),
 	writeHubDiscovery: vi.fn(),
+	hubProcessStartMatchesReport: vi.fn(() => true),
 	CLINE_RUN_AS_HUB_DAEMON_ENV: "CLINE_RUN_AS_HUB_DAEMON",
 }));
 
@@ -92,6 +94,10 @@ vi.mock("../discovery", () => ({
 	writeHubDiscovery,
 }));
 
+vi.mock("./process-identity", () => ({
+	hubProcessStartMatchesReport,
+}));
+
 describe("ensureDetachedHubServer", () => {
 	const fetchMock = vi.fn(async () => ({ ok: true }));
 
@@ -112,6 +118,8 @@ describe("ensureDetachedHubServer", () => {
 		requestHubShutdown.mockReset();
 		requestHubShutdown.mockResolvedValue(true);
 		readHubDiscovery.mockReset();
+		hubProcessStartMatchesReport.mockReset();
+		hubProcessStartMatchesReport.mockReturnValue(true);
 		vi.stubGlobal("fetch", fetchMock);
 	});
 
@@ -337,6 +345,7 @@ describe("ensureDetachedHubServer", () => {
 				protocolVersion: "v1",
 				buildId: "old-build",
 				pid: 12345,
+				startedAt: "2026-08-06T16:15:00.000Z",
 			});
 
 			const { prewarmDetachedHubServer } = await import(".");
@@ -352,6 +361,46 @@ describe("ensureDetachedHubServer", () => {
 				"ws://127.0.0.1:25463/hub",
 				expect.objectContaining({ endpoint: "version" }),
 			);
+			// The pid must also be bound to the reporting process via its /proc
+			// start time, using the startedAt the hub itself served.
+			expect(hubProcessStartMatchesReport).toHaveBeenCalledWith(
+				12345,
+				"2026-08-06T16:15:00.000Z",
+			);
+		} finally {
+			kill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not force-kill when the pid's process is younger than the hub's report", async () => {
+		// The P1 race: the daemon can die between answering /version and the
+		// kill, and the OS can hand its pid to a bystander. The /proc start-time
+		// check re-reads identity at the last instant, so a recycled pid —
+		// necessarily younger than the report it did not write — is spared.
+		vi.useFakeTimers();
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "",
+				pid: 12345,
+			});
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				pid: 12345,
+				startedAt: "2026-08-06T16:15:00.000Z",
+			});
+			hubProcessStartMatchesReport.mockReturnValue(false);
+
+			const { prewarmDetachedHubServer } = await import(".");
+			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
+			await vi.runAllTimersAsync();
+
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -317,6 +317,38 @@ describe("ensureDetachedHubServer", () => {
 		}
 	});
 
+	it("escalates to SIGKILL when a hub ignores the retirement signal", async () => {
+		// The CLI installs its own SIGTERM handling, so a daemon can ignore both the
+		// graceful shutdown request and the signal. Giving up there leaks it: the
+		// discovery record is cleared and a replacement binds the port, so every
+		// nightly auto-update would strand the previous build.
+		vi.useFakeTimers();
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "",
+				pid: 12345,
+			});
+			// Still answering after SIGTERM: the hub never retires.
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+			});
+
+			const { prewarmDetachedHubServer } = await import(".");
+			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
+			await vi.runAllTimersAsync();
+
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
+		} finally {
+			kill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
 	it("reuses a protocol-compatible healthy hub from a different build", async () => {
 		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 		try {

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -17,7 +17,8 @@ const {
 	resolveClineDataDir,
 	resolveHubBuildId,
 	writeHubDiscovery,
-	killHubProcessBoundToReport,
+	captureProcessStartTicket,
+	killHubProcessBoundToTicket,
 	CLINE_RUN_AS_HUB_DAEMON_ENV,
 } = vi.hoisted(() => ({
 	spawn: vi.fn(() => ({ unref: vi.fn() })),
@@ -43,7 +44,13 @@ const {
 	resolveClineDataDir: vi.fn(() => "/tmp/cline-data"),
 	resolveHubBuildId: vi.fn(() => "current-build"),
 	writeHubDiscovery: vi.fn(),
-	killHubProcessBoundToReport: vi.fn(() => "killed"),
+	captureProcessStartTicket: vi.fn(
+		(): { pid: number; startTicks: number } | undefined => ({
+			pid: 12345,
+			startTicks: 4_500_000,
+		}),
+	),
+	killHubProcessBoundToTicket: vi.fn(() => "killed"),
 	CLINE_RUN_AS_HUB_DAEMON_ENV: "CLINE_RUN_AS_HUB_DAEMON",
 }));
 
@@ -95,7 +102,8 @@ vi.mock("../discovery", () => ({
 }));
 
 vi.mock("./process-identity", () => ({
-	killHubProcessBoundToReport,
+	captureProcessStartTicket,
+	killHubProcessBoundToTicket,
 }));
 
 describe("ensureDetachedHubServer", () => {
@@ -118,8 +126,13 @@ describe("ensureDetachedHubServer", () => {
 		requestHubShutdown.mockReset();
 		requestHubShutdown.mockResolvedValue(true);
 		readHubDiscovery.mockReset();
-		killHubProcessBoundToReport.mockReset();
-		killHubProcessBoundToReport.mockReturnValue("killed");
+		captureProcessStartTicket.mockReset();
+		captureProcessStartTicket.mockReturnValue({
+			pid: 12345,
+			startTicks: 4_500_000,
+		});
+		killHubProcessBoundToTicket.mockReset();
+		killHubProcessBoundToTicket.mockReturnValue("killed");
 		vi.stubGlobal("fetch", fetchMock);
 	});
 
@@ -360,13 +373,14 @@ describe("ensureDetachedHubServer", () => {
 				"ws://127.0.0.1:25463/hub",
 				expect.objectContaining({ endpoint: "version" }),
 			);
-			// The force-kill goes through the identity-bound path (SIGSTOP →
-			// verify /proc start time against the startedAt the hub itself
-			// served → SIGKILL), never through a bare process.kill.
-			expect(killHubProcessBoundToReport).toHaveBeenCalledWith(
-				12345,
-				"2026-08-06T16:15:00.000Z",
-			);
+			// The force-kill goes through the identity-bound path (start tick
+			// captured before the probe, SIGSTOP, exact tick match re-read while
+			// frozen, then SIGKILL), never through a bare process.kill.
+			expect(captureProcessStartTicket).toHaveBeenCalledWith(12345);
+			expect(killHubProcessBoundToTicket).toHaveBeenCalledWith({
+				pid: 12345,
+				startTicks: 4_500_000,
+			});
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
@@ -374,12 +388,13 @@ describe("ensureDetachedHubServer", () => {
 		}
 	});
 
-	it("does not force-kill when the pid's process is younger than the hub's report", async () => {
+	it("does not force-kill when the frozen process no longer matches the ticket", async () => {
 		// The P1 race: the daemon can die between answering /version and the
 		// kill, and the OS can hand its pid to a bystander. The bound kill
-		// freezes the pid, verifies /proc identity while it cannot exit, and
-		// spares (SIGCONT) a recycled pid — necessarily younger than the
-		// report it did not write.
+		// freezes the pid and re-reads its start tick while it cannot exit; a
+		// recycled pid carries a strictly greater tick than the pre-probe
+		// ticket, so it is spared (SIGCONT) — no tolerance window to slip
+		// through, however fast the pid changed hands.
 		vi.useFakeTimers();
 		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 		try {
@@ -395,17 +410,17 @@ describe("ensureDetachedHubServer", () => {
 				pid: 12345,
 				startedAt: "2026-08-06T16:15:00.000Z",
 			});
-			killHubProcessBoundToReport.mockReturnValue("spared");
+			killHubProcessBoundToTicket.mockReturnValue("spared");
 
 			const { prewarmDetachedHubServer } = await import(".");
 			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
 			await vi.runAllTimersAsync();
 
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
-			expect(killHubProcessBoundToReport).toHaveBeenCalledWith(
-				12345,
-				"2026-08-06T16:15:00.000Z",
-			);
+			expect(killHubProcessBoundToTicket).toHaveBeenCalledWith({
+				pid: 12345,
+				startTicks: 4_500_000,
+			});
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
@@ -440,7 +455,41 @@ describe("ensureDetachedHubServer", () => {
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 			// A pid the serving hub does not claim never reaches the bound kill.
-			expect(killHubProcessBoundToReport).not.toHaveBeenCalled();
+			expect(killHubProcessBoundToTicket).not.toHaveBeenCalled();
+		} finally {
+			kill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not force-kill when no identity ticket can be captured", async () => {
+		// No readable /proc start tick — the recorded process is already gone,
+		// or this platform has no /proc. Without a captured identity there is
+		// nothing to bind a SIGKILL to, so none is sent.
+		vi.useFakeTimers();
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "",
+				pid: 12345,
+			});
+			probeHubServer.mockResolvedValue({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				pid: 12345,
+				startedAt: "2026-08-06T16:15:00.000Z",
+			});
+			captureProcessStartTicket.mockReturnValue(undefined);
+
+			const { prewarmDetachedHubServer } = await import(".");
+			prewarmDetachedHubServer("/workspace", { allowPortFallback: true });
+			await vi.runAllTimersAsync();
+
+			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
+			expect(killHubProcessBoundToTicket).not.toHaveBeenCalled();
+			expect(kill).not.toHaveBeenCalledWith(12345, "SIGKILL");
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -345,6 +345,13 @@ describe("ensureDetachedHubServer", () => {
 
 			expect(kill).toHaveBeenCalledWith(12345, "SIGTERM");
 			expect(kill).toHaveBeenCalledWith(12345, "SIGKILL");
+			// The identity probe must ask for /version. `/health` omits the pid and
+			// `/status` needs a token, so any other route makes this guard
+			// unsatisfiable against a real server however the mock is shaped.
+			expect(probeHubServer).toHaveBeenCalledWith(
+				"ws://127.0.0.1:25463/hub",
+				expect.objectContaining({ endpoint: "version" }),
+			);
 		} finally {
 			kill.mockRestore();
 			vi.useRealTimers();

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -124,7 +124,22 @@ async function retireDiscoveredHub(
 			// Best-effort cleanup only. A compatible hub may still start on a fallback port.
 		}
 	}
-	const retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
+	let retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
+	// Escalate rather than give up. The CLI installs its own SIGTERM handling, so
+	// a daemon can ignore both the graceful shutdown request and the signal and
+	// keep running. Giving up is not harmless: the discovery record is cleared
+	// below and a replacement binds the port, so the unretired daemon lingers with
+	// its heap and its sessions and nothing will ever reclaim it. A nightly
+	// auto-update retires the previous build through this path, which is how a
+	// long-lived host accumulates one orphaned hub per night.
+	if (!retired && record.pid) {
+		try {
+			process.kill(record.pid, "SIGKILL");
+		} catch {
+			// Already gone, or not ours to signal.
+		}
+		retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
+	}
 	await clearHubDiscovery(discoveryPath).catch(() => undefined);
 	return retired;
 }

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -33,7 +33,10 @@ import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
-import { killHubProcessBoundToReport } from "./process-identity";
+import {
+	captureProcessStartTicket,
+	killHubProcessBoundToTicket,
+} from "./process-identity";
 
 const HUB_STARTUP_TIMEOUT_MS = 8_000;
 const HUB_STARTUP_POLL_MS = 200;
@@ -138,28 +141,36 @@ async function retireDiscoveredHub(
 		// Force only what we can prove we own, with the proof bound to the very
 		// process the signal lands on. A discovery record outlives its daemon
 		// and the OS recycles pids, so the recorded pid may belong to anything
-		// by now — and SIGKILL to the wrong process is not survivable. First,
-		// the hub currently serving the URL must self-report the pid we are
-		// about to kill. `/version`, not the default probe: `/health` omits the
-		// pid entirely and `/status` needs a token this record may not have —
-		// which is exactly the tokenless retirement path. Then the kill itself
-		// is identity-bound: the pid is frozen with SIGSTOP, its /proc start
-		// time is verified against the hub's self-reported startedAt while it
-		// cannot exit (so the pid cannot be recycled under us), and only then
-		// SIGKILLed — or thawed with SIGCONT and spared when the identity does
-		// not hold. Where identity cannot be proven (a hub too old to report
-		// pid or startedAt, a platform without /proc) the daemon is left
-		// alone: leaking is the better failure, and new builds retire
-		// themselves via the in-daemon shutdown watchdog anyway. Every
-		// observed orphan lived on Linux.
-		const serving = await safeProbeHubServer(record.url, undefined, "version");
-		if (serving?.pid !== undefined && serving.pid === record.pid) {
-			const outcome = killHubProcessBoundToReport(
-				record.pid,
-				serving.startedAt,
+		// by now — and SIGKILL to the wrong process is not survivable. The
+		// identity is an exact bracket around the probe: the pid's kernel
+		// start tick (/proc, immutable per process, strictly increasing across
+		// successive holders of a recycled pid) is captured BEFORE the hub is
+		// probed, the hub currently serving the URL must then self-report this
+		// very pid, and the kill re-reads the tick AFTER freezing the pid with
+		// SIGSTOP — a stopped process cannot exit, so the pid cannot change
+		// hands between the read and the signal. Only an exact tick match is
+		// killed; no wall-clock conversion, no tolerance window, so a pid
+		// recycled at any point — however quickly — reads as a different
+		// process and is thawed with SIGCONT instead. `/version`, not the
+		// default probe: `/health` omits the pid entirely and `/status` needs
+		// a token this record may not have — which is exactly the tokenless
+		// retirement path. Where identity cannot be proven (a hub too old to
+		// report its pid, a platform without /proc) the daemon is left alone:
+		// leaking is the better failure, and new builds retire themselves via
+		// the in-daemon shutdown watchdog anyway. Every observed orphan lived
+		// on Linux.
+		const ticket = captureProcessStartTicket(record.pid);
+		if (ticket) {
+			const serving = await safeProbeHubServer(
+				record.url,
+				undefined,
+				"version",
 			);
-			if (outcome !== "spared") {
-				retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
+			if (serving?.pid !== undefined && serving.pid === record.pid) {
+				const outcome = killHubProcessBoundToTicket(ticket);
+				if (outcome !== "spared") {
+					retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
+				}
 			}
 		}
 	}

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -89,9 +89,10 @@ function withMatchingDiscoveryRetirementMetadata(
 async function safeProbeHubServer(
 	url: string,
 	authToken?: string,
+	endpoint?: "auto" | "version",
 ): Promise<HubServerProbeRecord | undefined> {
 	try {
-		return await probeHubServer(url, { authToken });
+		return await probeHubServer(url, { authToken, endpoint });
 	} catch {
 		return undefined;
 	}
@@ -140,7 +141,10 @@ async function retireDiscoveredHub(
 		// escalate only when the hub currently serving that URL reports the very
 		// pid we are about to kill. A hub too old to report its pid is left alone
 		// — leaking a daemon is the better failure.
-		const serving = await safeProbeHubServer(record.url);
+		// `/version`, not the default probe: `/health` omits the pid entirely and
+		// `/status` needs a token this record may not have — which is exactly the
+		// tokenless retirement path.
+		const serving = await safeProbeHubServer(record.url, undefined, "version");
 		if (serving?.pid !== undefined && serving.pid === record.pid) {
 			try {
 				process.kill(record.pid, "SIGKILL");

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -33,7 +33,7 @@ import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
-import { hubProcessStartMatchesReport } from "./process-identity";
+import { killHubProcessBoundToReport } from "./process-identity";
 
 const HUB_STARTUP_TIMEOUT_MS = 8_000;
 const HUB_STARTUP_POLL_MS = 200;
@@ -135,34 +135,32 @@ async function retireDiscoveredHub(
 	// auto-update retires the previous build through this path, which is how a
 	// long-lived host accumulates one orphaned hub per night.
 	if (!retired && record.pid) {
-		// Force only what we can prove we own, twice over. A discovery record
-		// outlives its daemon and the OS recycles pids, so the recorded pid may
-		// belong to anything by now — and SIGKILL to the wrong process is not
-		// survivable. First proof: the hub currently serving the URL must
-		// self-report the very pid we are about to kill. `/version`, not the
-		// default probe: `/health` omits the pid entirely and `/status` needs a
-		// token this record may not have — which is exactly the tokenless
-		// retirement path. Second proof: the process holding that pid must have
-		// started no later than the hub says it began serving, read from /proc
-		// at the last instant before the signal — a pid recycled after the
-		// probe answered belongs to a process younger than the answer, so it
-		// fails this even inside the probe-to-kill window. Where either proof
-		// is unavailable (a hub too old to report pid or startedAt, a platform
-		// without /proc) the daemon is left alone: leaking is the better
-		// failure, and new builds retire themselves via the in-daemon shutdown
-		// watchdog anyway. Every observed orphan lived on Linux.
+		// Force only what we can prove we own, with the proof bound to the very
+		// process the signal lands on. A discovery record outlives its daemon
+		// and the OS recycles pids, so the recorded pid may belong to anything
+		// by now — and SIGKILL to the wrong process is not survivable. First,
+		// the hub currently serving the URL must self-report the pid we are
+		// about to kill. `/version`, not the default probe: `/health` omits the
+		// pid entirely and `/status` needs a token this record may not have —
+		// which is exactly the tokenless retirement path. Then the kill itself
+		// is identity-bound: the pid is frozen with SIGSTOP, its /proc start
+		// time is verified against the hub's self-reported startedAt while it
+		// cannot exit (so the pid cannot be recycled under us), and only then
+		// SIGKILLed — or thawed with SIGCONT and spared when the identity does
+		// not hold. Where identity cannot be proven (a hub too old to report
+		// pid or startedAt, a platform without /proc) the daemon is left
+		// alone: leaking is the better failure, and new builds retire
+		// themselves via the in-daemon shutdown watchdog anyway. Every
+		// observed orphan lived on Linux.
 		const serving = await safeProbeHubServer(record.url, undefined, "version");
-		if (
-			serving?.pid !== undefined &&
-			serving.pid === record.pid &&
-			hubProcessStartMatchesReport(record.pid, serving.startedAt)
-		) {
-			try {
-				process.kill(record.pid, "SIGKILL");
-			} catch {
-				// Already gone, or not ours to signal.
+		if (serving?.pid !== undefined && serving.pid === record.pid) {
+			const outcome = killHubProcessBoundToReport(
+				record.pid,
+				serving.startedAt,
+			);
+			if (outcome !== "spared") {
+				retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
 			}
-			retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
 		}
 	}
 	await clearHubDiscovery(discoveryPath).catch(() => undefined);

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -33,6 +33,7 @@ import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
+import { hubProcessStartMatchesReport } from "./process-identity";
 
 const HUB_STARTUP_TIMEOUT_MS = 8_000;
 const HUB_STARTUP_POLL_MS = 200;
@@ -134,18 +135,28 @@ async function retireDiscoveredHub(
 	// auto-update retires the previous build through this path, which is how a
 	// long-lived host accumulates one orphaned hub per night.
 	if (!retired && record.pid) {
-		// Force only what we can prove we own. A discovery record outlives its
-		// daemon, and the OS recycles pids: the recorded pid may now belong to an
-		// unrelated process while a different daemon answers at the recorded URL.
-		// SIGTERM to the wrong process is usually survivable; SIGKILL is not, so
-		// escalate only when the hub currently serving that URL reports the very
-		// pid we are about to kill. A hub too old to report its pid is left alone
-		// — leaking a daemon is the better failure.
-		// `/version`, not the default probe: `/health` omits the pid entirely and
-		// `/status` needs a token this record may not have — which is exactly the
-		// tokenless retirement path.
+		// Force only what we can prove we own, twice over. A discovery record
+		// outlives its daemon and the OS recycles pids, so the recorded pid may
+		// belong to anything by now — and SIGKILL to the wrong process is not
+		// survivable. First proof: the hub currently serving the URL must
+		// self-report the very pid we are about to kill. `/version`, not the
+		// default probe: `/health` omits the pid entirely and `/status` needs a
+		// token this record may not have — which is exactly the tokenless
+		// retirement path. Second proof: the process holding that pid must have
+		// started no later than the hub says it began serving, read from /proc
+		// at the last instant before the signal — a pid recycled after the
+		// probe answered belongs to a process younger than the answer, so it
+		// fails this even inside the probe-to-kill window. Where either proof
+		// is unavailable (a hub too old to report pid or startedAt, a platform
+		// without /proc) the daemon is left alone: leaking is the better
+		// failure, and new builds retire themselves via the in-daemon shutdown
+		// watchdog anyway. Every observed orphan lived on Linux.
 		const serving = await safeProbeHubServer(record.url, undefined, "version");
-		if (serving?.pid !== undefined && serving.pid === record.pid) {
+		if (
+			serving?.pid !== undefined &&
+			serving.pid === record.pid &&
+			hubProcessStartMatchesReport(record.pid, serving.startedAt)
+		) {
 			try {
 				process.kill(record.pid, "SIGKILL");
 			} catch {

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -133,12 +133,22 @@ async function retireDiscoveredHub(
 	// auto-update retires the previous build through this path, which is how a
 	// long-lived host accumulates one orphaned hub per night.
 	if (!retired && record.pid) {
-		try {
-			process.kill(record.pid, "SIGKILL");
-		} catch {
-			// Already gone, or not ours to signal.
+		// Force only what we can prove we own. A discovery record outlives its
+		// daemon, and the OS recycles pids: the recorded pid may now belong to an
+		// unrelated process while a different daemon answers at the recorded URL.
+		// SIGTERM to the wrong process is usually survivable; SIGKILL is not, so
+		// escalate only when the hub currently serving that URL reports the very
+		// pid we are about to kill. A hub too old to report its pid is left alone
+		// — leaking a daemon is the better failure.
+		const serving = await safeProbeHubServer(record.url);
+		if (serving?.pid !== undefined && serving.pid === record.pid) {
+			try {
+				process.kill(record.pid, "SIGKILL");
+			} catch {
+				// Already gone, or not ours to signal.
+			}
+			retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
 		}
-		retired = await waitForHubToRetire(record.url, HUB_RETIRE_TIMEOUT_MS);
 	}
 	await clearHubDiscovery(discoveryPath).catch(() => undefined);
 	return retired;

--- a/sdk/packages/core/src/hub/daemon/process-identity.test.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
-	hubProcessStartMatchesReport,
-	killHubProcessBoundToReport,
+	captureProcessStartTicket,
+	killHubProcessBoundToTicket,
+	type ProcessStartTicket,
 	type ProcReader,
-	readLinuxProcessStartWallClockMs,
+	readLinuxProcessStartTicks,
 } from "./process-identity";
 
-const BOOT_SECONDS = 1_754_000_000;
-// starttime ticks are USER_HZ (100/s): 4_500_000 ticks = 45_000s after boot.
 const START_TICKS = 4_500_000;
-const PROCESS_START_MS = BOOT_SECONDS * 1_000 + START_TICKS * 10;
+
+function statLine(startTicks: number, comm = "(node)"): string {
+	return `12345 ${comm} S 1 12345 12345 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 11 0 ${startTicks} 1000000 500 18446744073709551615`;
+}
 
 function linuxReader(
 	overrides: Partial<Record<string, string>> = {},
@@ -24,106 +26,65 @@ function linuxReader(
 				}
 				return value;
 			}
-			if (path === "/proc/stat") {
-				return `cpu  1 2 3 4\nbtime ${BOOT_SECONDS}\nprocesses 999\n`;
-			}
 			if (path.startsWith("/proc/") && path.endsWith("/stat")) {
-				return `12345 (node) S 1 12345 12345 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 11 0 ${START_TICKS} 1000000 500 18446744073709551615`;
+				return statLine(START_TICKS);
 			}
 			throw new Error(`ENOENT: ${path}`);
 		},
 	};
 }
 
-describe("readLinuxProcessStartWallClockMs", () => {
-	it("converts starttime ticks anchored at boot time into wall-clock ms", () => {
-		expect(readLinuxProcessStartWallClockMs(12345, linuxReader())).toBe(
-			PROCESS_START_MS,
-		);
+const darwinReader: ProcReader = {
+	platform: "darwin",
+	readFile: () => {
+		throw new Error("should not be read");
+	},
+};
+
+describe("readLinuxProcessStartTicks", () => {
+	it("reads field 22 of /proc/<pid>/stat", () => {
+		expect(readLinuxProcessStartTicks(12345, linuxReader())).toBe(START_TICKS);
 	});
 
 	it("parses past a comm containing spaces and parens", () => {
-		// comm is an arbitrary process name: "(tmux: server)" is legal, and a
-		// first-")" parse would land on the wrong field and misread starttime.
+		// comm is an arbitrary process name: "(tmux: server (2))" is legal, and
+		// a first-")" parse would land on the wrong field and misread the tick.
 		const reader = linuxReader({
-			"/proc/12345/stat": `12345 (tmux: server (2)) S 1 12345 12345 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 11 0 ${START_TICKS} 1000000 500 18446744073709551615`,
+			"/proc/12345/stat": statLine(START_TICKS, "(tmux: server (2))"),
 		});
-		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBe(
-			PROCESS_START_MS,
-		);
+		expect(readLinuxProcessStartTicks(12345, reader)).toBe(START_TICKS);
 	});
 
 	it("returns undefined off Linux", () => {
-		const reader: ProcReader = {
-			platform: "darwin",
-			readFile: () => {
-				throw new Error("should not be read");
-			},
-		};
-		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
+		expect(readLinuxProcessStartTicks(12345, darwinReader)).toBeUndefined();
 	});
 
 	it("returns undefined when the process has already exited", () => {
 		const reader = linuxReader({ "/proc/12345/stat": undefined });
-		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
-	});
-
-	it("returns undefined when btime is missing", () => {
-		const reader = linuxReader({ "/proc/stat": "cpu  1 2 3 4\n" });
-		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
+		expect(readLinuxProcessStartTicks(12345, reader)).toBeUndefined();
 	});
 });
 
-describe("hubProcessStartMatchesReport", () => {
-	it("confirms a process that started before its reported listen time", () => {
-		// Normal case: the daemon booted, loaded modules, then began serving.
-		const startedAt = new Date(PROCESS_START_MS + 1_500).toISOString();
-		expect(hubProcessStartMatchesReport(12345, startedAt, linuxReader())).toBe(
-			true,
-		);
+describe("captureProcessStartTicket", () => {
+	it("captures the pid with its exact start tick", () => {
+		expect(captureProcessStartTicket(12345, linuxReader())).toEqual({
+			pid: 12345,
+			startTicks: START_TICKS,
+		});
 	});
 
-	it("rejects a process younger than the report — a recycled pid", () => {
-		// An impostor can only exist because the reporting daemon died after
-		// answering, so the impostor's start is always later than startedAt.
-		const startedAt = new Date(PROCESS_START_MS - 10_000).toISOString();
-		expect(hubProcessStartMatchesReport(12345, startedAt, linuxReader())).toBe(
-			false,
-		);
+	it("returns undefined off Linux, where identity cannot be proven", () => {
+		expect(captureProcessStartTicket(12345, darwinReader)).toBeUndefined();
 	});
 
-	it("rejects when the report carries no startedAt", () => {
-		expect(hubProcessStartMatchesReport(12345, undefined, linuxReader())).toBe(
-			false,
-		);
-	});
-
-	it("rejects when startedAt is unparsable", () => {
-		expect(
-			hubProcessStartMatchesReport(12345, "not-a-date", linuxReader()),
-		).toBe(false);
-	});
-
-	it("rejects off Linux, where identity cannot be proven", () => {
-		const reader: ProcReader = {
-			platform: "darwin",
-			readFile: () => {
-				throw new Error("should not be read");
-			},
-		};
-		expect(
-			hubProcessStartMatchesReport(
-				12345,
-				new Date(PROCESS_START_MS).toISOString(),
-				reader,
-			),
-		).toBe(false);
+	it("returns undefined when the process is already gone", () => {
+		const reader = linuxReader({ "/proc/12345/stat": undefined });
+		expect(captureProcessStartTicket(12345, reader)).toBeUndefined();
 	});
 });
 
-describe("killHubProcessBoundToReport", () => {
-	const OWNED_STARTED_AT = new Date(PROCESS_START_MS + 1_500).toISOString();
-	const FOREIGN_STARTED_AT = new Date(PROCESS_START_MS - 10_000).toISOString();
+describe("killHubProcessBoundToTicket", () => {
+	const TICKET: ProcessStartTicket = { pid: 12345, startTicks: START_TICKS };
 
 	function recordingKill(failWith?: Partial<Record<string, string>>) {
 		const sent: string[] = [];
@@ -141,10 +102,10 @@ describe("killHubProcessBoundToReport", () => {
 		};
 	}
 
-	it("freezes, verifies while frozen, then kills: SIGSTOP before SIGKILL", () => {
+	it("freezes, re-reads the tick while frozen, then kills on an exact match", () => {
 		// The freeze is the point: a stopped process cannot exit, so the pid
-		// cannot be recycled between the /proc read and the kill. The /proc
-		// read must therefore happen between the two signals.
+		// cannot be recycled between the /proc read and the kill. The re-read
+		// must therefore happen between the two signals.
 		const { sent, kill } = recordingKill();
 		let readsAfterStop = 0;
 		const reader = linuxReader();
@@ -157,7 +118,7 @@ describe("killHubProcessBoundToReport", () => {
 				return reader.readFile(path);
 			},
 		};
-		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+		const outcome = killHubProcessBoundToTicket(TICKET, {
 			reader: countingReader,
 			kill,
 		});
@@ -166,15 +127,16 @@ describe("killHubProcessBoundToReport", () => {
 		expect(readsAfterStop).toBeGreaterThan(0);
 	});
 
-	it("thaws and spares a process younger than the report", () => {
-		// A recycled pid: the impostor is frozen, examined, found younger than
-		// the report it never wrote, and resumed — losing microseconds, not
-		// its life.
+	it("thaws and spares a recycled pid — any successor has a different tick", () => {
+		// A successor on a recycled pid was created later, at a strictly
+		// greater tick, so exact equality cannot pass however fast the pid
+		// changed hands. The impostor is frozen, examined, resumed — losing
+		// microseconds, not its life.
 		const { sent, kill } = recordingKill();
-		const outcome = killHubProcessBoundToReport(12345, FOREIGN_STARTED_AT, {
-			reader: linuxReader(),
-			kill,
+		const reader = linuxReader({
+			"/proc/12345/stat": statLine(START_TICKS + 700),
 		});
+		const outcome = killHubProcessBoundToTicket(TICKET, { reader, kill });
 		expect(outcome).toBe("spared");
 		expect(sent).toEqual(["SIGSTOP", "SIGCONT"]);
 	});
@@ -182,17 +144,14 @@ describe("killHubProcessBoundToReport", () => {
 	it("thaws and spares when the process exits before it can be examined", () => {
 		const { sent, kill } = recordingKill();
 		const reader = linuxReader({ "/proc/12345/stat": undefined });
-		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
-			reader,
-			kill,
-		});
+		const outcome = killHubProcessBoundToTicket(TICKET, { reader, kill });
 		expect(outcome).toBe("spared");
 		expect(sent).toEqual(["SIGSTOP", "SIGCONT"]);
 	});
 
 	it("reports gone when the pid no longer exists at freeze time", () => {
 		const { sent, kill } = recordingKill({ SIGSTOP: "ESRCH" });
-		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+		const outcome = killHubProcessBoundToTicket(TICKET, {
 			reader: linuxReader(),
 			kill,
 		});
@@ -202,7 +161,7 @@ describe("killHubProcessBoundToReport", () => {
 
 	it("spares when the pid is not ours to signal", () => {
 		const { sent, kill } = recordingKill({ SIGSTOP: "EPERM" });
-		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+		const outcome = killHubProcessBoundToTicket(TICKET, {
 			reader: linuxReader(),
 			kill,
 		});
@@ -212,34 +171,11 @@ describe("killHubProcessBoundToReport", () => {
 
 	it("sends no signals at all off Linux", () => {
 		const { sent, kill } = recordingKill();
-		const reader: ProcReader = {
-			platform: "darwin",
-			readFile: () => {
-				throw new Error("should not be read");
-			},
-		};
-		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
-			reader,
+		const outcome = killHubProcessBoundToTicket(TICKET, {
+			reader: darwinReader,
 			kill,
 		});
 		expect(outcome).toBe("spared");
-		expect(sent).toEqual([]);
-	});
-
-	it("sends no signals without a parsable startedAt", () => {
-		const { sent, kill } = recordingKill();
-		expect(
-			killHubProcessBoundToReport(12345, undefined, {
-				reader: linuxReader(),
-				kill,
-			}),
-		).toBe("spared");
-		expect(
-			killHubProcessBoundToReport(12345, "not-a-date", {
-				reader: linuxReader(),
-				kill,
-			}),
-		).toBe("spared");
 		expect(sent).toEqual([]);
 	});
 });

--- a/sdk/packages/core/src/hub/daemon/process-identity.test.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	hubProcessStartMatchesReport,
+	killHubProcessBoundToReport,
 	type ProcReader,
 	readLinuxProcessStartWallClockMs,
 } from "./process-identity";
@@ -117,5 +118,128 @@ describe("hubProcessStartMatchesReport", () => {
 				reader,
 			),
 		).toBe(false);
+	});
+});
+
+describe("killHubProcessBoundToReport", () => {
+	const OWNED_STARTED_AT = new Date(PROCESS_START_MS + 1_500).toISOString();
+	const FOREIGN_STARTED_AT = new Date(PROCESS_START_MS - 10_000).toISOString();
+
+	function recordingKill(failWith?: Partial<Record<string, string>>) {
+		const sent: string[] = [];
+		return {
+			sent,
+			kill: (_pid: number, signal: NodeJS.Signals) => {
+				const code = failWith?.[signal];
+				if (code !== undefined) {
+					const error = new Error(code) as Error & { code: string };
+					error.code = code;
+					throw error;
+				}
+				sent.push(signal);
+			},
+		};
+	}
+
+	it("freezes, verifies while frozen, then kills: SIGSTOP before SIGKILL", () => {
+		// The freeze is the point: a stopped process cannot exit, so the pid
+		// cannot be recycled between the /proc read and the kill. The /proc
+		// read must therefore happen between the two signals.
+		const { sent, kill } = recordingKill();
+		let readsAfterStop = 0;
+		const reader = linuxReader();
+		const countingReader: ProcReader = {
+			platform: "linux",
+			readFile: (path) => {
+				if (sent.includes("SIGSTOP")) {
+					readsAfterStop += 1;
+				}
+				return reader.readFile(path);
+			},
+		};
+		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+			reader: countingReader,
+			kill,
+		});
+		expect(outcome).toBe("killed");
+		expect(sent).toEqual(["SIGSTOP", "SIGKILL"]);
+		expect(readsAfterStop).toBeGreaterThan(0);
+	});
+
+	it("thaws and spares a process younger than the report", () => {
+		// A recycled pid: the impostor is frozen, examined, found younger than
+		// the report it never wrote, and resumed — losing microseconds, not
+		// its life.
+		const { sent, kill } = recordingKill();
+		const outcome = killHubProcessBoundToReport(12345, FOREIGN_STARTED_AT, {
+			reader: linuxReader(),
+			kill,
+		});
+		expect(outcome).toBe("spared");
+		expect(sent).toEqual(["SIGSTOP", "SIGCONT"]);
+	});
+
+	it("thaws and spares when the process exits before it can be examined", () => {
+		const { sent, kill } = recordingKill();
+		const reader = linuxReader({ "/proc/12345/stat": undefined });
+		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+			reader,
+			kill,
+		});
+		expect(outcome).toBe("spared");
+		expect(sent).toEqual(["SIGSTOP", "SIGCONT"]);
+	});
+
+	it("reports gone when the pid no longer exists at freeze time", () => {
+		const { sent, kill } = recordingKill({ SIGSTOP: "ESRCH" });
+		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+			reader: linuxReader(),
+			kill,
+		});
+		expect(outcome).toBe("gone");
+		expect(sent).toEqual([]);
+	});
+
+	it("spares when the pid is not ours to signal", () => {
+		const { sent, kill } = recordingKill({ SIGSTOP: "EPERM" });
+		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+			reader: linuxReader(),
+			kill,
+		});
+		expect(outcome).toBe("spared");
+		expect(sent).toEqual([]);
+	});
+
+	it("sends no signals at all off Linux", () => {
+		const { sent, kill } = recordingKill();
+		const reader: ProcReader = {
+			platform: "darwin",
+			readFile: () => {
+				throw new Error("should not be read");
+			},
+		};
+		const outcome = killHubProcessBoundToReport(12345, OWNED_STARTED_AT, {
+			reader,
+			kill,
+		});
+		expect(outcome).toBe("spared");
+		expect(sent).toEqual([]);
+	});
+
+	it("sends no signals without a parsable startedAt", () => {
+		const { sent, kill } = recordingKill();
+		expect(
+			killHubProcessBoundToReport(12345, undefined, {
+				reader: linuxReader(),
+				kill,
+			}),
+		).toBe("spared");
+		expect(
+			killHubProcessBoundToReport(12345, "not-a-date", {
+				reader: linuxReader(),
+				kill,
+			}),
+		).toBe("spared");
+		expect(sent).toEqual([]);
 	});
 });

--- a/sdk/packages/core/src/hub/daemon/process-identity.test.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+	hubProcessStartMatchesReport,
+	type ProcReader,
+	readLinuxProcessStartWallClockMs,
+} from "./process-identity";
+
+const BOOT_SECONDS = 1_754_000_000;
+// starttime ticks are USER_HZ (100/s): 4_500_000 ticks = 45_000s after boot.
+const START_TICKS = 4_500_000;
+const PROCESS_START_MS = BOOT_SECONDS * 1_000 + START_TICKS * 10;
+
+function linuxReader(
+	overrides: Partial<Record<string, string>> = {},
+): ProcReader {
+	return {
+		platform: "linux",
+		readFile: (path: string) => {
+			if (path in overrides) {
+				const value = overrides[path];
+				if (value === undefined) {
+					throw new Error(`ENOENT: ${path}`);
+				}
+				return value;
+			}
+			if (path === "/proc/stat") {
+				return `cpu  1 2 3 4\nbtime ${BOOT_SECONDS}\nprocesses 999\n`;
+			}
+			if (path.startsWith("/proc/") && path.endsWith("/stat")) {
+				return `12345 (node) S 1 12345 12345 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 11 0 ${START_TICKS} 1000000 500 18446744073709551615`;
+			}
+			throw new Error(`ENOENT: ${path}`);
+		},
+	};
+}
+
+describe("readLinuxProcessStartWallClockMs", () => {
+	it("converts starttime ticks anchored at boot time into wall-clock ms", () => {
+		expect(readLinuxProcessStartWallClockMs(12345, linuxReader())).toBe(
+			PROCESS_START_MS,
+		);
+	});
+
+	it("parses past a comm containing spaces and parens", () => {
+		// comm is an arbitrary process name: "(tmux: server)" is legal, and a
+		// first-")" parse would land on the wrong field and misread starttime.
+		const reader = linuxReader({
+			"/proc/12345/stat": `12345 (tmux: server (2)) S 1 12345 12345 0 -1 4194560 100 0 0 0 5 3 0 0 20 0 11 0 ${START_TICKS} 1000000 500 18446744073709551615`,
+		});
+		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBe(
+			PROCESS_START_MS,
+		);
+	});
+
+	it("returns undefined off Linux", () => {
+		const reader: ProcReader = {
+			platform: "darwin",
+			readFile: () => {
+				throw new Error("should not be read");
+			},
+		};
+		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
+	});
+
+	it("returns undefined when the process has already exited", () => {
+		const reader = linuxReader({ "/proc/12345/stat": undefined });
+		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
+	});
+
+	it("returns undefined when btime is missing", () => {
+		const reader = linuxReader({ "/proc/stat": "cpu  1 2 3 4\n" });
+		expect(readLinuxProcessStartWallClockMs(12345, reader)).toBeUndefined();
+	});
+});
+
+describe("hubProcessStartMatchesReport", () => {
+	it("confirms a process that started before its reported listen time", () => {
+		// Normal case: the daemon booted, loaded modules, then began serving.
+		const startedAt = new Date(PROCESS_START_MS + 1_500).toISOString();
+		expect(hubProcessStartMatchesReport(12345, startedAt, linuxReader())).toBe(
+			true,
+		);
+	});
+
+	it("rejects a process younger than the report — a recycled pid", () => {
+		// An impostor can only exist because the reporting daemon died after
+		// answering, so the impostor's start is always later than startedAt.
+		const startedAt = new Date(PROCESS_START_MS - 10_000).toISOString();
+		expect(hubProcessStartMatchesReport(12345, startedAt, linuxReader())).toBe(
+			false,
+		);
+	});
+
+	it("rejects when the report carries no startedAt", () => {
+		expect(hubProcessStartMatchesReport(12345, undefined, linuxReader())).toBe(
+			false,
+		);
+	});
+
+	it("rejects when startedAt is unparsable", () => {
+		expect(
+			hubProcessStartMatchesReport(12345, "not-a-date", linuxReader()),
+		).toBe(false);
+	});
+
+	it("rejects off Linux, where identity cannot be proven", () => {
+		const reader: ProcReader = {
+			platform: "darwin",
+			readFile: () => {
+				throw new Error("should not be read");
+			},
+		};
+		expect(
+			hubProcessStartMatchesReport(
+				12345,
+				new Date(PROCESS_START_MS).toISOString(),
+				reader,
+			),
+		).toBe(false);
+	});
+});

--- a/sdk/packages/core/src/hub/daemon/process-identity.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * The tick unit of /proc/<pid>/stat starttime. Fixed at 100 by the kernel ABI
+ * exposed to userspace (USER_HZ), independent of the kernel's internal HZ.
+ */
+const LINUX_USER_HZ = 100;
+
+/**
+ * /proc/stat btime has whole-second granularity and starttime has tick
+ * granularity, so an honest comparison needs a little slack. Kept far below
+ * the ~3s minimum age of any process that could hold a recycled hub pid (see
+ * hubProcessStartMatchesReport).
+ */
+const HUB_PROCESS_START_SLACK_MS = 2_000;
+
+export interface ProcReader {
+	platform: NodeJS.Platform;
+	readFile(path: string): string;
+}
+
+const defaultProcReader: ProcReader = {
+	platform: process.platform,
+	readFile: (path) => readFileSync(path, "utf8"),
+};
+
+/**
+ * Wall-clock start of a process, from /proc/<pid>/stat field 22 (starttime,
+ * USER_HZ ticks since boot) anchored by /proc/stat btime (boot time, epoch
+ * seconds). Linux only; undefined wherever /proc is missing or unparsable.
+ */
+export function readLinuxProcessStartWallClockMs(
+	pid: number,
+	reader: ProcReader = defaultProcReader,
+): number | undefined {
+	if (reader.platform !== "linux") {
+		return undefined;
+	}
+	try {
+		const stat = reader.readFile(`/proc/${pid}/stat`);
+		// comm (field 2) is "(name)" and the name may itself contain spaces or
+		// parens, so the fixed-position fields start after the LAST ")".
+		const afterComm = stat.slice(stat.lastIndexOf(")") + 2);
+		const startTicks = Number(afterComm.split(" ")[19]);
+		const btimeLine = reader
+			.readFile("/proc/stat")
+			.split("\n")
+			.find((line) => line.startsWith("btime "));
+		const bootSeconds = Number(btimeLine?.slice("btime ".length).trim());
+		if (!Number.isFinite(startTicks) || !Number.isFinite(bootSeconds)) {
+			return undefined;
+		}
+		return bootSeconds * 1_000 + (startTicks * 1_000) / LINUX_USER_HZ;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * True only when the process behind `pid` provably is the hub that reported
+ * `startedAt`: a process always starts before its own listen timestamp, so
+ * the /proc start time must not be later than the report (plus clock-
+ * granularity slack). A recycled pid always fails this — recycling requires
+ * the reporting daemon to have died first, which is after it answered the
+ * probe, so any impostor is younger than the report, never older.
+ *
+ * /proc is read here, at the last instant before the caller signals, so the
+ * identity is bound to the process holding the pid now — not to whatever
+ * held it when the probe answered. Where /proc is unavailable (macOS,
+ * Windows) the identity cannot be proven and this returns false: leaking a
+ * daemon is the better failure than an unowned SIGKILL.
+ */
+export function hubProcessStartMatchesReport(
+	pid: number,
+	reportedStartedAt: string | undefined,
+	reader: ProcReader = defaultProcReader,
+): boolean {
+	if (!reportedStartedAt) {
+		return false;
+	}
+	const reportedMs = Date.parse(reportedStartedAt);
+	if (!Number.isFinite(reportedMs)) {
+		return false;
+	}
+	const processStartMs = readLinuxProcessStartWallClockMs(pid, reader);
+	if (processStartMs === undefined) {
+		return false;
+	}
+	return processStartMs <= reportedMs + HUB_PROCESS_START_SLACK_MS;
+}

--- a/sdk/packages/core/src/hub/daemon/process-identity.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.ts
@@ -1,19 +1,5 @@
 import { readFileSync } from "node:fs";
 
-/**
- * The tick unit of /proc/<pid>/stat starttime. Fixed at 100 by the kernel ABI
- * exposed to userspace (USER_HZ), independent of the kernel's internal HZ.
- */
-const LINUX_USER_HZ = 100;
-
-/**
- * /proc/stat btime has whole-second granularity and starttime has tick
- * granularity, so an honest comparison needs a little slack. Kept far below
- * the ~3s minimum age of any process that could hold a recycled hub pid (see
- * hubProcessStartMatchesReport).
- */
-const HUB_PROCESS_START_SLACK_MS = 2_000;
-
 export interface ProcReader {
 	platform: NodeJS.Platform;
 	readFile(path: string): string;
@@ -25,11 +11,15 @@ const defaultProcReader: ProcReader = {
 };
 
 /**
- * Wall-clock start of a process, from /proc/<pid>/stat field 22 (starttime,
- * USER_HZ ticks since boot) anchored by /proc/stat btime (boot time, epoch
- * seconds). Linux only; undefined wherever /proc is missing or unparsable.
+ * starttime: field 22 of /proc/<pid>/stat, the kernel's tick count at the
+ * instant the process was created. Immutable for the process's whole life
+ * and strictly increasing across successive holders of a recycled pid, so
+ * two reads returning the same integer for the same pid prove the pid was
+ * not recycled between them — an exact identity, needing no wall-clock
+ * conversion and no tolerance window. Linux only; undefined wherever /proc
+ * is missing or unparsable.
  */
-export function readLinuxProcessStartWallClockMs(
+export function readLinuxProcessStartTicks(
 	pid: number,
 	reader: ProcReader = defaultProcReader,
 ): number | undefined {
@@ -42,51 +32,29 @@ export function readLinuxProcessStartWallClockMs(
 		// parens, so the fixed-position fields start after the LAST ")".
 		const afterComm = stat.slice(stat.lastIndexOf(")") + 2);
 		const startTicks = Number(afterComm.split(" ")[19]);
-		const btimeLine = reader
-			.readFile("/proc/stat")
-			.split("\n")
-			.find((line) => line.startsWith("btime "));
-		const bootSeconds = Number(btimeLine?.slice("btime ".length).trim());
-		if (!Number.isFinite(startTicks) || !Number.isFinite(bootSeconds)) {
-			return undefined;
-		}
-		return bootSeconds * 1_000 + (startTicks * 1_000) / LINUX_USER_HZ;
+		return Number.isFinite(startTicks) ? startTicks : undefined;
 	} catch {
 		return undefined;
 	}
 }
 
 /**
- * True only when the process behind `pid` provably is the hub that reported
- * `startedAt`: a process always starts before its own listen timestamp, so
- * the /proc start time must not be later than the report (plus clock-
- * granularity slack). A recycled pid always fails this — recycling requires
- * the reporting daemon to have died first, which is after it answered the
- * probe, so any impostor is younger than the report, never older.
- *
- * /proc is read here, at the last instant before the caller signals, so the
- * identity is bound to the process holding the pid now — not to whatever
- * held it when the probe answered. Where /proc is unavailable (macOS,
- * Windows) the identity cannot be proven and this returns false: leaking a
- * daemon is the better failure than an unowned SIGKILL.
+ * A process identity captured at a point in time: this pid was held by the
+ * process with this exact start tick. Capture it BEFORE probing the hub, so
+ * that an unchanged ticket at kill time brackets the probe — whoever
+ * answered in between was this same process.
  */
-export function hubProcessStartMatchesReport(
+export interface ProcessStartTicket {
+	pid: number;
+	startTicks: number;
+}
+
+export function captureProcessStartTicket(
 	pid: number,
-	reportedStartedAt: string | undefined,
 	reader: ProcReader = defaultProcReader,
-): boolean {
-	if (!reportedStartedAt) {
-		return false;
-	}
-	const reportedMs = Date.parse(reportedStartedAt);
-	if (!Number.isFinite(reportedMs)) {
-		return false;
-	}
-	const processStartMs = readLinuxProcessStartWallClockMs(pid, reader);
-	if (processStartMs === undefined) {
-		return false;
-	}
-	return processStartMs <= reportedMs + HUB_PROCESS_START_SLACK_MS;
+): ProcessStartTicket | undefined {
+	const startTicks = readLinuxProcessStartTicks(pid, reader);
+	return startTicks === undefined ? undefined : { pid, startTicks };
 }
 
 export type BoundKillOutcome = "killed" | "spared" | "gone";
@@ -106,30 +74,37 @@ function isNoSuchProcessError(error: unknown): boolean {
 }
 
 /**
- * SIGKILLs `pid` only while it provably is the hub that reported
- * `startedAt`, with the verification bound to the very process the signal
- * lands on: the pid is frozen with SIGSTOP first, its /proc start time is
- * read while frozen, and only then is it SIGKILLed — or SIGCONTed and spared
- * when the identity does not hold.
+ * SIGKILLs the ticket's pid only while it is still the very process the
+ * ticket was captured from, with the verification bound to the process the
+ * signal lands on: the pid is frozen with SIGSTOP first, its start tick is
+ * re-read while frozen, and only an exact integer match is killed — anything
+ * else is thawed with SIGCONT and spared.
  *
- * The freeze is what closes the verify-to-kill window. A stopped process
- * cannot run, so it cannot exit, so its pid cannot be recycled between the
- * /proc read and the signal; and SIGSTOP cannot be caught, blocked, or
- * ignored. If pid reuse already happened before the freeze, the /proc read
- * sees the impostor's younger start time and the impostor is thawed with
- * SIGCONT, having lost only the microseconds it spent stopped — a
- * recoverable imposition, where SIGKILL is not. (A pidfd would remove even
- * the residual exposure to third parties signalling the frozen process, but
- * Node exposes no pidfd API; this is the strongest binding available from
- * userspace JS.)
+ * Two properties make this airtight against pid reuse, with no tolerance
+ * window to slip through:
+ *
+ * - The freeze closes the verify-to-kill gap. A stopped process cannot run,
+ *   so it cannot exit, so its pid cannot be recycled between the /proc read
+ *   and the signal; and SIGSTOP cannot be caught, blocked, or ignored.
+ * - The start tick is exact. It never changes for a live process, and any
+ *   successor on a recycled pid was necessarily created later, at a strictly
+ *   greater tick — so equality with the pre-probe ticket proves the frozen
+ *   process is the one that held the pid before the probe, and therefore the
+ *   one that answered it. There is no wall-clock conversion and no slack: a
+ *   recycled pid cannot pass, however quickly it was recycled.
+ *
+ * A process that fails the check loses only the microseconds it spent
+ * stopped — a recoverable imposition, where SIGKILL is not. (A pidfd would
+ * remove even the residual exposure to third parties signalling the frozen
+ * process, but Node exposes no pidfd API; this is the strongest binding
+ * available from userspace JS.)
  *
  * Non-Linux platforms return "spared" before any signal is sent: without
  * /proc there is no identity to verify, and leaking a daemon is the better
  * failure than an unowned kill.
  */
-export function killHubProcessBoundToReport(
-	pid: number,
-	reportedStartedAt: string | undefined,
+export function killHubProcessBoundToTicket(
+	ticket: ProcessStartTicket,
 	deps: BoundKillDeps = {
 		reader: defaultProcReader,
 		kill: (target, signal) => process.kill(target, signal),
@@ -138,26 +113,24 @@ export function killHubProcessBoundToReport(
 	if (deps.reader.platform !== "linux") {
 		return "spared";
 	}
-	if (!reportedStartedAt || !Number.isFinite(Date.parse(reportedStartedAt))) {
-		return "spared";
-	}
 	try {
-		deps.kill(pid, "SIGSTOP");
+		deps.kill(ticket.pid, "SIGSTOP");
 	} catch (error) {
 		// ESRCH: already exited, nothing left to retire. Anything else (EPERM):
 		// not ours to signal, so it cannot be the daemon we spawned.
 		return isNoSuchProcessError(error) ? "gone" : "spared";
 	}
-	if (!hubProcessStartMatchesReport(pid, reportedStartedAt, deps.reader)) {
+	const frozenTicks = readLinuxProcessStartTicks(ticket.pid, deps.reader);
+	if (frozenTicks === undefined || frozenTicks !== ticket.startTicks) {
 		try {
-			deps.kill(pid, "SIGCONT");
+			deps.kill(ticket.pid, "SIGCONT");
 		} catch {
 			// Exited while stopped, or was never ours; either way nothing to thaw.
 		}
 		return "spared";
 	}
 	try {
-		deps.kill(pid, "SIGKILL");
+		deps.kill(ticket.pid, "SIGKILL");
 	} catch (error) {
 		return isNoSuchProcessError(error) ? "gone" : "spared";
 	}

--- a/sdk/packages/core/src/hub/daemon/process-identity.ts
+++ b/sdk/packages/core/src/hub/daemon/process-identity.ts
@@ -88,3 +88,78 @@ export function hubProcessStartMatchesReport(
 	}
 	return processStartMs <= reportedMs + HUB_PROCESS_START_SLACK_MS;
 }
+
+export type BoundKillOutcome = "killed" | "spared" | "gone";
+
+export interface BoundKillDeps {
+	reader: ProcReader;
+	kill(pid: number, signal: NodeJS.Signals): void;
+}
+
+function isNoSuchProcessError(error: unknown): boolean {
+	return (
+		!!error &&
+		typeof error === "object" &&
+		"code" in error &&
+		(error as { code?: unknown }).code === "ESRCH"
+	);
+}
+
+/**
+ * SIGKILLs `pid` only while it provably is the hub that reported
+ * `startedAt`, with the verification bound to the very process the signal
+ * lands on: the pid is frozen with SIGSTOP first, its /proc start time is
+ * read while frozen, and only then is it SIGKILLed — or SIGCONTed and spared
+ * when the identity does not hold.
+ *
+ * The freeze is what closes the verify-to-kill window. A stopped process
+ * cannot run, so it cannot exit, so its pid cannot be recycled between the
+ * /proc read and the signal; and SIGSTOP cannot be caught, blocked, or
+ * ignored. If pid reuse already happened before the freeze, the /proc read
+ * sees the impostor's younger start time and the impostor is thawed with
+ * SIGCONT, having lost only the microseconds it spent stopped — a
+ * recoverable imposition, where SIGKILL is not. (A pidfd would remove even
+ * the residual exposure to third parties signalling the frozen process, but
+ * Node exposes no pidfd API; this is the strongest binding available from
+ * userspace JS.)
+ *
+ * Non-Linux platforms return "spared" before any signal is sent: without
+ * /proc there is no identity to verify, and leaking a daemon is the better
+ * failure than an unowned kill.
+ */
+export function killHubProcessBoundToReport(
+	pid: number,
+	reportedStartedAt: string | undefined,
+	deps: BoundKillDeps = {
+		reader: defaultProcReader,
+		kill: (target, signal) => process.kill(target, signal),
+	},
+): BoundKillOutcome {
+	if (deps.reader.platform !== "linux") {
+		return "spared";
+	}
+	if (!reportedStartedAt || !Number.isFinite(Date.parse(reportedStartedAt))) {
+		return "spared";
+	}
+	try {
+		deps.kill(pid, "SIGSTOP");
+	} catch (error) {
+		// ESRCH: already exited, nothing left to retire. Anything else (EPERM):
+		// not ours to signal, so it cannot be the daemon we spawned.
+		return isNoSuchProcessError(error) ? "gone" : "spared";
+	}
+	if (!hubProcessStartMatchesReport(pid, reportedStartedAt, deps.reader)) {
+		try {
+			deps.kill(pid, "SIGCONT");
+		} catch {
+			// Exited while stopped, or was never ours; either way nothing to thaw.
+		}
+		return "spared";
+	}
+	try {
+		deps.kill(pid, "SIGKILL");
+	} catch (error) {
+		return isNoSuchProcessError(error) ? "gone" : "spared";
+	}
+	return "killed";
+}

--- a/sdk/packages/core/src/hub/daemon/shutdown-watchdog.test.ts
+++ b/sdk/packages/core/src/hub/daemon/shutdown-watchdog.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	armHubDaemonShutdownWatchdog,
+	HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
+} from "./shutdown-watchdog";
+
+describe("armHubDaemonShutdownWatchdog", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("forces exit with the given code once the deadline lapses", () => {
+		const exit = vi.fn();
+		const onTimeout = vi.fn();
+		armHubDaemonShutdownWatchdog({
+			deadlineMs: 2_000,
+			exitCode: 0,
+			onTimeout,
+			exit,
+		});
+
+		vi.advanceTimersByTime(1_999);
+		expect(exit).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+
+	it("does not fire before the deadline, so a fast graceful exit wins", () => {
+		const exit = vi.fn();
+		armHubDaemonShutdownWatchdog({
+			deadlineMs: 2_000,
+			exitCode: 0,
+			exit,
+		});
+
+		// A graceful shutdown that completes calls process.exit itself; the
+		// watchdog must stay quiet until then.
+		vi.advanceTimersByTime(500);
+		expect(exit).not.toHaveBeenCalled();
+	});
+
+	it("keeps the daemon deadline below the retiring caller's 3s wait", () => {
+		// retireDiscoveredHub waits HUB_RETIRE_TIMEOUT_MS (3s) after SIGTERM
+		// before escalating to SIGKILL. The watchdog must beat that wait so
+		// routine retirement never needs to force-kill.
+		expect(HUB_DAEMON_SHUTDOWN_DEADLINE_MS).toBeLessThan(3_000);
+	});
+});

--- a/sdk/packages/core/src/hub/daemon/shutdown-watchdog.ts
+++ b/sdk/packages/core/src/hub/daemon/shutdown-watchdog.ts
@@ -1,0 +1,41 @@
+/**
+ * Kept below HUB_RETIRE_TIMEOUT_MS (3s): a retiring caller waits that long for
+ * this daemon to die after SIGTERM before escalating to SIGKILL, and a daemon
+ * that always beats the wait keeps routine retirement escalation-free.
+ */
+export const HUB_DAEMON_SHUTDOWN_DEADLINE_MS = 2_000;
+
+export interface HubDaemonShutdownWatchdogOptions {
+	deadlineMs: number;
+	exitCode: number;
+	/** Written to stderr-backed daemon log before the forced exit. */
+	onTimeout?: () => void;
+	/** Injectable for tests; defaults to process.exit. */
+	exit?: (code: number) => void;
+}
+
+/**
+ * Forces the daemon down if graceful shutdown stalls.
+ *
+ * Shutdown awaits server.close(), and under Bun's node:http a server that has
+ * accepted a WebSocket upgrade never delivers its close callback, even after
+ * every socket is terminated (verified against Bun 1.3.13: terminate() and
+ * wss.close() complete, server.close() never resolves). A hub with connectors
+ * attached always has such a socket, and installing a SIGTERM handler disables
+ * the runtime's default exit — so without a deadline, every retirement of a
+ * Bun-runtime daemon leaves the process alive forever. The watchdog makes exit
+ * unconditional: however close() behaves, the daemon is gone by the deadline.
+ *
+ * The timer is unref'd so it never extends the process's life; while shutdown
+ * is stalled the server's own handles keep the loop (and the timer) running.
+ */
+export function armHubDaemonShutdownWatchdog(
+	options: HubDaemonShutdownWatchdogOptions,
+): void {
+	const exit = options.exit ?? process.exit;
+	const timer = setTimeout(() => {
+		options.onTimeout?.();
+		exit(options.exitCode);
+	}, options.deadlineMs);
+	timer.unref?.();
+}

--- a/sdk/packages/core/src/hub/discovery/index.ts
+++ b/sdk/packages/core/src/hub/discovery/index.ts
@@ -259,11 +259,19 @@ export async function withHubStartupLock<T>(
 
 export async function probeHubServer(
 	url: string,
-	options?: { authToken?: string },
+	options?: { authToken?: string; endpoint?: "auto" | "version" },
 ): Promise<HubServerProbeRecord | undefined> {
 	try {
 		const response = await fetch(
-			options?.authToken ? toHubStatusUrl(url) : toHubHealthUrl(url),
+			// `/health` is deliberately minimal and omits the serving pid, and
+			// `/status` needs a token a legacy or tokenless record may not carry.
+			// `/version` is unauthenticated and serves the full payload, so callers
+			// that need the hub's identity ask for that route explicitly.
+			options?.endpoint === "version"
+				? toHubVersionUrl(url)
+				: options?.authToken
+					? toHubStatusUrl(url)
+					: toHubHealthUrl(url),
 			{
 				headers: options?.authToken
 					? { authorization: `Bearer ${options.authToken}` }
@@ -274,11 +282,22 @@ export async function probeHubServer(
 			return undefined;
 		}
 		const parsed = (await response.json()) as Partial<HubServerProbeRecord>;
+		// `/version` describes the daemon, not the endpoint it is reached through,
+		// so it carries no host/port/url. Those are known from the URL just
+		// requested, so fill them in rather than rejecting a valid response.
+		const requested =
+			options?.endpoint === "version" ? new URL(url) : undefined;
+		const host = parsed.host ?? requested?.hostname;
+		const port =
+			parsed.port ??
+			(requested ? Number.parseInt(requested.port, 10) : undefined);
+		const resolvedUrl = parsed.url ?? (requested ? url : undefined);
 		if (
 			typeof parsed.protocolVersion !== "string" ||
-			typeof parsed.host !== "string" ||
-			typeof parsed.port !== "number" ||
-			typeof parsed.url !== "string"
+			typeof host !== "string" ||
+			typeof port !== "number" ||
+			Number.isNaN(port) ||
+			typeof resolvedUrl !== "string"
 		) {
 			return undefined;
 		}
@@ -301,9 +320,9 @@ export async function probeHubServer(
 			coreVersion:
 				typeof parsed.coreVersion === "string" ? parsed.coreVersion : undefined,
 			buildId: typeof parsed.buildId === "string" ? parsed.buildId : undefined,
-			host: parsed.host,
-			port: parsed.port,
-			url: parsed.url,
+			host,
+			port,
+			url: resolvedUrl,
 			hubId: typeof parsed.hubId === "string" ? parsed.hubId : undefined,
 			authToken:
 				typeof parsed.authToken === "string" ? parsed.authToken : undefined,
@@ -331,6 +350,12 @@ export function toHubHealthUrl(wsUrl: string): string {
 	parsed.protocol = parsed.protocol === "wss:" ? "https:" : "http:";
 	parsed.pathname = "/health";
 	parsed.search = "";
+	return parsed.toString();
+}
+
+export function toHubVersionUrl(wsUrl: string): string {
+	const parsed = new URL(toHubHealthUrl(wsUrl));
+	parsed.pathname = "/version";
 	return parsed.toString();
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Two independent process-lifecycle bugs, both found on a host that had been running connectors for weeks. Neither is theoretical — each was reproduced on that machine, and the daemon-leak mechanism has now also been reproduced locally against a real daemon.

#### 1. A hub daemon leaks on every auto-update

**Symptom.** Nine hub daemons alive in one container, spawned ~24 hours apart, eight of them dead weight holding a full Node heap each. `cline doctor` listed all eight as stale.

**Root cause — verified against a real daemon.** The daemon's `SIGTERM` handler awaits `server.close()` before exiting, and installing that handler disables the runtime's default signal exit. Under Bun's `node:http` (the runtime for compiled-CLI installs and dev), `server.close()` **never resolves once the server has accepted a WebSocket upgrade** — even after every socket is `terminate()`d and `wss.close()` has completed (verified on Bun 1.3.13 by instrumenting the real daemon: the trace stops at `calling server.close()`, and the process survives indefinitely). A hub with connectors attached always has such a socket, so every nightly retirement of a Bun-runtime daemon leaves the old build running forever. Under Node 22 the identical close sequence resolves cleanly, so this is runtime-conditional — which is consistent with the leak being observed rather than universal. Idle daemons, HTTP keep-alive clients, and half-open TCP connections all shut down cleanly on both runtimes.

**Fix, in two layers:**

- **Root cause (`entry.ts` + `shutdown-watchdog.ts`):** shutdown no longer depends on the graceful path. A watchdog armed at the top of `shutdown()` (and `shutdownFatal()`) forces `process.exit()` when the close stalls past its deadline. The deadline (2s) is deliberately below the retiring caller's 3s wait, so a daemon carrying this fix always dies inside the first `SIGTERM` wait and retirement never needs to escalate. Verified empirically: the previously-immortal scenario (Bun daemon + attached WebSocket + `SIGTERM`) now exits 0 within the deadline, logging `graceful shutdown stalled; forcing exit` to the daemon log.

- **Backstop for already-installed builds (`retireDiscoveredHub`):** daemons without the watchdog can still ignore `SIGTERM`, so retirement escalates to `SIGKILL` rather than clearing the discovery record over a live process (clearing it is what makes the leak permanent — a replacement binds the port and nothing ever reclaims the old daemon). The escalation only fires on **exact** proof of identity — integer equality on the kernel's per-process start tick, with no wall-clock conversion and no tolerance window anywhere:
  1. *before* the identity probe, the pid's start tick is captured from `/proc/<pid>/stat` field 22 (`captureProcessStartTicket`) — an immutable per-process integer, strictly increasing across successive holders of a recycled pid;
  2. the hub currently serving the URL must then self-report that exact pid on `/version` (unauthenticated, unlike `/status`; carries the pid, unlike `/health`);
  3. the kill is a freeze-verify-kill sequence (`killHubProcessBoundToTicket`): the pid is frozen with `SIGSTOP` — which cannot be caught, blocked, or ignored — so the process **cannot exit and the pid cannot be recycled** between verification and signal; the start tick is re-read **while frozen** and must equal the pre-probe capture **exactly**, and only then is `SIGKILL` sent. Anything else is thawed with `SIGCONT`, having lost only the microseconds it spent stopped.

  The two reads bracket the probe: an unchanged tick proves the frozen process is the same process that held the pid before the probe, and therefore the process that answered it. A pid recycled at *any* point — between probe and freeze included, however quickly — carries a strictly greater tick and cannot pass; there is no acceptance window because the comparison is integer equality, not a timestamp within slack. Where identity can't be captured or proven — no `/proc` (macOS/Windows, gated before any signal is sent), the recorded process already gone, an unparsable stat, `EPERM` — the daemon is left alone: leaking is the better failure than an unowned `SIGKILL`, every failure direction spares the process by construction, and every observed orphan lived on Linux. (A `pidfd` would be the theoretical ideal, but Node exposes no pidfd API; this is the strongest binding available from userspace JS.) Once no supported build predates the watchdog, the escalation can be deleted.

#### 2. An exiting connector deletes another instance's state file

**Symptom.** After stopping a stale Slack connector that had been running alongside a newer one, the *surviving* connector kept serving Slack but disappeared from `cline doctor` (`active connectors 0`), and `connect --stop` could no longer find it. A live bot no tooling could see.

**Root cause.** All instances of a connector share one state path. The shutdown path called `removeStateFile(statePath)` unconditionally, so an exiting process happily deleted a record another process had since claimed.

**Fix.** New `removeStateFileIfOwnedBy` on `ConnectorBase` — remove the file only while it still names the exiting pid — wired into the Slack connector's shutdown.

The ownership guard is wired into Slack only, where the incident was observed. The other adapters have the same direct, unconditional `removeStateFile` call in their own shutdown paths (`whatsapp.ts:881`, `telegram.ts:625`/`1217`, `gchat.ts:865`, `discord.ts:1497`/`1579`, `linear.ts:891`), and Slack's `clearBindingSessionIds` has the same cross-instance exposure at lower severity — all queued for a dedicated follow-up PR rather than touching six adapters blind here.

### Test Procedure

**Empirical verification of the hang and the fix** (instrumented real daemon, isolated `CLINE_DATA_DIR`, real WebSocket client, real `SIGTERM`):

| Scenario | Bun 1.3.13 before fix | Bun 1.3.13 after fix | Node 22 |
|---|---|---|---|
| Idle daemon | clean exit | clean exit (graceful, no watchdog) | clean exit |
| HTTP keep-alive held open | clean exit | — | clean exit |
| Half-open TCP connection | clean exit | — | clean exit |
| WebSocket attached | **never exits** (`server.close()` stalls) | **exit 0 ≤ 2s** via watchdog | clean exit |

**Suites:**
- `bun -F @cline/core test:unit` — 1790 passing (new coverage: watchdog deadline semantics; `/proc` stat tick parsing incl. comm-with-parens; ticket capture; the freeze-verify-kill sequence — signal order `SIGSTOP` → re-read-while-frozen → `SIGKILL` on exact tick match only, thaw-and-spare for recycled/vanished pids, `ESRCH`/`EPERM` at freeze time, no signals off-Linux; escalation blocked when the serving hub doesn't claim the pid or no ticket could be captured)
- `bun -F @cline/cli test:unit` — 1130 passing
- `typecheck` clean on both packages; Biome clean on all changed files

New coverage: the daemon test simulates a hub that won't retire and asserts the force-kill goes only through the identity-bound path (never a bare `process.kill(pid, "SIGKILL")`), fires only when the serving hub claims the pid, and spares a process the frozen-identity check rejects. The bound-kill unit tests assert the `/proc` read happens **between** `SIGSTOP` and `SIGKILL` — the ordering that closes the race. Base tests cover the connector state-file guard both ways — a foreign-pid record survives, an owned or absent one is removed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

The daemon-leak fix intentionally narrows force-kill to Linux (where `/proc` provides provable process identity and where every observed orphan lived). A pre-watchdog daemon on macOS or Windows that ignores `SIGTERM` still leaks — accepted: that combination has never been observed, and all future builds carry the watchdog, which retires the daemon on every platform without any external signal escalation.
