### PR TITLE
feat: add HAI OpenAI-compatible provider

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -706,6 +706,17 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		defaults: { baseUrl: "https://api.groq.com/openai/v1" },
 	},
 	{
+		id: "hai",
+		name: "HAI",
+		description: "Japan-based OpenAI-compatible LLM Inference API (JPY billing)",
+		family: "openai-compatible",
+		defaultModelId: "kimi-k2.6",
+		apiKeyEnv: ["HAI_API_KEY"],
+		docsUrl: "https://hai.hcloud.ltd/docs",
+		defaults: { baseUrl: "https://hai-api.hcloud.ltd/v1" },
+	},
+
+	{
 		id: "cerebras",
 		name: "Cerebras",
 		description: "Fast inference on Cerebras wafer-scale chips",

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -33,6 +33,7 @@ export enum BUILT_IN_PROVIDER {
 	TOGETHER = "together",
 	FIREWORKS = "fireworks",
 	GROQ = "groq",
+	HAI = "hai",
 	POOLSIDE = "poolside",
 	CEREBRAS = "cerebras",
 	SAMBANOVA = "sambanova",


### PR DESCRIPTION
## Summary

Add **HAI** (https://hai.hcloud.ltd) as a built-in OpenAI-compatible provider.

HAI is a Japan-based OpenAI-compatible LLM Inference API with JPY billing.

### Config

| Field | Value |
|---|---|
| Provider ID | `hai` |
| Base URL | `https://hai-api.hcloud.ltd/v1` |
| API key env | `HAI_API_KEY` |
| Default model | `kimi-k2.6` |
| Docs | https://hai.hcloud.ltd/docs |

### Models

Users can use HAI model IDs such as:

- `kimi-k2.6` (default)
- `kimi-k3`
- `deepseek-v4-flash`
- `qwen3.6-35b-a3b`
- `qwen3.6-35b-a3b-uncensored`
- `gemma-4-31b-it`

A companion [models.dev PR](https://github.com/anomalyco/models.dev/pull/4411) adds full catalog metadata; after that lands, `bun -F @cline/llms generate:models` can refresh generated catalogs.

## Test plan

- [ ] Provider list shows **HAI**
- [ ] Set `HAI_API_KEY` / paste key in settings
- [ ] Chat with `kimi-k2.6` against `https://hai-api.hcloud.ltd/v1`