### PR TITLE
fix(cli): harden local Ollama agent shell and empty-response paths

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,54 @@
+# Fork notes (cli-v3.0.49 + local patches)
+
+This checkout is pinned at tag `cli-v3.0.49` on branch `fork-fixes`.
+The global `cline` command is `bun link`'d from `apps/cli` so it runs
+TypeScript source (via Bun), not the npm-published binary.
+
+`~/bin/cline-qwen` prefers `~/.bun/bin/cline` so sessions always use this fork.
+
+## Patches on this branch
+
+1. **Background-command detach** — `sdk/packages/core/src/extensions/tools/executors/bash.ts`
+   Resolve `run_commands` after the launched shell exits (with a short grace),
+   instead of waiting for inherited stdio pipes that a `nohup … &` grandchild
+   keeps open. Prevents the 30s timeout + process-group SIGKILL that used to
+   kill intentionally-backgrounded jobs.
+
+2. **Stringified `commands` unwrap** — `sdk/packages/core/src/extensions/tools/helpers.ts`
+   Some models emit `commands` as a JSON-encoded string (or a 1-element array
+   of that string). Unwrap before schema validation.
+
+3. **Empty-response hardening** — `sdk/packages/llms/src/providers/middleware/retry-empty-response.ts`
+   Treat whitespace-only deltas as empty; bump default max attempts 3 → 5.
+
+## Config (not code)
+
+- `~/.cline/data/settings/providers.json` → ollama `contextWindow: 65536`
+  (drives both Ollama `num_ctx` and the compaction budget).
+- `~/.cline/data/settings/global-settings.json` → `autoUpdateEnabled: false`
+  (the npm binary must not overwrite our linked fork's PATH preference mid-session).
+
+Compaction trigger / target ratios on this tag are already sensible
+(`COMPACTION_TRIGGER_RATIO = 0.9`); no source change needed for that.
+
+## Rebuild / re-link after edits
+
+```bash
+cd ~/src/cline
+export PATH="$HOME/.bun/bin:$PATH"
+bun run build:sdk          # required for bun-linked cline (no --conditions=development)
+# or, for a one-off without rebuild:
+bun run cli -- --version   # resolves packages from source
+```
+
+## Rebasing onto a newer CLI release
+
+```bash
+cd ~/src/cline
+git fetch origin
+git checkout fork-fixes
+git rebase cli-vX.Y.Z      # or merge
+# resolve any conflicts in the three files above
+bun install && bun run build:sdk
+cd apps/cli && bun link
+```

--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -439,4 +439,34 @@ describe.runIf(process.platform === "win32")("createWindowsExecutor", () => {
 		const output = await executor("echo shell-ok", process.cwd(), ctx);
 		expect(output.trim()).toBe("shell-ok");
 	});
+
+	it("returns promptly when a backgrounded job keeps stdout open", async () => {
+		// Reproduces the hang that used to SIGKILL the whole process group:
+		// `cd && nohup ... &` leaves a grandchild holding the shell's stdout
+		// pipe, so `close` never fires. After the fix, the shell's own `exit`
+		// settles the promise within the detach grace window.
+		const marker = join(
+			tmpdir(),
+			`cline-bg-alive-${Date.now()}-${Math.random().toString(16).slice(2)}.marker`,
+		);
+		const shell = createShellExecutor({ timeoutMs: 5_000 });
+		const started = Date.now();
+		const output = await shell(
+			`cd /tmp && nohup bash -c 'touch "${marker}"; sleep 30' >/dev/null 2>&1 & echo PID:$!`,
+			process.cwd(),
+			ctx,
+		);
+		const elapsed = Date.now() - started;
+		expect(elapsed).toBeLessThan(3_000);
+		expect(output).toMatch(/PID:\d+/);
+
+		// The background job must still be alive — we must not have
+		// process-group-killed it on settle.
+		const deadline = Date.now() + 2_000;
+		while (Date.now() < deadline && !(await fileExists(marker))) {
+			await new Promise((r) => setTimeout(r, 50));
+		}
+		expect(await fileExists(marker)).toBe(true);
+		await rm(marker, { force: true });
+	});
 });

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -29,6 +29,16 @@ export class CommandExitError extends Error {
 }
 
 /**
+ * Grace period after the launched shell exits before we resolve a command
+ * whose stdio pipes are still open. This only matters when a backgrounded or
+ * detached grandchild inherited the shell's stdout/stderr: the shell itself
+ * has exited (so `close` will never fire and we'd otherwise wait for the
+ * timeout and SIGKILL the whole process group), but a little slack lets any
+ * output the shell already emitted flush before we snapshot it.
+ */
+const BACKGROUND_DETACH_GRACE_MS = 750;
+
+/**
  * Options for the shell executor
  */
 export interface ShellExecutorOptions {
@@ -207,9 +217,11 @@ function spawnAndCollect(
 		};
 
 		let timeout: NodeJS.Timeout;
+		let exitGrace: NodeJS.Timeout | undefined;
 		const abortHandler = () => killAndReject(new Error("Command was aborted"));
 		const cleanup = () => {
 			clearTimeout(timeout);
+			if (exitGrace) clearTimeout(exitGrace);
 			context.signal?.removeEventListener("abort", abortHandler);
 		};
 		const killAndReject = (error: Error) => {
@@ -240,10 +252,7 @@ function spawnAndCollect(
 			stderr.append(data);
 		});
 
-		child.on("close", (code) => {
-			cleanup();
-			if (killed) return;
-
+		const finalizeFromStreams = (code: number | null) => {
 			const out = stdout.snapshot();
 			const err = stderr.snapshot();
 
@@ -283,6 +292,34 @@ function spawnAndCollect(
 				}
 				settle(() => resolve(output));
 			}
+		};
+
+		child.on("close", (code) => {
+			cleanup();
+			if (killed) return;
+			finalizeFromStreams(code);
+		});
+
+		// A backgrounded or detached grandchild (e.g. `nohup foo &`, or a
+		// `cd dir && cmd &` subshell) inherits the launched shell's stdout/
+		// stderr pipes, so `close` never fires even after the shell we spawned
+		// has already exited. Without this the command would sit until the
+		// timeout and then be SIGKILL'd as a process group — killing the
+		// intentionally-detached job too. Once the direct shell exits, give
+		// buffered output a brief window to flush, then resolve with what we
+		// have and leave the detached process running (no process-tree kill).
+		child.on("exit", (code) => {
+			if (settled || killed) return;
+			exitGrace = setTimeout(() => {
+				if (settled || killed) return;
+				cleanup();
+				// Stop waiting on the inherited pipe without killing the
+				// detached child (it keeps its own redirected fds).
+				child.stdout?.destroy();
+				child.stderr?.destroy();
+				child.unref?.();
+				finalizeFromStreams(code ?? 0);
+			}, BACKGROUND_DETACH_GRACE_MS);
 		});
 
 		child.on("error", (error) => {

--- a/sdk/packages/core/src/extensions/tools/helpers.test.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRunCommandsInput } from "./helpers";
+
+describe("normalizeRunCommandsInput", () => {
+	it("passes through a normal commands array", () => {
+		expect(normalizeRunCommandsInput({ commands: ["ls", "pwd"] })).toEqual([
+			"ls",
+			"pwd",
+		]);
+	});
+
+	it("unwraps a stringified JSON array in commands", () => {
+		expect(
+			normalizeRunCommandsInput({
+				commands: '["find /tmp -maxdepth 1","echo ok"]',
+			}),
+		).toEqual(["find /tmp -maxdepth 1", "echo ok"]);
+	});
+
+	it("unwraps a one-element array whose sole entry is a stringified array", () => {
+		expect(
+			normalizeRunCommandsInput({
+				commands: ['["echo a","echo b"]'],
+			}),
+		).toEqual(["echo a", "echo b"]);
+	});
+
+	it("leaves a legitimate single command that starts with [ alone", () => {
+		expect(
+			normalizeRunCommandsInput({
+				commands: ["[ -f /tmp/x ] && echo yes"],
+			}),
+		).toEqual(["[ -f /tmp/x ] && echo yes"]);
+	});
+});

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -134,10 +134,63 @@ export function coalesceOrphanReadRanges(input: unknown): unknown {
 	return input;
 }
 
+/**
+ * Parse a string that is a JSON array of strings, e.g. `'["ls","pwd"]'`.
+ * Returns undefined for anything else so a legitimate single command that
+ * merely starts with `[` is left untouched.
+ */
+function tryParseJsonStringArray(value: string): string[] | undefined {
+	const trimmed = value.trim();
+	if (trimmed[0] !== "[") return undefined;
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (Array.isArray(parsed) && parsed.every((x) => typeof x === "string")) {
+			return parsed;
+		}
+	} catch {
+		// Not valid JSON — treat as an ordinary command string.
+	}
+	return undefined;
+}
+
+/**
+ * Some models emit `commands` as a *stringified* JSON array (a single string
+ * like `'["find ...","grep ..."]'`) instead of an actual array, or as a
+ * one-element array whose sole element is that stringified array. Left as-is
+ * the shell would try to execute the literal `["..."]` text and fail. Unwrap
+ * those shapes back into a real array before schema validation.
+ */
+function unwrapStringifiedCommands(input: unknown): unknown {
+	if (
+		!input ||
+		typeof input !== "object" ||
+		Array.isArray(input) ||
+		!("commands" in input)
+	) {
+		return input;
+	}
+	const commands = (input as { commands: unknown }).commands;
+	if (typeof commands === "string") {
+		const parsed = tryParseJsonStringArray(commands);
+		if (parsed) return { ...input, commands: parsed };
+	} else if (
+		Array.isArray(commands) &&
+		commands.length === 1 &&
+		typeof commands[0] === "string"
+	) {
+		const parsed = tryParseJsonStringArray(commands[0]);
+		if (parsed) return { ...input, commands: parsed };
+	}
+	return input;
+}
+
 export function normalizeRunCommandsInput(
 	input: unknown,
 ): Array<string | StructuredCommandInput> {
-	const validate = validateWithZod(RunCommandsInputUnionSchema, input);
+	const validate = validateWithZod(
+		RunCommandsInputUnionSchema,
+		unwrapStringifiedCommands(input),
+	);
 
 	if (typeof validate === "string") {
 		return [validate];

--- a/sdk/packages/llms/src/providers/middleware/retry-empty-response.test.ts
+++ b/sdk/packages/llms/src/providers/middleware/retry-empty-response.test.ts
@@ -111,6 +111,23 @@ describe("createRetryEmptyResponseMiddleware", () => {
 		expect(parts.some((p) => p.type === "tool-call")).toBe(true);
 	});
 
+	it("retries a whitespace-only turn (not real content)", async () => {
+		const whitespaceParts = [
+			streamStart,
+			{ type: "text-delta" as const, id: "t", delta: " \n" },
+			finish(),
+		];
+		const doStream = vi
+			.fn()
+			.mockResolvedValueOnce(streamOf(whitespaceParts))
+			.mockResolvedValueOnce(streamOf(textParts));
+		const parts = await collect(await run(doStream));
+		expect(doStream).toHaveBeenCalledTimes(2);
+		expect(
+			parts.some((p) => p.type === "text-delta" && p.delta === "hello"),
+		).toBe(true);
+	});
+
 	it("gives up after maxAttempts and forwards the final empty finish", async () => {
 		const doStream = vi.fn(async () => streamOf(emptyParts));
 		const parts = await collect(await run(doStream, { maxAttempts: 3 }));

--- a/sdk/packages/llms/src/providers/middleware/retry-empty-response.ts
+++ b/sdk/packages/llms/src/providers/middleware/retry-empty-response.ts
@@ -42,8 +42,10 @@ export interface RetryEmptyResponseOptions {
 	logger?: RetryLogger;
 }
 
-/** Default total attempts (first try + 2 retries). */
-export const DEFAULT_EMPTY_RESPONSE_MAX_ATTEMPTS = 3;
+/** Default total attempts (first try + retries). Local backends (Ollama) can
+ * emit several empty turns in a row, so allow a few more than a cloud provider
+ * would need. */
+export const DEFAULT_EMPTY_RESPONSE_MAX_ATTEMPTS = 5;
 /** Default delay before a retry. */
 export const DEFAULT_EMPTY_RESPONSE_RETRY_DELAY_MS = 250;
 
@@ -66,7 +68,10 @@ function isContentPart(part: LanguageModelV3StreamPart): boolean {
 	switch (part.type) {
 		case "text-delta":
 		case "reasoning-delta":
-			return part.delta.length > 0;
+			// Whitespace-only deltas are not real output: some local backends
+			// emit a lone space/newline then stop, which would otherwise count
+			// as content and suppress the retry, surfacing an "empty response".
+			return part.delta.trim().length > 0;
 		case "tool-call":
 		case "tool-input-start":
 		case "tool-input-delta":


### PR DESCRIPTION
## Summary
- Resolve `run_commands` after the launched shell exits (with a short grace) so backgrounded/`nohup … &` jobs no longer wedge until the 30s timeout and get process-group SIGKILL'd
- Unwrap stringified JSON `commands` arrays some local models emit before schema validation
- Treat whitespace-only stream deltas as empty and raise default empty-response retries (3 → 5) for flaky Ollama turns

## Test plan
- [ ] `bun --filter @cline/core` / focused vitest: `bash.test.ts` background-detach case and `helpers.test.ts` stringified-commands cases
- [ ] `bun --filter @cline/llms` / `retry-empty-response.test.ts` whitespace-only retry case
- [ ] Manual: `run_commands` with `cd /tmp && nohup sleep 60 >/dev/null 2>&1 & echo PID:$!` returns promptly and the sleep keeps running
- [ ] Manual: Ollama empty/whitespace-only completion is retried instead of failing the turn immediately


Made with [Cursor](https://cursor.com)