### PR TITLE
fix(desktop): stop treating leftover plugin install dirs as installed

### DIFF
--- a/apps/examples/desktop-app/sidecar/marketplace.test.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getOfficialPluginInstallPath,
+	installMarketplaceEntry,
+	listMarketplaceInstalledEntries,
+} from "./marketplace";
+import type { JsonRecord } from "./types";
+
+const GOAL_ENTRY = {
+	id: "goal",
+	type: "plugin",
+	name: "Goal",
+	install: { args: ["goal"] },
+};
+
+let tempClineDir: string;
+let previousClineDir: string | undefined;
+
+beforeEach(async () => {
+	tempClineDir = await mkdtemp(join(tmpdir(), "desktop-marketplace-"));
+	previousClineDir = process.env.CLINE_DIR;
+	process.env.CLINE_DIR = tempClineDir;
+});
+
+afterEach(async () => {
+	if (previousClineDir === undefined) {
+		delete process.env.CLINE_DIR;
+	} else {
+		process.env.CLINE_DIR = previousClineDir;
+	}
+	await rm(tempClineDir, { recursive: true, force: true });
+});
+
+function goalInstallDir(): string {
+	const path = getOfficialPluginInstallPath("goal");
+	if (!path) {
+		throw new Error("expected an official install path for goal");
+	}
+	return path;
+}
+
+describe("official plugin install detection", () => {
+	it("does not treat a leftover empty install directory as installed", async () => {
+		// Regression: a failed or interrupted install can leave the directory
+		// behind with nothing in it. The next install attempt then returned
+		// "already installed" without running the CLI, so the UI flipped the
+		// entry to Uninstall with no error while nothing actually worked.
+		await mkdir(goalInstallDir(), { recursive: true });
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 1,
+			stdout: "",
+			stderr: "install exploded",
+		}));
+
+		await expect(
+			installMarketplaceEntry({ entry: GOAL_ENTRY }, { spawnCommand }),
+		).rejects.toThrow(/Plugin install failed/);
+		expect(spawnCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it("still short-circuits when the directory contains a plugin module", async () => {
+		const installDir = goalInstallDir();
+		await mkdir(join(installDir, "package"), { recursive: true });
+		await writeFile(
+			join(installDir, "package.json"),
+			JSON.stringify({
+				name: "goal",
+				private: true,
+				cline: { plugins: [{ paths: ["./package/index.ts"] }] },
+			}),
+		);
+		await writeFile(join(installDir, "package", "index.ts"), "export default {};");
+		const spawnCommand = vi.fn(async () => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		const result = await installMarketplaceEntry(
+			{ entry: GOAL_ENTRY },
+			{ spawnCommand },
+		);
+
+		expect(result).toMatchObject({
+			status: "installed",
+			message: "Goal is already installed.",
+		});
+		expect(spawnCommand).not.toHaveBeenCalled();
+	});
+
+	it("excludes partial install directories from the installed entries list", async () => {
+		await mkdir(goalInstallDir(), { recursive: true });
+
+		const empty = listMarketplaceInstalledEntries(
+			{ entries: [GOAL_ENTRY] },
+			{ plugins: [] } as JsonRecord,
+		);
+		expect(empty.installedKeys).toEqual([]);
+
+		const installDir = goalInstallDir();
+		await mkdir(join(installDir, "package"), { recursive: true });
+		await writeFile(join(installDir, "package", "index.ts"), "export default {};");
+		const populated = listMarketplaceInstalledEntries(
+			{ entries: [GOAL_ENTRY] },
+			{ plugins: [] } as JsonRecord,
+		);
+		expect(populated.installedKeys).toEqual(["plugin:goal"]);
+	});
+});

--- a/apps/examples/desktop-app/sidecar/marketplace.test.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.test.ts
@@ -61,6 +61,41 @@ describe("official plugin install detection", () => {
 		expect(spawnCommand).toHaveBeenCalledTimes(1);
 	});
 
+	it("passes --force so a retry can reclaim the leftover directory", async () => {
+		// Without --force the CLI refuses to replace the existing path
+		// ("Plugin is already installed at ... Use --force to replace it."),
+		// so every retry from the UI would fail against the stale directory.
+		await mkdir(goalInstallDir(), { recursive: true });
+		const spawnCommand = vi.fn(async (_command: string, _args: string[]) => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		const result = await installMarketplaceEntry(
+			{ entry: GOAL_ENTRY },
+			{ spawnCommand },
+		);
+
+		expect(result).toMatchObject({
+			status: "installed",
+			message: "Installed Goal.",
+		});
+		expect(spawnCommand.mock.calls[0]?.[1]).toContain("--force");
+	});
+
+	it("does not pass --force for a clean first install", async () => {
+		const spawnCommand = vi.fn(async (_command: string, _args: string[]) => ({
+			exitCode: 0,
+			stdout: "",
+			stderr: "",
+		}));
+
+		await installMarketplaceEntry({ entry: GOAL_ENTRY }, { spawnCommand });
+
+		expect(spawnCommand.mock.calls[0]?.[1]).not.toContain("--force");
+	});
+
 	it("still short-circuits when the directory contains a plugin module", async () => {
 		const installDir = goalInstallDir();
 		await mkdir(join(installDir, "package"), { recursive: true });
@@ -72,7 +107,10 @@ describe("official plugin install detection", () => {
 				cline: { plugins: [{ paths: ["./package/index.ts"] }] },
 			}),
 		);
-		await writeFile(join(installDir, "package", "index.ts"), "export default {};");
+		await writeFile(
+			join(installDir, "package", "index.ts"),
+			"export default {};",
+		);
 		const spawnCommand = vi.fn(async () => ({
 			exitCode: 0,
 			stdout: "",
@@ -94,15 +132,17 @@ describe("official plugin install detection", () => {
 	it("excludes partial install directories from the installed entries list", async () => {
 		await mkdir(goalInstallDir(), { recursive: true });
 
-		const empty = listMarketplaceInstalledEntries(
-			{ entries: [GOAL_ENTRY] },
-			{ plugins: [] } as JsonRecord,
-		);
+		const empty = listMarketplaceInstalledEntries({ entries: [GOAL_ENTRY] }, {
+			plugins: [],
+		} as JsonRecord);
 		expect(empty.installedKeys).toEqual([]);
 
 		const installDir = goalInstallDir();
 		await mkdir(join(installDir, "package"), { recursive: true });
-		await writeFile(join(installDir, "package", "index.ts"), "export default {};");
+		await writeFile(
+			join(installDir, "package", "index.ts"),
+			"export default {};",
+		);
 		const populated = listMarketplaceInstalledEntries(
 			{ entries: [GOAL_ENTRY] },
 			{ plugins: [] } as JsonRecord,

--- a/apps/examples/desktop-app/sidecar/marketplace.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.ts
@@ -602,22 +602,33 @@ export function getOfficialPluginInstallPath(
 	);
 }
 
-function isOfficialPluginInstalled(entry: MarketplaceInstallInput): boolean {
-	if (entry.type !== "plugin") return false;
+type OfficialPluginInstallState = "installed" | "partial" | "missing";
+
+function getOfficialPluginInstallState(
+	entry: MarketplaceInstallInput,
+): OfficialPluginInstallState {
+	if (entry.type !== "plugin") return "missing";
 	const [source] = entry.install.args ?? [];
-	if (!source) return false;
+	if (!source) return "missing";
 	const installPath = getOfficialPluginInstallPath(source);
-	if (!installPath || !existsSync(installPath)) return false;
+	if (!installPath || !existsSync(installPath)) return "missing";
 	// A bare directory is not an install: a failed or interrupted install can
 	// leave the directory behind with no plugin inside, and treating that as
 	// installed makes the next install attempt "succeed" silently ("already
 	// installed") while nothing actually works. Require a loadable plugin
-	// module before reporting the entry as installed.
+	// module before reporting the entry as installed; a directory without one
+	// is "partial" so the installer can reclaim it with --force.
 	try {
-		return discoverPluginModulePaths(installPath).length > 0;
+		return discoverPluginModulePaths(installPath).length > 0
+			? "installed"
+			: "partial";
 	} catch {
-		return false;
+		return "partial";
 	}
+}
+
+function isOfficialPluginInstalled(entry: MarketplaceInstallInput): boolean {
+	return getOfficialPluginInstallState(entry) === "installed";
 }
 
 function resolveHomeDir(): string {
@@ -820,7 +831,8 @@ async function installPlugin(
 			"Plugin marketplace installs currently support exactly one source argument.",
 		);
 	}
-	if (isOfficialPluginInstalled(entry)) {
+	const installState = getOfficialPluginInstallState(entry);
+	if (installState === "installed") {
 		return {
 			id: entry.id,
 			type: entry.type,
@@ -834,6 +846,12 @@ async function installPlugin(
 		"plugin",
 		"install",
 		installArgs[0] ?? "",
+		// Reclaim a leftover directory from a failed or interrupted install:
+		// without --force the CLI refuses to replace the existing path and
+		// every retry from the UI would fail the same way. This is safe
+		// because the state check just confirmed the directory contains no
+		// loadable plugin module.
+		...(installState === "partial" ? ["--force"] : []),
 		"--json",
 	]);
 	if (result.exitCode !== 0) {

--- a/apps/examples/desktop-app/sidecar/marketplace.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.ts
@@ -25,7 +25,10 @@ import {
 	uninstallMarketplaceEntry as uninstallCoreMarketplaceEntry,
 	uninstallPlugin as uninstallLocalPlugin,
 } from "@cline/core";
-import { resolveClineDir } from "@cline/shared/storage";
+import {
+	discoverPluginModulePaths,
+	resolveClineDir,
+} from "@cline/shared/storage";
 import { deleteMcpServer, readMcpServersResponse } from "./mcp";
 import type { JsonRecord } from "./types";
 
@@ -584,7 +587,9 @@ function isOfficialPluginSlug(source: string): boolean {
 	return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(source.trim());
 }
 
-function getOfficialPluginInstallPath(source: string): string | undefined {
+export function getOfficialPluginInstallPath(
+	source: string,
+): string | undefined {
 	const slug = source.trim();
 	if (!isOfficialPluginSlug(slug)) return undefined;
 	const sourceKey = `official:${OFFICIAL_PLUGINS_REPO}#plugins/${slug}`;
@@ -602,7 +607,17 @@ function isOfficialPluginInstalled(entry: MarketplaceInstallInput): boolean {
 	const [source] = entry.install.args ?? [];
 	if (!source) return false;
 	const installPath = getOfficialPluginInstallPath(source);
-	return Boolean(installPath && existsSync(installPath));
+	if (!installPath || !existsSync(installPath)) return false;
+	// A bare directory is not an install: a failed or interrupted install can
+	// leave the directory behind with no plugin inside, and treating that as
+	// installed makes the next install attempt "succeed" silently ("already
+	// installed") while nothing actually works. Require a loadable plugin
+	// module before reporting the entry as installed.
+	try {
+		return discoverPluginModulePaths(installPath).length > 0;
+	} catch {
+		return false;
+	}
 }
 
 function resolveHomeDir(): string {


### PR DESCRIPTION
isOfficialPluginInstalled() only checked that the marketplace install directory existed. A failed or interrupted install can leave that directory behind with no plugin inside, and the next install attempt then short-circuited with a fake 'already installed' success: the marketplace button flipped to Uninstall with no error while nothing actually worked, and the installed-entries listing kept reporting the broken entry as installed.

The check now requires a loadable plugin module inside the directory (via discoverPluginModulePaths) before reporting the entry as installed, so partial directories fall through to a real install attempt whose outcome is surfaced to the UI.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
