### PR TITLE
fix(vscode): make /newtask start a fresh task context instead of compacting

### DIFF
--- a/.changeset/newtask-fresh-context.md
+++ b/.changeset/newtask-fresh-context.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Make /newtask start a fresh task context instead of compacting the current conversation in place

--- a/apps/vscode/src/shared/slashCommands.ts
+++ b/apps/vscode/src/shared/slashCommands.ts
@@ -6,13 +6,12 @@ export interface SlashCommand {
 }
 
 export const BASE_SLASH_COMMANDS: SlashCommand[] = [
-	// `/newtask` is an alias of `/compact`: condensing achieves its goal
-	// (continue working with a fresh, summarized context window) without the
-	// legacy new_task tool. The webview intercepts all three spellings and
-	// runs the condense RPC (see useMessageHandlers.handleSendMessage).
+	// `/newtask` starts a fresh task with a clean context window — the webview
+	// routes it to TaskService.clearTask (see useMessageHandlers.handleSendMessage),
+	// unlike `/compact`/`/smol` which condense the current task in place.
 	{
 		name: "newtask",
-		description: "Condenses the current task and continues with a fresh context window",
+		description: "Start a fresh task with a clean context window",
 		section: "default",
 		cliCompatible: true,
 	},

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.test.tsx
@@ -139,7 +139,7 @@ describe("useMessageHandlers — send routing", () => {
 		expect(trackIntent).not.toHaveBeenCalled()
 	})
 
-	it("routes the /newtask alias to the condense RPC as well", async () => {
+	it("routes /newtask to a fresh task context instead of the condense RPC", async () => {
 		mockTurnState = { phase: "completed", seq: 7 }
 		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))
 
@@ -147,11 +147,27 @@ describe("useMessageHandlers — send routing", () => {
 			await result.current.handleSendMessage("/newtask", [], [])
 		})
 
-		expect(condense).toHaveBeenCalledTimes(1)
-		expect(condense).toHaveBeenCalledWith(expect.objectContaining({ value: "compact" }))
+		// /newtask must NOT alias /compact: the condense RPC must not fire, and the
+		// current task is cleared (TaskService.clearTask) so a fresh context window opens.
+		expect(condense).not.toHaveBeenCalled()
+		expect(clearTask).toHaveBeenCalledTimes(1)
 		expect(newTask).not.toHaveBeenCalled()
 		expect(askResponse).not.toHaveBeenCalled()
 		expect(trackIntent).not.toHaveBeenCalled()
+	})
+
+	it("does not emit a compaction event when /newtask starts a fresh task", async () => {
+		mockTurnState = { phase: "completed", seq: 7 }
+		const { result } = renderHook(() => useMessageHandlers(completedConversation, makeChatState(completedConversation)))
+
+		await act(async () => {
+			await result.current.handleSendMessage("/newtask", [], [])
+		})
+
+		// Regression for #13157: /newtask compacted the context (same as /compact)
+		// instead of starting a fresh task context. No compaction event is allowed.
+		expect(condense).not.toHaveBeenCalled()
+		expect(clearTask).toHaveBeenCalledWith(expect.objectContaining({}))
 	})
 
 	it("does not intercept /compact when there is no active task (starts a new task instead)", async () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -47,18 +47,12 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 			}
 
 			// Intercept the built-in compaction commands when an active task exists.
-			// `/compact` (and its aliases `/smol` and `/newtask`) must run a real
-			// SDK manual compaction via the condense RPC — sending the literal
-			// text to the model would make it improvise a fake summary instead of
-			// compacting the context window (CLINE-2503). `/newtask` aliases
-			// compaction because condensing achieves its goal (continue working
-			// with a fresh, summarized context) without the legacy new_task tool.
-			// With no active task there is nothing to compact, so fall through to
-			// normal new-task handling.
-			if (
-				messages.length > 0 &&
-				(messageToSend === "/compact" || messageToSend === "/smol" || messageToSend === "/newtask")
-			) {
+			// `/compact` (and its alias `/smol`) must run a real SDK manual
+			// compaction via the condense RPC — sending the literal text to the
+			// model would make it improvise a fake summary instead of compacting
+			// the context window (CLINE-2503). With no active task there is
+			// nothing to compact, so fall through to normal new-task handling.
+			if (messages.length > 0 && (messageToSend === "/compact" || messageToSend === "/smol")) {
 				// Clear the input before awaiting the RPC — condense resolves only
 				// after compaction finishes, and the typed command lingering in the
 				// field the whole time reads as if the send didn't register.
@@ -67,6 +61,23 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 				await SlashServiceClient.condense(StringRequest.create({ value: "compact" })).catch((err) =>
 					console.error("Failed to compact task:", err),
 				)
+				if ("disableAutoScrollRef" in chatState) {
+					;(chatState as any).disableAutoScrollRef.current = false
+				}
+				return
+			}
+
+			// `/newtask` is NOT an alias of `/compact`: it must start a fresh task
+			// context ("Condenses the current task and continues with a fresh
+			// context window"), not compact the current task in place. Route it
+			// through the same fresh-task path as the New Task button so the user
+			// lands on a clean context window (#13157).
+			if (messages.length > 0 && messageToSend === "/newtask") {
+				setInputValue("")
+				setActiveQuote(null)
+				setPendingUserMessage(undefined)
+				setPendingResponse(undefined)
+				await TaskServiceClient.clearTask(EmptyRequest.create({}))
 				if ("disableAutoScrollRef" in chatState) {
 					;(chatState as any).disableAutoScrollRef.current = false
 				}


### PR DESCRIPTION
## Problem

`/newtask` is currently intercepted by the webview as an alias of `/compact`: with an active task it runs the condense RPC (`SlashServiceClient.condense`), which compacts the current conversation in place. The user gets the exact same behavior as `/compact` — no fresh task is started. This contradicts the command's own description ("Condenses the current task and continues with a fresh context window") and the docs, which say `/newtask` "creates a new task" / "Start fresh task with distilled context from current conversation", unlike `/smol`/`/compact` which keep working in the same task.

Reported in #13157: invoking `/newtask` in the VS Code extension "compacts the context; it did what /compact would do".

## Root cause

In `apps/vscode/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts`, `handleSendMessage` groups `/newtask` together with `/compact` and `/smol`:

```ts
if (
	messages.length > 0 &&
	(messageToSend === "/compact" || messageToSend === "/smol" || messageToSend === "/newtask")
) {
	await SlashServiceClient.condense(StringRequest.create({ value: "compact" }))
	return
}
```

So `/newtask` never reaches the fresh-task path (`TaskService.clearTask`, the same path as the New Task button).

## Fix

Split `/newtask` out of the condense interception. `/compact` and `/smol` still run the condense RPC (compacting the current conversation is their documented behavior), but `/newtask` now routes to the same fresh-task path as the New Task button: it clears the input and calls `TaskServiceClient.clearTask`, opening a clean context window.

Also updates the stale comment in `apps/vscode/src/shared/slashCommands.ts` that described `/newtask` as an alias of `/compact`, and aligns the command description with the actual behavior.

## Test

Updates `useMessageHandlers.test.tsx`:
- `/newtask` with an active task routes to `clearTask` (fresh task context) and never calls the condense RPC.
- Regression: invoking `/newtask` with an active task emits no compaction event.

Both tests fail on the previous behavior (which called `condense`) and pass with the fix.

Fixes #13157