### PR TITLE
fix(vscode): preserve error details in release logs

### DIFF
--- a/apps/vscode/src/shared/services/Logger.test.ts
+++ b/apps/vscode/src/shared/services/Logger.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test"
+
+const originalIsDev = process.env.IS_DEV
+process.env.IS_DEV = "false"
+
+const { Logger } = await import("./Logger")
+
+const messages: string[] = []
+Logger.subscribe((message) => messages.push(message))
+
+describe("Logger", () => {
+	beforeEach(() => {
+		messages.length = 0
+	})
+
+	afterAll(() => {
+		if (originalIsDev === undefined) {
+			delete process.env.IS_DEV
+		} else {
+			process.env.IS_DEV = originalIsDev
+		}
+	})
+
+	test("includes Error details without exposing other release arguments", () => {
+		Logger.error("Transport error:", new Error("connection refused"), { token: "sensitive-value" })
+
+		expect(messages).toHaveLength(1)
+		expect(messages[0]).toMatch(/ ERROR Transport error: connection refused$/)
+		expect(messages[0]).not.toContain("sensitive-value")
+	})
+
+	test("keeps non-Error arguments out of release logs", () => {
+		Logger.error("Request failed:", { detail: "sensitive-value" })
+
+		expect(messages).toHaveLength(1)
+		expect(messages[0]).toMatch(/ ERROR Request failed:$/)
+		expect(messages[0]).not.toContain("sensitive-value")
+	})
+
+	test("keeps Error details out of non-error release logs", () => {
+		Logger.log("Request details:", new Error("sensitive-value"))
+
+		expect(messages).toHaveLength(1)
+		expect(messages[0]).toMatch(/ LOG Request details:$/)
+		expect(messages[0]).not.toContain("sensitive-value")
+	})
+})

--- a/apps/vscode/src/shared/services/Logger.ts
+++ b/apps/vscode/src/shared/services/Logger.ts
@@ -24,7 +24,13 @@ export class Logger {
 	}
 
 	static error(message: string, ...args: any[]) {
-		Logger.#output("ERROR", message, undefined, args)
+		const [firstArg, ...remainingArgs] = args
+		Logger.#output(
+			"ERROR",
+			message,
+			firstArg instanceof Error ? firstArg : undefined,
+			firstArg instanceof Error ? remainingArgs : args,
+		)
 	}
 
 	static warn(message: string, ...args: any[]) {


### PR DESCRIPTION
### Related Issue

**Issue:** #13080

### Description

Release builds intentionally omit variadic logger arguments, but `Logger.error` also passed `undefined` to the dedicated error slot in `Logger.#output`. As a result, callers such as MCP transport handlers lost the `Error.message` that the logger already knew how to append.

This change routes a leading `Error` through that existing path and removes it from the verbose argument list. Other arguments remain omitted in release builds, and non-error log levels keep their current behavior.

### Test Procedure

- Added focused release-mode coverage for `Error.message`, non-`Error` arguments, and non-error log levels.
- `bun test apps/vscode/src/shared/services/Logger.test.ts` — 3 passed, 0 failed.
- Release and development-mode smoke checks confirmed that the error message is retained without serializing the `Error` as `{}` or exposing surrounding release arguments.
- `node --check apps/vscode/src/shared/services/Logger.ts` and `node --check apps/vscode/src/shared/services/Logger.test.ts` — passed.
- `git diff --check` — passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes backend log output only.

### Additional Notes

- The release path appends only `Error.message`; it does not serialize stacks, causes, arbitrary objects, strings, or other arguments.
- The focused test and formatting checks passed locally. The full extension suite, project lint, and typecheck were not run because this isolated worktree does not contain installed workspace dependencies; CI remains the authoritative full-project check.
