### PR TITLE
fix(vscode): hide View Changes on completion rows until there are changes to show

### DIFF
--- a/.changeset/view-changes-hidden-until-changes.md
+++ b/.changeset/view-changes-hidden-until-changes.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Hide the "View Changes" button on completion rows until there are actually changes to show, instead of rendering it faded and disabled. Turns that changed nothing, non-git workspaces, and repos without commits no longer show a dead button with a misleading tooltip.

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
@@ -126,6 +126,30 @@ describe("CompletionOutputRow View Changes", () => {
 		expect(checkpointLatestChangesCount).not.toHaveBeenCalled()
 		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
 	})
+
+	it("re-checks instead of reusing a stale positive answer when showViewChanges toggles", async () => {
+		checkpointLatestChangesCount.mockResolvedValue({ value: 2 })
+
+		const { rerender } = renderWithViewChanges()
+		await screen.findByRole("button", { name: /View Changes/ })
+
+		rerender(<CompletionOutputRow handleQuoteClick={vi.fn()} quoteButtonState={hiddenQuoteButton} text="All done!" />)
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
+
+		// Second evaluation never resolves: the earlier `true` must not leak
+		// through and flash the button while the host is still checking.
+		checkpointLatestChangesCount.mockReturnValue(new Promise(() => {}))
+		rerender(
+			<CompletionOutputRow
+				handleQuoteClick={vi.fn()}
+				quoteButtonState={hiddenQuoteButton}
+				showViewChanges
+				text="All done!"
+			/>,
+		)
+		expect(checkpointLatestChangesCount).toHaveBeenCalledTimes(2)
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
+	})
 })
 
 describe("PlanCompletionOutputRow", () => {

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
@@ -11,6 +11,37 @@ vi.mock("@/components/common/MarkdownBlock", () => ({
 	default: ({ markdown }: { markdown: string }) => <div>{markdown}</div>,
 }))
 
+const checkpointLatestChangesCount = vi.fn()
+
+vi.mock("@/services/grpc-client", () => ({
+	CheckpointsServiceClient: {
+		checkpointLatestChangesCount: (...args: unknown[]) => checkpointLatestChangesCount(...args),
+		checkpointViewLatestChanges: vi.fn(() => Promise.resolve({})),
+	},
+}))
+
+// Render VSCodeButton (used by SuccessButton) as a native button so it is
+// observable through testing-library roles.
+vi.mock("@vscode/webview-ui-toolkit/react", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>()
+	return {
+		...actual,
+		VSCodeButton: ({
+			children,
+			disabled,
+			onClick,
+		}: {
+			children?: React.ReactNode
+			disabled?: boolean
+			onClick?: () => void
+		}) => (
+			<button disabled={disabled} onClick={onClick} type="button">
+				{children}
+			</button>
+		),
+	}
+})
+
 const hiddenQuoteButton = { visible: false, top: 0, left: 0, selectedText: "" }
 
 describe("CompletionOutputRow", () => {
@@ -34,6 +65,66 @@ describe("CompletionOutputRow", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Copy response" }))
 
 		await waitFor(() => expect(writeText).toHaveBeenCalledWith("All done!"))
+	})
+})
+
+describe("CompletionOutputRow View Changes", () => {
+	beforeEach(() => {
+		checkpointLatestChangesCount.mockReset()
+	})
+
+	const renderWithViewChanges = () =>
+		render(
+			<CompletionOutputRow
+				handleQuoteClick={vi.fn()}
+				quoteButtonState={hiddenQuoteButton}
+				showViewChanges
+				text="All done!"
+			/>,
+		)
+
+	it("shows the button once the host confirms the latest run changed files", async () => {
+		checkpointLatestChangesCount.mockResolvedValue({ value: 2 })
+
+		renderWithViewChanges()
+
+		const button = await screen.findByRole("button", { name: /View Changes/ })
+		expect(button).not.toBeDisabled()
+	})
+
+	it("stays hidden while the count is still being checked", () => {
+		checkpointLatestChangesCount.mockReturnValue(new Promise(() => {}))
+
+		renderWithViewChanges()
+
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
+	})
+
+	it("stays hidden when nothing changed since the last message", async () => {
+		checkpointLatestChangesCount.mockResolvedValue({ value: 0 })
+
+		renderWithViewChanges()
+
+		await waitFor(() => expect(checkpointLatestChangesCount).toHaveBeenCalled())
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
+	})
+
+	it("stays hidden when the count request fails (e.g. no checkpoint to compare against)", async () => {
+		checkpointLatestChangesCount.mockRejectedValue(new Error("boom"))
+
+		renderWithViewChanges()
+
+		await waitFor(() => expect(checkpointLatestChangesCount).toHaveBeenCalled())
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
+	})
+
+	it("never renders the button when showViewChanges is not set", () => {
+		checkpointLatestChangesCount.mockResolvedValue({ value: 2 })
+
+		render(<CompletionOutputRow handleQuoteClick={vi.fn()} quoteButtonState={hiddenQuoteButton} text="All done!" />)
+
+		expect(checkpointLatestChangesCount).not.toHaveBeenCalled()
+		expect(screen.queryByRole("button", { name: /View Changes/ })).toBeNull()
 	})
 })
 

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
@@ -1,7 +1,6 @@
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { GitCompareIcon } from "lucide-react"
 import { memo, useEffect, useState } from "react"
-import { cn } from "@/lib/utils"
 import { CheckpointsServiceClient } from "@/services/grpc-client"
 import { CopyButton } from "../common/CopyButton"
 import SuccessButton from "../common/SuccessButton"
@@ -14,12 +13,13 @@ interface CompletionOutputRowProps {
 	quoteButtonState: QuoteButtonState
 	handleQuoteClick: () => void
 	/**
-	 * Shows the "View Changes" action inside the card, which opens a
+	 * Allows the "View Changes" action inside the card, which opens a
 	 * multi-file diff of everything that changed between the latest checkpoint
 	 * (taken when the user's last message started the run) and the current
 	 * working tree. Only meaningful on the latest, finalized completion row.
-	 * The button renders faded and disabled until the host confirms there are
-	 * changes to show.
+	 * The button stays hidden until the host confirms there are changes to
+	 * show — no changes (or no checkpoint at all, e.g. a non-git workspace)
+	 * simply renders no button.
 	 */
 	showViewChanges?: boolean
 }
@@ -34,8 +34,11 @@ interface CompletionOutputRowProps {
 export const CompletionOutputRow = memo(
 	({ text, quoteButtonState, handleQuoteClick, showViewChanges }: CompletionOutputRowProps) => {
 		const [viewChangesPending, setViewChangesPending] = useState(false)
-		// undefined = still checking; the button stays faded + disabled until
-		// the host confirms the latest run actually changed files.
+		// undefined = still checking; the button stays hidden until the host
+		// confirms the latest run actually changed files. A count of 0 also
+		// covers "no checkpoint to compare against" (non-git workspace, no
+		// commits yet, or a comparison failure) — in all of those cases there
+		// is nothing to view, so no button is rendered.
 		const [hasChanges, setHasChanges] = useState<boolean | undefined>(undefined)
 
 		useEffect(() => {
@@ -72,25 +75,18 @@ export const CompletionOutputRow = memo(
 						<QuoteButton left={quoteButtonState.left} onClick={handleQuoteClick} top={quoteButtonState.top} />
 					)}
 				</div>
-				{showViewChanges && (
+				{showViewChanges && hasChanges === true && (
 					<div className="px-2 pb-2">
 						<SuccessButton
-							className={cn("w-full transition-opacity duration-300", hasChanges ? "opacity-100" : "opacity-40")}
-							disabled={hasChanges !== true || viewChangesPending}
+							className="w-full"
+							disabled={viewChangesPending}
 							onClick={() => {
 								setViewChangesPending(true)
 								CheckpointsServiceClient.checkpointViewLatestChanges(EmptyRequest.create({}))
 									.catch((err) => console.error("Failed to view latest changes:", err))
 									.finally(() => setViewChangesPending(false))
 							}}
-							style={{ cursor: viewChangesPending ? "wait" : hasChanges ? "pointer" : "default" }}
-							title={
-								hasChanges === undefined
-									? "Checking for changes…"
-									: hasChanges
-										? undefined
-										: "No file changes since your last message"
-							}>
+							style={{ cursor: viewChangesPending ? "wait" : "pointer" }}>
 							<GitCompareIcon className="size-3 mr-1.5" />
 							View Changes
 						</SuccessButton>

--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.tsx
@@ -42,6 +42,10 @@ export const CompletionOutputRow = memo(
 		const [hasChanges, setHasChanges] = useState<boolean | undefined>(undefined)
 
 		useEffect(() => {
+			// Reset on every re-check so a stale positive answer from a previous
+			// evaluation can't flash the button before the host confirms the new
+			// comparison.
+			setHasChanges(undefined)
 			if (!showViewChanges) {
 				return
 			}


### PR DESCRIPTION
The button previously always rendered on the latest completion row, faded and disabled when the count check came back 0 - which covers both 'nothing changed since your last message' and 'no checkpoint to compare against' (non-git workspace, repo with no commits, comparison failure). A dead button with a misleading tooltip in the non-git case is worse than no button: now the row renders nothing until the host confirms there are actual changes, and the button is always enabled when shown.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
