### PR TITLE
Desktop: needs-review indicator from persisted session completion metadata

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -580,7 +580,13 @@ export function AgentSidebar({
 				pendingAction?.sessionId === thread.id ? pendingAction.action : null
 			}
 			thread={thread}
-			unread={unreadSessionIds.has(thread.id)}
+			// The persisted needsAttention flag joins the in-memory unread set so
+			// "agent finished, needs review" survives restarts and other clients.
+			// The active thread is exempt: the user is already looking at it.
+			unread={
+				unreadSessionIds.has(thread.id) ||
+				(thread.needsAttention === true && activeThread !== thread.id)
+			}
 		/>
 	);
 

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
@@ -568,6 +568,15 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 													tone={sessionStatusTone(thread.status)}
 												/>
 												<span className="truncate">{thread.title}</span>
+												{thread.needsAttention &&
+												activeSessionId !== thread.id ? (
+													<span
+														aria-label="Agent finished, needs review"
+														className="size-2 shrink-0 rounded-full bg-blue-500"
+														role="status"
+														title="Agent finished, needs review"
+													/>
+												) : null}
 												{thread.pinned ? (
 													<Star
 														aria-label="Favorited"

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -12,9 +12,11 @@ import type {
 } from "@/lib/session-history";
 import {
 	getSessionMetadataGitBranch,
+	getSessionMetadataNeedsAttention,
 	getSessionMetadataPinned,
 	getSessionMetadataTitle,
 	getSessionSource,
+	NEEDS_ATTENTION_METADATA_KEY,
 	PINNED_METADATA_KEY,
 } from "@/lib/session-history";
 
@@ -37,6 +39,11 @@ export interface SessionThread {
 	totalCostUsd?: number;
 	status: SessionHistoryStatus;
 	pinned?: boolean;
+	/**
+	 * The agent finished a turn and nobody has viewed the result yet
+	 * (persisted in session metadata, shared across clients).
+	 */
+	needsAttention?: boolean;
 }
 
 type SessionHookEvent = {
@@ -261,6 +268,7 @@ function toThread(session: SessionHistoryItem): SessionThread {
 		gitBranch: getSessionMetadataGitBranch(session.metadata) || undefined,
 		status: normalizeDiscoveredStatus(session.status, session.prompt),
 		pinned: getSessionMetadataPinned(session.metadata),
+		needsAttention: getSessionMetadataNeedsAttention(session.metadata),
 	};
 }
 
@@ -399,7 +407,8 @@ function areThreadsEquivalent(
 			a.outputTokens !== b.outputTokens ||
 			a.totalCostUsd !== b.totalCostUsd ||
 			a.status !== b.status ||
-			a.pinned !== b.pinned
+			a.pinned !== b.pinned ||
+			a.needsAttention !== b.needsAttention
 		) {
 			return false;
 		}
@@ -1102,6 +1111,56 @@ export function useSessionHistory({
 		[],
 	);
 
+	/**
+	 * Acknowledges a persisted "needs attention" flag: the user is viewing the
+	 * session, so drop the indicator locally and clear the shared metadata key
+	 * so every other client drops it too. Fire-and-forget: a failed write just
+	 * leaves the flag for the next refresh to surface again.
+	 */
+	const clearThreadNeedsAttention = useCallback((threadId: string) => {
+		const session = sessionsRef.current.find(
+			(item) => item.sessionId === threadId,
+		);
+		if (!getSessionMetadataNeedsAttention(session?.metadata)) {
+			return;
+		}
+		setThreads((current) =>
+			updateThreadById(current, threadId, (thread) =>
+				thread.needsAttention ? { ...thread, needsAttention: false } : thread,
+			),
+		);
+		setSessions((current) =>
+			updateSessionById(current, threadId, (item) => ({
+				...item,
+				metadata: {
+					...(item.metadata ?? {}),
+					[NEEDS_ATTENTION_METADATA_KEY]: undefined,
+				},
+			})),
+		);
+		void desktopClient
+			.invoke("update_chat_session_metadata", {
+				sessionId: threadId,
+				metadata: { [NEEDS_ATTENTION_METADATA_KEY]: null },
+			})
+			.catch(() => {
+				// Leave rollback to the next history refresh.
+			});
+	}, []);
+
+	// A turn that finishes while its session is already open needs no
+	// indicator — the user is watching. Acknowledge as soon as a refresh
+	// surfaces the flag on the active session.
+	useEffect(() => {
+		if (!activeSessionId) {
+			return;
+		}
+		const active = threads.find((thread) => thread.id === activeSessionId);
+		if (active?.needsAttention) {
+			clearThreadNeedsAttention(activeSessionId);
+		}
+	}, [activeSessionId, threads, clearThreadNeedsAttention]);
+
 	const openThread = useCallback(
 		(threadId: string) => {
 			const session = getSessionByThreadId(threadId);
@@ -1114,10 +1173,11 @@ export function useSessionHistory({
 					next.delete(threadId);
 					return next;
 				});
+				clearThreadNeedsAttention(threadId);
 				onOpenSession?.(session);
 			}
 		},
-		[getSessionByThreadId, onOpenSession],
+		[clearThreadNeedsAttention, getSessionByThreadId, onOpenSession],
 	);
 
 	const renameThread = useCallback(
@@ -1416,6 +1476,7 @@ export function useSessionHistory({
 		loadOlderSessions,
 		loadMoreSessions,
 		mayHaveMoreSessions,
+		clearThreadNeedsAttention,
 		openThread,
 		pendingAction,
 		refreshSessions,

--- a/apps/examples/desktop-app/webview/lib/session-history.ts
+++ b/apps/examples/desktop-app/webview/lib/session-history.ts
@@ -12,6 +12,13 @@ export type SessionMetadata = {
 	 * state so every client reading the session sees the same flag.
 	 */
 	pinned?: boolean;
+	/**
+	 * Set by the SDK runtime when the agent finishes a turn on its own and no
+	 * human has seen the result yet. Clients clear it (write `null`) when the
+	 * user opens the session, so "needs review" indicators stay consistent
+	 * across every client reading the session.
+	 */
+	needsAttention?: boolean;
 	git?: {
 		url?: string;
 		branch?: string;
@@ -20,6 +27,7 @@ export type SessionMetadata = {
 };
 
 export const PINNED_METADATA_KEY = "pinned";
+export const NEEDS_ATTENTION_METADATA_KEY = "needsAttention";
 
 export interface SessionHistoryItem {
 	sessionId: string;
@@ -101,6 +109,12 @@ export function getSessionMetadataTitle(metadata?: SessionMetadata): string {
 
 export function getSessionMetadataPinned(metadata?: SessionMetadata): boolean {
 	return metadata?.[PINNED_METADATA_KEY] === true;
+}
+
+export function getSessionMetadataNeedsAttention(
+	metadata?: SessionMetadata,
+): boolean {
+	return metadata?.[NEEDS_ATTENTION_METADATA_KEY] === true;
 }
 
 export function getSessionMetadataGitBranch(


### PR DESCRIPTION
## What this shows

A small client UI built on the session completion metadata introduced in the base PR (persisted `needsAttention` / `lastTurnCompletion` fields on session metadata). Stacked separately so the metadata PR stays minimal; this one can be taken or left independently.

## Changes (desktop app only, 4 files)

- `SessionThread` carries a `needsAttention` flag read from session metadata (`getSessionMetadataNeedsAttention`, same pattern as the existing `pinned` flag).
- The sidebar's blue unread dot, which was in-memory only (lost on restart, desktop events only), now also reflects the persisted flag, so "agent finished, needs review" survives restarts and shows for sessions run from any client (CLI, VS Code, hub).
- The sessions table shows a matching blue dot after the title with an "Agent finished, needs review" tooltip.
- Opening a session, or having it open when the turn finishes, acknowledges the flag by writing `needsAttention: null` through the existing `update_chat_session_metadata` path, which clears the indicator for every client reading the session. The active session is exempt from showing the dot, since the user is already looking at it.

## Verified end to end with real agent turns

Ran a real interactive CLI session (left idle after a completed turn) and a one-shot run, then used the desktop app against the shared session store: the dot renders from persisted metadata, the tooltip shows on hover, and clicking the session clears the flag on disk and across views while unopened sessions keep theirs.

## Testing

- Desktop typecheck passes; `sessions-view` and `agent-sidebar` Vitest suites pass (27/27), plus `test:chat-ui` (65/65).
- Manually tested in the browser against the headless sidecar.