### PR TITLE
fix(webview): use editor foreground for diff block text colors

### DIFF
--- a/apps/vscode/webview-ui/src/components/common/codeblock-parser.css
+++ b/apps/vscode/webview-ui/src/components/common/codeblock-parser.css
@@ -157,13 +157,13 @@
 /* Deletion (for diffs) */
 .hljs-deletion {
 	background-color: var(--vscode-diffEditor-removedTextBackground);
-	color: var(--vscode-diffEditor-removedLineBackground);
+	color: var(--vscode-editor-foreground);
 }
 
 /* Addition (for diffs) */
 .hljs-addition {
 	background-color: var(--vscode-diffEditor-insertedTextBackground);
-	color: var(--vscode-diffEditor-insertedLineBackground);
+	color: var(--vscode-editor-foreground);
 }
 
 /* Section headers - slightly emphasized */


### PR DESCRIPTION
## Summary
- `.hljs-addition` and `.hljs-deletion` assigned `color` from the `*LineBackground` tokens (solid green/red background colors) instead of a text token, making diff text invisible on themes like "Dark 2026"
- both now use `color: var(--vscode-editor-foreground)`

Fixes #13159

## Testing
- inspected all usages of the `*LineBackground` tokens; `CodeBlock.tsx` and `theme.css` only set `background-color`, so no other changes needed