### PR TITLE
feat(hub): directional Hub upgrades with update-and-restart prompts in CLI and desktop

### DIFF
--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -490,6 +490,7 @@ export async function runInteractive(
 		tuiApp?.destroy();
 	});
 	let startupErrorReported = false;
+	let updateCliAfterExit = false;
 	const loadDeferredInitialMessages = resumeSessionId?.trim()
 		? async () => {
 				try {
@@ -749,6 +750,10 @@ export async function runInteractive(
 		onExit: () => {
 			tuiApp?.destroy();
 		},
+		onHubUpdateRestart: () => {
+			updateCliAfterExit = true;
+			tuiApp?.destroy();
+		},
 		onRunningChange: (running) => {
 			isRunning = running;
 			if (!running) {
@@ -876,5 +881,20 @@ export async function runInteractive(
 	if (exitSummary) {
 		prepareTerminalForPostTuiOutput();
 		writeln(formatInteractiveExitSummary(exitSummary));
+	}
+	if (updateCliAfterExit) {
+		if (!exitSummary) {
+			prepareTerminalForPostTuiOutput();
+		}
+		writeln(
+			"The shared Cline Hub was updated by another Cline installation. Updating this CLI…",
+		);
+		const { checkForUpdates } = await import("../commands/update");
+		const exitCode = await checkForUpdates({ includeKanban: false });
+		writeln(
+			exitCode === 0
+				? "Start cline again to reconnect to the updated Hub."
+				: "Update did not complete. Run 'cline update' manually, then start cline again.",
+		);
 	}
 }

--- a/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
@@ -1,3 +1,4 @@
+import type { Config } from "../../../utils/types";
 import type { DialogDismissKey } from "../../utils/dialog-keys";
 
 /**
@@ -11,4 +12,16 @@ export function resolveHubUpdateRequiredKeyAction(
 	if (key.name === "return" || key.name === "enter") return "update";
 	if (key.name === "escape") return "dismiss";
 	return "ignore";
+}
+
+/**
+ * Yolo and sandbox sessions force the local backend and never attach to the
+ * shared managed Hub (see the forceLocalBackend condition in the interactive
+ * session runtime), so a build mismatch on that Hub is another installation's
+ * concern and must not interrupt these sessions with an update dialog.
+ */
+export function shouldWatchManagedHubBuild(
+	config: Pick<Config, "mode" | "sandbox">,
+): boolean {
+	return config.mode !== "yolo" && config.sandbox !== true;
 }

--- a/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
@@ -1,0 +1,14 @@
+import type { DialogDismissKey } from "../../utils/dialog-keys";
+
+/**
+ * Enter starts the update-and-restart flow; Esc dismisses (the mismatch toast
+ * reminds the user to update manually). Other keys are ignored so the dialog
+ * is not lost to a stray keystroke mid-task.
+ */
+export function resolveHubUpdateRequiredKeyAction(
+	key: DialogDismissKey,
+): "update" | "dismiss" | "ignore" {
+	if (key.name === "return" || key.name === "enter") return "update";
+	if (key.name === "escape") return "dismiss";
+	return "ignore";
+}

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.test.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
+import {
+	resolveHubUpdateRequiredKeyAction,
+	shouldWatchManagedHubBuild,
+} from "./hub-update-required-helpers";
 
 describe("hub update required dialog", () => {
 	it("updates on Enter", () => {
@@ -20,6 +23,26 @@ describe("hub update required dialog", () => {
 		expect(resolveHubUpdateRequiredKeyAction({ name: "space" })).toBe("ignore");
 		expect(resolveHubUpdateRequiredKeyAction({ name: "c", ctrl: true })).toBe(
 			"ignore",
+		);
+	});
+});
+
+describe("shouldWatchManagedHubBuild", () => {
+	it("watches for hub-attached modes", () => {
+		expect(shouldWatchManagedHubBuild({ mode: "act", sandbox: false })).toBe(
+			true,
+		);
+		expect(shouldWatchManagedHubBuild({ mode: "plan", sandbox: false })).toBe(
+			true,
+		);
+	});
+
+	it("skips yolo and sandbox sessions, which force the local backend and never attach to the managed Hub", () => {
+		expect(shouldWatchManagedHubBuild({ mode: "yolo", sandbox: false })).toBe(
+			false,
+		);
+		expect(shouldWatchManagedHubBuild({ mode: "act", sandbox: true })).toBe(
+			false,
 		);
 	});
 });

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.test.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
+
+describe("hub update required dialog", () => {
+	it("updates on Enter", () => {
+		expect(resolveHubUpdateRequiredKeyAction({ name: "return" })).toBe(
+			"update",
+		);
+		expect(resolveHubUpdateRequiredKeyAction({ name: "enter" })).toBe("update");
+	});
+
+	it("dismisses only on Esc", () => {
+		expect(resolveHubUpdateRequiredKeyAction({ name: "escape" })).toBe(
+			"dismiss",
+		);
+	});
+
+	it("ignores stray keystrokes so a mid-task keypress cannot lose the prompt", () => {
+		expect(resolveHubUpdateRequiredKeyAction({ name: "a" })).toBe("ignore");
+		expect(resolveHubUpdateRequiredKeyAction({ name: "space" })).toBe("ignore");
+		expect(resolveHubUpdateRequiredKeyAction({ name: "c", ctrl: true })).toBe(
+			"ignore",
+		);
+	});
+});

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
@@ -1,0 +1,50 @@
+// @jsxImportSource @opentui/react
+import type { ChoiceContext } from "@opentui-ui/dialog";
+import { useDialogKeyboard } from "@opentui-ui/dialog/react";
+import { palette } from "../../palette";
+import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
+
+export interface HubUpdateRequiredDetails {
+	hubCoreVersion?: string;
+}
+
+export function HubUpdateRequiredContent(
+	props: ChoiceContext<boolean> & HubUpdateRequiredDetails,
+) {
+	const { dialogId, dismiss, hubCoreVersion, resolve } = props;
+
+	useDialogKeyboard((key) => {
+		const action = resolveHubUpdateRequiredKeyAction(key);
+		if (action === "ignore") return;
+		if (action === "update") {
+			resolve(true);
+			return;
+		}
+		dismiss();
+	}, dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1} gap={1}>
+			<text fg="yellow">Cline Hub was updated</text>
+			<box flexDirection="column">
+				<text selectable>
+					Another Cline installation restarted the shared Cline Hub
+					{hubCoreVersion ? ` (core ${hubCoreVersion})` : ""}, and it no longer
+					matches this CLI.
+				</text>
+				<text selectable>
+					Update and restart Cline so this CLI and the Hub run the same version
+					again.
+				</text>
+			</box>
+			<box flexDirection="row">
+				<box paddingX={1} backgroundColor={palette.act}>
+					<text fg={palette.textOnSelection}>Update and restart</text>
+				</box>
+			</box>
+			<text fg={palette.muted}>
+				Press Enter to update and restart, Esc to dismiss
+			</text>
+		</box>
+	);
+}

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -40,6 +40,7 @@ import {
 	findCommandPaletteShortcut,
 } from "./components/dialogs/command-palette-items";
 import { HubUpdateRequiredContent } from "./components/dialogs/hub-update-required";
+import { shouldWatchManagedHubBuild } from "./components/dialogs/hub-update-required-helpers";
 import {
 	SKILLS_MARKETPLACE_ACTION,
 	SKILLS_MARKETPLACE_URL,
@@ -570,11 +571,13 @@ function App(props: TuiProps) {
 
 	const [hubBuildMismatch, setHubBuildMismatch] =
 		useState<ManagedHubBuildMismatchEvent | null>(null);
+	const hubBuildWatchEnabled = shouldWatchManagedHubBuild(props.config);
 	useEffect(() => {
+		if (!hubBuildWatchEnabled) return;
 		return watchManagedHubBuildMismatch({
 			onMismatch: (mismatch) => setHubBuildMismatch(mismatch),
 		});
-	}, []);
+	}, [hubBuildWatchEnabled]);
 
 	const onHubUpdateRestart = props.onHubUpdateRestart;
 	useEffect(() => {

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -1,4 +1,9 @@
-import { getCurrentContextSize, summarizeUsageFromMessages } from "@cline/core";
+import {
+	getCurrentContextSize,
+	type ManagedHubBuildMismatchEvent,
+	summarizeUsageFromMessages,
+	watchManagedHubBuildMismatch,
+} from "@cline/core";
 import { formatDisplayUserInput } from "@cline/shared";
 import type { KeyEvent } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
@@ -34,6 +39,7 @@ import {
 	buildCommandPaletteItems,
 	findCommandPaletteShortcut,
 } from "./components/dialogs/command-palette-items";
+import { HubUpdateRequiredContent } from "./components/dialogs/hub-update-required";
 import {
 	SKILLS_MARKETPLACE_ACTION,
 	SKILLS_MARKETPLACE_URL,
@@ -561,6 +567,41 @@ function App(props: TuiProps) {
 		}, 0);
 		return () => clearTimeout(timeout);
 	}, [appView, currentProviderId, dialog, notice, onInitialNoticeShown]);
+
+	const [hubBuildMismatch, setHubBuildMismatch] =
+		useState<ManagedHubBuildMismatchEvent | null>(null);
+	useEffect(() => {
+		return watchManagedHubBuildMismatch({
+			onMismatch: (mismatch) => setHubBuildMismatch(mismatch),
+		});
+	}, []);
+
+	const onHubUpdateRestart = props.onHubUpdateRestart;
+	useEffect(() => {
+		if (!hubBuildMismatch) return;
+		setHubBuildMismatch(null);
+		const hubCoreVersion = hubBuildMismatch.hubCoreVersion;
+		void dialog
+			.choice<boolean>({
+				content: (ctx: ChoiceContext<boolean>) => (
+					<HubUpdateRequiredContent {...ctx} hubCoreVersion={hubCoreVersion} />
+				),
+			})
+			.then((update) => {
+				if (update) {
+					(onHubUpdateRestart ?? exitCline)();
+					return;
+				}
+				showToast(
+					"Hub still differs from this CLI. Run 'cline update' and restart when convenient.",
+					"info",
+				);
+				refocusTextareaRef.current();
+			})
+			.catch(() => {
+				refocusTextareaRef.current();
+			});
+	}, [dialog, exitCline, hubBuildMismatch, onHubUpdateRestart, showToast]);
 
 	const {
 		appendEntry: appendSessionEntry,

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -185,6 +185,11 @@ export interface TuiProps {
 	}) => Promise<PendingPromptMutationResult>;
 	onAbort: () => boolean;
 	onExit: () => void;
+	/**
+	 * Exit the TUI and run the CLI self-update afterwards. Invoked when the
+	 * user accepts the "Hub was updated by another Cline installation" dialog.
+	 */
+	onHubUpdateRestart?: () => void;
 	onRunningChange: (isRunning: boolean) => void;
 	onTurnErrorReported: (reported: boolean) => void;
 	onAutoApproveChange: (enabled: boolean) => void;

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -499,6 +499,7 @@ export function createSidecarContext(
 		logger: observability.logger,
 		telemetry: observability.telemetry,
 		unsubscribeSessionEvents: null,
+		hubBuildMismatch: null,
 	};
 }
 

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -45,11 +45,15 @@ function nowMs(): number {
 	return Date.now();
 }
 
-function sendEvent(ctx: SidecarContext, name: string, payload: unknown): void {
-	const encoded = JSON.stringify({
+export function encodeSidecarEvent(name: string, payload: unknown): string {
+	return JSON.stringify({
 		type: "event",
 		event: { name, payload },
 	});
+}
+
+function sendEvent(ctx: SidecarContext, name: string, payload: unknown): void {
+	const encoded = encodeSidecarEvent(name, payload);
 	for (const client of ctx.wsClients) {
 		try {
 			client.send(encoded);

--- a/apps/examples/desktop-app/sidecar/index.ts
+++ b/apps/examples/desktop-app/sidecar/index.ts
@@ -2,11 +2,13 @@ import { homedir } from "node:os";
 import {
 	createClineTelemetryServiceConfig,
 	setHomeDirIfUnset,
+	watchManagedHubBuildMismatch,
 } from "@cline/core";
 import { captureSdkError, claimHubDaemonProcess } from "@cline/shared";
 import { prewarmWorkspaceMetadata } from "./chat-session";
 import { configureConnectorCliLaunch } from "./connectors";
 import {
+	broadcastEvent,
 	createSidecarContext,
 	disposeSidecarContext,
 	initializeSessionManager,
@@ -130,6 +132,21 @@ async function main() {
 	observability.logger.log("Desktop sidecar ready", {
 		port,
 		mode: SIDECAR_MODE,
+	});
+
+	// Another Cline installation (e.g. an updated CLI) can replace the shared
+	// Hub daemon while this app is running. Surface that to the webview so it
+	// can prompt the user to update and restart.
+	watchManagedHubBuildMismatch({
+		onMismatch: (mismatch) => {
+			ctx.hubBuildMismatch = mismatch;
+			observability.logger.log("Managed hub build mismatch detected", {
+				hubBuildId: mismatch.hubBuildId,
+				hubCoreVersion: mismatch.hubCoreVersion,
+				reason: mismatch.reason,
+			});
+			broadcastEvent(ctx, "hub_build_mismatch", mismatch);
+		},
 	});
 
 	// A wildcard bind isn't a dialable address; advertise loopback instead.

--- a/apps/examples/desktop-app/sidecar/mcp.test.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.test.ts
@@ -21,6 +21,7 @@ function createContext(workspaceRoot: string): SidecarContext {
 		hubClient: null,
 		workspaceRoot,
 		unsubscribeSessionEvents: null,
+		hubBuildMismatch: null,
 	};
 }
 

--- a/apps/examples/desktop-app/sidecar/server.ts
+++ b/apps/examples/desktop-app/sidecar/server.ts
@@ -1,7 +1,7 @@
 import { captureSdkError } from "@cline/shared";
 import type { DesktopTransportRequest } from "../webview/lib/desktop-transport";
 import { handleCommand } from "./commands";
-import { sendEvent } from "./context";
+import { encodeSidecarEvent, sendEvent } from "./context";
 import { fetchMarketplaceCatalog } from "./marketplace";
 import { cancelMcpOAuthAuthorizationsForOwner } from "./mcp-oauth";
 import { cancelProviderOAuthLoginsForOwner } from "./oauth-login";
@@ -330,15 +330,7 @@ function createWebSocketHandler(ctx: SidecarContext) {
 			// Replay a pending mismatch so webviews that connect (or reload)
 			// after detection still prompt the user to update and restart.
 			if (ctx.hubBuildMismatch) {
-				ws.send(
-					JSON.stringify({
-						type: "event",
-						event: {
-							name: "hub_build_mismatch",
-							payload: ctx.hubBuildMismatch,
-						},
-					}),
-				);
+				ws.send(encodeSidecarEvent("hub_build_mismatch", ctx.hubBuildMismatch));
 			}
 		},
 		async message(ws: SidecarWebSocketClient, raw: string) {

--- a/apps/examples/desktop-app/sidecar/server.ts
+++ b/apps/examples/desktop-app/sidecar/server.ts
@@ -327,6 +327,19 @@ function createWebSocketHandler(ctx: SidecarContext) {
 				pid: process.pid,
 				mode: SIDECAR_MODE,
 			});
+			// Replay a pending mismatch so webviews that connect (or reload)
+			// after detection still prompt the user to update and restart.
+			if (ctx.hubBuildMismatch) {
+				ws.send(
+					JSON.stringify({
+						type: "event",
+						event: {
+							name: "hub_build_mismatch",
+							payload: ctx.hubBuildMismatch,
+						},
+					}),
+				);
+			}
 		},
 		async message(ws: SidecarWebSocketClient, raw: string) {
 			let request: DesktopTransportRequest;

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -3,6 +3,7 @@ import type {
 	BasicLogger,
 	ClineCore,
 	ITelemetryService,
+	ManagedHubBuildMismatchEvent,
 	NodeHubClient,
 	ToolApprovalResult,
 } from "@cline/core";
@@ -119,6 +120,11 @@ export type SidecarContext = {
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
 	unsubscribeSessionEvents: (() => void) | null;
+	/**
+	 * Latest managed Hub build mismatch, broadcast as `hub_build_mismatch` and
+	 * replayed to webviews that connect after the event fired.
+	 */
+	hubBuildMismatch: ManagedHubBuildMismatchEvent | null;
 };
 export type BunRuntimeApi = {
 	serve: (options: unknown) => { port: number; stop?: () => void };

--- a/apps/examples/desktop-app/src-tauri/Cargo.toml
+++ b/apps/examples/desktop-app/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.11.1", features = ["image-png", "tray-icon"] }
 tauri-plugin-updater = "2"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["sync", "time"] }
 rfd = "0.15"
 
 [target."cfg(target_os = \"macos\")".dependencies]

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -689,6 +689,20 @@ fn restart_to_apply_update(
     app.restart();
 }
 
+/// Run one updater check/download/stage cycle immediately instead of waiting
+/// for the next background interval, and report the resulting status. Used by
+/// flows that need an update staged right now (e.g. the "Cline Hub was
+/// updated" prompt), where restarting without a staged update would just
+/// relaunch the same version.
+#[tauri::command]
+async fn check_for_update_now(
+    app: tauri::AppHandle,
+    update_state: State<'_, Arc<UpdateState>>,
+) -> Result<UpdateStatus, String> {
+    check_and_install_update(&app, update_state.inner()).await;
+    Ok(update_state.snapshot())
+}
+
 /// Icon ids accepted by `set_app_icon`; kept in sync with APP_ICONS in
 /// webview/lib/app-icon.ts. Every non-default id has a matching bundled
 /// resource at icons/dock/<id>.png.
@@ -924,6 +938,7 @@ fn main() {
             open_mcp_settings_file,
             get_update_status,
             restart_to_apply_update,
+            check_for_update_now,
             set_app_icon,
             drain_desktop_menu_actions,
             set_tray_status

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -81,6 +81,12 @@ impl Default for UpdateStatus {
 #[derive(Default)]
 struct UpdateState {
     status: Mutex<UpdateStatus>,
+    // Serializes whole updater cycles. The periodic loop and the on-demand
+    // check_for_update_now command run the same check/download/stage cycle;
+    // without exclusion, overlapping cycles can download the same bundle
+    // concurrently and the later one can overwrite a freshly staged "ready"
+    // with "idle"/"error" decided from its stale pre-await snapshot.
+    cycle: tokio::sync::Mutex<()>,
 }
 
 impl UpdateState {
@@ -147,9 +153,11 @@ fn set_update_status(
 }
 
 async fn check_and_install_update(app: &tauri::AppHandle, state: &UpdateState) {
+    let _cycle = state.cycle.lock().await;
     // An update that already finished downloading only needs a restart; keep
     // reporting "ready" instead of flipping back to transient states unless a
-    // newer version shows up.
+    // newer version shows up. Reading it under the cycle lock makes the
+    // snapshot authoritative for this whole cycle.
     let ready_version = state.ready_version();
     if ready_version.is_none() {
         set_update_status(app, state, "checking", None, None);

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { AgentHeader } from "@/components/agent-header";
 import { AgentSidebar } from "@/components/agent-sidebar";
+import { HubUpdateRequiredDialog } from "@/components/hub-update-required-dialog";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -481,6 +482,7 @@ export default function Home() {
 					/>
 				</div>
 			) : null}
+			<HubUpdateRequiredDialog />
 		</AccountProvider>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -11,8 +11,12 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { restartToApplyUpdate } from "@/hooks/use-app-update";
+import {
+	checkForUpdateNow,
+	restartToApplyUpdate,
+} from "@/hooks/use-app-update";
 import { desktopClient } from "@/lib/desktop-client";
+import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
 
 type HubBuildMismatchPayload = {
 	hubBuildId?: string;
@@ -24,18 +28,24 @@ function mismatchKeyOf(payload: HubBuildMismatchPayload): string {
 	return `${payload.reason ?? ""}:${payload.hubBuildId ?? ""}`;
 }
 
+type UpdatePhase = "idle" | "updating" | "restarting";
+
 /**
  * Blocking prompt shown when the sidecar reports that another Cline
  * installation (for example an updated CLI) replaced the shared Cline Hub
- * with a different build. Restarting relaunches the app - applying any
- * staged auto-update - so the app and the Hub run the same version again.
+ * with a different build. Accepting runs an updater check/download right
+ * away and, once an update is staged, restarts into it so the app and the
+ * Hub run the same version again. If nothing is staged (no release published
+ * yet, or the check failed), the dialog explains why instead of restarting
+ * into the same version and immediately re-prompting.
  */
 export function HubUpdateRequiredDialog() {
 	const [mismatch, setMismatch] = useState<HubBuildMismatchPayload | null>(
 		null,
 	);
 	const [dismissedKey, setDismissedKey] = useState<string | null>(null);
-	const [restarting, setRestarting] = useState(false);
+	const [phase, setPhase] = useState<UpdatePhase>("idle");
+	const [updateHint, setUpdateHint] = useState<string | null>(null);
 
 	useEffect(() => {
 		return desktopClient.subscribe("hub_build_mismatch", (payload) => {
@@ -49,19 +59,27 @@ export function HubUpdateRequiredDialog() {
 	const mismatchKey = mismatch ? mismatchKeyOf(mismatch) : null;
 	const open = mismatchKey !== null && mismatchKey !== dismissedKey;
 
-	const handleRestart = useCallback(async () => {
-		setRestarting(true);
-		const restarted = await restartToApplyUpdate();
-		if (!restarted) {
-			setRestarting(false);
+	const handleUpdateAndRestart = useCallback(async () => {
+		setPhase("updating");
+		setUpdateHint(null);
+		const decision = resolveHubUpdateRestartDecision(await checkForUpdateNow());
+		if (decision.action === "restart") {
+			setPhase("restarting");
+			const restarted = await restartToApplyUpdate();
+			if (!restarted) {
+				setPhase("idle");
+			}
+			return;
 		}
+		setUpdateHint(decision.hint);
+		setPhase("idle");
 	}, []);
 
 	return (
 		<AlertDialog
 			open={open}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen && !restarting) {
+				if (!nextOpen && phase === "idle") {
 					setDismissedKey(mismatchKey);
 				}
 			}}
@@ -77,17 +95,28 @@ export function HubUpdateRequiredDialog() {
 						, and it no longer matches this app. Update and restart Cline Code
 						to stay in sync with the running Hub.
 					</AlertDialogDescription>
+					{updateHint ? (
+						<AlertDialogDescription>{updateHint}</AlertDialogDescription>
+					) : null}
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel disabled={restarting}>Later</AlertDialogCancel>
+					<AlertDialogCancel disabled={phase !== "idle"}>
+						Later
+					</AlertDialogCancel>
 					<AlertDialogAction
-						disabled={restarting}
+						disabled={phase !== "idle"}
 						onClick={(event) => {
 							event.preventDefault();
-							void handleRestart();
+							void handleUpdateAndRestart();
 						}}
 					>
-						{restarting ? "Restarting…" : "Update and restart"}
+						{phase === "restarting"
+							? "Restarting…"
+							: phase === "updating"
+								? "Checking for updates…"
+								: updateHint
+									? "Try again"
+									: "Update and restart"}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { restartToApplyUpdate } from "@/hooks/use-app-update";
+import { desktopClient } from "@/lib/desktop-client";
+
+type HubBuildMismatchPayload = {
+	hubBuildId?: string;
+	hubCoreVersion?: string;
+	reason?: string;
+};
+
+function mismatchKeyOf(payload: HubBuildMismatchPayload): string {
+	return `${payload.reason ?? ""}:${payload.hubBuildId ?? ""}`;
+}
+
+/**
+ * Blocking prompt shown when the sidecar reports that another Cline
+ * installation (for example an updated CLI) replaced the shared Cline Hub
+ * with a different build. Restarting relaunches the app - applying any
+ * staged auto-update - so the app and the Hub run the same version again.
+ */
+export function HubUpdateRequiredDialog() {
+	const [mismatch, setMismatch] = useState<HubBuildMismatchPayload | null>(
+		null,
+	);
+	const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+	const [restarting, setRestarting] = useState(false);
+
+	useEffect(() => {
+		return desktopClient.subscribe("hub_build_mismatch", (payload) => {
+			if (!payload || typeof payload !== "object") {
+				return;
+			}
+			setMismatch(payload as HubBuildMismatchPayload);
+		});
+	}, []);
+
+	const mismatchKey = mismatch ? mismatchKeyOf(mismatch) : null;
+	const open = mismatchKey !== null && mismatchKey !== dismissedKey;
+
+	const handleRestart = useCallback(async () => {
+		setRestarting(true);
+		const restarted = await restartToApplyUpdate();
+		if (!restarted) {
+			setRestarting(false);
+		}
+	}, []);
+
+	return (
+		<AlertDialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen && !restarting) {
+					setDismissedKey(mismatchKey);
+				}
+			}}
+		>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Cline Hub was updated</AlertDialogTitle>
+					<AlertDialogDescription>
+						Another Cline installation updated the shared Cline Hub
+						{mismatch?.hubCoreVersion
+							? ` (core ${mismatch.hubCoreVersion})`
+							: ""}
+						, and it no longer matches this app. Update and restart Cline Code
+						to stay in sync with the running Hub.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={restarting}>Later</AlertDialogCancel>
+					<AlertDialogAction
+						disabled={restarting}
+						onClick={(event) => {
+							event.preventDefault();
+							void handleRestart();
+						}}
+					>
+						{restarting ? "Restarting…" : "Update and restart"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -53,6 +53,10 @@ export function HubUpdateRequiredDialog() {
 				return;
 			}
 			setMismatch(payload as HubBuildMismatchPayload);
+			// A new mismatch is a fresh prompt: drop any "no update available"
+			// hint left over from a previous dialog so it reopens in its
+			// initial state instead of pre-set to "Try again".
+			setUpdateHint(null);
 		});
 	}, []);
 

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
+
+describe("resolveHubUpdateRestartDecision", () => {
+	it("restarts only once an update is staged", () => {
+		expect(resolveHubUpdateRestartDecision({ state: "ready" })).toEqual({
+			action: "restart",
+		});
+	});
+
+	it("stays open when no update is available, so the app is not relaunched into the same version", () => {
+		for (const state of ["idle", "checking", "downloading"] as const) {
+			const decision = resolveHubUpdateRestartDecision({ state });
+			expect(decision.action).toBe("stay");
+		}
+	});
+
+	it("stays open and surfaces the failure when the update check errors", () => {
+		const decision = resolveHubUpdateRestartDecision({
+			state: "error",
+			error: "endpoint unreachable",
+		});
+		expect(decision).toEqual({
+			action: "stay",
+			hint: "The update check failed: endpoint unreachable",
+		});
+	});
+
+	it("stays open when the check could not run at all (web mode or bridge failure)", () => {
+		expect(resolveHubUpdateRestartDecision(null).action).toBe("stay");
+	});
+});

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -1,0 +1,31 @@
+import type { AppUpdateStatus } from "@/hooks/use-app-update";
+
+export type HubUpdateRestartDecision =
+	| { action: "restart" }
+	| { action: "stay"; hint: string };
+
+/**
+ * Decide what "Update and restart" should do after an on-demand updater
+ * check. Restart only when an update is actually staged - relaunching the
+ * same version would bring the mismatch dialog straight back without
+ * restoring build parity with the Hub.
+ */
+export function resolveHubUpdateRestartDecision(
+	status: Pick<AppUpdateStatus, "state" | "error"> | null,
+): HubUpdateRestartDecision {
+	if (status?.state === "ready") {
+		return { action: "restart" };
+	}
+	if (status?.state === "error") {
+		return {
+			action: "stay",
+			hint: status.error
+				? `The update check failed: ${status.error}`
+				: "The update check failed. Try again in a moment.",
+		};
+	}
+	return {
+		action: "stay",
+		hint: "No app update is available to download yet. You can keep working - Cline stays connected to the updated Hub - and try again later.",
+	};
+}

--- a/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-app-update.tsx
@@ -67,6 +67,27 @@ export function useAppUpdateStatus(): AppUpdateStatus {
 }
 
 /**
+ * Ask the Rust shell to check for, download, and stage an update right now,
+ * instead of waiting for the next background updater interval. Resolves with
+ * the resulting updater status ("ready" means an update is staged and a
+ * restart will apply it), or null when the check could not run at all
+ * (web/sidecar mode, or a bridge failure).
+ */
+export async function checkForUpdateNow(): Promise<AppUpdateStatus | null> {
+	try {
+		const status = await desktopClient.invoke<AppUpdateStatus>(
+			"check_for_update_now",
+		);
+		// Keep the shared polled store in sync so the sidebar indicator and
+		// update toast reflect an update staged through this path too.
+		setUpdateStatus(status);
+		return status;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Restart the app so the staged update takes effect. Resolves false (after
  * surfacing a toast) if the restart command fails, so callers can reset
  * pending UI.

--- a/apps/examples/desktop-app/webview/lib/desktop-client.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.ts
@@ -146,6 +146,7 @@ const NATIVE_COMMANDS = new Set([
 	"open_mcp_settings_file",
 	"get_update_status",
 	"restart_to_apply_update",
+	"check_for_update_now",
 	"set_app_icon",
 	"drain_desktop_menu_actions",
 	"set_tray_status",

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -199,7 +199,15 @@ a protocol-compatible daemon from another build is retired before its
 replacement starts so upgrades cannot keep executing stale runtime code. SDK
 builds embed a deterministic fingerprint of the runtime sources, package
 manifests, build configuration, and dependency lock, so the identity changes
-with the executable Hub code even before package versions are bumped.
+with the executable Hub code even before package versions are bumped. Builds
+also embed a build epoch that orders them in time: when the fingerprints
+differ, a managed Hub produced *after* the client's own build is reused over
+the compatible wire protocol instead of being retired (replacing it would
+downgrade the daemon), and the client's build-mismatch watcher prompts the
+user to update and restart. Hubs that are older, unordered, or missing build
+metadata are retired and replaced as before, so two concurrently running
+installations converge on the newest build instead of repeatedly replacing
+each other's daemons.
 Explicit endpoints, including loopback URLs such as
 `ws://127.0.0.1:<port>/hub`, are sticky exact targets and remain protocol-only:
 reconnects may retry the same socket URL, but command recovery and

--- a/sdk/packages/core/bun.mts
+++ b/sdk/packages/core/bun.mts
@@ -39,6 +39,10 @@ const buildConfig = {
 	external,
 	define: {
 		__CLINE_CORE_RUNTIME_BUILD_ID__: JSON.stringify(runtimeBuildId),
+		// Unlike the deterministic fingerprint above, the epoch orders builds in
+		// time so managed-Hub compatibility can tell a newer daemon from a stale
+		// one. Consulted only when fingerprints already differ.
+		__CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__: JSON.stringify(Date.now()),
 	},
 } as const;
 

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -779,6 +779,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 		delete process.env.CLINE_HUB_BUILD_ID;
 		vi.resetModules();
 	});
@@ -871,6 +872,62 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
 		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
+		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
+	});
+
+	it("attaches to a managed hub from a newer build instead of retiring it", async () => {
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
+		const clearHubDiscoveryMock = vi.fn();
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				resolveHubBuildId: () => "current-build",
+				readHubDiscovery: vi.fn(async () => ({
+					hubId: "hub-test",
+					protocolVersion: "v1",
+					buildId: "newer-build",
+					buildEpochMs: 2_000,
+					authToken: "newer-token",
+					host: "127.0.0.1",
+					port: 59999,
+					url: "ws://127.0.0.1:59999/hub",
+					startedAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				})),
+				clearHubDiscovery: vi.fn(async (...args: unknown[]) => {
+					clearHubDiscoveryMock(...args);
+				}),
+				probeHubServer: vi.fn(async () => ({
+					hubId: "hub-test",
+					protocolVersion: "v1",
+					buildId: "newer-build",
+					buildEpochMs: 2_000,
+					host: "127.0.0.1",
+					port: 59999,
+					url: "ws://127.0.0.1:59999/hub",
+					startedAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				})),
+			};
+		});
+
+		const { resolveCompatibleLocalHubUrl } = await import(".");
+
+		await expect(resolveCompatibleLocalHubUrl()).resolves.toBe(
+			"ws://127.0.0.1:59999/hub",
+		);
 		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -18,6 +18,7 @@ import {
 	clearHubDiscovery,
 	getManagedHubCompatibility,
 	type HubOwnerContext,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
 	resolveHubBuildId,
@@ -863,16 +864,26 @@ async function probeCompatibleHubUrl(
 			url: normalized,
 		};
 	}
-	const compatibility = options?.requireCurrentBuild
-		? getManagedHubCompatibility(record, resolveHubBuildId())
-		: isHubProtocolCompatible(record);
-	if (!compatibility.compatible) {
+	if (options?.requireCurrentBuild) {
+		// Managed Hubs: reusable when the build matches or the Hub is a newer
+		// build (another installation upgraded it - attach and let the
+		// build-mismatch watcher prompt the user instead of downgrading it).
+		const expectedBuildId = resolveHubBuildId();
+		if (!isManagedHubReusable(record, { expectedBuildId })) {
+			const compatibility = getManagedHubCompatibility(record, expectedBuildId);
+			return {
+				status:
+					!compatibility.compatible &&
+					(compatibility.reason === "build_mismatch" ||
+						compatibility.reason === "missing_build")
+						? "build_mismatch"
+						: "protocol_mismatch",
+				url: normalized,
+			};
+		}
+	} else if (!isHubProtocolCompatible(record).compatible) {
 		return {
-			status:
-				compatibility.reason === "build_mismatch" ||
-				compatibility.reason === "missing_build"
-					? "build_mismatch"
-					: "protocol_mismatch",
+			status: "protocol_mismatch",
 			url: normalized,
 		};
 	}

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -869,15 +869,16 @@ async function probeCompatibleHubUrl(
 		// build (another installation upgraded it - attach and let the
 		// build-mismatch watcher prompt the user instead of downgrading it).
 		const expectedBuildId = resolveHubBuildId();
-		if (!isManagedHubReusable(record, { expectedBuildId })) {
-			const compatibility = getManagedHubCompatibility(record, expectedBuildId);
+		const compatibility = getManagedHubCompatibility(record, expectedBuildId);
+		if (
+			!compatibility.compatible &&
+			!isManagedHubReusable(record, { expectedBuildId })
+		) {
 			return {
 				status:
-					!compatibility.compatible &&
-					(compatibility.reason === "build_mismatch" ||
-						compatibility.reason === "missing_build")
-						? "build_mismatch"
-						: "protocol_mismatch",
+					compatibility.reason === "unsupported_protocol"
+						? "protocol_mismatch"
+						: "build_mismatch",
 				url: normalized,
 			};
 		}

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type DiscoveryMockOptions = {
+	record?: Record<string, unknown>;
+	probe?: Record<string, unknown> | undefined;
+	expectedBuildId?: string;
+};
+
+function mockDiscovery(options: DiscoveryMockOptions): void {
+	vi.doMock("../discovery/workspace", () => ({
+		resolveProductionHubOwnerContext: () => ({
+			ownerId: "hub-test",
+			discoveryPath: "/tmp/hub-watcher-discovery.json",
+		}),
+		resolveSharedHubOwnerContext: () => ({
+			ownerId: "hub-test",
+			discoveryPath: "/tmp/hub-watcher-discovery.json",
+		}),
+	}));
+	vi.doMock("../discovery", async () => {
+		const actual =
+			await vi.importActual<typeof import("../discovery")>("../discovery");
+		return {
+			...actual,
+			resolveHubBuildId: () => options.expectedBuildId ?? "current-build",
+			readHubDiscovery: vi.fn(async () => options.record),
+			probeHubServer: vi.fn(async () => options.probe),
+		};
+	});
+}
+
+const liveRecord = {
+	hubId: "hub-test",
+	protocolVersion: "v1",
+	buildId: "old-build",
+	authToken: "token",
+	host: "127.0.0.1",
+	port: 59999,
+	url: "ws://127.0.0.1:59999/hub",
+	startedAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
+
+describe("checkManagedHubBuildMismatch", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	it("reports a live hub running another build", async () => {
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "old-build",
+				coreVersion: "0.0.71",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toEqual({
+			url: "ws://127.0.0.1:59999/hub",
+			reason: "build_mismatch",
+			hubBuildId: "old-build",
+			hubCoreVersion: "0.0.71",
+			expectedBuildId: "current-build",
+		});
+	});
+
+	it("reports missing build metadata on a live hub", async () => {
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toMatchObject({
+			reason: "missing_build",
+		});
+	});
+
+	it("returns undefined when the hub matches this build", async () => {
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "current-build",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("returns undefined when no discovery record exists", async () => {
+		mockDiscovery({ record: undefined, probe: undefined });
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("returns undefined when the recorded hub is unreachable", async () => {
+		mockDiscovery({ record: liveRecord, probe: undefined });
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+});
+
+describe("watchManagedHubBuildMismatch", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	it("fires once per mismatched hub build and re-arms after recovery", async () => {
+		vi.useFakeTimers();
+		let probeResult: Record<string, unknown> | undefined = {
+			protocolVersion: "v1",
+			buildId: "old-build",
+			host: "127.0.0.1",
+			port: 59999,
+			url: "ws://127.0.0.1:59999/hub",
+		};
+		vi.doMock("../discovery/workspace", () => ({
+			resolveProductionHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-watcher-discovery.json",
+			}),
+			resolveSharedHubOwnerContext: () => ({
+				ownerId: "hub-test",
+				discoveryPath: "/tmp/hub-watcher-discovery.json",
+			}),
+		}));
+		vi.doMock("../discovery", async () => {
+			const actual =
+				await vi.importActual<typeof import("../discovery")>("../discovery");
+			return {
+				...actual,
+				resolveHubBuildId: () => "current-build",
+				readHubDiscovery: vi.fn(async () => liveRecord),
+				probeHubServer: vi.fn(async () => probeResult),
+			};
+		});
+		const { watchManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		const onMismatch = vi.fn();
+		const stop = watchManagedHubBuildMismatch({
+			onMismatch,
+			intervalMs: 1_000,
+		});
+		try {
+			await vi.advanceTimersByTimeAsync(1_000);
+			expect(onMismatch).toHaveBeenCalledTimes(1);
+			expect(onMismatch).toHaveBeenLastCalledWith(
+				expect.objectContaining({ hubBuildId: "old-build" }),
+			);
+
+			// Same mismatched build: no repeat notifications.
+			await vi.advanceTimersByTimeAsync(2_000);
+			expect(onMismatch).toHaveBeenCalledTimes(1);
+
+			// Hub becomes compatible, then mismatches again with a new build.
+			probeResult = {
+				protocolVersion: "v1",
+				buildId: "current-build",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			};
+			await vi.advanceTimersByTimeAsync(1_000);
+			expect(onMismatch).toHaveBeenCalledTimes(1);
+
+			probeResult = {
+				protocolVersion: "v1",
+				buildId: "newer-build",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			};
+			await vi.advanceTimersByTimeAsync(1_000);
+			expect(onMismatch).toHaveBeenCalledTimes(2);
+			expect(onMismatch).toHaveBeenLastCalledWith(
+				expect.objectContaining({ hubBuildId: "newer-build" }),
+			);
+		} finally {
+			stop();
+		}
+	});
+
+	it("does not start inside hub daemon processes or with explicit endpoints", async () => {
+		vi.useFakeTimers();
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "old-build",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		vi.stubEnv("CLINE_HUB_PORT", "25777");
+		const { watchManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		const onMismatch = vi.fn();
+		const stop = watchManagedHubBuildMismatch({
+			onMismatch,
+			intervalMs: 1_000,
+		});
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(onMismatch).not.toHaveBeenCalled();
+		stop();
+	});
+});

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
@@ -47,13 +47,15 @@ describe("checkManagedHubBuildMismatch", () => {
 		vi.resetModules();
 	});
 
-	it("reports a live hub running another build", async () => {
+	it("reports a live hub running a newer build", async () => {
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
 		mockDiscovery({
 			record: liveRecord,
 			probe: {
 				protocolVersion: "v1",
-				buildId: "old-build",
-				coreVersion: "0.0.71",
+				buildId: "newer-build",
+				buildEpochMs: 2_000,
+				coreVersion: "0.0.73",
 				host: "127.0.0.1",
 				port: 59999,
 				url: "ws://127.0.0.1:59999/hub",
@@ -66,13 +68,33 @@ describe("checkManagedHubBuildMismatch", () => {
 		await expect(checkManagedHubBuildMismatch()).resolves.toEqual({
 			url: "ws://127.0.0.1:59999/hub",
 			reason: "build_mismatch",
-			hubBuildId: "old-build",
-			hubCoreVersion: "0.0.71",
+			hubBuildId: "newer-build",
+			hubCoreVersion: "0.0.73",
 			expectedBuildId: "current-build",
 		});
 	});
 
-	it("reports missing build metadata on a live hub", async () => {
+	it("does not prompt for an older or unordered hub build (it gets replaced instead)", async () => {
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "old-build",
+				buildEpochMs: 500,
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("does not prompt for a legacy hub without build metadata", async () => {
 		mockDiscovery({
 			record: liveRecord,
 			probe: {
@@ -86,8 +108,26 @@ describe("checkManagedHubBuildMismatch", () => {
 			"./managed-hub-build-watcher"
 		);
 
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("prompts when the hub protocol is not supported by this client", async () => {
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v99",
+				buildId: "future-build",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
 		await expect(checkManagedHubBuildMismatch()).resolves.toMatchObject({
-			reason: "missing_build",
+			reason: "unsupported_protocol",
 		});
 	});
 
@@ -137,9 +177,11 @@ describe("watchManagedHubBuildMismatch", () => {
 
 	it("fires once per mismatched hub build and re-arms after recovery", async () => {
 		vi.useFakeTimers();
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
 		let probeResult: Record<string, unknown> | undefined = {
 			protocolVersion: "v1",
-			buildId: "old-build",
+			buildId: "newer-build",
+			buildEpochMs: 2_000,
 			host: "127.0.0.1",
 			port: 59999,
 			url: "ws://127.0.0.1:59999/hub",
@@ -177,7 +219,7 @@ describe("watchManagedHubBuildMismatch", () => {
 			await vi.advanceTimersByTimeAsync(1_000);
 			expect(onMismatch).toHaveBeenCalledTimes(1);
 			expect(onMismatch).toHaveBeenLastCalledWith(
-				expect.objectContaining({ hubBuildId: "old-build" }),
+				expect.objectContaining({ hubBuildId: "newer-build" }),
 			);
 
 			// Same mismatched build: no repeat notifications.
@@ -197,7 +239,8 @@ describe("watchManagedHubBuildMismatch", () => {
 
 			probeResult = {
 				protocolVersion: "v1",
-				buildId: "newer-build",
+				buildId: "even-newer-build",
+				buildEpochMs: 3_000,
 				host: "127.0.0.1",
 				port: 59999,
 				url: "ws://127.0.0.1:59999/hub",
@@ -205,7 +248,7 @@ describe("watchManagedHubBuildMismatch", () => {
 			await vi.advanceTimersByTimeAsync(1_000);
 			expect(onMismatch).toHaveBeenCalledTimes(2);
 			expect(onMismatch).toHaveBeenLastCalledWith(
-				expect.objectContaining({ hubBuildId: "newer-build" }),
+				expect.objectContaining({ hubBuildId: "even-newer-build" }),
 			);
 		} finally {
 			stop();

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -1,0 +1,151 @@
+import { existsSync } from "node:fs";
+import { isHubDaemonProcess, resolveClineBuildEnv } from "@cline/shared";
+import {
+	getManagedHubCompatibility,
+	type HubOwnerContext,
+	probeHubServer,
+	readHubDiscovery,
+	resolveHubBuildId,
+} from "../discovery";
+import {
+	resolveProductionHubOwnerContext,
+	resolveSharedHubOwnerContext,
+} from "../discovery/workspace";
+
+const DEFAULT_WATCH_INTERVAL_MS = 10_000;
+
+export interface ManagedHubBuildMismatchEvent {
+	/** WebSocket URL of the live managed Hub that does not match this build. */
+	url: string;
+	/** Why the running Hub is not usable by this client build. */
+	reason: "unsupported_protocol" | "missing_build" | "build_mismatch";
+	/** Build identity reported by the running Hub, when it reports one. */
+	hubBuildId?: string;
+	/** Core package version reported by the running Hub. */
+	hubCoreVersion?: string;
+	/** Build identity this client expects a managed Hub to match. */
+	expectedBuildId: string;
+}
+
+function resolveDefaultHubOwnerContext(): HubOwnerContext {
+	return resolveClineBuildEnv() === "production"
+		? resolveProductionHubOwnerContext()
+		: resolveSharedHubOwnerContext();
+}
+
+function isHubStartupLockHeld(discoveryPath: string): boolean {
+	try {
+		return existsSync(`${discoveryPath}.lock`);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Probe the managed local Hub once and report whether a live Hub is running
+ * a build this client cannot manage. Returns `undefined` when there is no
+ * discovery record, the recorded Hub is unreachable, a Hub startup
+ * transaction is in flight (another client may be mid-replacement), or the
+ * running Hub matches this build.
+ *
+ * A mismatch means another Cline installation replaced the shared Hub with a
+ * different build (for example, the CLI was updated while the desktop app
+ * kept running). This client can keep talking to it over the compatible wire
+ * protocol, but it should prompt the user to update and restart so client
+ * and Hub run the same code again.
+ */
+export async function checkManagedHubBuildMismatch(): Promise<
+	ManagedHubBuildMismatchEvent | undefined
+> {
+	const owner = resolveDefaultHubOwnerContext();
+	if (isHubStartupLockHeld(owner.discoveryPath)) {
+		return undefined;
+	}
+	const record = await readHubDiscovery(owner.discoveryPath).catch(
+		() => undefined,
+	);
+	if (!record?.url) {
+		return undefined;
+	}
+	const healthy = await probeHubServer(record.url).catch(() => undefined);
+	if (!healthy?.url) {
+		return undefined;
+	}
+	const expectedBuildId = resolveHubBuildId();
+	const compatibility = getManagedHubCompatibility(healthy, expectedBuildId);
+	if (compatibility.compatible) {
+		return undefined;
+	}
+	if (
+		compatibility.reason !== "unsupported_protocol" &&
+		compatibility.reason !== "missing_build" &&
+		compatibility.reason !== "build_mismatch"
+	) {
+		return undefined;
+	}
+	return {
+		url: healthy.url,
+		reason: compatibility.reason,
+		hubBuildId: healthy.buildId,
+		hubCoreVersion: healthy.coreVersion,
+		expectedBuildId,
+	};
+}
+
+export interface WatchManagedHubBuildOptions {
+	onMismatch: (event: ManagedHubBuildMismatchEvent) => void;
+	intervalMs?: number;
+}
+
+/**
+ * Periodically watch the managed local Hub for a build-identity mismatch and
+ * invoke `onMismatch` when another Cline installation has replaced the Hub
+ * with a different build. Fires once per observed Hub build (it will fire
+ * again only if the Hub changes to yet another mismatched build after a
+ * compatible one was seen, or a different mismatch reason appears).
+ *
+ * Start this only for managed Hub usage. Hosts configured with an explicit
+ * Hub endpoint keep protocol-only compatibility and must not show update
+ * prompts, so the watcher refuses to start when `CLINE_HUB_PORT` is set.
+ * The first check runs after one interval so app startup (which may itself
+ * be replacing a stale Hub) has settled.
+ *
+ * Returns a stop function.
+ */
+export function watchManagedHubBuildMismatch(
+	options: WatchManagedHubBuildOptions,
+): () => void {
+	if (isHubDaemonProcess() || process.env.CLINE_HUB_PORT?.trim()) {
+		return () => {};
+	}
+	const intervalMs = options.intervalMs ?? DEFAULT_WATCH_INTERVAL_MS;
+	let notifiedKey: string | undefined;
+	let checking = false;
+	const timer = setInterval(() => {
+		if (checking) {
+			return;
+		}
+		checking = true;
+		void checkManagedHubBuildMismatch()
+			.then((mismatch) => {
+				if (!mismatch) {
+					notifiedKey = undefined;
+					return;
+				}
+				const key = `${mismatch.reason}:${mismatch.hubBuildId ?? ""}`;
+				if (key === notifiedKey) {
+					return;
+				}
+				notifiedKey = key;
+				options.onMismatch(mismatch);
+			})
+			.catch(() => undefined)
+			.finally(() => {
+				checking = false;
+			});
+	}, intervalMs);
+	timer.unref?.();
+	return () => {
+		clearInterval(timer);
+	};
+}

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -13,6 +13,14 @@ import {
 } from "../discovery/workspace";
 
 const DEFAULT_WATCH_INTERVAL_MS = 10_000;
+const WATCH_INTERVAL_ENV = "CLINE_HUB_BUILD_WATCH_INTERVAL_MS";
+
+function resolveDefaultWatchIntervalMs(): number {
+	const configured = Number(process.env[WATCH_INTERVAL_ENV]);
+	return Number.isFinite(configured) && configured > 0
+		? configured
+		: DEFAULT_WATCH_INTERVAL_MS;
+}
 
 export interface ManagedHubBuildMismatchEvent {
 	/** WebSocket URL of the live managed Hub that does not match this build. */
@@ -118,7 +126,7 @@ export function watchManagedHubBuildMismatch(
 	if (isHubDaemonProcess() || process.env.CLINE_HUB_PORT?.trim()) {
 		return () => {};
 	}
-	const intervalMs = options.intervalMs ?? DEFAULT_WATCH_INTERVAL_MS;
+	const intervalMs = options.intervalMs ?? resolveDefaultWatchIntervalMs();
 	let notifiedKey: string | undefined;
 	let checking = false;
 	const timer = setInterval(() => {

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -3,6 +3,7 @@ import { isHubDaemonProcess, resolveClineBuildEnv } from "@cline/shared";
 import {
 	getManagedHubCompatibility,
 	type HubOwnerContext,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
 	resolveHubBuildId,
@@ -25,8 +26,9 @@ function resolveDefaultWatchIntervalMs(): number {
 export interface ManagedHubBuildMismatchEvent {
 	/** WebSocket URL of the live managed Hub that does not match this build. */
 	url: string;
-	/** Why the running Hub is not usable by this client build. */
-	reason: "unsupported_protocol" | "missing_build" | "build_mismatch";
+	/** Why this client should update: the running Hub is a newer build this
+	 * client stays attached to, or it speaks an unsupported protocol. */
+	reason: "unsupported_protocol" | "build_mismatch";
 	/** Build identity reported by the running Hub, when it reports one. */
 	hubBuildId?: string;
 	/** Core package version reported by the running Hub. */
@@ -84,16 +86,26 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	if (compatibility.compatible) {
 		return undefined;
 	}
+	// Prompt only for mismatches that persist and that updating this client
+	// resolves: a newer reusable Hub this client stays attached to, or a Hub
+	// whose protocol this client cannot speak at all. Older or unordered
+	// builds are retired and replaced automatically, so prompting would only
+	// flash a stale dialog.
 	if (
 		compatibility.reason !== "unsupported_protocol" &&
-		compatibility.reason !== "missing_build" &&
-		compatibility.reason !== "build_mismatch"
+		!(
+			compatibility.reason === "build_mismatch" &&
+			isManagedHubReusable(healthy, { expectedBuildId })
+		)
 	) {
 		return undefined;
 	}
 	return {
 		url: healthy.url,
-		reason: compatibility.reason,
+		reason:
+			compatibility.reason === "unsupported_protocol"
+				? "unsupported_protocol"
+				: "build_mismatch",
 		hubBuildId: healthy.buildId,
 		hubCoreVersion: healthy.coreVersion,
 		expectedBuildId,

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -91,25 +91,25 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	// whose protocol this client cannot speak at all. Older or unordered
 	// builds are retired and replaced automatically, so prompting would only
 	// flash a stale dialog.
-	if (
-		compatibility.reason !== "unsupported_protocol" &&
-		!(
-			compatibility.reason === "build_mismatch" &&
-			isManagedHubReusable(healthy, { expectedBuildId })
-		)
-	) {
-		return undefined;
-	}
-	return {
+	const report = (
+		reason: ManagedHubBuildMismatchEvent["reason"],
+	): ManagedHubBuildMismatchEvent => ({
 		url: healthy.url,
-		reason:
-			compatibility.reason === "unsupported_protocol"
-				? "unsupported_protocol"
-				: "build_mismatch",
+		reason,
 		hubBuildId: healthy.buildId,
 		hubCoreVersion: healthy.coreVersion,
 		expectedBuildId,
-	};
+	});
+	if (compatibility.reason === "unsupported_protocol") {
+		return report("unsupported_protocol");
+	}
+	if (
+		compatibility.reason === "build_mismatch" &&
+		isManagedHubReusable(healthy, { expectedBuildId })
+	) {
+		return report("build_mismatch");
+	}
+	return undefined;
 }
 
 export interface WatchManagedHubBuildOptions {

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -12,6 +12,7 @@ const {
 	createHubServerUrl,
 	clearHubDiscovery,
 	getManagedHubCompatibility,
+	isManagedHubReusable,
 	probeHubServer,
 	requestHubShutdown,
 	readHubDiscovery,
@@ -43,6 +44,17 @@ const {
 			compatible:
 				record.protocolVersion === "v1" && record.buildId === "current-build",
 		}),
+	),
+	// Mirrors the real semantics: same build, or a strictly newer build epoch.
+	isManagedHubReusable: vi.fn(
+		(record: {
+			protocolVersion?: string;
+			buildId?: string;
+			buildEpochMs?: number;
+		}) =>
+			record.protocolVersion === "v1" &&
+			(record.buildId === "current-build" ||
+				(record.buildEpochMs ?? 0) > 1_000_000),
 	),
 	probeHubServer: vi.fn(),
 	requestHubShutdown: vi.fn(async () => true),
@@ -98,6 +110,7 @@ vi.mock("../discovery", () => ({
 	clearHubDiscovery,
 	createHubServerUrl,
 	getManagedHubCompatibility,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
@@ -382,6 +395,38 @@ describe("ensureDetachedHubServer", () => {
 			expect(clearHubDiscovery).toHaveBeenCalledWith("/tmp/hub-discovery.json");
 			expect(spawn).toHaveBeenCalledOnce();
 			expect(verifyHubConnection).toHaveBeenCalledOnce();
+		} finally {
+			kill.mockRestore();
+		}
+	});
+
+	it("reuses a healthy hub from a newer build without retiring it", async () => {
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+		try {
+			readHubDiscovery.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "newer-hub-token",
+			});
+			probeHubServer.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "newer-build",
+				buildEpochMs: 2_000_000,
+				pid: 12345,
+			});
+			verifyHubConnection.mockResolvedValueOnce(true);
+
+			const { ensureDetachedHubServer } = await import(".");
+			const result = await ensureDetachedHubServer("/workspace");
+
+			expect(result).toEqual({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "newer-hub-token",
+			});
+			expect(requestHubShutdown).not.toHaveBeenCalled();
+			expect(kill).not.toHaveBeenCalled();
+			expect(clearHubDiscovery).not.toHaveBeenCalled();
+			expect(spawn).not.toHaveBeenCalled();
 		} finally {
 			kill.mockRestore();
 		}

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -16,10 +16,10 @@ import {
 import {
 	clearHubDiscovery,
 	createHubServerUrl,
-	getManagedHubCompatibility,
 	type HubOwnerContext,
 	type HubServerDiscoveryRecord,
 	type HubServerProbeRecord,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
@@ -69,8 +69,8 @@ function resolveDefaultHubOwnerContext() {
 		: resolveSharedHubOwnerContext();
 }
 
-function isCompatibleHubRecord(record: HubServerProbeRecord): boolean {
-	return getManagedHubCompatibility(record, resolveHubBuildId()).compatible;
+function isReusableHubRecord(record: HubServerProbeRecord): boolean {
+	return isManagedHubReusable(record, { expectedBuildId: resolveHubBuildId() });
 }
 
 function withMatchingDiscoveryRetirementMetadata(
@@ -135,7 +135,7 @@ async function retireIncompatibleHub(
 	record: HubServerProbeRecord,
 	discoveryPath: string,
 ): Promise<boolean> {
-	if (isCompatibleHubRecord(record)) {
+	if (isReusableHubRecord(record)) {
 		return true;
 	}
 	return retireDiscoveredHub(record, discoveryPath);
@@ -321,7 +321,7 @@ async function ensureDetachedHubServerLocked(
 			);
 			if (
 				healthy?.url &&
-				isCompatibleHubRecord(healthy) &&
+				isReusableHubRecord(healthy) &&
 				(await verifyHubConnection(healthy.url, {
 					authToken: discoveredAuthToken,
 				}))
@@ -348,7 +348,7 @@ async function ensureDetachedHubServerLocked(
 			discovered,
 			expectedUrl,
 		);
-		if (isCompatibleHubRecord(expected)) {
+		if (isReusableHubRecord(expected)) {
 			// Live hub is healthy but discovery is missing/unreadable (or auth
 			// token was empty). Prefer attaching via any known auth token rather
 			// than spawning a second daemon that dies with EADDRINUSE.
@@ -431,7 +431,7 @@ async function ensureDetachedHubServerLocked(
 			);
 			if (
 				healthy?.url &&
-				isCompatibleHubRecord(healthy) &&
+				isReusableHubRecord(healthy) &&
 				(await verifyHubConnection(healthy.url, {
 					authToken: nextDiscovery.authToken,
 				}))
@@ -443,7 +443,7 @@ async function ensureDetachedHubServerLocked(
 			}
 		}
 		const nextExpected = await safeProbeHubServer(expectedUrl);
-		if (nextExpected?.url && !isCompatibleHubRecord(nextExpected)) {
+		if (nextExpected?.url && !isReusableHubRecord(nextExpected)) {
 			const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
 				nextExpected,
 				nextDiscovery,

--- a/sdk/packages/core/src/hub/discovery/index.test.ts
+++ b/sdk/packages/core/src/hub/discovery/index.test.ts
@@ -5,8 +5,10 @@ import {
 	clearHubDiscovery,
 	clearHubDiscoveryIfOwned,
 	getManagedHubCompatibility,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
+	resolveHubBuildEpochMs,
 	resolveHubBuildId,
 	resolveHubOwnerContext,
 	writeHubDiscovery,
@@ -15,6 +17,7 @@ import {
 type EnvSnapshot = {
 	CLINE_DATA_DIR: string | undefined;
 	CLINE_HUB_BUILD_ID: string | undefined;
+	CLINE_HUB_BUILD_EPOCH_MS: string | undefined;
 	CLINE_HUB_DISCOVERY_PATH: string | undefined;
 };
 
@@ -22,6 +25,7 @@ function captureEnv(): EnvSnapshot {
 	return {
 		CLINE_DATA_DIR: process.env.CLINE_DATA_DIR,
 		CLINE_HUB_BUILD_ID: process.env.CLINE_HUB_BUILD_ID,
+		CLINE_HUB_BUILD_EPOCH_MS: process.env.CLINE_HUB_BUILD_EPOCH_MS,
 		CLINE_HUB_DISCOVERY_PATH: process.env.CLINE_HUB_DISCOVERY_PATH,
 	};
 }
@@ -29,6 +33,7 @@ function captureEnv(): EnvSnapshot {
 function restoreEnv(snapshot: EnvSnapshot): void {
 	process.env.CLINE_DATA_DIR = snapshot.CLINE_DATA_DIR;
 	process.env.CLINE_HUB_BUILD_ID = snapshot.CLINE_HUB_BUILD_ID;
+	process.env.CLINE_HUB_BUILD_EPOCH_MS = snapshot.CLINE_HUB_BUILD_EPOCH_MS;
 	process.env.CLINE_HUB_DISCOVERY_PATH = snapshot.CLINE_HUB_DISCOVERY_PATH;
 }
 
@@ -95,6 +100,82 @@ describe("hub discovery", () => {
 				"current-build",
 			),
 		).toEqual({ compatible: false, reason: "unsupported_protocol" });
+	});
+
+	it("allows tests to override the build epoch and treats sources as unordered", () => {
+		snapshot = captureEnv();
+		delete process.env.CLINE_HUB_BUILD_EPOCH_MS;
+		expect(resolveHubBuildEpochMs()).toBeUndefined();
+
+		process.env.CLINE_HUB_BUILD_EPOCH_MS = "12345";
+		expect(resolveHubBuildEpochMs()).toBe(12345);
+	});
+
+	it("reuses managed Hubs only for the same build or a strictly newer one", () => {
+		snapshot = captureEnv();
+		delete process.env.CLINE_HUB_BUILD_EPOCH_MS;
+		const reuseOptions = {
+			expectedBuildId: "current-build",
+			expectedBuildEpochMs: 1_000,
+		};
+		// Same build: reusable regardless of epoch.
+		expect(
+			isManagedHubReusable(
+				{ protocolVersion: "v1", buildId: "current-build" },
+				reuseOptions,
+			),
+		).toBe(true);
+		// Different build with a newer epoch: another install upgraded the Hub.
+		expect(
+			isManagedHubReusable(
+				{
+					protocolVersion: "v1",
+					buildId: "other-build",
+					buildEpochMs: 2_000,
+				},
+				reuseOptions,
+			),
+		).toBe(true);
+		// Different build that is older: retire and replace.
+		expect(
+			isManagedHubReusable(
+				{ protocolVersion: "v1", buildId: "other-build", buildEpochMs: 500 },
+				reuseOptions,
+			),
+		).toBe(false);
+		// Different build with no ordering information: replace (safe default).
+		expect(
+			isManagedHubReusable(
+				{ protocolVersion: "v1", buildId: "other-build" },
+				reuseOptions,
+			),
+		).toBe(false);
+		// Own epoch unknown (unbundled sources): replace.
+		expect(
+			isManagedHubReusable(
+				{
+					protocolVersion: "v1",
+					buildId: "other-build",
+					buildEpochMs: 2_000,
+				},
+				{ expectedBuildId: "current-build" },
+			),
+		).toBe(false);
+		// Legacy hub without build metadata: replace.
+		expect(isManagedHubReusable({ protocolVersion: "v1" }, reuseOptions)).toBe(
+			false,
+		);
+		// Protocol mismatch is never reusable, newer or not.
+		expect(
+			isManagedHubReusable(
+				{
+					protocolVersion: "v2",
+					buildId: "other-build",
+					buildEpochMs: 2_000,
+				},
+				reuseOptions,
+			),
+		).toBe(false);
 	});
 
 	it("writes and clears discovery records at the resolved location", async () => {

--- a/sdk/packages/core/src/hub/discovery/index.ts
+++ b/sdk/packages/core/src/hub/discovery/index.ts
@@ -11,9 +11,11 @@ import { resolveClineDataDir, resolveClineDir } from "@cline/shared/storage";
 import corePackage from "../../../package.json";
 
 declare const __CLINE_CORE_RUNTIME_BUILD_ID__: string | undefined;
+declare const __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__: number | undefined;
 
 const HUB_DISCOVERY_ENV = "CLINE_HUB_DISCOVERY_PATH";
 const HUB_BUILD_ID_ENV = "CLINE_HUB_BUILD_ID";
+const HUB_BUILD_EPOCH_ENV = "CLINE_HUB_BUILD_EPOCH_MS";
 const HUB_STARTUP_LOCK_MAX_AGE_MS = 30_000;
 const HUB_STARTUP_LOCK_WAIT_MS = 15_000;
 const HUB_STARTUP_LOCK_POLL_MS = 100;
@@ -26,6 +28,7 @@ export interface HubServerDiscoveryRecord {
 	capabilities?: readonly string[];
 	coreVersion?: string;
 	buildId?: string;
+	buildEpochMs?: number;
 	authToken: string;
 	host: string;
 	port: number;
@@ -42,6 +45,7 @@ export type HubServerProbeRecord = {
 	capabilities?: readonly string[];
 	coreVersion?: string;
 	buildId?: string;
+	buildEpochMs?: number;
 	host: string;
 	port: number;
 	url: string;
@@ -126,6 +130,23 @@ export function resolveHubBuildId(): string {
 	return embedded || `source-${String(corePackage.version)}`;
 }
 
+/**
+ * When this SDK build was produced, embedded at bundle time. Orders builds so
+ * managed-Hub handling can distinguish a newer daemon (attach and prompt the
+ * user to update) from a stale one (retire and replace). Undefined when
+ * running from unbundled sources, where no meaningful ordering exists.
+ */
+export function resolveHubBuildEpochMs(): number | undefined {
+	const configured = Number(process.env[HUB_BUILD_EPOCH_ENV]);
+	if (Number.isFinite(configured) && configured > 0) {
+		return configured;
+	}
+	return typeof __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__ === "number" &&
+		Number.isFinite(__CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__)
+		? __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__
+		: undefined;
+}
+
 export type ManagedHubCompatibilityResult =
 	| { compatible: true }
 	| {
@@ -159,6 +180,43 @@ export function getManagedHubCompatibility(
 		return { compatible: false, reason: "build_mismatch" };
 	}
 	return { compatible: true };
+}
+
+/**
+ * Whether a client may keep using a managed local Hub instead of retiring it.
+ *
+ * Same build: always reusable. Different build: reusable only when the Hub
+ * was produced *after* this client's own build (another installation
+ * upgraded the shared Hub) - the daemon is then running newer code, so
+ * replacing it would be a downgrade; the client attaches over the compatible
+ * wire protocol and the build-mismatch watcher prompts the user to update.
+ * A Hub that is older, unordered, or missing build metadata is not reusable
+ * and gets retired and replaced, preserving the stale-daemon fix.
+ */
+export function isManagedHubReusable(
+	record: HubProtocolMetadata & { buildId?: string; buildEpochMs?: number },
+	options?: { expectedBuildId?: string; expectedBuildEpochMs?: number },
+): boolean {
+	const compatibility = getManagedHubCompatibility(
+		record,
+		options?.expectedBuildId ?? resolveHubBuildId(),
+	);
+	if (compatibility.compatible) {
+		return true;
+	}
+	if (compatibility.reason !== "build_mismatch") {
+		return false;
+	}
+	const hubEpochMs = record.buildEpochMs;
+	const expectedEpochMs =
+		options?.expectedBuildEpochMs ?? resolveHubBuildEpochMs();
+	return (
+		typeof hubEpochMs === "number" &&
+		Number.isFinite(hubEpochMs) &&
+		typeof expectedEpochMs === "number" &&
+		Number.isFinite(expectedEpochMs) &&
+		hubEpochMs > expectedEpochMs
+	);
 }
 
 export function resolveHubOwnerContext(
@@ -222,6 +280,10 @@ export async function readHubDiscovery(
 			coreVersion:
 				typeof parsed.coreVersion === "string" ? parsed.coreVersion : undefined,
 			buildId: typeof parsed.buildId === "string" ? parsed.buildId : undefined,
+			buildEpochMs:
+				typeof parsed.buildEpochMs === "number"
+					? parsed.buildEpochMs
+					: undefined,
 			authToken: parsed.authToken,
 			host: parsed.host,
 			port: parsed.port,
@@ -419,6 +481,10 @@ export async function probeHubServer(
 			coreVersion:
 				typeof parsed.coreVersion === "string" ? parsed.coreVersion : undefined,
 			buildId: typeof parsed.buildId === "string" ? parsed.buildId : undefined,
+			buildEpochMs:
+				typeof parsed.buildEpochMs === "number"
+					? parsed.buildEpochMs
+					: undefined,
 			host: parsed.host,
 			port: parsed.port,
 			url: parsed.url,

--- a/sdk/packages/core/src/hub/index.ts
+++ b/sdk/packages/core/src/hub/index.ts
@@ -23,6 +23,7 @@ export {
 } from "../services/telemetry/OpenTelemetryProvider";
 export * from "./client";
 export * from "./client/connect";
+export * from "./client/managed-hub-build-watcher";
 export * from "./client/session-client";
 export * from "./client/ui-client";
 export * from "./daemon";

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -15,10 +15,11 @@ import {
 	clearHubDiscoveryIfOwned,
 	createHubAuthToken,
 	createHubServerUrl,
-	getManagedHubCompatibility,
 	type HubServerDiscoveryRecord,
+	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
+	resolveHubBuildEpochMs,
 	resolveHubBuildId,
 	resolveHubOwnerContext,
 	withHubStartupLock,
@@ -340,6 +341,7 @@ export async function startHubWebSocketServer(
 	let port = requestedPort;
 	let url = createHubServerUrl(host, requestedPort, pathname);
 	const buildId = resolveHubBuildId();
+	const buildEpochMs = resolveHubBuildEpochMs();
 	const authToken = createHubAuthToken();
 	const transport = new HubServerTransport(options);
 	await transport.start();
@@ -357,6 +359,7 @@ export async function startHubWebSocketServer(
 		capabilities: HUB_CAPABILITIES,
 		coreVersion: corePackage.version,
 		buildId,
+		buildEpochMs,
 		pid: process.pid,
 		startedAt,
 	} as const;
@@ -458,6 +461,7 @@ export async function startHubWebSocketServer(
 				maxClientProtocolVersion: versionPayload.maxClientProtocolVersion,
 				coreVersion: versionPayload.coreVersion,
 				buildId: versionPayload.buildId,
+				buildEpochMs: versionPayload.buildEpochMs,
 				host,
 				port,
 				url,
@@ -656,6 +660,7 @@ export async function startHubWebSocketServer(
 			capabilities: [...versionPayload.capabilities],
 			coreVersion: corePackage.version,
 			buildId,
+			buildEpochMs,
 			authToken,
 			host,
 			port,
@@ -759,7 +764,7 @@ export async function ensureHubWebSocketServer(
 			});
 			if (
 				healthy?.url &&
-				getManagedHubCompatibility(healthy, resolveHubBuildId()).compatible &&
+				isManagedHubReusable(healthy) &&
 				(await verifyHubConnection(healthy.url, {
 					authToken: discovered.authToken,
 				}))

--- a/sdk/packages/core/src/hub/server/index.test.ts
+++ b/sdk/packages/core/src/hub/server/index.test.ts
@@ -487,6 +487,39 @@ describe("hub server startup", () => {
 		}
 	});
 
+	it("reuses managed discovery from a newer build instead of starting a rival", async () => {
+		const owner = createInMemoryHubOwnerContext("hub-server-test-newer-build");
+		vi.stubEnv("CLINE_HUB_BUILD_ID", "newer-build");
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "2000");
+		try {
+			const newer = await startHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+			servers.add(newer);
+
+			vi.stubEnv("CLINE_HUB_BUILD_ID", "current-build");
+			vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
+			const result = await ensureHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				allowPortFallback: true,
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+
+			expect(result.action).toBe("reuse");
+			expect(result.url).toBe(newer.url);
+		} finally {
+			vi.unstubAllEnvs();
+			await clearHubDiscovery(owner.discoveryPath);
+		}
+	});
+
 	it("shuts down active server through the shutdown endpoint", async () => {
 		const owner = createInMemoryHubOwnerContext("hub-server-test-shutdown");
 		const onShutdownRequested = vi.fn();


### PR DESCRIPTION
### Related Issue

Follow-up to #13145. Stacked on `bee/hub-stale-fix`; retargets to `main` automatically once that merges.

### Description

After #13145, every Cline installation retires and replaces a shared local Hub daemon whose build differs from its own. Because build fingerprints are unordered, that rule is symmetric: when an updated CLI starts the Hub on its newer build, a still-running desktop app treats the new Hub as "not mine" and stomps it back to its older build within seconds (and vice versa), so concurrent installations replace each other's daemons instead of converging, and the user is never told to update.

This PR makes Hub replacement directional and adds the update prompts:

- Build ordering (`@cline/core`): SDK builds now embed a build epoch (`__CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__`) alongside the deterministic fingerprint from #13145, reported via `/health`, `/status`, and the discovery record as `buildEpochMs`. A new `isManagedHubReusable` helper decides: same fingerprint reuses as before; different fingerprint with a *newer* epoch is attached over the compatible wire protocol instead of retired (replacing it would downgrade the daemon); older, unordered, or metadata-less Hubs are retired and replaced exactly per #13145. Wired into the three replacement decision sites: the detached ensure path, the client probe used by startup and recovery, and the in-process `ensureHubWebSocketServer`. Overridable for tests via `CLINE_HUB_BUILD_EPOCH_MS`.
- Detection (`@cline/core`): `watchManagedHubBuildMismatch` polls the managed Hub and fires when the client is attached to a newer Hub build (or one whose protocol it cannot speak). Interval defaults to 10s, overridable via `CLINE_HUB_BUILD_WATCH_INTERVAL_MS`; dedupes per Hub build; skips during Hub startup transactions; no-ops in daemon processes and explicit-endpoint configs.
- CLI: a blocking "Cline Hub was updated" TUI dialog. Enter exits the TUI and runs the existing `checkForUpdates` self-update flow, then prints a reminder to start cline again; Esc dismisses with a toast pointing at `cline update`.
- Desktop app: the sidecar broadcasts `hub_build_mismatch` (replayed to webviews that connect after detection); the webview shows an `AlertDialog` whose "Update and restart" invokes the existing `restart_to_apply_update` command (applies any staged auto-update on relaunch).

Net behavior: whichever installation is newest owns the shared Hub; older installations keep working against it over the compatible protocol and prompt their user to update, instead of silently downgrading the daemon.

### Test Procedure

- Unit: reuse-decision matrix and epoch resolution in `discovery/index.test.ts`, watcher behavior (fires for newer builds and unsupported protocols, stays silent for older/legacy hubs that get auto-replaced) in `managed-hub-build-watcher.test.ts`, newer-build reuse without retirement in `daemon/index.test.ts` and `client/index.test.ts`, in-process reuse in `server/index.test.ts`, dialog key handling in `hub-update-required.test.ts`. Full hub suite: 222 passed.
- Regression: `bun -F @cline/cli test:unit` (all pass), runtime-host suite, desktop sidecar tests, `bun -F @cline/code test:chat-ui`, SDK-wide `bun run types`, Biome clean on all touched files.
- Manual end-to-end (screenshots below), simulating "another installation upgraded the Hub" by replacing the shared daemon with one reporting a different fingerprint and a newer epoch:
  - CLI: the running TUI attached to the newer Hub (verified it was not stomped back for 10+ seconds), showed the dialog, Esc dismissed with the toast, Enter exited into the self-update flow.
  - Desktop: the running app attached to the newer Hub (no replacement fight), showed the modal, and "Update and restart" relaunched the app, which then reused the newer Hub on startup. Note: in `tauri dev` the relaunch briefly shows a connection error because `app.restart()` outlives the dev web server; packaged builds bundle the webview and use the same restart command as the existing update-ready toast.

### Type of Change

-   [ ] 🐛 Bug fix
-   [x] ✨ New feature
-   [ ] 💥 Breaking change
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

Desktop modal after another installation upgraded the shared Hub:

![Desktop hub update modal](https://cursor.com/artifacts/c/art-968c7d67-6c90-44b2-9bf3-75f73fa82dd5)

CLI blocking dialog in the same scenario (the newer Hub stays attached, not replaced):

![CLI hub update dialog](https://cursor.com/artifacts/c/art-8baf5b07-be58-46fd-8df3-90ee2cfcc195)

Pressing Enter exits the TUI into the self-update flow:

![CLI update flow output](https://cursor.com/artifacts/c/art-67ee5f20-59eb-4fab-aa44-42448397b13d)

### Additional Notes

The build epoch intentionally trades byte-reproducible `dist/` output for orderability; the deterministic fingerprint from #13145 is unchanged and still solely decides *whether* builds differ - the epoch only decides *who yields* when they do. Builds without an epoch (unbundled sources, pre-epoch releases) are treated as unordered and replaced, preserving current behavior.