### PR TITLE
fix(core): preserve queued prompts across user-initiated aborts

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -2794,8 +2794,8 @@ describe("LocalRuntimeHost", () => {
 		expect(agentConfig?.telemetry).toBe(telemetry);
 	});
 
-	it("clears pending prompts after an interactive abort", async () => {
-		const sessionId = "sess-abort-clears-prompts";
+	it("preserves pending prompts through an interactive abort and drains them in order", async () => {
+		const sessionId = "sess-abort-preserves-prompts";
 		const manifest = createManifest(sessionId);
 		const sessionService = {
 			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
@@ -2825,6 +2825,7 @@ describe("LocalRuntimeHost", () => {
 		const runStarted = new Promise<void>((resolve) => {
 			markRunStarted = resolve;
 		});
+		const drainedPrompts: string[] = [];
 		const run = vi
 			.fn()
 			.mockImplementationOnce(
@@ -2838,10 +2839,17 @@ describe("LocalRuntimeHost", () => {
 						markRunStarted?.();
 					}),
 			)
-			.mockResolvedValueOnce(createResult({ text: "queued result" }));
+			.mockImplementation((prompt: string) => {
+				drainedPrompts.push(prompt);
+				return Promise.resolve(createResult({ text: "queued result" }));
+			});
+		const continueTurn = vi.fn().mockImplementation((prompt: string) => {
+			drainedPrompts.push(prompt);
+			return Promise.resolve(createResult());
+		});
 		const agent = {
 			run,
-			continue: vi.fn().mockResolvedValue(createResult()),
+			continue: continueTurn,
 			abort: vi.fn(),
 			subscribeEvents: vi.fn().mockReturnValue(() => {}),
 			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
@@ -2908,13 +2916,15 @@ describe("LocalRuntimeHost", () => {
 				}),
 			}),
 		);
-		expect(run).toHaveBeenCalledTimes(1);
-		expect(
-			(await manager.pendingPrompts.list({ sessionId })).map((prompt) => ({
-				prompt: prompt.prompt,
-				delivery: prompt.delivery,
-			})),
-		).toEqual([]);
+		// The abort must not eat the prompts the user queued: they drain once
+		// the abort settles, steered prompt first.
+		await vi.waitFor(async () => {
+			expect(drainedPrompts).toEqual([
+				'<user_input mode="act">steered prompt</user_input>',
+				'<user_input mode="act">queued prompt</user_input>',
+			]);
+			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
+		});
 	});
 
 	it("drains queued prompts after a turn that self-aborts (loop detector / mistake limit)", async () => {
@@ -3015,6 +3025,113 @@ describe("LocalRuntimeHost", () => {
 		await vi.waitFor(async () => {
 			expect(sentPrompts.slice(1)).toEqual([
 				'<user_input mode="act">queued prompt</user_input>',
+			]);
+			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
+		});
+	});
+
+	it("keeps queued prompts through a user-initiated abort and drains them after it settles", async () => {
+		const sessionId = "sess-user-abort-keeps-prompts";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest.json",
+				messagesPath: "/tmp/messages.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({
+				updated: true,
+				endedAt: "2026-01-01T00:00:05.000Z",
+			}),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({
+				tools: [],
+				shutdown: vi.fn(),
+			}),
+		};
+		let activeRun = false;
+		let rejectRun: ((error: Error) => void) | undefined;
+		let markRunStarted: (() => void) | undefined;
+		const runStarted = new Promise<void>((resolve) => {
+			markRunStarted = resolve;
+		});
+		const sentPrompts: string[] = [];
+		const run = vi.fn().mockImplementation((prompt: string) => {
+			sentPrompts.push(prompt);
+			activeRun = true;
+			markRunStarted?.();
+			return new Promise<AgentResult>((_resolve, reject) => {
+				rejectRun = (error: Error) => {
+					activeRun = false;
+					reject(error);
+				};
+			});
+		});
+		const continueTurn = vi.fn().mockImplementation((prompt: string) => {
+			sentPrompts.push(prompt);
+			return Promise.resolve(createResult({ text: "drained result" }));
+		});
+		const agent = {
+			run,
+			continue: continueTurn,
+			// A user abort tears the in-flight stream down, which surfaces to
+			// runTurn() as a rejection — the completeAbortedInteractiveTurn path.
+			abort: vi.fn().mockImplementation(() => {
+				rejectRun?.(new Error("aborted by user"));
+			}),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+			getMessages: vi.fn().mockReturnValue([]),
+			canStartRun: vi.fn(() => !activeRun),
+		};
+
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder,
+			createAgent: () => agent as never,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				interactive: true,
+			}),
+		);
+
+		const firstTurn = manager.runTurn({ sessionId, prompt: "slow" });
+		await runStarted;
+		await manager.runTurn({
+			sessionId,
+			prompt: "queued survivor",
+			delivery: "queue",
+		});
+		expect(
+			(await manager.pendingPrompts.list({ sessionId })).map((prompt) => ({
+				prompt: prompt.prompt,
+				delivery: prompt.delivery,
+			})),
+		).toEqual([{ prompt: "queued survivor", delivery: "queue" }]);
+
+		await manager.abort(sessionId);
+		await expect(firstTurn).resolves.toMatchObject({
+			finishReason: "aborted",
+		});
+
+		// The queued prompt must survive the abort and run once it settles —
+		// aborting only stops the in-flight turn, it must never eat input the
+		// user already typed and queued.
+		await vi.waitFor(async () => {
+			expect(sentPrompts.slice(1)).toEqual([
+				'<user_input mode="act">queued survivor</user_input>',
 			]);
 			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
 		});

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1025,10 +1025,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 			} else {
 				await this.completeInteractiveTurn(session, result.finishReason);
 			}
-			// Drain after "aborted" finishes too: internal stops (loop
-			// detector / mistake limit) would otherwise strand user-queued
-			// prompts forever, and user-initiated aborts already cleared the
-			// queue in abortSession(). "error" finishes deliberately do NOT
+			// Drain after "aborted" finishes too: both internal stops (loop
+			// detector / mistake limit) and user-initiated aborts keep the
+			// queue intact, so without a drain here the user-queued prompts
+			// would be stranded forever. "error" finishes deliberately do NOT
 			// drain — auto-running queued prompts into a failing provider
 			// would consume them; they stay queued and drain on the next
 			// enqueue/update or successful turn.
@@ -1076,8 +1076,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 			event: "session.aborted",
 			properties: { sessionId },
 		});
+		// Deliberately leave pendingPrompts untouched: aborting only stops the
+		// in-flight turn. Clearing here would silently destroy prompts the user
+		// already typed and queued — they drain once the abort completes.
 		session.aborting = true;
-		this.pendingPromptsController.clearAborted(session);
 		session.agent.abort(reason);
 	}
 
@@ -1725,6 +1727,13 @@ export class LocalRuntimeHost implements RuntimeHost {
 			usage,
 		});
 		await this.completeInteractiveTurn(session, "aborted");
+		// The abort is fully settled (aborting flag reset above), so prompts
+		// the user queued behind the stopped turn can run now. This mirrors
+		// the drain in runTurn() for turns that resolve with an "aborted"
+		// finish; this path handles turns that end by throwing instead.
+		queueMicrotask(() => {
+			void this.pendingPromptsController.drain(session.sessionId);
+		});
 		return {
 			text: "",
 			usage,

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -197,11 +197,6 @@ export class PendingPromptService {
 		state.pendingPrompts.unshift(entry);
 		return snapshotPrompts(state);
 	}
-
-	clear(state: PendingPromptQueueState): SessionPendingPrompt[] {
-		state.pendingPrompts.length = 0;
-		return [];
-	}
 }
 
 export class PendingPromptsController {
@@ -260,12 +255,6 @@ export class PendingPromptsController {
 		this.emitPrompts(session);
 		this.emitSubmitted(session, steer);
 		return steer;
-	}
-
-	clearAborted(session: ActiveSession): void {
-		if (session.pendingPrompts.length === 0) return;
-		this.service.clear(session);
-		this.emitPrompts(session);
 	}
 
 	emitPrompts(session: ActiveSession): void {


### PR DESCRIPTION
Pressing stop while prompts were queued silently destroyed them: abort() called clearAborted(), which emptied the pending prompt queue with no way to recover the typed input. The prompts vanished from the UI, were never sent, and left no trace in session artifacts.

Aborting now only stops the in-flight turn. Queued prompts stay in the queue and drain once the abort settles, matching the drain behavior that already existed for self-aborted turns (loop detector / mistake limit). The thrown-abort path (completeAbortedInteractiveTurn) now schedules the same drain that runTurn schedules for turns resolving with an aborted finish.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
