### PR TITLE
feat: surface checkpoint size-cap skips in the restore UI

### DIFF
--- a/apps/cli/src/tui/checkpoint-picker-items.test.ts
+++ b/apps/cli/src/tui/checkpoint-picker-items.test.ts
@@ -66,6 +66,28 @@ describe("buildCheckpointPickerItems", () => {
 		]);
 	});
 
+	it("carries skippedUntracked through so the confirm dialog can warn", () => {
+		const items = buildCheckpointPickerItems(
+			[userPrompt("first request")],
+			[
+				{
+					ref: "ref1",
+					createdAt: 1,
+					runCount: 1,
+					kind: "stash",
+					skippedUntracked: ["big.bin"],
+				},
+			],
+		);
+
+		expect(items).toEqual([
+			expect.objectContaining({
+				runCount: 1,
+				skippedUntracked: ["big.bin"],
+			}),
+		]);
+	});
+
 	it("counts a compaction summary as spanning the runs it folded", () => {
 		const compaction = {
 			role: "user",

--- a/apps/cli/src/tui/checkpoint-picker-items.ts
+++ b/apps/cli/src/tui/checkpoint-picker-items.ts
@@ -84,6 +84,9 @@ export function buildCheckpointPickerItems(
 			text: preview,
 			fullText: text,
 			createdAt: checkpoint.createdAt,
+			...(checkpoint.skippedUntracked?.length
+				? { skippedUntracked: checkpoint.skippedUntracked }
+				: {}),
 		});
 	}
 	return items;

--- a/apps/cli/src/tui/components/dialogs/checkpoint-confirm.tsx
+++ b/apps/cli/src/tui/components/dialogs/checkpoint-confirm.tsx
@@ -26,9 +26,12 @@ const OPTIONS: Array<{
 export function CheckpointConfirmContent(
 	props: ChoiceContext<CheckpointRestoreMode> & {
 		messagePreview: string;
+		/** Untracked files the snapshot excluded (size cap) — not rewound. */
+		skippedUntracked?: string[];
 	},
 ) {
-	const { resolve, dismiss, dialogId, messagePreview } = props;
+	const { resolve, dismiss, dialogId, messagePreview, skippedUntracked } =
+		props;
 	const [selected, setSelected] = useState(0);
 	const selectedRef = useRef(0);
 	const selectedMode = OPTIONS[selected]?.value;
@@ -101,9 +104,18 @@ export function CheckpointConfirmContent(
 			</box>
 
 			{selectedMode === "chat-and-workspace" && (
-				<text fg="yellow">
-					This runs git reset --hard and git clean -fd in the workspace.
-				</text>
+				<box flexDirection="column">
+					<text fg="yellow">
+						This runs git reset --hard and git clean -fd in the workspace.
+					</text>
+					{(skippedUntracked?.length ?? 0) > 0 && (
+						<text fg="yellow">
+							{skippedUntracked?.length === 1
+								? `1 large file was not captured by this checkpoint and stays at its current content: ${skippedUntracked[0]}`
+								: `${skippedUntracked?.length} large files were not captured by this checkpoint and stay at their current content: ${skippedUntracked?.slice(0, 3).join(", ")}${(skippedUntracked?.length ?? 0) > 3 ? ", …" : ""}`}
+						</text>
+					)}
+				</box>
 			)}
 
 			<text fg="gray">

--- a/apps/cli/src/tui/components/dialogs/checkpoint-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/checkpoint-picker.tsx
@@ -9,12 +9,18 @@ export interface CheckpointPickerItem {
 	text: string;
 	fullText: string;
 	createdAt: number;
+	/**
+	 * Untracked files the snapshot excluded over the size cap. They exist only
+	 * on disk, so a workspace restore leaves them at their current content.
+	 */
+	skippedUntracked?: string[];
 }
 
 export interface CheckpointPickerResult {
 	runCount: number;
 	messagePreview: string;
 	fullText: string;
+	skippedUntracked?: string[];
 }
 
 function formatRelativeTime(timestamp: number): string {
@@ -66,6 +72,7 @@ export function CheckpointPickerContent(
 					runCount: item.runCount,
 					messagePreview: item.text,
 					fullText: item.fullText,
+					skippedUntracked: item.skippedUntracked,
 				});
 			}
 			return;
@@ -138,6 +145,14 @@ export function CheckpointPickerContent(
 							<text fg={isSel ? palette.textOnSelection : undefined}>
 								{item.text}
 							</text>
+							{(item.skippedUntracked?.length ?? 0) > 0 && (
+								<text
+									fg={isSel ? palette.textOnSelection : "yellow"}
+									flexShrink={0}
+								>
+									◆ partial
+								</text>
+							)}
 							<text
 								fg={isSel ? palette.textOnSelection : "gray"}
 								flexShrink={0}

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -372,6 +372,7 @@ function App(props: TuiProps) {
 					<CheckpointConfirmContent
 						{...ctx}
 						messagePreview={picked.messagePreview}
+						skippedUntracked={picked.skippedUntracked}
 					/>
 				),
 			});

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1624,6 +1624,34 @@ export class Controller {
 	}
 
 	/**
+	 * Checkpoint run count → untracked paths that run's snapshot skipped over
+	 * the size cap, so the restore UI can warn that those files stay at their
+	 * current content when the workspace is reset. Runs without skips are
+	 * included (empty array) so the webview can resolve "nearest checkpoint at
+	 * or before run N" against a complete key set. Undefined when no entry
+	 * skipped anything (the common case) or no live session exists — after a
+	 * window reload the warning is simply absent rather than blocking restore.
+	 */
+	private async getCheckpointSkippedUntrackedByRun(): Promise<Record<number, string[]> | undefined> {
+		try {
+			const activeSession = this.sessions.getActiveSession()
+			const sessionId = activeSession?.sessionId
+			const sessionHost = activeSession?.sdkHost
+			if (!sessionId || !sessionHost) {
+				return undefined
+			}
+			const sessionRecord = await sessionHost.get(sessionId)
+			const history = readSessionCheckpointHistory(sessionRecord)
+			if (!history.some((entry) => entry.skippedUntracked?.length)) {
+				return undefined
+			}
+			return Object.fromEntries(history.map((entry) => [entry.runCount, entry.skippedUntracked ?? []]))
+		} catch {
+			return undefined
+		}
+	}
+
+	/**
 	 * Diffs the latest checkpoint — snapshotted when the user's last message
 	 * started a run — against the current working tree. Returns undefined when
 	 * no checkpoint exists (e.g. the workspace is not a git repository).
@@ -2094,6 +2122,7 @@ export class Controller {
 				// badge and anything else keyed on workspaceRoots depend on it.
 				workspaceManager: await this.ensureWorkspaceManager(),
 			})
+			state.checkpointSkippedUntrackedByRun = await this.getCheckpointSkippedUntrackedByRun()
 			const sdkTaskHistory = (await this.taskHistory.listHistory({ limit: 100, hydrate: false }))
 				.map(sessionHistoryRecordToHistoryItem)
 				.filter((item) => item.ts && item.task)

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -11,6 +11,7 @@ import {
 	createRestoredCheckpointMetadata,
 	createUserInstructionConfigService,
 	ensureChatWorkspace,
+	findCheckpointForRun,
 	getProviderAuthStorageId,
 	type PreparedRemoteConfigCoreIntegration,
 	readSessionCheckpointHistory,
@@ -69,6 +70,7 @@ import {
 import {
 	findVisibleCheckpointUserMessageByRun,
 	getCheckpointRunCountForMessage,
+	isCheckpointRunUserMessage,
 	isVisibleCheckpointUserMessage,
 } from "./sdk-checkpoints"
 import { SdkCompactionCoordinator } from "./sdk-compaction-coordinator"
@@ -1624,20 +1626,25 @@ export class Controller {
 	}
 
 	/**
-	 * Checkpoint run count → untracked paths that run's snapshot skipped over
-	 * the size cap, so the restore UI can warn that those files stay at their
-	 * current content when the workspace is reset. Runs without skips are
-	 * included (empty array) so the webview can resolve "nearest checkpoint at
-	 * or before run N" against a complete key set. Undefined when no entry
-	 * skipped anything (the common case) or no live session exists — after a
-	 * window reload the warning is simply absent rather than blocking restore.
+	 * Message ts → untracked paths that the checkpoint a restore from that
+	 * message would use skipped over the size cap, so the restore UI can warn
+	 * that those files stay at their current content when the workspace is
+	 * reset. Resolved with the exact chain editMessageAndRegenerate uses
+	 * (visible-row ordinal → persisted SDK message → run count → nearest
+	 * checkpoint at or before it), so the warning cannot diverge from what a
+	 * restore actually does — webview-side run counting would drift on
+	 * compaction summaries and hidden synthetic prompts, which advance the
+	 * run counter without a webview row. Undefined when no entry skipped
+	 * anything (the common case) or no live session exists — after a window
+	 * reload the warning is simply absent rather than blocking restore.
 	 */
-	private async getCheckpointSkippedUntrackedByRun(): Promise<Record<number, string[]> | undefined> {
+	private async getCheckpointSkippedUntrackedByMessageTs(): Promise<Record<number, string[]> | undefined> {
 		try {
 			const activeSession = this.sessions.getActiveSession()
 			const sessionId = activeSession?.sessionId
 			const sessionHost = activeSession?.sdkHost
-			if (!sessionId || !sessionHost) {
+			const currentTask = this.task
+			if (!sessionId || !sessionHost || !currentTask) {
 				return undefined
 			}
 			const sessionRecord = await sessionHost.get(sessionId)
@@ -1645,7 +1652,36 @@ export class Controller {
 			if (!history.some((entry) => entry.skippedUntracked?.length)) {
 				return undefined
 			}
-			return Object.fromEntries(history.map((entry) => [entry.runCount, entry.skippedUntracked ?? []]))
+			const clineMessages = currentTask.messageStateHandler.getClineMessages()
+			const sdkMessages = (await sessionHost.readMessages(sessionId)) as SdkUserMessage[]
+			const result: Record<number, string[]> = {}
+			let userOrdinal = 0
+			for (let index = 0; index < clineMessages.length; index += 1) {
+				const message = clineMessages[index]
+				if (!isVisibleCheckpointUserMessage(message)) {
+					continue
+				}
+				// The ordinal counts every visible user row (mirroring
+				// editMessageAndRegenerate); restore eligibility additionally
+				// excludes followup-answer rows.
+				userOrdinal += 1
+				if (!isCheckpointRunUserMessage(clineMessages, index)) {
+					continue
+				}
+				const sdkIndex = findSdkUserMessageIndexByOrdinal(sdkMessages, userOrdinal)
+				if (sdkIndex === -1) {
+					continue
+				}
+				const runCount = getSdkCheckpointRunCountForMessageIndex(sdkMessages, sdkIndex)
+				if (runCount === undefined) {
+					continue
+				}
+				const entry = findCheckpointForRun(history, runCount)
+				if (entry?.skippedUntracked?.length) {
+					result[message.ts] = entry.skippedUntracked
+				}
+			}
+			return Object.keys(result).length > 0 ? result : undefined
 		} catch {
 			return undefined
 		}
@@ -2122,7 +2158,7 @@ export class Controller {
 				// badge and anything else keyed on workspaceRoots depend on it.
 				workspaceManager: await this.ensureWorkspaceManager(),
 			})
-			state.checkpointSkippedUntrackedByRun = await this.getCheckpointSkippedUntrackedByRun()
+			state.checkpointSkippedUntrackedByTs = await this.getCheckpointSkippedUntrackedByMessageTs()
 			const sdkTaskHistory = (await this.taskHistory.listHistory({ limit: 100, hydrate: false }))
 				.map(sessionHistoryRecordToHistoryItem)
 				.filter((item) => item.ts && item.task)

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -53,13 +53,14 @@ export interface ExtensionState {
 		sessionId: string
 	}
 	/**
-	 * Checkpoint run count → untracked paths that run's snapshot skipped over
-	 * the size cap. Lets the restore UI warn that those files stay at their
-	 * current content when the workspace is reset. Includes runs with no
-	 * skips (empty array) so the webview can resolve "nearest checkpoint at
-	 * or before run N" without a gap-filled key set. SDK sessions only.
+	 * Message ts → untracked paths that the checkpoint a restore from that
+	 * message would use skipped over the size cap. Lets the restore UI warn
+	 * that those files stay at their current content when the workspace is
+	 * reset. Resolved host-side with the same mapping restore uses, so the
+	 * webview only does a ts lookup. Only messages with a non-empty skip
+	 * list appear. SDK sessions only.
 	 */
-	checkpointSkippedUntrackedByRun?: Record<number, string[]>
+	checkpointSkippedUntrackedByTs?: Record<number, string[]>
 	/**
 	 * The single authoritative UI mode for the current turn, owned by the extension. The webview
 	 * renders the footer/buttons/thinking indicator from this, NOT from the tail of clineMessages.

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -53,6 +53,14 @@ export interface ExtensionState {
 		sessionId: string
 	}
 	/**
+	 * Checkpoint run count → untracked paths that run's snapshot skipped over
+	 * the size cap. Lets the restore UI warn that those files stay at their
+	 * current content when the workspace is reset. Includes runs with no
+	 * skips (empty array) so the webview can resolve "nearest checkpoint at
+	 * or before run N" without a gap-filled key set. SDK sessions only.
+	 */
+	checkpointSkippedUntrackedByRun?: Record<number, string[]>
+	/**
 	 * The single authoritative UI mode for the current turn, owned by the extension. The webview
 	 * renders the footer/buttons/thinking indicator from this, NOT from the tail of clineMessages.
 	 * Optional for classic/legacy (absent => webview falls back to legacy tail heuristics).

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -33,7 +33,10 @@ import {
 } from "lucide-react"
 import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
-import { canRestoreWorkspaceFromMessage } from "@/components/chat/chat-view/utils/messageUtils"
+import {
+	canRestoreWorkspaceFromMessage,
+	checkpointSkippedUntrackedForMessage,
+} from "@/components/chat/chat-view/utils/messageUtils"
 import { OptionsButtons } from "@/components/chat/OptionsButtons"
 import { WithCopyButton } from "@/components/common/CopyButton"
 import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
@@ -153,6 +156,7 @@ export const ChatRowContent = memo(
 			clineMessages,
 			showFeatureTips,
 			enableCheckpointsSetting,
+			checkpointSkippedUntrackedByRun,
 		} = useExtensionState()
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
 			visible: false,
@@ -901,6 +905,11 @@ export const ChatRowContent = memo(
 								images={message.images}
 								messageTs={message.ts}
 								sendMessageFromChatRow={sendMessageFromChatRow}
+								skippedUntracked={checkpointSkippedUntrackedForMessage(
+									clineMessages,
+									message.ts,
+									checkpointSkippedUntrackedByRun,
+								)}
 								text={message.text}
 							/>
 						)

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -33,10 +33,7 @@ import {
 } from "lucide-react"
 import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
-import {
-	canRestoreWorkspaceFromMessage,
-	checkpointSkippedUntrackedForMessage,
-} from "@/components/chat/chat-view/utils/messageUtils"
+import { canRestoreWorkspaceFromMessage } from "@/components/chat/chat-view/utils/messageUtils"
 import { OptionsButtons } from "@/components/chat/OptionsButtons"
 import { WithCopyButton } from "@/components/common/CopyButton"
 import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
@@ -156,7 +153,7 @@ export const ChatRowContent = memo(
 			clineMessages,
 			showFeatureTips,
 			enableCheckpointsSetting,
-			checkpointSkippedUntrackedByRun,
+			checkpointSkippedUntrackedByTs,
 		} = useExtensionState()
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
 			visible: false,
@@ -905,11 +902,7 @@ export const ChatRowContent = memo(
 								images={message.images}
 								messageTs={message.ts}
 								sendMessageFromChatRow={sendMessageFromChatRow}
-								skippedUntracked={checkpointSkippedUntrackedForMessage(
-									clineMessages,
-									message.ts,
-									checkpointSkippedUntrackedByRun,
-								)}
+								skippedUntracked={checkpointSkippedUntrackedByTs?.[message.ts]}
 								text={message.text}
 							/>
 						)

--- a/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/UserMessage.tsx
@@ -13,9 +13,22 @@ interface UserMessageProps {
 	messageTs?: number
 	sendMessageFromChatRow?: (text: string, images: string[], files: string[]) => void
 	canRestoreWorkspace?: boolean
+	/**
+	 * Untracked files the checkpoint's snapshot skipped over its size cap —
+	 * "Reset Code" leaves them at their current content, so the edit panel
+	 * says so before the user commits to the restore.
+	 */
+	skippedUntracked?: string[]
 }
 
-const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageTs, canRestoreWorkspace = true }) => {
+const UserMessage: React.FC<UserMessageProps> = ({
+	text,
+	images,
+	files,
+	messageTs,
+	canRestoreWorkspace = true,
+	skippedUntracked,
+}) => {
 	const [isEditing, setIsEditing] = useState(false)
 	const [editedText, setEditedText] = useState(text ?? "")
 	const [editedImages, setEditedImages] = useState(images ?? [])
@@ -133,6 +146,15 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 						/>
 					)}
 					{errorMessage && <div className="text-xs text-(--vscode-errorForeground)">{errorMessage}</div>}
+					{canRestoreWorkspace && (skippedUntracked?.length ?? 0) > 0 && (
+						<div className="text-xs text-(--vscode-editorWarning-foreground)">
+							{skippedUntracked?.length === 1
+								? `1 large file was not captured by this checkpoint — Reset Code leaves it at its current content: ${skippedUntracked[0]}`
+								: `${skippedUntracked?.length} large files were not captured by this checkpoint — Reset Code leaves them at their current content: ${skippedUntracked
+										?.slice(0, 3)
+										.join(", ")}${(skippedUntracked?.length ?? 0) > 3 ? ", …" : ""}`}
+						</div>
+					)}
 					<div className="flex items-center justify-between gap-1.5">
 						<button
 							className="shrink-0 whitespace-nowrap px-1 py-1 rounded-xs border-0 bg-transparent text-badge-foreground/80 hover:text-badge-foreground cursor-pointer text-xs"

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -111,6 +111,44 @@ export function canRestoreWorkspaceFromMessage(messages: ClineMessage[], message
 }
 
 /**
+ * Untracked files that a workspace restore from this message would NOT rewind,
+ * because the checkpoint's snapshot skipped them over its size cap.
+ *
+ * The message's run number is its ordinal among restore-eligible user messages
+ * (the same predicates `canRestoreWorkspaceFromMessage` uses, mirroring the
+ * host's sdk-checkpoints.ts numbering), and the restore resolves to the
+ * nearest checkpoint at or before that run — so the lookup does too.
+ */
+export function checkpointSkippedUntrackedForMessage(
+	messages: ClineMessage[],
+	messageTs: number | undefined,
+	skippedByRun: Record<number, string[]> | undefined,
+): string[] | undefined {
+	if (messageTs === undefined || !skippedByRun) {
+		return undefined
+	}
+	const index = messages.findIndex((message) => message.ts === messageTs)
+	if (index === -1 || !isVisibleCheckpointUserMessage(messages[index]) || isCheckpointAnswerMessage(messages, index)) {
+		return undefined
+	}
+	let runCount = 0
+	for (let cursor = 0; cursor <= index; cursor += 1) {
+		if (isVisibleCheckpointUserMessage(messages[cursor]) && !isCheckpointAnswerMessage(messages, cursor)) {
+			runCount += 1
+		}
+	}
+	let nearestRun: number | undefined
+	for (const key of Object.keys(skippedByRun)) {
+		const run = Number(key)
+		if (Number.isInteger(run) && run <= runCount && (nearestRun === undefined || run > nearestRun)) {
+			nearestRun = run
+		}
+	}
+	const skipped = nearestRun === undefined ? undefined : skippedByRun[nearestRun]
+	return skipped && skipped.length > 0 ? skipped : undefined
+}
+
+/**
  * Filter messages that should be visible in the chat
  */
 export function filterVisibleMessages(messages: ClineMessage[]): ClineMessage[] {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -111,44 +111,6 @@ export function canRestoreWorkspaceFromMessage(messages: ClineMessage[], message
 }
 
 /**
- * Untracked files that a workspace restore from this message would NOT rewind,
- * because the checkpoint's snapshot skipped them over its size cap.
- *
- * The message's run number is its ordinal among restore-eligible user messages
- * (the same predicates `canRestoreWorkspaceFromMessage` uses, mirroring the
- * host's sdk-checkpoints.ts numbering), and the restore resolves to the
- * nearest checkpoint at or before that run — so the lookup does too.
- */
-export function checkpointSkippedUntrackedForMessage(
-	messages: ClineMessage[],
-	messageTs: number | undefined,
-	skippedByRun: Record<number, string[]> | undefined,
-): string[] | undefined {
-	if (messageTs === undefined || !skippedByRun) {
-		return undefined
-	}
-	const index = messages.findIndex((message) => message.ts === messageTs)
-	if (index === -1 || !isVisibleCheckpointUserMessage(messages[index]) || isCheckpointAnswerMessage(messages, index)) {
-		return undefined
-	}
-	let runCount = 0
-	for (let cursor = 0; cursor <= index; cursor += 1) {
-		if (isVisibleCheckpointUserMessage(messages[cursor]) && !isCheckpointAnswerMessage(messages, cursor)) {
-			runCount += 1
-		}
-	}
-	let nearestRun: number | undefined
-	for (const key of Object.keys(skippedByRun)) {
-		const run = Number(key)
-		if (Number.isInteger(run) && run <= runCount && (nearestRun === undefined || run > nearestRun)) {
-			nearestRun = run
-		}
-	}
-	const skipped = nearestRun === undefined ? undefined : skippedByRun[nearestRun]
-	return skipped && skipped.length > 0 ? skipped : undefined
-}
-
-/**
  * Filter messages that should be visible in the chat
  */
 export function filterVisibleMessages(messages: ClineMessage[]): ClineMessage[] {

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -57,7 +57,14 @@ const editorFeatures: FeatureToggle[] = [
 	{
 		id: "checkpoints",
 		label: "Checkpoints",
-		description: "Save progress at key points for easy rollback",
+		description: (
+			<>
+				Save progress at key points for easy rollback
+				<span className="block mt-0.5 opacity-70">
+					Untracked files over 100 MB aren't captured, so restoring a checkpoint leaves them unchanged.
+				</span>
+			</>
+		),
 		stateKey: "enableCheckpointsSetting",
 		settingKey: "enableCheckpointsSetting",
 	},
@@ -223,7 +230,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 							))}
 						</div>
 					</div>
-
 				</div>
 
 				{/* Advanced */}

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
@@ -1,0 +1,106 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { AgentMessage } from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+	type CheckpointMetadata,
+	createCheckpointHooks,
+} from "./checkpoint-hooks";
+
+// A stalled filesystem hangs syscalls, not just git subprocesses. Simulate it
+// by making every lstat never settle; the snapshot budget must still bound the
+// turn. Isolated in its own file because the module mock applies file-wide.
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		// A promise with no timer/handle: keeps nothing alive, never settles.
+		lstat: () => new Promise<never>(() => {}),
+	};
+});
+
+const execFile = promisify(execFileCallback);
+
+async function runGit(cwd: string, ...args: string[]): Promise<string> {
+	const result = await execFile("git", ["-C", cwd, ...args], {
+		windowsHide: true,
+	});
+	return result.stdout.trim();
+}
+
+const userMessage = (text: string): AgentMessage => ({
+	id: `user-${text}`,
+	role: "user",
+	content: [{ type: "text", text }],
+	createdAt: 1,
+});
+
+describe("checkpoint stat-scan timeout", () => {
+	it("degrades to a HEAD checkpoint when the untracked lstat scan hangs", async () => {
+		// importOriginal gives us the real fs back for fixture setup.
+		const realFs =
+			await vi.importActual<typeof import("node:fs/promises")>(
+				"node:fs/promises",
+			);
+		const cwd = await realFs.mkdtemp(join(tmpdir(), "core-checkpoint-stat-"));
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			await runGit(cwd, "init");
+			await runGit(cwd, "config", "user.name", "Codex Test");
+			await runGit(cwd, "config", "user.email", "codex@example.com");
+			await realFs.writeFile(join(cwd, "note.txt"), "base\n", "utf8");
+			await runGit(cwd, "add", "note.txt");
+			await runGit(cwd, "commit", "-m", "initial");
+			// An untracked file forces the snapshot into the lstat scan.
+			await realFs.writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
+
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId: "sess_stat_hang",
+				gitTimeoutMs: 1500,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			const messages = [userMessage("first request")];
+			const snapshot = {
+				agentId: "agent_1",
+				parentAgentId: undefined,
+				conversationId: "conv_1",
+				runId: "run_1",
+				status: "running" as const,
+				iteration: 1,
+				messages,
+				pendingToolCalls: [],
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+			};
+			const startedAt = performance.now();
+			await hooks.beforeRun?.({
+				snapshot: { ...snapshot, iteration: 0, messages: [] },
+			});
+			await hooks.beforeModel?.({
+				snapshot,
+				request: { messages: [], tools: [] },
+			});
+			const elapsed = performance.now() - startedAt;
+
+			// The turn is bounded by the budget instead of hanging on lstat, and
+			// the checkpoint degrades to the HEAD fallback.
+			expect(elapsed).toBeLessThan(10_000);
+			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
+			expect(checkpoint.latest.kind).toBe("commit");
+			expect(checkpoint.latest.ref).toMatch(/^[0-9a-f]{40}$/);
+		} finally {
+			await realFs.rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
@@ -56,10 +56,17 @@ describe("checkpoint stat-scan timeout", () => {
 			// An untracked file forces the snapshot into the lstat scan.
 			await realFs.writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
 
+			const events: { event: string; properties?: Record<string, unknown> }[] =
+				[];
 			const hooks = createCheckpointHooks({
 				cwd,
 				sessionId: "sess_stat_hang",
 				gitTimeoutMs: 1500,
+				telemetry: {
+					capture: (input) => {
+						events.push(input);
+					},
+				},
 				readSessionMetadata: async () => metadata,
 				writeSessionMetadata: async (next) => {
 					metadata = next;
@@ -118,6 +125,26 @@ describe("checkpoint stat-scan timeout", () => {
 			expect(vi.mocked(mockedFs.lstat).mock.calls.length).toBe(
 				lstatCallsAfterFirstTurn,
 			);
+
+			// Both degradations are reported with their distinct reasons.
+			expect(
+				events.map((entry) => ({
+					event: entry.event,
+					outcome: entry.properties?.outcome,
+					reason: entry.properties?.reason,
+				})),
+			).toEqual([
+				{
+					event: "checkpoint.snapshot",
+					outcome: "head_fallback",
+					reason: "timeout",
+				},
+				{
+					event: "checkpoint.snapshot",
+					outcome: "head_fallback",
+					reason: "stat_scan_pending",
+				},
+			]);
 		} finally {
 			await realFs.rm(cwd, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.stat-timeout.test.ts
@@ -17,7 +17,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 	return {
 		...actual,
 		// A promise with no timer/handle: keeps nothing alive, never settles.
-		lstat: () => new Promise<never>(() => {}),
+		lstat: vi.fn(() => new Promise<never>(() => {})),
 	};
 });
 
@@ -66,31 +66,38 @@ describe("checkpoint stat-scan timeout", () => {
 				},
 			});
 
-			const messages = [userMessage("first request")];
-			const snapshot = {
-				agentId: "agent_1",
-				parentAgentId: undefined,
-				conversationId: "conv_1",
-				runId: "run_1",
-				status: "running" as const,
-				iteration: 1,
-				messages,
-				pendingToolCalls: [],
-				usage: {
-					inputTokens: 0,
-					outputTokens: 0,
-					cacheReadTokens: 0,
-					cacheWriteTokens: 0,
-				},
+			const runTurn = async (messages: AgentMessage[]) => {
+				const snapshot = {
+					agentId: "agent_1",
+					parentAgentId: undefined,
+					conversationId: "conv_1",
+					runId: "run_1",
+					status: "running" as const,
+					iteration: 1,
+					messages,
+					pendingToolCalls: [],
+					usage: {
+						inputTokens: 0,
+						outputTokens: 0,
+						cacheReadTokens: 0,
+						cacheWriteTokens: 0,
+					},
+				};
+				await hooks.beforeRun?.({
+					snapshot: {
+						...snapshot,
+						iteration: 0,
+						messages: messages.slice(0, -1),
+					},
+				});
+				await hooks.beforeModel?.({
+					snapshot,
+					request: { messages: [], tools: [] },
+				});
 			};
+
 			const startedAt = performance.now();
-			await hooks.beforeRun?.({
-				snapshot: { ...snapshot, iteration: 0, messages: [] },
-			});
-			await hooks.beforeModel?.({
-				snapshot,
-				request: { messages: [], tools: [] },
-			});
+			await runTurn([userMessage("first request")]);
 			const elapsed = performance.now() - startedAt;
 
 			// The turn is bounded by the budget instead of hanging on lstat, and
@@ -99,6 +106,18 @@ describe("checkpoint stat-scan timeout", () => {
 			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
 			expect(checkpoint.latest.kind).toBe("commit");
 			expect(checkpoint.latest.ref).toMatch(/^[0-9a-f]{40}$/);
+
+			// The abandoned scan cannot be cancelled, so a later turn must not
+			// stack another lstat batch onto the stalled filesystem: the guard
+			// throws before scanning and the turn degrades to HEAD again.
+			const mockedFs = await import("node:fs/promises");
+			const lstatCallsAfterFirstTurn = vi.mocked(mockedFs.lstat).mock.calls
+				.length;
+			expect(lstatCallsAfterFirstTurn).toBeGreaterThan(0);
+			await runTurn([userMessage("first request"), userMessage("second")]);
+			expect(vi.mocked(mockedFs.lstat).mock.calls.length).toBe(
+				lstatCallsAfterFirstTurn,
+			);
 		} finally {
 			await realFs.rm(cwd, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -601,6 +601,8 @@ describe("createCheckpointHooks", () => {
 		const sessionId = "sess_size_cap";
 		let metadata: Record<string, unknown> | undefined;
 		const warnings: string[] = [];
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
 		try {
 			const hooks = createCheckpointHooks({
 				cwd,
@@ -610,6 +612,11 @@ describe("createCheckpointHooks", () => {
 					debug: () => {},
 					log: (message) => {
 						warnings.push(message);
+					},
+				},
+				telemetry: {
+					capture: (input) => {
+						events.push(input);
 					},
 				},
 				readSessionMetadata: async () => metadata,
@@ -636,6 +643,14 @@ describe("createCheckpointHooks", () => {
 			expect(warnings.some((message) => message.includes("big.bin"))).toBe(
 				true,
 			);
+			// The snapshot event reports the cap being hit — no paths, counts only.
+			expect(events).toHaveLength(1);
+			expect(events[0]?.event).toBe("checkpoint.snapshot");
+			expect(events[0]?.properties).toMatchObject({
+				outcome: "stash",
+				skippedUntrackedCount: 1,
+			});
+			expect(JSON.stringify(events[0])).not.toContain("big.bin");
 
 			// The same still-skipped file does not warn again on later turns.
 			const warningCount = warnings.length;
@@ -738,6 +753,8 @@ describe("createCheckpointHooks", () => {
 	it("skips the checkpoint without blocking or throwing when git exceeds the time budget", async () => {
 		const cwd = await createGitRepo();
 		let writes = 0;
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
 		try {
 			const hooks = createCheckpointHooks({
 				cwd,
@@ -745,6 +762,11 @@ describe("createCheckpointHooks", () => {
 				// Far below what even `git rev-parse` can finish in, so every git
 				// call this turn is killed by the budget.
 				gitTimeoutMs: 1,
+				telemetry: {
+					capture: (input) => {
+						events.push(input);
+					},
+				},
 				readSessionMetadata: async () => undefined,
 				writeSessionMetadata: async () => {
 					writes += 1;
@@ -755,6 +777,13 @@ describe("createCheckpointHooks", () => {
 			await runCheckpointHooks(hooks);
 
 			expect(writes).toBe(0);
+			// The degradation is observable in the field, not only in local logs.
+			expect(events).toHaveLength(1);
+			expect(events[0]?.event).toBe("checkpoint.snapshot");
+			expect(events[0]?.properties).toMatchObject({
+				outcome: "skipped",
+				reason: "timeout",
+			});
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -750,40 +750,46 @@ describe("createCheckpointHooks", () => {
 		}
 	});
 
-	it("skips the checkpoint without blocking or throwing when git exceeds the time budget", async () => {
+	it("degrades without blocking or throwing when the git time budget is exhausted", async () => {
 		const cwd = await createGitRepo();
-		let writes = 0;
+		let metadata: Record<string, unknown> | undefined;
 		const events: { event: string; properties?: Record<string, unknown> }[] =
 			[];
 		try {
 			const hooks = createCheckpointHooks({
 				cwd,
 				sessionId: "sess_timeout",
-				// Far below what even `git rev-parse` can finish in, so every git
-				// call this turn is killed by the budget.
-				gitTimeoutMs: 1,
+				// A zero budget makes the snapshot's remainingMs check throw
+				// deterministically. The repo probe and HEAD fallback run with a
+				// 1ms execFile kill, which a fast machine's git may win or lose —
+				// so the assertions below are the race-free contract: never a
+				// stash snapshot, at most one degraded HEAD entry, and the turn
+				// is always reported as a timeout.
+				gitTimeoutMs: 0,
 				telemetry: {
 					capture: (input) => {
 						events.push(input);
 					},
 				},
-				readSessionMetadata: async () => undefined,
-				writeSessionMetadata: async () => {
-					writes += 1;
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
 				},
 			});
 
 			await writeFile(join(cwd, "note.txt"), "dirty\n", "utf8");
 			await runCheckpointHooks(hooks);
 
-			expect(writes).toBe(0);
-			// The degradation is observable in the field, not only in local logs.
+			const checkpoint = metadata?.checkpoint as CheckpointMetadata | undefined;
+			if (checkpoint) {
+				expect(checkpoint.latest.kind).toBe("commit");
+			}
 			expect(events).toHaveLength(1);
 			expect(events[0]?.event).toBe("checkpoint.snapshot");
-			expect(events[0]?.properties).toMatchObject({
-				outcome: "skipped",
-				reason: "timeout",
-			});
+			expect(events[0]?.properties?.reason).toBe("timeout");
+			expect(["skipped", "head_fallback"]).toContain(
+				events[0]?.properties?.outcome,
+			);
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.test.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +9,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	type CheckpointEntry,
 	type CheckpointMetadata,
+	checkpointScratchDir,
 	createCheckpointHooks,
+	deleteCheckpointRefs,
 } from "./checkpoint-hooks";
 
 const execFile = promisify(execFileCallback);
@@ -591,5 +594,169 @@ describe("createCheckpointHooks", () => {
 		expect(
 			createCheckpoint.mock.calls.map(([input]) => input.runCount),
 		).toEqual([1, 2]);
+	});
+
+	it("skips untracked files over the size cap and records them on the entry", async () => {
+		const cwd = await createGitRepo();
+		const sessionId = "sess_size_cap";
+		let metadata: Record<string, unknown> | undefined;
+		const warnings: string[] = [];
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				maxUntrackedFileBytes: 16,
+				logger: {
+					debug: () => {},
+					log: (message) => {
+						warnings.push(message);
+					},
+				},
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			await writeFile(join(cwd, "big.bin"), "x".repeat(64), "utf8");
+			await writeFile(join(cwd, "small.txt"), "small\n", "utf8");
+			await runCheckpointHooks(hooks);
+
+			const checkpoint = metadata?.checkpoint as CheckpointMetadata;
+			expect(checkpoint.latest.kind).toBe("stash");
+			expect(checkpoint.latest.skippedUntracked).toEqual(["big.bin"]);
+			const untrackedTree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${checkpoint.latest.ref}^3`,
+			);
+			expect(untrackedTree.split("\n")).toEqual(["small.txt"]);
+			expect(warnings.some((message) => message.includes("big.bin"))).toBe(
+				true,
+			);
+
+			// The same still-skipped file does not warn again on later turns.
+			const warningCount = warnings.length;
+			await writeFile(join(cwd, "small.txt"), "small-two\n", "utf8");
+			await runCheckpointHooks(hooks, {
+				messages: [userMessage("first request"), userMessage("second request")],
+			});
+			expect(warnings.length).toBe(warningCount);
+			expect(
+				(metadata?.checkpoint as CheckpointMetadata).latest.skippedUntracked,
+			).toEqual(["big.bin"]);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("drops persistent-index entries for untracked files that disappear between runs", async () => {
+		// The per-session GIT_INDEX_FILE caches untracked hashes across turns so
+		// unchanged files are not re-hashed; a file that was deleted (or became
+		// tracked) in the meantime must not ghost into later snapshots.
+		const cwd = await createGitRepo();
+		const sessionId = "sess_stale_index";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+
+			await writeFile(join(cwd, "a.txt"), "a\n", "utf8");
+			await writeFile(join(cwd, "b.txt"), "b\n", "utf8");
+			await runCheckpointHooks(hooks);
+
+			const first = (metadata?.checkpoint as CheckpointMetadata).latest;
+			const firstTree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${first.ref}^3`,
+			);
+			expect(firstTree.split("\n").sort()).toEqual(["a.txt", "b.txt"]);
+			// The scratch index survives the turn — that is the cross-turn cache.
+			expect(existsSync(join(checkpointScratchDir(sessionId), "index"))).toBe(
+				true,
+			);
+
+			await rm(join(cwd, "a.txt"));
+			await runCheckpointHooks(hooks, {
+				messages: [userMessage("first request"), userMessage("second request")],
+			});
+
+			const second = (metadata?.checkpoint as CheckpointMetadata).latest;
+			expect(second.runCount).toBe(2);
+			const secondTree = await runGit(
+				cwd,
+				"ls-tree",
+				"-r",
+				"--name-only",
+				`${second.ref}^3`,
+			);
+			expect(secondTree.split("\n")).toEqual(["b.txt"]);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes the per-session scratch dir together with the checkpoint refs", async () => {
+		const cwd = await createGitRepo();
+		const sessionId = "sess_scratch_cleanup";
+		let metadata: Record<string, unknown> | undefined;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId,
+				readSessionMetadata: async () => metadata,
+				writeSessionMetadata: async (next) => {
+					metadata = next;
+				},
+			});
+			await writeFile(join(cwd, "loose.txt"), "loose\n", "utf8");
+			await runCheckpointHooks(hooks);
+			expect(existsSync(checkpointScratchDir(sessionId))).toBe(true);
+
+			await deleteCheckpointRefs(cwd, sessionId);
+
+			expect(existsSync(checkpointScratchDir(sessionId))).toBe(false);
+		} finally {
+			await deleteCheckpointRefs(cwd, sessionId);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("skips the checkpoint without blocking or throwing when git exceeds the time budget", async () => {
+		const cwd = await createGitRepo();
+		let writes = 0;
+		try {
+			const hooks = createCheckpointHooks({
+				cwd,
+				sessionId: "sess_timeout",
+				// Far below what even `git rev-parse` can finish in, so every git
+				// call this turn is killed by the budget.
+				gitTimeoutMs: 1,
+				readSessionMetadata: async () => undefined,
+				writeSessionMetadata: async () => {
+					writes += 1;
+				},
+			});
+
+			await writeFile(join(cwd, "note.txt"), "dirty\n", "utf8");
+			await runCheckpointHooks(hooks);
+
+			expect(writes).toBe(0);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
 	});
 });

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -160,6 +160,34 @@ function remainingMs(budget: SnapshotBudget): number {
 	return remaining;
 }
 
+/**
+ * Bounds non-git async work (e.g. the untracked `lstat` scan) with the same
+ * snapshot budget the git subprocesses use — a stalled filesystem must not be
+ * able to block the turn through a syscall any more than through git. The
+ * underlying work is not cancellable and may settle later; the caller just
+ * stops waiting for it.
+ */
+async function raceBudget<T>(
+	budget: SnapshotBudget,
+	work: Promise<T>,
+): Promise<T> {
+	const remaining = remainingMs(budget);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			work,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("checkpoint stat scan exceeded time budget")),
+					remaining,
+				);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 type SnapshotOptions = {
 	cwd: string;
 	scratchDir: string;
@@ -194,20 +222,23 @@ async function createUntrackedParentCommit(
 	const untrackedFiles = listing.stdout.split("\0").filter(Boolean);
 	const skipped: string[] = [];
 	const eligible: string[] = [];
-	await Promise.all(
-		untrackedFiles.map(async (path) => {
-			try {
-				const stats = await lstat(join(cwd, path));
-				if (stats.isFile() && stats.size > maxUntrackedFileBytes) {
-					skipped.push(path);
+	await raceBudget(
+		budget,
+		Promise.all(
+			untrackedFiles.map(async (path) => {
+				try {
+					const stats = await lstat(join(cwd, path));
+					if (stats.isFile() && stats.size > maxUntrackedFileBytes) {
+						skipped.push(path);
+						return;
+					}
+				} catch {
+					// Vanished between listing and stat — nothing to snapshot.
 					return;
 				}
-			} catch {
-				// Vanished between listing and stat — nothing to snapshot.
-				return;
-			}
-			eligible.push(path);
-		}),
+				eligible.push(path);
+			}),
+		),
 	);
 	skipped.sort();
 	eligible.sort();

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -188,11 +188,21 @@ async function raceBudget<T>(
 	}
 }
 
+/** At most this many lstat calls are issued concurrently by the size scan. */
+const STAT_SCAN_CONCURRENCY = 32;
+
 type SnapshotOptions = {
 	cwd: string;
 	scratchDir: string;
 	maxUntrackedFileBytes: number;
 	budget: SnapshotBudget;
+	/**
+	 * Cross-turn guard owned by the hook instance. An abandoned (timed-out)
+	 * stat scan cannot be cancelled, so while one is still pending no new scan
+	 * may start — otherwise every turn against a stalled filesystem would pile
+	 * another batch of in-flight syscalls onto the same threadpool.
+	 */
+	inflight: { statScan?: Promise<void> };
 };
 
 /**
@@ -209,7 +219,15 @@ type SnapshotOptions = {
 async function createUntrackedParentCommit(
 	options: SnapshotOptions,
 ): Promise<{ commit?: string; skipped: string[] }> {
-	const { cwd, scratchDir, maxUntrackedFileBytes, budget } = options;
+	const { cwd, scratchDir, maxUntrackedFileBytes, budget, inflight } = options;
+	if (inflight.statScan) {
+		// A previous turn's scan is still stuck in the filesystem. It clears
+		// itself when it finally settles; until then the caller degrades to a
+		// HEAD checkpoint rather than stacking another batch of syscalls.
+		throw new Error(
+			"previous checkpoint stat scan has not finished; skipping snapshot",
+		);
+	}
 	const listing = await execFile(
 		"git",
 		["-C", cwd, "ls-files", "--others", "--exclude-standard", "-z"],
@@ -222,24 +240,40 @@ async function createUntrackedParentCommit(
 	const untrackedFiles = listing.stdout.split("\0").filter(Boolean);
 	const skipped: string[] = [];
 	const eligible: string[] = [];
-	await raceBudget(
-		budget,
-		Promise.all(
-			untrackedFiles.map(async (path) => {
-				try {
-					const stats = await lstat(join(cwd, path));
-					if (stats.isFile() && stats.size > maxUntrackedFileBytes) {
-						skipped.push(path);
-						return;
+	// Bounded worker pool: an abandoned scan then holds at most
+	// STAT_SCAN_CONCURRENCY lstat calls in flight, not one per file. The
+	// mappers never reject (both branches catch), so the pool only resolves.
+	let nextIndex = 0;
+	const statScan = Promise.all(
+		Array.from(
+			{ length: Math.min(STAT_SCAN_CONCURRENCY, untrackedFiles.length) },
+			async () => {
+				while (nextIndex < untrackedFiles.length) {
+					const path = untrackedFiles[nextIndex];
+					nextIndex += 1;
+					if (path === undefined) continue;
+					try {
+						const stats = await lstat(join(cwd, path));
+						if (stats.isFile() && stats.size > maxUntrackedFileBytes) {
+							skipped.push(path);
+							continue;
+						}
+					} catch {
+						// Vanished between listing and stat — nothing to snapshot.
+						continue;
 					}
-				} catch {
-					// Vanished between listing and stat — nothing to snapshot.
-					return;
+					eligible.push(path);
 				}
-				eligible.push(path);
-			}),
+			},
 		),
-	);
+	).then(() => undefined);
+	inflight.statScan = statScan;
+	statScan.finally(() => {
+		if (inflight.statScan === statScan) {
+			inflight.statScan = undefined;
+		}
+	});
+	await raceBudget(budget, statScan);
 	skipped.sort();
 	eligible.sort();
 	if (eligible.length === 0) {
@@ -522,6 +556,8 @@ export function createCheckpointHooks(
 	// Paths already warn-logged as skipped, so a file that stays over the cap
 	// for the whole session produces one warning, not one per turn.
 	const warnedSkipped = new Set<string>();
+	// See SnapshotOptions.inflight — survives across turns of this session.
+	const inflight: { statScan?: Promise<void> } = {};
 
 	const ensureGitRepository = async (): Promise<boolean> => {
 		// Only cache the positive answer: a cwd that is not a git repo can
@@ -599,6 +635,7 @@ export function createCheckpointHooks(
 					scratchDir: checkpointScratchDir(options.sessionId),
 					maxUntrackedFileBytes,
 					budget: { timeoutAt: startedAt + gitTimeoutMs },
+					inflight,
 				},
 				message,
 			);

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -8,9 +8,24 @@ import { countUserRunMessages } from "../session/user-run-messages";
 
 const execFile = promisify(execFileCallback);
 const CHECKPOINT_STASH_MESSAGE_PREFIX = "cline checkpoint session=";
+const DEFAULT_MAX_UNTRACKED_FILE_BYTES = 100 * 1024 * 1024;
+const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+const LS_FILES_MAX_BUFFER = 1024 * 1024 * 64;
 
 export function isCheckpointStashMessage(message: string): boolean {
 	return message.includes(CHECKPOINT_STASH_MESSAGE_PREFIX);
+}
+
+/**
+ * Per-session scratch directory holding the persistent `GIT_INDEX_FILE` used
+ * to snapshot untracked files. Persisting the index across turns lets git's
+ * stat cache skip re-reading (and re-hashing) untracked files that have not
+ * changed since the previous checkpoint — without it, every turn re-hashes
+ * every untracked byte in the workspace. Removed by `deleteCheckpointRefs`.
+ */
+export function checkpointScratchDir(sessionId: string): string {
+	const safeId = sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+	return join(tmpdir(), `cline-checkpoint-${safeId}`);
 }
 
 export interface CheckpointEntry {
@@ -18,6 +33,13 @@ export interface CheckpointEntry {
 	createdAt: number;
 	runCount: number;
 	kind?: "stash" | "commit";
+	/**
+	 * Repo-relative paths of untracked files that were excluded from the
+	 * snapshot because they exceeded the size cap. They exist only on disk, so
+	 * the restore path must exempt them from its `git clean` — deleting them
+	 * would be unrecoverable data loss.
+	 */
+	skippedUntracked?: string[];
 }
 
 export interface CheckpointMetadata {
@@ -43,6 +65,17 @@ type CreateCheckpointHooksOptions = {
 		sessionId: string;
 		runCount: number;
 	}) => Promise<CheckpointEntry | undefined> | CheckpointEntry | undefined;
+	/**
+	 * Untracked files larger than this many bytes are left out of the snapshot
+	 * (and recorded on the entry as `skippedUntracked`). Defaults to 100 MiB.
+	 */
+	maxUntrackedFileBytes?: number;
+	/**
+	 * Overall time budget for the git snapshot on each turn. When exceeded the
+	 * checkpoint degrades to a HEAD-commit entry (or is skipped for that turn)
+	 * instead of blocking the request path. Defaults to 60s.
+	 */
+	gitTimeoutMs?: number;
 };
 
 function warn(logger: BasicLogger | undefined, message: string): void {
@@ -85,9 +118,11 @@ function readCheckpointMetadata(
 async function runGit(
 	cwd: string,
 	args: string[],
+	timeoutMs?: number,
 ): Promise<{ stdout: string; stderr: string }> {
 	const result = await execFile("git", ["-C", cwd, ...args], {
 		windowsHide: true,
+		...(timeoutMs !== undefined ? { timeout: Math.max(1, timeoutMs) } : {}),
 	});
 	return {
 		stdout: result.stdout.trim(),
@@ -99,61 +134,161 @@ async function runGitWithIndex(
 	cwd: string,
 	indexFile: string,
 	args: string[],
+	timeoutMs?: number,
 ): Promise<string> {
 	const result = await execFile("git", ["-C", cwd, ...args], {
 		windowsHide: true,
+		maxBuffer: LS_FILES_MAX_BUFFER,
 		env: { ...process.env, GIT_INDEX_FILE: indexFile },
+		...(timeoutMs !== undefined ? { timeout: Math.max(1, timeoutMs) } : {}),
 	});
 	return result.stdout.trim();
 }
+
+/**
+ * Shared time budget for all git calls of one snapshot attempt: each call gets
+ * only what is left, so the total can never exceed the configured timeout no
+ * matter how many git invocations the snapshot needs.
+ */
+type SnapshotBudget = { timeoutAt: number };
+
+function remainingMs(budget: SnapshotBudget): number {
+	const remaining = budget.timeoutAt - Date.now();
+	if (remaining <= 0) {
+		throw new Error("checkpoint git time budget exhausted");
+	}
+	return remaining;
+}
+
+type SnapshotOptions = {
+	cwd: string;
+	scratchDir: string;
+	maxUntrackedFileBytes: number;
+	budget: SnapshotBudget;
+};
 
 /**
  * Builds a commit whose tree contains only the current untracked (but not
  * git-ignored) files, without touching the working tree or the real index.
  * This mirrors the third parent that `git stash create --include-untracked`
  * records, which the plain `git stash create` used elsewhere omits. Returns
- * `undefined` when there are no untracked files to capture.
+ * an `undefined` commit when there are no untracked files to capture.
+ *
+ * Untracked files above the size cap are excluded and reported via `skipped`
+ * so the checkpoint entry (and later the restore path) knows they were never
+ * part of the snapshot.
  */
 async function createUntrackedParentCommit(
-	cwd: string,
-): Promise<string | undefined> {
+	options: SnapshotOptions,
+): Promise<{ commit?: string; skipped: string[] }> {
+	const { cwd, scratchDir, maxUntrackedFileBytes, budget } = options;
 	const listing = await execFile(
 		"git",
 		["-C", cwd, "ls-files", "--others", "--exclude-standard", "-z"],
-		{ windowsHide: true, maxBuffer: 1024 * 1024 * 64 },
+		{
+			windowsHide: true,
+			maxBuffer: LS_FILES_MAX_BUFFER,
+			timeout: remainingMs(budget),
+		},
 	);
 	const untrackedFiles = listing.stdout.split("\0").filter(Boolean);
-	if (untrackedFiles.length === 0) {
-		return undefined;
+	const skipped: string[] = [];
+	const eligible: string[] = [];
+	await Promise.all(
+		untrackedFiles.map(async (path) => {
+			try {
+				const stats = await lstat(join(cwd, path));
+				if (stats.isFile() && stats.size > maxUntrackedFileBytes) {
+					skipped.push(path);
+					return;
+				}
+			} catch {
+				// Vanished between listing and stat — nothing to snapshot.
+				return;
+			}
+			eligible.push(path);
+		}),
+	);
+	skipped.sort();
+	eligible.sort();
+	if (eligible.length === 0) {
+		return { commit: undefined, skipped };
 	}
-	const tempDir = await mkdtemp(join(tmpdir(), "cline-checkpoint-"));
-	const indexFile = join(tempDir, "index");
-	const pathspecFile = join(tempDir, "pathspec");
+	await mkdir(scratchDir, { recursive: true });
+	const indexFile = join(scratchDir, "index");
+	const pathspecFile = join(scratchDir, "pathspec");
+	// Feed paths via a NUL-delimited pathspec file so large untracked sets
+	// cannot overflow the command-line argument limit.
+	await writeFile(pathspecFile, `${eligible.join("\0")}\0`);
+	const addArgs = [
+		"add",
+		"--force",
+		"--pathspec-from-file",
+		pathspecFile,
+		"--pathspec-file-nul",
+	];
 	try {
-		// Feed paths via a NUL-delimited pathspec file so large untracked sets
-		// cannot overflow the command-line argument limit.
-		await writeFile(pathspecFile, `${untrackedFiles.join("\0")}\0`);
-		await runGitWithIndex(cwd, indexFile, [
-			"add",
-			"--force",
-			"--pathspec-from-file",
-			pathspecFile,
-			"--pathspec-file-nul",
-		]);
-		const tree = await runGitWithIndex(cwd, indexFile, ["write-tree"]);
-		if (!tree) {
-			return undefined;
-		}
-		const commit = await runGitWithIndex(cwd, indexFile, [
-			"commit-tree",
-			tree,
-			"-m",
-			"untracked files on cline checkpoint",
-		]);
-		return commit || undefined;
-	} finally {
-		await rm(tempDir, { recursive: true, force: true });
+		await runGitWithIndex(cwd, indexFile, addArgs, remainingMs(budget));
+	} catch {
+		// A corrupt index (crash mid-write, git version change) would otherwise
+		// fail every turn from here on; rebuild it from scratch once. The retry
+		// pays a full re-hash, so anything else propagates to the caller.
+		await rm(indexFile, { force: true });
+		await runGitWithIndex(cwd, indexFile, addArgs, remainingMs(budget));
 	}
+	// Drop index entries that fell out of the eligible set (file deleted,
+	// became tracked, or grew past the cap) so they don't ghost into the
+	// snapshot tree — `git add` with a pathspec never removes entries.
+	const indexedListing = await execFile("git", ["-C", cwd, "ls-files", "-z"], {
+		windowsHide: true,
+		maxBuffer: LS_FILES_MAX_BUFFER,
+		env: { ...process.env, GIT_INDEX_FILE: indexFile },
+		timeout: remainingMs(budget),
+	});
+	const eligibleSet = new Set(eligible);
+	const stale = indexedListing.stdout
+		.split("\0")
+		.filter(Boolean)
+		.filter((path) => !eligibleSet.has(path));
+	// `update-index` has no --pathspec-from-file, so pass paths as arguments in
+	// length-bounded batches to stay under Windows' ~32k command-line limit.
+	let batch: string[] = [];
+	let batchLength = 0;
+	const flushBatch = async () => {
+		if (batch.length === 0) return;
+		await runGitWithIndex(
+			cwd,
+			indexFile,
+			["update-index", "--force-remove", "--", ...batch],
+			remainingMs(budget),
+		);
+		batch = [];
+		batchLength = 0;
+	};
+	for (const path of stale) {
+		if (batch.length > 0 && batchLength + path.length > 8000) {
+			await flushBatch();
+		}
+		batch.push(path);
+		batchLength += path.length + 1;
+	}
+	await flushBatch();
+	const tree = await runGitWithIndex(
+		cwd,
+		indexFile,
+		["write-tree"],
+		remainingMs(budget),
+	);
+	if (!tree) {
+		return { commit: undefined, skipped };
+	}
+	const commit = await runGitWithIndex(
+		cwd,
+		indexFile,
+		["commit-tree", tree, "-m", "untracked files on cline checkpoint"],
+		remainingMs(budget),
+	);
+	return { commit: commit || undefined, skipped };
 }
 
 /**
@@ -166,84 +301,109 @@ async function createUntrackedParentCommit(
  * untracked files), letting the caller fall back to a HEAD commit checkpoint.
  */
 async function createWorktreeStashCommit(
-	cwd: string,
+	options: SnapshotOptions,
 	message: string,
-): Promise<string | undefined> {
-	const stashRef = (await runGit(cwd, ["stash", "create", message])).stdout;
-	const untrackedParent = await createUntrackedParentCommit(cwd);
+): Promise<{ ref?: string; skipped: string[] }> {
+	const { cwd, budget } = options;
+	const stashRef = (
+		await runGit(cwd, ["stash", "create", message], remainingMs(budget))
+	).stdout;
+	const untracked = await createUntrackedParentCommit(options);
+	const untrackedParent = untracked.commit;
+	const skipped = untracked.skipped;
 
 	if (stashRef) {
 		if (!untrackedParent) {
 			// Tracked changes only — the plain stash already captures them.
-			return stashRef;
+			return { ref: stashRef, skipped };
 		}
-		const tree = (await runGit(cwd, ["rev-parse", `${stashRef}^{tree}`]))
-			.stdout;
-		const base = (await runGit(cwd, ["rev-parse", `${stashRef}^1`])).stdout;
-		const indexParent = (await runGit(cwd, ["rev-parse", `${stashRef}^2`]))
-			.stdout;
+		const tree = (
+			await runGit(
+				cwd,
+				["rev-parse", `${stashRef}^{tree}`],
+				remainingMs(budget),
+			)
+		).stdout;
+		const base = (
+			await runGit(cwd, ["rev-parse", `${stashRef}^1`], remainingMs(budget))
+		).stdout;
+		const indexParent = (
+			await runGit(cwd, ["rev-parse", `${stashRef}^2`], remainingMs(budget))
+		).stdout;
 		if (!tree || !base || !indexParent) {
-			return stashRef;
+			return { ref: stashRef, skipped };
 		}
-		return (
-			(
-				await runGit(cwd, [
-					"commit-tree",
-					tree,
-					"-p",
-					base,
-					"-p",
-					indexParent,
-					"-p",
-					untrackedParent,
-					"-m",
-					message,
-				])
-			).stdout || stashRef
-		);
+		return {
+			ref:
+				(
+					await runGit(
+						cwd,
+						[
+							"commit-tree",
+							tree,
+							"-p",
+							base,
+							"-p",
+							indexParent,
+							"-p",
+							untrackedParent,
+							"-m",
+							message,
+						],
+						remainingMs(budget),
+					)
+				).stdout || stashRef,
+			skipped,
+		};
 	}
 
 	// Tracked worktree is clean. Only synthesize a stash when there are
 	// untracked files to preserve; otherwise the caller uses a HEAD checkpoint.
 	if (!untrackedParent) {
-		return undefined;
+		return { ref: undefined, skipped };
 	}
-	const head = (await runGit(cwd, ["rev-parse", "HEAD"])).stdout;
-	const headTree = (await runGit(cwd, ["rev-parse", "HEAD^{tree}"])).stdout;
+	const head = (await runGit(cwd, ["rev-parse", "HEAD"], remainingMs(budget)))
+		.stdout;
+	const headTree = (
+		await runGit(cwd, ["rev-parse", "HEAD^{tree}"], remainingMs(budget))
+	).stdout;
 	if (!head || !headTree) {
-		return undefined;
+		return { ref: undefined, skipped };
 	}
 	// The index parent mirrors the (unchanged) HEAD tree so the synthesized
 	// commit has the two/three-parent shape `git stash apply` expects.
 	const indexParent = (
-		await runGit(cwd, [
-			"commit-tree",
-			headTree,
-			"-p",
-			head,
-			"-m",
-			"index on cline checkpoint",
-		])
+		await runGit(
+			cwd,
+			["commit-tree", headTree, "-p", head, "-m", "index on cline checkpoint"],
+			remainingMs(budget),
+		)
 	).stdout;
 	if (!indexParent) {
-		return undefined;
+		return { ref: undefined, skipped };
 	}
-	return (
-		(
-			await runGit(cwd, [
-				"commit-tree",
-				headTree,
-				"-p",
-				head,
-				"-p",
-				indexParent,
-				"-p",
-				untrackedParent,
-				"-m",
-				message,
-			])
-		).stdout || undefined
-	);
+	return {
+		ref:
+			(
+				await runGit(
+					cwd,
+					[
+						"commit-tree",
+						headTree,
+						"-p",
+						head,
+						"-p",
+						indexParent,
+						"-p",
+						untrackedParent,
+						"-m",
+						message,
+					],
+					remainingMs(budget),
+				)
+			).stdout || undefined,
+		skipped,
+	};
 }
 
 /**
@@ -256,6 +416,12 @@ export async function deleteCheckpointRefs(
 	cwd: string | null | undefined,
 	sessionId: string,
 ): Promise<void> {
+	// The scratch dir (persistent untracked index) is keyed by session id
+	// alone, so clean it up even when no cwd is known.
+	await rm(checkpointScratchDir(sessionId), {
+		recursive: true,
+		force: true,
+	}).catch(() => undefined);
 	if (!cwd) return;
 	const prefix = `refs/cline/checkpoints/${sessionId}/`;
 	try {
@@ -319,6 +485,12 @@ export function createCheckpointHooks(
 	// to undefined — so the durable persisted checkpoint history is what
 	// actually prevents duplicate/overwriting checkpoints.
 	let rootRunMessageStart: number | undefined;
+	const maxUntrackedFileBytes =
+		options.maxUntrackedFileBytes ?? DEFAULT_MAX_UNTRACKED_FILE_BYTES;
+	const gitTimeoutMs = options.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
+	// Paths already warn-logged as skipped, so a file that stays over the cap
+	// for the whole session produces one warning, not one per turn.
+	const warnedSkipped = new Set<string>();
 
 	const ensureGitRepository = async (): Promise<boolean> => {
 		// Only cache the positive answer: a cwd that is not a git repo can
@@ -329,10 +501,11 @@ export function createCheckpointHooks(
 			return true;
 		}
 		try {
-			const result = await runGit(options.cwd, [
-				"rev-parse",
-				"--is-inside-work-tree",
-			]);
+			const result = await runGit(
+				options.cwd,
+				["rev-parse", "--is-inside-work-tree"],
+				gitTimeoutMs,
+			);
 			repoSupported = result.stdout === "true";
 		} catch {
 			repoSupported = false;
@@ -359,7 +532,13 @@ export function createCheckpointHooks(
 			warnPrefix: string,
 		): Promise<CheckpointEntry | undefined> => {
 			try {
-				const result = await runGit(options.cwd, ["rev-parse", "HEAD"]);
+				// Deliberately a fresh timeout rather than the snapshot budget: the
+				// fallback must still work when the budget is what just expired.
+				const result = await runGit(
+					options.cwd,
+					["rev-parse", "HEAD"],
+					gitTimeoutMs,
+				);
 				const ref = result.stdout.trim();
 				if (!ref) {
 					return undefined;
@@ -380,16 +559,38 @@ export function createCheckpointHooks(
 		};
 
 		const message = `${CHECKPOINT_STASH_MESSAGE_PREFIX}${options.sessionId} run=${runCount}`;
-		let ref = "";
+		const startedAt = Date.now();
+		let snapshot: { ref?: string; skipped: string[] };
 		try {
-			ref = (await createWorktreeStashCommit(options.cwd, message)) ?? "";
+			snapshot = await createWorktreeStashCommit(
+				{
+					cwd: options.cwd,
+					scratchDir: checkpointScratchDir(options.sessionId),
+					maxUntrackedFileBytes,
+					budget: { timeoutAt: startedAt + gitTimeoutMs },
+				},
+				message,
+			);
 		} catch (error) {
 			warn(
 				options.logger,
-				`Checkpoint snapshot failed: ${error instanceof Error ? error.message : String(error)}`,
+				`Checkpoint snapshot failed after ${Date.now() - startedAt}ms: ${error instanceof Error ? error.message : String(error)}`,
 			);
 			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
 		}
+		const newSkipped = snapshot.skipped.filter(
+			(path) => !warnedSkipped.has(path),
+		);
+		if (newSkipped.length > 0) {
+			for (const path of newSkipped) {
+				warnedSkipped.add(path);
+			}
+			warn(
+				options.logger,
+				`Checkpoint skipped ${newSkipped.length} untracked file(s) over ${maxUntrackedFileBytes} bytes (they will not be restorable): ${newSkipped.slice(0, 10).join(", ")}${newSkipped.length > 10 ? ", …" : ""}`,
+			);
+		}
+		const ref = snapshot.ref ?? "";
 		if (!ref) {
 			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
 		}
@@ -402,7 +603,7 @@ export function createCheckpointHooks(
 		// on the restore path, so no restore-side changes are needed.
 		const privateRef = `refs/cline/checkpoints/${options.sessionId}/${runCount}`;
 		try {
-			await runGit(options.cwd, ["update-ref", privateRef, ref]);
+			await runGit(options.cwd, ["update-ref", privateRef, ref], gitTimeoutMs);
 		} catch (error) {
 			warn(
 				options.logger,
@@ -416,6 +617,9 @@ export function createCheckpointHooks(
 			createdAt: Date.now(),
 			runCount,
 			kind: "stash",
+			...(snapshot.skipped.length > 0
+				? { skippedUntracked: snapshot.skipped }
+				: {}),
 		};
 	};
 

--- a/sdk/packages/core/src/hooks/checkpoint-hooks.ts
+++ b/sdk/packages/core/src/hooks/checkpoint-hooks.ts
@@ -3,7 +3,7 @@ import { lstat, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { AgentHooks, BasicLogger } from "@cline/shared";
+import type { AgentHooks, BasicLogger, ITelemetryService } from "@cline/shared";
 import { countUserRunMessages } from "../session/user-run-messages";
 
 const execFile = promisify(execFileCallback);
@@ -76,6 +76,13 @@ type CreateCheckpointHooksOptions = {
 	 * instead of blocking the request path. Defaults to 60s.
 	 */
 	gitTimeoutMs?: number;
+	/**
+	 * Emits one `checkpoint.snapshot` event per built-in snapshot attempt so
+	 * degradations (timeouts, HEAD fallbacks, size-cap skips) are observable in
+	 * the field, not only in local logs. Properties carry outcome, duration,
+	 * and counts — never file paths or contents.
+	 */
+	telemetry?: Pick<ITelemetryService, "capture">;
 };
 
 function warn(logger: BasicLogger | undefined, message: string): void {
@@ -152,10 +159,35 @@ async function runGitWithIndex(
  */
 type SnapshotBudget = { timeoutAt: number };
 
+/** Budget expiry — kept distinct from git failures so telemetry can tell them apart. */
+class CheckpointTimeoutError extends Error {}
+/** A previous turn's stat scan is still pending (see SnapshotOptions.inflight). */
+class CheckpointScanPendingError extends Error {}
+
+type CheckpointFailureReason = "timeout" | "stat_scan_pending" | "git_error";
+
+function classifyCheckpointFailure(error: unknown): CheckpointFailureReason {
+	if (error instanceof CheckpointScanPendingError) {
+		return "stat_scan_pending";
+	}
+	if (error instanceof CheckpointTimeoutError) {
+		return "timeout";
+	}
+	// execFile sets `killed` when it terminated the child on its timeout.
+	if (
+		!!error &&
+		typeof error === "object" &&
+		(error as { killed?: boolean }).killed === true
+	) {
+		return "timeout";
+	}
+	return "git_error";
+}
+
 function remainingMs(budget: SnapshotBudget): number {
 	const remaining = budget.timeoutAt - Date.now();
 	if (remaining <= 0) {
-		throw new Error("checkpoint git time budget exhausted");
+		throw new CheckpointTimeoutError("checkpoint git time budget exhausted");
 	}
 	return remaining;
 }
@@ -178,7 +210,12 @@ async function raceBudget<T>(
 			work,
 			new Promise<never>((_, reject) => {
 				timer = setTimeout(
-					() => reject(new Error("checkpoint stat scan exceeded time budget")),
+					() =>
+						reject(
+							new CheckpointTimeoutError(
+								"checkpoint stat scan exceeded time budget",
+							),
+						),
 					remaining,
 				);
 			}),
@@ -224,7 +261,7 @@ async function createUntrackedParentCommit(
 		// A previous turn's scan is still stuck in the filesystem. It clears
 		// itself when it finally settles; until then the caller degrades to a
 		// HEAD checkpoint rather than stacking another batch of syscalls.
-		throw new Error(
+		throw new CheckpointScanPendingError(
 			"previous checkpoint stat scan has not finished; skipping snapshot",
 		);
 	}
@@ -559,6 +596,11 @@ export function createCheckpointHooks(
 	// See SnapshotOptions.inflight — survives across turns of this session.
 	const inflight: { statScan?: Promise<void> } = {};
 
+	// Why the repo probe failed, when it failed abnormally. A plain "this is
+	// not a git repo" answer stays undefined — that is a normal state, not a
+	// degradation worth reporting.
+	let probeFailure: CheckpointFailureReason | undefined;
+
 	const ensureGitRepository = async (): Promise<boolean> => {
 		// Only cache the positive answer: a cwd that is not a git repo can
 		// become one mid-session (the user runs `git init`), and this probe
@@ -567,6 +609,7 @@ export function createCheckpointHooks(
 		if (repoSupported === true) {
 			return true;
 		}
+		probeFailure = undefined;
 		try {
 			const result = await runGit(
 				options.cwd,
@@ -574,7 +617,8 @@ export function createCheckpointHooks(
 				gitTimeoutMs,
 			);
 			repoSupported = result.stdout === "true";
-		} catch {
+		} catch (error) {
+			probeFailure = classifyCheckpointFailure(error);
 			repoSupported = false;
 		}
 		return repoSupported;
@@ -591,7 +635,33 @@ export function createCheckpointHooks(
 			});
 		}
 
+		const startedAt = Date.now();
+		// One event per built-in snapshot attempt. Outcomes: "stash" (full
+		// snapshot), "head_clean" (clean worktree, HEAD entry is the normal
+		// result), "head_fallback" (degraded to HEAD after a failure), and
+		// "skipped" (no checkpoint written this turn). Counts and durations
+		// only — never paths.
+		const captureSnapshot = (
+			outcome: "stash" | "head_clean" | "head_fallback" | "skipped",
+			extra?: Record<string, string | number | boolean>,
+		): void => {
+			options.telemetry?.capture({
+				event: "checkpoint.snapshot",
+				properties: {
+					sessionId: options.sessionId,
+					runCount,
+					outcome,
+					durationMs: Date.now() - startedAt,
+					...extra,
+				},
+			});
+		};
+
 		if (!(await ensureGitRepository())) {
+			// Only a timed-out probe is a degradation; "not a repo" is normal.
+			if (probeFailure === "timeout") {
+				captureSnapshot("skipped", { reason: probeFailure });
+			}
 			return undefined;
 		}
 
@@ -626,7 +696,6 @@ export function createCheckpointHooks(
 		};
 
 		const message = `${CHECKPOINT_STASH_MESSAGE_PREFIX}${options.sessionId} run=${runCount}`;
-		const startedAt = Date.now();
 		let snapshot: { ref?: string; skipped: string[] };
 		try {
 			snapshot = await createWorktreeStashCommit(
@@ -644,7 +713,12 @@ export function createCheckpointHooks(
 				options.logger,
 				`Checkpoint snapshot failed after ${Date.now() - startedAt}ms: ${error instanceof Error ? error.message : String(error)}`,
 			);
-			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
+			const reason = classifyCheckpointFailure(error);
+			const fallback = await createHeadCheckpoint(
+				"Checkpoint HEAD fallback failed",
+			);
+			captureSnapshot(fallback ? "head_fallback" : "skipped", { reason });
+			return fallback;
 		}
 		const newSkipped = snapshot.skipped.filter(
 			(path) => !warnedSkipped.has(path),
@@ -660,7 +734,15 @@ export function createCheckpointHooks(
 		}
 		const ref = snapshot.ref ?? "";
 		if (!ref) {
-			return createHeadCheckpoint("Checkpoint HEAD fallback failed");
+			// A clean worktree with no untracked files — the HEAD entry is the
+			// expected result here, not a degradation.
+			const fallback = await createHeadCheckpoint(
+				"Checkpoint HEAD fallback failed",
+			);
+			captureSnapshot(fallback ? "head_clean" : "skipped", {
+				skippedUntrackedCount: snapshot.skipped.length,
+			});
+			return fallback;
 		}
 
 		// Store the stash commit under a private ref namespace so it is
@@ -677,9 +759,13 @@ export function createCheckpointHooks(
 				options.logger,
 				`Checkpoint store failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
+			captureSnapshot("skipped", { reason: classifyCheckpointFailure(error) });
 			return undefined;
 		}
 
+		captureSnapshot("stash", {
+			skippedUntrackedCount: snapshot.skipped.length,
+		});
 		return {
 			ref,
 			createdAt: Date.now(),

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -959,6 +959,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	): Promise<RestoreSessionResult> {
 		return this.sessionVersioning.restoreCheckpoint({
 			...input,
+			telemetry: this.defaultTelemetry,
 			getSession: (sessionId) => this.getSession(sessionId),
 			readMessages: (sessionId) => this.readSessionMessages(sessionId),
 			buildStartInput: (context, startInput) => {

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -223,7 +223,15 @@ export function splitCoreSessionConfig(config: ClineCoreStartConfig): {
 	return {
 		config: {
 			...transportConfig,
-			...(checkpoint ? { checkpoint: { enabled: checkpoint.enabled } } : {}),
+			...(checkpoint
+				? {
+						checkpoint: {
+							enabled: checkpoint.enabled,
+							maxUntrackedFileBytes: checkpoint.maxUntrackedFileBytes,
+							gitTimeoutMs: checkpoint.gitTimeoutMs,
+						},
+					}
+				: {}),
 			...(compaction
 				? {
 						compaction: {

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -403,6 +403,8 @@ export async function prepareLocalRuntimeBootstrap(
 					sessionId,
 					logger: baseConfig.logger,
 					createCheckpoint: baseConfig.checkpoint?.createCheckpoint,
+					maxUntrackedFileBytes: baseConfig.checkpoint?.maxUntrackedFileBytes,
+					gitTimeoutMs: baseConfig.checkpoint?.gitTimeoutMs,
 					readSessionMetadata,
 					writeSessionMetadata,
 				})

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -405,6 +405,7 @@ export async function prepareLocalRuntimeBootstrap(
 					createCheckpoint: baseConfig.checkpoint?.createCheckpoint,
 					maxUntrackedFileBytes: baseConfig.checkpoint?.maxUntrackedFileBytes,
 					gitTimeoutMs: baseConfig.checkpoint?.gitTimeoutMs,
+					telemetry: baseConfig.telemetry,
 					readSessionMetadata,
 					writeSessionMetadata,
 				})

--- a/sdk/packages/core/src/session/checkpoint-restore.test.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.test.ts
@@ -23,6 +23,7 @@ import {
 	trimMessagesBeforeUserRun,
 	trimMessagesToCheckpoint,
 } from "./checkpoint-restore";
+import { SessionVersioningService } from "./session-versioning-service";
 
 function git(cwd: string, args: string[]): string {
 	return execFileSync("git", ["-C", cwd, ...args], {
@@ -314,6 +315,66 @@ describe("applyCheckpointToWorktree", () => {
 				"refs/cline/restore-transactions",
 			]),
 		).toBe("");
+	});
+
+	it("keeps preserved untracked files in the worktree through the restore transaction", async () => {
+		// The recovery stash must not swallow files the checkpoint never
+		// captured: stash push removes untracked files from the worktree, and
+		// nothing on the restore path would put a size-capped file back.
+		writeFileSync(join(dir, "big.bin"), "capped content", "utf8");
+		writeFileSync(join(dir, "other.txt"), "rewindable\n", "utf8");
+
+		const transaction = await beginWorktreeRestoreTransaction(dir, ["big.bin"]);
+		// The preserved file never left the worktree; the other untracked file
+		// was captured (and removed) as usual.
+		expect(readFileSync(join(dir, "big.bin"), "utf8")).toBe("capped content");
+		expect(existsSync(join(dir, "other.txt"))).toBe(false);
+
+		await transaction.rollback();
+		// Rollback's clean also spares the preserved file while restoring the
+		// captured one.
+		expect(readFileSync(join(dir, "big.bin"), "utf8")).toBe("capped content");
+		expect(readFileSync(join(dir, "other.txt"), "utf8")).toBe("rewindable\n");
+	});
+
+	it("keeps size-capped files on disk through a full workspace restore (transaction + apply)", async () => {
+		// Composition-level regression test: the per-function guards passed
+		// while the real restore path (transaction first, then apply) deleted
+		// the capped file, because the recovery stash swallowed it.
+		writeFileSync(join(dir, "big.bin"), "capped content", "utf8");
+		writeFileSync(join(dir, "small.txt"), "keep me\n", "utf8");
+		const checkpoint = await snapshotCurrentWorktree(dir, "snap-full-restore", {
+			maxUntrackedFileBytes: 8,
+		});
+		expect(checkpoint.skippedUntracked).toEqual(["big.bin"]);
+
+		writeFileSync(join(dir, "big.bin"), "capped content v2", "utf8");
+		writeFileSync(join(dir, "small.txt"), "changed after checkpoint\n", "utf8");
+		writeFileSync(join(dir, "created-after.txt"), "remove me\n", "utf8");
+
+		const session = {
+			sessionId: "restore-session",
+			cwd: dir,
+			metadata: { checkpoint: { latest: checkpoint, history: [checkpoint] } },
+		} as unknown as import("../types/sessions").SessionRecord;
+		await new SessionVersioningService().restoreCheckpoint({
+			sessionId: "restore-session",
+			checkpointRunCount: 1,
+			cwd: dir,
+			restore: { messages: false, workspace: true },
+			getSession: async () => session,
+			readMessages: async () => {
+				throw new Error("messages should not be read");
+			},
+		});
+
+		// The capped file stays at its *current* content — it was never part
+		// of the snapshot, so restore must not touch it in either direction.
+		expect(readFileSync(join(dir, "big.bin"), "utf8")).toBe(
+			"capped content v2",
+		);
+		expect(readFileSync(join(dir, "small.txt"), "utf8")).toBe("keep me\n");
+		expect(existsSync(join(dir, "created-after.txt"))).toBe(false);
 	});
 
 	it("leaves size-capped untracked files on disk when rewinding a snapshot", async () => {

--- a/sdk/packages/core/src/session/checkpoint-restore.test.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	type CheckpointEntry,
+	checkpointScratchDir,
 	createCheckpointHooks,
 } from "../hooks/checkpoint-hooks";
 import {
@@ -38,11 +39,13 @@ function git(cwd: string, args: string[]): string {
 async function snapshotCurrentWorktree(
 	cwd: string,
 	sessionId = "snap",
+	options: { maxUntrackedFileBytes?: number } = {},
 ): Promise<CheckpointEntry> {
 	let metadata: Record<string, unknown> | undefined;
 	const hooks = createCheckpointHooks({
 		cwd,
 		sessionId,
+		...options,
 		readSessionMetadata: async () => metadata,
 		writeSessionMetadata: async (next) => {
 			metadata = next;
@@ -75,6 +78,9 @@ async function snapshotCurrentWorktree(
 	const checkpoint = (
 		metadata?.checkpoint as { latest?: CheckpointEntry } | undefined
 	)?.latest;
+	// Each call acts as a one-shot session, so drop the persistent untracked
+	// index instead of leaking it into the runner's tmpdir.
+	rmSync(checkpointScratchDir(sessionId), { recursive: true, force: true });
 	if (!checkpoint) {
 		throw new Error("failed to record a checkpoint for the current worktree");
 	}
@@ -308,6 +314,61 @@ describe("applyCheckpointToWorktree", () => {
 				"refs/cline/restore-transactions",
 			]),
 		).toBe("");
+	});
+
+	it("leaves size-capped untracked files on disk when rewinding a snapshot", async () => {
+		// A file over the snapshot's size cap was never captured in ^3, so the
+		// pre-apply `git clean` must spare it — deleting it would be
+		// unrecoverable data loss (the reporter's case is a 4.8 GB data file).
+		const bigContent = "B".repeat(64);
+		writeFileSync(join(dir, "big.bin"), bigContent, "utf8");
+		writeFileSync(join(dir, "small.txt"), "keep me\n", "utf8");
+		const checkpoint = await snapshotCurrentWorktree(dir, "snap-skip", {
+			maxUntrackedFileBytes: 16,
+		});
+		expect(checkpoint.skippedUntracked).toEqual(["big.bin"]);
+
+		// Post-checkpoint changes that the restore is expected to rewind.
+		writeFileSync(join(dir, "small.txt"), "changed after checkpoint\n", "utf8");
+		writeFileSync(join(dir, "created-after.txt"), "remove me\n", "utf8");
+
+		await applyCheckpointToWorktree(dir, checkpoint);
+
+		expect(readFileSync(join(dir, "big.bin"), "utf8")).toBe(bigContent);
+		expect(readFileSync(join(dir, "small.txt"), "utf8")).toBe("keep me\n");
+		expect(existsSync(join(dir, "created-after.txt"))).toBe(false);
+	});
+
+	it("preserves skippedUntracked when reading checkpoint history from session metadata", () => {
+		const metadata = createRestoredCheckpointMetadata(
+			{
+				metadata: {
+					checkpoint: {
+						latest: {
+							ref: "aaaa",
+							createdAt: 1,
+							runCount: 1,
+							kind: "stash",
+							skippedUntracked: ["big.bin", 7, ""],
+						},
+						history: [
+							{
+								ref: "aaaa",
+								createdAt: 1,
+								runCount: 1,
+								kind: "stash",
+								skippedUntracked: ["big.bin", 7, ""],
+							},
+						],
+					},
+				},
+			},
+			1,
+		);
+
+		// Non-string and empty entries are dropped; real paths survive the
+		// round-trip so the restore-side clean can exempt them.
+		expect(metadata?.latest.skippedUntracked).toEqual(["big.bin"]);
 	});
 
 	it("carries checkpoint metadata through the restored run", () => {

--- a/sdk/packages/core/src/session/checkpoint-restore.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.ts
@@ -46,9 +46,18 @@ async function resolveOptionalGitRef(
  * `git clean -fd`. Use a short-lived `stash push --include-untracked`, move
  * its object behind a private ref, and immediately remove it from the user's
  * visible stash list. The private ref remains only until commit or rollback.
+ *
+ * `preserveUntracked` names untracked files the checkpoint never captured
+ * (its size cap): they must survive the restore *in the worktree*. Without
+ * the exemption `stash push --include-untracked` moves them into the
+ * recovery stash, nothing restores them (they are not in the snapshot's
+ * third parent), and commit() discards the recovery ref — silently deleting
+ * them. Excluding them here also spares hashing files the cap was added to
+ * avoid hashing; rollback's `git clean` exempts the same paths.
  */
 export async function beginWorktreeRestoreTransaction(
 	cwd: string,
+	preserveUntracked: readonly string[] = [],
 ): Promise<WorktreeRestoreTransaction> {
 	const check = await execFile(
 		"git",
@@ -66,6 +75,20 @@ export async function beginWorktreeRestoreTransaction(
 	const previousStashRef = await resolveOptionalGitRef(cwd, "refs/stash");
 	const transactionId = randomUUID();
 	const privateRef = `refs/cline/restore-transactions/${transactionId}`;
+	// Pathspec form: everything except the preserved files. `literal` keeps
+	// glob metacharacters in filenames from being interpreted.
+	const stashPathspec =
+		preserveUntracked.length > 0
+			? [
+					"--",
+					".",
+					...preserveUntracked.map((path) => `:(exclude,literal)${path}`),
+				]
+			: [];
+	const cleanExcludeArgs = preserveUntracked.flatMap((path) => [
+		"-e",
+		toCleanExcludePattern(path),
+	]);
 
 	await execFile(
 		"git",
@@ -77,6 +100,7 @@ export async function beginWorktreeRestoreTransaction(
 			"--include-untracked",
 			"--message",
 			`cline restore transaction ${transactionId}`,
+			...stashPathspec,
 		],
 		{ windowsHide: true },
 	);
@@ -99,9 +123,11 @@ export async function beginWorktreeRestoreTransaction(
 				await execFile("git", ["-C", cwd, "reset", "--hard", originalHead], {
 					windowsHide: true,
 				});
-				await execFile("git", ["-C", cwd, "clean", "-fd"], {
-					windowsHide: true,
-				});
+				await execFile(
+					"git",
+					["-C", cwd, "clean", "-fd", ...cleanExcludeArgs],
+					{ windowsHide: true },
+				);
 				await execFile(
 					"git",
 					["-C", cwd, "stash", "apply", "--index", capturedRef],
@@ -135,7 +161,7 @@ export async function beginWorktreeRestoreTransaction(
 			await execFile("git", ["-C", cwd, "reset", "--hard", originalHead], {
 				windowsHide: true,
 			});
-			await execFile("git", ["-C", cwd, "clean", "-fd"], {
+			await execFile("git", ["-C", cwd, "clean", "-fd", ...cleanExcludeArgs], {
 				windowsHide: true,
 			});
 			if (hasSnapshot) {

--- a/sdk/packages/core/src/session/checkpoint-restore.ts
+++ b/sdk/packages/core/src/session/checkpoint-restore.ts
@@ -184,7 +184,21 @@ export function readSessionCheckpointHistory(
 				entry.kind === "stash" || entry.kind === "commit"
 					? entry.kind
 					: undefined;
-			return [{ ref, createdAt, runCount, ...(kind ? { kind } : {}) }];
+			const skippedUntracked = Array.isArray(entry.skippedUntracked)
+				? entry.skippedUntracked.filter(
+						(path): path is string =>
+							typeof path === "string" && path.length > 0,
+					)
+				: [];
+			return [
+				{
+					ref,
+					createdAt,
+					runCount,
+					...(kind ? { kind } : {}),
+					...(skippedUntracked.length > 0 ? { skippedUntracked } : {}),
+				},
+			];
 		});
 }
 
@@ -354,6 +368,15 @@ async function checkpointCapturedUntracked(
 	}
 }
 
+/**
+ * Anchored gitignore-style pattern matching exactly one repo-relative path,
+ * for `git clean -e`. Glob metacharacters in the filename are escaped so a
+ * literal `data[1].bin` cannot match (or fail to match) as a character class.
+ */
+function toCleanExcludePattern(path: string): string {
+	return `/${path.replace(/([\\*?[\]])/g, "\\$1")}`;
+}
+
 export async function applyCheckpointToWorktree(
 	cwd: string,
 	checkpoint: CheckpointEntry,
@@ -401,8 +424,16 @@ export async function applyCheckpointToWorktree(
 	// avoids "already exists" apply conflicts. For 2-parent stashes and
 	// HEAD-commit fallbacks (no ^3) untracked files can't be reconstructed, so
 	// they are left untouched — deleting them would be unrecoverable data loss.
+	// The same reasoning exempts files the snapshot skipped over its size cap:
+	// they exist only on disk, so they must survive the clean.
 	if (capturedUntracked) {
-		await execFile("git", ["-C", cwd, "clean", "-fd"], { windowsHide: true });
+		const excludeArgs = (checkpoint.skippedUntracked ?? []).flatMap((path) => [
+			"-e",
+			toCleanExcludePattern(path),
+		]);
+		await execFile("git", ["-C", cwd, "clean", "-fd", ...excludeArgs], {
+			windowsHide: true,
+		});
 	}
 	if (checkpointKind === "commit") {
 		return;

--- a/sdk/packages/core/src/session/session-versioning-service.test.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.test.ts
@@ -408,6 +408,8 @@ describe("SessionVersioningService", () => {
 
 	it("supports workspace-only restore without starting a new session", async () => {
 		const applyWorkspaceCheckpoint = vi.fn(async () => undefined);
+		const events: { event: string; properties?: Record<string, unknown> }[] =
+			[];
 		const result = await new SessionVersioningService().restoreCheckpoint({
 			sessionId: "source-session",
 			checkpointRunCount: 1,
@@ -417,11 +419,24 @@ describe("SessionVersioningService", () => {
 				throw new Error("messages should not be read");
 			},
 			applyWorkspaceCheckpoint,
+			telemetry: {
+				capture: (input) => {
+					events.push(input);
+				},
+			},
 		});
 
 		expect(result.sessionId).toBeUndefined();
 		expect(result.checkpoint).toMatchObject({ ref: "aaaa", runCount: 1 });
 		expect(applyWorkspaceCheckpoint).toHaveBeenCalledOnce();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.event).toBe("checkpoint.restore");
+		expect(events[0]?.properties).toMatchObject({
+			outcome: "success",
+			restoreWorkspace: true,
+			restoreMessages: false,
+			checkpointRunCount: 1,
+		});
 	});
 
 	it("raises typed validation errors", async () => {

--- a/sdk/packages/core/src/session/session-versioning-service.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.ts
@@ -267,7 +267,14 @@ export class SessionVersioningService {
 			input.beginWorkspaceRestoreTransaction ??
 			(input.applyWorkspaceCheckpoint
 				? undefined
-				: beginWorktreeRestoreTransaction);
+				: // Untracked files the snapshot skipped (size cap) exist only in the
+					// worktree; the recovery stash must leave them in place or nothing
+					// ever puts them back.
+					(transactionCwd: string) =>
+						beginWorktreeRestoreTransaction(
+							transactionCwd,
+							plan.checkpoint.skippedUntracked ?? [],
+						));
 		const transaction =
 			restoreWorkspace && beginWorkspaceRestoreTransaction
 				? await beginWorkspaceRestoreTransaction(plan.cwd)

--- a/sdk/packages/core/src/session/session-versioning-service.ts
+++ b/sdk/packages/core/src/session/session-versioning-service.ts
@@ -1,4 +1,5 @@
 import type * as LlmsProviders from "@cline/llms";
+import type { ITelemetryService } from "@cline/shared";
 import type {
 	CheckpointEntry,
 	CheckpointMetadata,
@@ -90,6 +91,13 @@ export interface SessionCheckpointRestoreInput<
 		sessionId: string,
 		history: CheckpointEntry[],
 	) => Promise<void>;
+	/**
+	 * Emits one `checkpoint.restore` event per restore attempt. Restores are
+	 * rare and destructive, so field visibility matters: duration (the
+	 * worktree transaction still hashes all untracked files), outcome, and
+	 * whether the restored entry had size-capped files that cannot be rewound.
+	 */
+	telemetry?: Pick<ITelemetryService, "capture">;
 }
 
 function validateRestoreOptions(input: {
@@ -176,6 +184,26 @@ export class SessionVersioningService {
 			session: sourceSession,
 			messages: sourceMessages,
 		});
+		const restoreStartedAt = Date.now();
+		const captureRestore = (
+			outcome: "success" | "failed",
+			extra?: Record<string, string | number | boolean>,
+		): void => {
+			input.telemetry?.capture({
+				event: "checkpoint.restore",
+				properties: {
+					sessionId: sourceSessionId,
+					checkpointRunCount: input.checkpointRunCount,
+					restoreWorkspace,
+					restoreMessages,
+					checkpointKind: plan.checkpoint.kind ?? "unknown",
+					skippedUntrackedCount: plan.checkpoint.skippedUntracked?.length ?? 0,
+					outcome,
+					durationMs: Date.now() - restoreStartedAt,
+					...extra,
+				},
+			});
+		};
 		let restoredCheckpointMetadata: CheckpointMetadata | undefined;
 		let initialMessages: LlmsProviders.Message[] = [];
 		let startInput: TStartInput | undefined;
@@ -258,6 +286,7 @@ export class SessionVersioningService {
 			if (!messageRestoreOperations) {
 				await transaction?.commit();
 				workspaceCommitted = true;
+				captureRestore("success");
 				return { checkpoint: plan.checkpoint, sourceSnapshot };
 			}
 
@@ -292,6 +321,7 @@ export class SessionVersioningService {
 				: undefined;
 			await transaction?.commit();
 			workspaceCommitted = true;
+			captureRestore("success");
 			return {
 				sessionId: newSessionId,
 				startResult,
@@ -316,6 +346,10 @@ export class SessionVersioningService {
 					recoveryErrors.push(rollbackError);
 				}
 			}
+			captureRestore("failed", {
+				workspaceRolledBack: !!transaction && !workspaceCommitted,
+				recovered: recoveryErrors.length === 0,
+			});
 			if (recoveryErrors.length > 0) {
 				throw new AggregateError(
 					[error, ...recoveryErrors],

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -234,6 +234,21 @@ export interface CoreCheckpointConfig {
 				kind?: "stash" | "commit";
 		  }
 		| undefined;
+	/**
+	 * Untracked files larger than this many bytes are excluded from the
+	 * built-in git snapshot (and from checkpoint restore, which leaves them
+	 * untouched on disk). Snapshotting has to re-read changed untracked files
+	 * on every user turn, so very large ones would stall each message.
+	 * Defaults to 100 MiB.
+	 */
+	maxUntrackedFileBytes?: number;
+	/**
+	 * Overall time budget in milliseconds for the git work of one checkpoint.
+	 * When exceeded, the turn degrades to a HEAD-commit checkpoint (or skips
+	 * the checkpoint) instead of blocking the message indefinitely on a slow
+	 * filesystem. Defaults to 60 000.
+	 */
+	gitTimeoutMs?: number;
 }
 
 export interface CoreSessionConfig


### PR DESCRIPTION
**Stacked on #13199** — merge that first, then retarget this to `main`. Linear: [CLINE-2942](https://linear.app/cline-bot/issue/CLINE-2942/checkpoints-sdk-cap-cache-and-time-bound-untracked-file-snapshot-work) (transparency companion).

#13199 introduces a deliberate trade-off: untracked files over the size cap (default 100 MiB) are excluded from checkpoint snapshots, and restore leaves them at their current content. Shipping that silently — a log warning only — isn't acceptable for a semantics change users can hit during a restore, so this PR makes it visible at the moments it matters. It should land before the cap reaches a **stable** release; nightly carrying #13199 alone for a few days is acceptable.

## CLI

- `/undo` picker rows show a `◆ partial` badge when that checkpoint skipped files.
- The restore confirm dialog, when "Restore chat and workspace" is selected, lists the uncaptured files: *"1 large file was not captured by this checkpoint and stays at its current content: big.bin"*.

Verified live end-to-end via tuistory against a repo with a 120 MB untracked file: badge renders, warning renders, and the restore itself leaves the capped file intact (that live run is also what caught the recovery-stash data-loss bug fixed in #13199's last commit).

## VS Code / JetBrains webview

- The restore entry point is the user-message edit panel ("Reset Chat" / "Reset Code"); it now warns next to the buttons when the checkpoint it would restore skipped files.
- Data flow: `SdkController` layers `checkpointSkippedUntrackedByTs` (message ts → skipped paths) onto `ExtensionState` — no proto change, state travels as JSON. The mapping is resolved host-side with the exact chain `editMessageAndRegenerate` uses (visible-row ordinal → persisted SDK message → run count → nearest checkpoint at or before it), so the warning cannot diverge from what a restore actually does — webview-side run counting would drift on compaction summaries and hidden synthetic prompts, which advance the run counter without a webview row (caught in review). The webview's contribution is a plain ts lookup.
- The Checkpoints settings toggle gains a sub-description: *"Untracked files over 100 MB aren't captured, so restoring a checkpoint leaves them unchanged."*

## Known limits

- The webview warning needs a live SDK session; after a window reload it's absent (restore still works). The map is `undefined` in the common no-skips case, so the state payload doesn't grow for typical sessions.
- Hub/desktop UI (`apps/cline-hub`) has its own checkpoint component and is not covered here.

