### PR TITLE
fix: use workspace cwd for Claude Code provider

### DIFF
--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -118,6 +118,7 @@ export function buildDelegatedAgentConfig(
 
 	return {
 		...options.configProvider.getConnectionConfig(),
+		cwd: options.cwd ?? runtimeConfig.cwd,
 		systemPrompt,
 		tools: options.tools,
 		maxIterations: options.maxIterations ?? runtimeConfig.maxIterations,

--- a/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/spawn-agent-tool.test.ts
@@ -64,6 +64,7 @@ describe("createSpawnAgentTool", () => {
 			configProvider: createDelegatedAgentConfigProvider({
 				providerId: "anthropic",
 				modelId: "mock-model",
+				cwd: "/workspace/project",
 				extensions,
 			}),
 			defaultMaxIterations: 4,
@@ -101,6 +102,7 @@ describe("createSpawnAgentTool", () => {
 			expect.objectContaining({
 				parentAgentId: "parent-1",
 				maxIterations: 4,
+				cwd: "/workspace/project",
 				extensions,
 			}),
 		);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -516,6 +516,7 @@ describe("LocalRuntimeHost", () => {
 			expect.objectContaining({
 				providerId: "cline-pass",
 				apiKey: "workos:resolved-token",
+				cwd: "/tmp/project",
 			}),
 		);
 	});

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -671,6 +671,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 
 		const agentConfig = {
 			sessionId,
+			cwd: configWithProvider.cwd,
 			providerId: providerConfig.providerId,
 			modelId: providerConfig.modelId,
 			apiKey: providerConfig.apiKey,

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -593,6 +593,78 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards the session cwd to Claude Code while preserving explicit settings", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "claude-code",
+				modelId: "claude-sonnet-4-5",
+				cwd: "C:\\workspace\\project",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "claude-code",
+					modelId: "claude-sonnet-4-5",
+					claudeCode: {
+						defaultSettings: { permissionMode: "plan" },
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "claude-code",
+						options: {
+							defaultSettings: {
+								cwd: "C:\\workspace\\project",
+								permissionMode: "plan",
+							},
+						},
+					}),
+				],
+			}),
+		);
+	});
+
+	it("prefers an explicit Claude Code cwd over the session cwd", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "claude-code",
+				modelId: "claude-sonnet-4-5",
+				cwd: "C:\\workspace\\project",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "claude-code",
+					modelId: "claude-sonnet-4-5",
+					claudeCode: {
+						defaultSettings: { cwd: "D:\\explicit" },
+					},
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						options: {
+							defaultSettings: { cwd: "D:\\explicit" },
+						},
+					}),
+				],
+			}),
+		);
+	});
+
 	it("uses a registered handler (adapter) instead of the gateway, building it lazily", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -34,6 +34,7 @@ function usesOpenAICompatibleClient(config: ProviderConfig): boolean {
 
 function buildGatewayProviderOptions(
 	config: ProviderConfig,
+	cwd?: string,
 ): Record<string, unknown> | undefined {
 	const options: Record<string, unknown> = {
 		region: config.region,
@@ -76,6 +77,16 @@ function buildGatewayProviderOptions(
 
 	if (config.providerId === "sapaicore") {
 		Object.assign(options, config.sap);
+	}
+
+	if (config.providerId === "claude-code") {
+		const defaultSettings = config.claudeCode?.defaultSettings ?? {};
+		Object.assign(options, config.claudeCode, {
+			defaultSettings: {
+				...(cwd ? { cwd } : {}),
+				...defaultSettings,
+			},
+		});
 	}
 
 	return compactOptions(options);
@@ -235,7 +246,10 @@ export function createAgentModelFromConfig(
 				headers: normalizedProviderConfig.headers,
 				timeoutMs: normalizedProviderConfig.timeoutMs,
 				fetch: normalizedProviderConfig.fetch,
-				options: buildGatewayProviderOptions(normalizedProviderConfig),
+				options: buildGatewayProviderOptions(
+					normalizedProviderConfig,
+					config.cwd,
+				),
 				models: normalizedProviderConfig.knownModels
 					? Object.entries(normalizedProviderConfig.knownModels).map(
 							([id, model]) => toGatewayConfiguredModel(id, model),

--- a/sdk/packages/llms/src/providers/config.ts
+++ b/sdk/packages/llms/src/providers/config.ts
@@ -218,6 +218,7 @@ export interface CodexConfig {
  * Claude Code provider options
  */
 export interface ClaudeCodeConfig {
+	defaultSettings?: Record<string, unknown>;
 	[key: string]: unknown;
 }
 

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -699,6 +699,8 @@ export interface AgentConfig {
 	baseUrl?: string;
 	/** Additional headers for API requests */
 	headers?: Record<string, string>;
+	/** Session working directory used by providers that spawn local processes. */
+	cwd?: string;
 	/**
 	 * Called when a run fails with an auth-like provider error (e.g. an OAuth
 	 * access token that expired mid-run). Hosts refresh credentials and push


### PR DESCRIPTION
### Related Issue

**Issue:** #13160

### Description

The Claude Code provider currently starts its local process without the active Cline workspace as its working directory. On Windows, that lets the process inherit the VS Code/Cline installation directory instead of the session workspace.

This change:

- preserves the host session `cwd` when constructing both root and delegated `AgentConfig` objects;
- forwards that cwd through Claude Code's `defaultSettings`;
- preserves an explicitly configured `claudeCode.defaultSettings.cwd` as the higher-priority override;
- leaves other gateway providers unchanged.

### Test Procedure

- `bun run build:sdk`
- `vitest run src/services/llms/handler-factory.test.ts src/extensions/tools/team/spawn-agent-tool.test.ts src/runtime/host/local-runtime-host.test.ts --config vitest.config.ts` from `sdk/packages/core`: **100 passed**
- `bun -F @cline/shared typecheck`
- `bun -F @cline/llms typecheck`
- `bun -F @cline/core typecheck`
- Biome check on all eight changed files

Regression coverage verifies the session cwd is forwarded, unrelated Claude Code settings are retained, an explicit cwd override wins, and delegated agents retain the workspace cwd.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor Changes
- [ ] Cosmetic Changes
- [ ] Documentation update
- [ ] Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single bugfix
- [x] Focused tests, SDK builds, type checks, formatting, and linting pass
- [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable; this is a provider/runtime fix with no UI changes.
