### PR TITLE
fix(cli): make queued message text readable on light theme TUI

### DIFF
--- a/apps/cli/src/tui/components/queued-prompts.tsx
+++ b/apps/cli/src/tui/components/queued-prompts.tsx
@@ -117,7 +117,10 @@ function QueuedPromptRow(props: {
 					flexGrow={1}
 				/>
 			) : (
-				<text fg={selected ? theme.textOnSelection : undefined} flexGrow={1}>
+				<text
+					fg={selected ? theme.textOnSelection : theme.defaultForeground}
+					flexGrow={1}
+				>
 					{truncatePrompt(item.prompt)}
 				</text>
 			)}


### PR DESCRIPTION
### Related Issue

N/A (small bug fix)

### Description

On light themes (Cline Light, Solarized Light, or Auto on a light terminal), queued message text in the TUI was invisible. The unselected row in `QueuedPromptRow` rendered its prompt with `fg={undefined}`, which falls back to OpenTUI's renderer default foreground (white), producing white text on the white/light background.

The fix passes `theme.defaultForeground` as the fallback, matching what every other component on the main themed surface already does (chat entries, status bar, autocomplete dropdown, etc.). On dark "auto" sessions `defaultForeground` is `undefined`, so dark behavior is byte-for-byte unchanged; themed dark palettes now use their canonical foreground, which matches the rest of the transcript.

### Test Procedure

- Reproduced the bug by driving the TUI headlessly with tuistory: launched with `CLINE_THEME=light`, started a live turn, and queued two messages while it ran. The queued rows rendered as blank lines (screenshots below).
- Applied the fix, restarted, repeated the same steps: queued text now renders in the theme foreground, and the selected/steer state (arrow up) still renders white-on-blue correctly.
- Repeated the same flow with `CLINE_THEME=dark` to confirm no regression.
- `bun run test:unit` in `apps/cli`: 1129 tests pass. `bunx biome check` on the changed file is clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (light theme, two queued messages present but invisible):

![Queued messages invisible on light theme before fix](https://cursor.com/artifacts/c/art-ea750879-4208-4e4f-96e8-abb87c66d216)

After (same flow, text visible):

![Queued messages visible on light theme after fix](https://cursor.com/artifacts/c/art-cf9580c5-c27e-4b33-9989-c0639247b0b2)

After, selected state still readable:

![Selected queued message on light theme after fix](https://cursor.com/artifacts/c/art-51a81f23-cabd-473c-a539-3fd96d343e7e)

Dark theme unchanged:

![Queued messages on dark theme unchanged](https://cursor.com/artifacts/c/art-8898c465-18c9-4d2e-abf4-e2e9bf6b2932)

### Additional Notes

The other `fg={... : undefined}` fallbacks in the codebase live on dialog surfaces, which are always dark (`getDialogAccents`), so they are not affected by this issue.