### PR TITLE
fix(llms): skip GLM reasoning controls for generic openai-compatible providers

### DIFF
--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -69,6 +69,17 @@ function hasGlmThinkingProviderRouting(
 	);
 }
 
+function hasProviderReasoningRouting(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return (
+		input.context.provider.metadata?.routing?.reasoning != null ||
+		isClineProvider(input.request.providerId) ||
+		input.request.providerId === "openrouter" ||
+		input.request.providerId === "vercel"
+	);
+}
+
 function usesMiniMaxThinkingProviderRouting(
 	input: ProviderOptionMatchInput,
 ): boolean {
@@ -489,7 +500,8 @@ const routedGlmReasoningRule: ProviderOptionRule = {
 		"Routed GLM models use the generic reasoning include/exclude shape, not thinking.type.",
 	applies: (input) =>
 		!usesGlmThinkingProviderRouting(input) &&
-		isGlmModel(input.request, input.context),
+		isGlmModel(input.request, input.context) &&
+		hasProviderReasoningRouting(input),
 	suppresses: { genericThinking: true },
 	build: (input) =>
 		buildRoutedGlmReasoningProviderOptionsPatch(

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -76,7 +76,7 @@ function hasProviderReasoningRouting(
 		input.context.provider.metadata?.routing?.reasoning != null ||
 		isClineProvider(input.request.providerId) ||
 		input.request.providerId === "openrouter" ||
-		input.request.providerId === "vercel"
+		input.request.providerId === "vercel-ai-gateway"
 	);
 }
 


### PR DESCRIPTION
Fixes #11086

When a GLM model (e.g. `zai-org/GLM-5.1`) is used through a generic openai-compatible provider like FriendliAI or self-hosted vLLM/SGLang, the `routedGlmReasoningRule` injects `reasoning: { exclude: true }` into the request body. Strict OpenAI-compatible endpoints reject this unknown field with a 400 error.

The fix adds a `hasProviderReasoningRouting` guard to the rule's `applies` predicate so it only fires when the provider has explicit reasoning routing metadata or is a known reasoning-aware gateway (cline, openrouter, vercel). Generic endpoints without routing metadata are no longer affected.

This addresses the review feedback on #11087 which asked for routing-metadata-based detection instead of a narrow `providerId === "openai-compatible"` check.