### PR TITLE
fix(vscode): trim full request body from persisted api_req_started messages

### DIFF
--- a/.changeset/fix-api-req-started-request-body.md
+++ b/.changeset/fix-api-req-started-request-body.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Trim the full request body from persisted api_req_started messages so reopening large conversations no longer crashes the webview

--- a/apps/vscode/src/sdk/sdk-message-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-message-coordinator.test.ts
@@ -66,6 +66,59 @@ describe("SdkMessageCoordinator", () => {
 		expect(JSON.parse(finalized[2].text ?? "{}")).toEqual({ cancelReason: "user_cancelled" })
 	})
 
+	it("drops the full request body from api_req_started messages, keeping only metadata", () => {
+		const coordinator = new SdkMessageCoordinator({ getTask: () => undefined })
+		const hugeRequestBody = JSON.stringify({
+			system: "you are a helpful assistant",
+			messages: Array.from({ length: 3000 }, (_, i) => ({ role: "user", content: `message ${i} ${"x".repeat(20)}` })),
+		})
+		expect(hugeRequestBody.length).toBeGreaterThan(40_000)
+		const finalized = coordinator.finalizeMessagesForSave([
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ request: hugeRequestBody, tokensIn: 100, tokensOut: 50, cost: 0.1 }),
+				partial: false,
+			},
+		])
+
+		const info = JSON.parse(finalized[0].text ?? "{}") as { request?: string; tokensIn?: number; cost?: number }
+		expect(info.request).toBeUndefined()
+		expect(info.tokensIn).toBe(100)
+		expect(info.cost).toBe(0.1)
+		// The metadata-only text must be small; the 40KB+ body must not reach the webview.
+		expect((finalized[0].text ?? "").length).toBeLessThan(500)
+	})
+
+	it("drops the request body even when stamping a cancel reason on an unfinished api_req", () => {
+		const coordinator = new SdkMessageCoordinator({ getTask: () => undefined })
+		const finalized = coordinator.finalizeMessagesForSave([
+			{
+				ts: 1,
+				type: "say",
+				say: "api_req_started",
+				text: JSON.stringify({ request: "x".repeat(45_000) }),
+				partial: false,
+			},
+		])
+
+		const info = JSON.parse(finalized[0].text ?? "{}") as { request?: string; cancelReason?: string }
+		expect(info.request).toBeUndefined()
+		expect(info.cancelReason).toBe("user_cancelled")
+	})
+
+	it("finalizes partial ask messages so their streaming state is never rendered as pending", () => {
+		const coordinator = new SdkMessageCoordinator({ getTask: () => undefined })
+		const finalized = coordinator.finalizeMessagesForSave([
+			{ ts: 1, type: "ask", ask: "tool", text: "mid-stream tool call", partial: true },
+		])
+
+		expect(finalized[0].partial).toBeUndefined()
+		expect(finalized[0].type).toBe("ask")
+		expect(finalized[0].ask).toBe("tool")
+	})
+
 	it("stamps seq and epoch from the shared minter on append", () => {
 		const minter = new MessageIdMinter()
 		const task = createTaskProxy("session-123", vi.fn(), vi.fn())

--- a/apps/vscode/src/sdk/sdk-message-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-message-coordinator.ts
@@ -121,13 +121,21 @@ export class SdkMessageCoordinator {
 			if (updated.type === "say" && updated.say === "api_req_started") {
 				try {
 					const info: ClineApiReqInfo = JSON.parse(updated.text || "{}")
+					// The webview only renders token/cost metadata. Classic/legacy Cline
+					// persisted the FULL request body in `request` (40KB+ once environment
+					// details, file contents and history are included), and replaying it on
+					// conversation load crashes the webview React render. Strip it so only
+					// metadata survives.
+					if (info.request !== undefined) {
+						delete info.request
+					}
 					if (info.cost === undefined && info.cancelReason === undefined) {
 						const isLast = !messages.slice(index + 1).some((m) => m.type === "say" && m.say === "api_req_started")
 						if (isLast) {
 							info.cancelReason = "user_cancelled"
-							updated.text = JSON.stringify(info)
 						}
 					}
+					updated.text = JSON.stringify(info)
 				} catch {
 					// Ignore parse errors from legacy or malformed messages.
 				}


### PR DESCRIPTION
This fixes #13132.

## Problem

Reopening a large conversation can gray out / freeze the entire Cline panel, requiring a VS Code restart. The reporter's diagnosis: `ui_messages.json` accumulates messages that crash the webview React render when a conversation is loaded:

1. `api_req_started` messages persisted the FULL request body (environment details, full file contents, conversation history) in their `text` payload — single messages reach 45KB+.
2. `partial: true` ask messages (mid-stream tool-call states) were written to disk and replayed as pending rows.

The webview only ever reads token/cost metadata (`cost`, `cancelReason`, `streamingFailedMessage`, token counts) from `api_req_started` rows — the full request body is never used.

## Fix

`sdk-message-coordinator.ts`'s `finalizeMessagesForSave` (the chokepoint that prepares persisted messages before they are replayed to the webview on task load) now strips the `request` body from `api_req_started` messages, keeping only the metadata the UI actually renders. `partial` flags were already stripped here; a regression test now locks in both behaviors.

## Test

Adds three unit tests to `sdk-message-coordinator.test.ts`:
- an `api_req_started` message carrying a 40KB+ `request` body is trimmed to metadata only (text under 500 chars),
- the `request` body is dropped even when the last unfinished `api_req` is stamped with a `user_cancelled` cancel reason,
- a `partial: true` ask message has its streaming flag stripped.

The first two fail on the old code (the 40KB+ body is passed through to the webview) and pass with the fix.