### PR TITLE
fix(core): never run a foreign compiled plugin-sandbox bootstrap for a source host

### DIFF
--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
@@ -669,7 +669,53 @@ describe("plugin-sandbox", () => {
 		]);
 	});
 
-	it("resolves sandbox bootstrap from the npm wrapper platform package", async () => {
+	it("selects sibling, then source, then installed bootstrap candidates", async () => {
+		const { selectBootstrapCandidate } = await import("./plugin-sandbox");
+		const makeExists = (existing: string[]) => (path: string) =>
+			existing.includes(path);
+
+		// Compiled bundle: the sibling bootstrap matches the host build.
+		expect(
+			selectBootstrapCandidate({
+				siblingCandidates: ["/dist/extensions/plugin-sandbox-bootstrap.js"],
+				sourceBootstrapPath: "/src/plugin-sandbox-bootstrap.ts",
+				installedCandidates: ["/wrapper/extensions/bootstrap.js"],
+				exists: makeExists([
+					"/dist/extensions/plugin-sandbox-bootstrap.js",
+					"/wrapper/extensions/bootstrap.js",
+				]),
+			}),
+		).toEqual({ file: "/dist/extensions/plugin-sandbox-bootstrap.js" });
+
+		// Source host: the source bootstrap must win over a separately
+		// installed CLI package's compiled bootstrap. A published bootstrap
+		// resolves modules against the other installation's layout and
+		// silently breaks plugin loading for the source host.
+		expect(
+			selectBootstrapCandidate({
+				siblingCandidates: ["/src/plugin-sandbox-bootstrap.js"],
+				sourceBootstrapPath: "/src/plugin-sandbox-bootstrap.ts",
+				installedCandidates: ["/wrapper/extensions/bootstrap.js"],
+				exists: makeExists([
+					"/src/plugin-sandbox-bootstrap.ts",
+					"/wrapper/extensions/bootstrap.js",
+				]),
+			}),
+		).toEqual({ sourcePath: "/src/plugin-sandbox-bootstrap.ts" });
+
+		// Compiled binary (bunfs import.meta): nothing exists on disk next to
+		// the module, so the installed wrapper bootstrap is the right one.
+		expect(
+			selectBootstrapCandidate({
+				siblingCandidates: ["/$bunfs/root/plugin-sandbox-bootstrap.js"],
+				sourceBootstrapPath: "/$bunfs/root/plugin-sandbox-bootstrap.ts",
+				installedCandidates: [undefined, "/wrapper/extensions/bootstrap.js"],
+				exists: makeExists(["/wrapper/extensions/bootstrap.js"]),
+			}),
+		).toEqual({ file: "/wrapper/extensions/bootstrap.js" });
+	});
+
+	it("ignores the npm wrapper platform package bootstrap when running from source", async () => {
 		const previousWrapperPath = process.env.CLINE_WRAPPER_PATH;
 		const wrapperRoot = await mkdtemp(
 			join(tmpdir(), "core-plugin-sandbox-wrapper-"),
@@ -742,13 +788,19 @@ describe("plugin-sandbox", () => {
 			});
 
 			try {
+				// Regression: this host runs from source, so the sandbox must run
+				// the source bootstrap, NOT the wrapper package's compiled one. The
+				// fake wrapper bootstrap would report a "wrapper-bootstrap" plugin
+				// and emit wrapper_bootstrap_selected; with the source bootstrap in
+				// charge, the (nonexistent) plugin path simply fails to load.
 				expect(
-					sandboxed.extensions?.map((extension) => extension.name),
-				).toEqual(["wrapper-bootstrap"]);
-				expect(events).toContainEqual({
+					sandboxed.extensions?.map((extension) => extension.name) ?? [],
+				).toEqual([]);
+				expect(events).not.toContainEqual({
 					name: "wrapper_bootstrap_selected",
 					payload: { ok: true },
 				});
+				expect(sandboxed.failures.length).toBeGreaterThan(0);
 			} finally {
 				await sandboxed.shutdown();
 			}

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -179,6 +179,39 @@ function resolveBootstrapFromExecutable(): string | undefined {
 }
 
 /**
+ * Pick the bootstrap the sandbox subprocess should run.
+ *
+ * Sibling compiled candidates always match the running host build, so they
+ * win. When the host runs from source (the `.ts` bootstrap exists next to
+ * this module), the sandbox must run that SAME source bootstrap: the
+ * wrapper/executable fallbacks locate compiled bootstraps from a separately
+ * installed CLI package (e.g. a published version in the package-manager
+ * cache), and mixing that code with a source host silently breaks plugin
+ * loading because its module resolution points at the other installation's
+ * layout. Those fallbacks exist only for compiled hosts
+ * (`bun build --compile`) where import.meta points inside the binary and no
+ * sibling file exists on real disk.
+ */
+export function selectBootstrapCandidate(options: {
+	siblingCandidates: string[];
+	sourceBootstrapPath: string;
+	installedCandidates: Array<string | undefined>;
+	exists?: (path: string) => boolean;
+}): { file: string } | { sourcePath: string } {
+	const exists = options.exists ?? existsSync;
+	for (const candidate of options.siblingCandidates) {
+		if (exists(candidate)) return { file: candidate };
+	}
+	if (exists(options.sourceBootstrapPath)) {
+		return { sourcePath: options.sourceBootstrapPath };
+	}
+	for (const candidate of options.installedCandidates) {
+		if (candidate && exists(candidate)) return { file: candidate };
+	}
+	return { sourcePath: options.sourceBootstrapPath };
+}
+
+/**
  * Resolve the bootstrap for the sandbox subprocess.
  *
  * In production (bundled), the compiled `.js` file lives next to this module
@@ -193,19 +226,22 @@ function resolveBootstrap(): { file: string } | { script: string } {
 	// In production, the main bundle is at dist/ and the bootstrap is emitted
 	// under dist/extensions/. Keep the older dist/agents/ fallback for
 	// compatibility with previously built layouts.
-	const candidates = [
-		join(dir, "plugin-sandbox-bootstrap.js"),
-		join(dir, "extensions", "plugin-sandbox-bootstrap.js"),
-		join(dir, "agents", "plugin-sandbox-bootstrap.js"),
-		resolveBootstrapFromWrapper(),
-		resolveBootstrapFromExecutable(),
-	];
-	for (const candidate of candidates.filter(
-		(candidate): candidate is string => typeof candidate === "string",
-	)) {
-		if (existsSync(candidate)) return { file: candidate };
+	const selected = selectBootstrapCandidate({
+		siblingCandidates: [
+			join(dir, "plugin-sandbox-bootstrap.js"),
+			join(dir, "extensions", "plugin-sandbox-bootstrap.js"),
+			join(dir, "agents", "plugin-sandbox-bootstrap.js"),
+		],
+		sourceBootstrapPath: join(dir, "plugin-sandbox-bootstrap.ts"),
+		installedCandidates: [
+			resolveBootstrapFromWrapper(),
+			resolveBootstrapFromExecutable(),
+		],
+	});
+	if ("file" in selected) {
+		return selected;
 	}
-	const tsPath = join(dir, "plugin-sandbox-bootstrap.ts");
+	const tsPath = selected.sourcePath;
 	let jitiSpecifier = "jiti";
 	try {
 		jitiSpecifier = requireFromHere.resolve("jiti");

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -440,9 +440,9 @@ export class CoreSettingsService {
 						};
 					}
 				} catch {
-				// Settings listing is best-effort; unreadable plugin roots should
-				// not hide rules, skills, workflows, or built-in tools.
-			}
+					// Settings listing is best-effort; unreadable plugin roots should
+					// not hide rules, skills, workflows, or built-in tools.
+				}
 			}
 
 			const mcpSettingsPath = resolveDefaultMcpSettingsPath();

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -440,9 +440,9 @@ export class CoreSettingsService {
 						};
 					}
 				} catch {
-					// Settings listing is best-effort; unreadable plugin roots should
-					// not hide rules, skills, workflows, or built-in tools.
-				}
+				// Settings listing is best-effort; unreadable plugin roots should
+				// not hide rules, skills, workflows, or built-in tools.
+			}
 			}
 
 			const mcpSettingsPath = resolveDefaultMcpSettingsPath();


### PR DESCRIPTION
the hub daemon (running from source with CLINE_WRAPPER_PATH set) picked a published 3.0.51 plugin-sandbox-bootstrap.js out of Bun's install cache, so every plugin failed with Cannot find module '@cline/core' and the failure was swallowed. Bootstrap selection (now the testable selectBootstrapCandidate) prefers sibling compiled, then source, then installed fallbacks (which remain for compiled binaries). Verified end to end: Settings > Tools now lists the background-terminal plugin's three tools.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
