### PR TITLE
fix(core): exit the hub daemon when shutdown arrives over HTTP

### DIFF
--- a/sdk/packages/core/src/hub/daemon/entry.test.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.test.ts
@@ -11,6 +11,7 @@ const {
 	mockResolveSharedHubOwnerContext,
 	mockReconnectDaemonConnectors,
 	mockStartHubWebSocketServer,
+	mockArmHubDaemonShutdownWatchdog,
 } = vi.hoisted(() => ({
 	mockCreateLocalHubScheduleRuntimeHandlers: vi.fn(() => ({
 		startSession: vi.fn(),
@@ -35,9 +36,12 @@ const {
 		discoveryPath: "/tmp/cline-data/locks/hub/owners/shared.json",
 	})),
 	mockReconnectDaemonConnectors: vi.fn(async () => []),
-	mockStartHubWebSocketServer: vi.fn(async () => ({
-		close: vi.fn(async () => undefined),
-	})),
+	mockStartHubWebSocketServer: vi.fn(
+		async (_options?: { onShutdownRequested?: () => void }) => ({
+			close: vi.fn(async () => undefined),
+		}),
+	),
+	mockArmHubDaemonShutdownWatchdog: vi.fn(),
 }));
 
 const {
@@ -96,6 +100,11 @@ vi.mock("./telemetry", () => ({
 	createHubDaemonTelemetry: mockCreateHubDaemonTelemetry,
 }));
 
+vi.mock("./shutdown-watchdog", () => ({
+	HUB_DAEMON_SHUTDOWN_DEADLINE_MS: 2_000,
+	armHubDaemonShutdownWatchdog: mockArmHubDaemonShutdownWatchdog,
+}));
+
 const originalArgv = [...process.argv];
 const originalCwd = process.cwd();
 
@@ -114,6 +123,7 @@ describe("hub daemon entry", () => {
 		mockResolveSharedHubOwnerContext.mockClear();
 		mockReconnectDaemonConnectors.mockClear();
 		mockStartHubWebSocketServer.mockClear();
+		mockArmHubDaemonShutdownWatchdog.mockClear();
 		mockCreateHubDaemonTelemetry.mockClear();
 		mockDaemonTelemetryDispose.mockClear();
 		for (const dir of tempDirs.splice(0)) {
@@ -186,6 +196,38 @@ describe("hub daemon entry", () => {
 		await vi.waitFor(() => {
 			expect(mockReconnectDaemonConnectors).toHaveBeenCalledOnce();
 		});
+	});
+
+	it("ends the daemon when an authorized shutdown arrives before startup completes", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "cline-hub-entry-test-"));
+		tempDirs.push(cwd);
+		process.argv = ["node", "entry.js", "--cwd", cwd];
+		vi.spyOn(process, "on").mockImplementation(() => process);
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation(() => undefined as never);
+
+		const close = vi.fn(async () => undefined);
+		mockStartHubWebSocketServer.mockImplementationOnce(async (options) => {
+			// A retiring caller can read the freshly written discovery record
+			// and POST /shutdown before startHubWebSocketServer resolves; a
+			// duplicate delivery (HTTP followed by SIGTERM) shares one gate.
+			options?.onShutdownRequested?.();
+			options?.onShutdownRequested?.();
+			// The watchdog must be armed by the request itself, not deferred
+			// until the daemon finishes starting up.
+			expect(mockArmHubDaemonShutdownWatchdog).toHaveBeenCalledTimes(1);
+			expect(exitSpy).not.toHaveBeenCalled();
+			return { close };
+		});
+
+		await import("./entry");
+		await vi.waitFor(() => {
+			expect(exitSpy).toHaveBeenCalledWith(0);
+		});
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(mockArmHubDaemonShutdownWatchdog).toHaveBeenCalledTimes(1);
+		expect(mockDaemonTelemetryDispose).toHaveBeenCalled();
 	});
 
 	it("disposes telemetry and exits when server startup fails", async () => {

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -90,9 +90,17 @@ async function main(): Promise<void> {
 
 	const daemonTelemetry = createHubDaemonTelemetry();
 
+	// Bound after `shutdown` is defined below. The daemon's lifetime is tied to
+	// its server, so an authorized HTTP `POST /shutdown` must end the process
+	// just like SIGTERM does — that route is how auto-update restarts and
+	// `cline hub stop` retire the hub, and neither sends a signal when the
+	// HTTP request succeeds.
+	let requestDaemonShutdown: () => void = () => {};
+
 	let server: Awaited<ReturnType<typeof startHubWebSocketServer>>;
 	try {
 		server = await startHubWebSocketServer({
+			onShutdownRequested: () => requestDaemonShutdown(),
 			host: endpoint.host,
 			port: endpoint.port,
 			pathname: endpoint.pathname,
@@ -121,7 +129,14 @@ async function main(): Promise<void> {
 	});
 	setActiveConnectorSupervisor(supervisor);
 
+	let shutdownStarted = false;
 	const shutdown = async (): Promise<void> => {
+		// A retiring caller can request shutdown more than once (the HTTP
+		// /shutdown route followed by SIGTERM); run the teardown only once.
+		if (shutdownStarted) {
+			return;
+		}
+		shutdownStarted = true;
 		// server.close() can stall forever (Bun never resolves it once a WebSocket
 		// upgrade happened), and with signal handlers installed nothing else will
 		// end the process — so the exit must not depend on the graceful path.
@@ -142,6 +157,9 @@ async function main(): Promise<void> {
 		await server.close();
 		await daemonTelemetry.dispose().catch(() => undefined);
 		process.exit(0);
+	};
+	requestDaemonShutdown = () => {
+		void shutdown();
 	};
 
 	let fatalShutdownStarted = false;

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -90,17 +90,43 @@ async function main(): Promise<void> {
 
 	const daemonTelemetry = createHubDaemonTelemetry();
 
-	// Bound after `shutdown` is defined below. The daemon's lifetime is tied to
-	// its server, so an authorized HTTP `POST /shutdown` must end the process
-	// just like SIGTERM does — that route is how auto-update restarts and
-	// `cline hub stop` retire the hub, and neither sends a signal when the
-	// HTTP request succeeds.
-	let requestDaemonShutdown: () => void = () => {};
+	// The daemon's lifetime is tied to its server, so an authorized HTTP
+	// `POST /shutdown` must end the process just like SIGTERM does — that
+	// route is how auto-update restarts and `cline hub stop` retire the hub,
+	// and neither sends a signal when the HTTP request succeeds. The route is
+	// reachable with an authorized request the moment the discovery record is
+	// written, which happens before startHubWebSocketServer() resolves, so
+	// the exit path must exist before the server starts: an early request
+	// arms the exit watchdog immediately, and the rest of the teardown runs
+	// once the server handle is available. HTTP- and signal-delivered
+	// requests share this gate, so a caller that sends both (as
+	// retireDiscoveredHub does) runs a single teardown.
+	let shutdownStarted = false;
+	let completeShutdown: (() => void) | undefined;
+	const requestDaemonShutdown = (): void => {
+		if (shutdownStarted) {
+			return;
+		}
+		shutdownStarted = true;
+		// server.close() can stall forever (Bun never resolves it once a WebSocket
+		// upgrade happened), and with signal handlers installed nothing else will
+		// end the process — so the exit must not depend on the graceful path.
+		armHubDaemonShutdownWatchdog({
+			deadlineMs: HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
+			exitCode: 0,
+			onTimeout: () => {
+				process.stderr.write(
+					"[hub-daemon] graceful shutdown stalled; forcing exit\n",
+				);
+			},
+		});
+		completeShutdown?.();
+	};
 
 	let server: Awaited<ReturnType<typeof startHubWebSocketServer>>;
 	try {
 		server = await startHubWebSocketServer({
-			onShutdownRequested: () => requestDaemonShutdown(),
+			onShutdownRequested: requestDaemonShutdown,
 			host: endpoint.host,
 			port: endpoint.port,
 			pathname: endpoint.pathname,
@@ -129,38 +155,23 @@ async function main(): Promise<void> {
 	});
 	setActiveConnectorSupervisor(supervisor);
 
-	let shutdownStarted = false;
-	const shutdown = async (): Promise<void> => {
-		// A retiring caller can request shutdown more than once (the HTTP
-		// /shutdown route followed by SIGTERM); run the teardown only once.
-		if (shutdownStarted) {
-			return;
-		}
-		shutdownStarted = true;
-		// server.close() can stall forever (Bun never resolves it once a WebSocket
-		// upgrade happened), and with signal handlers installed nothing else will
-		// end the process — so the exit must not depend on the graceful path.
-		armHubDaemonShutdownWatchdog({
-			deadlineMs: HUB_DAEMON_SHUTDOWN_DEADLINE_MS,
-			exitCode: 0,
-			onTimeout: () => {
-				process.stderr.write(
-					"[hub-daemon] graceful shutdown stalled; forcing exit\n",
-				);
-			},
-		});
-		// Stop supervising but leave the connectors running: they are detached on
-		// purpose so a hub restart does not disconnect Slack/Telegram, and the next
-		// hub adopts them from their state files.
-		supervisor.dispose();
-		setActiveConnectorSupervisor(undefined);
-		await server.close();
-		await daemonTelemetry.dispose().catch(() => undefined);
-		process.exit(0);
+	completeShutdown = () => {
+		void (async () => {
+			// Stop supervising but leave the connectors running: they are detached on
+			// purpose so a hub restart does not disconnect Slack/Telegram, and the next
+			// hub adopts them from their state files.
+			supervisor.dispose();
+			setActiveConnectorSupervisor(undefined);
+			await server.close();
+			await daemonTelemetry.dispose().catch(() => undefined);
+			process.exit(0);
+		})();
 	};
-	requestDaemonShutdown = () => {
-		void shutdown();
-	};
+	if (shutdownStarted) {
+		// An authorized /shutdown landed while the server was still starting.
+		// The watchdog is already armed; finish the teardown now.
+		completeShutdown();
+	}
 
 	let fatalShutdownStarted = false;
 	const shutdownFatal = (label: string, error: unknown): void => {
@@ -202,10 +213,10 @@ async function main(): Promise<void> {
 	};
 
 	process.on("SIGINT", () => {
-		void shutdown();
+		requestDaemonShutdown();
 	});
 	process.on("SIGTERM", () => {
-		void shutdown();
+		requestDaemonShutdown();
 	});
 	process.on("uncaughtException", (error) => {
 		shutdownFatal("uncaughtException", error);

--- a/sdk/packages/core/src/hub/server/hub-server-options.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-options.ts
@@ -48,6 +48,17 @@ export interface HubWebSocketServerOptions {
 	 * Ignored when `sessionHost` is supplied.
 	 */
 	logger?: BasicLogger;
+	/**
+	 * Invoked when an authorized HTTP `POST /shutdown` is accepted, before the
+	 * server begins closing. The server always closes itself either way; this
+	 * exists so a process whose lifetime is bound to the server — the detached
+	 * hub daemon — can arm its shutdown watchdog and exit. Without it, only
+	 * signal-delivered shutdowns end the daemon process, and callers that stop
+	 * the hub over HTTP (auto-update restart, `cline hub stop`) leave the
+	 * process alive when `server.close()` stalls (Bun never resolves it once a
+	 * WebSocket upgrade happened).
+	 */
+	onShutdownRequested?: () => void;
 }
 
 export interface HubWebSocketServer {

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -420,6 +420,11 @@ export async function startHubWebSocketServer(
 			res.setHeader("content-type", "application/json");
 			res.end(JSON.stringify({ ok: true }));
 			queueMicrotask(() => {
+				// Notify before closing so a daemon can arm its exit watchdog
+				// ahead of a close() that may never resolve. closeServer() is
+				// idempotent, so the callback awaiting server.close() joins
+				// this same close rather than racing it.
+				options.onShutdownRequested?.();
 				void closeServer();
 			});
 			return;

--- a/sdk/packages/core/src/hub/server/index.test.ts
+++ b/sdk/packages/core/src/hub/server/index.test.ts
@@ -242,6 +242,53 @@ describe("hub server startup", () => {
 		throw new Error("Timed out waiting for hub shutdown");
 	});
 
+	it("notifies onShutdownRequested when an authorized shutdown is accepted", async () => {
+		const owner = createInMemoryHubOwnerContext(
+			"hub-server-test-shutdown-callback",
+		);
+		const onShutdownRequested = vi.fn();
+		const result = await ensureHubWebSocketServer({
+			owner,
+			host: "127.0.0.1",
+			port: 0,
+			pathname: "/hub",
+			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			onShutdownRequested,
+		});
+		const server = requireServer(result.server);
+		servers.add(server);
+
+		const shutdownUrl = new URL(toHubHealthUrl(result.url));
+		shutdownUrl.pathname = "/shutdown";
+		const discovery = await readHubDiscovery(owner.discoveryPath);
+		if (!discovery) {
+			throw new Error("Expected hub discovery to be written");
+		}
+
+		// An unauthorized request must not fire the callback: the daemon exits
+		// on this signal, so a tokenless caller must not be able to end it.
+		const unauthorized = await fetch(shutdownUrl, { method: "POST" });
+		expect(unauthorized.status).toBe(401);
+		expect(onShutdownRequested).not.toHaveBeenCalled();
+
+		const response = await fetch(shutdownUrl, {
+			method: "POST",
+			headers: { authorization: `Bearer ${discovery.authToken}` },
+		});
+		expect(response.status).toBe(202);
+
+		await vi.waitFor(() => {
+			expect(onShutdownRequested).toHaveBeenCalledTimes(1);
+		});
+
+		// The server still closes itself; the callback is a notification, not
+		// a replacement for the close.
+		await vi.waitFor(async () => {
+			expect(await readHubDiscovery(owner.discoveryPath)).toBeUndefined();
+		});
+		servers.delete(server);
+	});
+
 	it("rejects shutdown request with 401 when no auth token is provided", async () => {
 		const owner = createInMemoryHubOwnerContext(
 			"hub-server-test-shutdown-unauth",


### PR DESCRIPTION
### Related Issue

Stacked on #13073 (targets `bee/hub-leak`, shows only this delta). Closes the remaining leak path from the same investigation.

### Description

#13073 arms the shutdown watchdog in the daemon's SIGTERM/SIGINT handler and in `shutdownFatal`, which fixes every retirement that delivers a signal. But the two callers that retire the hub most often do not deliver a signal when things go well:

- The auto-update restart (`restartHubServerIfRunning` in `apps/cli/src/commands/update.ts`) calls `stopLocalHubServerGracefully`, which sends an authorized `POST /shutdown`. It only falls back to SIGTERM when that HTTP request fails. On success (202), no signal is ever sent.
- `cline hub stop` does the same.

The `/shutdown` route in `hub-websocket-server.ts` only ran `closeServer()`, which stalls forever at `server.close()` under Bun once a WebSocket upgrade has happened (the exact stall #13073 documents). The route never exits the process and never armed the watchdog, so the nightly auto-update path, the one that produces "one orphaned hub per night", still leaked a daemon with #13073 applied.

Reproduced empirically on Bun 1.3.13 with a real daemon and an attached WebSocket, on the `bee/hub-leak` branch:

- SIGTERM: watchdog fires, exit 0 in ~2.3s (the PR works for signals)
- `POST /shutdown` (202): listener closes in ~3ms, process still alive 12s later, orphan

**Fix.** New optional `onShutdownRequested` callback on `HubWebSocketServerOptions`, invoked by the `/shutdown` route after the 202 is written and before `closeServer()` starts. The daemon entry passes a callback that funnels into the same `shutdown()` used for signals: watchdog armed, connector supervisor disposed, telemetry flushed, `process.exit(0)`. `closeServer()` is idempotent (single `closePromise`), so `shutdown()` awaiting `server.close()` joins the close the route already started rather than racing it. `shutdown()` is now guarded to run once, since `retireDiscoveredHub` intentionally sends both `/shutdown` and SIGTERM.

The option is opt-in, so in-process embedders of `ensureHubWebSocketServer` (VS Code extension, cline-hub app) are unaffected; only the detached daemon binds its process lifetime to the route.

### Test Procedure

Empirical, against a real daemon spawned from `entry.ts` under Bun 1.3.13, isolated `CLINE_DATA_DIR`/`CLINE_HUB_DISCOVERY_PATH`, real WebSocket client attached, then a real authorized `POST /shutdown`:

| Scenario | main | bee/hub-leak | this branch |
|---|---|---|---|
| `POST /shutdown` (202) | never exits | **never exits** | exit 0 in ~2.3s |
| SIGTERM | never exits | exit 0 in ~2.3s | exit 0 in ~2.3s |

Suites:
- New test in `src/hub/server/index.test.ts`: the callback fires exactly once on an authorized shutdown, does not fire on a 401, and the server still closes itself (discovery cleared).
- `bun -F @cline/core test:unit`: 1790 passing; the only failure is the documented cloud-VM git `insteadOf` environment artifact in `workspace-manifest.test.ts`.
- `bun -F @cline/core typecheck` clean, Biome clean on changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal evidence from the repro on this branch:

```
daemon up: pid=4135 url=ws://127.0.0.1:31286/hub
websocket attached
POST /shutdown -> 202
listener closed after 3ms
[daemon err] [hub-daemon] graceful shutdown stalled; forcing exit
RESULT: process exited after 2256ms (code=0 signal=null)
```

Same repro on `bee/hub-leak` without this change:

```
POST /shutdown -> 202
listener closed after 2ms
RESULT: process STILL ALIVE 12s after shutdown (pid=3528, listener closed at 2ms) -> ORPHAN DAEMON
```

### Additional Notes

Like the watchdog itself, this stops the bleeding one release after it ships: the retiring caller runs old code during an update, so a pre-fix daemon stopped over HTTP still leaks until the first post-fix daemon is in place. Existing orphans (listener closed, process alive) are only reachable by pid, which stays `cline doctor` territory.

Related but not addressed here: hub compatibility is protocol-version only (`v1` everywhere), so a still-listening stale-build daemon is indistinguishable from a fresh one and gets re-attached to after a disconnect. That is the "stale one could still get connected" half of the report and is what #11264 is about.