### PR TITLE
fix(core): stop checkpoints from re-hashing unchanged untracked files every turn

### DIFF
--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +9,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	type CheckpointEntry,
 	type CheckpointMetadata,
+	checkpointScratchDir,
 	createCheckpointHooks,
+	deleteCheckpointRefs,
 } from "./checkpoint-hooks";
 
 const execFile = promisify(execFileCallback);
@@ -592,4 +595,127 @@ describe("createCheckpointHooks", () => {
 			createCheckpoint.mock.calls.map(([input]) => input.runCount),
 		).toEqual([1, 2]);
 	});
+
+	it("emits one checkpoint.snapshot event per snapshot attempt without file paths", async () => {
+		const cwd = await createGitRepo();
+		const sessionId = "sess_telemetry";
+		let metadata: Record<string, unknown> | undefined;
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				telemetry: {
+					capture: (input) => {
+						events.push(input);
+					},
+				},
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			await writeFile(join(cwd, "loose-data.txt"), "loose\n", "utf8");
+			await runCheckpointHooks(hooks);
+
+			expect(events).toHaveLength(1);
+			expect(events[0]?.event).toBe("checkpoint.snapshot");
+			expect(events[0]?.properties).toMatchObject({
+				sessionId,
+				runCount: 1,
+				outcome: "stash",
+			});
+			expect(typeof events[0]?.properties?.durationMs).toBe("number");
+			// Durations and outcomes only — never workspace file paths.
+			expect(JSON.stringify(events[0])).not.toContain("loose-data");
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("drops persistent-index entries for untracked files that disappear between runs", async () => {
+		// The per-session GIT_INDEX_FILE caches untracked hashes across turns so
+		// unchanged files are not re-hashed; a file that was deleted (or became
+		// tracked) in the meantime must not ghost into later snapshots.
+		const cwd = await createGitRepo();
+		const sessionId = "sess_stale_index";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			await writeFile(join(cwd, "a.txt"), "a\n", "utf8");
+			await writeFile(join(cwd, "b.txt"), "b\n", "utf8");
+			await runCheckpointHooks(hooks);
+
+			const first = (metadata?.checkpoint as CheckpointMetadata).latest;
+			const firstTree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${first.ref}^3`,
+			);
+			expect(firstTree.split("\n").sort()).toEqual(["a.txt", "b.txt"]);
+			// The scratch index survives the turn — that is the cross-turn cache.
+			expect(existsSync(join(checkpointScratchDir(sessionId), "index"))).toBe(
+				true,
+			);
+
+			await rm(join(cwd, "a.txt"));
+			await runCheckpointHooks(hooks, {
+				messages: [userMessage("first request"), userMessage("second request")],
+			});
+
+			const second = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(second.runCount).toBe(2);
+			const secondTree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${second.ref}^3`,
+			);
+			expect(secondTree.split("\n")).toEqual(["b.txt"]);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes the per-session scratch dir together with the checkpoint refs", async () => {
+		const cwd = await createGitRepo();
+		const sessionId = "sess_scratch_cleanup";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+			await writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
+			await runCheckpointHooks(hooks);
+			expect(existsSync(checkpointScratchDir(sessionId))).toBe(true);
+
+			await deleteCheckpointRefs(cwd, sessionId);
+
+			expect(existsSync(checkpointScratchDir(sessionId))).toBe(false);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 });

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -805,4 +805,46 @@ describe("createCheckpointHooks", () => {
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
+
+	it("detects untracked content changes across turns when core.ignorestat is enabled", async () => {
+		// With core.ignorestat=true git marks entries it writes as
+		// assume-unchanged and stops stat-checking them. The throwaway per-turn
+		// index never carried that bit across turns; a persistent index does,
+		// so without pinning the setting the second snapshot silently keeps the
+		// first turn's content.
+		const cwd = await createGitRepo();
+		const sessionId = "sess_ignorestat";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			await runGit(cwd, "config", "core.ignorestat", "true");
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			await writeFile(join(cwd, "data.txt"), "before", "utf8");
+			await runCheckpointHooks(hooks);
+			const first = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(await runGit(cwd, "show", `${first.ref}^3:data.txt`)).toBe(
+				"before",
+			);
+
+			await writeFile(join(cwd, "data.txt"), "after!", "utf8");
+			await runCheckpointHooks(hooks, {
+				messages: [userMessage("first request"), userMessage("second request")],
+			});
+			const second = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(second.runCount).toBe(2);
+			expect(await runGit(cwd, "show", `${second.ref}^3:data.txt`)).toBe(
+				"after!",
+			);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -1,6 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -667,9 +667,9 @@ describe("createCheckpointHooks", () => {
 			);
 			expect(firstTree.split("\n").sort()).toEqual(["a.txt", "b.txt"]);
 			// The scratch index survives the turn — that is the cross-turn cache.
-			expect(existsSync(join(checkpointScratchDir(sessionId), "index"))).toBe(
-				true,
-			);
+			expect(
+				existsSync(join(checkpointScratchDir(cwd, sessionId), "index")),
+			).toBe(true);
 
 			await rm(join(cwd, "a.txt"));
 			await runCheckpointHooks(hooks, {
@@ -707,15 +707,102 @@ describe("createCheckpointHooks", () => {
 			});
 			await writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
 			await runCheckpointHooks(hooks);
-			expect(existsSync(checkpointScratchDir(sessionId))).toBe(true);
+			expect(existsSync(checkpointScratchDir(cwd, sessionId))).toBe(true);
 
 			await deleteCheckpointRefs(cwd, sessionId);
 
-			expect(existsSync(checkpointScratchDir(sessionId))).toBe(false);
+			expect(existsSync(checkpointScratchDir(cwd, sessionId))).toBe(false);
 		} finally {
 			await deleteCheckpointRefs(cwd, sessionId);
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
 
+	it("recovers from a stale index.lock left by a killed git process", async () => {
+		const cwd = await createGitRepo();
+		const sessionId = "sess_stale_lock";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+			// A SIGKILLed git leaves the lock file next to the persistent index;
+			// the rebuild must clear it or every later turn degrades to HEAD-only.
+			const scratch = checkpointScratchDir(cwd, sessionId);
+			await mkdir(scratch, { recursive: true });
+			await writeFile(join(scratch, "index.lock"), "", "utf8");
+			await writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
+
+			await runCheckpointHooks(hooks);
+
+			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
+			expect(checkpoint.latest.kind).toBe("stash");
+			const tree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${checkpoint.latest.ref}^3`,
+			);
+			expect(tree.split("\n")).toEqual(["loose.txt"]);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps an untracked nested repository's gitlink across turns", async () => {
+		// `ls-files --others` reports a nested repo as "sub/" while the index
+		// records the gitlink as "sub"; the stale sweep must not treat that
+		// name difference as a deleted entry.
+		const cwd = await createGitRepo();
+		const sessionId = "sess_nested_repo";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const sub = join(cwd, "sub");
+			await mkdir(sub);
+			await runGit(sub, "init");
+			await runGit(sub, "config", "user.name", "Codex Test");
+			await runGit(sub, "config", "user.email", "codex@example.com");
+			await writeFile(join(sub, "inner.txt"), "inner\n", "utf8");
+			await runGit(sub, "add", "inner.txt");
+			await runGit(sub, "commit", "-m", "inner");
+
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+			await runCheckpointHooks(hooks);
+
+			const first = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(first.kind).toBe("stash");
+			expect(await runGit(cwd, "ls-tree", `${first.ref}^3`)).toMatch(
+				/160000 commit [0-9a-f]{40}\tsub/,
+			);
+
+			// The second turn exercises the stale sweep against the now-populated
+			// persistent index.
+			await writeFile(join(cwd, "extra.txt"), "extra\n", "utf8");
+			await runCheckpointHooks(hooks, {
+				messages: [userMessage("first request"), userMessage("second request")],
+			});
+			const second = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(second.runCount).toBe(2);
+			expect(await runGit(cwd, "ls-tree", `${second.ref}^3`)).toMatch(
+				/160000 commit [0-9a-f]{40}\tsub/,
+			);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -1,16 +1,29 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { AgentHooks, BasicLogger } from "@cline/shared";
+import type { AgentHooks, BasicLogger, ITelemetryService } from "@cline/shared";
 import { countUserRunMessages } from "../session/user-run-messages";
 
 const execFile = promisify(execFileCallback);
 const CHECKPOINT_STASH_MESSAGE_PREFIX = "cline checkpoint session=";
+const LS_FILES_MAX_BUFFER = 1024 * 1024 * 64;
 
 export function isCheckpointStashMessage(message: string): boolean {
 	return message.includes(CHECKPOINT_STASH_MESSAGE_PREFIX);
+}
+
+/**
+ * Per-session scratch directory holding the persistent `GIT_INDEX_FILE` used
+ * to snapshot untracked files. Persisting the index across turns lets git's
+ * stat cache skip re-reading (and re-hashing) untracked files that have not
+ * changed since the previous checkpoint — without it, every turn re-hashes
+ * every untracked byte in the workspace. Removed by `deleteCheckpointRefs`.
+ */
+export function checkpointScratchDir(sessionId: string): string {
+	const safeId = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+	return join(tmpdir(), `cline-checkpoint-${safeId}`);
 }
 
 export interface CheckpointEntry {
@@ -43,6 +56,13 @@ type CreateCheckpointHooksOptions = {
 		sessionId: string;
 		runCount: number;
 	}) => Promise<CheckpointEntry | undefined> | CheckpointEntry | undefined;
+	/**
+	 * Emits one `checkpoint.snapshot` event per built-in snapshot attempt so
+	 * snapshot cost and degradations (HEAD fallbacks, skipped turns) are
+	 * observable in the field, not only in local logs. Properties carry
+	 * outcome and duration — never file paths or contents.
+	 */
+	telemetry?: Pick<ITelemetryService, "capture">;
 };
 
 function warn(logger: BasicLogger | undefined, message: string): void {
@@ -102,6 +122,7 @@ async function runGitWithIndex(
 ): Promise<string> {
 	const result = await execFile("git", ["-C", cwd, ...args], {
 		windowsHide: true,
+		maxBuffer: LS_FILES_MAX_BUFFER,
 		env: { ...process.env, GIT_INDEX_FILE: indexFile },
 	});
 	return result.stdout.trim();
@@ -116,44 +137,86 @@ async function runGitWithIndex(
  */
 async function createUntrackedParentCommit(
 	cwd: string,
+	scratchDir: string,
 ): Promise<string | undefined> {
 	const listing = await execFile(
 		"git",
 		["-C", cwd, "ls-files", "--others", "--exclude-standard", "-z"],
-		{ windowsHide: true, maxBuffer: 1024 * 1024 * 64 },
+		{ windowsHide: true, maxBuffer: LS_FILES_MAX_BUFFER },
 	);
 	const untrackedFiles = listing.stdout.split("\0").filter(Boolean);
 	if (untrackedFiles.length === 0) {
 		return undefined;
 	}
-	const tempDir = await mkdtemp(join(tmpdir(), "cline-checkpoint-"));
-	const indexFile = join(tempDir, "index");
-	const pathspecFile = join(tempDir, "pathspec");
+	await mkdir(scratchDir, { recursive: true });
+	const indexFile = join(scratchDir, "index");
+	const pathspecFile = join(scratchDir, "pathspec");
+	// Feed paths via a NUL-delimited pathspec file so large untracked sets
+	// cannot overflow the command-line argument limit.
+	await writeFile(pathspecFile, `${untrackedFiles.join("\0")}\0`);
+	const addArgs = [
+		"add",
+		"--force",
+		"--pathspec-from-file",
+		pathspecFile,
+		"--pathspec-file-nul",
+	];
 	try {
-		// Feed paths via a NUL-delimited pathspec file so large untracked sets
-		// cannot overflow the command-line argument limit.
-		await writeFile(pathspecFile, `${untrackedFiles.join("\0")}\0`);
-		await runGitWithIndex(cwd, indexFile, [
-			"add",
-			"--force",
-			"--pathspec-from-file",
-			pathspecFile,
-			"--pathspec-file-nul",
-		]);
-		const tree = await runGitWithIndex(cwd, indexFile, ["write-tree"]);
-		if (!tree) {
-			return undefined;
-		}
-		const commit = await runGitWithIndex(cwd, indexFile, [
-			"commit-tree",
-			tree,
-			"-m",
-			"untracked files on cline checkpoint",
-		]);
-		return commit || undefined;
-	} finally {
-		await rm(tempDir, { recursive: true, force: true });
+		await runGitWithIndex(cwd, indexFile, addArgs);
+	} catch {
+		// A corrupt index (crash mid-write, git version change) would otherwise
+		// fail every turn from here on; rebuild it from scratch once. The retry
+		// pays a full re-hash, so anything else propagates to the caller.
+		await rm(indexFile, { force: true });
+		await runGitWithIndex(cwd, indexFile, addArgs);
 	}
+	// Drop index entries that fell out of the untracked set (file deleted or
+	// became tracked) so they don't ghost into the snapshot tree — `git add`
+	// with a pathspec never removes entries.
+	const indexedListing = await execFile("git", ["-C", cwd, "ls-files", "-z"], {
+		windowsHide: true,
+		maxBuffer: LS_FILES_MAX_BUFFER,
+		env: { ...process.env, GIT_INDEX_FILE: indexFile },
+	});
+	const untrackedSet = new Set(untrackedFiles);
+	const stale = indexedListing.stdout
+		.split("\0")
+		.filter(Boolean)
+		.filter((path) => !untrackedSet.has(path));
+	// `update-index` has no --pathspec-from-file, so pass paths as arguments in
+	// length-bounded batches to stay under Windows' ~32k command-line limit.
+	let batch: string[] = [];
+	let batchLength = 0;
+	const flushBatch = async () => {
+		if (batch.length === 0) return;
+		await runGitWithIndex(cwd, indexFile, [
+			"update-index",
+			"--force-remove",
+			"--",
+			...batch,
+		]);
+		batch = [];
+		batchLength = 0;
+	};
+	for (const path of stale) {
+		if (batch.length > 0 && batchLength + path.length > 8000) {
+			await flushBatch();
+		}
+		batch.push(path);
+		batchLength += path.length + 1;
+	}
+	await flushBatch();
+	const tree = await runGitWithIndex(cwd, indexFile, ["write-tree"]);
+	if (!tree) {
+		return undefined;
+	}
+	const commit = await runGitWithIndex(cwd, indexFile, [
+		"commit-tree",
+		tree,
+		"-m",
+		"untracked files on cline checkpoint",
+	]);
+	return commit || undefined;
 }
 
 /**
@@ -167,10 +230,11 @@ async function createUntrackedParentCommit(
  */
 async function createWorktreeStashCommit(
 	cwd: string,
+	scratchDir: string,
 	message: string,
 ): Promise<string | undefined> {
 	const stashRef = (await runGit(cwd, ["stash", "create", message])).stdout;
-	const untrackedParent = await createUntrackedParentCommit(cwd);
+	const untrackedParent = await createUntrackedParentCommit(cwd, scratchDir);
 
 	if (stashRef) {
 		if (!untrackedParent) {
@@ -256,6 +320,12 @@ export async function deleteCheckpointRefs(
 	cwd: string | null | undefined,
 	sessionId: string,
 ): Promise<void> {
+	// The scratch dir (persistent untracked index) is keyed by session id
+	// alone, so clean it up even when no cwd is known.
+	await rm(checkpointScratchDir(sessionId), {
+		recursive: true,
+		force: true,
+	}).catch(() => undefined);
 	if (!cwd) return;
 	const prefix = `refs/cline/checkpoints/${sessionId}/`;
 	try {
@@ -355,6 +425,26 @@ export function createCheckpointHooks(
 			return undefined;
 		}
 
+		const startedAt = Date.now();
+		// One event per built-in snapshot attempt. Outcomes: "stash" (full
+		// snapshot), "head_clean" (clean worktree, HEAD entry is the normal
+		// result), "head_fallback" (degraded to HEAD after a failure), and
+		// "skipped" (no checkpoint written this turn). Durations only — never
+		// file paths or contents.
+		const captureSnapshot = (
+			outcome: "stash" | "head_clean" | "head_fallback" | "skipped",
+		): void => {
+			options.telemetry?.capture({
+				event: "checkpoint.snapshot",
+				properties: {
+					sessionId: options.sessionId,
+					runCount,
+					outcome,
+					durationMs: Date.now() - startedAt,
+				},
+			});
+		};
+
 		const createHeadCheckpoint = async (
 			warnPrefix: string,
 		): Promise<CheckpointEntry | undefined> => {
@@ -382,16 +472,31 @@ export function createCheckpointHooks(
 		const message = `${CHECKPOINT_STASH_MESSAGE_PREFIX}${options.sessionId} run=${runCount}`;
 		let ref = "";
 		try {
-			ref = (await createWorktreeStashCommit(options.cwd, message)) ?? "";
+			ref =
+				(await createWorktreeStashCommit(
+					options.cwd,
+					checkpointScratchDir(options.sessionId),
+					message,
+				)) ?? "";
 		} catch (error) {
 			warn(
 				options.logger,
-				`Checkpoint snapshot failed: ${error instanceof Error ? error.message : String(error)}`,
+				`Checkpoint snapshot failed after ${Date.now() - startedAt}ms: ${error instanceof Error ? error.message : String(error)}`,
 			);
-			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
+			const fallback = await createHeadCheckpoint(
+				"Checkpoint HEAD fallback failed",
+			);
+			captureSnapshot(fallback ? "head_fallback" : "skipped");
+			return fallback;
 		}
 		if (!ref) {
-			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
+			// A clean worktree with no untracked files — the HEAD entry is the
+			// expected result here, not a degradation.
+			const fallback = await createHeadCheckpoint(
+				"Checkpoint HEAD fallback failed",
+			);
+			captureSnapshot(fallback ? "head_clean" : "skipped");
+			return fallback;
 		}
 
 		// Store the stash commit under a private ref namespace so it is
@@ -408,9 +513,11 @@ export function createCheckpointHooks(
 				options.logger,
 				`Checkpoint store failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
+			captureSnapshot("skipped");
 			return undefined;
 		}
 
+		captureSnapshot("stash");
 		return {
 			ref,
 			createdAt: Date.now(),

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -166,16 +166,37 @@ async function runGit(
 	};
 }
 
+/**
+ * Config pinned for every command that touches the scratch index. A persistent
+ * index inherits whatever the repo's config makes git write into it, and some
+ * settings break cross-turn change detection: `core.ignorestat=true` marks
+ * added entries assume-unchanged, so later turns never stat them again and a
+ * modified file keeps its first-turn content in every subsequent snapshot. The
+ * throwaway per-turn index of the original implementation was immune to this
+ * by construction. `core.splitIndex` would additionally scatter shared-index
+ * files for our private index into the user's `.git`.
+ */
+const SCRATCH_INDEX_GIT_CONFIG = [
+	"-c",
+	"core.ignorestat=false",
+	"-c",
+	"core.splitIndex=false",
+];
+
 async function runGitWithIndex(
 	cwd: string,
 	indexFile: string,
 	args: string[],
 ): Promise<string> {
-	const result = await execFile("git", ["-C", cwd, ...args], {
-		windowsHide: true,
-		maxBuffer: LS_FILES_MAX_BUFFER,
-		env: { ...process.env, GIT_INDEX_FILE: indexFile },
-	});
+	const result = await execFile(
+		"git",
+		["-C", cwd, ...SCRATCH_INDEX_GIT_CONFIG, ...args],
+		{
+			windowsHide: true,
+			maxBuffer: LS_FILES_MAX_BUFFER,
+			env: { ...process.env, GIT_INDEX_FILE: indexFile },
+		},
+	);
 	return result.stdout.trim();
 }
 
@@ -187,11 +208,15 @@ function runGitWithIndexStdin(
 	input: string,
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
-		const child = spawn("git", ["-C", cwd, ...args], {
-			windowsHide: true,
-			env: { ...process.env, GIT_INDEX_FILE: indexFile },
-			stdio: ["pipe", "ignore", "pipe"],
-		});
+		const child = spawn(
+			"git",
+			["-C", cwd, ...SCRATCH_INDEX_GIT_CONFIG, ...args],
+			{
+				windowsHide: true,
+				env: { ...process.env, GIT_INDEX_FILE: indexFile },
+				stdio: ["pipe", "ignore", "pipe"],
+			},
+		);
 		let stderr = "";
 		child.stderr.on("data", (chunk) => {
 			stderr += chunk;
@@ -271,11 +296,15 @@ async function createUntrackedParentCommit(
 	// comparing: `ls-files --others` reports an untracked nested repo as
 	// "sub/", but the index records its gitlink entry as "sub" — without the
 	// normalization the gitlink would be purged the same turn it was added.
-	const indexedListing = await execFile("git", ["-C", cwd, "ls-files", "-z"], {
-		windowsHide: true,
-		maxBuffer: LS_FILES_MAX_BUFFER,
-		env: { ...process.env, GIT_INDEX_FILE: indexFile },
-	});
+	const indexedListing = await execFile(
+		"git",
+		["-C", cwd, ...SCRATCH_INDEX_GIT_CONFIG, "ls-files", "-z"],
+		{
+			windowsHide: true,
+			maxBuffer: LS_FILES_MAX_BUFFER,
+			env: { ...process.env, GIT_INDEX_FILE: indexFile },
+		},
+	);
 	const untrackedSet = new Set(
 		untrackedFiles.map((path) =>
 			path.endsWith("/") ? path.slice(0, -1) : path,

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -1,17 +1,29 @@
-import { execFile as execFileCallback } from "node:child_process";
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { AgentHooks, BasicLogger, ITelemetryService } from "@cline/shared";
+import { resolveClineDataDir } from "@cline/shared/storage";
 import { countUserRunMessages } from "../session/user-run-messages";
 
 const execFile = promisify(execFileCallback);
 const CHECKPOINT_STASH_MESSAGE_PREFIX = "cline checkpoint session=";
 const LS_FILES_MAX_BUFFER = 1024 * 1024 * 64;
+/**
+ * Scratch dirs whose mtime is older than this are reaped opportunistically.
+ * Each snapshot rewrites the index (and so touches the dir), so any live
+ * session refreshes its dir every turn; only sessions idle for this long —
+ * typically ones never explicitly deleted — are affected.
+ */
+const SCRATCH_DIR_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
 export function isCheckpointStashMessage(message: string): boolean {
 	return message.includes(CHECKPOINT_STASH_MESSAGE_PREFIX);
+}
+
+function checkpointScratchBaseDir(): string {
+	return join(resolveClineDataDir(), "checkpoint-scratch");
 }
 
 /**
@@ -19,11 +31,50 @@ export function isCheckpointStashMessage(message: string): boolean {
  * to snapshot untracked files. Persisting the index across turns lets git's
  * stat cache skip re-reading (and re-hashing) untracked files that have not
  * changed since the previous checkpoint — without it, every turn re-hashes
- * every untracked byte in the workspace. Removed by `deleteCheckpointRefs`.
+ * every untracked byte in the workspace.
+ *
+ * Lives under the user's Cline data dir (never the world-shared OS tmpdir:
+ * the index and pathspec files enumerate workspace paths) and is keyed by a
+ * hash of cwd + session id: hashing avoids sanitization collisions between
+ * distinct ids, and folding in cwd keeps a session restored against a
+ * different workspace from inheriting a foreign index. Removed by
+ * `deleteCheckpointRefs` and by the age-based reaper.
  */
-export function checkpointScratchDir(sessionId: string): string {
-	const safeId = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
-	return join(tmpdir(), `cline-checkpoint-${safeId}`);
+export function checkpointScratchDir(cwd: string, sessionId: string): string {
+	const key = createHash("sha256")
+		.update(`${cwd}\0${sessionId}`)
+		.digest("hex")
+		.slice(0, 32);
+	return join(checkpointScratchBaseDir(), key);
+}
+
+/**
+ * Best-effort reaper for scratch dirs of sessions that were never explicitly
+ * deleted. Everything under the base dir is ours, so age is the only
+ * criterion. Errors (missing base dir, races with concurrent sessions) are
+ * ignored — the next hook instance tries again.
+ */
+async function pruneStaleScratchDirs(): Promise<void> {
+	try {
+		const base = checkpointScratchBaseDir();
+		const cutoff = Date.now() - SCRATCH_DIR_MAX_AGE_MS;
+		const entries = await readdir(base, { withFileTypes: true });
+		await Promise.all(
+			entries.map(async (entry) => {
+				if (!entry.isDirectory()) return;
+				const dir = join(base, entry.name);
+				try {
+					if ((await stat(dir)).mtimeMs < cutoff) {
+						await rm(dir, { recursive: true, force: true });
+					}
+				} catch {
+					// Raced with another process — ignore.
+				}
+			}),
+		);
+	} catch {
+		// Base dir missing or unreadable — nothing to prune.
+	}
 }
 
 export interface CheckpointEntry {
@@ -128,6 +179,41 @@ async function runGitWithIndex(
 	return result.stdout.trim();
 }
 
+/** Like `runGitWithIndex`, but feeds `input` to the child's stdin. */
+function runGitWithIndexStdin(
+	cwd: string,
+	indexFile: string,
+	args: string[],
+	input: string,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("git", ["-C", cwd, ...args], {
+			windowsHide: true,
+			env: { ...process.env, GIT_INDEX_FILE: indexFile },
+			stdio: ["pipe", "ignore", "pipe"],
+		});
+		let stderr = "";
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(
+					new Error(`git ${args[0]} exited with ${code}: ${stderr.trim()}`),
+				);
+			}
+		});
+		child.stdin.on("error", () => {
+			// The close handler reports the real failure; without this listener a
+			// child that exits before consuming stdin crashes the process (EPIPE).
+		});
+		child.stdin.end(input);
+	});
+}
+
 /**
  * Builds a commit whose tree contains only the current untracked (but not
  * git-ignored) files, without touching the working tree or the real index.
@@ -148,7 +234,9 @@ async function createUntrackedParentCommit(
 	if (untrackedFiles.length === 0) {
 		return undefined;
 	}
-	await mkdir(scratchDir, { recursive: true });
+	// 0700: the index and pathspec enumerate workspace paths — private to the
+	// user (mode is a no-op on Windows, where the data dir is per-user anyway).
+	await mkdir(scratchDir, { recursive: true, mode: 0o700 });
 	const indexFile = join(scratchDir, "index");
 	const pathspecFile = join(scratchDir, "pathspec");
 	// Feed paths via a NUL-delimited pathspec file so large untracked sets
@@ -163,49 +251,50 @@ async function createUntrackedParentCommit(
 	];
 	try {
 		await runGitWithIndex(cwd, indexFile, addArgs);
-	} catch {
-		// A corrupt index (crash mid-write, git version change) would otherwise
-		// fail every turn from here on; rebuild it from scratch once. The retry
-		// pays a full re-hash, so anything else propagates to the caller.
+	} catch (error) {
+		// A listed file vanishing before the add is a per-turn race, not index
+		// damage — keep the cache and let the caller degrade this turn only.
+		const stderr = String((error as { stderr?: unknown }).stderr ?? "");
+		if (stderr.includes("did not match any files")) {
+			throw error;
+		}
+		// A corrupt index or stale index.lock (crash mid-write, SIGKILLed git)
+		// would otherwise fail every turn from here on; clear both and rebuild
+		// once. The retry pays a full re-hash, so anything else propagates.
 		await rm(indexFile, { force: true });
+		await rm(`${indexFile}.lock`, { force: true });
 		await runGitWithIndex(cwd, indexFile, addArgs);
 	}
 	// Drop index entries that fell out of the untracked set (file deleted or
 	// became tracked) so they don't ghost into the snapshot tree — `git add`
-	// with a pathspec never removes entries.
+	// with a pathspec never removes entries. Normalize trailing slashes when
+	// comparing: `ls-files --others` reports an untracked nested repo as
+	// "sub/", but the index records its gitlink entry as "sub" — without the
+	// normalization the gitlink would be purged the same turn it was added.
 	const indexedListing = await execFile("git", ["-C", cwd, "ls-files", "-z"], {
 		windowsHide: true,
 		maxBuffer: LS_FILES_MAX_BUFFER,
 		env: { ...process.env, GIT_INDEX_FILE: indexFile },
 	});
-	const untrackedSet = new Set(untrackedFiles);
+	const untrackedSet = new Set(
+		untrackedFiles.map((path) =>
+			path.endsWith("/") ? path.slice(0, -1) : path,
+		),
+	);
 	const stale = indexedListing.stdout
 		.split("\0")
 		.filter(Boolean)
 		.filter((path) => !untrackedSet.has(path));
-	// `update-index` has no --pathspec-from-file, so pass paths as arguments in
-	// length-bounded batches to stay under Windows' ~32k command-line limit.
-	let batch: string[] = [];
-	let batchLength = 0;
-	const flushBatch = async () => {
-		if (batch.length === 0) return;
-		await runGitWithIndex(cwd, indexFile, [
-			"update-index",
-			"--force-remove",
-			"--",
-			...batch,
-		]);
-		batch = [];
-		batchLength = 0;
-	};
-	for (const path of stale) {
-		if (batch.length > 0 && batchLength + path.length > 8000) {
-			await flushBatch();
-		}
-		batch.push(path);
-		batchLength += path.length + 1;
+	if (stale.length > 0) {
+		// Paths go over stdin (`-z --stdin`): one git process regardless of how
+		// many entries went stale, and no command-line length limits.
+		await runGitWithIndexStdin(
+			cwd,
+			indexFile,
+			["update-index", "-z", "--force-remove", "--stdin"],
+			`${stale.join("\0")}\0`,
+		);
 	}
-	await flushBatch();
 	const tree = await runGitWithIndex(cwd, indexFile, ["write-tree"]);
 	if (!tree) {
 		return undefined;
@@ -320,13 +409,14 @@ export async function deleteCheckpointRefs(
 	cwd: string | null | undefined,
 	sessionId: string,
 ): Promise<void> {
-	// The scratch dir (persistent untracked index) is keyed by session id
-	// alone, so clean it up even when no cwd is known.
-	await rm(checkpointScratchDir(sessionId), {
+	if (!cwd) return;
+	// The scratch dir (persistent untracked index) is keyed by cwd + session
+	// id. A session whose cwd is unknown at deletion time is covered by the
+	// age-based reaper instead.
+	await rm(checkpointScratchDir(cwd, sessionId), {
 		recursive: true,
 		force: true,
 	}).catch(() => undefined);
-	if (!cwd) return;
 	const prefix = `refs/cline/checkpoints/${sessionId}/`;
 	try {
 		const { stdout } = await runGit(cwd, [
@@ -378,6 +468,9 @@ function upsertCheckpointHistory(
 export function createCheckpointHooks(
 	options: CreateCheckpointHooksOptions,
 ): AgentHooks {
+	// Reap scratch dirs left behind by sessions that were never explicitly
+	// deleted. Fire-and-forget: pruning failures never affect the session.
+	void pruneStaleScratchDirs();
 	let repoSupported: boolean | undefined;
 	// Number of messages present when the current run started, captured in
 	// beforeRun. For hosts that append the run's prompt *after* beforeRun (e.g.
@@ -475,7 +568,7 @@ export function createCheckpointHooks(
 			ref =
 				(await createWorktreeStashCommit(
 					options.cwd,
-					checkpointScratchDir(options.sessionId),
+					checkpointScratchDir(options.cwd, options.sessionId),
 					message,
 				)) ?? "";
 		} catch (error) {

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -573,6 +573,7 @@ export async function handleSessionRestore(
 		const result = await service.restoreCheckpoint({
 			sessionId: sourceSessionId,
 			checkpointRunCount,
+			telemetry: ctx.telemetry,
 			restore: {
 				messages: restoreOptions.messages as boolean | undefined,
 				workspace: restoreOptions.workspace as boolean | undefined,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1009,6 +1009,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	): Promise<RestoreSessionResult> {
 		return this.sessionVersioning.restoreCheckpoint({
 			...input,
+			telemetry: this.defaultTelemetry,
 			getSession: (sessionId) => this.getSession(sessionId),
 			readMessages: (sessionId) => this.readSessionMessages(sessionId),
 			buildStartInput: (context, startInput) => {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -431,6 +431,7 @@ export async function prepareLocalRuntimeBootstrap(
 					sessionId,
 					logger: baseConfig.logger,
 					createCheckpoint: baseConfig.checkpoint?.createCheckpoint,
+					telemetry: baseConfig.telemetry,
 					readSessionMetadata,
 					writeSessionMetadata,
 				})

--- a/sdk/packages/core/src/session/session-versioning-service.test.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.test.ts
@@ -408,6 +408,8 @@ describe("SessionVersioningService", () => {
 
 	it("supports workspace-only restore without starting a new session", async () => {
 		const applyWorkspaceCheckpoint = vi.fn(async () => undefined);
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
 		const result = await new SessionVersioningService().restoreCheckpoint({
 			sessionId: "source-session",
 			checkpointRunCount: 1,
@@ -417,11 +419,24 @@ describe("SessionVersioningService", () => {
 				throw new Error("messages should not be read");
 			},
 			applyWorkspaceCheckpoint,
+			telemetry: {
+				capture: (input) => {
+					events.push(input);
+				},
+			},
 		});
 
 		expect(result.sessionId).toBeUndefined();
 		expect(result.checkpoint).toMatchObject({ ref: "aaaa", runCount: 1 });
 		expect(applyWorkspaceCheckpoint).toHaveBeenCalledOnce();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.event).toBe("checkpoint.restore");
+		expect(events[0]?.properties).toMatchObject({
+			outcome: "success",
+			restoreWorkspace: true,
+			restoreMessages: false,
+			checkpointRunCount: 1,
+		});
 	});
 
 	it("raises typed validation errors", async () => {

--- a/sdk/packages/core/src/session/session-versioning-service.test.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.test.ts
@@ -439,7 +439,9 @@ describe("SessionVersioningService", () => {
 		});
 	});
 
-	it("raises typed validation errors", async () => {
+	it("raises typed validation errors and still emits a failed restore event", async () => {
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
 		await expect(
 			new SessionVersioningService().restoreCheckpoint({
 				sessionId: "source-session",
@@ -447,10 +449,24 @@ describe("SessionVersioningService", () => {
 				restore: { messages: true, workspace: false },
 				getSession: async () => makeSession(),
 				readMessages: async () => [],
+				telemetry: {
+					capture: (input) => {
+						events.push(input);
+					},
+				},
 			}),
 		).rejects.toMatchObject({
 			code: "invalid_restore",
 			message: "start is required when restore.messages is true",
 		} satisfies Partial<SessionVersioningError>);
+
+		// Failures during validation/planning are the most common restore
+		// failures in the field; they must be counted, not just thrown.
+		expect(events).toHaveLength(1);
+		expect(events[0]?.event).toBe("checkpoint.restore");
+		expect(events[0]?.properties).toMatchObject({
+			outcome: "failed",
+			phase: "plan",
+		});
 	});
 });

--- a/sdk/packages/core/src/session/session-versioning-service.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.ts
@@ -1,4 +1,5 @@
 import type * as LlmsProviders from "@cline/llms";
+import type { ITelemetryService } from "@cline/shared";
 import type {
 	CheckpointEntry,
 	CheckpointMetadata,
@@ -90,6 +91,13 @@ export interface SessionCheckpointRestoreInput<
 		sessionId: string,
 		history: CheckpointEntry[],
 	) => Promise<void>;
+	/**
+	 * Emits one `checkpoint.restore` event per restore attempt. Restores are
+	 * rare and destructive, so field visibility matters: outcome, duration
+	 * (the worktree transaction hashes all untracked files), and the
+	 * checkpoint kind. Never file paths or contents.
+	 */
+	telemetry?: Pick<ITelemetryService, "capture">;
 }
 
 function validateRestoreOptions(input: {
@@ -176,6 +184,25 @@ export class SessionVersioningService {
 			session: sourceSession,
 			messages: sourceMessages,
 		});
+		const restoreStartedAt = Date.now();
+		const captureRestore = (
+			outcome: "success" | "failed",
+			extra?: Record<string, string | number | boolean>,
+		): void => {
+			input.telemetry?.capture({
+				event: "checkpoint.restore",
+				properties: {
+					sessionId: sourceSessionId,
+					checkpointRunCount: input.checkpointRunCount,
+					restoreWorkspace,
+					restoreMessages,
+					checkpointKind: plan.checkpoint.kind ?? "unknown",
+					outcome,
+					durationMs: Date.now() - restoreStartedAt,
+					...extra,
+				},
+			});
+		};
 		let restoredCheckpointMetadata: CheckpointMetadata | undefined;
 		let initialMessages: LlmsProviders.MessageWithMetadata[] = [];
 		let startInput: TStartInput | undefined;
@@ -258,6 +285,7 @@ export class SessionVersioningService {
 			if (!messageRestoreOperations) {
 				await transaction?.commit();
 				workspaceCommitted = true;
+				captureRestore("success");
 				return { checkpoint: plan.checkpoint, sourceSnapshot };
 			}
 
@@ -292,6 +320,7 @@ export class SessionVersioningService {
 				: undefined;
 			await transaction?.commit();
 			workspaceCommitted = true;
+			captureRestore("success");
 			return {
 				sessionId: newSessionId,
 				startResult,
@@ -316,6 +345,10 @@ export class SessionVersioningService {
 					recoveryErrors.push(rollbackError);
 				}
 			}
+			captureRestore("failed", {
+				workspaceRolledBack: !!transaction && !workspaceCommitted,
+				recovered: recoveryErrors.length === 0,
+			});
 			if (recoveryErrors.length > 0) {
 				throw new AggregateError(
 					[error, ...recoveryErrors],

--- a/sdk/packages/core/src/session/session-versioning-service.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.ts
@@ -148,43 +148,11 @@ export class SessionVersioningService {
 	): Promise<SessionCheckpointRestoreResult<TStartResult>> {
 		const restoreMessages = input.restore?.messages !== false;
 		const restoreWorkspace = input.restore?.workspace !== false;
-		const sourceSessionId = validateRestoreOptions({
-			sessionId: input.sessionId,
-			restoreMessages,
-			restoreWorkspace,
-			requiresStart: input.start === undefined,
-			checkpointRunCount: input.checkpointRunCount,
-		});
-
-		const sourceSession = await input.getSession(sourceSessionId);
-		if (!sourceSession) {
-			throw new SessionVersioningError(
-				"session_not_found",
-				`Session ${sourceSessionId} not found`,
-			);
-		}
-		const sourceMessages = restoreMessages
-			? await input.readMessages(sourceSessionId)
-			: undefined;
-		if (restoreMessages && sourceMessages?.length === 0) {
-			throw new SessionVersioningError(
-				"session_messages_not_found",
-				`No messages found for session ${sourceSessionId}`,
-			);
-		}
-
-		const plan = createCheckpointRestorePlan({
-			session: sourceSession,
-			messages: sourceMessages,
-			checkpointRunCount: input.checkpointRunCount,
-			cwd: input.cwd,
-			restoreMessages,
-		});
-		const sourceSnapshot = createCoreSessionSnapshot({
-			session: sourceSession,
-			messages: sourceMessages,
-		});
+		// Declared before any throwing setup so validation and lookup failures —
+		// the most common restore failures — are counted too. The checkpoint kind
+		// is only known once the plan exists.
 		const restoreStartedAt = Date.now();
+		let plannedCheckpoint: CheckpointEntry | undefined;
 		const captureRestore = (
 			outcome: "success" | "failed",
 			extra?: Record<string, string | number | boolean>,
@@ -192,17 +160,64 @@ export class SessionVersioningService {
 			input.telemetry?.capture({
 				event: "checkpoint.restore",
 				properties: {
-					sessionId: sourceSessionId,
+					sessionId: input.sessionId,
 					checkpointRunCount: input.checkpointRunCount,
 					restoreWorkspace,
 					restoreMessages,
-					checkpointKind: plan.checkpoint.kind ?? "unknown",
+					checkpointKind: plannedCheckpoint?.kind ?? "unknown",
 					outcome,
 					durationMs: Date.now() - restoreStartedAt,
 					...extra,
 				},
 			});
 		};
+
+		let sourceSession: SessionRecord;
+		let sourceMessages: LlmsProviders.MessageWithMetadata[] | undefined;
+		let plan: CheckpointRestorePlan;
+		try {
+			const sourceSessionId = validateRestoreOptions({
+				sessionId: input.sessionId,
+				restoreMessages,
+				restoreWorkspace,
+				requiresStart: input.start === undefined,
+				checkpointRunCount: input.checkpointRunCount,
+			});
+
+			const session = await input.getSession(sourceSessionId);
+			if (!session) {
+				throw new SessionVersioningError(
+					"session_not_found",
+					`Session ${sourceSessionId} not found`,
+				);
+			}
+			sourceSession = session;
+			sourceMessages = restoreMessages
+				? await input.readMessages(sourceSessionId)
+				: undefined;
+			if (restoreMessages && sourceMessages?.length === 0) {
+				throw new SessionVersioningError(
+					"session_messages_not_found",
+					`No messages found for session ${sourceSessionId}`,
+				);
+			}
+
+			plan = createCheckpointRestorePlan({
+				session: sourceSession,
+				messages: sourceMessages,
+				checkpointRunCount: input.checkpointRunCount,
+				cwd: input.cwd,
+				restoreMessages,
+			});
+			plannedCheckpoint = plan.checkpoint;
+		} catch (error) {
+			captureRestore("failed", { phase: "plan" });
+			throw error;
+		}
+		const sourceSnapshot = createCoreSessionSnapshot({
+			session: sourceSession,
+			messages: sourceMessages,
+		});
 		let restoredCheckpointMetadata: CheckpointMetadata | undefined;
 		let initialMessages: LlmsProviders.MessageWithMetadata[] = [];
 		let startInput: TStartInput | undefined;


### PR DESCRIPTION
Part of #13131 · Linear: [CLINE-2942](https://linear.app/cline-bot/issue/CLINE-2942/checkpoints-sdk-cap-cache-and-time-bound-untracked-file-snapshot-work)

**Scope note:** this PR was narrowed after the team decision (Aug 20 weekly) to fix checkpoint performance forward without changing checkpoint semantics. It now contains only behavior-preserving changes — snapshots stay byte-identical; no size caps, no timeouts, no restore changes. Those are deferred pending the semantics discussion (the built machinery lives on in #13208, closed, branch kept), and snapshot exclusions (legacy-parity default patterns + Git LFS patterns) are planned as focused follow-up PRs.

## Problem

Checkpoint creation rebuilt a throwaway `GIT_INDEX_FILE` on every user turn, so git re-read and re-hashed **every untracked file on every message**. With multi-GB untracked data files this blocks each turn for seconds to minutes (~90 s in #13131, on a cloud-synced Windows workspace). Production telemetry (`task.provider_request_started`, Aug 11–13): 250 users' median pre-model wait exceeded 5 s; 34 users exceeded 30 s.

## Change

- **Persistent per-session snapshot index.** The untracked-file index lives in a per-session scratch dir (`checkpointScratchDir()`) and is reused across turns, so git's stat cache skips unchanged files — from the second turn the snapshot cost is roughly git process overhead. Stale entries (file deleted or became tracked) are removed each turn so they can't ghost into snapshot trees; a corrupt index self-heals with one rebuild-and-retry; `deleteCheckpointRefs` removes the scratch dir with the refs.
- **Telemetry**: one `checkpoint.snapshot` event per snapshot attempt (outcome: `stash` / `head_clean` / `head_fallback` / `skipped`, plus duration) and one `checkpoint.restore` event per restore (outcome, duration, checkpoint kind). Durations and outcomes only, never file paths — this makes checkpoint cost measurable in the field and informs the deferred decisions (cap value, exclusions) with data.

## Testing

- New tests: stale-index-entry removal (a deleted untracked file must not appear in later snapshot trees), scratch-dir cleanup, snapshot telemetry (event shape + no file paths in the payload), restore telemetry.
- Full `@cline/core` suite: 2087 passed. Typecheck + biome clean.
- Measured earlier on this mechanism: repo with 260 MB of untracked files — turn 1 hashes once, turns 2+ ≈ 128 ms vs. re-hashing everything every turn before.

First-turn cost is unchanged by design (everything is hashed once to build the cache); the follow-up exclusion PRs address that half.
