### PR TITLE
fix(llms): replace all-empty-text messages with placeholder content

### DIFF
--- a/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.test.ts
@@ -79,6 +79,53 @@ describe("formatMessagesForAiSdk", () => {
 		]);
 	});
 
+	it("replaces messages whose parts are all empty text with explicit error text", () => {
+		const messages = formatMessagesForAiSdk(undefined, [
+			{ role: "user", content: [{ type: "text", text: "" }] },
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "   \n\t  " },
+					{ type: "text", text: "" },
+				],
+			},
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: EMPTY_CONTENT_TEXT }],
+			},
+		]);
+	});
+
+	it("keeps messages that pair empty text with other content", () => {
+		const image = imageData(16);
+		const messages = formatMessagesForAiSdk(undefined, [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "" },
+					{ type: "image", image, mediaType: "image/png" },
+				],
+			},
+		]);
+
+		expect(messages).toEqual([
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "" },
+					{ type: "file", data: image, mediaType: "image/png" },
+				],
+			},
+		]);
+	});
+
 	it("preserves providerOptions on text parts", () => {
 		const messages = formatMessagesForAiSdk(undefined, [
 			{

--- a/sdk/packages/shared/src/llms/ai-sdk-format.ts
+++ b/sdk/packages/shared/src/llms/ai-sdk-format.ts
@@ -691,6 +691,24 @@ export function formatMessagesForAiSdk(
 			}
 		}
 
+		// A message whose parts are all empty text is effectively empty: the AI SDK
+		// strips empty text parts before sending, and providers like Vercel reject
+		// the resulting `content: []` ("user message must have content").
+		if (
+			messageParts.length > 0 &&
+			messageParts.every(
+				(part) =>
+					part.type === "text" &&
+					typeof part.text === "string" &&
+					part.text.trim().length === 0,
+			)
+		) {
+			messageParts.splice(0, messageParts.length, {
+				type: "text",
+				text: EMPTY_CONTENT_TEXT,
+			});
+		}
+
 		if (messageParts.length > 0) {
 			pushAiSdkMessage(result, { role: message.role, content: messageParts });
 		}


### PR DESCRIPTION
### Related Issue

Backend-reported prod errors (no GitHub issue): Vercel AI Gateway 400s on `moonshotai/kimi-k3` — `user message must have content` at `messages.N.content`.

### Description

**The problem.** The backend team flagged a stream of 4xx validation errors from Vercel for kimi-k3:

```
request failed with status 400: {"error":{"message":"user message must have content","type":"invalid_request_error","param":"messages.7.content","code":"invalid_request_error"}}
```

We traced both sides. core-api is a byte-level proxy for `messages` — it only rewrites the top-level `model` (public → private id, which is why the logs show `moonshotai/kimi-k3` rather than `cline-pass/kimi-k3`), `stream`, and `user`/`metadata` keys before forwarding the client's body to the Vercel gateway. So the empty user message was already in the request our client built. It surfaces specifically on kimi-k3 because that model routes to Vercel only (no failover provider), and Vercel validates empty content strictly where OpenRouter/CoreWeave tolerate it.

**The hole.** `formatMessagesForAiSdk` in `sdk/packages/shared/src/llms/ai-sdk-format.ts` already guards two empty-content shapes, substituting the `EMPTY_CONTENT_TEXT` placeholder:

- `content: ""` (whitespace-trimmed string)
- `content: []` (empty array)

But a content array whose parts are all *empty text* — `[{type: "text", text: ""}]` — slips through both guards: the array isn't empty, and the `text` case pushes the part with no emptiness check. The AI SDK (`ai@7`) then explicitly filters empty text parts in `convertToLanguageModelPrompt` (`.filter(part => part.type !== 'text' || part.text !== '')`), and `@ai-sdk/openai-compatible` serializes the leftover empty array as `{"role":"user","content":[]}` — exactly what Vercel rejects. We confirmed both hops by executing the installed `ai@7.0.51` / `@ai-sdk/openai-compatible@3.0.22` packages directly against these message shapes.

**How the shape arises in practice.** A few real paths persist a user message that is only-empty-text, e.g.:

- `user-input-builder.ts` always prepends `{type: "text", text: userMessage}` even when the user sent only images (message editing explicitly allows empty text + images), and the agent-message codec can drop non-string image payloads on round-trip — leaving just the empty text block.
- The legacy-history resume sanitizer converts a persisted `content: ""` user turn into `[{type: "text", text: ""}]`.
- Basic-compaction budget truncation blanks text blocks to `text: ""`, and its pruning only removes zero-length arrays — worse, the truncated messages are persisted, so once produced the 400 repeats on every subsequent request of that task.

Rather than chase every producer, this PR closes the one choke point all requests flow through: if a message's parts are all empty text (and nothing else), substitute the same `EMPTY_CONTENT_TEXT` placeholder the existing guards use. Mixed content is untouched — `[{text: ""}, {image}]` keeps its image and the SDK's empty-text filter handles the rest.

**Why now.** The AI SDK 7 upgrade (#12891, Aug 3) is the likely onset: the new stack's empty-text-part filter plus the openai-compatible converter's serialization is what turns a benign empty text block into an invalid body. Message editing (#12691, Jul 30) added a producer of empty-text user turns around the same time.

### Test Procedure

- Added two tests to `ai-sdk-format.test.ts`: all-empty-text parts (single `""` and multiple whitespace/empty parts) get replaced with `EMPTY_CONTENT_TEXT`, and empty text paired with an image is left alone.
- Full `ai-sdk-format` suite passes (49 tests), biome clean, package typechecks.
- Verified the wire-level failure mode by running the installed AI SDK converters directly: `[{type:"text",text:""}]` → AI SDK filters to `content: []` → openai-compatible emits `{"role":"user","content":[]}`, which matches the prod error shape byte-for-byte.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The behavior matches what the existing `""`/`[]` guards already do, so a model occasionally seeing `ERROR: EMPTY CONTENT` instead of a hard provider 400 is the intended trade. Follow-up candidates deliberately left out to keep this surgical: the legacy `toGatewayRequestMessages` converter (`compat.ts`) has no empty-content guard at all, and basic compaction persists blanked text blocks into the transcript — both can be separate PRs if they show up in telemetry after this lands.
