### PR TITLE
fix(sdk): propagate returned tool failures

### DIFF
--- a/sdk/packages/agents/README.md
+++ b/sdk/packages/agents/README.md
@@ -125,8 +125,10 @@ const summarize: AgentTool<{ text: string }, { summary: string }> = {
 ```
 
 The runtime wraps successful tool outputs in an internal tool-result message.
-Throw from `execute(...)` to report a tool failure, or use an `afterTool` hook
-to transform the internal `AgentToolResult` envelope.
+Throw from `execute(...)` to report a tool failure. If a tool returns a domain
+result for both success and failure, provide `isError(output)` to classify the
+returned value. An `afterTool` hook can also transform the internal
+`AgentToolResult` envelope.
 
 ### Events
 

--- a/sdk/packages/agents/README.md
+++ b/sdk/packages/agents/README.md
@@ -126,8 +126,10 @@ const summarize: AgentTool<{ text: string }, { summary: string }> = {
 
 The runtime wraps successful tool outputs in an internal tool-result message.
 Throw from `execute(...)` to report a tool failure. If a tool returns a domain
-result for both success and failure, provide `isError(output)` to classify the
-returned value. An `afterTool` hook can also transform the internal
+result for both success and failure, an in-process tool can provide
+`isError(output)` to classify the returned value. Sandboxed plugin tools must
+throw instead; registration rejects classifier callbacks until the sandbox
+protocol can carry them. An `afterTool` hook can also transform the internal
 `AgentToolResult` envelope.
 
 ### Events

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -802,6 +802,102 @@ describe("AgentRuntime", () => {
 		expect(model.requests).toHaveLength(1);
 	});
 
+	it("marks a classified returned failure while preserving its output", async () => {
+		const tool: AgentTool<unknown, { success: boolean; error?: string }> = {
+			name: "returned_failure",
+			description: "Return a structured operation result",
+			inputSchema: { type: "object" },
+			isError: (output) => !output.success,
+			async execute() {
+				return { success: false, error: "operation failed" };
+			},
+		};
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_failure",
+					toolName: "returned_failure",
+					inputText: "{}",
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			(request) => {
+				expect(request.messages.at(-1)?.content[0]).toMatchObject({
+					type: "tool-result",
+					isError: true,
+					output: { success: false, error: "operation failed" },
+				});
+				return [
+					{ type: "text-delta", text: "recovered" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({ model, tools: [tool] });
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("recovered");
+		expect(model.requests).toHaveLength(2);
+	});
+
+	it("does not complete a terminal tool until its returned result is accepted", async () => {
+		let attempts = 0;
+		const submitTool: AgentTool<
+			unknown,
+			{ accepted: boolean; error?: string }
+		> = {
+			name: "submit",
+			description: "Submit final answer",
+			inputSchema: { type: "object" },
+			lifecycle: { completesRun: true },
+			isError: (output) => !output.accepted,
+			async execute() {
+				attempts += 1;
+				return attempts === 1
+					? { accepted: false, error: "summary is required" }
+					: { accepted: true };
+			},
+		};
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_submit_1",
+					toolName: "submit",
+					inputText: "{}",
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			(request) => {
+				expect(request.messages.at(-1)?.content[0]).toMatchObject({
+					type: "tool-result",
+					isError: true,
+					output: { accepted: false, error: "summary is required" },
+				});
+				return [
+					{
+						type: "tool-call-delta",
+						toolCallId: "call_submit_2",
+						toolName: "submit",
+						inputText: "{}",
+					},
+					{ type: "finish", reason: "tool-calls" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({ model, tools: [submitTool] });
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(result.iterations).toBe(2);
+		expect(result.outputText).toBe('{"accepted":true}');
+		expect(attempts).toBe(2);
+	});
+
 	it("preserves structured multimodal tool results for the next model request", async () => {
 		const structuredOutput = [
 			{ type: "text", text: "Successfully read image" },

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1707,7 +1707,12 @@ export class AgentRuntime {
 						});
 					},
 				});
-				result = { output };
+				result = {
+					output,
+					...(prepared.tool.isError?.(output) === true
+						? { isError: true }
+						: {}),
+				};
 			} catch (error) {
 				result = {
 					output: {

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox-bootstrap.ts
@@ -32,6 +32,7 @@ interface PluginTool {
 	inputSchema?: unknown;
 	timeoutMs?: number;
 	retryable?: boolean;
+	isError?: unknown;
 	execute: (input: unknown, context: unknown) => Promise<unknown>;
 }
 
@@ -113,10 +114,7 @@ interface PluginSetupCtx {
  * setters are host concerns and are intentionally no-ops in the sandbox.
  */
 interface PluginTelemetryBridge {
-	capture(input: {
-		event: string;
-		properties?: Record<string, unknown>;
-	}): void;
+	capture(input: { event: string; properties?: Record<string, unknown> }): void;
 	captureRequired(event: string, properties?: Record<string, unknown>): void;
 	recordCounter(
 		name: string,
@@ -561,6 +559,11 @@ async function loadPluginDescriptor(args: {
 
 		const api: PluginApi = {
 			registerTool: (tool) => {
+				if (tool.isError !== undefined) {
+					throw new Error(
+						"Sandboxed plugin tools do not support isError callbacks; throw from execute() to report a failure",
+					);
+				}
 				const id = makeId(args.pluginId, "tool");
 				handlers.tools.set(id, tool.execute);
 				contributions.tools.push({

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
@@ -947,6 +947,48 @@ describe("plugin-sandbox", () => {
 		}
 	});
 
+	it("rejects returned-failure classifiers in sandboxed plugin tools", async () => {
+		const pluginPath = join(dir, "plugin-unsupported-classifier.mjs");
+		await writeFile(
+			pluginPath,
+			[
+				"export default {",
+				"  name: 'sandbox-unsupported-classifier',",
+				"  manifest: { capabilities: ['tools'] },",
+				"  setup(api) {",
+				"    api.registerTool({",
+				"      name: 'classified_tool',",
+				"      description: 'classified result',",
+				"      inputSchema: { type: 'object', properties: {} },",
+				"      isError: (output) => output.success === false,",
+				"      execute: async () => ({ success: false }),",
+				"    });",
+				"  },",
+				"};",
+			].join("\n"),
+			"utf8",
+		);
+
+		const sandboxed = await loadSandboxedPlugins({
+			pluginPaths: [pluginPath],
+		});
+
+		try {
+			expect(sandboxed.extensions).toEqual([]);
+			expect(sandboxed.failures).toEqual([
+				expect.objectContaining({
+					pluginName: "sandbox-unsupported-classifier",
+					phase: "setup",
+					message: expect.stringContaining(
+						"Sandboxed plugin tools do not support isError callbacks",
+					),
+				}),
+			]);
+		} finally {
+			await sandboxed.shutdown();
+		}
+	});
+
 	it("keeps the later duplicate sandbox plugin and reports the override", async () => {
 		const sandboxed = await loadSandboxedPlugins({
 			pluginPaths: [

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1,4 +1,4 @@
-import type { ITelemetryService } from "@cline/shared";
+import { type ITelemetryService, toAiSdkToolResultOutput } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
 	buildRunCommandsDescription,
@@ -1370,6 +1370,43 @@ describe("default run_commands tool", () => {
 });
 
 describe("default read_files tool", () => {
+	it("preserves a successful image when another read in the batch fails", async () => {
+		const tool = createReadFilesTool(async (request) => {
+			if (request.path === "/tmp/missing.png") {
+				throw new Error("file not found");
+			}
+			return [
+				{
+					type: "image",
+					data: "aGVsbG8=",
+					mediaType: "image/png",
+				},
+			];
+		});
+
+		const result = await tool.execute(
+			{
+				files: [{ path: "/tmp/image.png" }, { path: "/tmp/missing.png" }],
+			},
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result.map((operation) => operation.success)).toEqual([true, false]);
+		expect(tool.isError?.(result)).toBe(false);
+		expect(
+			toAiSdkToolResultOutput(result, tool.isError?.(result)),
+		).toMatchObject({
+			type: "content",
+			value: expect.arrayContaining([
+				expect.objectContaining({ type: "file", mediaType: "image/png" }),
+			]),
+		});
+	});
+
 	it("validates ranged file requests and passes them to the executor", async () => {
 		const execute = vi.fn(async () => "selected lines");
 		const tool = createReadFilesTool(execute);

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -818,6 +818,38 @@ describe("default run_commands tool", () => {
 				success: false,
 			},
 		]);
+		expect(tool.isError?.(result)).toBe(true);
+	});
+
+	it("classifies a mixed command batch as failed without dropping results", async () => {
+		const execute = vi.fn(async (command: string | { command: string }) => {
+			const value = typeof command === "string" ? command : command.command;
+			if (value === "fail") {
+				throw new CommandExitError(1, "failed output");
+			}
+			return "successful output";
+		});
+		const tool = createShellTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["pass", "fail"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{ query: "pass", result: "successful output", success: true },
+			{
+				query: "fail",
+				result: "failed output",
+				error: "Command exited with code 1",
+				success: false,
+			},
+		]);
+		expect(tool.isError?.(result)).toBe(true);
 	});
 
 	it("coalesces split heredoc command arrays before execution", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -77,6 +77,14 @@ import type {
 // Helper Functions
 // =============================================================================
 
+function hasFailedOperation(
+	output: ToolOperationResult | ToolOperationResult[],
+): boolean {
+	return (Array.isArray(output) ? output : [output]).some(
+		(operation) => !operation.success,
+	);
+}
+
 function getStringMetadata(
 	context: AgentToolContext,
 	key: string,
@@ -262,6 +270,7 @@ export function createReadFilesTool(
 		timeoutMs: timeoutMs * 2, // Account for multiple files
 		retryable: true,
 		maxRetries: 1,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			const validate = validateWithZod(
 				ReadFilesInputUnionSchema,
@@ -358,6 +367,7 @@ export function createSearchTool(
 		timeoutMs: timeoutMs * 2,
 		retryable: true,
 		maxRetries: 1,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			// Validate input with Zod schema
 			const validate = validateWithZod(SearchCodebaseUnionInputSchema, input);
@@ -482,6 +492,7 @@ export function createShellTool(
 		timeoutMs: timeoutMs * 2,
 		retryable: false,
 		maxRetries: 0,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			const commands = coalesceAdjacentStringHeredocs(
 				normalizeRunCommandsInput(input),
@@ -531,6 +542,7 @@ export function createWebFetchTool(
 		timeoutMs: timeoutMs * 2,
 		retryable: true,
 		maxRetries: 2,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			// Validate input with Zod schema
 			const validatedInput = validateWithZod(FetchWebContentInputSchema, input);
@@ -622,6 +634,7 @@ export function createApplyPatchTool(
 		timeoutMs,
 		retryable: false,
 		maxRetries: 0,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			const validate = validateWithZod(ApplyPatchInputUnionSchema, input);
 			const patchInput =
@@ -676,6 +689,7 @@ export function createEditorTool(
 		timeoutMs,
 		retryable: false, // Editing operations are stateful and should not auto-retry
 		maxRetries: 0,
+		isError: hasFailedOperation,
 		execute: async (input, context) => {
 			const validatedInput = validateWithZod(EditFileInputSchema, input);
 			const operation = validatedInput.insert_line == null ? "edit" : "insert";

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -85,6 +85,10 @@ function hasFailedOperation(
 	);
 }
 
+function allOperationsFailed(output: ToolOperationResult[]): boolean {
+	return output.length > 0 && output.every((operation) => !operation.success);
+}
+
 function getStringMetadata(
 	context: AgentToolContext,
 	key: string,
@@ -270,7 +274,9 @@ export function createReadFilesTool(
 		timeoutMs: timeoutMs * 2, // Account for multiple files
 		retryable: true,
 		maxRetries: 1,
-		isError: hasFailedOperation,
+		// A mixed read may contain a successful image. Keep the batch model-visible
+		// as a normal result so the provider formatter preserves that media.
+		isError: allOperationsFailed,
 		execute: async (input, context) => {
 			const validate = validateWithZod(
 				ReadFilesInputUnionSchema,

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -181,7 +181,13 @@ export interface AgentTool<TInput = unknown, TOutput = unknown>
 	timeoutMs?: number;
 	retryable?: boolean;
 	maxRetries?: number;
-	/** Classify a returned output as a failed tool execution. */
+	/**
+	 * Classify a returned output as a failed tool execution.
+	 *
+	 * This callback is only supported for in-process tools. Sandboxed plugin
+	 * tools must throw from `execute` until the sandbox protocol supports
+	 * returned-failure classification.
+	 */
 	isError?(output: TOutput): boolean;
 	execute: (
 		input: TInput,

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -181,6 +181,8 @@ export interface AgentTool<TInput = unknown, TOutput = unknown>
 	timeoutMs?: number;
 	retryable?: boolean;
 	maxRetries?: number;
+	/** Classify a returned output as a failed tool execution. */
+	isError?(output: TOutput): boolean;
 	execute: (
 		input: TInput,
 		context: AgentToolContext,

--- a/sdk/packages/shared/src/tools/create.test.ts
+++ b/sdk/packages/shared/src/tools/create.test.ts
@@ -46,6 +46,7 @@ describe("createTool", () => {
 	});
 
 	it("preserves explicit execution policy fields", () => {
+		const isError = (output: { ok: boolean }) => !output.ok;
 		const tool = createTool({
 			name: "custom_policy_tool",
 			description: "Tool with custom execution policy",
@@ -53,12 +54,14 @@ describe("createTool", () => {
 			timeoutMs: 1_000,
 			retryable: false,
 			maxRetries: 0,
+			isError,
 			execute: async () => ({ ok: true }),
 		});
 
 		expect(tool.timeoutMs).toBe(1_000);
 		expect(tool.retryable).toBe(false);
 		expect(tool.maxRetries).toBe(0);
+		expect(tool.isError).toBe(isError);
 	});
 
 	it("strips the $schema meta-key emitted by Zod v4's toJSONSchema", () => {

--- a/sdk/packages/shared/src/tools/create.ts
+++ b/sdk/packages/shared/src/tools/create.ts
@@ -87,6 +87,7 @@ export function createTool<TInput, TOutput>(config: {
 	timeoutMs?: number;
 	retryable?: boolean;
 	maxRetries?: number;
+	isError?: AgentTool<TInput, TOutput>["isError"];
 }): AgentTool<TInput, TOutput>;
 export function createTool<TSchema extends z.ZodTypeAny, TOutput>(config: {
 	name: string;
@@ -100,6 +101,7 @@ export function createTool<TSchema extends z.ZodTypeAny, TOutput>(config: {
 	timeoutMs?: number;
 	retryable?: boolean;
 	maxRetries?: number;
+	isError?: AgentTool<z.infer<TSchema>, TOutput>["isError"];
 }): AgentTool<z.infer<TSchema>, TOutput>;
 export function createTool<TInput, TOutput>(config: {
 	name: string;
@@ -110,6 +112,7 @@ export function createTool<TInput, TOutput>(config: {
 	timeoutMs?: number;
 	retryable?: boolean;
 	maxRetries?: number;
+	isError?: AgentTool<TInput, TOutput>["isError"];
 }): AgentTool<TInput, TOutput> {
 	const inputSchema = normalizeToolInputSchema(
 		config.inputSchema instanceof z.ZodType
@@ -125,6 +128,7 @@ export function createTool<TInput, TOutput>(config: {
 		timeoutMs: config.timeoutMs ?? 30_000,
 		retryable: config.retryable ?? true,
 		maxRetries: config.maxRetries ?? 3,
+		isError: config.isError,
 		execute: config.execute,
 	};
 }


### PR DESCRIPTION
## What changed

- let tools explicitly classify returned outputs as errors
- propagate classified failures through the existing `isError` channel
- classify failed built-in file, search, command, web, patch, and editor operations
- keep rejected terminal-tool results from completing the run

## Why

Some built-in tools return structured results such as `{ success: false, error }` instead of throwing. The model sees the failure, but runtime bookkeeping previously treated the call as successful. That made error telemetry and terminal-tool completion disagree with the actual result.

This keeps failure classification opt-in, so the runtime does not guess based on arbitrary output shapes.

## Validation

- `bun run build:sdk`
- `bun run types`
- `bun -F @cline/shared test` — 326 passed
- `bun -F @cline/agents test` — 66 passed
- `bun -F @cline/core test:unit` — 1,803 passed, 14 skipped
