### PR TITLE
fix(cli): apply ACP mode changes to initialized sessions

### DIFF
--- a/apps/cli/src/acp/acpAgent.test.ts
+++ b/apps/cli/src/acp/acpAgent.test.ts
@@ -1,0 +1,263 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import type { Message } from "@cline/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	createCliCore: vi.fn(),
+	resolveSystemPrompt: vi.fn(
+		async ({ mode }: { mode: "plan" | "act" }) => `system-${mode}`,
+	),
+	randomSessionId: vi.fn(() => "acp-session"),
+	sendCurrentModeUpdate: vi.fn(),
+	sendSessionInfoUpdate: vi.fn(),
+	subscribeToAgentEvents: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@agentclientprotocol/sdk", () => ({
+	PROTOCOL_VERSION: 1,
+	RequestError: {
+		authRequired: vi.fn(),
+		internalError: vi.fn(),
+		invalidParams: vi.fn(),
+		resourceNotFound: vi.fn(),
+	},
+}));
+
+vi.mock("@cline/core", () => ({
+	Llms: {
+		getModelsForProvider: vi.fn(async () => ({
+			"model-1": { name: "Model 1" },
+		})),
+		getProvider: vi.fn(async () => ({ defaultModelId: "model-1" })),
+	},
+	ProviderSettingsManager: class {},
+	SessionSource: { CLI: "cli" },
+}));
+
+vi.mock("@cline/shared", () => ({
+	isLikelyAuthError: vi.fn(() => false),
+}));
+
+vi.mock("../commands/auth", () => ({
+	getPersistedProviderApiKey: vi.fn(),
+}));
+
+vi.mock("../runtime/prompt", () => ({
+	resolveSystemPrompt: mocks.resolveSystemPrompt,
+}));
+
+vi.mock("../runtime/session-events", () => ({
+	subscribeToAgentEvents: mocks.subscribeToAgentEvents,
+}));
+
+vi.mock("../session/session", () => ({
+	createCliCore: mocks.createCliCore,
+}));
+
+vi.mock("../utils/cline-pass-errors", () => ({
+	isClineOrgIndividualInferenceSubscriptionErrorMessage: vi.fn(() => false),
+}));
+
+vi.mock("../utils/common", () => ({
+	getCliBuildInfo: vi.fn(() => ({ name: "cline", version: "test" })),
+}));
+
+vi.mock("../utils/helpers", () => ({
+	randomSessionId: mocks.randomSessionId,
+	resolveWorkspaceRoot: vi.fn((cwd: string) => cwd),
+}));
+
+vi.mock("./auth", () => ({
+	ACP_AUTH_METHODS: [],
+	authenticateAcpProvider: vi.fn(),
+	isAcpAuthMethodId: vi.fn(() => false),
+}));
+
+vi.mock("./auto-approve", () => ({
+	AUTO_APPROVE_CONFIG_ID: "auto-approve",
+	buildAutoApproveConfigOption: vi.fn((value: boolean) => ({
+		type: "boolean",
+		id: "auto-approve",
+		name: "Auto approve",
+		currentValue: value,
+	})),
+	parseAutoApproveValue: vi.fn(),
+}));
+
+vi.mock("./organizations", () => ({
+	ORGANIZATION_CONFIG_ID: "organization",
+	PERSONAL_ACCOUNT_VALUE: "personal",
+	buildOrganizationConfigOption: vi.fn(),
+	fetchClineOrganizations: vi.fn(),
+	getAcpOrgSubscriptionMessage: vi.fn(),
+	switchClineOrganization: vi.fn(),
+	usesClineAccount: vi.fn(() => false),
+}));
+
+vi.mock("./permissions", () => ({
+	requestAcpToolApproval: vi.fn(),
+}));
+
+vi.mock("./session-load", () => ({
+	replaySessionHistory: vi.fn(),
+}));
+
+vi.mock("./session-updates", () => ({
+	describeAgentError: vi.fn((error: unknown) => String(error)),
+	forwardAgentEvent: vi.fn(),
+	sendConfigOptionUpdate: vi.fn(),
+	sendCurrentModeUpdate: mocks.sendCurrentModeUpdate,
+	sendSessionInfoUpdate: mocks.sendSessionInfoUpdate,
+}));
+
+import { AcpAgent } from "./acpAgent";
+
+const envSnapshot = {
+	CLINE_API_KEY: process.env.CLINE_API_KEY,
+	CLINE_MODEL: process.env.CLINE_MODEL,
+	CLINE_PROVIDER: process.env.CLINE_PROVIDER,
+};
+
+function makeSessionManager(sessionId: string) {
+	return {
+		abort: vi.fn(async () => {}),
+		dispose: vi.fn(async () => {}),
+		readMessages: vi.fn<() => Promise<Message[]>>(async () => []),
+		send: vi.fn(async () => ({ finishReason: "completed" })),
+		start: vi.fn(async () => ({ sessionId })),
+	};
+}
+
+describe("AcpAgent session modes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.createCliCore.mockReset();
+		process.env.CLINE_API_KEY = "test-key";
+		delete process.env.CLINE_MODEL;
+		delete process.env.CLINE_PROVIDER;
+	});
+
+	afterEach(() => {
+		for (const [key, value] of Object.entries(envSnapshot)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	it("restarts an initialized session with act-mode config after session/set_mode", async () => {
+		const planManager = makeSessionManager("core-plan");
+		const actManager = makeSessionManager("core-act");
+		const history = [
+			{ role: "user" as const, content: "Plan the change" },
+			{ role: "assistant" as const, content: "Here is the plan" },
+		];
+		planManager.readMessages.mockResolvedValue(history);
+		mocks.createCliCore
+			.mockResolvedValueOnce(planManager)
+			.mockResolvedValueOnce(actManager);
+
+		const agent = new AcpAgent({} as AgentSideConnection);
+		const { sessionId } = await agent.newSession({
+			cwd: "/workspace",
+			mcpServers: [],
+		});
+
+		await agent.setSessionMode({ sessionId, modeId: "plan" });
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "Plan the change" }],
+		});
+
+		expect(planManager.start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.objectContaining({ mode: "plan", sessionId }),
+				initialMessages: undefined,
+			}),
+		);
+
+		await agent.setSessionMode({ sessionId, modeId: "act" });
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "Apply the change" }],
+		});
+
+		expect(mocks.createCliCore).toHaveBeenCalledTimes(2);
+		expect(planManager.readMessages).toHaveBeenCalledWith("core-plan");
+		expect(planManager.dispose).toHaveBeenCalledTimes(1);
+		expect(actManager.start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.objectContaining({ mode: "act", sessionId }),
+				initialMessages: history,
+				interactive: true,
+			}),
+		);
+		expect(actManager.send).toHaveBeenCalledWith({
+			sessionId: "core-act",
+			prompt: "Apply the change",
+		});
+	});
+
+	it("does not restart when the requested mode is already active", async () => {
+		const manager = makeSessionManager("core-act");
+		mocks.createCliCore.mockResolvedValueOnce(manager);
+
+		const agent = new AcpAgent({} as AgentSideConnection);
+		const { sessionId } = await agent.newSession({
+			cwd: "/workspace",
+			mcpServers: [],
+		});
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "Start" }],
+		});
+
+		await agent.setSessionMode({ sessionId, modeId: "act" });
+
+		expect(manager.readMessages).not.toHaveBeenCalled();
+		expect(manager.dispose).not.toHaveBeenCalled();
+		expect(mocks.sendCurrentModeUpdate).toHaveBeenCalledWith(
+			expect.anything(),
+			sessionId,
+			"act",
+		);
+	});
+
+	it("uses the same restart path for the mode config option", async () => {
+		const manager = makeSessionManager("core-act");
+		const history: Message[] = [{ role: "user", content: "Start in act mode" }];
+		manager.readMessages.mockResolvedValue(history);
+		mocks.createCliCore.mockResolvedValueOnce(manager);
+
+		const agent = new AcpAgent({} as AgentSideConnection);
+		const { sessionId } = await agent.newSession({
+			cwd: "/workspace",
+			mcpServers: [],
+		});
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "Start in act mode" }],
+		});
+
+		const response = await agent.setSessionConfigOption({
+			sessionId,
+			configId: "mode",
+			value: "plan",
+		});
+
+		expect(manager.readMessages).toHaveBeenCalledWith("core-act");
+		expect(manager.dispose).toHaveBeenCalledTimes(1);
+		expect(response.configOptions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "mode", currentValue: "plan" }),
+			]),
+		);
+		expect(mocks.sendCurrentModeUpdate).toHaveBeenCalledWith(
+			expect.anything(),
+			sessionId,
+			"plan",
+		);
+	});
+});

--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -416,7 +416,7 @@ export class AcpAgent implements Agent {
 		if (!session) {
 			throw new Error(`unknown session: ${params.sessionId}`);
 		}
-		session.currentMode = params.modeId;
+		await this.applySessionMode(session, params.modeId);
 		sendCurrentModeUpdate(this.conn, params.sessionId, params.modeId);
 		return {};
 	}
@@ -521,7 +521,7 @@ export class AcpAgent implements Agent {
 						`Invalid mode: ${value} (must be "plan" or "act")`,
 					);
 				}
-				session.currentMode = value;
+				await this.applySessionMode(session, value);
 				sendCurrentModeUpdate(this.conn, params.sessionId, value);
 				break;
 			}
@@ -596,6 +596,24 @@ export class AcpAgent implements Agent {
 		return process.env.CLINE_API_KEY ?? this.authResult?.apiKey ?? "";
 	}
 
+	private async applySessionMode(
+		session: SessionState,
+		mode: "plan" | "act",
+	): Promise<void> {
+		if (session.currentMode === mode) {
+			return;
+		}
+
+		if (session.sessionManager) {
+			// Mode controls the runtime's system prompt, tools, and command guards.
+			// Rebuild the active runtime so a completed plan turn cannot leave the
+			// next act turn attached to the old read-only task.
+			await this.teardownSessionManager(session, "session_manager_dispose");
+		}
+
+		session.currentMode = mode;
+	}
+
 	private async getOrganizationConfigOption(
 		providerId: string,
 	): Promise<SessionConfigOption | undefined> {
@@ -636,7 +654,10 @@ export class AcpAgent implements Agent {
 	 * Tear down the current session manager, preserving conversation messages
 	 * so they can be replayed into a new session manager.
 	 */
-	private async teardownSessionManager(session: SessionState): Promise<void> {
+	private async teardownSessionManager(
+		session: SessionState,
+		disposeReason = "provider_change",
+	): Promise<void> {
 		if (!session.sessionManager) {
 			return;
 		}
@@ -659,7 +680,7 @@ export class AcpAgent implements Agent {
 				.abort(session.activeSessionId)
 				.catch(() => {});
 		}
-		await session.sessionManager.dispose("provider_change").catch(() => {});
+		await session.sessionManager.dispose(disposeReason).catch(() => {});
 		session.sessionManager = undefined;
 		session.activeSessionId = undefined;
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #13040

### Description

After an ACP prompt initialized a Core session in plan mode, `session/set_mode` only updated the ACP-facing mode value. The existing Core runtime kept its plan-mode system prompt, tools, and command guards, so subsequent turns still rejected file changes after the client switched to act mode.

Mode changes now preserve the conversation and dispose the initialized runtime. The next prompt lazily rebuilds the same ACP session with the new mode. The dedicated `session/set_mode` request and the mode config option share this behavior, while repeated requests for the current mode continue without a restart.

### Test Procedure

- Added ACP lifecycle coverage for plan-to-act rebuilding with preserved history, same-mode no-op behavior, and the mode config option.
- Confirmed the main regression test fails against the previous logic because the Core session is created only once, then passes with the fix.
- Ran all ACP unit tests: 5 files and 24 tests passed.
- Ran Biome on both changed TypeScript files and `git diff --check`: passed.
- Ran the broader CLI unit suite: 1,127 of 1,131 tests passed. The four unrelated failures came from the isolated workspace lacking Bun on `PATH` for subprocess tests and from a borrowed dependency cache that does not match the current lockfile. For the same reason, the borrowed-cache typecheck reports dependency-version and missing-package errors outside the changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Focused tests and formatting checks pass. The complete repository checks could not be validated with the exact Bun 1.3.13 dependency environment in this isolated workspace.

### Screenshots

N/A — this changes ACP session lifecycle behavior without a visual UI change.

### Additional Notes

The unit test exercises the faulty lifecycle without requiring a model or credentials: it initializes a plan-mode Core session, switches to act, and verifies that the replacement session receives the preserved history and act-mode config.
