### PR TITLE
Add baseline (non-AVX2) x64 builds for the CLI

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -165,10 +165,13 @@ jobs:
           EXPECTED=(
             "@cline/cli-darwin-arm64"
             "@cline/cli-darwin-x64"
+            "@cline/cli-darwin-x64-baseline"
             "@cline/cli-linux-arm64"
             "@cline/cli-linux-x64"
+            "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
+            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do
@@ -394,10 +397,13 @@ jobs:
           EXPECTED=(
             "@cline/cli-darwin-arm64"
             "@cline/cli-darwin-x64"
+            "@cline/cli-darwin-x64-baseline"
             "@cline/cli-linux-arm64"
             "@cline/cli-linux-x64"
+            "@cline/cli-linux-x64-baseline"
             "@cline/cli-windows-arm64"
             "@cline/cli-windows-x64"
+            "@cline/cli-windows-x64-baseline"
           )
 
           for package_name in "${EXPECTED[@]}"; do

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -14,17 +14,22 @@ Bun's `--compile` flag produces a single self-contained executable that includes
 
 ## What Gets Published
 
-Publishing the CLI publishes 7 packages to npm:
+Publishing the CLI publishes 10 packages to npm:
 
 | Package | Description |
 |---|---|
 | `@cline/cli-darwin-arm64` | macOS Apple Silicon binary |
 | `@cline/cli-darwin-x64` | macOS Intel binary |
+| `@cline/cli-darwin-x64-baseline` | macOS Intel baseline binary (no AVX2) |
 | `@cline/cli-linux-arm64` | Linux ARM binary |
 | `@cline/cli-linux-x64` | Linux x64 binary |
+| `@cline/cli-linux-x64-baseline` | Linux x64 baseline binary (no AVX2) |
 | `@cline/cli-windows-x64` | Windows x64 binary |
+| `@cline/cli-windows-x64-baseline` | Windows x64 baseline binary (no AVX2) |
 | `@cline/cli-windows-arm64` | Windows ARM binary |
 | `cline` | Wrapper package (pulls the right binary via `optionalDependencies`) |
+
+The `-baseline` packages are compiled with Bun's `-baseline` targets, which do not require AVX2. Bun's default x64 builds crash with an illegal instruction (SIGILL) on older CPUs (pre-2013, pre-Haswell) and on VMs whose hypervisor does not expose AVX2. The postinstall script and the `bin/cline` resolver detect AVX2 at install/run time (via `bin/baseline.cjs`) and prefer the baseline package when AVX2 is missing.
 
 Each platform package contains a compiled binary and a minimal `package.json` with `os` and `cpu` fields:
 
@@ -57,9 +62,12 @@ The `cline` wrapper package contains no binary -- just the resolver script, post
   "optionalDependencies": {
     "@cline/cli-darwin-arm64": "0.1.0",
     "@cline/cli-darwin-x64": "0.1.0",
+    "@cline/cli-darwin-x64-baseline": "0.1.0",
     "@cline/cli-linux-arm64": "0.1.0",
     "@cline/cli-linux-x64": "0.1.0",
+    "@cline/cli-linux-x64-baseline": "0.1.0",
     "@cline/cli-windows-x64": "0.1.0",
+    "@cline/cli-windows-x64-baseline": "0.1.0",
     "@cline/cli-windows-arm64": "0.1.0"
   }
 }
@@ -141,19 +149,24 @@ User runs: npm i -g cline
   |
   v
 npm installs cline (wrapper package)
-  + optionalDependencies (only the matching platform gets installed):
+  + optionalDependencies (only matching platforms get installed; x64
+    machines get both the default and the -baseline package):
     - @cline/cli-darwin-arm64
     - @cline/cli-darwin-x64
+    - @cline/cli-darwin-x64-baseline
     - @cline/cli-linux-arm64
     - @cline/cli-linux-x64
+    - @cline/cli-linux-x64-baseline
     - @cline/cli-windows-x64
+    - @cline/cli-windows-x64-baseline
     - @cline/cli-windows-arm64
   |
   v
 postinstall script runs:
-  - Detects platform/arch
-  - Finds the installed platform package
-  - Creates a cached hard link for fast startup
+  - Detects platform/arch (and AVX2 support on x64)
+  - Finds the installed platform package, preferring -baseline when
+    AVX2 is missing
+  - Creates a cached hard link for fast startup and verifies it runs
   |
   v
 User runs: cline
@@ -162,7 +175,8 @@ User runs: cline
 bin/cline (Node.js resolver) executes:
   1. Check CLINE_BIN_PATH env var override
   2. Check cached binary at bin/.cline
-  3. Walk up node_modules for the platform package
+  3. Walk up node_modules for the platform package (same AVX2-aware
+     preference order as postinstall)
   4. Execute the compiled binary
 ```
 
@@ -172,6 +186,7 @@ bin/cline (Node.js resolver) executes:
 apps/cli/
   bin/
     cline                   # Node.js resolver script (npm entry point)
+    baseline.cjs            # AVX2 detection + package preference order
   script/
     build.ts                # Cross-compile for all platforms
     publish-npm.ts          # npm publish orchestration
@@ -184,7 +199,7 @@ From `apps/cli/`:
 
 ```bash
 bun run build:platforms:single  # build only current platform
-bun run build:platforms         # build all 6 platform binaries
+bun run build:platforms         # build all 9 platform binaries
 bun run publish:npm:dry         # preview generated npm package publishing
 ```
 
@@ -197,13 +212,14 @@ Cross-compiles the CLI for all target platforms:
 1. When `--install-native-variants` is passed, pre-installs all platform variants of `@opentui/core` using `bun install --os="*" --cpu="*"` so Bun can resolve native FFI binaries for cross-compilation. Without this, Bun only has the host platform's native binary and cross-compiled builds fail.
 2. Builds SDK packages (`bun run build:sdk`) and the CLI JS bundle (`bun -F @cline/cli build`)
 3. For each target platform:
-   - Runs `bun build --compile --target bun-{os}-{arch}` to create a standalone executable
+   - Runs `bun build --compile --target bun-{os}-{arch}` to create a standalone executable (x64 targets additionally get a `bun-{os}-x64-baseline` build without AVX2)
    - Generates a `package.json` with `os` and `cpu` fields for npm platform filtering
    - Runs a smoke test on the current platform's binary (`cline --version`)
    - Copies the plugin sandbox bootstrap file if present
 
 Flags:
 - `--single` -- build only for the current platform (faster for local testing)
+- `--baseline` -- with `--single`, also build the current platform's baseline (non-AVX2) variant
 - `--install-native-variants` -- allow the script to download all OpenTUI native packages required for cross-platform builds
 - `--skip-install` -- skip re-downloading platform-specific native packages if they're already installed
 - `--skip-sdk-build` -- skip rebuilding SDK packages (if already built)
@@ -213,7 +229,7 @@ Flags:
 Orchestrates publishing all packages to npm:
 
 1. Reads built packages from `dist/`
-2. Publishes all 6 platform packages in parallel (`@cline/cli-darwin-arm64`, etc.)
+2. Publishes all 9 platform packages in parallel (`@cline/cli-darwin-arm64`, etc.)
 3. Generates a clean main package (`cline`) with:
    - `bin.cline` pointing to the resolver script
    - `postinstall` running the binary caching script
@@ -233,11 +249,11 @@ The shebang is `#!/usr/bin/env node` because Node.js is guaranteed to be availab
 Resolution chain:
 1. `CLINE_BIN_PATH` env var (for development or custom deployments)
 2. `bin/.cline` cached hard link (created by postinstall for fast startup)
-3. Walk up `node_modules` from the script directory to find the platform package
+3. Walk up `node_modules` from the script directory to find the platform package, trying package names in the AVX2-aware preference order from `bin/baseline.cjs`
 
 ## Postinstall (`script/postinstall.mjs`)
 
-Runs after `npm install cline`. Creates a hard link from the platform binary to `bin/.cline` for fast startup on subsequent runs. Falls back to file copy if hard linking fails (NFS, cross-device, network-mounted filesystems).
+Runs after `npm install cline`. Picks the platform package using the AVX2-aware preference order from `bin/baseline.cjs`, creates a hard link from the platform binary to `bin/.cline` for fast startup on subsequent runs, and verifies the cached binary actually runs (`--version`) so a wrong pick (e.g. an AVX2 binary on a non-AVX2 CPU) falls through to the next candidate. Falls back to file copy if hard linking fails (NFS, cross-device, network-mounted filesystems).
 
 The postinstall is defensive: it wraps everything in try/catch and always exits 0 (the `|| true` in the npm script). If postinstall fails, the resolver script has its own fallback logic to find the binary at runtime, so the cached binary is just an optimization.
 
@@ -259,10 +275,13 @@ During development, `bin` in package.json points to `src/index.ts` for `bun link
 When building for a different platform (e.g., compiling for Linux on a Mac), Bun needs the target platform's native binaries for `@opentui/core`. The build script handles this by pre-downloading all platform variants with `bun install --os="*" --cpu="*"`.
 
 ### Version synchronization
-All 7 packages (6 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
+All 10 packages (9 platform + 1 wrapper) must have the same version. The build script reads the version from `apps/cli/package.json`. The publish script verifies that the built package versions match each other and `apps/cli/package.json`.
 
 ### Package naming and scoping
-Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 7 package names.
+Platform packages are published under the `@cline` scope. The generated wrapper package is published as `cline`, so npm trusted publishing must be configured for all 10 package names.
+
+### Baseline (non-AVX2) builds
+The `-baseline` x64 packages carry the same `os`/`cpu` fields as the default x64 packages, so npm installs both on x64 machines and the postinstall/resolver picks at runtime. Detection reads `/proc/cpuinfo` on Linux, `sysctl hw.optional.avx2_0` on macOS, and `IsProcessorFeaturePresent(40)` via PowerShell on Windows (same approach as opencode). Baseline binaries run fine on AVX2 CPUs (just without AVX2 optimizations), so when detection is inconclusive, preferring baseline is the safe direction.
 
 ### postinstall reliability
 The postinstall script runs in diverse environments (CI, Docker, restricted permissions, network-mounted filesystems where hard links fail). It always wraps operations in try/catch and exits 0. The resolver script is the ultimate fallback.
@@ -274,4 +293,4 @@ Windows binaries are `.exe` files. The build script appends `.exe` to the output
 Compiled binaries need to be executable (`chmod 755`). The build script sets this after copying. The postinstall also sets permissions on the cached binary. Some npm packaging steps can strip permissions, so both handle this defensively.
 
 ### Package size
-Each compiled binary is ~30-60MB (Bun runtime + all bundled code + native addons). This is normal for compiled CLI tools. Users only download their platform's variant thanks to `optionalDependencies`.
+Each compiled binary is ~30-60MB (Bun runtime + all bundled code + native addons). This is normal for compiled CLI tools. Users only download their platform's variants thanks to `optionalDependencies` (x64 users get two: the default and the baseline build).

--- a/apps/cli/DISTRIBUTION.md
+++ b/apps/cli/DISTRIBUTION.md
@@ -175,9 +175,10 @@ User runs: cline
 bin/cline (Node.js resolver) executes:
   1. Check CLINE_BIN_PATH env var override
   2. Check cached binary at bin/.cline
-  3. Walk up node_modules for the platform package (same AVX2-aware
+  3. Walk up node_modules for the platform packages (same AVX2-aware
      preference order as postinstall)
-  4. Execute the compiled binary
+  4. Execute the compiled binary; if it fails to start (spawn error or
+     SIGILL at startup), fall through to the next candidate
 ```
 
 ## File Layout
@@ -247,9 +248,11 @@ A Node.js script that serves as the entry point when users run `cline`. It finds
 The shebang is `#!/usr/bin/env node` because Node.js is guaranteed to be available wherever npm is. The resolver uses only CommonJS (`require`) and Node.js APIs -- no `bun:` imports or Bun-specific APIs. It then spawns the compiled binary which has Bun embedded.
 
 Resolution chain:
-1. `CLINE_BIN_PATH` env var (for development or custom deployments)
+1. `CLINE_BIN_PATH` env var (for development or custom deployments; no fallback, fails loudly)
 2. `bin/.cline` cached hard link (created by postinstall for fast startup)
-3. Walk up `node_modules` from the script directory to find the platform package, trying package names in the AVX2-aware preference order from `bin/baseline.cjs`
+3. Walk up `node_modules` from the script directory to find the platform packages, trying package names in the AVX2-aware preference order from `bin/baseline.cjs`
+
+If a candidate fails to start (spawn error, or SIGILL from an AVX2 binary on a CPU without AVX2 -- Bun dies at startup before doing any work), the resolver falls through to the next candidate instead of giving up. This covers stale caches, e.g. a container image where `npm install` ran on an AVX2 build host but the image runs on a non-AVX2 host. Ordinary nonzero exits are propagated immediately and never retried, since the child runs the user's actual command.
 
 ## Postinstall (`script/postinstall.mjs`)
 

--- a/apps/cli/bin/baseline.cjs
+++ b/apps/cli/bin/baseline.cjs
@@ -1,0 +1,115 @@
+"use strict";
+
+// Baseline (non-AVX2) binary selection for the Cline CLI.
+//
+// Bun's default x64 builds require AVX2 and crash with an illegal
+// instruction (SIGILL) on older CPUs and on VMs whose hypervisor does not
+// expose AVX2. Bun also ships "baseline" compile targets that run on those
+// systems, so we publish a `-baseline` variant of every x64 platform
+// package and pick the right one at install/run time.
+//
+// This module must stay plain CommonJS with Node-only APIs: it is required
+// by both the `bin/cline` resolver and `postinstall.mjs`, which run under
+// whatever Node.js npm used.
+
+const childProcess = require("child_process");
+const fs = require("fs");
+
+// `platform` uses package-name convention ("windows", not "win32").
+function supportsAvx2(platform, arch) {
+	if (arch !== "x64") {
+		return false;
+	}
+
+	if (platform === "linux") {
+		try {
+			return /(^|\s)avx2(\s|$)/i.test(fs.readFileSync("/proc/cpuinfo", "utf8"));
+		} catch {
+			return false;
+		}
+	}
+
+	if (platform === "darwin") {
+		try {
+			const result = childProcess.spawnSync(
+				"sysctl",
+				["-n", "hw.optional.avx2_0"],
+				{
+					encoding: "utf8",
+					timeout: 1500,
+				},
+			);
+			if (result.status !== 0) {
+				return false;
+			}
+			return (result.stdout || "").trim() === "1";
+		} catch {
+			return false;
+		}
+	}
+
+	if (platform === "windows") {
+		// PF_AVX2_INSTRUCTIONS_AVAILABLE = 40
+		const command =
+			'(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)';
+
+		for (const executable of [
+			"powershell.exe",
+			"pwsh.exe",
+			"pwsh",
+			"powershell",
+		]) {
+			try {
+				const result = childProcess.spawnSync(
+					executable,
+					["-NoProfile", "-NonInteractive", "-Command", command],
+					{
+						encoding: "utf8",
+						timeout: 3000,
+						windowsHide: true,
+					},
+				);
+				if (result.status !== 0) {
+					continue;
+				}
+				const output = (result.stdout || "").trim().toLowerCase();
+				if (output === "true" || output === "1") {
+					return true;
+				}
+				if (output === "false" || output === "0") {
+					return false;
+				}
+			} catch {
+				// Try the next PowerShell executable.
+			}
+		}
+		return false;
+	}
+
+	return false;
+}
+
+// Ordered list of platform package names to try. When AVX2 is missing the
+// baseline package comes first; the non-baseline package stays in the list
+// as a last resort so a missing baseline package still resolves to
+// something rather than nothing.
+function platformPackageNames(platform, arch, avx2) {
+	const base = "@cline/cli-" + platform + "-" + arch;
+	if (arch !== "x64") {
+		return [base];
+	}
+	if (avx2) {
+		return [base, base + "-baseline"];
+	}
+	return [base + "-baseline", base];
+}
+
+function resolvePlatformPackageNames(platform, arch) {
+	return platformPackageNames(platform, arch, supportsAvx2(platform, arch));
+}
+
+module.exports = {
+	supportsAvx2,
+	platformPackageNames,
+	resolvePlatformPackageNames,
+};

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -116,11 +116,17 @@ if (!arch) {
 	arch = os.arch();
 }
 
-const base = "@cline/cli-" + platform + "-" + arch;
 const binary = platform === "windows" ? "cline.exe" : "cline";
 
-// Build fallback chain of package names to try
-const names = [base];
+// Build fallback chain of package names to try. On x64 CPUs without AVX2
+// the default Bun build crashes with SIGILL, so prefer the baseline package.
+let names;
+try {
+	const baseline = require("./baseline.cjs");
+	names = baseline.resolvePlatformPackageNames(platform, arch);
+} catch {
+	names = ["@cline/cli-" + platform + "-" + arch];
+}
 
 function findBinary(startDir) {
 	let current = startDir;

--- a/apps/cli/bin/cline
+++ b/apps/cli/bin/cline
@@ -65,11 +65,30 @@ try {
 	// Best effort: fall back to the runtime's default trust on any failure.
 }
 
-function run(target) {
+// Execute a candidate binary. Never returns on success or on an ordinary
+// failure (the child's exit status is propagated). Returns only when the
+// binary failed to start at all (spawn error, or SIGILL from an AVX2
+// binary on a CPU without AVX2 -- Bun dies at startup, before any work)
+// AND a fallback candidate remains; the caller then tries the next one.
+// Ordinary nonzero exits must NOT fall through: the child runs the user's
+// actual command, and retrying would execute it twice.
+function run(target, hasFallback) {
 	const result = childProcess.spawnSync(target, process.argv.slice(2), {
 		stdio: "inherit",
 		env: childEnv,
 	});
+	if (hasFallback && (result.error || result.signal === "SIGILL")) {
+		console.error(
+			"[cline] " +
+				target +
+				" failed to start" +
+				(result.signal === "SIGILL"
+					? " (illegal instruction; this CPU may lack AVX2)"
+					: "") +
+				"; trying fallback binary.",
+		);
+		return;
+	}
 	if (result.error) {
 		console.error(result.error.message);
 		process.exit(1);
@@ -84,17 +103,13 @@ function run(target) {
 	process.exit(1);
 }
 
-// 1. Check env var override
+// 1. Check env var override (explicit choice: no fallback, fail loudly)
 const envPath = process.env.CLINE_BIN_PATH;
 if (envPath) {
-	run(envPath);
+	run(envPath, false);
 }
 
-// 2. Check cached binary
 const cached = path.join(scriptDir, ".cline");
-if (fs.existsSync(cached)) {
-	run(cached);
-}
 
 // 3. Detect platform and architecture
 const platformMap = {
@@ -128,7 +143,12 @@ try {
 	names = ["@cline/cli-" + platform + "-" + arch];
 }
 
-function findBinary(startDir) {
+// Collect every existing candidate binary (in preference order) instead of
+// just the first, so a binary that fails to start can fall through to the
+// next installed sibling (e.g. a cached AVX2 binary from an install done on
+// different hardware falling back to the baseline package).
+function findBinaries(startDir) {
+	const found = [];
 	let current = startDir;
 	for (;;) {
 		const modules = path.join(current, "node_modules");
@@ -137,19 +157,27 @@ function findBinary(startDir) {
 				// Scoped package: @cline/cli-darwin-arm64 lives at
 				// node_modules/@cline/cli-darwin-arm64
 				const candidate = path.join(modules, name, "bin", binary);
-				if (fs.existsSync(candidate)) return candidate;
+				if (fs.existsSync(candidate) && found.indexOf(candidate) === -1) {
+					found.push(candidate);
+				}
 			}
 		}
 		const parent = path.dirname(current);
 		if (parent === current) {
-			return undefined;
+			return found;
 		}
 		current = parent;
 	}
 }
 
-const resolved = findBinary(scriptDir);
-if (!resolved) {
+// 2. Cached binary (created by postinstall), then package binaries in
+// preference order.
+const candidates = findBinaries(scriptDir);
+if (fs.existsSync(cached)) {
+	candidates.unshift(cached);
+}
+
+if (candidates.length === 0) {
 	console.error(
 		"Could not find the Cline CLI binary for your platform.\n" +
 			"Your platform: " +
@@ -167,4 +195,13 @@ if (!resolved) {
 	process.exit(1);
 }
 
-run(resolved);
+for (let i = 0; i < candidates.length; i++) {
+	run(candidates[i], i < candidates.length - 1);
+}
+
+// Every candidate failed to start (run() exits the process otherwise).
+console.error(
+	"All Cline CLI binaries failed to start. " +
+		"If this machine's CPU lacks AVX2, reinstall so the baseline binary is selected: npm install -g cline",
+);
+process.exit(1);

--- a/apps/cli/script/build-options.ts
+++ b/apps/cli/script/build-options.ts
@@ -1,5 +1,6 @@
 export interface BuildOptions {
 	single: boolean;
+	baseline: boolean;
 	skipInstall: boolean;
 	skipSdkBuild: boolean;
 	installNativeVariants: boolean;
@@ -8,6 +9,7 @@ export interface BuildOptions {
 export function parseBuildOptions(args: readonly string[]): BuildOptions {
 	return {
 		single: args.includes("--single"),
+		baseline: args.includes("--baseline"),
 		skipInstall: args.includes("--skip-install"),
 		skipSdkBuild: args.includes("--skip-sdk-build"),
 		installNativeVariants: args.includes("--install-native-variants"),

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -53,22 +53,37 @@ console.log(`Building @cline/cli v${version}`);
 
 const buildOptions = parseBuildOptions(process.argv.slice(2));
 
+// Baseline targets are compiled without AVX2 (Bun's `-baseline` compile
+// targets) so the CLI runs on older x64 CPUs and on VMs whose hypervisor
+// does not expose AVX2. The default x64 builds crash with SIGILL there.
 const allTargets: {
 	os: string;
 	arch: "arm64" | "x64";
+	baseline?: true;
 }[] = [
 	{ os: "linux", arch: "arm64" },
 	{ os: "linux", arch: "x64" },
+	{ os: "linux", arch: "x64", baseline: true },
 	{ os: "darwin", arch: "arm64" },
 	{ os: "darwin", arch: "x64" },
+	{ os: "darwin", arch: "x64", baseline: true },
 	{ os: "win32", arch: "x64" },
+	{ os: "win32", arch: "x64", baseline: true },
 	{ os: "win32", arch: "arm64" },
 ];
 
 const targets = buildOptions.single
-	? allTargets.filter(
-			(item) => item.os === process.platform && item.arch === process.arch,
-		)
+	? allTargets.filter((item) => {
+			if (item.os !== process.platform || item.arch !== process.arch) {
+				return false;
+			}
+			// Baseline builds need extra Bun compile artifacts, so only
+			// include them in --single mode when explicitly requested.
+			if (item.baseline) {
+				return buildOptions.baseline;
+			}
+			return true;
+		})
 	: allTargets;
 
 const opentuiVersion = pkg.dependencies["@opentui/core"];
@@ -164,7 +179,8 @@ function getBunTarget(
 	item: (typeof allTargets)[number],
 ): Bun.Build.CompileTarget {
 	const targetOs = item.os === "win32" ? "windows" : item.os;
-	return `bun-${targetOs}-${item.arch}` as Bun.Build.CompileTarget;
+	const suffix = item.baseline ? "-baseline" : "";
+	return `bun-${targetOs}-${item.arch}${suffix}` as Bun.Build.CompileTarget;
 }
 
 async function buildCompiledBinary(input: {
@@ -225,8 +241,9 @@ async function buildCompiledBinary(input: {
 for (const item of targets) {
 	// npm treats "win32" specially in os field, but for package naming use "windows"
 	const displayOs = item.os === "win32" ? "windows" : item.os;
-	const name = `@cline/cli-${displayOs}-${item.arch}`;
-	const dirName = `cli-${displayOs}-${item.arch}`;
+	const baselineSuffix = item.baseline ? "-baseline" : "";
+	const name = `@cline/cli-${displayOs}-${item.arch}${baselineSuffix}`;
+	const dirName = `cli-${displayOs}-${item.arch}${baselineSuffix}`;
 	const binaryName = item.os === "win32" ? "cline.exe" : "cline";
 	const bunTarget = getBunTarget(item);
 
@@ -283,7 +300,9 @@ for (const item of targets) {
 			{
 				name,
 				version,
-				description: `Cline CLI binary for ${displayOs} ${item.arch}`,
+				description: `Cline CLI binary for ${displayOs} ${item.arch}${
+					item.baseline ? " (baseline build for CPUs without AVX2)" : ""
+				}`,
 				os: [item.os],
 				cpu: [item.arch],
 				...(repository ? { repository } : {}),

--- a/apps/cli/script/postinstall.mjs
+++ b/apps/cli/script/postinstall.mjs
@@ -8,6 +8,7 @@
 // This script must use only Node.js APIs (no Bun) since it runs via
 // "node script/postinstall.mjs" in the npm lifecycle.
 
+import childProcess from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
@@ -16,6 +17,34 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
+
+// In the published package this script sits at the package root next to
+// bin/. In the source tree it lives in script/ with bin/ one level up.
+const binDir =
+	path.basename(__dirname) === "script"
+		? path.join(__dirname, "..", "bin")
+		: path.join(__dirname, "bin");
+
+// Verify a candidate binary actually runs. On x64 CPUs without AVX2 the
+// default Bun build dies with SIGILL, so this catches a wrong pick even if
+// CPU-feature detection was inconclusive. If the binary could not be
+// spawned at all (sandboxes that block exec), treat that as inconclusive
+// rather than a rejection.
+function verifyBinary(binaryPath) {
+	try {
+		const result = childProcess.spawnSync(binaryPath, ["--version"], {
+			stdio: "ignore",
+			timeout: 15000,
+			windowsHide: true,
+		});
+		if (result.error) {
+			return true;
+		}
+		return result.status === 0;
+	} catch {
+		return true;
+	}
+}
 
 function main() {
 	if (os.platform() === "win32") {
@@ -31,52 +60,62 @@ function main() {
 	};
 	const platform = platformMap[os.platform()] || os.platform();
 	const arch = os.arch();
-	const packageName = `@cline/cli-${platform}-${arch}`;
 	const binaryName = "cline";
 
-	let binaryPath;
-	try {
-		const packageJsonPath = require.resolve(`${packageName}/package.json`);
-		const packageDir = path.dirname(packageJsonPath);
-		binaryPath = path.join(packageDir, "bin", binaryName);
+	const baseline = require(path.join(binDir, "baseline.cjs"));
+	const packageNames = baseline.resolvePlatformPackageNames(platform, arch);
 
-		if (!fs.existsSync(binaryPath)) {
-			throw new Error(`Binary not found at ${binaryPath}`);
+	const target = path.join(binDir, ".cline");
+
+	for (const packageName of packageNames) {
+		let binaryPath;
+		try {
+			const packageJsonPath = require.resolve(`${packageName}/package.json`);
+			const packageDir = path.dirname(packageJsonPath);
+			binaryPath = path.join(packageDir, "bin", binaryName);
+
+			if (!fs.existsSync(binaryPath)) {
+				throw new Error(`Binary not found at ${binaryPath}`);
+			}
+		} catch (_error) {
+			// Platform package not available; try the next candidate. The
+			// resolver script will also search node_modules at runtime.
+			continue;
 		}
-	} catch (_error) {
-		// Platform package not available. The resolver script will find
-		// it at runtime by walking node_modules. This is expected on
-		// platforms we don't ship binaries for.
-		console.log(`Note: ${packageName} not found, skipping binary cache`);
+
+		// Ensure bin directory exists
+		if (!fs.existsSync(binDir)) {
+			fs.mkdirSync(binDir, { recursive: true });
+		}
+
+		// Remove existing cached binary
+		if (fs.existsSync(target)) {
+			fs.unlinkSync(target);
+		}
+
+		// Hard link preferred (shares disk space), copy as fallback
+		// (hard links fail on some filesystems like NFS or cross-device)
+		try {
+			fs.linkSync(binaryPath, target);
+		} catch {
+			fs.copyFileSync(binaryPath, target);
+		}
+
+		fs.chmodSync(target, 0o755);
+
+		if (!verifyBinary(target)) {
+			console.log(`Note: ${packageName} binary failed to run, trying next`);
+			fs.unlinkSync(target);
+			continue;
+		}
+
+		console.log(`Cached cline binary at ${target}`);
 		return;
 	}
 
-	const binDir =
-		path.basename(__dirname) === "script"
-			? path.join(__dirname, "..", "bin")
-			: path.join(__dirname, "bin");
-	const target = path.join(binDir, ".cline");
-
-	// Ensure bin directory exists
-	if (!fs.existsSync(binDir)) {
-		fs.mkdirSync(binDir, { recursive: true });
-	}
-
-	// Remove existing cached binary
-	if (fs.existsSync(target)) {
-		fs.unlinkSync(target);
-	}
-
-	// Hard link preferred (shares disk space), copy as fallback
-	// (hard links fail on some filesystems like NFS or cross-device)
-	try {
-		fs.linkSync(binaryPath, target);
-	} catch {
-		fs.copyFileSync(binaryPath, target);
-	}
-
-	fs.chmodSync(target, 0o755);
-	console.log(`Cached cline binary at ${target}`);
+	console.log(
+		`Note: no working platform package found (looked for ${packageNames.join(", ")}), skipping binary cache`,
+	);
 }
 
 try {

--- a/apps/cli/script/publish-npm.ts
+++ b/apps/cli/script/publish-npm.ts
@@ -35,10 +35,13 @@ const wrapperPackageName = "cline";
 const expectedPlatformPackages = [
 	"@cline/cli-darwin-arm64",
 	"@cline/cli-darwin-x64",
+	"@cline/cli-darwin-x64-baseline",
 	"@cline/cli-linux-arm64",
 	"@cline/cli-linux-x64",
+	"@cline/cli-linux-x64-baseline",
 	"@cline/cli-windows-arm64",
 	"@cline/cli-windows-x64",
+	"@cline/cli-windows-x64-baseline",
 ] as const;
 
 const hostSdkPackages = [

--- a/apps/cli/src/commands/baseline-selection.test.ts
+++ b/apps/cli/src/commands/baseline-selection.test.ts
@@ -1,4 +1,16 @@
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -54,3 +66,104 @@ describe("baseline binary selection", () => {
 		expect(names).toEqual(baseline.platformPackageNames("linux", "x64", avx2));
 	});
 });
+
+describe.skipIf(process.platform === "win32")(
+	"bin/cline runtime fallback",
+	() => {
+		const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+		// Build a fake installed tree: node_modules/cline holds the resolver, and
+		// the platform package(s) hold stub "binaries" (shell scripts).
+		function setupTree(input: {
+			cachedScript?: string;
+			packageScripts: Record<string, string>;
+		}): { treeDir: string; resolver: string } {
+			const treeDir = mkdtempSync(join(tmpdir(), "cline-resolver-test-"));
+			const wrapperBin = join(treeDir, "node_modules", "cline", "bin");
+			mkdirSync(wrapperBin, { recursive: true });
+			cpSync(join(cliRoot, "bin", "cline"), join(wrapperBin, "cline"));
+			cpSync(
+				join(cliRoot, "bin", "baseline.cjs"),
+				join(wrapperBin, "baseline.cjs"),
+			);
+			if (input.cachedScript) {
+				const cachedPath = join(wrapperBin, ".cline");
+				writeFileSync(cachedPath, input.cachedScript);
+				chmodSync(cachedPath, 0o755);
+			}
+			for (const [name, script] of Object.entries(input.packageScripts)) {
+				const binDir = join(treeDir, "node_modules", name, "bin");
+				mkdirSync(binDir, { recursive: true });
+				const binPath = join(binDir, "cline");
+				writeFileSync(binPath, script);
+				chmodSync(binPath, 0o755);
+			}
+			return { treeDir, resolver: join(wrapperBin, "cline") };
+		}
+
+		function currentPlatformPackage(): string {
+			const platform =
+				process.platform === "win32" ? "windows" : process.platform;
+			return baseline.resolvePlatformPackageNames(platform, process.arch)[0];
+		}
+
+		it("falls back to the next candidate when a binary dies at startup", () => {
+			const { treeDir, resolver } = setupTree({
+				// Simulates an AVX2 binary cached on different hardware: dies
+				// with SIGILL before doing any work.
+				cachedScript: "#!/bin/sh\nkill -ILL $$\n",
+				packageScripts: {
+					[currentPlatformPackage()]: "#!/bin/sh\necho FALLBACK_OK\n",
+				},
+			});
+			try {
+				const result = spawnSync(process.execPath, [resolver], {
+					encoding: "utf8",
+				});
+				expect(result.stdout).toContain("FALLBACK_OK");
+				expect(result.stderr).toContain("failed to start");
+				expect(result.status).toBe(0);
+			} finally {
+				rmSync(treeDir, { recursive: true, force: true });
+			}
+		});
+
+		it("does not retry on an ordinary nonzero exit", () => {
+			const { treeDir, resolver } = setupTree({
+				// Runs the user's command and fails normally; the resolver must
+				// propagate the exit code without executing another binary.
+				cachedScript: "#!/bin/sh\necho RAN_ONCE\nexit 3\n",
+				packageScripts: {
+					[currentPlatformPackage()]: "#!/bin/sh\necho SHOULD_NOT_RUN\n",
+				},
+			});
+			try {
+				const result = spawnSync(process.execPath, [resolver], {
+					encoding: "utf8",
+				});
+				expect(result.stdout).toContain("RAN_ONCE");
+				expect(result.stdout).not.toContain("SHOULD_NOT_RUN");
+				expect(result.status).toBe(3);
+			} finally {
+				rmSync(treeDir, { recursive: true, force: true });
+			}
+		});
+
+		it("propagates the crash when no fallback candidate remains", () => {
+			const { treeDir, resolver } = setupTree({
+				packageScripts: {
+					[currentPlatformPackage()]: "#!/bin/sh\nkill -ILL $$\n",
+				},
+			});
+			try {
+				const result = spawnSync(process.execPath, [resolver], {
+					encoding: "utf8",
+				});
+				expect(result.status).not.toBe(0);
+				expect(result.stdout).not.toContain("FALLBACK_OK");
+			} finally {
+				rmSync(treeDir, { recursive: true, force: true });
+			}
+		});
+	},
+);

--- a/apps/cli/src/commands/baseline-selection.test.ts
+++ b/apps/cli/src/commands/baseline-selection.test.ts
@@ -1,0 +1,56 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+const baseline = require("../../bin/baseline.cjs") as {
+	supportsAvx2: (platform: string, arch: string) => boolean;
+	platformPackageNames: (
+		platform: string,
+		arch: string,
+		avx2: boolean,
+	) => string[];
+	resolvePlatformPackageNames: (platform: string, arch: string) => string[];
+};
+
+describe("baseline binary selection", () => {
+	it("prefers the default package on x64 with AVX2", () => {
+		expect(baseline.platformPackageNames("linux", "x64", true)).toEqual([
+			"@cline/cli-linux-x64",
+			"@cline/cli-linux-x64-baseline",
+		]);
+	});
+
+	it("prefers the baseline package on x64 without AVX2", () => {
+		for (const platform of ["linux", "darwin", "windows"]) {
+			expect(baseline.platformPackageNames(platform, "x64", false)).toEqual([
+				`@cline/cli-${platform}-x64-baseline`,
+				`@cline/cli-${platform}-x64`,
+			]);
+		}
+	});
+
+	it("only offers the default package on non-x64 architectures", () => {
+		expect(baseline.platformPackageNames("darwin", "arm64", false)).toEqual([
+			"@cline/cli-darwin-arm64",
+		]);
+		expect(baseline.platformPackageNames("linux", "arm64", true)).toEqual([
+			"@cline/cli-linux-arm64",
+		]);
+	});
+
+	it("reports no AVX2 on non-x64 architectures", () => {
+		expect(baseline.supportsAvx2("darwin", "arm64")).toBe(false);
+		expect(baseline.supportsAvx2("linux", "arm64")).toBe(false);
+	});
+
+	it("reports no AVX2 on unknown platforms", () => {
+		expect(baseline.supportsAvx2("freebsd", "x64")).toBe(false);
+	});
+
+	it("resolves a coherent preference order for the current machine", () => {
+		const names = baseline.resolvePlatformPackageNames("linux", "x64");
+		const avx2 = baseline.supportsAvx2("linux", "x64");
+		expect(names).toEqual(baseline.platformPackageNames("linux", "x64", avx2));
+	});
+});


### PR DESCRIPTION
### Related Issue

Reported by Mark: the compiled CLI crashes with an illegal instruction on some VMs. Bun's default x64 builds require AVX2, which older CPUs (pre-Haswell) and some hypervisors don't expose. opencode solves this by shipping Bun `-baseline` builds and choosing the right one on install; this PR does the same for the npm distribution of `cline`.

### Description

- `script/build.ts` now builds three additional targets with Bun's `-baseline` compile targets (compiled without AVX2): `@cline/cli-linux-x64-baseline`, `@cline/cli-darwin-x64-baseline`, and `@cline/cli-windows-x64-baseline`. `--single` skips baseline unless `--baseline` is passed (baseline compilation downloads extra Bun artifacts).
- New `bin/baseline.cjs` holds the AVX2 detection (reads `/proc/cpuinfo` on Linux, `sysctl hw.optional.avx2_0` on macOS, `IsProcessorFeaturePresent(40)` via PowerShell on Windows, same approach as opencode) and the package preference order. It is shared by the `bin/cline` resolver and `postinstall.mjs`.
- `postinstall.mjs` now tries package candidates in preference order (baseline first when AVX2 is missing), and verifies the cached binary actually runs (`--version`). If the preferred binary fails to run (e.g. SIGILL because detection was inconclusive), it falls through to the next candidate.
- `bin/cline` walks node_modules with the same AVX2-aware fallback chain instead of a single package name.
- `publish-npm.ts` and the two `EXPECTED` lists in `cli-publish.yml` now expect 9 platform packages. The baseline packages carry the same `os`/`cpu` fields as the default x64 packages, so npm installs both on x64 machines and the postinstall/resolver picks at runtime (identical to how opencode's npm packages work).
- `DISTRIBUTION.md` updated accordingly.

Baseline binaries run fine on AVX2 CPUs (just without AVX2 optimizations), so when detection is inconclusive the failure mode is a slightly slower binary, not a crash.

### Test Procedure

- Built `@cline/cli-linux-x64` and `@cline/cli-linux-x64-baseline` from this branch; both pass the build's smoke test natively.
- Reproduced Mark's crash and verified the fix under QEMU with a pre-AVX2 CPU model (`qemu-x86_64 -cpu Nehalem`): the default binary dies with `Illegal instruction (SIGILL)`, the baseline binary prints the version and exits 0.
- Simulated an installed npm tree (wrapper package + both x64 platform packages) and verified all selection paths:
  - postinstall on an AVX2 host caches the default binary (verified by checksum);
  - postinstall with a bind-mounted `/proc/cpuinfo` lacking `avx2` caches the baseline binary;
  - the `bin/cline` resolver (no cache) picks the baseline package without AVX2 and the default package with AVX2;
  - when the preferred binary crashes, postinstall logs `binary failed to run, trying next` and caches the baseline binary instead.
- New unit tests for the selection logic in `src/commands/baseline-selection.test.ts`; they pass along with the existing distribution-package tests, and `biome check` is clean on the touched files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal evidence from the QEMU reproduction (pre-AVX2 Nehalem CPU model):

```
=== modern binary under Nehalem (no AVX2) ===
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
exit=132

=== baseline binary under Nehalem (no AVX2) ===
3.0.52
exit=0
```

### Additional Notes

- Before the next release, npm trusted publishing must be configured for the three new package names (`@cline/cli-linux-x64-baseline`, `@cline/cli-darwin-x64-baseline`, `@cline/cli-windows-x64-baseline`), same as the existing platform packages. Note npm requires the first version of a new package to exist before a trusted publisher can be configured, so the first release including these may need a token-based or local publish for the three new packages.
- x64 installs now download two binaries (~2x size for x64 users). This matches opencode's trade-off; the alternative (an npm-install-on-demand postinstall like opencode also has as a fallback) can be added later if the size is a concern.
- CI cross-compilation of baseline targets makes Bun download additional compile artifacts during `build:platforms`; opencode notes these downloads can occasionally be flaky, which is why `--single` skips baseline by default.