### PR TITLE
refactor(ui): one row per tool call, terminal-style commands, and review fixes

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -756,7 +756,9 @@ function ChatInputBarImpl({
 					)}
 					<div
 						className={cn(
-							"flex items-end gap-2 rounded-lg border border-border bg-background px-3 py-2.5 transition-[border-color,box-shadow] focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20",
+							// Focus feedback lands instantly — no transition — so the
+							// border reads as state, not animation.
+							"flex items-end gap-2 rounded-lg border border-border bg-background px-3 py-2.5 focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20",
 							variant === "welcome" &&
 								"min-h-16 rounded-none border-0 bg-transparent px-0 py-0 focus-within:ring-0",
 						)}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -141,8 +141,9 @@ const EFFORT_LEVELS: ReasoningEffortOption[] = [
 	{ label: "High", value: "high" },
 	{ label: "Extra", value: "xhigh" },
 ];
-const PROMPT_INPUT_COLLAPSED_ROWS = 1;
-const PROMPT_INPUT_EXPANDED_ROWS = 2;
+// The composer keeps a steady two-line height whether or not it has focus —
+// resizing on blur made the bottom of the conversation jump around.
+const PROMPT_INPUT_ROWS = 2;
 const PROMPT_INPUT_MAX_ROWS = 5;
 const PROMPT_INPUT_LINE_HEIGHT_REM = 1.25;
 
@@ -377,7 +378,6 @@ function ChatInputBarImpl({
 	}, [onSend, promptInput, setPromptInput]);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
-	const [promptInputFocused, setPromptInputFocused] = useState(false);
 	const [cursorIndex, setCursorIndex] = useState(() => promptInput.length);
 	// Mention/slash detection is derived synchronously from the input +
 	// cursor. Deriving (rather than syncing through effects) keeps a keystroke
@@ -429,10 +429,7 @@ function ChatInputBarImpl({
 			: !hasExplicitReasoningSelection && modelSupportsReasoning === false
 				? "None"
 				: (EFFORT_LEVELS[effortIndex]?.label ?? "Reasoning");
-	const promptInputRows =
-		variant === "welcome" || promptInputFocused
-			? PROMPT_INPUT_EXPANDED_ROWS
-			: PROMPT_INPUT_COLLAPSED_ROWS;
+	const promptInputRows = PROMPT_INPUT_ROWS;
 	const handleEffortChange = useCallback(
 		(value: string) => {
 			if (modelSupportsReasoning !== true) {
@@ -797,8 +794,6 @@ function ChatInputBarImpl({
 									e.currentTarget.selectionStart ?? promptInput.length,
 								)
 							}
-							onBlur={() => setPromptInputFocused(false)}
-							onFocus={() => setPromptInputFocused(true)}
 							onPaste={(e) => {
 								const images = imageFilesFromClipboard(e.clipboardData);
 								if (images.length > 0) {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -669,12 +669,12 @@ describe("ChatMessages tool disclosures", () => {
 		expect(userActions?.classList.contains("absolute")).toBe(true);
 		expect(userActions?.classList.contains("right-0")).toBe(true);
 		expect(userActions?.classList.contains("top-full")).toBe(true);
-		expect(userActions?.classList.contains("translate-y-2")).toBe(true);
+		expect(userActions?.classList.contains("pt-2")).toBe(true);
 		expect(assistantMessage?.classList.contains("relative")).toBe(true);
 		expect(assistantActions?.classList.contains("absolute")).toBe(true);
 		expect(assistantActions?.classList.contains("left-0")).toBe(true);
 		expect(assistantActions?.classList.contains("top-full")).toBe(true);
-		expect(assistantActions?.classList.contains("translate-y-2")).toBe(true);
+		expect(assistantActions?.classList.contains("pt-2")).toBe(true);
 		expect(assistantActions?.getAttribute("data-visible")).toBe("true");
 		const userAction = userActions?.querySelector(".cline-chat-message-action");
 		expect(userAction?.classList.contains("min-w-0")).toBe(true);

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -225,12 +225,12 @@ describe("ChatMessages tool disclosures", () => {
 		expect(container.querySelectorAll(".cline-chat-tool")).toHaveLength(5);
 		expect(container.textContent).toContain("Read 2 files");
 		for (const path of ["one.ts", "two.ts", "three.ts", "four.ts"]) {
-			expect(container.textContent).toContain(`Edited ${path}`);
+			expect(container.textContent).toContain(`Edited file ${path}`);
 		}
 		expect(container.textContent).not.toContain("·");
 	});
 
-	it("renders a single command as a terminal prompt with output on expand", async () => {
+	it("leads a command row with the action and shows output on expand", async () => {
 		await renderMessages([
 			{
 				id: "command",
@@ -246,7 +246,7 @@ describe("ChatMessages tool disclosures", () => {
 		]);
 
 		const trigger = [...container.querySelectorAll("button")].find((element) =>
-			element.textContent?.includes("$ bun run test"),
+			element.textContent?.includes("Ran command bun run test"),
 		);
 		expect(trigger).toBeDefined();
 		await act(async () => trigger?.click());
@@ -500,9 +500,9 @@ describe("ChatMessages tool disclosures", () => {
 		const labels = [...container.querySelectorAll(".cline-chat-tool")].map(
 			(row) => row.textContent ?? "",
 		);
-		expect(labels[0]).toContain("Read before.ts");
-		expect(labels[1]).toContain("Edited change.ts");
-		expect(labels[2]).toContain("Read after.ts");
+		expect(labels[0]).toContain("Read file before.ts");
+		expect(labels[1]).toContain("Edited file change.ts");
+		expect(labels[2]).toContain("Read file after.ts");
 	});
 
 	it("starts a new tool group after non-tool content", async () => {
@@ -530,8 +530,8 @@ describe("ChatMessages tool disclosures", () => {
 			tool("second", 3),
 		]);
 
-		expect(container.textContent).toContain("Read first.ts");
-		expect(container.textContent).toContain("Read second.ts");
+		expect(container.textContent).toContain("Read file first.ts");
+		expect(container.textContent).toContain("Read file second.ts");
 	});
 
 	it("normalizes payload-backed configured subagent names", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -669,12 +669,12 @@ describe("ChatMessages tool disclosures", () => {
 		expect(userActions?.classList.contains("absolute")).toBe(true);
 		expect(userActions?.classList.contains("right-0")).toBe(true);
 		expect(userActions?.classList.contains("top-full")).toBe(true);
-		expect(userActions?.classList.contains("-translate-y-1")).toBe(true);
+		expect(userActions?.classList.contains("translate-y-0.5")).toBe(true);
 		expect(assistantMessage?.classList.contains("relative")).toBe(true);
 		expect(assistantActions?.classList.contains("absolute")).toBe(true);
 		expect(assistantActions?.classList.contains("left-0")).toBe(true);
 		expect(assistantActions?.classList.contains("top-full")).toBe(true);
-		expect(assistantActions?.classList.contains("-translate-y-1")).toBe(true);
+		expect(assistantActions?.classList.contains("translate-y-0.5")).toBe(true);
 		expect(assistantActions?.getAttribute("data-visible")).toBe("true");
 		const userAction = userActions?.querySelector(".cline-chat-message-action");
 		expect(userAction?.classList.contains("min-w-0")).toBe(true);

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -1389,15 +1389,43 @@ describe("ChatMessages thinking indicator", () => {
 					id: "tool-1",
 					sessionId: "session-1",
 					role: "tool",
-					content: "not-json",
+					content: JSON.stringify({
+						toolName: "read_files",
+						input: { paths: ["pending.ts"] },
+						result: null,
+					}),
 					createdAt: 2,
-					meta: { toolName: "search" },
+					meta: { hookEventName: "tool_call_start" },
 				},
 			],
 			{ status: "running" },
 		);
 
 		expect(container.textContent).not.toContain("Thinking...");
+	});
+
+	it("shows between a finished tool and the next output", async () => {
+		// The quiet stretch while the model composes its next step (e.g.
+		// streams tool-call arguments) used to render nothing and look frozen.
+		await renderMessages(
+			[
+				userMessage,
+				{
+					id: "tool-1",
+					sessionId: "session-1",
+					role: "tool",
+					content: JSON.stringify({
+						toolName: "read_files",
+						input: { paths: ["done.ts"] },
+						result: { content: "done" },
+					}),
+					createdAt: 2,
+				},
+			],
+			{ status: "running" },
+		);
+
+		expect(container.textContent).toContain("Thinking...");
 	});
 
 	it("hides while a tool approval is pending", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -6,6 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage } from "@/lib/chat-schema";
 import { ChatMessages } from "./chat-messages";
 
+// @pierre/diffs' custom element adopts constructable stylesheets, which jsdom
+// does not implement; without this the suite exits nonzero on an unhandled
+// error even with every test passing.
+CSSStyleSheet.prototype.replaceSync ??= function replaceSync() {} as never;
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -185,7 +190,7 @@ describe("ChatMessages tool disclosures", () => {
 		);
 	});
 
-	it("groups consecutive tool calls and combines matching activity totals", async () => {
+	it("renders consecutive tool calls as individual rows", async () => {
 		const tools: ChatMessage[] = [
 			{
 				id: "read",
@@ -215,8 +220,37 @@ describe("ChatMessages tool disclosures", () => {
 
 		await renderMessages(tools);
 
-		expect(container.textContent).toContain("Read 2 files · Edited 4 files");
-		expect(container.textContent?.match(/Read 2 files/g)).toHaveLength(1);
+		// One row per call — the multi-file read keeps its own count, and each
+		// edit stands alone; nothing merges across calls.
+		expect(container.querySelectorAll(".cline-chat-tool")).toHaveLength(5);
+		expect(container.textContent).toContain("Read 2 files");
+		for (const path of ["one.ts", "two.ts", "three.ts", "four.ts"]) {
+			expect(container.textContent).toContain(`Edited ${path}`);
+		}
+		expect(container.textContent).not.toContain("·");
+	});
+
+	it("renders a single command as a terminal prompt with output on expand", async () => {
+		await renderMessages([
+			{
+				id: "command",
+				sessionId: "session-1",
+				role: "tool",
+				content: JSON.stringify({
+					toolName: "run_commands",
+					input: { commands: ["bun run test"] },
+					result: "45 tests passed",
+				}),
+				createdAt: 1,
+			},
+		]);
+
+		const trigger = [...container.querySelectorAll("button")].find((element) =>
+			element.textContent?.includes("$ bun run test"),
+		);
+		expect(trigger).toBeDefined();
+		await act(async () => trigger?.click());
+		expect(container.textContent).toContain("45 tests passed");
 	});
 
 	it("pre-expands tool groups that contain edit diffs", async () => {
@@ -313,11 +347,13 @@ describe("ChatMessages tool disclosures", () => {
 			),
 		);
 
-		const trigger = [...container.querySelectorAll("button")].find((element) =>
-			element.textContent?.includes("Spawned 3 teammates"),
+		const triggers = [...container.querySelectorAll("button")].filter(
+			(element) => element.textContent?.includes("Spawned 1 teammate"),
 		);
-		expect(trigger).toBeDefined();
-		await act(async () => trigger?.click());
+		expect(triggers).toHaveLength(3);
+		for (const trigger of triggers) {
+			await act(async () => trigger.click());
+		}
 		expect(container.textContent).toContain("reviewer");
 		expect(container.textContent).toContain("tester");
 		expect(container.textContent).toContain("writer");
@@ -340,11 +376,13 @@ describe("ChatMessages tool disclosures", () => {
 			),
 		);
 
-		const trigger = [...container.querySelectorAll("button")].find((element) =>
-			element.textContent?.includes("Assigned 2 team tasks"),
+		const triggers = [...container.querySelectorAll("button")].filter(
+			(element) => element.textContent?.includes("Assigned 1 team task"),
 		);
-		expect(trigger).toBeDefined();
-		await act(async () => trigger?.click());
+		expect(triggers).toHaveLength(2);
+		for (const trigger of triggers) {
+			await act(async () => trigger.click());
+		}
 		expect(container.textContent).toContain("async reviewer queued");
 		expect(container.textContent).toContain("async tester queued");
 	});
@@ -458,9 +496,13 @@ describe("ChatMessages tool disclosures", () => {
 			read("read-after", "after.ts", 3),
 		]);
 
-		expect(container.textContent).toContain(
-			"Read 1 file · Edited 1 file · Read 1 file",
+		// Rows keep call order, each with its own specific label.
+		const labels = [...container.querySelectorAll(".cline-chat-tool")].map(
+			(row) => row.textContent ?? "",
 		);
+		expect(labels[0]).toContain("Read before.ts");
+		expect(labels[1]).toContain("Edited change.ts");
+		expect(labels[2]).toContain("Read after.ts");
 	});
 
 	it("starts a new tool group after non-tool content", async () => {
@@ -520,9 +562,8 @@ describe("ChatMessages tool disclosures", () => {
 			),
 		]);
 
-		expect(container.textContent).toContain(
-			"Ran 2 commands · Spawned 3 agents",
-		);
+		expect(container.textContent).toContain("Ran 2 commands");
+		expect(container.textContent?.match(/Spawned agent/g)).toHaveLength(3);
 		expect(container.textContent).not.toContain("subagent_subagent");
 	});
 
@@ -1067,7 +1108,9 @@ describe("ChatMessages reasoning disclosure", () => {
 				role: "tool",
 				content: JSON.stringify({
 					toolName: "run_commands",
-					input: { commands: ["git status"] },
+					// Two commands so the expanded panel renders detail rows (a
+					// single untruncated command lives in the label alone).
+					input: { commands: ["git status", "git diff"] },
 					result: {},
 				}),
 				createdAt: 3_000,

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -669,12 +669,12 @@ describe("ChatMessages tool disclosures", () => {
 		expect(userActions?.classList.contains("absolute")).toBe(true);
 		expect(userActions?.classList.contains("right-0")).toBe(true);
 		expect(userActions?.classList.contains("top-full")).toBe(true);
-		expect(userActions?.classList.contains("translate-y-1.5")).toBe(true);
+		expect(userActions?.classList.contains("translate-y-2")).toBe(true);
 		expect(assistantMessage?.classList.contains("relative")).toBe(true);
 		expect(assistantActions?.classList.contains("absolute")).toBe(true);
 		expect(assistantActions?.classList.contains("left-0")).toBe(true);
 		expect(assistantActions?.classList.contains("top-full")).toBe(true);
-		expect(assistantActions?.classList.contains("translate-y-1.5")).toBe(true);
+		expect(assistantActions?.classList.contains("translate-y-2")).toBe(true);
 		expect(assistantActions?.getAttribute("data-visible")).toBe("true");
 		const userAction = userActions?.querySelector(".cline-chat-message-action");
 		expect(userAction?.classList.contains("min-w-0")).toBe(true);

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -669,12 +669,12 @@ describe("ChatMessages tool disclosures", () => {
 		expect(userActions?.classList.contains("absolute")).toBe(true);
 		expect(userActions?.classList.contains("right-0")).toBe(true);
 		expect(userActions?.classList.contains("top-full")).toBe(true);
-		expect(userActions?.classList.contains("translate-y-0.5")).toBe(true);
+		expect(userActions?.classList.contains("translate-y-1.5")).toBe(true);
 		expect(assistantMessage?.classList.contains("relative")).toBe(true);
 		expect(assistantActions?.classList.contains("absolute")).toBe(true);
 		expect(assistantActions?.classList.contains("left-0")).toBe(true);
 		expect(assistantActions?.classList.contains("top-full")).toBe(true);
-		expect(assistantActions?.classList.contains("translate-y-0.5")).toBe(true);
+		expect(assistantActions?.classList.contains("translate-y-1.5")).toBe(true);
 		expect(assistantActions?.getAttribute("data-visible")).toBe("true");
 		const userAction = userActions?.querySelector(".cline-chat-message-action");
 		expect(userAction?.classList.contains("min-w-0")).toBe(true);

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -21,7 +21,7 @@ import {
 	ToolActivityTrigger,
 } from "@cline/ui/components/agent-chat";
 import { ToolFileDiff } from "@cline/ui/components/agent-chat/tool-diff";
-import { buildGroupedToolLabel } from "@cline/ui/components/agent-chat/tool-summary";
+import type { ToolLabelPart } from "@cline/ui/components/agent-chat/tool-summary";
 import {
 	AlertCircle,
 	BrainIcon,
@@ -33,7 +33,6 @@ import {
 	ShieldAlert,
 	SplitIcon,
 	UndoIcon,
-	WrenchIcon,
 	X,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
@@ -1221,166 +1220,192 @@ function pruneRequestMap<T extends string>(
 // Memoized with element-wise comparison: the grouping pass wraps the same
 // message objects in fresh arrays every commit, so reference-comparing the
 // contents lets finished tool blocks skip re-rendering during streaming.
+function ToolLabel({
+	parts,
+	isRunning,
+}: {
+	parts: ToolLabelPart[];
+	isRunning: boolean;
+}) {
+	return (
+		<span className={cn(isRunning && STREAMING_TITLE_CLASS)}>
+			{parts.map((part, index) =>
+				part.code ? (
+					<span
+						className="font-mono text-[0.92em]"
+						// biome-ignore lint/suspicious/noArrayIndexKey: parts are positional
+						key={index}
+					>
+						{part.text}
+					</span>
+				) : (
+					// biome-ignore lint/suspicious/noArrayIndexKey: parts are positional
+					<span key={index}>{part.text}</span>
+				),
+			)}
+		</span>
+	);
+}
+
+// Every tool call renders as its own row: commands read like a terminal
+// prompt, edits carry their diff, and nothing is merged across calls.
+const ToolCallRow = memo(function ToolCallRow({
+	message,
+}: {
+	message: ChatMessage;
+}) {
+	const { payload, toolName, inProgress, summary } =
+		buildToolPresentation(message);
+	const fileDiffs = summary.items.flatMap((item, index) => {
+		if (item.type !== "file") return [];
+		const hunks =
+			item.hunks ??
+			(item.newText !== undefined
+				? [{ oldText: item.oldText, newText: item.newText }]
+				: null);
+		if (hunks) {
+			return hunks.map((hunk, hunkIndex) => ({
+				key: `${message.id}_diff_${index}_${hunkIndex}`,
+				kind: "rich" as const,
+				item,
+				hunk,
+			}));
+		}
+		return item.diff
+			? [
+					{
+						key: `${message.id}_diff_${index}`,
+						kind: "text" as const,
+						item,
+						hunk: null,
+					},
+				]
+			: [];
+	});
+	// Edit rows open pre-expanded so their diffs are immediately visible.
+	// `defaultOpen` alone misses the streaming path: a row can mount before
+	// its diff arrives, so open when one first appears — unless the user has
+	// taken over the disclosure.
+	const hasFileDiffs = fileDiffs.length > 0;
+	const [open, setOpen] = useState(hasFileDiffs);
+	const [userToggled, setUserToggled] = useState(false);
+	useEffect(() => {
+		if (hasFileDiffs && !userToggled) {
+			setOpen(true);
+		}
+	}, [hasFileDiffs, userToggled]);
+	const handleOpenChange = useCallback((nextOpen: boolean) => {
+		setUserToggled(true);
+		setOpen(nextOpen);
+	}, []);
+
+	const hasError = Boolean(payload?.isError);
+	const Icon = getToolNameIcon(toolName);
+	const isCommand = summary.kind === "command";
+	// Index-based keys: identical detail lines (the same file read twice)
+	// would collide on a content-derived key.
+	const details = summary.details.map((detail, index) => ({
+		detail,
+		key: `${message.id}_${index}`,
+	}));
+	const inputPreview =
+		IS_DEBUG && payload ? formatToolValue(payload.input) : "";
+	const hasExpandedSections =
+		details.length > 0 ||
+		fileDiffs.length > 0 ||
+		Boolean(summary.outputText) ||
+		Boolean(summary.errorText) ||
+		Boolean(inputPreview);
+
+	return (
+		<ToolActivity
+			className="my-0"
+			expandable={hasExpandedSections}
+			onOpenChange={handleOpenChange}
+			open={open}
+		>
+			<ToolActivityTrigger
+				additions={summary.diff?.additions || undefined}
+				deletions={summary.diff?.deletions || undefined}
+				icon={
+					hasError ? (
+						<AlertCircle className="size-4 text-destructive/80" />
+					) : (
+						<Icon className="size-4" />
+					)
+				}
+				label={<ToolLabel isRunning={inProgress} parts={summary.labelParts} />}
+				showDisclosureIcon={false}
+				status={hasError ? "error" : inProgress ? "running" : "success"}
+			/>
+			<ToolActivityContent className={EXPANDED_PANEL_RAIL_CLASS}>
+				{details.length > 0 ? (
+					<ToolActivityDetails
+						className={cn(
+							"whitespace-pre-wrap",
+							isCommand && "font-mono text-xs",
+						)}
+					>
+						{details.map(({ detail, key }) => (
+							<div key={key}>{isCommand ? `$ ${detail}` : detail}</div>
+						))}
+					</ToolActivityDetails>
+				) : null}
+				{fileDiffs.map((entry) =>
+					entry.kind === "rich" && entry.hunk ? (
+						<ToolFileDiff
+							className="mt-1"
+							fragment={entry.item.fragment}
+							key={entry.key}
+							newText={entry.hunk.newText}
+							oldText={entry.hunk.oldText}
+							path={entry.item.path}
+						/>
+					) : (
+						<ToolActivityCode
+							className="mt-1 overflow-x-auto text-xs"
+							key={entry.key}
+						>
+							{entry.item.diff}
+						</ToolActivityCode>
+					),
+				)}
+				{summary.outputText ? (
+					<ToolActivityCode className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs">
+						{summary.outputText}
+					</ToolActivityCode>
+				) : null}
+				{inputPreview ? (
+					<div className="space-y-1">
+						<div className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
+							Input
+						</div>
+						<ToolActivityCode className="text-sm">
+							{inputPreview}
+						</ToolActivityCode>
+					</div>
+				) : null}
+				{summary.errorText ? (
+					<div className="mt-1 break-words text-destructive">
+						{summary.errorText}
+					</div>
+				) : null}
+			</ToolActivityContent>
+		</ToolActivity>
+	);
+});
+
+// Consecutive tool messages stack as individual rows; the element-wise
+// comparison lets finished rows skip re-rendering during streaming.
 const ToolMessageBlock = memo(
 	function ToolMessageBlock({ messages }: { messages: ChatMessage[] }) {
-		const presentations = messages.map(buildToolPresentation);
-		const hasFileDiffs = presentations.some(({ summary }) =>
-			summary.items.some(
-				(item) =>
-					item.type === "file" && (item.newText !== undefined || item.diff),
-			),
-		);
-		// Edit rows open pre-expanded so their diffs are immediately visible.
-		// `defaultOpen` alone misses the streaming path: a group mounts with its
-		// first (often read) call and only gains the edit later, so open when a
-		// diff first arrives — unless the user has taken over the disclosure.
-		const [open, setOpen] = useState(hasFileDiffs);
-		const [userToggled, setUserToggled] = useState(false);
-		useEffect(() => {
-			if (hasFileDiffs && !userToggled) {
-				setOpen(true);
-			}
-		}, [hasFileDiffs, userToggled]);
-		const handleOpenChange = useCallback((nextOpen: boolean) => {
-			setUserToggled(true);
-			setOpen(nextOpen);
-		}, []);
-		if (presentations.length === 0) return null;
-		const hasError = presentations.some(({ payload }) => payload?.isError);
-		const isRunning = presentations.some(({ inProgress }) => inProgress);
-		const label = buildGroupedToolLabel(
-			presentations.map(({ summary, inProgress }) => ({
-				label: summary.label,
-				aggregate: summary.aggregate,
-				inProgress,
-			})),
-		);
-		const icons = presentations.map(({ toolName }) =>
-			getToolNameIcon(toolName),
-		);
-		const firstIcon = icons[0] ?? WrenchIcon;
-		const Icon = icons.every((icon) => icon === firstIcon)
-			? firstIcon
-			: WrenchIcon;
-		// Index-based keys: identical detail lines (the same file read twice)
-		// would collide on a content-derived key.
-		const details = presentations.flatMap(({ message, summary }) =>
-			summary.details.map((detail, index) => ({
-				detail,
-				key: `${message.id}_${index}`,
-			})),
-		);
-		const fileDiffs = presentations.flatMap(({ message, summary }) =>
-			summary.items.flatMap((item, index) =>
-				item.type === "file" && (item.newText !== undefined || item.diff)
-					? [{ item, key: `${message.id}_diff_${index}` }]
-					: [],
-			),
-		);
-		const inputPreviews = IS_DEBUG
-			? presentations
-					.map(({ message, payload, toolName }) => ({
-						key: message.id,
-						toolName,
-						value: payload ? formatToolValue(payload.input) : "",
-					}))
-					.filter(({ value }) => Boolean(value))
-			: [];
-		const errorPreviews = presentations
-			.map(({ message, summary, toolName }) => ({
-				key: message.id,
-				toolName,
-				value: summary.errorText ?? "",
-			}))
-			.filter(({ value }) => Boolean(value));
-		const hasExpandedSections =
-			details.length > 0 ||
-			fileDiffs.length > 0 ||
-			inputPreviews.length > 0 ||
-			errorPreviews.length > 0;
-		const diff = presentations.reduce(
-			(total, { summary }) => ({
-				additions: total.additions + (summary.diff?.additions ?? 0),
-				deletions: total.deletions + (summary.diff?.deletions ?? 0),
-			}),
-			{ additions: 0, deletions: 0 },
-		);
-
+		if (messages.length === 0) return null;
 		return (
-			<ToolActivity
-				className="my-0"
-				expandable={hasExpandedSections}
-				onOpenChange={handleOpenChange}
-				open={open}
-			>
-				<ToolActivityTrigger
-					additions={diff.additions || undefined}
-					deletions={diff.deletions || undefined}
-					icon={
-						hasError ? (
-							<AlertCircle className="size-4 text-destructive/80" />
-						) : (
-							<Icon className="size-4" />
-						)
-					}
-					label={
-						<span className={cn(isRunning && STREAMING_TITLE_CLASS)}>
-							{label}
-						</span>
-					}
-					showDisclosureIcon={false}
-					status={hasError ? "error" : isRunning ? "running" : "success"}
-				/>
-				<ToolActivityContent className={EXPANDED_PANEL_RAIL_CLASS}>
-					{details.length > 0 ? (
-						<ToolActivityDetails className="whitespace-pre-wrap">
-							{details.map(({ detail, key }) => (
-								<div key={key}>{detail}</div>
-							))}
-						</ToolActivityDetails>
-					) : null}
-					{fileDiffs.map((entry) =>
-						entry.item.newText !== undefined ? (
-							<ToolFileDiff
-								className="mt-1"
-								fragment={entry.item.fragment}
-								key={entry.key}
-								newText={entry.item.newText}
-								oldText={entry.item.oldText}
-								path={entry.item.path}
-							/>
-						) : (
-							<ToolActivityCode
-								className="mt-1 overflow-x-auto text-xs"
-								key={entry.key}
-							>
-								{entry.item.diff}
-							</ToolActivityCode>
-						),
-					)}
-					{inputPreviews.map((preview) => (
-						<div className="space-y-1" key={`input_${preview.key}`}>
-							<div className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
-								{presentations.length > 1
-									? `${preview.toolName} input`
-									: "Input"}
-							</div>
-							<ToolActivityCode className="text-sm">
-								{preview.value}
-							</ToolActivityCode>
-						</div>
-					))}
-					{errorPreviews.map((preview) => (
-						<div
-							className="mt-1 break-words text-destructive"
-							key={`result_${preview.key}`}
-						>
-							{presentations.length > 1 ? `${preview.toolName}: ` : null}
-							{preview.value}
-						</div>
-					))}
-				</ToolActivityContent>
-			</ToolActivity>
+			<div className="flex flex-col gap-1">
+				{messages.map((message) => (
+					<ToolCallRow key={message.id} message={message} />
+				))}
+			</div>
 		);
 	},
 	(prev, next) =>

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -671,8 +671,11 @@ function ChatMessagesImpl({
 					) : null}
 					{(status === "starting" || isAwaitingFirstOutput) &&
 					!isSessionSwitching ? (
-						<div className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
-							<Loader2 className="h-4 w-4 animate-spin" />
+						// Mirrors the tool-row trigger metrics (min-h-7, py-1, gap-2,
+						// 16px icon, font-medium) so text does not shift when this
+						// swaps with an arriving tool row.
+						<div className="mt-2 flex min-h-7 items-center gap-2 py-1 text-sm font-medium text-muted-foreground">
+							<Loader2 className="size-4 animate-spin" />
 							<span className={STREAMING_TITLE_CLASS}>Thinking...</span>
 						</div>
 					) : null}
@@ -1045,7 +1048,7 @@ const MessageBubble = memo(function MessageBubble({
 			{shouldRenderUserActions ? (
 				<>
 					<MessageActions
-						className="absolute right-0 top-full z-10 -translate-y-1"
+						className="absolute right-0 top-full z-10 translate-y-0.5"
 						visible={keepUserActionsVisible}
 					>
 						{onCopyMessage ? (
@@ -1113,7 +1116,7 @@ const MessageBubble = memo(function MessageBubble({
 
 			{shouldRenderAssistantActions ? (
 				<MessageActions
-					className="absolute left-0 top-full z-10 -translate-y-1"
+					className="absolute left-0 top-full z-10 translate-y-0.5"
 					visible={keepAssistantActionsVisible}
 				>
 					{onCopyMessage ? (

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -525,7 +525,9 @@ function ChatMessagesImpl({
 				<ConversationContent
 					className={cn(
 						"relative mx-auto min-h-full w-full min-w-0 max-w-full",
-						showIdleDetails ? "p-0" : "px-6 py-6",
+						// Extra bottom padding keeps the last message (and the
+						// hover actions hanging below it) clear of the composer.
+						showIdleDetails ? "p-0" : "px-6 pt-6 pb-14",
 					)}
 				>
 					{showIdleDetails ? null : (

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -170,13 +170,21 @@ function ChatMessagesImpl({
 	}, [messages]);
 	const shouldShowErrorBanner =
 		Boolean(error) && (!lastErrorMessage || lastErrorMessage.content !== error);
-	// Core reports "running" as soon as the turn is dispatched, well before the
-	// first streamed chunk arrives, so keep the thinking indicator up until the
-	// model produces output (or something else needs the user's attention).
+	// Core reports "running" as soon as the turn is dispatched, and there are
+	// quiet stretches mid-turn with nothing visibly active — most notably
+	// while the model streams a tool call's arguments, before any tool row
+	// exists. Show the thinking indicator whenever the turn is running and
+	// neither streaming text nor an in-progress tool row is on screen.
+	const lastToolInProgress = useMemo(
+		() =>
+			lastConversationMessage?.role === "tool" &&
+			buildToolPresentation(lastConversationMessage).inProgress,
+		[lastConversationMessage],
+	);
 	const isAwaitingFirstOutput =
 		status === "running" &&
 		!streamingMessageId &&
-		lastConversationMessage?.role === "user" &&
+		!lastToolInProgress &&
 		pendingToolApprovals.length === 0 &&
 		pendingAskQuestions.length === 0;
 	const [showSwitchTransition, setShowSwitchTransition] = useState(false);

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -673,8 +673,11 @@ function ChatMessagesImpl({
 					!isSessionSwitching ? (
 						// Mirrors the tool-row trigger metrics (min-h-7, py-1, gap-2,
 						// 16px icon, font-medium) so text does not shift when this
-						// swaps with an arriving tool row.
-						<div className="mt-2 flex min-h-7 items-center gap-2 py-1 text-sm font-medium text-muted-foreground">
+						// swaps with an arriving tool row. No margin of its own: the
+						// conversation column's gap already matches the spacing a tool
+						// row would get, so any extra margin makes this render lower
+						// than its replacement.
+						<div className="flex min-h-7 items-center gap-2 py-1 text-sm font-medium text-muted-foreground">
 							<Loader2 className="size-4 animate-spin" />
 							<span className={STREAMING_TITLE_CLASS}>Thinking...</span>
 						</div>

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -995,7 +995,7 @@ const MessageBubble = memo(function MessageBubble({
 		: null;
 	const messageTimestamp = messageTime ? (
 		<time
-			className="shrink-0 whitespace-nowrap text-sm leading-none text-muted-foreground/70"
+			className="shrink-0 whitespace-nowrap text-xs leading-none text-muted-foreground/70"
 			dateTime={messageDate.toISOString()}
 			title={messageDate.toLocaleString()}
 		>
@@ -1051,7 +1051,7 @@ const MessageBubble = memo(function MessageBubble({
 			{shouldRenderUserActions ? (
 				<>
 					<MessageActions
-						className="absolute right-0 top-full z-10 translate-y-1.5"
+						className="absolute right-0 top-full z-10 translate-y-2"
 						visible={keepUserActionsVisible}
 					>
 						{onCopyMessage ? (
@@ -1062,9 +1062,9 @@ const MessageBubble = memo(function MessageBubble({
 								title={wasCopied ? "Copied" : "Copy message"}
 							>
 								{wasCopied ? (
-									<Check className="size-4" />
+									<Check className="size-3.5" />
 								) : (
-									<Copy className="size-4" />
+									<Copy className="size-3.5" />
 								)}
 							</MessageAction>
 						) : null}
@@ -1079,9 +1079,9 @@ const MessageBubble = memo(function MessageBubble({
 								title="Edit message and restart from this point"
 							>
 								{editPending ? (
-									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+									<Loader2 className="size-3.5 animate-spin" />
 								) : (
-									<PencilIcon className="size-4" />
+									<PencilIcon className="size-3.5" />
 								)}
 							</MessageAction>
 						) : null}
@@ -1096,9 +1096,9 @@ const MessageBubble = memo(function MessageBubble({
 								title="Restore checkpoint"
 							>
 								{restorePending ? (
-									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+									<Loader2 className="size-3.5 animate-spin" />
 								) : (
-									<UndoIcon className="size-4" />
+									<UndoIcon className="size-3.5" />
 								)}
 							</MessageAction>
 						) : null}
@@ -1119,7 +1119,7 @@ const MessageBubble = memo(function MessageBubble({
 
 			{shouldRenderAssistantActions ? (
 				<MessageActions
-					className="absolute left-0 top-full z-10 translate-y-1.5"
+					className="absolute left-0 top-full z-10 translate-y-2"
 					visible={keepAssistantActionsVisible}
 				>
 					{onCopyMessage ? (
@@ -1134,9 +1134,9 @@ const MessageBubble = memo(function MessageBubble({
 							title={wasCopied ? "Copied" : "Copy raw assistant output"}
 						>
 							{wasCopied ? (
-								<Check className="size-4" />
+								<Check className="size-3.5" />
 							) : (
-								<Copy className="size-4" />
+								<Copy className="size-3.5" />
 							)}
 						</MessageAction>
 					) : null}
@@ -1149,9 +1149,9 @@ const MessageBubble = memo(function MessageBubble({
 							title="Fork session - copy full message history into a new session"
 						>
 							{forkPending ? (
-								<Loader2 className="size-4 animate-spin" />
+								<Loader2 className="size-3.5 animate-spin" />
 							) : (
-								<SplitIcon className="size-4 rotate-90" />
+								<SplitIcon className="size-3.5 rotate-90" />
 							)}
 						</MessageAction>
 					) : null}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -1240,7 +1240,7 @@ function ToolLabel({
 			{parts.map((part, index) =>
 				part.code ? (
 					<span
-						className="font-mono text-[0.92em]"
+						className="font-mono"
 						// biome-ignore lint/suspicious/noArrayIndexKey: parts are positional
 						key={index}
 					>

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -1048,7 +1048,7 @@ const MessageBubble = memo(function MessageBubble({
 			{shouldRenderUserActions ? (
 				<>
 					<MessageActions
-						className="absolute right-0 top-full z-10 translate-y-0.5"
+						className="absolute right-0 top-full z-10 translate-y-1.5"
 						visible={keepUserActionsVisible}
 					>
 						{onCopyMessage ? (
@@ -1116,7 +1116,7 @@ const MessageBubble = memo(function MessageBubble({
 
 			{shouldRenderAssistantActions ? (
 				<MessageActions
-					className="absolute left-0 top-full z-10 translate-y-0.5"
+					className="absolute left-0 top-full z-10 translate-y-1.5"
 					visible={keepAssistantActionsVisible}
 				>
 					{onCopyMessage ? (

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -532,35 +532,6 @@ function ChatMessagesImpl({
 				>
 					{showIdleDetails ? null : (
 						<div className="flex min-h-full w-full min-w-0 flex-col gap-2">
-							{pendingToolApprovals.length > 0 ? (
-								<ToolApprovalPanel
-									items={pendingToolApprovals}
-									onApprove={(requestId) =>
-										handleToolApprovalDecision(
-											requestId,
-											"approving",
-											onApproveToolApproval,
-										)
-									}
-									onReject={(requestId) =>
-										handleToolApprovalDecision(
-											requestId,
-											"rejecting",
-											onRejectToolApproval,
-										)
-									}
-									pendingActions={toolApprovalActions}
-									requestErrors={toolApprovalErrors}
-								/>
-							) : null}
-							{askQuestionItems.length > 0 ? (
-								<AgentAskQuestion
-									errors={askQuestionErrors}
-									items={askQuestionItems}
-									onAnswer={handleAskQuestionAnswer}
-									pendingAnswers={askQuestionActions}
-								/>
-							) : null}
 							{renderItems.map((item) => {
 								if (item.type === "tools") {
 									return (
@@ -647,6 +618,38 @@ function ChatMessagesImpl({
 									/>
 								);
 							})}
+							{/* Pending interactions render inline at the end of the
+							    transcript — they are the newest thing that happened,
+							    not a banner pinned to the top. */}
+							{pendingToolApprovals.length > 0 ? (
+								<ToolApprovalPanel
+									items={pendingToolApprovals}
+									onApprove={(requestId) =>
+										handleToolApprovalDecision(
+											requestId,
+											"approving",
+											onApproveToolApproval,
+										)
+									}
+									onReject={(requestId) =>
+										handleToolApprovalDecision(
+											requestId,
+											"rejecting",
+											onRejectToolApproval,
+										)
+									}
+									pendingActions={toolApprovalActions}
+									requestErrors={toolApprovalErrors}
+								/>
+							) : null}
+							{askQuestionItems.length > 0 ? (
+								<AgentAskQuestion
+									errors={askQuestionErrors}
+									items={askQuestionItems}
+									onAnswer={handleAskQuestionAnswer}
+									pendingAnswers={askQuestionActions}
+								/>
+							) : null}
 						</div>
 					)}
 					{showSwitchTransition ? (

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -995,7 +995,7 @@ const MessageBubble = memo(function MessageBubble({
 		: null;
 	const messageTimestamp = messageTime ? (
 		<time
-			className="shrink-0 whitespace-nowrap text-[11px] leading-none text-muted-foreground"
+			className="shrink-0 whitespace-nowrap text-sm leading-none text-muted-foreground/70"
 			dateTime={messageDate.toISOString()}
 			title={messageDate.toLocaleString()}
 		>
@@ -1056,21 +1056,21 @@ const MessageBubble = memo(function MessageBubble({
 					>
 						{onCopyMessage ? (
 							<MessageAction
-								className="min-w-0 p-0"
+								className="min-w-0 p-0 text-muted-foreground/70 hover:text-foreground"
 								label={wasCopied ? "Copied user message" : "Copy user message"}
 								onClick={() => void onCopyMessage(message.id, message.content)}
 								title={wasCopied ? "Copied" : "Copy message"}
 							>
 								{wasCopied ? (
-									<Check className="h-3.5 w-3.5" />
+									<Check className="size-4" />
 								) : (
-									<Copy className="h-3.5 w-3.5" />
+									<Copy className="size-4" />
 								)}
 							</MessageAction>
 						) : null}
 						{onEditMessage && runCount && displayContent.trim() ? (
 							<MessageAction
-								className="min-w-0 p-0"
+								className="min-w-0 p-0 text-muted-foreground/70 hover:text-foreground"
 								disabled={editDisabled || editPending}
 								label="Edit user message"
 								onClick={() =>
@@ -1081,13 +1081,13 @@ const MessageBubble = memo(function MessageBubble({
 								{editPending ? (
 									<Loader2 className="h-3.5 w-3.5 animate-spin" />
 								) : (
-									<PencilIcon className="h-3.5 w-3.5" />
+									<PencilIcon className="size-4" />
 								)}
 							</MessageAction>
 						) : null}
 						{checkpoint ? (
 							<MessageAction
-								className="min-w-0 p-0"
+								className="min-w-0 p-0 text-muted-foreground/70 hover:text-foreground"
 								disabled={restoreDisabled || restorePending}
 								label="Restore checkpoint"
 								onClick={() =>
@@ -1098,7 +1098,7 @@ const MessageBubble = memo(function MessageBubble({
 								{restorePending ? (
 									<Loader2 className="h-3.5 w-3.5 animate-spin" />
 								) : (
-									<UndoIcon className="h-3.5 w-3.5" />
+									<UndoIcon className="size-4" />
 								)}
 							</MessageAction>
 						) : null}
@@ -1124,7 +1124,7 @@ const MessageBubble = memo(function MessageBubble({
 				>
 					{onCopyMessage ? (
 						<MessageAction
-							className="min-w-0 p-0"
+							className="min-w-0 p-0 text-muted-foreground/70 hover:text-foreground"
 							label={
 								wasCopied
 									? "Copied assistant message"
@@ -1134,24 +1134,24 @@ const MessageBubble = memo(function MessageBubble({
 							title={wasCopied ? "Copied" : "Copy raw assistant output"}
 						>
 							{wasCopied ? (
-								<Check className="h-3 w-3" />
+								<Check className="size-4" />
 							) : (
-								<Copy className="h-3 w-3" />
+								<Copy className="size-4" />
 							)}
 						</MessageAction>
 					) : null}
 					{onForkSession ? (
 						<MessageAction
-							className="min-w-0 p-0"
+							className="min-w-0 p-0 text-muted-foreground/70 hover:text-foreground"
 							disabled={forkDisabled || forkPending}
 							label="Fork session"
 							onClick={() => void onForkSession(message.id)}
 							title="Fork session - copy full message history into a new session"
 						>
 							{forkPending ? (
-								<Loader2 className="h-3 w-3 animate-spin" />
+								<Loader2 className="size-4 animate-spin" />
 							) : (
-								<SplitIcon className="h-3 w-3 rotate-90" />
+								<SplitIcon className="size-4 rotate-90" />
 							)}
 						</MessageAction>
 					) : null}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -1056,7 +1056,10 @@ const MessageBubble = memo(function MessageBubble({
 			{shouldRenderUserActions ? (
 				<>
 					<MessageActions
-						className="absolute right-0 top-full z-10 translate-y-2"
+						// The 8px offset is padding, not translation: a translated gap
+					// is dead space that breaks the parent's :hover on the way to
+					// the buttons, hiding them before they can be clicked.
+					className="absolute right-0 top-full z-10 pt-2"
 						visible={keepUserActionsVisible}
 					>
 						{onCopyMessage ? (
@@ -1124,7 +1127,7 @@ const MessageBubble = memo(function MessageBubble({
 
 			{shouldRenderAssistantActions ? (
 				<MessageActions
-					className="absolute left-0 top-full z-10 translate-y-2"
+					className="absolute left-0 top-full z-10 pt-2"
 					visible={keepAssistantActionsVisible}
 				>
 					{onCopyMessage ? (

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/constants.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/constants.ts
@@ -8,8 +8,11 @@ export const STREAMING_TITLE_CLASS = "cline-chat-streaming-title";
  * use this verbatim, and it overrides the panel chrome (border box, radius,
  * background, inset) that `agent-chat.css` gives each of them by default.
  *
+ * Expanded content renders at full opacity — the user opened it, so it is the
+ * thing they are reading; no hover-to-unfade.
+ *
  * Reasoning stays capped and scrollable, while tool output grows into the
  * conversation scroller and wraps to avoid a nested scrolling region.
  */
 export const EXPANDED_PANEL_RAIL_CLASS =
-	"ml-1 mt-0 max-w-full rounded-none border-0 border-l border-border bg-transparent py-1 px-2 text-sm opacity-70 hover:opacity-100 focus-within:opacity-100";
+	"ml-1 mt-0 max-w-full rounded-none border-0 border-l border-border bg-transparent py-1 px-2 text-sm";

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/tool-summaries.test.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/tool-summaries.test.ts
@@ -125,7 +125,7 @@ describe("buildGroupedToolLabel over presentations", () => {
 			toolName: "read_files",
 			input: { paths: ["a.ts"] },
 		});
-		expect(buildGroupedToolLabel([toGroupInput(only)])).toBe("Read a.ts");
+		expect(buildGroupedToolLabel([toGroupInput(only)])).toBe("Read file a.ts");
 	});
 
 	it("merges consecutive aggregates that share a key", () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.test.tsx
@@ -108,7 +108,9 @@ describe("WelcomeWorkspaceControls manual path entry", () => {
 
 		const pathOption = [
 			...container.querySelectorAll<HTMLButtonElement>("button"),
-		].find((candidate) => candidate.textContent?.includes("Open folder \u201c"));
+		].find((candidate) =>
+			candidate.textContent?.includes("Open folder \u201c"),
+		);
 		expect(pathOption).toBeUndefined();
 	});
 

--- a/sdk/packages/ui/components/agent-ask-question.css
+++ b/sdk/packages/ui/components/agent-ask-question.css
@@ -1,7 +1,14 @@
 .cline-ui-agent-ask-question {
-	/* Defaults match the desktop palette (blue-500/blue-400); hosts may override. */
-	--cline-ui-agent-ask-question-accent: oklch(62.3% 0.214 259.815);
-	--cline-ui-agent-ask-question-accent-border: oklch(70.7% 0.165 254.624);
+	/* Brand violet, falling back to a literal for hosts without the theme
+	 * tokens; hosts may override. */
+	--cline-ui-agent-ask-question-accent: var(
+		--brand-violet,
+		oklch(0.55 0.22 293)
+	);
+	--cline-ui-agent-ask-question-accent-border: var(
+		--brand-violet,
+		oklch(0.62 0.19 293)
+	);
 }
 
 .cline-ui-agent-ask-question,

--- a/sdk/packages/ui/components/agent-ask-question.tsx
+++ b/sdk/packages/ui/components/agent-ask-question.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useId } from "react";
+import type { ReactNode } from "react";
 
 export interface AgentAskQuestionItem {
 	description?: ReactNode;
@@ -48,83 +48,70 @@ export function AgentAskQuestion({
 	onAnswer,
 	pendingAnswers = {},
 }: AgentAskQuestionProps) {
-	const headingId = useId();
-
 	return (
 		<section
-			aria-labelledby={headingId}
-			className="cline-ui-agent-ask-question rounded-cline-ui-xl border border-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent-border)_40%,transparent)] bg-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent)_5%,transparent)] p-3"
+			aria-label="Follow-up question"
+			className="cline-ui-agent-ask-question flex flex-col gap-2"
 		>
-			<h2
-				className="cline-ui-agent-ask-question__heading m-0 flex items-center gap-2 font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm"
-				id={headingId}
-			>
-				<QuestionIcon />
-				Follow-up question
-			</h2>
-			<p className="cline-ui-agent-ask-question__intro m-0 mt-1 text-cline-ui-muted-foreground text-cline-ui-xs">
-				Choose one option to continue the current agent turn.
-			</p>
-			<div className="cline-ui-agent-ask-question__items mt-3 flex flex-col gap-2">
-				{items.map((item) => {
-					const pendingAnswer = pendingAnswers[item.id];
-					const isPending = Boolean(pendingAnswer);
-					const error = errors[item.id];
+			{items.map((item) => {
+				const pendingAnswer = pendingAnswers[item.id];
+				const isPending = Boolean(pendingAnswer);
+				const error = errors[item.id];
 
-					return (
-						<div
-							aria-busy={isPending || undefined}
-							className="cline-ui-agent-ask-question__item rounded-cline-ui-lg border border-cline-ui-border/80 bg-cline-ui-background/70 p-3"
-							key={item.id}
-						>
-							<div className="cline-ui-agent-ask-question__item-header flex items-center justify-between gap-2">
-								<div className="cline-ui-agent-ask-question__question font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm">
-									{item.question}
-								</div>
-								{item.meta ? (
-									<div className="cline-ui-agent-ask-question__meta inline-flex items-center gap-1 text-[11px] text-cline-ui-muted-foreground">
-										{item.meta}
-									</div>
-								) : null}
+				return (
+					<div
+						aria-busy={isPending || undefined}
+						className="cline-ui-agent-ask-question__item rounded-cline-ui-xl border border-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent-border)_40%,transparent)] bg-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent)_5%,transparent)] p-3"
+						key={item.id}
+					>
+						<div className="cline-ui-agent-ask-question__item-header flex items-start justify-between gap-2">
+							<div className="cline-ui-agent-ask-question__question flex items-center gap-2 font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm">
+								<QuestionIcon />
+								{item.question}
 							</div>
-							{item.description ? (
-								<div className="cline-ui-agent-ask-question__description mt-1 text-[11px] text-cline-ui-muted-foreground">
-									{item.description}
+							{item.meta ? (
+								<div className="cline-ui-agent-ask-question__meta inline-flex items-center gap-1 text-[11px] text-cline-ui-muted-foreground">
+									{item.meta}
 								</div>
 							) : null}
-							{error ? (
-								<div
-									className="cline-ui-agent-ask-question__error mt-2 text-cline-ui-destructive text-cline-ui-xs"
-									role="alert"
-								>
-									{error}
-								</div>
-							) : null}
-							<div className="cline-ui-agent-ask-question__options mt-3 flex flex-wrap items-center gap-2">
-								{/* Options are model-supplied and may repeat; repeats submit the same answer. */}
-								{[...new Set(item.options)].map((option) => (
-									<button
-										className="cline-ui-agent-ask-question__option inline-flex min-h-8 max-w-full flex-none cursor-pointer items-center justify-center gap-1.5 whitespace-normal rounded-cline-ui-md border border-cline-ui-border bg-cline-ui-background px-3 py-0 font-cline-ui-medium text-cline-ui-foreground shadow-xs transition-[color,background-color,border-color,box-shadow] duration-150 ease-[ease] [overflow-wrap:anywhere] [&:hover]:bg-cline-ui-accent [&:hover]:text-cline-ui-accent-foreground focus-visible:outline-3 focus-visible:outline-cline-ui-ring/50 focus-visible:outline-offset-0 disabled:pointer-events-none disabled:opacity-50 cline-ui-dark:border-cline-ui-input cline-ui-dark:bg-cline-ui-input/30 cline-ui-dark:[&:hover]:bg-cline-ui-input/50"
-										disabled={isPending}
-										key={option}
-										onClick={() => onAnswer(item.id, option)}
-										type="button"
-									>
-										{pendingAnswer === option ? (
-											<>
-												<Spinner />
-												Sending…
-											</>
-										) : (
-											option
-										)}
-									</button>
-								))}
-							</div>
 						</div>
-					);
-				})}
-			</div>
+						{item.description ? (
+							<div className="cline-ui-agent-ask-question__description mt-1 pl-6 text-[11px] text-cline-ui-muted-foreground">
+								{item.description}
+							</div>
+						) : null}
+						{error ? (
+							<div
+								className="cline-ui-agent-ask-question__error mt-2 pl-6 text-cline-ui-destructive text-cline-ui-xs"
+								role="alert"
+							>
+								{error}
+							</div>
+						) : null}
+						<div className="cline-ui-agent-ask-question__options mt-2.5 flex flex-wrap items-center gap-2 pl-6">
+							{/* Options are model-supplied and may repeat; repeats submit the same answer. */}
+							{[...new Set(item.options)].map((option) => (
+								<button
+									className="cline-ui-agent-ask-question__option inline-flex min-h-8 max-w-full flex-none cursor-pointer items-center justify-center gap-1.5 whitespace-normal rounded-cline-ui-md border border-cline-ui-border bg-cline-ui-background px-3 py-0 font-cline-ui-medium text-cline-ui-foreground shadow-xs transition-[color,background-color,border-color,box-shadow] duration-150 ease-[ease] [overflow-wrap:anywhere] [&:hover]:bg-cline-ui-accent [&:hover]:text-cline-ui-accent-foreground focus-visible:outline-3 focus-visible:outline-cline-ui-ring/50 focus-visible:outline-offset-0 disabled:pointer-events-none disabled:opacity-50 cline-ui-dark:border-cline-ui-input cline-ui-dark:bg-cline-ui-input/30 cline-ui-dark:[&:hover]:bg-cline-ui-input/50"
+									disabled={isPending}
+									key={option}
+									onClick={() => onAnswer(item.id, option)}
+									type="button"
+								>
+									{pendingAnswer === option ? (
+										<>
+											<Spinner />
+											Sending…
+										</>
+									) : (
+										option
+									)}
+								</button>
+							))}
+						</div>
+					</div>
+				);
+			})}
 		</section>
 	);
 }

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -132,6 +132,8 @@
 		color: var(--muted-foreground);
 	}
 
+	/* Actions appear and vanish instantly — a fade on hover chrome reads as
+	 * lag, not polish. */
 	.cline-chat-message-actions {
 		display: flex;
 		min-height: 1.5rem;
@@ -139,7 +141,6 @@
 		gap: 0.25rem;
 		pointer-events: none;
 		opacity: 0;
-		transition: opacity 150ms ease;
 	}
 
 	.cline-chat-message:hover > .cline-chat-message-actions,
@@ -359,7 +360,6 @@
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.cline-chat-message-actions,
 		.cline-chat-disclosure-icon {
 			transition: none;
 		}

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -286,9 +286,13 @@
 		place-items: center;
 	}
 
+	/* Row labels stay on one line, take the full available width, and
+	 * ellipsize at the container edge — the data layer never truncates. */
 	.cline-chat-tool-label {
 		min-width: 0;
-		overflow-wrap: anywhere;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.cline-chat-tool-diff {

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -109,12 +109,14 @@
 		color: var(--foreground);
 	}
 
+	/* User bubbles sit on the brand surface so the person's words read as the
+	 * strongest element in the transcript rather than blending into cards. */
 	.cline-chat-message[data-role="user"] > .cline-chat-message-content {
 		max-width: 85%;
 		padding: 0.5rem;
 		border-radius: calc(var(--radius) - 4px);
-		background: var(--card);
-		color: color-mix(in oklab, var(--foreground) 80%, transparent);
+		background: var(--brand-violet-surface, var(--primary));
+		color: var(--brand-violet-surface-foreground, var(--primary-foreground));
 	}
 
 	.cline-chat-message[data-role="error"] > .cline-chat-message-content {

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -305,10 +305,14 @@
 		color: var(--error-text);
 	}
 
+	/* The spinner stands in for the tool icon while the call is in flight, so
+	 * it fills the same 1rem box the icons render at and the label never
+	 * shifts when they swap. */
 	.cline-chat-tool-progress {
-		width: 0.75rem;
-		height: 0.75rem;
+		width: 1rem;
+		height: 1rem;
 		flex: 0 0 auto;
+		box-sizing: border-box;
 		border: 2px solid
 			color-mix(in oklab, var(--brand-violet, var(--primary)) 25%, transparent);
 		border-top-color: var(--brand-violet, var(--primary));

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -245,13 +245,9 @@
 		margin: 0.5rem 0;
 	}
 
-	.cline-chat-tool-trigger {
-		color: var(--success-text);
-	}
-
 	/* Active tool rows carry the brand accent; finished rows settle into the
-	 * muted gray of older transcript chrome. Hover brightens without shifting
-	 * hue. */
+	 * muted gray of older transcript chrome (the base trigger color above).
+	 * Hover brightens without shifting hue. */
 	.cline-chat-tool-trigger[data-status="running"] {
 		color: var(--brand-violet, var(--primary));
 	}

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -245,31 +245,15 @@
 		margin: 0.5rem 0;
 	}
 
-	/* Active tool rows carry the brand accent; finished rows settle into the
-	 * muted gray of older transcript chrome (the base trigger color above).
-	 * Hover brightens without shifting hue. */
-	.cline-chat-tool-trigger[data-status="running"] {
-		color: var(--brand-violet, var(--primary));
-	}
-
+	/* Running rows share the thinking indicator's muted gray (the base trigger
+	 * color above) — the spinner alone signals activity. Errors go red; hover
+	 * brightens without shifting hue. */
 	.cline-chat-tool-trigger[data-status="error"] {
 		color: var(--error-text);
 	}
 
-	.cline-chat-tool-trigger[data-status="pending"] {
-		color: var(--muted-foreground);
-	}
-
 	button.cline-chat-tool-trigger:hover {
 		color: var(--foreground);
-	}
-
-	button.cline-chat-tool-trigger[data-status="running"]:hover {
-		color: color-mix(
-			in oklab,
-			var(--brand-violet, var(--primary)) 80%,
-			var(--foreground)
-		);
 	}
 
 	button.cline-chat-tool-trigger[data-status="error"]:hover {
@@ -307,15 +291,15 @@
 
 	/* The spinner stands in for the tool icon while the call is in flight, so
 	 * it fills the same 1rem box the icons render at and the label never
-	 * shifts when they swap. */
+	 * shifts when they swap. It draws in currentColor to match whatever the
+	 * row text renders as (muted gray normally, red on error). */
 	.cline-chat-tool-progress {
 		width: 1rem;
 		height: 1rem;
 		flex: 0 0 auto;
 		box-sizing: border-box;
-		border: 2px solid
-			color-mix(in oklab, var(--brand-violet, var(--primary)) 25%, transparent);
-		border-top-color: var(--brand-violet, var(--primary));
+		border: 2px solid color-mix(in oklab, currentColor 25%, transparent);
+		border-top-color: currentColor;
 		border-radius: 9999px;
 		animation: cline-chat-spin 800ms linear infinite;
 	}

--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -194,7 +194,7 @@
 		padding: 0.25rem 0;
 		border: 0;
 		background: transparent;
-		color: color-mix(in oklab, var(--foreground) 70%, transparent);
+		color: var(--muted-foreground);
 		font: inherit;
 		font-size: var(--text-sm);
 		font-weight: var(--font-weight-medium);
@@ -249,8 +249,11 @@
 		color: var(--success-text);
 	}
 
+	/* Active tool rows carry the brand accent; finished rows settle into the
+	 * muted gray of older transcript chrome. Hover brightens without shifting
+	 * hue. */
 	.cline-chat-tool-trigger[data-status="running"] {
-		color: var(--primary);
+		color: var(--brand-violet, var(--primary));
 	}
 
 	.cline-chat-tool-trigger[data-status="error"] {
@@ -262,15 +265,19 @@
 	}
 
 	button.cline-chat-tool-trigger:hover {
-		color: color-mix(in oklab, var(--success-text) 80%, transparent);
+		color: var(--foreground);
 	}
 
 	button.cline-chat-tool-trigger[data-status="running"]:hover {
-		color: color-mix(in oklab, var(--primary) 80%, transparent);
+		color: color-mix(
+			in oklab,
+			var(--brand-violet, var(--primary)) 80%,
+			var(--foreground)
+		);
 	}
 
 	button.cline-chat-tool-trigger[data-status="error"]:hover {
-		color: color-mix(in oklab, var(--error-text) 80%, transparent);
+		color: color-mix(in oklab, var(--error-text) 80%, var(--foreground));
 	}
 
 	.cline-chat-tool-icon {
@@ -302,8 +309,9 @@
 		width: 0.75rem;
 		height: 0.75rem;
 		flex: 0 0 auto;
-		border: 2px solid color-mix(in oklab, var(--primary) 25%, transparent);
-		border-top-color: var(--primary);
+		border: 2px solid
+			color-mix(in oklab, var(--brand-violet, var(--primary)) 25%, transparent);
+		border-top-color: var(--brand-violet, var(--primary));
 		border-radius: 9999px;
 		animation: cline-chat-spin 800ms linear infinite;
 	}

--- a/sdk/packages/ui/components/agent-chat/index.tsx
+++ b/sdk/packages/ui/components/agent-chat/index.tsx
@@ -67,6 +67,7 @@ export const Conversation = forwardRef<HTMLDivElement, ConversationProps>(
 		const shouldStickToBottom = useRef(true);
 		const isProgrammaticScroll = useRef(false);
 		const lastProgrammaticScrollTop = useRef(0);
+		const lastObservedScrollTop = useRef(0);
 		const programmaticScrollTimer = useRef<number | null>(null);
 
 		const clearProgrammaticScroll = useCallback(() => {
@@ -80,6 +81,9 @@ export const Conversation = forwardRef<HTMLDivElement, ConversationProps>(
 			if (!viewport) return;
 			const distance =
 				viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+			const scrolledUp =
+				viewport.scrollTop < lastObservedScrollTop.current - 1;
+			lastObservedScrollTop.current = viewport.scrollTop;
 			if (isProgrammaticScroll.current) {
 				if (viewport.scrollTop + 1 < lastProgrammaticScrollTop.current) {
 					isProgrammaticScroll.current = false;
@@ -95,7 +99,16 @@ export const Conversation = forwardRef<HTMLDivElement, ConversationProps>(
 					return;
 				}
 			}
-			shouldStickToBottom.current = distance <= STICK_TO_BOTTOM_THRESHOLD_PX;
+			// Sticking is an intent, not a position: content growing under a
+			// pinned viewport briefly widens `distance` before the resize
+			// observer re-pins, and a scroll event landing in that window must
+			// not read as the user leaving the bottom. Only an actual upward
+			// scroll releases the pin; reaching the bottom always restores it.
+			if (distance <= STICK_TO_BOTTOM_THRESHOLD_PX) {
+				shouldStickToBottom.current = true;
+			} else if (scrolledUp) {
+				shouldStickToBottom.current = false;
+			}
 			setShowScrollButton(distance > SCROLL_BUTTON_THRESHOLD_PX);
 		}, [clearProgrammaticScroll, viewport]);
 
@@ -116,6 +129,7 @@ export const Conversation = forwardRef<HTMLDivElement, ConversationProps>(
 					top: viewport.scrollHeight,
 					behavior: effectiveBehavior,
 				});
+				lastObservedScrollTop.current = viewport.scrollTop;
 				setShowScrollButton(false);
 				if (!isSmooth) return;
 				programmaticScrollTimer.current = window.setTimeout(() => {

--- a/sdk/packages/ui/components/agent-chat/index.tsx
+++ b/sdk/packages/ui/components/agent-chat/index.tsx
@@ -636,9 +636,16 @@ export const ToolActivityTrigger = ({
 	...props
 }: ToolActivityTriggerProps) => {
 	const { expandable, isOpen, panelId, setIsOpen } = useToolActivity();
+	// While the tool is still working, the spinner takes the icon's slot so the
+	// row reads as one glyph + label instead of sprouting chrome on the right.
+	const inFlight = status === "running" || status === "pending";
 	const content = children ?? (
 		<>
-			{icon ? <span className="cline-chat-tool-icon">{icon}</span> : null}
+			{inFlight ? (
+				<output aria-label={status} className="cline-chat-tool-progress" />
+			) : icon ? (
+				<span className="cline-chat-tool-icon">{icon}</span>
+			) : null}
 			<span className="cline-chat-tool-label">{label}</span>
 			{additions !== undefined || deletions !== undefined ? (
 				<span className="cline-chat-tool-diff">
@@ -649,9 +656,6 @@ export const ToolActivityTrigger = ({
 						<span data-diff="deletions">-{deletions}</span>
 					) : null}
 				</span>
-			) : null}
-			{status === "running" || status === "pending" ? (
-				<output aria-label={status} className="cline-chat-tool-progress" />
 			) : null}
 			{expandable && showDisclosureIcon ? (
 				<ChevronDownIcon className="cline-chat-disclosure-icon" />

--- a/sdk/packages/ui/components/agent-chat/tool-diff.tsx
+++ b/sdk/packages/ui/components/agent-chat/tool-diff.tsx
@@ -51,8 +51,10 @@ const BASE_OPTIONS: DiffOptions = {
 
 // Tool payloads carry code fragments that rarely end in a newline, which
 // would otherwise litter every diff with "No newline at end of file"
-// markers — meaningless noise for chat rows.
+// markers — meaningless noise for chat rows. Empty text stays empty so an
+// empty side diffs as zero lines rather than one blank line.
 function ensureTrailingNewline(text: string): string {
+	if (!text) return "";
 	return text.endsWith("\n") ? text : `${text}\n`;
 }
 

--- a/sdk/packages/ui/components/agent-chat/tool-summary/diff.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/diff.ts
@@ -59,8 +59,10 @@ export function makeUnifiedDiff(
 	ctx = 3,
 	options?: MakeUnifiedDiffOptions,
 ): string {
+	// Empty text means zero lines, not one blank line — otherwise creating an
+	// empty file or deleting all content reports a phantom blank addition.
 	const oldArr = oldText ? oldText.split("\n") : [];
-	const newArr = newText.split("\n");
+	const newArr = newText ? newText.split("\n") : [];
 	const ops = diffLines(oldArr, newArr);
 
 	const output: string[] = [];

--- a/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
@@ -440,7 +440,7 @@ export function buildToolSummary(
 				...labeled(
 					single
 						? [
-								{ text: `${inProgress ? "Reading" : "Read"} ` },
+								{ text: `${inProgress ? "Reading" : "Read"} file ` },
 								{
 									text: `${displayFileName(single.path)}${lineRangeLabelSuffix(single.startLine, single.endLine)}`,
 									code: true,
@@ -476,11 +476,11 @@ export function buildToolSummary(
 					: null;
 			return {
 				...base,
-				// Single commands read like a terminal prompt: `$ bun test`.
+				// Single commands lead with the action, command in mono after.
 				...labeled(
 					singleInline !== null
 						? [
-								{ text: "$ ", code: true },
+								{ text: `${inProgress ? "Running" : "Ran"} command ` },
 								{ text: singleInline, code: true },
 							]
 						: [
@@ -574,15 +574,15 @@ export function buildToolSummary(
 			const actionVerb = (action: "add" | "update" | "delete") =>
 				action === "add"
 					? inProgress
-						? "Creating"
-						: "Created"
+						? "Creating file"
+						: "Created file"
 					: action === "delete"
 						? inProgress
-							? "Deleting"
-							: "Deleted"
+							? "Deleting file"
+							: "Deleted file"
 						: inProgress
-							? "Editing"
-							: "Edited";
+							? "Editing file"
+							: "Edited file";
 			// Renames display as `old → new`.
 			const fileLabel = (file: (typeof info.files)[number]) =>
 				file.movedTo
@@ -671,15 +671,15 @@ export function buildToolSummary(
 							: "edit";
 		const verb = inProgress
 			? command === "create"
-				? "Creating"
+				? "Creating file"
 				: command === "insert"
 					? "Inserting into"
-					: "Editing"
+					: "Editing file"
 			: command === "create"
-				? "Created"
+				? "Created file"
 				: command === "insert"
 					? "Inserted into"
-					: "Edited";
+					: "Edited file";
 
 		let diff: ToolSummary["diff"];
 		let diffText: string | undefined;

--- a/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
@@ -107,18 +107,34 @@ export type ToolSummaryItem =
 			 * complete contents — renderers should hide absolute line numbers.
 			 */
 			fragment?: boolean;
+			/**
+			 * Per-hunk before/after texts when the change has more than one
+			 * hunk (apply_patch). Render one diff per hunk — re-diffing
+			 * concatenated hunks pairs deletions with unrelated additions.
+			 * When present, prefer it over oldText/newText.
+			 */
+			hunks?: Array<{ oldText: string; newText: string }>;
 	  }
 	| { type: "command"; command: string }
 	| { type: "query"; query: string }
 	| { type: "url"; url: string }
 	| { type: "text"; text: string };
 
+/**
+ * One styled segment of a row label. Segments with `code: true` carry code
+ * (file names, commands, queries, URLs) and should render in a monospace
+ * face; plain segments are prose.
+ */
+export type ToolLabelPart = { text: string; code?: boolean };
+
 export type ToolSummary = {
 	/** Normalized tool name (aliases applied). */
 	toolName: string;
 	kind: ToolKind;
-	/** Row label, e.g. `Read app.tsx (10–80)` or `Ran 3 commands`. */
+	/** Row label, e.g. `Read app.tsx (10–80)` or `$ bun test`. */
 	label: string;
+	/** The label broken into styled segments; joins to `label`. */
+	labelParts: ToolLabelPart[];
 	/** Present when this call can merge into grouped-row counts. */
 	aggregate?: ToolAggregate;
 	/** Structured per-item detail for custom rendering. */
@@ -334,6 +350,13 @@ function aggregateLabel(
 	return `${verb} ${pluralize(count, aggregate.noun, aggregate.pluralNoun)}`;
 }
 
+/** Derive the plain-text label and its styled segments together. */
+function labeled(
+	parts: ToolLabelPart[],
+): Pick<ToolSummary, "label" | "labelParts"> {
+	return { label: parts.map((part) => part.text).join(""), labelParts: parts };
+}
+
 // Fallback summaries (unparsable or absent input) still carry an aggregate
 // so consecutive calls merge into grouped counts ("Spawned 3 agents") rather
 // than repeating the generic label.
@@ -370,7 +393,7 @@ export function buildToolSummary(
 	const base: ToolSummary = {
 		toolName,
 		kind,
-		label: fallbackLabel(kind, toolName, inProgress),
+		...labeled([{ text: fallbackLabel(kind, toolName, inProgress) }]),
 		aggregate: fallbackAggregate
 			? { ...fallbackAggregate, count: 1 }
 			: undefined,
@@ -392,7 +415,7 @@ export function buildToolSummary(
 		if (team) {
 			return {
 				...base,
-				label: team.label,
+				...labeled([{ text: team.label }]),
 				aggregate: team.aggregate,
 				details: team.details,
 				items: team.details.map((text) => ({ type: "text", text })),
@@ -414,9 +437,25 @@ export function buildToolSummary(
 			const single = info.files.length === 1 ? info.files[0] : null;
 			return {
 				...base,
-				label: single
-					? `${inProgress ? "Reading" : "Read"} ${displayFileName(single.path)}${lineRangeLabelSuffix(single.startLine, single.endLine)}`
-					: aggregateLabel(READ_AGGREGATE, info.files.length, inProgress),
+				...labeled(
+					single
+						? [
+								{ text: `${inProgress ? "Reading" : "Read"} ` },
+								{
+									text: `${displayFileName(single.path)}${lineRangeLabelSuffix(single.startLine, single.endLine)}`,
+									code: true,
+								},
+							]
+						: [
+								{
+									text: aggregateLabel(
+										READ_AGGREGATE,
+										info.files.length,
+										inProgress,
+									),
+								},
+							],
+				),
 				aggregate: { ...READ_AGGREGATE, count: info.files.length },
 				items,
 				details: info.files.map(
@@ -431,15 +470,34 @@ export function buildToolSummary(
 		const info = parseRunCommandsInput(input);
 		if (info) {
 			const commands = info.commands.map((command) => command.trim());
+			const singleInline =
+				commands.length === 1
+					? truncate(commands[0], opts.maxInlineChars)
+					: null;
 			return {
 				...base,
-				label:
-					commands.length === 1
-						? `${inProgress ? "Running" : "Ran"} ${truncate(commands[0], opts.maxInlineChars)}`
-						: aggregateLabel(COMMAND_AGGREGATE, commands.length, inProgress),
+				// Single commands read like a terminal prompt: `$ bun test`.
+				...labeled(
+					singleInline !== null
+						? [
+								{ text: "$ ", code: true },
+								{ text: singleInline, code: true },
+							]
+						: [
+								{
+									text: aggregateLabel(
+										COMMAND_AGGREGATE,
+										commands.length,
+										inProgress,
+									),
+								},
+							],
+				),
 				aggregate: { ...COMMAND_AGGREGATE, count: commands.length },
 				items: commands.map((command) => ({ type: "command", command })),
-				details: commands,
+				// A single untruncated command already sits in the label; the
+				// detail line would just repeat it.
+				details: singleInline === commands[0] ? [] : commands,
 				outputText: isError
 					? undefined
 					: capText(extractOutputText(payload.result), opts.maxOutputChars),
@@ -452,10 +510,25 @@ export function buildToolSummary(
 		if (info) {
 			return {
 				...base,
-				label:
+				...labeled(
 					info.queries.length === 1
-						? `${inProgress ? "Searching" : "Searched"} ${truncate(info.queries[0], opts.maxInlineChars)}`
-						: aggregateLabel(SEARCH_AGGREGATE, info.queries.length, inProgress),
+						? [
+								{ text: `${inProgress ? "Searching" : "Searched"} ` },
+								{
+									text: truncate(info.queries[0], opts.maxInlineChars),
+									code: true,
+								},
+							]
+						: [
+								{
+									text: aggregateLabel(
+										SEARCH_AGGREGATE,
+										info.queries.length,
+										inProgress,
+									),
+								},
+							],
+				),
 				aggregate: { ...SEARCH_AGGREGATE, count: info.queries.length },
 				items: info.queries.map((query) => ({ type: "query", query })),
 				details: info.queries,
@@ -468,10 +541,25 @@ export function buildToolSummary(
 		if (info) {
 			return {
 				...base,
-				label:
+				...labeled(
 					info.urls.length === 1
-						? `${inProgress ? "Fetching" : "Fetched"} ${truncate(info.urls[0], opts.maxInlineChars)}`
-						: aggregateLabel(WEB_AGGREGATE, info.urls.length, inProgress),
+						? [
+								{ text: `${inProgress ? "Fetching" : "Fetched"} ` },
+								{
+									text: truncate(info.urls[0], opts.maxInlineChars),
+									code: true,
+								},
+							]
+						: [
+								{
+									text: aggregateLabel(
+										WEB_AGGREGATE,
+										info.urls.length,
+										inProgress,
+									),
+								},
+							],
+				),
 				aggregate: { ...WEB_AGGREGATE, count: info.urls.length },
 				items: info.urls.map((url) => ({ type: "url", url })),
 				details: info.urls,
@@ -483,34 +571,83 @@ export function buildToolSummary(
 		const info = parseApplyPatchInput(input);
 		if (info) {
 			const single = info.files.length === 1 ? info.files[0] : null;
+			const actionVerb = (action: "add" | "update" | "delete") =>
+				action === "add"
+					? inProgress
+						? "Creating"
+						: "Created"
+					: action === "delete"
+						? inProgress
+							? "Deleting"
+							: "Deleted"
+						: inProgress
+							? "Editing"
+							: "Edited";
+			// Renames display as `old → new`.
+			const fileLabel = (file: (typeof info.files)[number]) =>
+				file.movedTo
+					? `${displayFileName(file.path)} → ${displayFileName(file.movedTo)}`
+					: displayFileName(file.path);
+			const filePathDetail = (file: (typeof info.files)[number]) =>
+				file.movedTo
+					? `${formatPath(file.path, opts.pathStyle)} → ${formatPath(file.movedTo, opts.pathStyle)}`
+					: formatPath(file.path, opts.pathStyle);
 			return {
 				...base,
-				label: single
-					? `${inProgress ? "Editing" : "Edited"} ${displayFileName(single.path)}`
-					: aggregateLabel(EDIT_AGGREGATE, info.files.length, inProgress),
+				...labeled(
+					single
+						? [
+								{ text: `${actionVerb(single.action)} ` },
+								{ text: fileLabel(single), code: true },
+							]
+						: [
+								{
+									text: aggregateLabel(
+										EDIT_AGGREGATE,
+										info.files.length,
+										inProgress,
+									),
+								},
+							],
+				),
 				aggregate: { ...EDIT_AGGREGATE, count: info.files.length },
 				diff: { additions: info.additions, deletions: info.deletions },
 				items: info.files.map((file) => ({
 					type: "file",
-					path: file.path,
-					displayPath: formatPath(file.path, opts.pathStyle),
-					language: detectLanguage(file.path),
+					path: file.movedTo ?? file.path,
+					displayPath: formatPath(file.movedTo ?? file.path, opts.pathStyle),
+					language: detectLanguage(file.movedTo ?? file.path),
 					additions: file.additions,
 					deletions: file.deletions,
 					diff: file.diff,
-					oldText: file.wholeFile ? undefined : file.oldText,
-					newText: file.newText,
-					fragment: !file.wholeFile,
+					// Deletions have no meaningful rich diff; single-hunk changes
+					// expose plain texts, multi-hunk changes must render per hunk.
+					oldText:
+						file.action !== "delete" && file.hunks.length === 1
+							? file.action === "add"
+								? undefined
+								: file.hunks[0].oldText
+							: undefined,
+					newText:
+						file.action !== "delete" && file.hunks.length === 1
+							? file.hunks[0].newText
+							: undefined,
+					hunks:
+						file.action !== "delete" && file.hunks.length > 1
+							? file.hunks
+							: undefined,
+					fragment: file.action !== "add",
 				})),
-				details: info.files.map(
-					(file) =>
-						`${formatPath(file.path, opts.pathStyle)} +${file.additions} -${file.deletions}`,
+				details: info.files.map((file) =>
+					file.action === "delete"
+						? `Deleted ${filePathDetail(file)}`
+						: `${filePathDetail(file)} +${file.additions} -${file.deletions}`,
 				),
 			};
 		}
 		return {
 			...base,
-			label: inProgress ? "Applying patch" : "Applied patch",
+			...labeled([{ text: inProgress ? "Applying patch" : "Applied patch" }]),
 			aggregate: { ...EDIT_AGGREGATE, count: 1 },
 		};
 	}
@@ -566,7 +703,10 @@ export function buildToolSummary(
 		if (path) {
 			return {
 				...base,
-				label: `${verb} ${displayFileName(path)}`,
+				...labeled([
+					{ text: `${verb} ` },
+					{ text: displayFileName(path), code: true },
+				]),
 				aggregate: { ...EDIT_AGGREGATE, count: 1 },
 				diff,
 				items: [
@@ -594,7 +734,10 @@ export function buildToolSummary(
 		if (info) {
 			return {
 				...base,
-				label: `${inProgress ? "Spawning" : "Spawned"} agent: ${truncate(info.task, opts.maxInlineChars)}`,
+				...labeled([
+					{ text: `${inProgress ? "Spawning" : "Spawned"} agent: ` },
+					{ text: truncate(info.task, opts.maxInlineChars) },
+				]),
 				aggregate: { ...SPAWN_AGGREGATE, count: 1 },
 				items: [{ type: "text", text: info.task }],
 				details: [info.task],
@@ -610,7 +753,10 @@ export function buildToolSummary(
 			const detail = args ? `${skill} ${args}` : skill;
 			return {
 				...base,
-				label: `${inProgress ? "Using" : "Used"} skill ${truncate(skill, opts.maxInlineChars)}`,
+				...labeled([
+					{ text: `${inProgress ? "Using" : "Used"} skill ` },
+					{ text: truncate(skill, opts.maxInlineChars), code: true },
+				]),
 				items: [{ type: "text", text: detail }],
 				details: [detail],
 			};
@@ -622,7 +768,11 @@ export function buildToolSummary(
 		if (info) {
 			return {
 				...base,
-				label: `${inProgress ? "Asking" : "Asked"} "${truncate(info.question, opts.maxInlineChars)}"`,
+				...labeled([
+					{
+						text: `${inProgress ? "Asking" : "Asked"} "${truncate(info.question, opts.maxInlineChars)}"`,
+					},
+				]),
 				items: [
 					{ type: "text", text: info.question },
 					...info.options.map((option): ToolSummaryItem => {
@@ -638,17 +788,16 @@ export function buildToolSummary(
 	}
 
 	// Unknown/MCP tools: humanized name, plus whatever text the result holds.
-	const resultRecord = isRecord(normalizeValue(payload.result))
-		? (normalizeValue(payload.result) as Record<string, unknown>)
-		: null;
+	const normalizedResult = normalizeValue(payload.result);
+	const resultRecord = isRecord(normalizedResult) ? normalizedResult : null;
 	const query =
 		typeof resultRecord?.query === "string" ? resultRecord.query : "";
 	return {
 		...base,
-		label: query ? truncate(query, opts.maxInlineChars) : base.label,
+		...(query ? labeled([{ text: truncate(query, opts.maxInlineChars) }]) : {}),
 		outputText: isError
 			? undefined
-			: capText(extractOutputText(payload.result), opts.maxOutputChars),
+			: capText(extractOutputText(normalizedResult), opts.maxOutputChars),
 	};
 }
 

--- a/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
@@ -155,9 +155,10 @@ export type ToolSummaryOptions = {
 	/** Cap on extracted output/error text. Default: 64 KiB. */
 	maxOutputChars?: number;
 	/**
-	 * Safety cap on inline label text (commands, tasks, questions). High by
-	 * default — rows should show the real command and let layout handle
-	 * overflow; this only guards against pathological payloads. Default: 200.
+	 * Optional cap on inline label text (commands, tasks, questions).
+	 * Unlimited by default: labels carry the full text (whitespace collapsed
+	 * to one line) and the consumer's layout ellipsizes at the container
+	 * edge. Set a number only for width-constrained surfaces like TUIs.
 	 */
 	maxInlineChars?: number;
 };
@@ -165,7 +166,7 @@ export type ToolSummaryOptions = {
 const DEFAULT_OPTIONS: Required<ToolSummaryOptions> = {
 	pathStyle: "shortened",
 	maxOutputChars: 64 * 1024,
-	maxInlineChars: 200,
+	maxInlineChars: Number.POSITIVE_INFINITY,
 };
 
 export const TOOL_NAME_ALIASES: Record<string, string> = {
@@ -499,9 +500,9 @@ export function buildToolSummary(
 				),
 				aggregate: { ...COMMAND_AGGREGATE, count: commands.length },
 				items: commands.map((command) => ({ type: "command", command })),
-				// A single untruncated command already sits in the label; the
-				// detail line would just repeat it.
-				details: singleInline === commands[0] ? [] : commands,
+				// The label may be ellipsized by the consumer's layout, so the
+				// expanded panel always carries the full command text.
+				details: commands,
 				outputText: isError
 					? undefined
 					: capText(extractOutputText(payload.result), opts.maxOutputChars),

--- a/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/index.ts
@@ -154,14 +154,18 @@ export type ToolSummaryOptions = {
 	pathStyle?: "shortened" | "basename" | "full";
 	/** Cap on extracted output/error text. Default: 64 KiB. */
 	maxOutputChars?: number;
-	/** Cap on inline label text (commands, tasks, questions). Default: 60. */
+	/**
+	 * Safety cap on inline label text (commands, tasks, questions). High by
+	 * default — rows should show the real command and let layout handle
+	 * overflow; this only guards against pathological payloads. Default: 200.
+	 */
 	maxInlineChars?: number;
 };
 
 const DEFAULT_OPTIONS: Required<ToolSummaryOptions> = {
 	pathStyle: "shortened",
 	maxOutputChars: 64 * 1024,
-	maxInlineChars: 60,
+	maxInlineChars: 200,
 };
 
 export const TOOL_NAME_ALIASES: Record<string, string> = {
@@ -723,8 +727,9 @@ export function buildToolSummary(
 						fragment: command !== "create",
 					},
 				],
-				// The label already carries the file; the diff renders from items.
-				details: [],
+				// The label carries the basename; the expanded panel leads with
+				// the fuller path above the diff, matching read rows.
+				details: [formatPath(path, opts.pathStyle)],
 			};
 		}
 	}

--- a/sdk/packages/ui/components/agent-chat/tool-summary/parsers.ts
+++ b/sdk/packages/ui/components/agent-chat/tool-summary/parsers.ts
@@ -75,36 +75,43 @@ export interface RunCommandsInfo {
 }
 
 /**
- * run_commands entries can be shell strings or structured `{ command, args }`;
- * the input itself may be `{ commands: [...] }`, `{ command }`, or a string.
+ * run_commands accepts every shape in core's RunCommandsInputUnionSchema:
+ * `{ commands: [...] }` (strings or `{ command, args }` entries, or a single
+ * entry instead of an array), a bare array of either, a top-level
+ * `{ command, args }`, `{ cmd }`, or a bare string.
  */
 export function parseRunCommandsInput(
 	input: unknown,
 ): RunCommandsInfo | undefined {
 	const normalized = normalizeValue(input);
-	if (typeof normalized === "string" && normalized.length > 0) {
-		return { commands: [normalized] };
-	}
-	if (!isRecord(normalized)) return undefined;
-
-	const raw = Array.isArray(normalized.commands)
-		? normalized.commands
-		: typeof normalized.command === "string"
-			? [normalized.command]
-			: null;
-	if (!raw) return undefined;
-
 	const commands: string[] = [];
-	for (const entry of raw) {
+	const pushEntry = (entry: unknown) => {
 		if (typeof entry === "string" && entry.length > 0) {
 			commands.push(entry);
-			continue;
+			return;
 		}
-		if (isRecord(entry) && typeof entry.command === "string") {
+		if (isRecord(entry) && typeof entry.command === "string" && entry.command) {
 			const args = Array.isArray(entry.args)
 				? entry.args.filter((a): a is string => typeof a === "string").join(" ")
 				: "";
 			commands.push(args ? `${entry.command} ${args}` : entry.command);
+		}
+	};
+
+	if (typeof normalized === "string" || Array.isArray(normalized)) {
+		for (const entry of Array.isArray(normalized) ? normalized : [normalized]) {
+			pushEntry(entry);
+		}
+	} else if (isRecord(normalized)) {
+		if (normalized.commands !== undefined) {
+			const raw = normalized.commands;
+			for (const entry of Array.isArray(raw) ? raw : [raw]) {
+				pushEntry(entry);
+			}
+		} else if (typeof normalized.command === "string") {
+			pushEntry(normalized);
+		} else if (typeof normalized.cmd === "string") {
+			pushEntry(normalized.cmd);
 		}
 	}
 	return commands.length > 0 ? { commands } : undefined;
@@ -159,7 +166,7 @@ export function parseWebFetchInput(input: unknown): WebFetchInfo | undefined {
 	if (!Array.isArray(normalized.requests)) return undefined;
 	const urls = normalized.requests
 		.filter((r): r is Record<string, unknown> => isRecord(r))
-		.map((r) => String(r.url ?? ""))
+		.map((r) => (typeof r.url === "string" ? r.url : ""))
 		.filter(Boolean);
 	return urls.length > 0 ? { urls } : undefined;
 }
@@ -194,17 +201,27 @@ export function parseAskQuestionInput(
 	return { question: normalized.question, options };
 }
 
+/** Before/after texts reconstructed from one `@@`-delimited patch section. */
+export interface ApplyPatchHunk {
+	oldText: string;
+	newText: string;
+}
+
 export interface ApplyPatchFile {
 	path: string;
+	/** From the section header: `Add File`, `Update File`, or `Delete File`. */
+	action: "add" | "update" | "delete";
+	/** Destination path from a `*** Move to:` line, when the file was renamed. */
+	movedTo?: string;
 	additions: number;
 	deletions: number;
 	diff: string;
-	/** True for `Add File` sections, whose body is the complete file. */
-	wholeFile: boolean;
-	/** Before/after texts reconstructed from the patch body (fragments for
-	 * Update/Delete sections, complete contents for Add sections). */
-	oldText: string;
-	newText: string;
+	/**
+	 * Per-hunk before/after texts, boundaries preserved. Rendering each hunk
+	 * separately matters: concatenating hunks and re-diffing would let a
+	 * deletion in one hunk pair up with an addition in another.
+	 */
+	hunks: ApplyPatchHunk[];
 }
 
 export interface ApplyPatchInfo {
@@ -215,8 +232,11 @@ export interface ApplyPatchInfo {
 }
 
 const FILE_ACTION_RE = /^\*\*\* (Add|Update|Delete) File: (.+)/;
+const MOVE_TO_RE = /^\*\*\* Move to: (.+)/;
+// `@@ …` context markers delimit hunks and are handled separately below.
+const HUNK_MARKER_RE = /^@@/;
 const SKIP_LINES =
-	/^(?:\*\*\* (?:Begin|End) Patch|%%bash|```|EOF|apply_patch\b|@@|\*\*\* (?:Move to:|End of File))/;
+	/^(?:\*\*\* (?:Begin|End) Patch|%%bash|```|EOF|apply_patch\b|\*\*\* End of File)/;
 
 /**
  * Parse the apply_patch envelope (`*** Add/Update/Delete File:` sections)
@@ -237,11 +257,13 @@ export function parseApplyPatchInput(
 	const files: ApplyPatchFile[] = [];
 	let current: {
 		path: string;
-		wholeFile: boolean;
+		action: "add" | "update" | "delete";
+		movedTo?: string;
 		lines: string[];
 		hunk: string[];
 		oldLines: string[];
 		newLines: string[];
+		hunks: ApplyPatchHunk[];
 		additions: number;
 		deletions: number;
 	} | null = null;
@@ -251,22 +273,30 @@ export function parseApplyPatchInput(
 		// Update/Delete sections are file fragments; only Add File sections
 		// carry complete contents, so only they get real hunk positions.
 		current.lines.push(
-			current.wholeFile ? hunkHeader(current.hunk) : FRAGMENT_HUNK_HEADER,
+			current.action === "add"
+				? hunkHeader(current.hunk)
+				: FRAGMENT_HUNK_HEADER,
 			...current.hunk,
 		);
+		current.hunks.push({
+			oldText: current.oldLines.join("\n"),
+			newText: current.newLines.join("\n"),
+		});
 		current.hunk = [];
+		current.oldLines = [];
+		current.newLines = [];
 	};
 	const flushFile = () => {
 		if (!current) return;
 		flushHunk();
 		files.push({
 			path: current.path,
+			action: current.action,
+			movedTo: current.movedTo,
 			additions: current.additions,
 			deletions: current.deletions,
 			diff: current.lines.join("\n"),
-			wholeFile: current.wholeFile,
-			oldText: current.oldLines.join("\n"),
-			newText: current.newLines.join("\n"),
+			hunks: current.hunks,
 		});
 		current = null;
 	};
@@ -278,14 +308,24 @@ export function parseApplyPatchInput(
 			const path = fileMatch[2].trim();
 			current = {
 				path,
-				wholeFile: fileMatch[1] === "Add",
+				action: fileMatch[1].toLowerCase() as "add" | "update" | "delete",
 				lines: [`--- a/${path}`, `+++ b/${path}`],
 				hunk: [],
 				oldLines: [],
 				newLines: [],
+				hunks: [],
 				additions: 0,
 				deletions: 0,
 			};
+			continue;
+		}
+		const moveMatch = MOVE_TO_RE.exec(line);
+		if (moveMatch) {
+			if (current) current.movedTo = moveMatch[1].trim();
+			continue;
+		}
+		if (HUNK_MARKER_RE.test(line.trim())) {
+			flushHunk();
 			continue;
 		}
 		if (SKIP_LINES.test(line.trim())) continue;

--- a/sdk/packages/ui/scripts/smoke-package.ts
+++ b/sdk/packages/ui/scripts/smoke-package.ts
@@ -44,7 +44,7 @@ const summary = buildToolSummary({
 	toolName: "read_files",
 	input: { files: [{ path: "src/app.tsx", start_line: 10, end_line: 80 }] },
 });
-if (summary.label !== "Read app.tsx (10–80)" || summary.kind !== "read") {
+if (summary.label !== "Read file app.tsx (10–80)" || summary.kind !== "read") {
 	throw new Error("tool-summary subpath returned an unexpected summary");
 }
 if (typeof ToolFileDiff !== "function") {

--- a/sdk/packages/ui/stories/agent-chat.stories.tsx
+++ b/sdk/packages/ui/stories/agent-chat.stories.tsx
@@ -23,6 +23,7 @@ import {
 	buildToolSummary,
 	type ToolKind,
 	type ToolSummary,
+	type ToolSummaryItem,
 } from "../components/agent-chat/tool-summary";
 
 const meta: Meta<typeof Conversation> = {
@@ -204,11 +205,34 @@ const SUMMARY_ICONS: Partial<Record<ToolKind, () => React.ReactNode>> = {
 	search: SearchIcon,
 };
 
+type SummaryDiffEntry = {
+	key: string;
+	kind: "rich" | "text";
+	item: Extract<ToolSummaryItem, { type: "file" }>;
+	hunk: { oldText?: string; newText: string } | null;
+};
+
 function SummaryToolRow({ summary }: { summary: ToolSummary }) {
 	const Icon = SUMMARY_ICONS[summary.kind] ?? TerminalIcon;
-	const diffs = summary.items.filter(
-		(item) => item.type === "file" && (item.newText !== undefined || item.diff),
-	);
+	const diffs = summary.items.flatMap<SummaryDiffEntry>((item, index) => {
+		if (item.type !== "file") return [];
+		const hunks =
+			item.hunks ??
+			(item.newText !== undefined
+				? [{ oldText: item.oldText, newText: item.newText }]
+				: null);
+		if (hunks) {
+			return hunks.map((hunk, hunkIndex) => ({
+				key: `${index}-${hunkIndex}`,
+				kind: "rich" as const,
+				item,
+				hunk,
+			}));
+		}
+		return item.diff
+			? [{ key: `${index}`, kind: "text" as const, item, hunk: null }]
+			: [];
+	});
 	const expandable =
 		summary.details.length > 0 ||
 		diffs.length > 0 ||
@@ -220,7 +244,24 @@ function SummaryToolRow({ summary }: { summary: ToolSummary }) {
 				additions={summary.diff?.additions || undefined}
 				deletions={summary.diff?.deletions || undefined}
 				icon={<Icon />}
-				label={summary.label}
+				label={
+					<span>
+						{summary.labelParts.map((part, index) =>
+							part.code ? (
+								<span
+									className="font-mono text-[0.92em]"
+									// biome-ignore lint/suspicious/noArrayIndexKey: positional
+									key={index}
+								>
+									{part.text}
+								</span>
+							) : (
+								// biome-ignore lint/suspicious/noArrayIndexKey: positional
+								<span key={index}>{part.text}</span>
+							),
+						)}
+					</span>
+				}
 				status={summary.errorText ? "error" : "success"}
 			/>
 			<ToolActivityContent>
@@ -232,17 +273,19 @@ function SummaryToolRow({ summary }: { summary: ToolSummary }) {
 						))}
 					</ToolActivityDetails>
 				) : null}
-				{diffs.map((item) =>
-					item.type !== "file" ? null : item.newText !== undefined ? (
+				{diffs.map((entry) =>
+					entry.kind === "rich" && entry.hunk ? (
 						<ToolFileDiff
-							fragment={item.fragment}
-							key={item.path}
-							newText={item.newText}
-							oldText={item.oldText}
-							path={item.path}
+							fragment={entry.item.fragment}
+							key={entry.key}
+							newText={entry.hunk.newText}
+							oldText={entry.hunk.oldText}
+							path={entry.item.path}
 						/>
 					) : (
-						<ToolActivityCode key={item.path}>{item.diff}</ToolActivityCode>
+						<ToolActivityCode key={entry.key}>
+							{entry.item.diff}
+						</ToolActivityCode>
 					),
 				)}
 				{summary.outputText ? (

--- a/sdk/packages/ui/stories/agent-chat.stories.tsx
+++ b/sdk/packages/ui/stories/agent-chat.stories.tsx
@@ -249,7 +249,7 @@ function SummaryToolRow({ summary }: { summary: ToolSummary }) {
 						{summary.labelParts.map((part, index) =>
 							part.code ? (
 								<span
-									className="font-mono text-[0.92em]"
+									className="font-mono"
 									// biome-ignore lint/suspicious/noArrayIndexKey: positional
 									key={index}
 								>

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -44,10 +44,12 @@ describe("AgentAskQuestion", () => {
 		const buttons = container.querySelectorAll("button");
 		await act(async () => buttons[1]?.click());
 
+		// The element carries no visible heading — the question itself leads —
+		// but stays labelled for assistive tech.
 		const section = container.querySelector("section");
-		const heading = container.querySelector("h2");
-		expect(section?.getAttribute("aria-labelledby")).toBe(heading?.id);
-		expect(heading?.textContent).toBe("Follow-up question");
+		expect(section?.getAttribute("aria-label")).toBe("Follow-up question");
+		expect(container.querySelector("h2")).toBeNull();
+		expect(container.textContent).toContain("Continue this task?");
 		expect(onAnswer).toHaveBeenCalledWith("request-1", "Stop");
 		expect(container.textContent).toContain("Request request-1 · Iteration 2");
 	});

--- a/sdk/packages/ui/tests/agent-chat.test.tsx
+++ b/sdk/packages/ui/tests/agent-chat.test.tsx
@@ -127,7 +127,10 @@ describe("@cline/ui agent chat primitives", () => {
 	it("hides the disclosure chevron on request while keeping the row clickable", async () => {
 		await render(
 			<ToolActivity>
-				<ToolActivityTrigger label="Edited 2 files" showDisclosureIcon={false} />
+				<ToolActivityTrigger
+					label="Edited 2 files"
+					showDisclosureIcon={false}
+				/>
 				<ToolActivityContent>theme.css</ToolActivityContent>
 			</ToolActivity>,
 		);

--- a/sdk/packages/ui/tests/agent-chat.test.tsx
+++ b/sdk/packages/ui/tests/agent-chat.test.tsx
@@ -101,6 +101,38 @@ describe("@cline/ui agent chat primitives", () => {
 		expect(summary?.closest("button")).toBeNull();
 	});
 
+	it("swaps the icon for the spinner while the tool is in flight", async () => {
+		await render(
+			<ToolActivity expandable={false}>
+				<ToolActivityTrigger
+					icon={<svg data-testid="tool-icon" />}
+					label="Editing file app.tsx"
+					status="running"
+				/>
+			</ToolActivity>,
+		);
+
+		expect(
+			container.querySelector(".cline-chat-tool-progress"),
+		).not.toBeNull();
+		expect(container.querySelector("[data-testid='tool-icon']")).toBeNull();
+
+		await render(
+			<ToolActivity expandable={false}>
+				<ToolActivityTrigger
+					icon={<svg data-testid="tool-icon" />}
+					label="Edited file app.tsx"
+					status="success"
+				/>
+			</ToolActivity>,
+		);
+
+		expect(container.querySelector(".cline-chat-tool-progress")).toBeNull();
+		expect(
+			container.querySelector("[data-testid='tool-icon']"),
+		).not.toBeNull();
+	});
+
 	it("toggles expandable tool details", async () => {
 		await render(
 			<ToolActivity>

--- a/sdk/packages/ui/tests/tool-summary.test.ts
+++ b/sdk/packages/ui/tests/tool-summary.test.ts
@@ -130,16 +130,26 @@ describe("run_commands summaries", () => {
 		expect(summary.details).toEqual([]);
 	});
 
-	it("truncates long single commands and keeps the full text in details", () => {
+	it("keeps realistic commands untruncated in the label", () => {
+		const command = `bun run test --filter @cline/ui --reporter verbose ${"x".repeat(60)}`;
 		const summary = buildToolSummary({
 			toolName: "run_commands",
-			input: { commands: [`echo ${"x".repeat(100)}`] },
+			input: { commands: [command] },
+		});
+		expect(summary.label).toBe(`Ran command ${command}`);
+		expect(summary.details).toEqual([]);
+	});
+
+	it("truncates only pathological commands and keeps the full text in details", () => {
+		const summary = buildToolSummary({
+			toolName: "run_commands",
+			input: { commands: [`echo ${"x".repeat(400)}`] },
 		});
 		expect(summary.label.length).toBeLessThanOrEqual(
-			"Ran command ".length + 60,
+			"Ran command ".length + 200,
 		);
 		expect(summary.label.endsWith("…")).toBe(true);
-		expect(summary.details[0]).toBe(`echo ${"x".repeat(100)}`);
+		expect(summary.details[0]).toBe(`echo ${"x".repeat(400)}`);
 	});
 
 	it("accepts every run_commands union shape", () => {
@@ -232,6 +242,8 @@ describe("editor summaries", () => {
 			},
 		});
 		expect(summary.label).toBe("Edited file util.ts");
+		// The expanded panel leads with the fuller path, like read rows.
+		expect(summary.details).toEqual(["src/util.ts"]);
 		expect(summary.diff).toEqual({ additions: 2, deletions: 1 });
 		const item = summary.items[0];
 		expect(item.type).toBe("file");

--- a/sdk/packages/ui/tests/tool-summary.test.ts
+++ b/sdk/packages/ui/tests/tool-summary.test.ts
@@ -48,6 +48,10 @@ describe("read_files summaries", () => {
 			input: { files: [{ path: "src/app.tsx", start_line: 10, end_line: 80 }] },
 		});
 		expect(summary.label).toBe("Read app.tsx (10–80)");
+		expect(summary.labelParts).toEqual([
+			{ text: "Read " },
+			{ text: "app.tsx (10–80)", code: true },
+		]);
 		expect(summary.kind).toBe("read");
 		expect(summary.details).toEqual(["src/app.tsx:10-80"]);
 		expect(summary.items).toEqual([
@@ -109,25 +113,52 @@ describe("read_files summaries", () => {
 });
 
 describe("run_commands summaries", () => {
-	it("puts a single command inline in the label", () => {
+	it("renders a single command as a terminal prompt", () => {
 		const summary = buildToolSummary({
 			toolName: "run_commands",
 			input: { commands: ["bun run test"] },
 		});
-		expect(summary.label).toBe("Ran bun run test");
+		expect(summary.label).toBe("$ bun run test");
+		expect(summary.labelParts).toEqual([
+			{ text: "$ ", code: true },
+			{ text: "bun run test", code: true },
+		]);
 		expect(summary.items).toEqual([
 			{ type: "command", command: "bun run test" },
 		]);
+		// The untruncated command already sits in the label; no duplicate detail.
+		expect(summary.details).toEqual([]);
 	});
 
-	it("truncates long single commands", () => {
+	it("truncates long single commands and keeps the full text in details", () => {
 		const summary = buildToolSummary({
 			toolName: "run_commands",
 			input: { commands: [`echo ${"x".repeat(100)}`] },
 		});
-		expect(summary.label.length).toBeLessThanOrEqual("Ran ".length + 60);
+		expect(summary.label.length).toBeLessThanOrEqual("$ ".length + 60);
 		expect(summary.label.endsWith("…")).toBe(true);
 		expect(summary.details[0]).toBe(`echo ${"x".repeat(100)}`);
+	});
+
+	it("accepts every run_commands union shape", () => {
+		const cases: Array<[unknown, string[]]> = [
+			[{ commands: "ls -la" }, ["ls -la"]],
+			[{ commands: { command: "git", args: ["status"] } }, ["git status"]],
+			[[{ command: "bun", args: ["test"] }], ["bun test"]],
+			[{ command: "bun", args: ["run", "lint"] }, ["bun run lint"]],
+			[{ cmd: "pwd" }, ["pwd"]],
+			[
+				["ls", "pwd"],
+				["ls", "pwd"],
+			],
+			["whoami", ["whoami"]],
+		];
+		for (const [input, expected] of cases) {
+			const summary = buildToolSummary({ toolName: "run_commands", input });
+			expect(summary.items).toEqual(
+				expected.map((command) => ({ type: "command", command })),
+			);
+		}
 	});
 
 	it("aggregates multiple commands and joins structured entries", () => {
@@ -239,6 +270,19 @@ describe("editor summaries", () => {
 		expect(summary.diff).toEqual({ additions: 2, deletions: 0 });
 	});
 
+	it("does not report phantom lines for empty texts", () => {
+		const emptied = buildToolSummary({
+			toolName: "editor",
+			input: { path: "a.ts", old_text: "line", new_text: "" },
+		});
+		expect(emptied.diff).toEqual({ additions: 0, deletions: 1 });
+		const emptyCreate = buildToolSummary({
+			toolName: "editor",
+			input: { path: "b.ts", new_text: "" },
+		});
+		expect(emptyCreate.diff).toEqual({ additions: 0, deletions: 0 });
+	});
+
 	it("uses in-progress verbs", () => {
 		const summary = buildToolSummary({
 			toolName: "editor",
@@ -290,15 +334,79 @@ describe("apply_patch summaries", () => {
 		expect(info?.files[1].diff).toMatch(/@@ -\d+,\d+ \+\d+,\d+ @@/);
 		// Reconstructed texts for rich diff renderers.
 		expect(info?.files[0]).toMatchObject({
-			wholeFile: false,
-			oldText: "old line",
-			newText: "new line\nextra line",
+			action: "update",
+			hunks: [{ oldText: "old line", newText: "new line\nextra line" }],
 		});
 		expect(info?.files[1]).toMatchObject({
-			wholeFile: true,
-			oldText: "",
-			newText: "created",
+			action: "add",
+			hunks: [{ oldText: "", newText: "created" }],
 		});
+	});
+
+	it("preserves hunk boundaries instead of re-diffing across them", () => {
+		const multiHunk = [
+			"*** Begin Patch",
+			"*** Update File: src/multi.ts",
+			"@@ first",
+			"-a",
+			"+b",
+			"@@ second",
+			"-b",
+			"+c",
+			"*** End Patch",
+		].join("\n");
+		const info = parseApplyPatchInput(multiHunk);
+		// Concatenated-and-re-diffed would collapse the -b/+b pair into
+		// context; separate hunks keep both changes intact.
+		expect(info?.files[0].hunks).toEqual([
+			{ oldText: "a", newText: "b" },
+			{ oldText: "b", newText: "c" },
+		]);
+		expect(info?.files[0]).toMatchObject({ additions: 2, deletions: 2 });
+		const summary = buildToolSummary({
+			toolName: "apply_patch",
+			input: multiHunk,
+		});
+		const item = summary.items[0];
+		if (item.type === "file") {
+			expect(item.hunks).toHaveLength(2);
+			expect(item.oldText).toBeUndefined();
+		} else {
+			expect.unreachable("expected a file item");
+		}
+	});
+
+	it("labels deleted and renamed files from their section metadata", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Delete File: src/gone.ts",
+			"*** End Patch",
+		].join("\n");
+		const summary = buildToolSummary({ toolName: "apply_patch", input: patch });
+		expect(summary.label).toBe("Deleted gone.ts");
+		expect(summary.details).toEqual(["Deleted src/gone.ts"]);
+		const item = summary.items[0];
+		if (item.type === "file") {
+			expect(item.newText).toBeUndefined();
+			expect(item.hunks).toBeUndefined();
+		}
+
+		const rename = [
+			"*** Begin Patch",
+			"*** Update File: src/old-name.ts",
+			"*** Move to: src/new-name.ts",
+			"-a",
+			"+b",
+			"*** End Patch",
+		].join("\n");
+		const renamed = buildToolSummary({
+			toolName: "apply_patch",
+			input: rename,
+		});
+		expect(renamed.label).toBe("Edited old-name.ts → new-name.ts");
+		expect(renamed.details).toEqual([
+			"src/old-name.ts → src/new-name.ts +1 -1",
+		]);
 	});
 
 	it("labels multi-file patches with counts and per-file details", () => {

--- a/sdk/packages/ui/tests/tool-summary.test.ts
+++ b/sdk/packages/ui/tests/tool-summary.test.ts
@@ -47,9 +47,9 @@ describe("read_files summaries", () => {
 			toolName: "read_files",
 			input: { files: [{ path: "src/app.tsx", start_line: 10, end_line: 80 }] },
 		});
-		expect(summary.label).toBe("Read app.tsx (10–80)");
+		expect(summary.label).toBe("Read file app.tsx (10–80)");
 		expect(summary.labelParts).toEqual([
-			{ text: "Read " },
+			{ text: "Read file " },
 			{ text: "app.tsx (10–80)", code: true },
 		]);
 		expect(summary.kind).toBe("read");
@@ -71,7 +71,7 @@ describe("read_files summaries", () => {
 			toolName: "read_files",
 			input: { files: [{ path: "a.ts", start_line: 100 }] },
 		});
-		expect(summary.label).toBe("Read a.ts (100+)");
+		expect(summary.label).toBe("Read file a.ts (100+)");
 		expect(summary.details).toEqual(["a.ts:100+"]);
 	});
 
@@ -90,13 +90,13 @@ describe("read_files summaries", () => {
 		expect(
 			buildToolSummary({ toolName: "read_files", input: { paths: ["x.go"] } })
 				.label,
-		).toBe("Read x.go");
+		).toBe("Read file x.go");
 		expect(
 			buildToolSummary({
 				toolName: "read_files",
 				input: '{"file_paths":["y.rs"]}',
 			}).label,
-		).toBe("Read y.rs");
+		).toBe("Read file y.rs");
 	});
 
 	it("shortens long paths in details but keeps basenames in labels", () => {
@@ -106,21 +106,21 @@ describe("read_files summaries", () => {
 			toolName: "read_files",
 			input: { file_paths: [longPath] },
 		});
-		expect(summary.label).toBe("Read chat-messages.tsx");
+		expect(summary.label).toBe("Read file chat-messages.tsx");
 		expect(summary.details[0]).toBe(shortenPath(longPath));
 		expect(summary.details[0].startsWith(".../")).toBe(true);
 	});
 });
 
 describe("run_commands summaries", () => {
-	it("renders a single command as a terminal prompt", () => {
+	it("leads a single command with the action, command in mono", () => {
 		const summary = buildToolSummary({
 			toolName: "run_commands",
 			input: { commands: ["bun run test"] },
 		});
-		expect(summary.label).toBe("$ bun run test");
+		expect(summary.label).toBe("Ran command bun run test");
 		expect(summary.labelParts).toEqual([
-			{ text: "$ ", code: true },
+			{ text: "Ran command " },
 			{ text: "bun run test", code: true },
 		]);
 		expect(summary.items).toEqual([
@@ -135,7 +135,9 @@ describe("run_commands summaries", () => {
 			toolName: "run_commands",
 			input: { commands: [`echo ${"x".repeat(100)}`] },
 		});
-		expect(summary.label.length).toBeLessThanOrEqual("$ ".length + 60);
+		expect(summary.label.length).toBeLessThanOrEqual(
+			"Ran command ".length + 60,
+		);
 		expect(summary.label.endsWith("…")).toBe(true);
 		expect(summary.details[0]).toBe(`echo ${"x".repeat(100)}`);
 	});
@@ -229,7 +231,7 @@ describe("editor summaries", () => {
 				new_text: "const a = 1;\nconst b = 3;\nconst c = 4;",
 			},
 		});
-		expect(summary.label).toBe("Edited util.ts");
+		expect(summary.label).toBe("Edited file util.ts");
 		expect(summary.diff).toEqual({ additions: 2, deletions: 1 });
 		const item = summary.items[0];
 		expect(item.type).toBe("file");
@@ -266,7 +268,7 @@ describe("editor summaries", () => {
 			toolName: "editor",
 			input: { path: "new.py", new_text: "print(1)\nprint(2)" },
 		});
-		expect(summary.label).toBe("Created new.py");
+		expect(summary.label).toBe("Created file new.py");
 		expect(summary.diff).toEqual({ additions: 2, deletions: 0 });
 	});
 
@@ -289,7 +291,7 @@ describe("editor summaries", () => {
 			input: { path: "a.ts", old_text: "x", new_text: "y" },
 			inProgress: true,
 		});
-		expect(summary.label).toBe("Editing a.ts");
+		expect(summary.label).toBe("Editing file a.ts");
 	});
 
 	it("falls back to +N:/-N: counts from the result", () => {
@@ -298,7 +300,7 @@ describe("editor summaries", () => {
 			input: { path: "a.ts" },
 			result: { result: "+12: added line\n-13: removed line\n+14: another" },
 		});
-		expect(summary.label).toBe("Edited a.ts");
+		expect(summary.label).toBe("Edited file a.ts");
 		expect(summary.diff).toEqual({ additions: 2, deletions: 1 });
 	});
 });
@@ -383,7 +385,7 @@ describe("apply_patch summaries", () => {
 			"*** End Patch",
 		].join("\n");
 		const summary = buildToolSummary({ toolName: "apply_patch", input: patch });
-		expect(summary.label).toBe("Deleted gone.ts");
+		expect(summary.label).toBe("Deleted file gone.ts");
 		expect(summary.details).toEqual(["Deleted src/gone.ts"]);
 		const item = summary.items[0];
 		if (item.type === "file") {
@@ -403,7 +405,7 @@ describe("apply_patch summaries", () => {
 			toolName: "apply_patch",
 			input: rename,
 		});
-		expect(renamed.label).toBe("Edited old-name.ts → new-name.ts");
+		expect(renamed.label).toBe("Edited file old-name.ts → new-name.ts");
 		expect(renamed.details).toEqual([
 			"src/old-name.ts → src/new-name.ts +1 -1",
 		]);
@@ -425,7 +427,7 @@ describe("apply_patch summaries", () => {
 		].join("\n");
 		expect(
 			buildToolSummary({ toolName: "apply_patch", input: single }).label,
-		).toBe("Edited only.ts");
+		).toBe("Edited file only.ts");
 	});
 
 	it("degrades to a generic label when the envelope is unparsable", () => {
@@ -566,7 +568,7 @@ describe("buildGroupedToolLabel", () => {
 			toolName: "read_files",
 			input: { files: [{ path: "a.ts", start_line: 1, end_line: 5 }] },
 		});
-		expect(buildGroupedToolLabel([summary])).toBe("Read a.ts (1–5)");
+		expect(buildGroupedToolLabel([summary])).toBe("Read file a.ts (1–5)");
 	});
 
 	it("merges input-less fallback summaries into grouped counts", () => {

--- a/sdk/packages/ui/tests/tool-summary.test.ts
+++ b/sdk/packages/ui/tests/tool-summary.test.ts
@@ -126,27 +126,30 @@ describe("run_commands summaries", () => {
 		expect(summary.items).toEqual([
 			{ type: "command", command: "bun run test" },
 		]);
-		// The untruncated command already sits in the label; no duplicate detail.
-		expect(summary.details).toEqual([]);
+		// The layer above may ellipsize the label, so the expanded panel
+		// always carries the full command.
+		expect(summary.details).toEqual(["bun run test"]);
 	});
 
-	it("keeps realistic commands untruncated in the label", () => {
-		const command = `bun run test --filter @cline/ui --reporter verbose ${"x".repeat(60)}`;
+	it("never truncates labels by default — layout owns overflow", () => {
+		const command = `echo ${"x".repeat(400)}`;
 		const summary = buildToolSummary({
 			toolName: "run_commands",
 			input: { commands: [command] },
 		});
 		expect(summary.label).toBe(`Ran command ${command}`);
-		expect(summary.details).toEqual([]);
 	});
 
-	it("truncates only pathological commands and keeps the full text in details", () => {
-		const summary = buildToolSummary({
-			toolName: "run_commands",
-			input: { commands: [`echo ${"x".repeat(400)}`] },
-		});
+	it("applies maxInlineChars only when a consumer opts in", () => {
+		const summary = buildToolSummary(
+			{
+				toolName: "run_commands",
+				input: { commands: [`echo ${"x".repeat(400)}`] },
+			},
+			{ maxInlineChars: 60 },
+		);
 		expect(summary.label.length).toBeLessThanOrEqual(
-			"Ran command ".length + 200,
+			"Ran command ".length + 60,
 		);
 		expect(summary.label.endsWith("…")).toBe(true);
 		expect(summary.details[0]).toBe(`echo ${"x".repeat(400)}`);

--- a/sdk/packages/ui/theme/palette.css
+++ b/sdk/packages/ui/theme/palette.css
@@ -181,7 +181,7 @@
 	--neutral-1: #121216;
 	--neutral-2: #18191b;
 	--neutral-3: #212225;
-	--neutral-4: #2F2F37;
+	--neutral-4: #2f2f37;
 	--neutral-5: #2e3135;
 	--neutral-6: #363a3f;
 	--neutral-7: #43484e;

--- a/sdk/packages/ui/theme/scoped-tokens.css
+++ b/sdk/packages/ui/theme/scoped-tokens.css
@@ -179,7 +179,7 @@
 	--neutral-1: #121216;
 	--neutral-2: #18191b;
 	--neutral-3: #212225;
-	--neutral-4: #2F2F37;
+	--neutral-4: #2f2f37;
 	--neutral-5: #2e3135;
 	--neutral-6: #363a3f;
 	--neutral-7: #43484e;

--- a/sdk/packages/ui/theme/scoped-tokens.css
+++ b/sdk/packages/ui/theme/scoped-tokens.css
@@ -347,6 +347,10 @@
 .cline-ui-theme {
 	/* Brand extensions for artwork; components should prefer semantic tokens. */
 	--brand-violet: oklch(0.55 0.22 293);
+	/* Filled brand surface (user chat bubbles): deep enough in both themes to
+	 * carry near-white text at readable contrast. */
+	--brand-violet-surface: oklch(0.55 0.22 293);
+	--brand-violet-surface-foreground: oklch(0.985 0.005 293);
 	--brand-lilac: oklch(0.88 0.09 315);
 	--brand-magenta: oklch(0.75 0.15 330);
 	--brand-periwinkle: oklch(0.69 0.14 275);
@@ -395,6 +399,8 @@
 .dark .cline-ui-theme,
 .cline-ui-theme.dark {
 	--brand-violet: oklch(0.7 0.17 293);
+	--brand-violet-surface: oklch(0.48 0.18 293);
+	--brand-violet-surface-foreground: oklch(0.97 0.01 293);
 	--brand-lilac: oklch(0.68 0.13 315);
 	--brand-magenta: oklch(0.64 0.17 330);
 	--brand-periwinkle: oklch(0.63 0.16 275);

--- a/sdk/packages/ui/theme/tokens.css
+++ b/sdk/packages/ui/theme/tokens.css
@@ -11,6 +11,10 @@
 :root {
 	/* Brand extensions for artwork; components should prefer semantic tokens. */
 	--brand-violet: oklch(0.55 0.22 293);
+	/* Filled brand surface (user chat bubbles): deep enough in both themes to
+	 * carry near-white text at readable contrast. */
+	--brand-violet-surface: oklch(0.55 0.22 293);
+	--brand-violet-surface-foreground: oklch(0.985 0.005 293);
 	--brand-lilac: oklch(0.88 0.09 315);
 	--brand-magenta: oklch(0.75 0.15 330);
 	--brand-periwinkle: oklch(0.69 0.14 275);
@@ -58,6 +62,8 @@
 
 .dark {
 	--brand-violet: oklch(0.7 0.17 293);
+	--brand-violet-surface: oklch(0.48 0.18 293);
+	--brand-violet-surface-foreground: oklch(0.97 0.01 293);
 	--brand-lilac: oklch(0.68 0.13 315);
 	--brand-magenta: oklch(0.64 0.17 330);
 	--brand-periwinkle: oklch(0.63 0.16 275);


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — follow-up to #13151 from design review; must land before the `@cline/ui@0.2.0-next.3` publish.

### Description

Two threads converged here: design feedback from actually using the desktop app, and post-merge review findings on #13151.

**Design: one row per tool call.** The grouped rows from #13151 ("Read 3 files · Ran 2 commands") compressed too much — you couldn't see individual calls executing, and commands/edits had no room for their own treatment. Every tool call now renders as its own row:

- **Commands read like a terminal**: `$ bun run test` in monospace (no more "Ran bun run test" prose), spinner while running, captured output in a capped scrollable mono block on expand, `$ `-prefixed detail lines for multi-command calls. An untruncated single command no longer duplicates itself as a detail line.
- **Edits are diff-first**: verb + mono filename + ±badge in the row, pierre diff open by default underneath (with the user-toggle override so a collapsed row stays collapsed).
- **Reads/searches/fetches** keep inline specifics, with the code-ish segment (file name, query, URL) in monospace.

To support per-kind styling without consumers re-parsing label strings, `ToolSummary` gains **`labelParts`** — `{text, code?}[]` segments that join to the plain `label`. Consumers render `code: true` segments in a mono face.

**Review findings addressed** (both review passes on #13151):

- **`test:chat-ui` exit-1 regression (blocking)**: `@pierre/diffs`' custom element calls `CSSStyleSheet.replaceSync` in its constructor, which jsdom doesn't implement — the suite passed all tests but exited 1 on an unhandled error, which would have failed `ui-publish.yml`'s gate before `npm publish`. Fixed with a prototype polyfill in the test file (kept the real component in the tree rather than mocking, so the pre-expand assertions still exercise real DOM).
- **Multi-hunk apply_patch mis-render (P1)**: hunks were concatenated then re-diffed, letting LCS pair a deletion in one hunk with an addition in another (`-a/+b` + `-b/+c` rendered as `-a`, context `b`, `+c` while the badge said +2 −2). `ApplyPatchFile` and file items now carry per-hunk `oldText`/`newText`, and consumers render one diff per hunk. Pinned by a test that fails on the old concatenate-and-re-diff behavior.
- **Patch action metadata discarded (P2)**: `Delete File` sections now label as `Deleted x` with no phantom `+0 −0` diff item; `*** Move to:` renames display as `old → new` in labels and details.
- **run_commands shapes lost (P2)**: the parser now accepts every `RunCommandsInputUnionSchema` shape — single entry instead of array, bare arrays, top-level `{command, args}`, `{cmd}` — verified against the schema in `sdk/packages/core`.
- **Empty `new_text` phantom addition (P2)**: `makeUnifiedDiff` treats empty text as zero lines; creating an empty file reports +0, deleting all content reports just the deletions.
- Non-blocking nits: `parseWebFetchInput` drops non-string URLs instead of rendering `[object Object]`; hoisted a double `normalizeValue` in the unknown-tool fallback.

`buildGroupedToolLabel` stays exported (cloud or other consumers may want it) but the desktop no longer uses it.

### Test Procedure

All exit codes checked explicitly this round (the previous miss was grepping the Tests line without the exit code):

- `bun -F @cline/ui test` — 90/90, exit 0 (new: labelParts, `$` command labels, union shapes, per-hunk boundaries, delete/rename labels, empty-text diffs)
- `bun -F @cline/code test:chat-ui` — 93/93, **exit 0** (was exit 1 on the merged main)
- `bun -F @cline/ui typecheck`, `bun -F @cline/code typecheck` — clean
- `bun -F @cline/ui test:package` — packed-tarball smoke green in Bun/React 19 and npm/Node/React 18 consumers
- biome clean on all touched files
- Eyeballed live in the browser-mode desktop app (real session) and the `ToolSummaries` Storybook story

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The `ToolSummaries` story (`bun -F @cline/ui storybook`) shows the full row vocabulary with the new treatment; the desktop app in browser mode shows it live during a session.

### Additional Notes

This gates the `@cline/ui@0.2.0-next.3` publish — `ui-publish.yml` runs `test:chat-ui`, which exits 1 on current main without the polyfill here. Rollout stays: land this → dispatch `ui-publish.yml` (`npm_tag: next`) → regenerate the core-platform lockfile on cline/core-platform#3149 (which will also be updated to render per-hunk diffs and mono label parts).
