### PR TITLE
fix(vscode): offer Sonnet 1M variants on the Vertex global endpoint

### DIFF
--- a/apps/vscode/src/shared/__tests__/api.test.ts
+++ b/apps/vscode/src/shared/__tests__/api.test.ts
@@ -1,12 +1,13 @@
-import { expect } from "chai"
+import { expect } from "chai";
 import {
 	buildModelInfoNameMap,
 	clinePassModelInfoSaneDefaults,
 	internationalZAiModels,
-	mainlandZAiModels,
 	type ModelInfo,
+	mainlandZAiModels,
 	resolveClinePassModelInfo,
-} from "../api"
+	vertexGlobalModels,
+} from "../api";
 
 describe("ClinePass model info", () => {
 	const createModelInfo = (name: string, contextWindow: number): ModelInfo => ({
@@ -16,7 +17,7 @@ describe("ClinePass model info", () => {
 		supportsPromptCache: false,
 		supportsReasoning: false,
 		thinkingConfig: { maxBudget: 16_384 },
-	})
+	});
 
 	it("prefers dynamic model metadata for ClinePass GLM aliases", () => {
 		const modelInfo = resolveClinePassModelInfo(
@@ -24,20 +25,20 @@ describe("ClinePass model info", () => {
 			buildModelInfoNameMap({
 				"z-ai/glm-5.2": createModelInfo("OpenRouter GLM 5.2", 1_000_000),
 			}),
-		)
+		);
 
-		expect(modelInfo.name).to.equal("OpenRouter GLM 5.2")
-		expect(modelInfo.contextWindow).to.equal(1_000_000)
-		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 })
-	})
+		expect(modelInfo.name).to.equal("OpenRouter GLM 5.2");
+		expect(modelInfo.contextWindow).to.equal(1_000_000);
+		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 });
+	});
 
 	it("falls back to static ClinePass metadata when dynamic metadata is unavailable", () => {
-		const modelInfo = resolveClinePassModelInfo("cline-pass/glm-5.2")
+		const modelInfo = resolveClinePassModelInfo("cline-pass/glm-5.2");
 
-		expect(modelInfo.contextWindow).to.equal(202_752)
-		expect(modelInfo.supportsReasoning).to.equal(true)
-		expect(modelInfo.thinkingConfig).to.equal(undefined)
-	})
+		expect(modelInfo.contextWindow).to.equal(202_752);
+		expect(modelInfo.supportsReasoning).to.equal(true);
+		expect(modelInfo.thinkingConfig).to.equal(undefined);
+	});
 
 	it("preserves dynamic ClinePass model info when no static alias exists", () => {
 		const modelInfo = resolveClinePassModelInfo(
@@ -45,38 +46,47 @@ describe("ClinePass model info", () => {
 			buildModelInfoNameMap({
 				"zai/new-model": createModelInfo("New model", 1_000_000),
 			}),
-		)
+		);
 
-		expect(modelInfo.name).to.equal("New model")
-		expect(modelInfo.supportsReasoning).to.equal(false)
-		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 })
-	})
+		expect(modelInfo.name).to.equal("New model");
+		expect(modelInfo.supportsReasoning).to.equal(false);
+		expect(modelInfo.thinkingConfig).to.deep.equal({ maxBudget: 16_384 });
+	});
 
 	it("returns stored info for a free (non cline-pass prefixed) model id", () => {
-		const freeModelInfo = createModelInfo("Trinity Large Preview", 512_000)
+		const freeModelInfo = createModelInfo("Trinity Large Preview", 512_000);
 		const modelInfo = resolveClinePassModelInfo(
 			"arcee-ai/trinity-large-preview:free",
-			buildModelInfoNameMap({ "arcee-ai/trinity-large-preview:free": freeModelInfo }),
-		)
+			buildModelInfoNameMap({
+				"arcee-ai/trinity-large-preview:free": freeModelInfo,
+			}),
+		);
 
-		expect(modelInfo).to.deep.equal(freeModelInfo)
-	})
+		expect(modelInfo).to.deep.equal(freeModelInfo);
+	});
 
 	it("falls back to sane defaults for a free model id without dynamic metadata", () => {
-		const modelInfo = resolveClinePassModelInfo("kwaipilot/kat-coder-pro")
+		const modelInfo = resolveClinePassModelInfo("kwaipilot/kat-coder-pro");
 
-		expect(modelInfo).to.deep.equal(clinePassModelInfoSaneDefaults)
-	})
-})
+		expect(modelInfo).to.deep.equal(clinePassModelInfoSaneDefaults);
+	});
+});
 
 describe("Z AI model info", () => {
 	it("includes GLM 5.2 for both direct Z AI entrypoints", () => {
 		for (const models of [internationalZAiModels, mainlandZAiModels]) {
-			expect(models["glm-5.2"].contextWindow).to.equal(1_000_000)
-			expect(models["glm-5.2"].maxTokens).to.equal(128_000)
-			expect(models["glm-5.2"].inputPrice).to.equal(1.4)
-			expect(models["glm-5.2"].outputPrice).to.equal(4.4)
-			expect(models["glm-5.2"].cacheReadsPrice).to.equal(0.26)
+			expect(models["glm-5.2"].contextWindow).to.equal(1_000_000);
+			expect(models["glm-5.2"].maxTokens).to.equal(128_000);
+			expect(models["glm-5.2"].inputPrice).to.equal(1.4);
+			expect(models["glm-5.2"].outputPrice).to.equal(4.4);
+			expect(models["glm-5.2"].cacheReadsPrice).to.equal(0.26);
 		}
-	})
-})
+	});
+});
+
+describe("Vertex global endpoint models", () => {
+	it("offers the 1M context variants of Sonnet 5 and Sonnet 4.6", () => {
+		expect(vertexGlobalModels).to.have.property("claude-sonnet-5:1m");
+		expect(vertexGlobalModels).to.have.property("claude-sonnet-4-6:1m");
+	});
+});

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -1,5 +1,5 @@
-import { ApiFormat } from "./proto/cline/models"
-import type { ApiHandlerSettings } from "./storage/state-keys"
+import { ApiFormat } from "./proto/cline/models";
+import type { ApiHandlerSettings } from "./storage/state-keys";
 
 export type ApiProvider =
 	| "anthropic"
@@ -44,75 +44,80 @@ export type ApiProvider =
 	| "minimax"
 	| "hicap"
 	| "nousResearch"
-	| "wandb"
+	| "wandb";
 
-export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
+export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider;
 
 export interface ApiHandlerOptions extends Partial<ApiHandlerSettings> {
-	ulid?: string // Used to identify the task in API requests
-	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void // Callback function
+	ulid?: string; // Used to identify the task in API requests
+	onRetryAttempt?: (
+		attempt: number,
+		maxRetries: number,
+		delay: number,
+		error: any,
+	) => void; // Callback function
 }
 
-export type ApiConfiguration = ApiHandlerOptions
+export type ApiConfiguration = ApiHandlerOptions;
 
 // Models
 
 interface PriceTier {
-	tokenLimit: number // Upper limit (inclusive) of *input* tokens for this price. Use Infinity for the highest tier.
-	price: number // Price per million tokens for this tier.
+	tokenLimit: number; // Upper limit (inclusive) of *input* tokens for this price. Use Infinity for the highest tier.
+	price: number; // Price per million tokens for this tier.
 }
 
 export interface ModelInfo {
-	name?: string
-	maxTokens?: number
-	contextWindow?: number
-	supportsImages?: boolean
-	supportsPromptCache: boolean // this value is hardcoded for now
-	supportsReasoning?: boolean // Whether the model supports reasoning/thinking mode
-	inputPrice?: number // Keep for non-tiered input models
-	outputPrice?: number // Keep for non-tiered output models
+	name?: string;
+	maxTokens?: number;
+	contextWindow?: number;
+	supportsImages?: boolean;
+	supportsPromptCache: boolean; // this value is hardcoded for now
+	supportsReasoning?: boolean; // Whether the model supports reasoning/thinking mode
+	inputPrice?: number; // Keep for non-tiered input models
+	outputPrice?: number; // Keep for non-tiered output models
 	thinkingConfig?: {
-		maxBudget?: number // Max allowed thinking budget tokens
-		outputPrice?: number // Output price per million tokens when budget > 0
-		outputPriceTiers?: PriceTier[] // Optional: Tiered output price when budget > 0
-		geminiThinkingLevel?: "low" | "high" // Optional: preset thinking level
-		supportsThinkingLevel?: boolean // Whether the model supports thinking level (low/high)
-	}
-	supportsGlobalEndpoint?: boolean // Whether the model supports a global endpoint with Vertex AI
-	cacheWritesPrice?: number
-	cacheReadsPrice?: number
-	description?: string
+		maxBudget?: number; // Max allowed thinking budget tokens
+		outputPrice?: number; // Output price per million tokens when budget > 0
+		outputPriceTiers?: PriceTier[]; // Optional: Tiered output price when budget > 0
+		geminiThinkingLevel?: "low" | "high"; // Optional: preset thinking level
+		supportsThinkingLevel?: boolean; // Whether the model supports thinking level (low/high)
+	};
+	supportsGlobalEndpoint?: boolean; // Whether the model supports a global endpoint with Vertex AI
+	cacheWritesPrice?: number;
+	cacheReadsPrice?: number;
+	description?: string;
 	tiers?: {
-		contextWindow: number
-		inputPrice?: number
-		outputPrice?: number
-		cacheWritesPrice?: number
-		cacheReadsPrice?: number
-	}[]
-	temperature?: number
-	apiFormat?: ApiFormat // The API format used by this model
+		contextWindow: number;
+		inputPrice?: number;
+		outputPrice?: number;
+		cacheWritesPrice?: number;
+		cacheReadsPrice?: number;
+	}[];
+	temperature?: number;
+	apiFormat?: ApiFormat; // The API format used by this model
 }
 
 export interface OpenAiCompatibleModelInfo extends ModelInfo {
-	temperature?: number
-	isR1FormatRequired?: boolean
-	systemRole?: "developer" | "system"
-	supportsReasoningEffort?: boolean
-	supportsTools?: boolean
-	supportsStreaming?: boolean
+	temperature?: number;
+	isR1FormatRequired?: boolean;
+	systemRole?: "developer" | "system";
+	supportsReasoningEffort?: boolean;
+	supportsTools?: boolean;
+	supportsStreaming?: boolean;
 }
 
 export interface OcaModelInfo extends OpenAiCompatibleModelInfo {
-	modelName: string
-	surveyId?: string
-	banner?: string
-	surveyContent?: string
-	supportsReasoning?: boolean
-	reasoningEffortOptions: string[]
+	modelName: string;
+	surveyId?: string;
+	banner?: string;
+	surveyContent?: string;
+	supportsReasoning?: boolean;
+	reasoningEffortOptions: string[];
 }
 
-export const CLAUDE_SONNET_1M_SUFFIX = ":1m"
-export const ANTHROPIC_FAST_MODE_SUFFIX = ":fast"
+export const CLAUDE_SONNET_1M_SUFFIX = ":1m";
+export const ANTHROPIC_FAST_MODE_SUFFIX = ":fast";
 export const CLAUDE_SONNET_1M_TIERS = [
 	{
 		contextWindow: 200000,
@@ -128,7 +133,7 @@ export const CLAUDE_SONNET_1M_TIERS = [
 		cacheWritesPrice: 7.5,
 		cacheReadsPrice: 0.6,
 	},
-]
+];
 // Claude 4.6+ opus models include the full 1M context window at standard pricing (no long-context premium)
 export const CLAUDE_OPUS_1M_TIERS = [
 	{
@@ -145,7 +150,7 @@ export const CLAUDE_OPUS_1M_TIERS = [
 		cacheWritesPrice: 6.25,
 		cacheReadsPrice: 0.5,
 	},
-]
+];
 export const CLAUDE_FABLE_1M_TIERS = [
 	{
 		contextWindow: 200000,
@@ -161,10 +166,10 @@ export const CLAUDE_FABLE_1M_TIERS = [
 		cacheWritesPrice: 12.5,
 		cacheReadsPrice: 1,
 	},
-]
+];
 
 export interface HicapCompatibleModelInfo extends ModelInfo {
-	temperature?: number
+	temperature?: number;
 }
 
 export const hicapModelInfoSaneDefaults: HicapCompatibleModelInfo = {
@@ -175,14 +180,14 @@ export const hicapModelInfoSaneDefaults: HicapCompatibleModelInfo = {
 	inputPrice: 0,
 	outputPrice: 0,
 	temperature: 1,
-}
+};
 
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
-export type AnthropicModelId = keyof typeof anthropicModels
-export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-5"
-export const ANTHROPIC_MIN_THINKING_BUDGET = 1_024
-export const ANTHROPIC_MAX_THINKING_BUDGET = 6_000
+export type AnthropicModelId = keyof typeof anthropicModels;
+export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-5";
+export const ANTHROPIC_MIN_THINKING_BUDGET = 1_024;
+export const ANTHROPIC_MAX_THINKING_BUDGET = 6_000;
 export const anthropicModels = {
 	"claude-sonnet-5": {
 		maxTokens: 128_000,
@@ -514,11 +519,11 @@ export const anthropicModels = {
 		cacheWritesPrice: 0.3,
 		cacheReadsPrice: 0.03,
 	},
-} as const satisfies Record<string, ModelInfo> // as const assertion makes the object deeply readonly
+} as const satisfies Record<string, ModelInfo>; // as const assertion makes the object deeply readonly
 
 // Claude Code
-export type ClaudeCodeModelId = keyof typeof claudeCodeModels
-export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-5"
+export type ClaudeCodeModelId = keyof typeof claudeCodeModels;
+export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-5";
 export const claudeCodeModels = {
 	sonnet: {
 		...anthropicModels["claude-sonnet-5"],
@@ -660,12 +665,13 @@ export const claudeCodeModels = {
 		supportsImages: true,
 		supportsPromptCache: false,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
-export type BedrockModelId = keyof typeof bedrockModels
-export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-5"
+export type BedrockModelId = keyof typeof bedrockModels;
+export const bedrockDefaultModelId: BedrockModelId =
+	"anthropic.claude-sonnet-5";
 export const bedrockModels = {
 	"anthropic.claude-sonnet-5": {
 		maxTokens: 128_000,
@@ -1105,20 +1111,20 @@ export const bedrockModels = {
 		description:
 			"Qwen3 Coder 480B flagship MoE model with 35B activated parameters, designed for complex coding tasks with advanced reasoning capabilities and 256K context window.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // OpenRouter
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
-export const openRouterDefaultModelId = "anthropic/claude-sonnet-5" // will always exist in openRouterModels
-export const openRouterClaudeSonnet41mModelId = `anthropic/claude-sonnet-4${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeSonnet461mModelId = `anthropic/claude-sonnet-4.6${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeSonnet51mModelId = `anthropic/claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeOpus461mModelId = `anthropic/claude-opus-4.6${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeOpus471mModelId = `anthropic/claude-opus-4.7${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeOpus481mModelId = `anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeOpus51mModelId = `anthropic/claude-opus-5${CLAUDE_SONNET_1M_SUFFIX}`
-export const openRouterClaudeFable51mModelId = `anthropic/claude-fable-5${CLAUDE_SONNET_1M_SUFFIX}`
+export const openRouterDefaultModelId = "anthropic/claude-sonnet-5"; // will always exist in openRouterModels
+export const openRouterClaudeSonnet41mModelId = `anthropic/claude-sonnet-4${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeSonnet461mModelId = `anthropic/claude-sonnet-4.6${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeSonnet51mModelId = `anthropic/claude-sonnet-5${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeOpus461mModelId = `anthropic/claude-opus-4.6${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeOpus471mModelId = `anthropic/claude-opus-4.7${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeOpus481mModelId = `anthropic/claude-opus-4.8${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeOpus51mModelId = `anthropic/claude-opus-5${CLAUDE_SONNET_1M_SUFFIX}`;
+export const openRouterClaudeFable51mModelId = `anthropic/claude-fable-5${CLAUDE_SONNET_1M_SUFFIX}`;
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 128_000,
 	contextWindow: 200_000,
@@ -1130,7 +1136,7 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 	cacheReadsPrice: 0.2,
 	description:
 		"Claude Sonnet 5 is Anthropic's latest Sonnet model for coding, agents, and professional work. It supports adaptive thinking, prompt caching, image inputs, and long-context workflows.",
-}
+};
 
 // Cline custom model - Devstral
 export const clineDevstralModelInfo: ModelInfo = {
@@ -1142,10 +1148,10 @@ export const clineDevstralModelInfo: ModelInfo = {
 	cacheReadsPrice: 0,
 	cacheWritesPrice: 0,
 	description: "A stealth model for agentic coding tasks",
-}
+};
 
-export type ClinePassModelId = keyof typeof clinePassModels
-export const clinePassDefaultModelId = "cline-pass/glm-5.2"
+export type ClinePassModelId = keyof typeof clinePassModels;
+export const clinePassDefaultModelId = "cline-pass/glm-5.2";
 export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	maxTokens: 8_192,
 	contextWindow: 128_000,
@@ -1157,7 +1163,7 @@ export const clinePassModelInfoSaneDefaults: ModelInfo = {
 	cacheReadsPrice: 0,
 	cacheWritesPrice: 0,
 	description: "",
-}
+};
 export const clinePassModels = {
 	"cline-pass/glm-5.2": {
 		name: "cline-pass/glm-5.2",
@@ -1172,34 +1178,42 @@ export const clinePassModels = {
 		cacheWritesPrice: 0,
 		description: "",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 export function getModelSlug(modelId: string): string {
-	return modelId.split("/").at(-1) ?? modelId
+	return modelId.split("/").at(-1) ?? modelId;
 }
 
-export function buildModelInfoNameMap(models: Record<string, ModelInfo>): Record<string, ModelInfo> {
-	const nameMap: Record<string, ModelInfo> = {}
+export function buildModelInfoNameMap(
+	models: Record<string, ModelInfo>,
+): Record<string, ModelInfo> {
+	const nameMap: Record<string, ModelInfo> = {};
 
 	for (const [id, info] of Object.entries(models)) {
-		nameMap[getModelSlug(id)] = info
+		nameMap[getModelSlug(id)] = info;
 	}
 
-	return nameMap
+	return nameMap;
 }
 
-export function resolveClinePassModelInfo(modelId: string, modelInfoByName?: Record<string, ModelInfo>): ModelInfo {
-	const modelSlug = getModelSlug(modelId)
-	const clinePassSlugModelId = `cline-pass/${modelSlug}`
+export function resolveClinePassModelInfo(
+	modelId: string,
+	modelInfoByName?: Record<string, ModelInfo>,
+): ModelInfo {
+	const modelSlug = getModelSlug(modelId);
+	const clinePassSlugModelId = `cline-pass/${modelSlug}`;
 	return (
 		modelInfoByName?.[modelSlug] ??
 		clinePassModels[modelId as keyof typeof clinePassModels] ??
 		clinePassModels[clinePassSlugModelId as keyof typeof clinePassModels] ??
 		clinePassModelInfoSaneDefaults
-	)
+	);
 }
 
-export const OPENROUTER_PROVIDER_PREFERENCES: Record<string, { order: string[]; allow_fallbacks: boolean }> = {
+export const OPENROUTER_PROVIDER_PREFERENCES: Record<
+	string,
+	{ order: string[]; allow_fallbacks: boolean }
+> = {
 	// Exacto Providers
 	"moonshotai/kimi-k2:exacto": {
 		order: ["groq", "moonshotai"],
@@ -1283,13 +1297,13 @@ export const OPENROUTER_PROVIDER_PREFERENCES: Record<string, { order: string[]; 
 		order: ["z-ai", "novita", "baseten", "fireworks", "chutes"],
 		allow_fallbacks: false,
 	},
-}
+};
 
 // Vertex AI
 // https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
 // https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models
-export type VertexModelId = keyof typeof vertexModels
-export const vertexDefaultModelId: VertexModelId = "gemini-3-pro-preview"
+export type VertexModelId = keyof typeof vertexModels;
+export const vertexDefaultModelId: VertexModelId = "gemini-3-pro-preview";
 export const vertexModels = {
 	"gemini-3.5-flash": {
 		maxTokens: 65536,
@@ -1371,6 +1385,7 @@ export const vertexModels = {
 		contextWindow: 1_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
 		inputPrice: 2.0,
 		outputPrice: 10.0,
 		cacheWritesPrice: 2.5,
@@ -1396,6 +1411,7 @@ export const vertexModels = {
 		contextWindow: 1_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
 		inputPrice: 3.0,
 		outputPrice: 15.0,
 		cacheWritesPrice: 3.75,
@@ -1928,11 +1944,13 @@ export const vertexModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 export const vertexGlobalModels: Record<string, ModelInfo> = Object.fromEntries(
-	Object.entries(vertexModels).filter(([_k, v]) => Object.hasOwn(v, "supportsGlobalEndpoint")),
-) as Record<string, ModelInfo>
+	Object.entries(vertexModels).filter(([_k, v]) =>
+		Object.hasOwn(v, "supportsGlobalEndpoint"),
+	),
+) as Record<string, ModelInfo>;
 
 // Defaults for custom (free-form) Vertex model entries. Context window, max output
 // tokens, image support, and reasoning support are user-editable in settings.
@@ -1943,16 +1961,18 @@ export const vertexCustomModelInfoSaneDefaults: ModelInfo = {
 	supportsReasoning: true,
 	supportsPromptCache: true,
 	supportsGlobalEndpoint: true,
-}
+};
 
-export function getVertexCustomModelInfo(customModelInfo?: ModelInfo): ModelInfo {
+export function getVertexCustomModelInfo(
+	customModelInfo?: ModelInfo,
+): ModelInfo {
 	return {
 		...vertexCustomModelInfoSaneDefaults,
 		...customModelInfo,
 		// Fixed for all custom Vertex models regardless of user edits.
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-	}
+	};
 }
 
 export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
@@ -1964,12 +1984,12 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 	inputPrice: 0,
 	outputPrice: 0,
 	temperature: 0,
-}
+};
 
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
-export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview"
+export type GeminiModelId = keyof typeof geminiModels;
+export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview";
 export const geminiModels = {
 	"gemini-3.5-flash": {
 		maxTokens: 65536,
@@ -2237,12 +2257,12 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // OpenAI Native
 // https://openai.com/api/pricing/
-export type OpenAiNativeModelId = keyof typeof openAiNativeModels
-export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5.5"
+export type OpenAiNativeModelId = keyof typeof openAiNativeModels;
+export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-5.5";
 export const openAiNativeModels = {
 	"gpt-5.5": {
 		maxTokens: 8_192,
@@ -2611,13 +2631,13 @@ export const openAiNativeModels = {
 		outputPrice: 15,
 		temperature: 0,
 	},
-} as const satisfies Record<string, OpenAiCompatibleModelInfo>
+} as const satisfies Record<string, OpenAiCompatibleModelInfo>;
 
 // OpenAI Codex (ChatGPT Plus/Pro subscription)
 // Uses OAuth authentication via ChatGPT, routes to chatgpt.com/backend-api/codex/responses
 // Subscription-based pricing (all costs are $0)
-export type OpenAiCodexModelId = keyof typeof openAiCodexModels
-export const openAiCodexDefaultModelId: OpenAiCodexModelId = "gpt-5.3-codex"
+export type OpenAiCodexModelId = keyof typeof openAiCodexModels;
+export const openAiCodexDefaultModelId: OpenAiCodexModelId = "gpt-5.3-codex";
 export const openAiCodexModels = {
 	"gpt-5.6-sol": {
 		maxTokens: 128_000,
@@ -2629,7 +2649,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.6 Sol: OpenAI's latest frontier agentic coding model via ChatGPT subscription",
+		description:
+			"GPT-5.6 Sol: OpenAI's latest frontier agentic coding model via ChatGPT subscription",
 	},
 	"gpt-5.6-terra": {
 		maxTokens: 128_000,
@@ -2641,7 +2662,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.6 Terra: OpenAI's balanced agentic coding model via ChatGPT subscription",
+		description:
+			"GPT-5.6 Terra: OpenAI's balanced agentic coding model via ChatGPT subscription",
 	},
 	"gpt-5.6-luna": {
 		maxTokens: 128_000,
@@ -2653,7 +2675,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.6 Luna: OpenAI's fast agentic coding model via ChatGPT subscription",
+		description:
+			"GPT-5.6 Luna: OpenAI's fast agentic coding model via ChatGPT subscription",
 	},
 	"gpt-5.5": {
 		maxTokens: 128_000,
@@ -2665,7 +2688,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.5 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
+		description:
+			"GPT-5.5 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
 	},
 	"gpt-5.4": {
 		maxTokens: 128_000,
@@ -2677,7 +2701,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.4 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
+		description:
+			"GPT-5.4 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
 	},
 	"gpt-5.3-codex": {
 		maxTokens: 128_000,
@@ -2689,7 +2714,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.3 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
+		description:
+			"GPT-5.3 Codex: OpenAI's latest flagship coding model via ChatGPT subscription",
 	},
 	"gpt-5.2-codex": {
 		maxTokens: 128_000,
@@ -2701,7 +2727,8 @@ export const openAiCodexModels = {
 		// Subscription-based: no per-token costs
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.2 Codex: OpenAI's flagship coding model via ChatGPT subscription",
+		description:
+			"GPT-5.2 Codex: OpenAI's flagship coding model via ChatGPT subscription",
 	},
 	"gpt-5.1-codex-max": {
 		maxTokens: 128_000,
@@ -2712,7 +2739,8 @@ export const openAiCodexModels = {
 		apiFormat: ApiFormat.OPENAI_RESPONSES,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.1 Codex Max: Maximum capability coding model via ChatGPT subscription",
+		description:
+			"GPT-5.1 Codex Max: Maximum capability coding model via ChatGPT subscription",
 	},
 	"gpt-5.1-codex-mini": {
 		maxTokens: 128_000,
@@ -2723,7 +2751,8 @@ export const openAiCodexModels = {
 		apiFormat: ApiFormat.OPENAI_RESPONSES,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "GPT-5.1 Codex Mini: Faster version for coding tasks via ChatGPT subscription",
+		description:
+			"GPT-5.1 Codex Mini: Faster version for coding tasks via ChatGPT subscription",
 	},
 	"gpt-5.2": {
 		maxTokens: 128_000,
@@ -2736,17 +2765,17 @@ export const openAiCodexModels = {
 		outputPrice: 0,
 		description: "GPT-5.2: Latest GPT model via ChatGPT subscription",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Azure OpenAI
 // https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation
 // https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
-export const azureOpenAiDefaultApiVersion = "2024-08-01-preview"
+export const azureOpenAiDefaultApiVersion = "2024-08-01-preview";
 
 // DeepSeek
 // https://api-docs.deepseek.com/quick_start/pricing
-export type DeepSeekModelId = keyof typeof deepSeekModels
-export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat"
+export type DeepSeekModelId = keyof typeof deepSeekModels;
+export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat";
 export const deepSeekModels = {
 	"deepseek-v4-flash": {
 		maxTokens: 384_000,
@@ -2790,12 +2819,13 @@ export const deepSeekModels = {
 		cacheWritesPrice: 0.55,
 		cacheReadsPrice: 0.14,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Hugging Face Inference Providers
 // https://huggingface.co/docs/inference-providers/en/index
-export type HuggingFaceModelId = keyof typeof huggingFaceModels
-export const huggingFaceDefaultModelId: HuggingFaceModelId = "moonshotai/Kimi-K2-Instruct"
+export type HuggingFaceModelId = keyof typeof huggingFaceModels;
+export const huggingFaceDefaultModelId: HuggingFaceModelId =
+	"moonshotai/Kimi-K2-Instruct";
 export const huggingFaceModels = {
 	"openai/gpt-oss-120b": {
 		maxTokens: 32766,
@@ -2824,7 +2854,8 @@ export const huggingFaceModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "Advanced reasoning model with superior performance across coding, math, and general capabilities.",
+		description:
+			"Advanced reasoning model with superior performance across coding, math, and general capabilities.",
 	},
 	"deepseek-ai/DeepSeek-V3-0324": {
 		maxTokens: 8192,
@@ -2833,7 +2864,8 @@ export const huggingFaceModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "Advanced reasoning model with superior performance across coding, math, and general capabilities.",
+		description:
+			"Advanced reasoning model with superior performance across coding, math, and general capabilities.",
 	},
 	"deepseek-ai/DeepSeek-R1": {
 		maxTokens: 8192,
@@ -2842,7 +2874,8 @@ export const huggingFaceModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "DeepSeek's reasoning model with step-by-step thinking capabilities.",
+		description:
+			"DeepSeek's reasoning model with step-by-step thinking capabilities.",
 	},
 	"deepseek-ai/DeepSeek-R1-0528": {
 		maxTokens: 64_000,
@@ -2851,7 +2884,8 @@ export const huggingFaceModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "DeepSeek's reasoning model's latest version with step-by-step thinking capabilities",
+		description:
+			"DeepSeek's reasoning model's latest version with step-by-step thinking capabilities",
 	},
 	"meta-llama/Llama-3.1-8B-Instruct": {
 		maxTokens: 8192,
@@ -2860,9 +2894,10 @@ export const huggingFaceModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		description: "Efficient 8B parameter Llama model for general-purpose tasks.",
+		description:
+			"Efficient 8B parameter Llama model for general-purpose tasks.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Qwen
 // https://bailian.console.aliyun.com/
@@ -3204,7 +3239,7 @@ export const internationalQwenModels = {
 		cacheWritesPrice: 1.5,
 		cacheReadsPrice: 4.5,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 export const mainlandQwenModels = {
 	"qwen3-235b-a22b": {
@@ -3547,24 +3582,25 @@ export const mainlandQwenModels = {
 		cacheWritesPrice: 1.5,
 		cacheReadsPrice: 4.5,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 export enum QwenApiRegions {
 	CHINA = "china",
 	INTERNATIONAL = "international",
 }
-export type MainlandQwenModelId = keyof typeof mainlandQwenModels
-export type InternationalQwenModelId = keyof typeof internationalQwenModels
+export type MainlandQwenModelId = keyof typeof mainlandQwenModels;
+export type InternationalQwenModelId = keyof typeof internationalQwenModels;
 // Set first model in the list as the default model for each region
-export const internationalQwenDefaultModelId: InternationalQwenModelId = Object.keys(
-	internationalQwenModels,
-)[0] as InternationalQwenModelId
-export const mainlandQwenDefaultModelId: MainlandQwenModelId = Object.keys(mainlandQwenModels)[0] as MainlandQwenModelId
+export const internationalQwenDefaultModelId: InternationalQwenModelId =
+	Object.keys(internationalQwenModels)[0] as InternationalQwenModelId;
+export const mainlandQwenDefaultModelId: MainlandQwenModelId = Object.keys(
+	mainlandQwenModels,
+)[0] as MainlandQwenModelId;
 
 // Doubao
 // https://www.volcengine.com/docs/82379/1298459
 // https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement
-export type DoubaoModelId = keyof typeof doubaoModels
-export const doubaoDefaultModelId: DoubaoModelId = "doubao-1-5-pro-256k-250115"
+export type DoubaoModelId = keyof typeof doubaoModels;
+export const doubaoDefaultModelId: DoubaoModelId = "doubao-1-5-pro-256k-250115";
 export const doubaoModels = {
 	"doubao-1-5-pro-256k-250115": {
 		maxTokens: 12_288,
@@ -3606,12 +3642,12 @@ export const doubaoModels = {
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Mistral
 // https://docs.mistral.ai/getting-started/models/models_overview/
-export type MistralModelId = keyof typeof mistralModels
-export const mistralDefaultModelId: MistralModelId = "devstral-2512"
+export type MistralModelId = keyof typeof mistralModels;
+export const mistralDefaultModelId: MistralModelId = "devstral-2512";
 export const mistralModels = {
 	"devstral-2512": {
 		maxTokens: 256_000,
@@ -3749,14 +3785,14 @@ export const mistralModels = {
 		inputPrice: 0.4,
 		outputPrice: 2.0,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // LiteLLM
 // https://docs.litellm.ai/docs/
-export type LiteLLMModelId = string
-export const liteLlmDefaultModelId = "anthropic/claude-3-7-sonnet-20250219"
+export type LiteLLMModelId = string;
+export const liteLlmDefaultModelId = "anthropic/claude-3-7-sonnet-20250219";
 export interface LiteLLMModelInfo extends ModelInfo {
-	temperature?: number
+	temperature?: number;
 }
 
 export const liteLlmModelInfoSaneDefaults: LiteLLMModelInfo = {
@@ -3769,13 +3805,13 @@ export const liteLlmModelInfoSaneDefaults: LiteLLMModelInfo = {
 	cacheWritesPrice: 0,
 	cacheReadsPrice: 0,
 	temperature: 0,
-}
+};
 
 // AskSage Models
 // https://docs.asksage.ai/
-export type AskSageModelId = keyof typeof askSageModels
-export const askSageDefaultModelId: AskSageModelId = "claude-4-sonnet"
-export const askSageDefaultURL: string = "https://api.asksage.ai/server"
+export type AskSageModelId = keyof typeof askSageModels;
+export const askSageDefaultModelId: AskSageModelId = "claude-4-sonnet";
+export const askSageDefaultURL: string = "https://api.asksage.ai/server";
 export const askSageModels = {
 	"gpt-4o": {
 		maxTokens: 4096,
@@ -3897,7 +3933,7 @@ export const askSageModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
-}
+};
 
 // Nebius AI Studio
 // https://docs.nebius.com/studio/inference/models
@@ -4078,9 +4114,10 @@ export const nebiusModels = {
 		inputPrice: 0.2,
 		outputPrice: 0.6,
 	},
-} as const satisfies Record<string, ModelInfo>
-export type NebiusModelId = keyof typeof nebiusModels
-export const nebiusDefaultModelId = "Qwen/Qwen2.5-32B-Instruct-fast" satisfies NebiusModelId
+} as const satisfies Record<string, ModelInfo>;
+export type NebiusModelId = keyof typeof nebiusModels;
+export const nebiusDefaultModelId =
+	"Qwen/Qwen2.5-32B-Instruct-fast" satisfies NebiusModelId;
 
 // W&B Inference by CoreWeave
 // https://docs.wandb.ai/inference/models
@@ -4092,7 +4129,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.55,
 		outputPrice: 1.65,
-		description: "A large hybrid model that supports both thinking and non-thinking modes via prompt templates",
+		description:
+			"A large hybrid model that supports both thinking and non-thinking modes via prompt templates",
 	},
 	"meta-llama/Llama-4-Scout-17B-16E-Instruct": {
 		maxTokens: 16_384,
@@ -4101,7 +4139,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.17,
 		outputPrice: 0.66,
-		description: "Multimodal model integrating text and image understanding, ideal for visual tasks and combined analysis",
+		description:
+			"Multimodal model integrating text and image understanding, ideal for visual tasks and combined analysis",
 	},
 	"meta-llama/Llama-3.3-70B-Instruct": {
 		maxTokens: 8_192,
@@ -4110,7 +4149,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.71,
 		outputPrice: 0.71,
-		description: "Multilingual model excelling in conversational tasks, detailed instruction-following, and coding",
+		description:
+			"Multilingual model excelling in conversational tasks, detailed instruction-following, and coding",
 	},
 	"meta-llama/Llama-3.1-70B-Instruct": {
 		maxTokens: 8_192,
@@ -4119,7 +4159,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.8,
 		outputPrice: 0.8,
-		description: "Efficient conversational model optimized for responsive multilingual chatbot interactions",
+		description:
+			"Efficient conversational model optimized for responsive multilingual chatbot interactions",
 	},
 	"meta-llama/Llama-3.1-8B-Instruct": {
 		maxTokens: 8_192,
@@ -4128,7 +4169,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.22,
 		outputPrice: 0.22,
-		description: "Efficient conversational model optimized for responsive multilingual chatbot interactions",
+		description:
+			"Efficient conversational model optimized for responsive multilingual chatbot interactions",
 	},
 	"microsoft/Phi-4-mini-instruct": {
 		maxTokens: 4_096,
@@ -4137,7 +4179,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.08,
 		outputPrice: 0.35,
-		description: "Compact, efficient model ideal for fast responses in resource-constrained environments",
+		description:
+			"Compact, efficient model ideal for fast responses in resource-constrained environments",
 	},
 	"MiniMaxAI/MiniMax-M2.5": {
 		maxTokens: 40_960,
@@ -4156,7 +4199,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.2,
 		outputPrice: 0.8,
-		description: "A LatentMoE model designed to deliver strong agentic, reasoning, and conversational capabilities",
+		description:
+			"A LatentMoE model designed to deliver strong agentic, reasoning, and conversational capabilities",
 	},
 	"openai/gpt-oss-120b": {
 		maxTokens: 32_768,
@@ -4165,7 +4209,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.15,
 		outputPrice: 0.6,
-		description: "Efficient Mixture-of-Experts model designed for high-reasoning, agentic and general-purpose use cases",
+		description:
+			"Efficient Mixture-of-Experts model designed for high-reasoning, agentic and general-purpose use cases",
 	},
 	"openai/gpt-oss-20b": {
 		maxTokens: 32_768,
@@ -4204,7 +4249,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.1,
 		outputPrice: 0.1,
-		description: "Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning",
+		description:
+			"Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning",
 	},
 	"Qwen/Qwen3-30B-A3B-Instruct-2507": {
 		maxTokens: 8_192,
@@ -4213,7 +4259,8 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.1,
 		outputPrice: 0.3,
-		description: "MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding",
+		description:
+			"MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding",
 	},
 	"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 		maxTokens: 32_768,
@@ -4232,16 +4279,18 @@ export const wandbModels = {
 		supportsPromptCache: false,
 		inputPrice: 1.0,
 		outputPrice: 3.2,
-		description: "Mixture-of-Experts model for long-horizon agentic tasks with strong performance on reasoning and coding",
+		description:
+			"Mixture-of-Experts model for long-horizon agentic tasks with strong performance on reasoning and coding",
 	},
-} as const satisfies Record<string, ModelInfo>
-export type WandbModelId = keyof typeof wandbModels
-export const wandbDefaultModelId = "meta-llama/Llama-3.3-70B-Instruct" satisfies WandbModelId
+} as const satisfies Record<string, ModelInfo>;
+export type WandbModelId = keyof typeof wandbModels;
+export const wandbDefaultModelId =
+	"meta-llama/Llama-3.3-70B-Instruct" satisfies WandbModelId;
 
 // X AI
 // https://docs.x.ai/docs/api-reference
-export type XAIModelId = keyof typeof xaiModels
-export const xaiDefaultModelId: XAIModelId = "grok-4"
+export type XAIModelId = keyof typeof xaiModels;
+export const xaiDefaultModelId: XAIModelId = "grok-4";
 export const xaiModels = {
 	"grok-4-1-fast-reasoning": {
 		contextWindow: 2_000_000,
@@ -4250,7 +4299,8 @@ export const xaiModels = {
 		inputPrice: 0.2,
 		cacheReadsPrice: 0.05,
 		outputPrice: 0.5,
-		description: "xAI's Grok 4.1 Reasoning Fast - multimodal model with 2M context.",
+		description:
+			"xAI's Grok 4.1 Reasoning Fast - multimodal model with 2M context.",
 	},
 	"grok-4-1-fast-non-reasoning": {
 		contextWindow: 2_000_000,
@@ -4259,7 +4309,8 @@ export const xaiModels = {
 		inputPrice: 0.2,
 		cacheReadsPrice: 0.05,
 		outputPrice: 0.5,
-		description: "xAI's Grok 4.1 Non-Reasoning Fast - multimodal model with 2M context.",
+		description:
+			"xAI's Grok 4.1 Non-Reasoning Fast - multimodal model with 2M context.",
 	},
 	"grok-code-fast-1": {
 		contextWindow: 256_000,
@@ -4368,7 +4419,8 @@ export const xaiModels = {
 		supportsPromptCache: false,
 		inputPrice: 2.0,
 		outputPrice: 10.0,
-		description: "X AI's Grok-2 model - latest version with 131K context window",
+		description:
+			"X AI's Grok-2 model - latest version with 131K context window",
 	},
 	"grok-2": {
 		maxTokens: 8192,
@@ -4395,7 +4447,8 @@ export const xaiModels = {
 		supportsPromptCache: false,
 		inputPrice: 2.0,
 		outputPrice: 10.0,
-		description: "X AI's Grok-2 Vision model - latest version with image support and 32K context window",
+		description:
+			"X AI's Grok-2 Vision model - latest version with image support and 32K context window",
 	},
 	"grok-2-vision": {
 		maxTokens: 8192,
@@ -4404,7 +4457,8 @@ export const xaiModels = {
 		supportsPromptCache: false,
 		inputPrice: 2.0,
 		outputPrice: 10.0,
-		description: "X AI's Grok-2 Vision model with image support and 32K context window",
+		description:
+			"X AI's Grok-2 Vision model with image support and 32K context window",
 	},
 	"grok-2-vision-1212": {
 		maxTokens: 8192,
@@ -4413,7 +4467,8 @@ export const xaiModels = {
 		supportsPromptCache: false,
 		inputPrice: 2.0,
 		outputPrice: 10.0,
-		description: "X AI's Grok-2 Vision model (version 1212) with image support and 32K context window",
+		description:
+			"X AI's Grok-2 Vision model (version 1212) with image support and 32K context window",
 	},
 	"grok-vision-beta": {
 		maxTokens: 8192,
@@ -4422,7 +4477,8 @@ export const xaiModels = {
 		supportsPromptCache: false,
 		inputPrice: 5.0,
 		outputPrice: 15.0,
-		description: "X AI's Grok Vision Beta model with image support and 8K context window",
+		description:
+			"X AI's Grok Vision Beta model with image support and 8K context window",
 	},
 	"grok-beta": {
 		maxTokens: 8192,
@@ -4433,12 +4489,13 @@ export const xaiModels = {
 		outputPrice: 15.0,
 		description: "X AI's Grok Beta model (legacy) with 131K context window",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // SambaNova
 // https://docs.sambanova.ai/cloud/docs/get-started/supported-models
-export type SambanovaModelId = keyof typeof sambanovaModels
-export const sambanovaDefaultModelId: SambanovaModelId = "Meta-Llama-3.3-70B-Instruct"
+export type SambanovaModelId = keyof typeof sambanovaModels;
+export const sambanovaDefaultModelId: SambanovaModelId =
+	"Meta-Llama-3.3-70B-Instruct";
 export const sambanovaModels = {
 	"DeepSeek-V3.1": {
 		maxTokens: 7168,
@@ -4485,12 +4542,12 @@ export const sambanovaModels = {
 		inputPrice: 0.6,
 		outputPrice: 2.4,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Cerebras
 // https://inference-docs.cerebras.ai/api-reference/models
-export type CerebrasModelId = keyof typeof cerebrasModels
-export const cerebrasDefaultModelId: CerebrasModelId = "zai-glm-4.7"
+export type CerebrasModelId = keyof typeof cerebrasModels;
+export const cerebrasDefaultModelId: CerebrasModelId = "zai-glm-4.7";
 export const cerebrasModels = {
 	"zai-glm-4.7": {
 		maxTokens: 40000,
@@ -4521,13 +4578,14 @@ export const cerebrasModels = {
 		outputPrice: 0,
 		description: "Intelligent model with ~1400 tokens/s",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Groq
 // https://console.groq.com/docs/models
 // https://groq.com/pricing/
-export type GroqModelId = keyof typeof groqModels
-export const groqDefaultModelId: GroqModelId = "moonshotai/kimi-k2-instruct-0905"
+export type GroqModelId = keyof typeof groqModels;
+export const groqDefaultModelId: GroqModelId =
+	"moonshotai/kimi-k2-instruct-0905";
 export const groqModels = {
 	"openai/gpt-oss-120b": {
 		maxTokens: 32766, // Model fails if you try to use more than 32K tokens
@@ -4567,7 +4625,8 @@ export const groqModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.0,
 		outputPrice: 0.0,
-		description: "Lightweight compound model for faster inference while maintaining tool use capabilities.",
+		description:
+			"Lightweight compound model for faster inference while maintaining tool use capabilities.",
 	},
 	// DeepSeek Models - Reasoning-optimized
 	"deepseek-r1-distill-llama-70b": {
@@ -4588,7 +4647,8 @@ export const groqModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.2,
 		outputPrice: 0.6,
-		description: "Meta's Llama 4 Maverick 17B model with 128 experts, supports vision and multimodal tasks.",
+		description:
+			"Meta's Llama 4 Maverick 17B model with 128 experts, supports vision and multimodal tasks.",
 	},
 	"meta-llama/llama-4-scout-17b-16e-instruct": {
 		maxTokens: 8192,
@@ -4597,7 +4657,8 @@ export const groqModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.11,
 		outputPrice: 0.34,
-		description: "Meta's Llama 4 Scout 17B model with 16 experts, optimized for fast inference and general tasks.",
+		description:
+			"Meta's Llama 4 Scout 17B model with 16 experts, optimized for fast inference and general tasks.",
 	},
 	// Llama 3.3 Models
 	"llama-3.3-70b-versatile": {
@@ -4607,7 +4668,8 @@ export const groqModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.59,
 		outputPrice: 0.79,
-		description: "Meta's latest Llama 3.3 70B model optimized for versatile use cases with excellent performance and speed.",
+		description:
+			"Meta's latest Llama 3.3 70B model optimized for versatile use cases with excellent performance and speed.",
 	},
 	// Llama 3.1 Models - Fast inference
 	"llama-3.1-8b-instant": {
@@ -4617,7 +4679,8 @@ export const groqModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.05,
 		outputPrice: 0.08,
-		description: "Fast and efficient Llama 3.1 8B model optimized for speed, low latency, and reliable tool execution.",
+		description:
+			"Fast and efficient Llama 3.1 8B model optimized for speed, low latency, and reliable tool execution.",
 	},
 	// Moonshot Models
 	"moonshotai/kimi-k2-instruct": {
@@ -4642,11 +4705,11 @@ export const groqModels = {
 		description:
 			"Kimi K2 model gets a new version update: Agentic coding: more accurate, better generalization across scaffolds. Frontend coding: improved aesthetics and functionalities on web, 3d, and other tasks. Context length: extended from 128k to 256k, providing better long-horizon support.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Requesty
 // https://requesty.ai/models
-export const requestyDefaultModelId = "anthropic/claude-sonnet-5"
+export const requestyDefaultModelId = "anthropic/claude-sonnet-5";
 export const requestyDefaultModelInfo: ModelInfo = {
 	maxTokens: 128_000,
 	contextWindow: 200_000,
@@ -4657,14 +4720,17 @@ export const requestyDefaultModelInfo: ModelInfo = {
 	outputPrice: 10.0,
 	cacheWritesPrice: 2.5,
 	cacheReadsPrice: 0.2,
-	description: "Anthropic's latest Sonnet model for coding, agents, and professional work.",
-}
+	description:
+		"Anthropic's latest Sonnet model for coding, agents, and professional work.",
+};
 
 // SAP AI Core
-export type SapAiCoreModelId = keyof typeof sapAiCoreModels
-export const sapAiCoreDefaultModelId: SapAiCoreModelId = "anthropic--claude-3.5-sonnet"
+export type SapAiCoreModelId = keyof typeof sapAiCoreModels;
+export const sapAiCoreDefaultModelId: SapAiCoreModelId =
+	"anthropic--claude-3.5-sonnet";
 // Pricing is calculated using Capacity Units, not directly in USD
-const sapAiCoreModelDescription = "Pricing is calculated using SAP's Capacity Units rather than direct USD pricing."
+const sapAiCoreModelDescription =
+	"Pricing is calculated using SAP's Capacity Units rather than direct USD pricing.";
 export const sapAiCoreModels = {
 	"anthropic--claude-sonnet-5": {
 		maxTokens: 128_000,
@@ -4983,7 +5049,7 @@ export const sapAiCoreModels = {
 		supportsPromptCache: false,
 		description: sapAiCoreModelDescription,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Moonshot AI Studio
 // https://platform.moonshot.ai/docs/pricing/chat
@@ -5063,15 +5129,17 @@ export const moonshotModels = {
 		outputPrice: 10,
 		temperature: 1.0,
 	},
-} as const satisfies Record<string, OpenAiCompatibleModelInfo>
-export type MoonshotModelId = keyof typeof moonshotModels
-export const moonshotDefaultModelId = "kimi-k2-0905-preview" satisfies MoonshotModelId
+} as const satisfies Record<string, OpenAiCompatibleModelInfo>;
+export type MoonshotModelId = keyof typeof moonshotModels;
+export const moonshotDefaultModelId =
+	"kimi-k2-0905-preview" satisfies MoonshotModelId;
 
 // Huawei Cloud MaaS
 // Dify.ai - No model selection needed, models are configured in Dify workflows
 
-export type HuaweiCloudMaasModelId = keyof typeof huaweiCloudMaasModels
-export const huaweiCloudMaasDefaultModelId: HuaweiCloudMaasModelId = "DeepSeek-V3"
+export type HuaweiCloudMaasModelId = keyof typeof huaweiCloudMaasModels;
+export const huaweiCloudMaasDefaultModelId: HuaweiCloudMaasModelId =
+	"DeepSeek-V3";
 export const huaweiCloudMaasModels = {
 	"DeepSeek-V3": {
 		maxTokens: 16_384,
@@ -5139,13 +5207,13 @@ export const huaweiCloudMaasModels = {
 			outputPrice: 1.1,
 		},
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Baseten
 // https://baseten.co/products/model-apis/
 // Extended ModelInfo to include supportedFeatures, like tools
 export interface BasetenModelInfo extends ModelInfo {
-	supportedFeatures?: string[]
+	supportedFeatures?: string[];
 }
 
 export const basetenModels = {
@@ -5158,7 +5226,8 @@ export const basetenModels = {
 		outputPrice: 2.5,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Kimi K2 Thinking - A model with enhanced reasoning capabilities from Kimi K2",
+		description:
+			"Kimi K2 Thinking - A model with enhanced reasoning capabilities from Kimi K2",
 		supportsReasoning: true,
 	},
 	"zai-org/GLM-4.6": {
@@ -5170,7 +5239,8 @@ export const basetenModels = {
 		outputPrice: 2.2,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Frontier open model with advanced agentic, reasoning and coding capabilities",
+		description:
+			"Frontier open model with advanced agentic, reasoning and coding capabilities",
 		supportsReasoning: true,
 	},
 	"deepseek-ai/DeepSeek-R1": {
@@ -5194,7 +5264,8 @@ export const basetenModels = {
 		outputPrice: 5.95,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "The latest revision of DeepSeek's first-generation reasoning model",
+		description:
+			"The latest revision of DeepSeek's first-generation reasoning model",
 		supportsReasoning: true,
 	},
 	"deepseek-ai/DeepSeek-V3-0324": {
@@ -5206,7 +5277,8 @@ export const basetenModels = {
 		outputPrice: 0.77,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Fast general-purpose LLM with enhanced reasoning capabilities",
+		description:
+			"Fast general-purpose LLM with enhanced reasoning capabilities",
 		supportsReasoning: true,
 	},
 	"deepseek-ai/DeepSeek-V3.1": {
@@ -5218,7 +5290,8 @@ export const basetenModels = {
 		outputPrice: 1.5,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Extremely capable general-purpose LLM with hybrid reasoning capabilities and advanced tool calling",
+		description:
+			"Extremely capable general-purpose LLM with hybrid reasoning capabilities and advanced tool calling",
 		supportsReasoning: true,
 	},
 	"deepseek-ai/DeepSeek-V3.2": {
@@ -5230,7 +5303,8 @@ export const basetenModels = {
 		outputPrice: 0.45,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "DeepSeek's hybrid reasoning model with efficient long context scaling with GPT-5 level performance",
+		description:
+			"DeepSeek's hybrid reasoning model with efficient long context scaling with GPT-5 level performance",
 		supportsReasoning: true,
 	},
 	"Qwen/Qwen3-235B-A22B-Instruct-2507": {
@@ -5254,7 +5328,8 @@ export const basetenModels = {
 		outputPrice: 1.53,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Mixture-of-experts LLM with advanced coding and reasoning capabilities",
+		description:
+			"Mixture-of-experts LLM with advanced coding and reasoning capabilities",
 		supportsReasoning: false,
 	},
 	"openai/gpt-oss-120b": {
@@ -5266,7 +5341,8 @@ export const basetenModels = {
 		outputPrice: 0.5,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Extremely capable general-purpose LLM with strong, controllable reasoning capabilities",
+		description:
+			"Extremely capable general-purpose LLM with strong, controllable reasoning capabilities",
 		supportsReasoning: true,
 	},
 	"moonshotai/Kimi-K2-Instruct-0905": {
@@ -5278,20 +5354,22 @@ export const basetenModels = {
 		outputPrice: 2.5,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "State of the art language model for agentic and coding tasks. September Update.",
+		description:
+			"State of the art language model for agentic and coding tasks. September Update.",
 		supportsReasoning: false,
 	},
-} as const satisfies Record<string, ModelInfo>
-export type BasetenModelId = keyof typeof basetenModels
-export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
+} as const satisfies Record<string, ModelInfo>;
+export type BasetenModelId = keyof typeof basetenModels;
+export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId;
 
 // Z AI
 // https://docs.z.ai/guides/llm/glm-5.2
 // https://docs.z.ai/guides/llm/glm-5.1
 // https://docs.z.ai/guides/llm/glm-5
 // https://docs.z.ai/guides/overview/pricing
-export type internationalZAiModelId = keyof typeof internationalZAiModels
-export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-5.1"
+export type internationalZAiModelId = keyof typeof internationalZAiModels;
+export const internationalZAiDefaultModelId: internationalZAiModelId =
+	"glm-5.1";
 export const internationalZAiModels = {
 	"glm-5.2": {
 		maxTokens: 128_000,
@@ -5362,10 +5440,10 @@ export const internationalZAiModels = {
 		description:
 			"GLM-4.5-Air is the lightweight version of GLM-4.5. It balances performance and cost-effectiveness, and can flexibly switch to hybrid thinking models.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
-export type mainlandZAiModelId = keyof typeof mainlandZAiModels
-export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5.1"
+export type mainlandZAiModelId = keyof typeof mainlandZAiModels;
+export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5.1";
 export const mainlandZAiModels = {
 	"glm-5.2": {
 		maxTokens: 128_000,
@@ -5476,11 +5554,12 @@ export const mainlandZAiModels = {
 			},
 		],
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Fireworks AI
-export type FireworksModelId = keyof typeof fireworksModels
-export const fireworksDefaultModelId: FireworksModelId = "accounts/fireworks/models/kimi-k2p6"
+export type FireworksModelId = keyof typeof fireworksModels;
+export const fireworksDefaultModelId: FireworksModelId =
+	"accounts/fireworks/models/kimi-k2p6";
 export const fireworksModels = {
 	"accounts/fireworks/models/kimi-k2p7-code": {
 		maxTokens: 262000,
@@ -5515,7 +5594,8 @@ export const fireworksModels = {
 		outputPrice: 8,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.3,
-		description: "Kimi K2.6 Turbo router for high-performance agentic workloads with vision and text reasoning.",
+		description:
+			"Kimi K2.6 Turbo router for high-performance agentic workloads with vision and text reasoning.",
 	},
 	"accounts/fireworks/routers/kimi-k2p6-fast": {
 		maxTokens: 262000,
@@ -5526,7 +5606,8 @@ export const fireworksModels = {
 		outputPrice: 8,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.3,
-		description: "Kimi K2.6 Fast router for high-performance agentic workloads with vision and text reasoning.",
+		description:
+			"Kimi K2.6 Fast router for high-performance agentic workloads with vision and text reasoning.",
 	},
 	"accounts/fireworks/routers/kimi-k2p7-code-fast": {
 		maxTokens: 262000,
@@ -5537,7 +5618,8 @@ export const fireworksModels = {
 		outputPrice: 8,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.38,
-		description: "Kimi K2.7 Code Fast router for high-performance coding workloads with vision and text reasoning.",
+		description:
+			"Kimi K2.7 Code Fast router for high-performance coding workloads with vision and text reasoning.",
 	},
 	"accounts/fireworks/models/deepseek-v4-flash": {
 		maxTokens: 384000,
@@ -5584,7 +5666,8 @@ export const fireworksModels = {
 		outputPrice: 4.4,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.26,
-		description: "GLM 5.1 is a next-generation general-purpose model optimized for coding, reasoning, and agentic workflows.",
+		description:
+			"GLM 5.1 is a next-generation general-purpose model optimized for coding, reasoning, and agentic workflows.",
 	},
 	"accounts/fireworks/routers/glm-5p1-fast": {
 		maxTokens: 131072,
@@ -5595,7 +5678,8 @@ export const fireworksModels = {
 		outputPrice: 8.8,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.52,
-		description: "GLM 5.1 Fast router for high-throughput coding, reasoning, and agentic workflows.",
+		description:
+			"GLM 5.1 Fast router for high-throughput coding, reasoning, and agentic workflows.",
 	},
 	"accounts/fireworks/models/minimax-m3": {
 		maxTokens: 512000,
@@ -5606,7 +5690,8 @@ export const fireworksModels = {
 		outputPrice: 1.2,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.06,
-		description: "MiniMax M3 is built for state-of-the-art coding, agentic tool use, and long-context multimodal tasks.",
+		description:
+			"MiniMax M3 is built for state-of-the-art coding, agentic tool use, and long-context multimodal tasks.",
 	},
 	"accounts/fireworks/models/minimax-m2p7": {
 		maxTokens: 196608,
@@ -5629,7 +5714,8 @@ export const fireworksModels = {
 		outputPrice: 1.6,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.08,
-		description: "Qwen 3.7 Plus with strong multimodal reasoning, long context support, and function calling.",
+		description:
+			"Qwen 3.7 Plus with strong multimodal reasoning, long context support, and function calling.",
 	},
 	"accounts/fireworks/models/gpt-oss-120b": {
 		maxTokens: 32768,
@@ -5640,7 +5726,8 @@ export const fireworksModels = {
 		outputPrice: 0.6,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.015,
-		description: "OpenAI GPT OSS 120B open-weight model for production and high-reasoning use cases.",
+		description:
+			"OpenAI GPT OSS 120B open-weight model for production and high-reasoning use cases.",
 	},
 	"accounts/fireworks/models/gpt-oss-20b": {
 		maxTokens: 32768,
@@ -5651,9 +5738,10 @@ export const fireworksModels = {
 		outputPrice: 0.3,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.035,
-		description: "OpenAI GPT OSS 20B open-weight model for efficient production and reasoning use cases.",
+		description:
+			"OpenAI GPT OSS 20B open-weight model for efficient production and reasoning use cases.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // Qwen Code
 // https://chat.qwen.ai/
@@ -5667,7 +5755,8 @@ export const qwenCodeModels = {
 		outputPrice: 0,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Qwen3 Coder Plus - High-performance coding model with 1M context window for large codebases",
+		description:
+			"Qwen3 Coder Plus - High-performance coding model with 1M context window for large codebases",
 	},
 	"qwen3-coder-flash": {
 		maxTokens: 65_536,
@@ -5678,17 +5767,18 @@ export const qwenCodeModels = {
 		outputPrice: 0,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
-		description: "Qwen3 Coder Flash - Fast coding model with 1M context window optimized for speed",
+		description:
+			"Qwen3 Coder Flash - Fast coding model with 1M context window optimized for speed",
 	},
-} as const satisfies Record<string, ModelInfo>
-export type QwenCodeModelId = keyof typeof qwenCodeModels
-export const qwenCodeDefaultModelId: QwenCodeModelId = "qwen3-coder-plus"
+} as const satisfies Record<string, ModelInfo>;
+export type QwenCodeModelId = keyof typeof qwenCodeModels;
+export const qwenCodeDefaultModelId: QwenCodeModelId = "qwen3-coder-plus";
 
 // Minimax
 // https://www.minimax.io/platform/document/text_api_intro
 // https://www.minimax.io/platform/document/pricing
-export type MinimaxModelId = keyof typeof minimaxModels
-export const minimaxDefaultModelId: MinimaxModelId = "MiniMax-M2.7"
+export type MinimaxModelId = keyof typeof minimaxModels;
+export const minimaxDefaultModelId: MinimaxModelId = "MiniMax-M2.7";
 export const minimaxModels = {
 	"MiniMax-M3": {
 		maxTokens: 32_000,
@@ -5716,7 +5806,8 @@ export const minimaxModels = {
 				cacheReadsPrice: 0.24,
 			},
 		],
-		description: "Latest M-series model for coding, agentic reasoning, tool use, and long-context multimodal tasks",
+		description:
+			"Latest M-series model for coding, agentic reasoning, tool use, and long-context multimodal tasks",
 	},
 	"MiniMax-M2.7": {
 		maxTokens: 128_000,
@@ -5794,12 +5885,12 @@ export const minimaxModels = {
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;
 
 // NousResearch
 // https://inference-api.nousResearch.com
-export type NousResearchModelId = keyof typeof nousResearchModels
-export const nousResearchDefaultModelId: NousResearchModelId = "Hermes-4-405B"
+export type NousResearchModelId = keyof typeof nousResearchModels;
+export const nousResearchDefaultModelId: NousResearchModelId = "Hermes-4-405B";
 export const nousResearchModels = {
 	"Hermes-4-405B": {
 		maxTokens: 8192,
@@ -5821,4 +5912,4 @@ export const nousResearchModels = {
 		description:
 			"This incarnation of Hermes 4 balances scale and size. It handles complex reasoning tasks, while staying fast and cost effective. A versatile choice for many use cases.",
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, ModelInfo>;


### PR DESCRIPTION
Refs #6759

`vertexGlobalModels` filters `vertexModels` by presence of the `supportsGlobalEndpoint` key (`apps/vscode/src/shared/api.ts:1935`), and `VertexProvider.tsx:69` swaps the picker over to that filtered list when `vertexRegion === "global"`. Two entries were missing the key:

- `claude-sonnet-5:1m` (`api.ts:1369`)
- `claude-sonnet-4-6:1m` (`api.ts:1394`)

So at `region = global` you can pick Claude Opus 5 with a 1M context window but not Claude Sonnet 5 with one.

## Why this is an omission rather than a capability difference

- Every other Claude `:1m` entry in `vertexModels` already carries the flag: `claude-opus-5:1m` (:1503), `claude-opus-4-8:1m` (:1529), plus the 4.7, 4.6 and Fable 5 variants.
- Both non-1M siblings carry it: `claude-sonnet-5` (:1361), `claude-sonnet-4-6` (:1387).
- The Bedrock counterparts carry it: `anthropic.claude-sonnet-5:1m` (:688), `anthropic.claude-sonnet-4-6:1m` (:713).
- Anthropic's Vertex documentation lists Claude Sonnet 5 and Claude Sonnet 4.6 among the models with a 1M token context window on Vertex, and states that specific regional endpoints support Claude Sonnet 4.6 and earlier while newer models use the global or multi-region endpoints.

## Impact and regression risk

The `:1m` suffix is stripped before the request is built (`apps/vscode/src/core/api/providers/vertex.ts:85-88`), so the id on the wire is `claude-sonnet-5`, which is already offered at `global` today. The only thing the suffix changes is the `anthropic-beta: context-1m-2025-08-07` header (`vertex.ts:150-158`). This makes an already reachable model selectable; it does not create a new request shape.

What does not change: no filter logic, no pricing, no token limits, no behavior in any other region, and no models added. `supportsGlobalEndpoint` is never read in the Vertex request path, so on Vertex it is picker-filter-only. The other consumer is Bedrock (`bedrock.ts:332`, `BedrockProvider.tsx:380`), which sources from `bedrockModels` and cannot see Vertex ids.

## Testing

Added a regression test in `apps/vscode/src/shared/__tests__/api.test.ts`. It fails on `legacy-extension` and passes with this change.

    npm --prefix apps/vscode ci
    npm --prefix apps/vscode run protos
    npm --prefix apps/vscode run test:unit -- --grep "Vertex global endpoint"

Before: `AssertionError: expected { Object (gemini-3.5-flash, ...) } to have property 'claude-sonnet-5:1m'`
After: `1 passing`

`npm run check-types` and `npm run lint` both exit 0. The full unit suite is green apart from a few `BannerService` timeouts that also occur on an unmodified checkout of this branch.