### PR TITLE
Fade the View Changes button until changes since the last message are confirmed

### DIFF
--- a/apps/vscode/proto/cline/checkpoints.proto
+++ b/apps/vscode/proto/cline/checkpoints.proto
@@ -14,6 +14,10 @@ service CheckpointsService {
   // checkpoint (snapshotted when the user's last message started a run) and
   // the current working tree.
   rpc checkpointViewLatestChanges(EmptyRequest) returns (Empty);
+  // Returns how many files changed between the latest checkpoint and the
+  // current working tree (0 when no checkpoint exists). Used to enable the
+  // "View Changes" button only when there is something to show.
+  rpc checkpointLatestChangesCount(EmptyRequest) returns (Int64);
 }
 
 message CheckpointRestoreRequest {

--- a/apps/vscode/src/core/controller/checkpoints/checkpointLatestChangesCount.ts
+++ b/apps/vscode/src/core/controller/checkpoints/checkpointLatestChangesCount.ts
@@ -1,0 +1,20 @@
+import { EmptyRequest, Int64 } from "@shared/proto/cline/common"
+import { Controller } from ".."
+
+/**
+ * Returns how many files changed between the latest checkpoint and the
+ * current working tree (0 when nothing can be compared). The webview uses
+ * this to enable the "View Changes" button on the completion row only when
+ * there is something to show.
+ */
+export async function checkpointLatestChangesCount(controller: Controller, _request: EmptyRequest): Promise<Int64> {
+	const sdkGetLatestCheckpointChangesCount = (
+		controller as Controller & {
+			getLatestCheckpointChangesCount?: () => Promise<number>
+		}
+	).getLatestCheckpointChangesCount
+	if (sdkGetLatestCheckpointChangesCount) {
+		return Int64.create({ value: await sdkGetLatestCheckpointChangesCount.call(controller) })
+	}
+	return Int64.create({ value: 0 })
+}

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import {
+	type CompareCheckpointResult,
 	createRestoredCheckpointMetadata,
 	createUserInstructionConfigService,
 	ensureChatWorkspace,
@@ -1623,11 +1624,12 @@ export class Controller {
 	}
 
 	/**
-	 * "View Changes" on the completion row: opens a multi-file diff of
-	 * everything that changed between the latest checkpoint — snapshotted when
-	 * the user's last message started this run — and the current working tree.
+	 * Diffs the latest checkpoint — snapshotted when the user's last message
+	 * started a run — against the current working tree. Returns undefined when
+	 * no checkpoint exists (e.g. the workspace is not a git repository).
+	 * Throws when there is no task at all.
 	 */
-	async viewLatestCheckpointChanges(): Promise<void> {
+	private async computeLatestCheckpointChanges(): Promise<CompareCheckpointResult["diffs"] | undefined> {
 		const activeSession = this.sessions.getActiveSession()
 		const sessionId = activeSession?.sessionId ?? this.task?.taskId
 		if (!sessionId) {
@@ -1648,11 +1650,7 @@ export class Controller {
 				undefined as ReturnType<typeof readSessionCheckpointHistory>[number] | undefined,
 			)
 			if (!latestCheckpoint) {
-				HostProvider.window.showMessage({
-					type: ShowMessageType.INFORMATION,
-					message: "No checkpoint was taken for this task. Checkpoints require the workspace to be a git repository.",
-				})
-				return
+				return undefined
 			}
 
 			const cwd = sessionRecord?.cwd?.trim() || sessionRecord?.workspaceRoot?.trim() || (await this.getWorkspaceRoot())
@@ -1661,25 +1659,56 @@ export class Controller {
 				checkpointRunCount: latestCheckpoint.runCount,
 				cwd,
 			})
-			if (diffs.length === 0) {
-				HostProvider.window.showMessage({
-					type: ShowMessageType.INFORMATION,
-					message: "No file changes found since your last message.",
-				})
-				return
-			}
-
-			await HostProvider.diff.openMultiFileDiff({
-				title: "Changes since your last message",
-				diffs: diffs.map((diff) => ({
-					filePath: diff.filePath,
-					leftContent: diff.leftContent,
-					rightContent: diff.rightContent,
-				})),
-			})
+			return diffs
 		} finally {
 			await tempHost?.dispose("viewLatestCheckpointChanges")
 		}
+	}
+
+	/**
+	 * Gates the "View Changes" button on the completion row: the number of
+	 * files changed since the latest checkpoint, or 0 when nothing can be
+	 * compared (no task, no checkpoint, comparison failure).
+	 */
+	async getLatestCheckpointChangesCount(): Promise<number> {
+		try {
+			return (await this.computeLatestCheckpointChanges())?.length ?? 0
+		} catch (error) {
+			Logger.debug(`[SdkController] Failed to count latest checkpoint changes: ${error}`)
+			return 0
+		}
+	}
+
+	/**
+	 * "View Changes" on the completion row: opens a multi-file diff of
+	 * everything that changed between the latest checkpoint — snapshotted when
+	 * the user's last message started this run — and the current working tree.
+	 */
+	async viewLatestCheckpointChanges(): Promise<void> {
+		const diffs = await this.computeLatestCheckpointChanges()
+		if (diffs === undefined) {
+			HostProvider.window.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "No checkpoint was taken for this task. Checkpoints require the workspace to be a git repository.",
+			})
+			return
+		}
+		if (diffs.length === 0) {
+			HostProvider.window.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "No file changes found since your last message.",
+			})
+			return
+		}
+
+		await HostProvider.diff.openMultiFileDiff({
+			title: "Changes since your last message",
+			diffs: diffs.map((diff) => ({
+				filePath: diff.filePath,
+				leftContent: diff.leftContent,
+				rightContent: diff.rightContent,
+			})),
+		})
 	}
 
 	/**

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
@@ -1,6 +1,7 @@
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { GitCompareIcon } from "lucide-react"
-import { memo, useState } from "react"
+import { memo, useEffect, useState } from "react"
+import { cn } from "@/lib/utils"
 import { CheckpointsServiceClient } from "@/services/grpc-client"
 import { CopyButton } from "../common/CopyButton"
 import SuccessButton from "../common/SuccessButton"
@@ -17,6 +18,8 @@ interface CompletionOutputRowProps {
 	 * multi-file diff of everything that changed between the latest checkpoint
 	 * (taken when the user's last message started the run) and the current
 	 * working tree. Only meaningful on the latest, finalized completion row.
+	 * The button renders faded and disabled until the host confirms there are
+	 * changes to show.
 	 */
 	showViewChanges?: boolean
 }
@@ -31,6 +34,31 @@ interface CompletionOutputRowProps {
 export const CompletionOutputRow = memo(
 	({ text, quoteButtonState, handleQuoteClick, showViewChanges }: CompletionOutputRowProps) => {
 		const [viewChangesPending, setViewChangesPending] = useState(false)
+		// undefined = still checking; the button stays faded + disabled until
+		// the host confirms the latest run actually changed files.
+		const [hasChanges, setHasChanges] = useState<boolean | undefined>(undefined)
+
+		useEffect(() => {
+			if (!showViewChanges) {
+				return
+			}
+			let cancelled = false
+			CheckpointsServiceClient.checkpointLatestChangesCount(EmptyRequest.create({}))
+				.then((count) => {
+					if (!cancelled) {
+						setHasChanges((count.value ?? 0) > 0)
+					}
+				})
+				.catch((err) => {
+					console.error("Failed to check for latest changes:", err)
+					if (!cancelled) {
+						setHasChanges(false)
+					}
+				})
+			return () => {
+				cancelled = true
+			}
+		}, [showViewChanges])
 
 		return (
 			<div className="rounded-sm border border-success/20 overflow-visible bg-success/10">
@@ -47,15 +75,22 @@ export const CompletionOutputRow = memo(
 				{showViewChanges && (
 					<div className="px-2 pb-2">
 						<SuccessButton
-							className="w-full"
-							disabled={viewChangesPending}
+							className={cn("w-full transition-opacity duration-300", hasChanges ? "opacity-100" : "opacity-40")}
+							disabled={hasChanges !== true || viewChangesPending}
 							onClick={() => {
 								setViewChangesPending(true)
 								CheckpointsServiceClient.checkpointViewLatestChanges(EmptyRequest.create({}))
 									.catch((err) => console.error("Failed to view latest changes:", err))
 									.finally(() => setViewChangesPending(false))
 							}}
-							style={{ cursor: viewChangesPending ? "wait" : "pointer" }}>
+							style={{ cursor: viewChangesPending ? "wait" : hasChanges ? "pointer" : "default" }}
+							title={
+								hasChanges === undefined
+									? "Checking for changes…"
+									: hasChanges
+										? undefined
+										: "No file changes since your last message"
+							}>
 							<GitCompareIcon className="size-3 mr-1.5" />
 							View Changes
 						</SuccessButton>


### PR DESCRIPTION
### Related Issue

Follow-up to #13072 (this commit landed on that branch after the PR was squash-merged)

### Description

On the completion card, the "View Changes" button previously showed enabled on every latest completion, even when the turn changed no files (clicking then showed a "no changes" toast). This tightens the UX: the button now renders faded (low opacity) and disabled, and only enables once the host confirms the latest run actually changed files. No layout pop-in, and no dead button clicks on turns that did not touch the workspace.

- New `checkpointLatestChangesCount` RPC on `CheckpointsService`: returns the number of files changed between the latest checkpoint and the working tree (0 when nothing can be compared).
- `SdkController`: the checkpoint diff computation is extracted into a shared `computeLatestCheckpointChanges()`, backing both the new `getLatestCheckpointChangesCount()` (returns 0 on any failure, never throws) and the existing `viewLatestCheckpointChanges()` (behavior unchanged, info toasts kept as a race guard).
- `CompletionOutputRow`: when the card finalizes, the webview fires the count check once; the button transitions to full opacity and enables only if the count is greater than 0. Tooltips reflect the state ("Checking for changes..." / "No file changes since your last message").

### Test Procedure

- `bun run check-types`, `bun run lint`, and `bun run test:unit` (1060 tests, 72 files) all pass on this branch.
- Manual end-to-end test in the extension development host with a real OpenRouter-backed task:
  - A turn that edited a file: the button enabled after the check and clicking opened the "Changes since your last message" diff scoped to that run's change. When changes exist the check resolves fast enough that the faded state is only a brief flash, so there is no flicker in the common case.
  - A turn told not to touch any files: the button stayed faded and disabled, and clicking it did nothing.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The count check runs once per finalized latest completion and costs one git comparison, the same work the click itself performs.