### PR TITLE
fix: respect user max output tokens in compaction summarizer requests

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -752,7 +752,8 @@ describe("buildSessionConfig", () => {
 		// the top level (manual compaction budgets).
 		expect(config.knownModels).toBeDefined()
 		expect((config.providerConfig as any).knownModels).toBeDefined()
-		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
+		// Mirrored onto providerConfig for the compaction summarizer (CLINE-2911).
+		expect((config.providerConfig as any).maxOutputTokens).toBe(4_096)
 		expect((config as any).maxTokensPerTurn).toBe(4_096)
 	})
 
@@ -826,6 +827,7 @@ describe("buildSessionConfig", () => {
 		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
 
 		expect((config as any).maxTokensPerTurn).toBeUndefined()
+		expect((config.providerConfig as any).maxOutputTokens).toBeUndefined()
 		expect((config as any).temperature).toBeUndefined()
 		const knownModel = (config.providerConfig as any).knownModels["custom-reasoner"]
 		expect(knownModel).not.toHaveProperty("maxTokens")

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -961,6 +961,10 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 		...(baseUrl !== undefined ? { baseUrl } : {}),
 		...(apiLine !== undefined ? { apiLine } : {}),
 		...(knownModels && Object.keys(knownModels).length > 0 ? { knownModels } : {}),
+		// Mirror the user's Max Output Tokens for consumers that build handlers
+		// straight from providerConfig — notably the compaction summarizer, which
+		// otherwise falls back to a small default output cap (CLINE-2911).
+		...(maxTokensPerTurn !== undefined ? { maxOutputTokens: maxTokensPerTurn } : {}),
 		fetch,
 	}
 

--- a/sdk/packages/core/scripts/compact-session.ts
+++ b/sdk/packages/core/scripts/compact-session.ts
@@ -5,7 +5,10 @@ import { extname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import type { MessageWithMetadata } from "@cline/shared";
 import { createContextCompactionPrepareTurn } from "../src/extensions/context/compaction";
-import { getCompactionSummaryMetadata } from "../src/extensions/context/compaction-shared";
+import {
+	DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS,
+	getCompactionSummaryMetadata,
+} from "../src/extensions/context/compaction-shared";
 import { normalizeStoredMessagesForPersistence } from "../src/services/session-data";
 import type { ProviderConfig } from "../src/types/provider-settings";
 
@@ -33,7 +36,7 @@ Options:
 	                              (agentic compaction only)
   --base-url <url>            Custom provider base URL
   --max-input-tokens <count>  Summarizer input limit (default: 128000)
-  --max-output-tokens <count> Summarizer output limit (default: 1024)
+  --max-output-tokens <count> Summarizer output limit (default: 4096)
   --preserve-recent-tokens <count>
                               Verbatim tail to retain (default: 0)
 	  --output <path>             Write canonical compacted messages JSON. With
@@ -192,7 +195,7 @@ const maxInputTokens = positiveInteger(
 const maxOutputTokens = positiveInteger(
 	values["max-output-tokens"],
 	"--max-output-tokens",
-	1_024,
+	DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS,
 );
 const preserveRecentTokens = nonNegativeInteger(
 	values["preserve-recent-tokens"],

--- a/sdk/packages/core/src/extensions/context/agentic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/agentic-compaction.ts
@@ -59,13 +59,23 @@ export function buildAgenticSummaryInputBudget(options: {
 	});
 }
 
+interface SummaryGenerationResult {
+	text: string;
+	/** Reasoning/thinking output length; discarded from the summary itself. */
+	reasoningChars: number;
+	/** Provider-reported reason the response is incomplete (e.g. "max_output_tokens"). */
+	incompleteReason?: string;
+}
+
 async function generateSummary(options: {
 	providerConfig: ProviderConfig;
 	request: string;
 	logger?: BasicLogger;
-}): Promise<string> {
+}): Promise<SummaryGenerationResult> {
 	const handler = await createHandlerAsync(options.providerConfig);
 	let text = "";
+	let reasoningChars = 0;
+	let incompleteReason: string | undefined;
 	for await (const chunk of handler.createMessage(
 		"Summarize the provided coding session into a concise continuation note with detailed next steps.",
 		[{ role: "user", content: options.request }],
@@ -74,16 +84,25 @@ async function generateSummary(options: {
 			text += chunk.text;
 			continue;
 		}
-		if (chunk.type === "done" && !chunk.success && chunk.error) {
-			throw new Error(chunk.error);
+		if (chunk.type === "reasoning") {
+			reasoningChars += chunk.reasoning?.length ?? 0;
+			continue;
+		}
+		if (chunk.type === "done") {
+			if (!chunk.success && chunk.error) {
+				throw new Error(chunk.error);
+			}
+			incompleteReason = chunk.incompleteReason ?? incompleteReason;
 		}
 	}
 	options.logger?.debug("Generated compaction summary", {
 		outputChars: text.length,
+		reasoningChars,
+		incompleteReason,
 		modelId: options.providerConfig.modelId,
 		providerId: options.providerConfig.providerId,
 	});
-	return text.trim();
+	return { text: text.trim(), reasoningChars, incompleteReason };
 }
 
 function safeJsonSize(value: unknown): number {
@@ -231,12 +250,28 @@ export async function runAgenticCompaction(options: {
 		maxInputTokens: options.context.budget.request.maxInputTokens,
 		triggerTokens: options.context.budget.request.triggerTokens,
 	});
-	const rawSummary = await generateSummary({
+	const summaryResult = await generateSummary({
 		providerConfig: summarizerProviderConfig,
 		request: summaryRequest,
 		logger: options.logger,
 	});
-	if (!rawSummary.trim()) {
+	const rawSummary = summaryResult.text;
+	if (!rawSummary) {
+		options.logger?.log(
+			"Skipped agentic compaction: summarizer returned no summary text",
+			{
+				severity: "warn",
+				summarizerProviderId: summarizerProviderConfig.providerId,
+				summarizerModelId: summarizerProviderConfig.modelId,
+				summarizerMaxOutputTokens: summarizerProviderConfig.maxOutputTokens,
+				reasoningChars: summaryResult.reasoningChars,
+				incompleteReason: summaryResult.incompleteReason,
+				likelyCause:
+					summaryResult.reasoningChars > 0
+						? "output_budget_consumed_by_reasoning"
+						: "empty_response",
+			},
+		);
 		return undefined;
 	}
 

--- a/sdk/packages/core/src/extensions/context/compaction-shared.ts
+++ b/sdk/packages/core/src/extensions/context/compaction-shared.ts
@@ -688,19 +688,22 @@ Edited: ${options.fileOps.modifiedFiles.join(", ") || "none"}`,
 /**
  * The summarizer output budget is a cap, not a target: reasoning models need
  * headroom beyond their thinking output or no summary text ever arrives and
- * compaction is skipped.
+ * compaction is skipped. An explicit configuration wins as-is; otherwise the
+ * default applies, with model metadata (`maxTokens` is reported capability,
+ * not a product default) only ever lowering it.
  */
 function resolveSummaryMaxOutputTokens(config: ProviderConfig): number {
 	if (isPositiveFiniteNumber(config.maxOutputTokens)) {
 		return Math.floor(config.maxOutputTokens);
 	}
-	const modelInfoMaxTokens = config.modelInfo?.maxTokens;
-	if (isPositiveFiniteNumber(modelInfoMaxTokens)) {
-		return Math.floor(modelInfoMaxTokens);
-	}
-	const knownModelMaxTokens = config.knownModels?.[config.modelId]?.maxTokens;
-	if (isPositiveFiniteNumber(knownModelMaxTokens)) {
-		return Math.floor(knownModelMaxTokens);
+	const modelMaxTokens =
+		config.modelInfo?.maxTokens ??
+		config.knownModels?.[config.modelId]?.maxTokens;
+	if (isPositiveFiniteNumber(modelMaxTokens)) {
+		return Math.min(
+			DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS,
+			Math.floor(modelMaxTokens),
+		);
 	}
 	return DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS;
 }

--- a/sdk/packages/core/src/extensions/context/compaction-shared.ts
+++ b/sdk/packages/core/src/extensions/context/compaction-shared.ts
@@ -17,7 +17,7 @@ export const CONTEXT_WINDOW_INPUT_RATIO = 0.9;
 export const COMPACTION_TRIGGER_RATIO = 0.9;
 export const DEFAULT_TARGET_RATIO = 0.7;
 export const DEFAULT_PRESERVE_RECENT_TOKENS = 20_000;
-export const DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS = 1_024;
+export const DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS = 4_096;
 export const TOOL_RESULT_CHAR_LIMIT = 2_000;
 export const FILE_CONTENT_CHAR_LIMIT = 2_000;
 export const MIN_TRUNCATED_MESSAGE_TOKENS = 8;
@@ -685,6 +685,26 @@ Edited: ${options.fileOps.modifiedFiles.join(", ") || "none"}`,
 	return parts.join("\n\n");
 }
 
+/**
+ * The summarizer output budget is a cap, not a target: reasoning models need
+ * headroom beyond their thinking output or no summary text ever arrives and
+ * compaction is skipped.
+ */
+function resolveSummaryMaxOutputTokens(config: ProviderConfig): number {
+	if (isPositiveFiniteNumber(config.maxOutputTokens)) {
+		return Math.floor(config.maxOutputTokens);
+	}
+	const modelInfoMaxTokens = config.modelInfo?.maxTokens;
+	if (isPositiveFiniteNumber(modelInfoMaxTokens)) {
+		return Math.floor(modelInfoMaxTokens);
+	}
+	const knownModelMaxTokens = config.knownModels?.[config.modelId]?.maxTokens;
+	if (isPositiveFiniteNumber(knownModelMaxTokens)) {
+		return Math.floor(knownModelMaxTokens);
+	}
+	return DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS;
+}
+
 export function resolveSummarizerConfig(options: {
 	activeProviderConfig: ProviderConfig;
 	summarizer?: CoreCompactionSummarizerConfig;
@@ -700,8 +720,7 @@ export function resolveSummarizerConfig(options: {
 		}
 		return {
 			...config,
-			maxOutputTokens:
-				config.maxOutputTokens ?? DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS,
+			maxOutputTokens: resolveSummaryMaxOutputTokens(config),
 			thinking: false,
 		};
 	};
@@ -722,7 +741,7 @@ export function resolveSummarizerConfig(options: {
 		modelInfo: summarizer.modelInfo ?? baseProviderConfig?.modelInfo,
 		knownModels: summarizer.knownModels ?? baseProviderConfig?.knownModels,
 		maxOutputTokens:
-			summarizer.maxOutputTokens ?? DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS,
+			summarizer.maxOutputTokens ?? baseProviderConfig?.maxOutputTokens,
 	});
 }
 

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -1182,7 +1182,146 @@ describe("createContextCompactionPrepareTurn", () => {
 
 		expect(codexConfig).not.toHaveProperty("maxOutputTokens");
 		expect(codexConfig.thinking).toBe(false);
-		expect(anthropicConfig.maxOutputTokens).toBe(1_024);
+		expect(anthropicConfig.maxOutputTokens).toBe(4_096);
+	});
+
+	it("resolves the summarizer output budget from config before model info before the default", () => {
+		const explicitWins = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "openai",
+				modelId: "local-model",
+				maxOutputTokens: 16_000,
+				modelInfo: { id: "local-model", maxTokens: 8_000 },
+			} as LlmsProviders.ProviderConfig,
+		});
+		expect(explicitWins.maxOutputTokens).toBe(16_000);
+
+		const fromModelInfo = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "openai",
+				modelId: "local-model",
+				modelInfo: { id: "local-model", maxTokens: 8_000 },
+			} as LlmsProviders.ProviderConfig,
+		});
+		expect(fromModelInfo.maxOutputTokens).toBe(8_000);
+
+		const fromKnownModels = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "openai",
+				modelId: "local-model",
+				knownModels: {
+					"local-model": { id: "local-model", maxTokens: 12_000 },
+				},
+			} as LlmsProviders.ProviderConfig,
+		});
+		expect(fromKnownModels.maxOutputTokens).toBe(12_000);
+
+		const fromDefault = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "openai",
+				modelId: "local-model",
+			} as LlmsProviders.ProviderConfig,
+		});
+		expect(fromDefault.maxOutputTokens).toBe(4_096);
+	});
+
+	it("resolves an explicit summarizer's output budget from its own model info", () => {
+		const resolved = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "anthropic",
+				modelId: "primary-model",
+			} as LlmsProviders.ProviderConfig,
+			summarizer: {
+				providerId: "openai",
+				modelId: "small-summary",
+				modelInfo: { id: "small-summary", maxTokens: 2_000 },
+			},
+		});
+
+		expect(resolved.maxOutputTokens).toBe(2_000);
+	});
+
+	it("skips with a diagnostic warning when the summarizer only produced reasoning output", async () => {
+		// Repro for CLINE-2911: a reasoning model can spend the entire output
+		// budget thinking. Reasoning chunks are discarded, so no summary text
+		// arrives and compaction is skipped — that skip must be diagnosable.
+		const logger = { debug: vi.fn(), log: vi.fn() };
+		const emitStatusNotice = vi.fn();
+		createHandlerMock.mockReturnValue({
+			createMessage: vi.fn(() =>
+				streamChunks([
+					{
+						type: "reasoning",
+						id: "summary-think",
+						reasoning: "thinking about the summary...",
+					},
+					{
+						type: "done",
+						id: "summary-think",
+						success: true,
+						incompleteReason: "max_output_tokens",
+					},
+				]),
+			),
+		});
+
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "openai",
+			modelId: "local-reasoner",
+			providerConfig: {
+				providerId: "openai",
+				modelId: "local-reasoner",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				strategy: "agentic",
+				preserveRecentTokens: 1,
+			},
+			logger,
+		});
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "You are helpful.",
+			tools: [],
+			messages: [
+				{ role: "user", content: "Old turn" },
+				{ role: "assistant", content: "Old answer" },
+				{ role: "user", content: "Latest turn" },
+				{ role: "assistant", content: "Latest answer" },
+			],
+			apiMessages: [
+				{ role: "user", content: "Old turn" },
+				{ role: "assistant", content: "Old answer" },
+				{ role: "user", content: "Latest turn" },
+				{ role: "assistant", content: "Latest answer" },
+			],
+			model: {
+				id: "local-reasoner",
+				provider: "openai",
+				info: { id: "local-reasoner", maxInputTokens: 10 },
+			},
+			emitStatusNotice,
+		});
+
+		expect(result).toBeUndefined();
+		expect(emitStatusNotice).toHaveBeenCalledWith(
+			"auto-compaction-skipped",
+			expect.objectContaining({ phase: "skipped" }),
+		);
+		expect(logger.log).toHaveBeenCalledWith(
+			"Skipped agentic compaction: summarizer returned no summary text",
+			expect.objectContaining({
+				severity: "warn",
+				reasoningChars: "thinking about the summary...".length,
+				incompleteReason: "max_output_tokens",
+				likelyCause: "output_budget_consumed_by_reasoning",
+			}),
+		);
 	});
 
 	it("preserves summarizer modelInfo without a nested providerConfig", () => {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -1185,7 +1185,9 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(anthropicConfig.maxOutputTokens).toBe(4_096);
 	});
 
-	it("resolves the summarizer output budget from config before model info before the default", () => {
+	it("resolves the summarizer output budget from explicit config, else the default clamped by model metadata", () => {
+		// An explicit value is user/product intent and wins as-is (the gateway
+		// still clamps against model limits and remaining context per request).
 		const explicitWins = resolveSummarizerConfig({
 			activeProviderConfig: {
 				providerId: "openai",
@@ -1196,25 +1198,36 @@ describe("createContextCompactionPrepareTurn", () => {
 		});
 		expect(explicitWins.maxOutputTokens).toBe(16_000);
 
-		const fromModelInfo = resolveSummarizerConfig({
+		// Model metadata is reported capability, not a request default: it only
+		// ever lowers the default, never raises it.
+		const clampedByModelInfo = resolveSummarizerConfig({
 			activeProviderConfig: {
 				providerId: "openai",
 				modelId: "local-model",
-				modelInfo: { id: "local-model", maxTokens: 8_000 },
+				modelInfo: { id: "local-model", maxTokens: 2_000 },
 			} as LlmsProviders.ProviderConfig,
 		});
-		expect(fromModelInfo.maxOutputTokens).toBe(8_000);
+		expect(clampedByModelInfo.maxOutputTokens).toBe(2_000);
 
-		const fromKnownModels = resolveSummarizerConfig({
+		const notRaisedByModelInfo = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "openai",
+				modelId: "local-model",
+				modelInfo: { id: "local-model", maxTokens: 64_000 },
+			} as LlmsProviders.ProviderConfig,
+		});
+		expect(notRaisedByModelInfo.maxOutputTokens).toBe(4_096);
+
+		const clampedByKnownModels = resolveSummarizerConfig({
 			activeProviderConfig: {
 				providerId: "openai",
 				modelId: "local-model",
 				knownModels: {
-					"local-model": { id: "local-model", maxTokens: 12_000 },
+					"local-model": { id: "local-model", maxTokens: 3_000 },
 				},
 			} as LlmsProviders.ProviderConfig,
 		});
-		expect(fromKnownModels.maxOutputTokens).toBe(12_000);
+		expect(clampedByKnownModels.maxOutputTokens).toBe(3_000);
 
 		const fromDefault = resolveSummarizerConfig({
 			activeProviderConfig: {
@@ -1225,8 +1238,8 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(fromDefault.maxOutputTokens).toBe(4_096);
 	});
 
-	it("resolves an explicit summarizer's output budget from its own model info", () => {
-		const resolved = resolveSummarizerConfig({
+	it("clamps an explicit summarizer's default budget by its own model info but lets its explicit value win", () => {
+		const clamped = resolveSummarizerConfig({
 			activeProviderConfig: {
 				providerId: "anthropic",
 				modelId: "primary-model",
@@ -1237,8 +1250,21 @@ describe("createContextCompactionPrepareTurn", () => {
 				modelInfo: { id: "small-summary", maxTokens: 2_000 },
 			},
 		});
+		expect(clamped.maxOutputTokens).toBe(2_000);
 
-		expect(resolved.maxOutputTokens).toBe(2_000);
+		const explicitWins = resolveSummarizerConfig({
+			activeProviderConfig: {
+				providerId: "anthropic",
+				modelId: "primary-model",
+			} as LlmsProviders.ProviderConfig,
+			summarizer: {
+				providerId: "openai",
+				modelId: "small-summary",
+				modelInfo: { id: "small-summary", maxTokens: 2_000 },
+				maxOutputTokens: 6_000,
+			},
+		});
+		expect(explicitWins.maxOutputTokens).toBe(6_000);
 	});
 
 	it("skips with a diagnostic warning when the summarizer only produced reasoning output", async () => {


### PR DESCRIPTION
## Problem

Auto and manual context compaction always fail with "Compaction skipped" when using OpenAI-compatible local models (llama-server) with reasoning models like Qwen 3.x.

Fixes https://github.com/cline/cline/issues/13127
Linear: [CLINE-2911](https://linear.app/cline-bot/issue/CLINE-2911/auto-compaction-always-got-compaction-skipped)

## Root cause

Three compounding parts:

1. `resolveSummarizerConfig` (`sdk/packages/core/src/extensions/context/compaction-shared.ts`) defaulted the summarizer's `maxOutputTokens` to a hardcoded 1024 whenever the provider config didn't carry one, with no way for the user's setting to reach it.
2. The VSCode host never set `maxOutputTokens` on `providerConfig`. The user's Max Output Tokens setting becomes top-level `maxTokensPerTurn` (consumed by the main loop), but both auto and manual compaction build the summarizer handler straight from `providerConfig` — so summarizer requests always went out with `max_tokens: 1024` regardless of the setting. The CLI doesn't have this bug (`toProviderConfig` maps the setting through).
3. Why "skipped" rather than a truncated summary: reasoning models emit thinking as `reasoning` stream chunks, which `generateSummary` discards. The model spends the entire 1024-token budget thinking, zero summary text arrives, and the empty result maps to the generic "Compaction skipped" with no diagnostic.

Note on history: `maxOutputTokens` on `providerConfig` was previously removed on purpose ("revert OpenAI-compatible metadata limit plumbing") — but the problem then was fabricating limits from model *metadata*; the explicit `maxTokensPerTurn` was its replacement. This change mirrors that same explicit value, and the only direct consumers of `providerConfig` are the compaction summarizer (the fix target) and `createAgentModelFromConfig`, which already overwrites the field with the identical value — the main loop is untouched.

## Changes

- **`apps/vscode/src/sdk/cline-session-factory.ts`** — mirror `maxTokensPerTurn` onto `providerConfig.maxOutputTokens`, so the compaction summarizer honors the user's Max Output Tokens for both auto and manual compaction.
- **`sdk/packages/core/src/extensions/context/compaction-shared.ts`** — resolve the summarizer output budget as: explicit config wins as-is; otherwise the default (raised from 1024 to 4096), clamped down — never up — by the model's reported `maxTokens`. Model metadata is capability, not a product default, so it only ever lowers the requested cap; the budget itself is a cap, not a target, and 4096 gives reasoning models room to think and still emit the summary when nothing is configured. The gateway additionally clamps every request against model limits and remaining context (`resolveGatewayRequestMaxTokens`); the only non-gateway handler (`vscode-lm`) ignores `maxOutputTokens` entirely.
- **`sdk/packages/core/src/extensions/context/agentic-compaction.ts`** — when the summarizer returns no summary text, log a warning with the resolved output budget, reasoning output size, and the provider's `incompleteReason` (e.g. `max_output_tokens`), distinguishing "output budget consumed by reasoning" from a genuinely empty response, so future skips are diagnosable from logs.
- **`sdk/packages/core/scripts/compact-session.ts`** — the offline repro script now shares `DEFAULT_SUMMARY_MAX_OUTPUT_TOKENS` instead of its own 1024.

## Tests

- Unit tests for the output-budget policy: explicit wins (including over smaller model metadata, for both the active provider and an explicit summarizer), metadata clamps the default down (2000-cap model → 2000) but never raises it (64k-capability model → 4096), and the plain default when nothing is known.
- Regression test reproducing the reported scenario: a summarizer stream yielding only reasoning chunks + `incompleteReason: "max_output_tokens"` → compaction skips and emits the diagnostic warning.
- Session-factory tests assert `providerConfig.maxOutputTokens` mirrors the user's setting and stays absent when unset.
- Full `@cline/core` unit suite (1789 passed) and all VSCode SDK adapter tests (974 passed) green; typecheck and biome clean.