### PR TITLE
fix(desktop): canonicalize diff panel paths against the session cwd

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -625,6 +625,7 @@ export function useChatSession() {
 		setPromptsInQueue(value as PromptInQueue[]);
 	}, []);
 
+	const sessionDiffCwd = (config.cwd || config.workspaceRoot || "").trim();
 	const refreshSessionDiffSummary = useCallback(
 		async (targetSessionId: string) => {
 			try {
@@ -632,7 +633,7 @@ export function useChatSession() {
 					"read_session_hooks",
 					{ sessionId: targetSessionId, limit: MAX_MESSAGES },
 				);
-				const diffState = buildSessionDiffState(events);
+				const diffState = buildSessionDiffState(events, sessionDiffCwd);
 				setFileDiffs(diffState.fileDiffs);
 				setDiffSummary(diffState.summary);
 				setToolCalls(
@@ -645,7 +646,7 @@ export function useChatSession() {
 				// Ignore in non-Tauri mode.
 			}
 		},
-		[],
+		[sessionDiffCwd],
 	);
 
 	// ---- Message helpers ----
@@ -914,13 +915,13 @@ export function useChatSession() {
 		if (events.length === 0) {
 			return;
 		}
-		const diffState = buildSessionDiffState(events);
+		const diffState = buildSessionDiffState(events, sessionDiffCwd);
 		if (diffState.fileDiffs.length === 0) {
 			return;
 		}
 		setFileDiffs(diffState.fileDiffs);
 		setDiffSummary(diffState.summary);
-	}, [sessionId, messages, fileDiffs.length]);
+	}, [sessionId, messages, fileDiffs.length, sessionDiffCwd]);
 
 	useEffect(() => {
 		const activeSessionId = sessionId;

--- a/apps/examples/desktop-app/webview/lib/session-diff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.test.ts
@@ -47,6 +47,54 @@ describe("mergeToolDiffs path canonicalization", () => {
 		expect(merged[0]?.hunks).toHaveLength(2);
 	});
 
+	it("collapses parent segments so escaped spellings merge with the absolute path", () => {
+		const merged = mergeToolDiffs(
+			[
+				editorCreateEvent("../shared/config.txt", "x"),
+				editorReplaceEvent("/tmp/shared/config.txt", "+2: y"),
+			],
+			"/tmp/qa-ws",
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			path: "/tmp/shared/config.txt",
+			additions: 2,
+			deletions: 0,
+		});
+	});
+
+	it("collapses redundant segments inside the workspace", () => {
+		const merged = mergeToolDiffs(
+			[
+				editorCreateEvent("sub/../journal.txt", "one"),
+				editorReplaceEvent("/tmp/qa-ws/./journal.txt", "+2: two"),
+			],
+			"/tmp/qa-ws",
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			path: "journal.txt",
+			additions: 2,
+			deletions: 0,
+		});
+	});
+
+	it("keeps canonicalizing when the cwd is the filesystem root", () => {
+		const merged = mergeToolDiffs(
+			[
+				editorCreateEvent("notes.txt", "one"),
+				editorReplaceEvent("/notes.txt", "+2: two"),
+			],
+			"/",
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			path: "notes.txt",
+			additions: 2,
+			deletions: 0,
+		});
+	});
+
 	it("keeps files outside the cwd on their resolved path", () => {
 		const merged = mergeToolDiffs(
 			[editorCreateEvent("/etc/other/config.txt", "x")],

--- a/apps/examples/desktop-app/webview/lib/session-diff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.test.ts
@@ -14,10 +14,7 @@ function editorCreateEvent(path: string, newText: string): SessionHookEvent {
 	};
 }
 
-function editorReplaceEvent(
-	path: string,
-	diffBody: string,
-): SessionHookEvent {
+function editorReplaceEvent(path: string, diffBody: string): SessionHookEvent {
 	return {
 		hookName: "tool_result",
 		toolName: "editor",

--- a/apps/examples/desktop-app/webview/lib/session-diff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.test.ts
@@ -95,6 +95,22 @@ describe("mergeToolDiffs path canonicalization", () => {
 		});
 	});
 
+	it("merges Windows casing variants of the same file", () => {
+		const merged = mergeToolDiffs(
+			[
+				editorCreateEvent("Journal.txt", "one"),
+				editorReplaceEvent("c:\\users\\saoud\\journal.txt", "+2: two"),
+			],
+			"C:\\Users\\Saoud",
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			path: "Journal.txt",
+			additions: 2,
+			deletions: 0,
+		});
+	});
+
 	it("keeps files outside the cwd on their resolved path", () => {
 		const merged = mergeToolDiffs(
 			[editorCreateEvent("/etc/other/config.txt", "x")],

--- a/apps/examples/desktop-app/webview/lib/session-diff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSessionDiffState,
+	mergeToolDiffs,
+	type SessionHookEvent,
+} from "./session-diff";
+
+function editorCreateEvent(path: string, newText: string): SessionHookEvent {
+	return {
+		hookName: "tool_result",
+		toolName: "editor",
+		toolInput: { path, new_text: newText },
+		toolOutput: { success: true, result: `File created: ${path}` },
+	};
+}
+
+function editorReplaceEvent(
+	path: string,
+	diffBody: string,
+): SessionHookEvent {
+	return {
+		hookName: "tool_result",
+		toolName: "editor",
+		toolInput: { path, old_text: "before", new_text: "after" },
+		toolOutput: {
+			success: true,
+			result: `Edited ${path}\n\`\`\`diff\n${diffBody}\n\`\`\``,
+		},
+	};
+}
+
+describe("mergeToolDiffs path canonicalization", () => {
+	it("merges relative and absolute spellings of the same file into one entry", () => {
+		// Regression: a file created with a relative path and later edited via
+		// its absolute path was listed twice, splitting the counts and showing
+		// stale content as a separate entry.
+		const events = [
+			editorCreateEvent("journal.txt", "line one\nline two"),
+			editorReplaceEvent("/tmp/qa-ws/journal.txt", "+3: line three"),
+		];
+
+		const merged = mergeToolDiffs(events, "/tmp/qa-ws");
+
+		expect(merged).toHaveLength(1);
+		expect(merged[0]).toMatchObject({
+			path: "journal.txt",
+			additions: 3,
+			deletions: 0,
+		});
+		expect(merged[0]?.hunks).toHaveLength(2);
+	});
+
+	it("keeps files outside the cwd on their resolved path", () => {
+		const merged = mergeToolDiffs(
+			[editorCreateEvent("/etc/other/config.txt", "x")],
+			"/tmp/qa-ws",
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0]?.path).toBe("/etc/other/config.txt");
+	});
+
+	it("keeps distinct files separate", () => {
+		const merged = mergeToolDiffs(
+			[
+				editorCreateEvent("a.txt", "one"),
+				editorCreateEvent("/tmp/qa-ws/b.txt", "two"),
+			],
+			"/tmp/qa-ws",
+		);
+		expect(merged.map((entry) => entry.path).sort()).toEqual([
+			"a.txt",
+			"b.txt",
+		]);
+	});
+
+	it("falls back to raw path keys without a cwd", () => {
+		const merged = mergeToolDiffs([
+			editorCreateEvent("journal.txt", "one"),
+			editorCreateEvent("/tmp/qa-ws/journal.txt", "two"),
+		]);
+		// Without a cwd there is no way to know these are the same file.
+		expect(merged).toHaveLength(2);
+	});
+
+	it("sums the summary across canonicalized entries", () => {
+		const state = buildSessionDiffState(
+			[
+				editorCreateEvent("journal.txt", "line one\nline two"),
+				editorReplaceEvent("/tmp/qa-ws/journal.txt", "+3: line three"),
+			],
+			"/tmp/qa-ws",
+		);
+		expect(state.summary).toEqual({ additions: 3, deletions: 0 });
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/session-diff.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.ts
@@ -459,30 +459,76 @@ function parseApplyPatchFileDiffs(event: SessionHookEvent): SessionFileDiff[] {
 }
 
 /**
+ * Collapses "." and ".." segments and rebuilds the path with the given
+ * separator. The webview has no `node:path`, so this is a string-level
+ * equivalent; both separator styles are treated as separators, matching
+ * `resolveWorkspaceFilePath`. ".." segments that would climb above an
+ * absolute root are dropped; on relative paths leading ".." is kept.
+ */
+function collapsePathSegments(path: string, separator: string): string {
+	const rootMatch = path.match(/^(?:\\\\|[A-Za-z]:[\\/]|[\\/])/);
+	const rawRoot = rootMatch?.[0] ?? "";
+	const root =
+		rawRoot === ""
+			? ""
+			: rawRoot === "\\\\"
+				? "\\\\"
+				: /^[A-Za-z]:/.test(rawRoot)
+					? rawRoot.slice(0, 2) + separator
+					: separator;
+	const segments: string[] = [];
+	for (const segment of path.slice(rawRoot.length).split(/[\\/]+/)) {
+		if (!segment || segment === ".") {
+			continue;
+		}
+		if (segment === "..") {
+			if (segments.length > 0 && segments[segments.length - 1] !== "..") {
+				segments.pop();
+			} else if (!root) {
+				segments.push("..");
+			}
+			continue;
+		}
+		segments.push(segment);
+	}
+	return root + segments.join(separator);
+}
+
+/**
  * Tool calls address the same file inconsistently across a session — one
  * edit uses "journal.txt", a later one "/tmp/workspace/journal.txt". Keying
  * diffs by the raw string would list that file twice with split counts, so
- * paths are canonicalized against the session cwd first. Files inside the
- * cwd display as workspace-relative paths; everything else displays as the
- * resolved path.
+ * paths are canonicalized against the session cwd first: resolved against
+ * the cwd with "." and ".." segments collapsed, so "../shared/file.txt"
+ * and its absolute spelling share one key, and a filesystem-root cwd such
+ * as "/" still canonicalizes. Files inside the cwd display as
+ * workspace-relative paths; everything else displays as the resolved path.
  */
 function canonicalizeDiffPath(
 	path: string,
 	cwd?: string,
 ): { key: string; display: string } {
 	const trimmed = path.trim().replace(/^\.\//, "");
-	const base = (cwd ?? "").trim().replace(/[\\/]+$/, "");
+	const baseRaw = (cwd ?? "").trim();
+	if (!baseRaw) {
+		return { key: trimmed, display: trimmed };
+	}
+	const separator =
+		baseRaw.includes("\\") && !baseRaw.includes("/") ? "\\" : "/";
+	const base = collapsePathSegments(baseRaw, separator);
 	if (!base) {
 		return { key: trimmed, display: trimmed };
 	}
-	const resolved = resolveWorkspaceFilePath(trimmed, base);
+	const resolved = collapsePathSegments(
+		resolveWorkspaceFilePath(trimmed, base),
+		separator,
+	);
+	const basePrefix = base.endsWith(separator) ? base : base + separator;
 	const withinBase =
-		resolved.length > base.length + 1 &&
-		resolved.startsWith(base) &&
-		(resolved[base.length] === "/" || resolved[base.length] === "\\");
+		resolved.length > basePrefix.length && resolved.startsWith(basePrefix);
 	return {
 		key: resolved,
-		display: withinBase ? resolved.slice(base.length + 1) : resolved,
+		display: withinBase ? resolved.slice(basePrefix.length) : resolved,
 	};
 }
 

--- a/apps/examples/desktop-app/webview/lib/session-diff.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.ts
@@ -501,8 +501,10 @@ function collapsePathSegments(path: string, separator: string): string {
  * paths are canonicalized against the session cwd first: resolved against
  * the cwd with "." and ".." segments collapsed, so "../shared/file.txt"
  * and its absolute spelling share one key, and a filesystem-root cwd such
- * as "/" still canonicalizes. Files inside the cwd display as
- * workspace-relative paths; everything else displays as the resolved path.
+ * as "/" still canonicalizes. Windows sessions (drive-letter or UNC cwd)
+ * compare case-insensitively, matching `normalizeWorkspacePath`. Files
+ * inside the cwd display as workspace-relative paths; everything else
+ * displays as the resolved path, both in the first spelling seen.
  */
 function canonicalizeDiffPath(
 	path: string,
@@ -523,11 +525,15 @@ function canonicalizeDiffPath(
 		resolveWorkspaceFilePath(trimmed, base),
 		separator,
 	);
+	const caseInsensitive = /^[A-Za-z]:/.test(base) || base.startsWith("\\\\");
+	const comparable = (value: string) =>
+		caseInsensitive ? value.toLowerCase() : value;
 	const basePrefix = base.endsWith(separator) ? base : base + separator;
 	const withinBase =
-		resolved.length > basePrefix.length && resolved.startsWith(basePrefix);
+		resolved.length > basePrefix.length &&
+		comparable(resolved).startsWith(comparable(basePrefix));
 	return {
-		key: resolved,
+		key: comparable(resolved),
 		display: withinBase ? resolved.slice(basePrefix.length) : resolved,
 	};
 }

--- a/apps/examples/desktop-app/webview/lib/session-diff.ts
+++ b/apps/examples/desktop-app/webview/lib/session-diff.ts
@@ -1,3 +1,5 @@
+import { resolveWorkspaceFilePath } from "./workspace-paths";
+
 export type SessionHookEvent = {
 	hookEventName?:
 		| "tool_call"
@@ -456,7 +458,38 @@ function parseApplyPatchFileDiffs(event: SessionHookEvent): SessionFileDiff[] {
 	return parseApplyPatchInput(patchInput);
 }
 
-export function mergeToolDiffs(events: SessionHookEvent[]): SessionFileDiff[] {
+/**
+ * Tool calls address the same file inconsistently across a session — one
+ * edit uses "journal.txt", a later one "/tmp/workspace/journal.txt". Keying
+ * diffs by the raw string would list that file twice with split counts, so
+ * paths are canonicalized against the session cwd first. Files inside the
+ * cwd display as workspace-relative paths; everything else displays as the
+ * resolved path.
+ */
+function canonicalizeDiffPath(
+	path: string,
+	cwd?: string,
+): { key: string; display: string } {
+	const trimmed = path.trim().replace(/^\.\//, "");
+	const base = (cwd ?? "").trim().replace(/[\\/]+$/, "");
+	if (!base) {
+		return { key: trimmed, display: trimmed };
+	}
+	const resolved = resolveWorkspaceFilePath(trimmed, base);
+	const withinBase =
+		resolved.length > base.length + 1 &&
+		resolved.startsWith(base) &&
+		(resolved[base.length] === "/" || resolved[base.length] === "\\");
+	return {
+		key: resolved,
+		display: withinBase ? resolved.slice(base.length + 1) : resolved,
+	};
+}
+
+export function mergeToolDiffs(
+	events: SessionHookEvent[],
+	cwd?: string,
+): SessionFileDiff[] {
 	const byPath = new Map<string, SessionFileDiff>();
 
 	for (const event of events) {
@@ -471,13 +504,14 @@ export function mergeToolDiffs(events: SessionHookEvent[]): SessionFileDiff[] {
 		}
 
 		for (const diff of diffs) {
-			const existing = byPath.get(diff.path);
+			const { key, display } = canonicalizeDiffPath(diff.path, cwd);
+			const existing = byPath.get(key);
 			if (!existing) {
-				byPath.set(diff.path, diff);
+				byPath.set(key, { ...diff, path: display });
 				continue;
 			}
 
-			byPath.set(diff.path, {
+			byPath.set(key, {
 				...existing,
 				additions: existing.additions + diff.additions,
 				deletions: existing.deletions + diff.deletions,
@@ -504,8 +538,9 @@ export function summarizeFileDiffs(
 
 export function buildSessionDiffState(
 	events: SessionHookEvent[],
+	cwd?: string,
 ): SessionDiffState {
-	const fileDiffs = mergeToolDiffs(events);
+	const fileDiffs = mergeToolDiffs(events, cwd);
 	return {
 		fileDiffs,
 		summary: summarizeFileDiffs(fileDiffs),


### PR DESCRIPTION
Tool calls address the same file inconsistently across a session: one edit uses a workspace-relative path (journal.txt), a later one the absolute path (/tmp/ws/journal.txt). mergeToolDiffs keyed entries by the raw string, so the same file was listed twice in the diff panel with split +/- counts and inconsistent naming, most visibly after git was initialized mid-session and the model switched to absolute paths.

Diff paths are now canonicalized against the session cwd before merging: entries for the same file collapse into one, files inside the cwd display as workspace-relative paths, and files outside it display their resolved path. Without a cwd the previous raw-key behavior is kept.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
