### PR TITLE
fix(vscode): make YOLO mode actually bypass approvals in the SDK extension

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -250,6 +250,11 @@ export class Controller {
 	// the chat view). Warmed in the constructor and refreshed on every call.
 	private lastKnownWorkspaceRoot?: string
 
+	// Re-entrancy guard for the YOLO plan->act auto-switch: a turn can settle
+	// through more than one session event, and a second togglePlanActMode while
+	// the first rebuild is in flight would race the exclusive rebuild scheduler.
+	private yoloPlanToActSwitchInFlight = false
+
 	get remoteConfig(): RemoteConfig | undefined {
 		return this.remoteConfigCoreIntegration?.prepared.bundle?.remoteConfig
 	}
@@ -353,6 +358,9 @@ export class Controller {
 				const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")
 				return autoApprovalSettings ? isToolAutoApproved(request.toolName, autoApprovalSettings, this.mcpHub) : false
 			},
+			// getGlobalSettingsKey gives remote config precedence, so an enterprise
+			// yoloModeAllowed=false lock forces this to false regardless of the toggle.
+			isYoloModeEnabled: () => !!this.stateManager.getGlobalSettingsKey("yoloModeToggled"),
 			getCwd: () => this.lastKnownWorkspaceRoot,
 		})
 		this.sessions = new SdkSessionLifecycle({
@@ -634,6 +642,7 @@ export class Controller {
 			getTurnPhase: () => this.turnStateTracker.currentPhase,
 			captureProviderApiError: (event) => this.captureProviderFailure(event),
 			beginProviderFailureTelemetryTurn: () => this.beginProviderFailureTelemetryTurn(),
+			onTurnAwaitingFollowup: () => this.maybeAutoSwitchPlanToActForYolo(),
 		})
 		// Subscribe to MCP tool list changes so we can restart the SDK session
 		// when servers are added/removed/reconnected. The SDK's DefaultSessionBuilder
@@ -1743,12 +1752,49 @@ export class Controller {
 
 	// ---- Mode switching ----
 
-	async toggleActModeForYoloMode(): Promise<boolean> {
-		return this.mode.toggleActModeForYoloMode()
-	}
-
 	async togglePlanActMode(modeToSwitchTo: Mode, chatContent?: ChatContent): Promise<boolean> {
 		return this.mode.togglePlanActMode(modeToSwitchTo, chatContent)
+	}
+
+	/**
+	 * YOLO parity with the legacy extension: when a plan-mode turn finishes by
+	 * presenting a plan while YOLO is enabled, switch to act mode automatically
+	 * instead of waiting for the user to approve the plan. The switch goes
+	 * through togglePlanActMode so the session is rebuilt with act-mode tools
+	 * and the existing plan-presented detection auto-continues the task.
+	 * Guarded on the plan-completion row so a plan turn that merely stopped
+	 * (no plan presented) never triggers a silent mode flip.
+	 */
+	private maybeAutoSwitchPlanToActForYolo(): void {
+		if (this.yoloPlanToActSwitchInFlight) {
+			return
+		}
+		if (!this.stateManager.getGlobalSettingsKey("yoloModeToggled")) {
+			return
+		}
+		if (this.stateManager.getGlobalSettingsKey("mode") !== "plan") {
+			return
+		}
+		const clineMessages = this.task?.messageStateHandler.getClineMessages() ?? []
+		const latestAssistantResult = [...clineMessages]
+			.reverse()
+			.find(
+				(message) =>
+					message.type === "say" && (message.say === "plan_completion_result" || message.say === "completion_result"),
+			)
+		if (latestAssistantResult?.say !== "plan_completion_result" || latestAssistantResult.partial) {
+			return
+		}
+		Logger.log("[SdkController] YOLO mode: plan presented; auto-switching to act mode")
+		this.yoloPlanToActSwitchInFlight = true
+		this.mode
+			.togglePlanActMode("act")
+			.catch((error) => {
+				Logger.error("[SdkController] YOLO mode: failed to auto-switch to act mode:", error)
+			})
+			.finally(() => {
+				this.yoloPlanToActSwitchInFlight = false
+			})
 	}
 
 	// ---- Telemetry ----

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -308,6 +308,79 @@ describe("SdkInteractionCoordinator", () => {
 		expect(recordApprovedToolMessage).not.toHaveBeenCalled()
 	})
 
+	it("auto-approves every tool when YOLO mode is enabled, even when settings deny it", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview,
+			shouldAutoApproveTool: () => false,
+			isYoloModeEnabled: () => true,
+		})
+
+		// File edits are the exact case from cline/cline#13114: policy forces the
+		// approval callback and the per-action setting (editFiles) is off.
+		await expect(
+			coordinator.handleRequestToolApproval({
+				agentId: "agent",
+				conversationId: "conversation",
+				iteration: 1,
+				toolCallId: "tool-call",
+				toolName: "editor",
+				input: { path: "hello.txt", new_text: "hi" },
+				policy: { autoApprove: false },
+			}),
+		).resolves.toEqual({ approved: true })
+
+		expect(task.messageStateHandler.getClineMessages()).toHaveLength(0)
+		expect(postStateToWebview).not.toHaveBeenCalled()
+	})
+
+	it("still asks for approval when YOLO mode is off and settings deny the tool", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			shouldAutoApproveTool: () => false,
+			isYoloModeEnabled: () => false,
+		})
+
+		void coordinator.handleRequestToolApproval({
+			agentId: "agent",
+			conversationId: "conversation",
+			iteration: 1,
+			toolCallId: "tool-call",
+			toolName: "editor",
+			input: { path: "hello.txt", new_text: "hi" },
+			policy: { autoApprove: false },
+		})
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
+		expect(task.messageStateHandler.getClineMessages()[0]).toMatchObject({ type: "ask", ask: "tool" })
+	})
+
+	it("auto-responds to ask_question when YOLO mode is enabled instead of blocking", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			isYoloModeEnabled: () => true,
+		})
+
+		const answer = await coordinator.handleAskQuestion("Which database do you use?", [], undefined)
+		expect(answer).toContain("YOLO MODE")
+		expect(answer).toContain("Which database do you use?")
+
+		// The question surfaces as a non-blocking info row, not a followup ask.
+		const clineMessages = task.messageStateHandler.getClineMessages()
+		expect(clineMessages).toHaveLength(1)
+		expect(clineMessages[0]).toMatchObject({ type: "say", say: "info" })
+		expect(clineMessages[0].text).toContain("Which database do you use?")
+		expect(coordinator.resolvePendingAskQuestion("stale")).toBe(false)
+	})
+
 	it("emits an MCP approval ask with server, tool, and arguments", async () => {
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
 		const coordinator = new SdkInteractionCoordinator({

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -22,6 +22,15 @@ export interface SdkInteractionCoordinatorOptions {
 	getSessionId: () => string
 	postStateToWebview: () => Promise<void>
 	shouldAutoApproveTool?: (request: ToolApprovalRequest) => boolean
+	/**
+	 * YOLO mode is a blanket runtime override (legacy-extension parity): while
+	 * enabled, every tool approval is granted and ask_question is auto-answered,
+	 * WITHOUT mutating the user's saved per-action auto-approval settings — so
+	 * turning YOLO off restores exactly the configuration they had before.
+	 * Evaluated per request so mid-task toggles (and remote-config locks, which
+	 * take precedence in StateManager) apply immediately.
+	 */
+	isYoloModeEnabled?: () => boolean
 	recordApprovedToolMessage?: (toolCallId: string, messageTs: number) => void
 	recordDeniedToolApproval?: (toolCallId: string, toolName: string, reason: string) => void
 	/**
@@ -92,6 +101,10 @@ export class SdkInteractionCoordinator {
 	}
 
 	async handleRequestToolApproval(request: ToolApprovalRequest): Promise<{ approved: boolean; reason?: string }> {
+		if (this.options.isYoloModeEnabled?.() === true) {
+			Logger.log(`[SdkController] YOLO mode: auto-approving tool execution: tool=${request.toolName}`)
+			return { approved: true }
+		}
 		if (request.policy.autoApprove === true || this.options.shouldAutoApproveTool?.(request) === true) {
 			Logger.log(`[SdkController] Auto-approving tool execution: tool=${request.toolName}`)
 			return { approved: true }
@@ -131,6 +144,24 @@ export class SdkInteractionCoordinator {
 	}
 
 	async handleAskQuestion(question: string, options: string[], _context: unknown): Promise<string> {
+		// YOLO mode runs unattended, so blocking on user input would defeat it.
+		// Match the legacy extension: surface the question as an info row, then
+		// auto-respond telling the model to find the answer with tools instead.
+		if (this.options.isYoloModeEnabled?.() === true) {
+			const infoMessage: ClineMessage = {
+				ts: this.nextMessageTs(),
+				type: "say",
+				say: "info",
+				text: `[YOLO MODE] Auto-responding to question: "${question.substring(0, 100)}${question.length > 100 ? "..." : ""}"`,
+				partial: false,
+			}
+			this.options.messages.appendAndEmit([infoMessage], {
+				type: "status",
+				payload: { sessionId: this.options.getSessionId(), status: "running" },
+			})
+			return `[YOLO MODE: User input is not available in non-interactive mode. You must use available tools (read files, search, run commands, etc.) to gather the information you need instead of asking the user. Proceed with using tools to find the answer to your question: "${question}"]`
+		}
+
 		const askData: ClineAskQuestion = {
 			question,
 			options: options?.length ? options : undefined,

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.ts
@@ -128,16 +128,6 @@ export class SdkModeCoordinator {
 		}
 	}
 
-	async toggleActModeForYoloMode(): Promise<boolean> {
-		const currentMode = this.options.stateManager.getGlobalSettingsKey("mode")
-		if (currentMode === "act") {
-			return false
-		}
-		await this.options.stateManager.setGlobalState("mode", "act")
-		await this.options.postStateToWebview()
-		return true
-	}
-
 	async togglePlanActMode(modeToSwitchTo: Mode, chatContent?: ChatContent): Promise<boolean> {
 		const currentMode = this.options.stateManager.getGlobalSettingsKey("mode")
 		if (currentMode === modeToSwitchTo) {

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.test.ts
@@ -110,6 +110,43 @@ describe("SdkSessionEventCoordinator", () => {
 		expect(options.postStateToWebview).toHaveBeenCalledOnce()
 	})
 
+	it("notifies onTurnAwaitingFollowup only after a clean turn settles to awaiting_followup", async () => {
+		const { coordinator, options, event } = makeCoordinator({
+			translation: {
+				messages: [],
+				sessionEnded: false,
+				turnComplete: true,
+			},
+		})
+
+		await coordinator.handleSessionEvent(event)
+
+		expect(options.setTurnPhase).toHaveBeenCalledWith("awaiting_followup")
+		expect(options.onTurnAwaitingFollowup).toHaveBeenCalledOnce()
+		// Called after the running flag is cleared, so the handler observes the settled state.
+		expect(options.sessions.setRunning.mock.invocationCallOrder[0]).toBeLessThan(
+			options.onTurnAwaitingFollowup.mock.invocationCallOrder[0],
+		)
+	})
+
+	it("does NOT notify onTurnAwaitingFollowup for completed or error turns", async () => {
+		const completed = makeCoordinator({
+			translation: { messages: [], sessionEnded: false, turnComplete: true },
+		})
+		completed.options.messageTranslatorState.setAttemptCompletionSeen()
+		await completed.coordinator.handleSessionEvent(completed.event)
+		expect(completed.options.setTurnPhase).toHaveBeenCalledWith("completed")
+		expect(completed.options.onTurnAwaitingFollowup).not.toHaveBeenCalled()
+
+		const errored = makeCoordinator({
+			translation: { messages: [], sessionEnded: false, turnComplete: true },
+		})
+		errored.options.messageTranslatorState.setErrorSeen()
+		await errored.coordinator.handleSessionEvent(errored.event)
+		expect(errored.options.setTurnPhase).toHaveBeenCalledWith("error")
+		expect(errored.options.onTurnAwaitingFollowup).not.toHaveBeenCalled()
+	})
+
 	it("resolves the turn phase to 'error' when the turn surfaced a provider error", async () => {
 		const { coordinator, options, event } = makeCoordinator({
 			translation: {
@@ -421,6 +458,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		beginProviderFailureTelemetryTurn: vi.fn(),
 		translateSessionEvent: vi.fn(() => input.translation ?? { messages: [], sessionEnded: false, turnComplete: false }),
 		isClineFreeModel: input.isClineFreeModel,
+		onTurnAwaitingFollowup: vi.fn(),
 	} as unknown as SdkSessionEventCoordinatorOptions & {
 		sessions: SdkSessionEventCoordinatorOptions["sessions"] & {
 			getActiveSession: ReturnType<typeof vi.fn>
@@ -433,6 +471,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		beginProviderFailureTelemetryTurn: ReturnType<typeof vi.fn>
 		translateSessionEvent: ReturnType<typeof vi.fn>
 		messageTranslatorState: MessageTranslatorState
+		onTurnAwaitingFollowup: ReturnType<typeof vi.fn>
 	}
 
 	return {

--- a/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-session-event-coordinator.ts
@@ -39,6 +39,14 @@ export interface SdkSessionEventCoordinatorOptions {
 	getTurnPhase?: () => TurnPhase
 	captureProviderApiError?: (event: ProviderFailureTelemetry) => void
 	beginProviderFailureTelemetryTurn?: () => void
+	/**
+	 * Fired after a clean (non-error, non-cancelled) turn settles to
+	 * "awaiting_followup" and the running flag is cleared. Used by the
+	 * controller to auto-switch plan -> act when YOLO mode is enabled and the
+	 * settled turn presented a plan. Called after the phase/running updates so
+	 * the handler observes the same state the mode coordinator will re-check.
+	 */
+	onTurnAwaitingFollowup?: () => void
 }
 
 export class SdkSessionEventCoordinator {
@@ -113,6 +121,7 @@ export class SdkSessionEventCoordinator {
 				// isRunning back to false mid-turn (see fireAndForgetSend). Keying on isRunning
 				// alone made the queued turn's real completion look like this straggler, leaving
 				// the phase stuck on "streaming" (endless Thinking).
+				let settledAwaitingFollowup = false
 				if (!activeSession.isRunning && this.options.getTurnPhase?.() === "resumable") {
 					Logger.debug("[SdkController] turn-complete straggler after cancel; preserving resumable phase")
 				} else if (this.options.messageTranslatorState.wasErrorSeen()) {
@@ -123,9 +132,13 @@ export class SdkSessionEventCoordinator {
 					this.options.setTurnPhase?.("completed")
 				} else {
 					this.options.setTurnPhase?.("awaiting_followup")
+					settledAwaitingFollowup = true
 				}
 
 				this.options.sessions.setRunning(false)
+				if (settledAwaitingFollowup) {
+					this.options.onTurnAwaitingFollowup?.()
+				}
 			}
 
 			if (result.usage && activeSession.startResult) {


### PR DESCRIPTION
### Related Issue

**Issue:** #13114

### Description

In the Next (SDK) extension, the YOLO mode toggle was stored and displayed (Settings -> Features, and the AutoApproveBar even replaces itself with "Auto-approve: YOLO"), but nothing in the SDK approval path ever read it. Tool approvals fell through to the individual auto-approval settings, so whatever per-action toggles the user happened to have saved silently governed YOLO runs. That is exactly the report in #13114: reads and commands auto-approved (those toggles were on), file edits still prompted (editFiles was off).

Rather than having the toggle bulk-write all auto-approve settings (which would destroy the user's curated configuration and not restore it on toggle-off), this restores the legacy extension's YOLO semantics as a runtime override that leaves the saved settings untouched:

- `SdkInteractionCoordinator.handleRequestToolApproval` now grants every approval request while YOLO is enabled (edits, commands, reads, browser, MCP tools). Evaluated per request, so mid-task toggles apply immediately without a session rebuild.
- `ask_question` no longer blocks under YOLO: it surfaces the question as an info row and auto-responds with the same canned "use tools to find the answer" reply the legacy handler used.
- When a plan-mode turn finishes by presenting a plan while YOLO is on, the controller auto-switches to act mode through the existing `togglePlanActMode` path, so the session is rebuilt with act tools and the plan-presented auto-continue kicks in (legacy `PlanModeRespondHandler` parity).
- Removed the dead `toggleActModeForYoloMode` carried over from the legacy controller; it set the mode without rebuilding the session, which is wrong for the SDK architecture, and nothing called it.

Enterprise remote-config locks keep working: the checks read `yoloModeToggled` through `StateManager.getGlobalSettingsKey`, where remote config takes precedence, so `yoloModeAllowed: false` still forces YOLO off.

### Test Procedure

**Automated:**
- New unit tests in `sdk-interaction-coordinator.test.ts`: YOLO auto-approves a denied edit tool (the exact #13114 case), YOLO off still asks, and `ask_question` auto-responds with an info row instead of a pending followup.
- New unit tests in `sdk-session-event-coordinator.test.ts`: the new `onTurnAwaitingFollowup` callback fires only when a clean turn settles to `awaiting_followup` (after the running flag clears), not for completed or error turns.
- Full `bun run test:vitest` (1036 tests, 78 files) and `bun run test:unit` (1060 tests, 72 files) pass; `bun run check-types` and `bun run lint` clean.

**Manual (dev extension host, OpenRouter / claude-haiku-4.5):** disabled every individual auto-approve toggle, enabled Yolo Mode in Settings -> Features, and asked Cline to create `hello.txt`. The message was sent while still in Plan mode, which ended up exercising both new paths in one run: the plan response triggered the automatic Plan -> Act switch, and the file creation then proceeded with no Approve/Reject buttons and completed autonomously. Extension host log from the run:

```
[SdkController] YOLO mode: plan presented; auto-switching to act mode
[SdkController] YOLO mode: auto-approving tool execution: tool=editor
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

End state of the manual test: completed conversation with the "create a new file" tool row that required no approval click, "Auto-approve: YOLO" bar, and `hello.txt` open with the requested content.

![YOLO mode task completed without approval clicks](https://cursor.com/artifacts/c/art-3e9fe013-0b0a-44b1-8f65-bdbe40667d7a)

### Additional Notes

The AutoApproveBar already communicated override semantics (it replaces the per-action controls with "Auto-approve: YOLO" while the toggle is on), so no webview changes were needed.