### PR TITLE
fix(vscode): don't discard a successfully refreshed Cline token after expiry

### DIFF
--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -363,6 +363,33 @@ describe("AuthService", () => {
 			const token = await authService.getAuthToken()
 			expect(token).toBeNull()
 		})
+
+		it("returns the refreshed token when an already-expired token refreshes successfully", async () => {
+			// Regression test: the process sat idle past token expiry (e.g. across
+			// a laptop suspend), so the refresh happens after expiresAt has passed.
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo({
+				expiresAt: Math.floor(Date.now() / 1000) - 100, // already expired
+			})
+			testAccess(authService)._authenticated = true
+			vi.mocked(getValidClineCredentials).mockResolvedValue(createTestOAuthCredentials())
+
+			const token = await authService.getAuthToken()
+			expect(token).toBe("workos:oauth-access-token")
+		})
+
+		it("still rejects a token that comes back from refresh already expired", async () => {
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo({
+				expiresAt: Math.floor(Date.now() / 1000) - 100, // already expired
+			})
+			testAccess(authService)._authenticated = true
+			vi.mocked(getValidClineCredentials).mockResolvedValue({
+				...createTestOAuthCredentials(),
+				expires: Date.now() - 1000, // refresh returned an expired token (ms)
+			})
+
+			const token = await authService.getAuthToken()
+			expect(token).toBeNull()
+		})
 	})
 
 	describe("createAuthRequest()", () => {

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -375,8 +375,12 @@ export class AuthService {
 			}
 		}
 
-		// Verify the token is still valid (not past expiry)
-		if (expiresAt && Date.now() / 1000 >= expiresAt) {
+		// Verify the token is still valid (not past expiry). Re-read the expiry:
+		// a successful refresh above replaces _clineAuthInfo, and the expiry
+		// captured before it belongs to the old token — which has already passed
+		// whenever the process sat idle beyond token lifetime.
+		const currentExpiresAt = this._clineAuthInfo.expiresAt
+		if (currentExpiresAt && Date.now() / 1000 >= currentExpiresAt) {
 			return null
 		}
 


### PR DESCRIPTION
### Related Issue

One of the two next-side auth bugs documented as "not fixed here" in https://github.com/cline/cline/pull/12826 — `getAuthToken` discarding a successful refresh of an expired token.

### Description

`SdkAuthService.getAuthToken()` captures `expiresAt` before deciding whether to refresh, and then validates the token against that same captured value *after* the refresh:

- **About-to-expire (within the 5-minute buffer, not yet expired):** refresh succeeds, the old `expiresAt` is still in the future, the check passes — works fine.
- **Already expired:** refresh succeeds and replaces `_clineAuthInfo` with a fresh token and expiry, but the staleness check still compares `Date.now()` against the *old* token's expiry, which has passed → returns `null` despite the process holding valid, just-refreshed credentials.

The failure is transient (the next call sees the new `expiresAt` and succeeds) and doesn't clear credentials, but whatever rode on that first call fails: a request goes out unauthenticated or the caller renders a signed-out state. "Already expired at call time" is exactly what happens whenever the host process sits idle past token lifetime — laptop suspends, long-lived IDE processes — so the first Cline action of the day is the typical victim.

Fix: re-read `expiresAt` from `_clineAuthInfo` after the refresh path instead of reusing the pre-refresh capture. A token that genuinely comes back expired from refresh is still rejected.

### Test Procedure

Two new cases in `apps/vscode/src/sdk/auth-service.test.ts`:
- already-expired token + successful refresh → returns the refreshed `workos:`-prefixed token (fails on unfixed code with `null`, verified);
- refresh that itself returns an expired token → still `null`.

Full file: 33/33 pass. `tsc --noEmit` clean.