### PR TITLE
fix(vscode): repair native tool calling paths on legacy — stale opt-out migration, redundant tool_choice, websocket Responses coverage

### DIFF
--- a/apps/vscode/src/core/api/transform/tool-call-processor.ts
+++ b/apps/vscode/src/core/api/transform/tool-call-processor.ts
@@ -1,8 +1,4 @@
-import type {
-	ChatCompletionChunk,
-	ChatCompletionToolChoiceOption,
-	ChatCompletionTool as OpenAITool,
-} from "openai/resources/chat/completions"
+import type { ChatCompletionChunk, ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
 import { Logger } from "@/shared/services/Logger"
 import type { ApiStreamToolCallsChunk } from "./stream"
 
@@ -96,9 +92,11 @@ export function getOpenAIToolParams(tools?: OpenAITool[], enableParallelToolCall
 		}
 	}
 
+	// tool_choice is deliberately omitted: "auto" is already the API default, and some
+	// OpenAI-compatible gateways mistranslate an explicit tool_choice when bridging to the
+	// Responses API (https://github.com/cline/cline/issues/13138). The SDK arch omits it too.
 	return {
 		tools,
-		tool_choice: "auto" as ChatCompletionToolChoiceOption,
 		parallel_tool_calls: enableParallelToolCalls,
 	}
 }

--- a/apps/vscode/src/core/storage/StateManager.ts
+++ b/apps/vscode/src/core/storage/StateManager.ts
@@ -29,7 +29,12 @@ import {
 } from "./disk"
 import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
 import { filterAllowedRemoteConfigFields } from "./remote-config/utils"
-import { readGlobalStateFromStorage, readSecretsFromStorage, readWorkspaceStateFromStorage } from "./utils/state-helpers"
+import {
+	migrateStaleNativeToolCallSetting,
+	readGlobalStateFromStorage,
+	readSecretsFromStorage,
+	readWorkspaceStateFromStorage,
+} from "./utils/state-helpers"
 export interface PersistenceErrorEvent {
 	error: Error
 }
@@ -136,6 +141,10 @@ export class StateManager {
 
 		try {
 			await initializeDistinctId(storage)
+
+			// One-time reset of a stale default-off nativeToolCallEnabled value; must run
+			// before the cache is populated so the corrected value is what gets loaded.
+			await migrateStaleNativeToolCallSetting(storage.globalState)
 
 			// Load all extension state from file-backed stores
 			const globalState = await readGlobalStateFromStorage(storage.globalState)

--- a/apps/vscode/src/core/storage/__tests__/state-helpers.test.ts
+++ b/apps/vscode/src/core/storage/__tests__/state-helpers.test.ts
@@ -1,0 +1,98 @@
+import fs from "fs/promises"
+import { describe, it, beforeEach, afterEach } from "mocha"
+import os from "os"
+import path from "path"
+import should from "should"
+import { ClineFileStorage } from "@/shared/storage/ClineFileStorage"
+import { migrateStaleNativeToolCallSetting } from "../utils/state-helpers"
+
+describe("migrateStaleNativeToolCallSetting", () => {
+	let tempDir: string
+	let store: ClineFileStorage
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `state-helpers-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		await fs.mkdir(tempDir, { recursive: true })
+		store = new ClineFileStorage(path.join(tempDir, "globalState.json"), "GlobalState")
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	it("resets a stale persisted false to true and sets the migration marker", async () => {
+		await store.update("nativeToolCallEnabled", false)
+
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.true()
+		store.get("nativeToolCallEnabledDefaultMigrated")!.should.be.true()
+	})
+
+	it("leaves a false value intact once the migration marker is set (deliberate opt-out)", async () => {
+		await store.update("nativeToolCallEnabled", false)
+		await store.update("nativeToolCallEnabledDefaultMigrated", true)
+
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.false()
+	})
+
+	it("does not create a value when none is persisted, but still sets the marker", async () => {
+		await migrateStaleNativeToolCallSetting(store)
+
+		should(store.get("nativeToolCallEnabled")).be.undefined()
+		store.get("nativeToolCallEnabledDefaultMigrated")!.should.be.true()
+	})
+
+	it("leaves an explicit true untouched", async () => {
+		await store.update("nativeToolCallEnabled", true)
+
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.true()
+	})
+
+	it("is a no-op on the second run after a user opts back out", async () => {
+		await store.update("nativeToolCallEnabled", false)
+		await migrateStaleNativeToolCallSetting(store)
+
+		// User deliberately turns the setting off again
+		await store.update("nativeToolCallEnabled", false)
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.false()
+	})
+
+	it("skips OpenAI-Compatible users without setting the marker", async () => {
+		await store.update("nativeToolCallEnabled", false)
+		await store.update("actModeApiProvider", "openai")
+
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.false()
+		should(store.get("nativeToolCallEnabledDefaultMigrated")).be.undefined()
+	})
+
+	it("skips when only the plan-mode provider is OpenAI-Compatible", async () => {
+		await store.update("nativeToolCallEnabled", false)
+		await store.update("planModeApiProvider", "openai")
+		await store.update("actModeApiProvider", "openrouter")
+
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.false()
+	})
+
+	it("migrates a previously skipped user after they switch away from OpenAI-Compatible", async () => {
+		await store.update("nativeToolCallEnabled", false)
+		await store.update("actModeApiProvider", "openai")
+		await migrateStaleNativeToolCallSetting(store)
+
+		await store.update("actModeApiProvider", "openrouter")
+		await migrateStaleNativeToolCallSetting(store)
+
+		store.get("nativeToolCallEnabled")!.should.be.true()
+		store.get("nativeToolCallEnabledDefaultMigrated")!.should.be.true()
+	})
+})

--- a/apps/vscode/src/core/storage/utils/state-helpers.ts
+++ b/apps/vscode/src/core/storage/utils/state-helpers.ts
@@ -19,6 +19,43 @@ import { StateManager } from "../StateManager"
 
 // ─── File-backed storage readers (used by StateManager) ────────────────────
 
+// The native tool call setting shipped default-off behind a feature flag, and the default was
+// later flipped to on. A `false` persisted during the default-off era keeps users on text-based
+// tool calling forever, which GPT-5-class models intermittently refuse to run with
+// (https://github.com/cline/cline/issues/13138).
+const NATIVE_TOOL_CALL_DEFAULT_MIGRATION_KEY = "nativeToolCallEnabledDefaultMigrated"
+
+/**
+ * One-time reset of a persisted `nativeToolCallEnabled: false` back to the default (true).
+ * The migration marker ensures a deliberate opt-out made after this runs is left intact.
+ *
+ * Users on the OpenAI-Compatible provider are skipped (without setting the marker): their
+ * endpoints are arbitrary gateways where native tool calling can genuinely fail, so a
+ * persisted `false` may be a deliberate, still-needed opt-out. If they later switch to a
+ * provider served by our own request paths, the migration applies on the next startup.
+ */
+export async function migrateStaleNativeToolCallSetting(store: ClineMemento): Promise<void> {
+	try {
+		if (store.get(NATIVE_TOOL_CALL_DEFAULT_MIGRATION_KEY) === true) {
+			return
+		}
+		if (store.get("nativeToolCallEnabled") !== false) {
+			// Nothing to reset — mark done so any later opt-out is treated as deliberate.
+			await store.update(NATIVE_TOOL_CALL_DEFAULT_MIGRATION_KEY, true)
+			return
+		}
+		const providers = [store.get("planModeApiProvider"), store.get("actModeApiProvider")]
+		if (providers.includes("openai")) {
+			return
+		}
+		await store.update("nativeToolCallEnabled", true)
+		await store.update(NATIVE_TOOL_CALL_DEFAULT_MIGRATION_KEY, true)
+		Logger.log("[Storage Migration] Reset stale nativeToolCallEnabled=false to the default (true)")
+	} catch (error) {
+		Logger.error("[Storage Migration] Failed to migrate nativeToolCallEnabled:", error)
+	}
+}
+
 /**
  * Read secrets from a ClineFileStorage instance.
  */

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -95,6 +95,7 @@ import {
 	isLocalModel,
 	isNextGenModelFamily,
 	isParallelToolCallingEnabled,
+	modelRequiresNativeToolCalls,
 } from "@utils/model-utils";
 import { arePathsEqual, getDesktopDir } from "@utils/path";
 import { filterExistingFiles } from "@utils/tabFiltering";
@@ -128,7 +129,6 @@ import type {
 	ClineToolResponseContent,
 	ClineUserContent,
 } from "@/shared/messages";
-import { ApiFormat } from "@/shared/proto/cline/models";
 import { ShowMessageType } from "@/shared/proto/index.host";
 import { Logger } from "@/shared/services/Logger";
 import { Session } from "@/shared/services/Session";
@@ -2329,7 +2329,7 @@ export class Task {
 			isSubagentRun: false,
 			isCliEnvironment,
 			enableNativeToolCalls:
-				providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
+				modelRequiresNativeToolCalls(providerInfo.model.info) ||
 				this.stateManager.getGlobalStateKey("nativeToolCallEnabled"),
 			enableParallelToolCalling: this.isParallelToolCallingEnabled(),
 			terminalExecutionMode: this.terminalExecutionMode,
@@ -4062,10 +4062,10 @@ export class Task {
 		const ulid = this.ulid;
 		const focusChainSettings =
 			this.stateManager.getGlobalSettingsKey("focusChainSettings");
-		const useNativeToolCalls = this.stateManager.getGlobalStateKey(
-			"nativeToolCallEnabled",
-		);
 		const providerInfo = this.getCurrentProviderInfo();
+		const useNativeToolCalls =
+			modelRequiresNativeToolCalls(providerInfo.model.info) ||
+			this.stateManager.getGlobalStateKey("nativeToolCallEnabled");
 		const cwd = this.cwd;
 		const { localWorkflowToggles, globalWorkflowToggles } =
 			await refreshWorkflowToggles(this.controller, cwd);

--- a/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/apps/vscode/src/core/task/tools/subagent/SubagentRunner.ts
@@ -20,9 +20,8 @@ import { checkContextWindowExceededError } from "@/core/context/context-manageme
 import { getContextWindowInfo } from "@/core/context/context-management/context-window-utils";
 import { HostRegistryInfo } from "@/registry";
 import { ClineError, ClineErrorType } from "@/services/error";
-import { ApiFormat } from "@/shared/proto/cline/models";
 import { calculateApiCostAnthropic } from "@/utils/cost";
-import { isNextGenModelFamily } from "@/utils/model-utils";
+import { isNextGenModelFamily, modelRequiresNativeToolCalls } from "@/utils/model-utils";
 import { TaskState } from "../../TaskState";
 import { ToolExecutorCoordinator } from "../ToolExecutorCoordinator";
 import { ToolValidator } from "../ToolValidator";
@@ -377,7 +376,7 @@ export class SubagentRunner {
 			};
 			stats.contextWindow = providerInfo.model.info.contextWindow || 0;
 			const nativeToolCallsRequested =
-				providerInfo.model.info.apiFormat === ApiFormat.OPENAI_RESPONSES ||
+				modelRequiresNativeToolCalls(providerInfo.model.info) ||
 				!!this.baseConfig.services.stateManager.getGlobalStateKey(
 					"nativeToolCallEnabled",
 				);

--- a/apps/vscode/src/utils/model-utils.ts
+++ b/apps/vscode/src/utils/model-utils.ts
@@ -1,5 +1,6 @@
 import { ApiHandlerModel, ApiProviderInfo } from "@core/api"
-import { AnthropicModelId, anthropicModels } from "@/shared/api"
+import { AnthropicModelId, anthropicModels, ModelInfo } from "@/shared/api"
+import { ApiFormat } from "@/shared/proto/cline/models"
 
 export { supportsReasoningEffortForModel } from "@shared/utils/reasoning-support"
 
@@ -234,6 +235,14 @@ export function parsePrice(priceString: string | undefined): number {
 	}
 	// Convert from per-token to per-million-tokens (multiply by 1,000,000)
 	return parsed * 1_000_000
+}
+
+/**
+ * Responses-API models only support native tool calling, so the user-level
+ * "Native Tool Call" toggle must not switch them to text-based tools.
+ */
+export function modelRequiresNativeToolCalls(modelInfo: ModelInfo): boolean {
+	return modelInfo.apiFormat === ApiFormat.OPENAI_RESPONSES || modelInfo.apiFormat === ApiFormat.OPENAI_RESPONSES_WEBSOCKET_MODE
 }
 
 /**

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -43,7 +43,8 @@ const agentFeatures: FeatureToggle[] = [
 	{
 		id: "native-tool-call",
 		label: "Native Tool Call",
-		description: "Use native function calling when available",
+		description:
+			"Use native function calling when available. Turning this off can make GPT-5 and other frontier models refuse to use tools.",
 		stateKey: "nativeToolCallSetting",
 		settingKey: "nativeToolCallEnabled",
 	},


### PR DESCRIPTION
Fixes #13138 — Linear: [CLINE-2920](https://linear.app/cline-bot/issue/CLINE-2920)

### Problem

Legacy users can end up stuck on text-based (XML) tool calling, which GPT-5-class models intermittently refuse — replying that the session "exposes no filesystem or terminal tools". Confirmed from a reporter's core log: every request selected the `gpt-5` XML prompt variant instead of `native-gpt-5-1`. Telemetry over the last 7 days shows ~900 users still emitting XML tool calls with gpt-5-family models.

Two distinct causes, plus a discovery from the reporter's follow-up:

1. **Stale setting**: the native tool call setting shipped default-off behind a feature flag (#7193) and the default was later flipped to on, but a `false` persisted during the default-off era wins forever.
2. **Websocket Responses gap**: the "Responses API forces native tools" check used strict equality against `ApiFormat.OPENAI_RESPONSES` only, so `OPENAI_RESPONSES_WEBSOCKET_MODE` models (the `gpt-5.x-codex` entries) could also be downgraded to XML tools, which that API can't run.
3. **Deliberate opt-outs exist**: the reporter disabled the setting on purpose because their LiteLLM gateway mistranslates our explicit `tool_choice: "auto"` (a valid Chat Completions string) into `{"type": "auto"}` when bridging to the Responses API, producing a 400 on every native-mode request.

### Changes

- **Omit redundant `tool_choice`** in `getOpenAIToolParams`: `"auto"` is already the API default, and omitting it sidesteps the gateway mistranslation. This matches the SDK arch, which never sends `tool_choice` (`parallel_tool_calls`, a deliberate non-default, is kept).
- **One-time migration** in `StateManager.initialize`: a persisted `nativeToolCallEnabled: false` is reset to the default (`true`), with a marker so a deliberate opt-out made afterwards is left intact. **OpenAI-Compatible provider users are skipped** (without the marker): their endpoints are arbitrary gateways where native tools can genuinely fail, so an existing `false` may be a deliberate, still-needed opt-out. If they later switch to a provider served by our own request paths, the migration applies on next startup. Runs on the shared file-backed storage, covering VSCode, CLI, and JetBrains.
- **New `modelRequiresNativeToolCalls` helper** replaces the duplicated strict-equality checks in `Task` and `SubagentRunner`, now covering both `OPENAI_RESPONSES` and `OPENAI_RESPONSES_WEBSOCKET_MODE`; also applied to the slash-command parsing path.
- **Feature toggle description** now warns that turning the setting off can make GPT-5-class models refuse to use tools. The toggle itself stays — it remains the escape hatch for gateways without working function calling.

### Testing

- Unit tests for the migration: stale-false reset, marker semantics, opt-out preserved, OpenAI-Compatible skip (marker deliberately not set), migration after switching providers.
- Full unit suite passes (1583 passing); `tsc --noEmit` clean for core and webview-ui; `npm run lint` clean.
