### PR TITLE
fix(core): full-stop semantics and abort-window queue edits for surviving queues

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -2794,8 +2794,8 @@ describe("LocalRuntimeHost", () => {
 		expect(agentConfig?.telemetry).toBe(telemetry);
 	});
 
-	it("clears pending prompts after an interactive abort", async () => {
-		const sessionId = "sess-abort-clears-prompts";
+	it("preserves pending prompts through an interactive abort and drains them in order", async () => {
+		const sessionId = "sess-abort-preserves-prompts";
 		const manifest = createManifest(sessionId);
 		const sessionService = {
 			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
@@ -2825,6 +2825,7 @@ describe("LocalRuntimeHost", () => {
 		const runStarted = new Promise<void>((resolve) => {
 			markRunStarted = resolve;
 		});
+		const drainedPrompts: string[] = [];
 		const run = vi
 			.fn()
 			.mockImplementationOnce(
@@ -2838,10 +2839,17 @@ describe("LocalRuntimeHost", () => {
 						markRunStarted?.();
 					}),
 			)
-			.mockResolvedValueOnce(createResult({ text: "queued result" }));
+			.mockImplementation((prompt: string) => {
+				drainedPrompts.push(prompt);
+				return Promise.resolve(createResult({ text: "queued result" }));
+			});
+		const continueTurn = vi.fn().mockImplementation((prompt: string) => {
+			drainedPrompts.push(prompt);
+			return Promise.resolve(createResult());
+		});
 		const agent = {
 			run,
-			continue: vi.fn().mockResolvedValue(createResult()),
+			continue: continueTurn,
 			abort: vi.fn(),
 			subscribeEvents: vi.fn().mockReturnValue(() => {}),
 			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
@@ -2908,13 +2916,15 @@ describe("LocalRuntimeHost", () => {
 				}),
 			}),
 		);
-		expect(run).toHaveBeenCalledTimes(1);
-		expect(
-			(await manager.pendingPrompts.list({ sessionId })).map((prompt) => ({
-				prompt: prompt.prompt,
-				delivery: prompt.delivery,
-			})),
-		).toEqual([]);
+		// The abort must not eat the prompts the user queued: they drain once
+		// the abort settles, steered prompt first.
+		await vi.waitFor(async () => {
+			expect(drainedPrompts).toEqual([
+				'<user_input mode="act">steered prompt</user_input>',
+				'<user_input mode="act">queued prompt</user_input>',
+			]);
+			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
+		});
 	});
 
 	it("drains queued prompts after a turn that self-aborts (loop detector / mistake limit)", async () => {
@@ -3015,6 +3025,113 @@ describe("LocalRuntimeHost", () => {
 		await vi.waitFor(async () => {
 			expect(sentPrompts.slice(1)).toEqual([
 				'<user_input mode="act">queued prompt</user_input>',
+			]);
+			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
+		});
+	});
+
+	it("keeps queued prompts through a user-initiated abort and drains them after it settles", async () => {
+		const sessionId = "sess-user-abort-keeps-prompts";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest.json",
+				messagesPath: "/tmp/messages.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({
+				updated: true,
+				endedAt: "2026-01-01T00:00:05.000Z",
+			}),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({
+				tools: [],
+				shutdown: vi.fn(),
+			}),
+		};
+		let activeRun = false;
+		let rejectRun: ((error: Error) => void) | undefined;
+		let markRunStarted: (() => void) | undefined;
+		const runStarted = new Promise<void>((resolve) => {
+			markRunStarted = resolve;
+		});
+		const sentPrompts: string[] = [];
+		const run = vi.fn().mockImplementation((prompt: string) => {
+			sentPrompts.push(prompt);
+			activeRun = true;
+			markRunStarted?.();
+			return new Promise<AgentResult>((_resolve, reject) => {
+				rejectRun = (error: Error) => {
+					activeRun = false;
+					reject(error);
+				};
+			});
+		});
+		const continueTurn = vi.fn().mockImplementation((prompt: string) => {
+			sentPrompts.push(prompt);
+			return Promise.resolve(createResult({ text: "drained result" }));
+		});
+		const agent = {
+			run,
+			continue: continueTurn,
+			// A user abort tears the in-flight stream down, which surfaces to
+			// runTurn() as a rejection — the completeAbortedInteractiveTurn path.
+			abort: vi.fn().mockImplementation(() => {
+				rejectRun?.(new Error("aborted by user"));
+			}),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+			getMessages: vi.fn().mockReturnValue([]),
+			canStartRun: vi.fn(() => !activeRun),
+		};
+
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder,
+			createAgent: () => agent as never,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				interactive: true,
+			}),
+		);
+
+		const firstTurn = manager.runTurn({ sessionId, prompt: "slow" });
+		await runStarted;
+		await manager.runTurn({
+			sessionId,
+			prompt: "queued survivor",
+			delivery: "queue",
+		});
+		expect(
+			(await manager.pendingPrompts.list({ sessionId })).map((prompt) => ({
+				prompt: prompt.prompt,
+				delivery: prompt.delivery,
+			})),
+		).toEqual([{ prompt: "queued survivor", delivery: "queue" }]);
+
+		await manager.abort(sessionId);
+		await expect(firstTurn).resolves.toMatchObject({
+			finishReason: "aborted",
+		});
+
+		// The queued prompt must survive the abort and run once it settles —
+		// aborting only stops the in-flight turn, it must never eat input the
+		// user already typed and queued.
+		await vi.waitFor(async () => {
+			expect(sentPrompts.slice(1)).toEqual([
+				'<user_input mode="act">queued survivor</user_input>',
 			]);
 			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
 		});

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -3137,6 +3137,118 @@ describe("LocalRuntimeHost", () => {
 		});
 	});
 
+	it("clears the remaining queue when a queue-initiated turn is aborted", async () => {
+		const sessionId = "sess-second-abort-clears-queue";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest.json",
+				messagesPath: "/tmp/messages.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({
+				updated: true,
+				endedAt: "2026-01-01T00:00:05.000Z",
+			}),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({
+				tools: [],
+				shutdown: vi.fn(),
+			}),
+		};
+		let activeRun = false;
+		const sentPrompts: string[] = [];
+		const rejectors: Array<(error: Error) => void> = [];
+		// Every run hangs until aborted, so each abort targets the turn that
+		// is actually in flight (first the user turn, then the drained turn).
+		const run = vi.fn().mockImplementation(
+			(prompt: string) =>
+				new Promise<AgentResult>((_resolve, reject) => {
+					sentPrompts.push(prompt);
+					activeRun = true;
+					rejectors.push((error) => {
+						activeRun = false;
+						reject(error);
+					});
+				}),
+		);
+		const agent = {
+			run,
+			continue: vi.fn().mockResolvedValue(createResult()),
+			abort: vi.fn(() => {
+				rejectors.shift()?.(new Error("user cancelled"));
+			}),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+			getMessages: vi.fn().mockReturnValue([]),
+			canStartRun: vi.fn(() => !activeRun),
+		};
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder,
+			createAgent: () => agent as never,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				interactive: true,
+			}),
+		);
+
+		const firstTurn = manager.runTurn({ sessionId, prompt: "slow" });
+		await vi.waitFor(() => {
+			expect(run).toHaveBeenCalledTimes(1);
+		});
+		await manager.runTurn({
+			sessionId,
+			prompt: "queued one",
+			delivery: "queue",
+		});
+		await manager.runTurn({
+			sessionId,
+			prompt: "queued two",
+			delivery: "queue",
+		});
+
+		// First abort: the user-initiated turn stops, the queue survives, and
+		// the drain starts running "queued one".
+		await manager.abort(sessionId, new Error("first abort"));
+		await expect(firstTurn).resolves.toMatchObject({
+			finishReason: "aborted",
+		});
+		await vi.waitFor(() => {
+			expect(run).toHaveBeenCalledTimes(2);
+		});
+		expect(sentPrompts[1]).toContain("queued one");
+		expect(
+			(await manager.pendingPrompts.list({ sessionId })).map(
+				(prompt) => prompt.prompt,
+			),
+		).toEqual(["queued two"]);
+
+		// Second abort lands on a queue-initiated turn: that means "stop the
+		// queued work too" — the remainder is dropped so repeated aborts
+		// reliably bring the session to a full stop instead of consuming one
+		// queued prompt (and one provider call) per abort.
+		await manager.abort(sessionId, new Error("second abort"));
+		await vi.waitFor(async () => {
+			expect(await manager.pendingPrompts.list({ sessionId })).toEqual([]);
+		});
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(run).toHaveBeenCalledTimes(2);
+		expect(sentPrompts).toHaveLength(2);
+	});
+
 	it("does not drain queued prompts after a turn that finishes with error", async () => {
 		const sessionId = "sess-error-holds-prompts";
 		const manifest = createManifest(sessionId);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1076,10 +1076,18 @@ export class LocalRuntimeHost implements RuntimeHost {
 			event: "session.aborted",
 			properties: { sessionId },
 		});
-		// Deliberately leave pendingPrompts untouched: aborting only stops the
-		// in-flight turn. Clearing here would silently destroy prompts the user
-		// already typed and queued — they drain once the abort completes.
+		// Aborting a user-initiated turn leaves pendingPrompts untouched:
+		// clearing here would silently destroy prompts the user already typed
+		// and queued — they drain once the abort completes. Aborting a
+		// queue-initiated turn (drainingPendingPrompts) is the opposite
+		// gesture: the user is cancelling the queued work itself, so drop the
+		// remainder — otherwise every Escape would consume one queued prompt
+		// and start a fresh provider call, and the session could never be
+		// brought to a full stop.
 		session.aborting = true;
+		if (session.drainingPendingPrompts) {
+			this.pendingPromptsController.discardQueue(session);
+		}
 		session.agent.abort(reason);
 	}
 

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1025,10 +1025,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 			} else {
 				await this.completeInteractiveTurn(session, result.finishReason);
 			}
-			// Drain after "aborted" finishes too: internal stops (loop
-			// detector / mistake limit) would otherwise strand user-queued
-			// prompts forever, and user-initiated aborts already cleared the
-			// queue in abortSession(). "error" finishes deliberately do NOT
+			// Drain after "aborted" finishes too: both internal stops (loop
+			// detector / mistake limit) and user-initiated aborts keep the
+			// queue intact, so without a drain here the user-queued prompts
+			// would be stranded forever. "error" finishes deliberately do NOT
 			// drain — auto-running queued prompts into a failing provider
 			// would consume them; they stay queued and drain on the next
 			// enqueue/update or successful turn.
@@ -1076,8 +1076,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 			event: "session.aborted",
 			properties: { sessionId },
 		});
+		// Deliberately leave pendingPrompts untouched: aborting only stops the
+		// in-flight turn. Clearing here would silently destroy prompts the user
+		// already typed and queued — they drain once the abort completes.
 		session.aborting = true;
-		this.pendingPromptsController.clearAborted(session);
 		session.agent.abort(reason);
 	}
 
@@ -1725,6 +1727,13 @@ export class LocalRuntimeHost implements RuntimeHost {
 			usage,
 		});
 		await this.completeInteractiveTurn(session, "aborted");
+		// The abort is fully settled (aborting flag reset above), so prompts
+		// the user queued behind the stopped turn can run now. This mirrors
+		// the drain in runTurn() for turns that resolve with an "aborted"
+		// finish; this path handles turns that end by throwing instead.
+		queueMicrotask(() => {
+			void this.pendingPromptsController.drain(session.sessionId);
+		});
 		return {
 			text: "",
 			usage,

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.test.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.test.ts
@@ -120,6 +120,42 @@ describe("PendingPromptService", () => {
 		).toThrow("prompt cannot be empty");
 	});
 
+	it("keeps prompts enqueued while the session is aborting", async () => {
+		const sessionId = "sess-enqueue-while-aborting";
+		const session = {
+			sessionId,
+			pendingPrompts: [],
+			aborting: true,
+			drainingPendingPrompts: false,
+			status: "running",
+			agent: {
+				canStartRun: () => false,
+			},
+		} as unknown as ActiveSession;
+		const events: CoreSessionEvent[] = [];
+		const send = vi.fn().mockResolvedValue(undefined);
+		const controller = new PendingPromptsController({
+			getSession: () => session,
+			emit: (event) => events.push(event),
+			send,
+		});
+
+		// A prompt typed right after Escape lands during the abort window; it
+		// must join the queue (which survives the abort) instead of being
+		// silently dropped.
+		controller.enqueue(sessionId, {
+			prompt: "typed after escape",
+			delivery: "queue",
+		});
+
+		expect(controller.list(sessionId).map((prompt) => prompt.prompt)).toEqual([
+			"typed after escape",
+		]);
+		// The drain must not start while the abort is still settling.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(send).not.toHaveBeenCalled();
+	});
+
 	it("requeues a drained prompt when send fails", async () => {
 		const sessionId = "sess-drain-failure";
 		const session = {

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -197,11 +197,6 @@ export class PendingPromptService {
 		state.pendingPrompts.unshift(entry);
 		return snapshotPrompts(state);
 	}
-
-	clear(state: PendingPromptQueueState): SessionPendingPrompt[] {
-		state.pendingPrompts.length = 0;
-		return [];
-	}
 }
 
 export class PendingPromptsController {
@@ -260,12 +255,6 @@ export class PendingPromptsController {
 		this.emitPrompts(session);
 		this.emitSubmitted(session, steer);
 		return steer;
-	}
-
-	clearAborted(session: ActiveSession): void {
-		if (session.pendingPrompts.length === 0) return;
-		this.service.clear(session);
-		this.emitPrompts(session);
 	}
 
 	emitPrompts(session: ActiveSession): void {

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -197,6 +197,11 @@ export class PendingPromptService {
 		state.pendingPrompts.unshift(entry);
 		return snapshotPrompts(state);
 	}
+
+	clear(state: PendingPromptQueueState): SessionPendingPrompt[] {
+		state.pendingPrompts.length = 0;
+		return [];
+	}
 }
 
 export class PendingPromptsController {
@@ -210,7 +215,7 @@ export class PendingPromptsController {
 
 	update(input: PendingPromptsUpdateInput): PendingPromptMutationResult {
 		const session = this.deps.getSession(input.sessionId);
-		if (!session || session.aborting) {
+		if (!session) {
 			return { sessionId: input.sessionId, prompts: [], updated: false };
 		}
 		const result = this.service.update(session, input);
@@ -221,7 +226,7 @@ export class PendingPromptsController {
 
 	delete(input: PendingPromptsDeleteInput): PendingPromptMutationResult {
 		const session = this.deps.getSession(input.sessionId);
-		if (!session || session.aborting) {
+		if (!session) {
 			return { sessionId: input.sessionId, prompts: [], removed: false };
 		}
 		const result = this.service.delete(session, input);
@@ -241,7 +246,13 @@ export class PendingPromptsController {
 		},
 	): void {
 		const session = this.deps.getSession(sessionId);
-		if (!session || session.aborting) return;
+		if (!session) return;
+		// The queue survives aborts and is visible while one settles, so
+		// queue operations must keep working during the abort window: a
+		// prompt typed right after Escape joins the queue instead of being
+		// silently dropped, and queued prompts stay editable/deletable before
+		// they auto-run. scheduleDrain/drain still refuse to run while the
+		// abort is settling.
 		this.service.enqueue(session, entry);
 		this.emitPrompts(session);
 		this.scheduleDrain(sessionId, session);
@@ -255,6 +266,17 @@ export class PendingPromptsController {
 		this.emitPrompts(session);
 		this.emitSubmitted(session, steer);
 		return steer;
+	}
+
+	/**
+	 * Drops every queued prompt. Only called when the user aborts a
+	 * queue-initiated turn — that gesture means "stop the queued work", not
+	 * just "stop this response", so the remainder must not auto-run.
+	 */
+	discardQueue(session: ActiveSession): void {
+		if (session.pendingPrompts.length === 0) return;
+		this.service.clear(session);
+		this.emitPrompts(session);
 	}
 
 	emitPrompts(session: ActiveSession): void {


### PR DESCRIPTION
Follow-up to #13090 (this branch is stacked on its head; once #13090 merges this PR shows only the delta commit).

#13090 makes queued prompts survive a user abort and auto-run once the abort settles. Two gaps remained.

1. No full stop. Aborting a queue-initiated turn also kept draining, so every Escape consumed one queued prompt and immediately started a fresh provider call. A session with queued messages could never be brought to rest by cancelling. Aborting a drained turn now discards the remaining queue: the first Escape skips to your queued follow-ups, a second Escape stops the queued work too.

2. Queue operations were still rejected while an abort settled. The pending-prompt controller ignored enqueue/update/delete while `session.aborting` was set, so a prompt typed right after Escape was silently dropped, and queued prompts were briefly uneditable and undeletable even though they were about to auto-run. Queue operations now work during the abort window; scheduleDrain/drain still refuse to start until the abort settles.

### Related Issue

Follow-up to #13090.

### Description

- `LocalRuntimeHost.abort()` discards the queue only when the aborted turn was queue-initiated (`session.drainingPendingPrompts`), via a restored `discardQueue` controller method. User-initiated aborts leave the queue untouched, as introduced in #13090.
- `PendingPromptsController.enqueue/update/delete` no longer bail while `session.aborting` is set. The drain guards are unchanged, so nothing runs until the abort settles.

### Test Procedure

- New unit test: "clears the remaining queue when a queue-initiated turn is aborted" drives abort -> auto-drain -> second abort and asserts the remainder is dropped and no third run starts.
- New unit test: "keeps prompts enqueued while the session is aborting" asserts an enqueue during the abort window is kept and not drained early.
- Focused suites (`pending-prompt-service.test.ts`, `local-runtime-host.test.ts`): 83 passed.
- Full `@cline/core` unit suite: 1781 passed; only the two documented cloud-VM git insteadOf artifacts failed. `bun -F @cline/core typecheck` passes.
- Manually verified end to end in the interactive TUI against a mock OpenAI-compatible streaming server: queue survives a first Escape and auto-runs in order, a second Escape during a drained turn stops everything, and a message typed during the abort window is queued instead of dropped.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)