### PR TITLE
fix(hub): stop fanning events out once per historical client connection

### DIFF
--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -265,6 +265,44 @@ describe("NodeHubClient", () => {
 
 			await client.dispose();
 		});
+
+		it("ignores frames arriving on a superseded socket after reconnect", async () => {
+			// Regression: during a hub swap or transport recovery the client
+			// re-dials while the old socket can linger half-open. Frames still
+			// arriving on it must not be dispatched alongside the new socket's,
+			// or every listener sees each event twice (rendered as duplicated
+			// assistant text in the CLI and desktop app).
+			vi.stubGlobal("WebSocket", MockWebSocket);
+
+			const client = new NodeHubClient({ url: "ws://127.0.0.1:25463/hub" });
+			await client.connect();
+			const received: unknown[] = [];
+			client.subscribe((event) => received.push(event));
+
+			const firstSocket = MockWebSocket.instances[0];
+			client.close();
+			await client.connect();
+			const secondSocket = MockWebSocket.instances[1];
+			expect(secondSocket).toBeDefined();
+
+			const eventFrame = JSON.stringify({
+				kind: "event",
+				envelope: {
+					version: "v1",
+					event: "session.updated",
+					sessionId: "session-1",
+					payload: {},
+				},
+			});
+			secondSocket.emit("message", { data: eventFrame });
+			// The superseded socket is still delivering (its close never fired):
+			// its copy must be dropped.
+			firstSocket.emit("message", { data: eventFrame });
+
+			expect(received).toHaveLength(1);
+
+			await client.dispose();
+		});
 	});
 
 	describe("timeouts", () => {

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -413,6 +413,13 @@ export class NodeHubClient {
 		});
 
 		socket.addEventListener("message", (data: unknown) => {
+			if (this.socket !== socket) {
+				// A reconnect superseded this socket. Frames still arriving on
+				// it (in-flight events, a slow server-side close) must not be
+				// dispatched alongside the new socket's — every listener would
+				// see each event twice.
+				return;
+			}
 			this.handleFrame(JSON.parse(decodeSocketData(data)) as HubTransportFrame);
 		});
 		socket.addEventListener("close", (event: unknown) => {

--- a/sdk/packages/core/src/hub/server/browser-websocket.test.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.test.ts
@@ -288,6 +288,72 @@ describe("BrowserWebSocketHubAdapter", () => {
 			expect(unregisterCalls()).toHaveLength(1);
 		});
 
+		it("does not let a dead old socket unregister the replacement mid-register", async () => {
+			// handleClientRegister publishes hub.client.registered synchronously
+			// inside command handling — before the adapter processes the reply.
+			// That publish reaches the OLD connection's global subscription; if
+			// its socket is dead (readyState 3, close never fired), dead-socket
+			// teardown runs mid-publish. Ownership must already belong to the
+			// registering connection at that instant, or the old connection's
+			// close path unregisters the client that is being registered right
+			// now (and the transport-side unregister callback would drop the
+			// clientId's listeners entirely — silent event loss).
+			const capturedListeners: Array<(envelope: unknown) => void> = [];
+			const transport = {
+				command: vi.fn((envelope: { command?: string; payload?: unknown }) => {
+					if (envelope.command === "client.register") {
+						const clientId = (envelope.payload as { clientId?: string })
+							?.clientId;
+						for (const listener of [...capturedListeners]) {
+							listener({
+								version: "v1",
+								event: "hub.client.registered",
+								payload: { clientId },
+							});
+						}
+					}
+					return Promise.resolve({
+						version: "v1",
+						requestId: "req",
+						ok: true,
+						payload: {},
+					} as HubReplyEnvelope);
+				}),
+				subscribe: vi.fn(
+					(
+						_clientId: string | undefined,
+						onEvent: (envelope: unknown) => void,
+						_options?: { sessionId?: string },
+					) => {
+						capturedListeners.push(onEvent);
+						return vi.fn();
+					},
+				),
+			};
+			const adapter = new BrowserWebSocketHubAdapter(transport);
+			const oldSocket = Object.assign(createSocket(), { readyState: 1 });
+			const newSocket = createSocket();
+			adapter.attach(oldSocket);
+			adapter.attach(newSocket);
+
+			oldSocket.emitMessage(registerFrame("client-a", "req-1"));
+			await settle();
+			// Global subscription: receives client lifecycle events.
+			oldSocket.emitMessage(subscribeFrame("client-a"));
+			await settle();
+
+			// The old socket dies without a close event.
+			oldSocket.readyState = 3;
+
+			newSocket.emitMessage(registerFrame("client-a", "req-2"));
+			await settle();
+
+			const unregisterCalls = transport.command.mock.calls.filter(
+				([envelope]) => envelope?.command === "client.unregister",
+			);
+			expect(unregisterCalls).toHaveLength(0);
+		});
+
 		it("tears down delivery when the socket is dead but close never fired", async () => {
 			const transport = createTransport();
 			const adapter = new BrowserWebSocketHubAdapter(transport);
@@ -315,6 +381,12 @@ describe("BrowserWebSocketHubAdapter", () => {
 			onEvent({ version: "v1", event: "session.updated", payload: {} });
 			expect(socket.sent).toHaveLength(sentBefore);
 			expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+			// Frames still queued from the dead connection must not create new
+			// delivery state after teardown — nothing would ever clean it up.
+			socket.emitMessage(subscribeFrame("client-a", "session-9"));
+			await settle();
+			expect(transport.subscribe).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/sdk/packages/core/src/hub/server/browser-websocket.test.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.test.ts
@@ -170,4 +170,151 @@ describe("BrowserWebSocketHubAdapter", () => {
 			},
 		});
 	});
+
+	// Regression: a client that reconnects (hub swap, transport recovery)
+	// re-registers its clientId from a NEW connection while the old one may
+	// linger half-open. Without supersede semantics the hub accumulates one
+	// delivery path per connection and fans every event out N times —
+	// observed in the field as word-by-word duplicated assistant text in the
+	// CLI and desktop app (multiple client.register entries, zero
+	// client.unregister, doubling starting mid-stream on re-register).
+	describe("clientId re-registration supersedes older connections", () => {
+		function createTransport() {
+			return {
+				command: vi.fn((_envelope: { command?: string }) =>
+					Promise.resolve({
+						version: "v1",
+						requestId: "req",
+						ok: true,
+						payload: {},
+					} as HubReplyEnvelope),
+				),
+				subscribe: vi.fn(
+					(
+						_clientId: string | undefined,
+						_onEvent: (envelope: unknown) => void,
+						_options?: { sessionId?: string },
+					) => vi.fn(),
+				),
+			};
+		}
+
+		function registerFrame(clientId: string, requestId: string) {
+			return JSON.stringify({
+				kind: "command",
+				envelope: {
+					version: "v1",
+					command: "client.register",
+					requestId,
+					clientId,
+					payload: { clientId, clientType: "test" },
+				},
+			});
+		}
+
+		function subscribeFrame(clientId: string, sessionId?: string) {
+			return JSON.stringify({
+				kind: "stream.subscribe",
+				clientId,
+				...(sessionId ? { sessionId } : {}),
+			});
+		}
+
+		async function settle() {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+
+		it("evicts the old connection's subscriptions when the clientId re-registers", async () => {
+			const transport = createTransport();
+			const adapter = new BrowserWebSocketHubAdapter(transport);
+			const oldSocket = createSocket();
+			const newSocket = createSocket();
+			adapter.attach(oldSocket);
+			adapter.attach(newSocket);
+
+			oldSocket.emitMessage(registerFrame("client-a", "req-1"));
+			await settle();
+			oldSocket.emitMessage(subscribeFrame("client-a", "session-1"));
+			await settle();
+			expect(transport.subscribe).toHaveBeenCalledTimes(1);
+			const oldUnsubscribe = transport.subscribe.mock.results[0]
+				?.value as ReturnType<typeof vi.fn>;
+
+			// Same clientId re-registers on a new connection (reconnect).
+			newSocket.emitMessage(registerFrame("client-a", "req-2"));
+			await settle();
+			expect(oldUnsubscribe).toHaveBeenCalledTimes(1);
+
+			// A late subscribe from the superseded connection must not
+			// re-create a second delivery path.
+			oldSocket.emitMessage(subscribeFrame("client-a", "session-1"));
+			await settle();
+			expect(transport.subscribe).toHaveBeenCalledTimes(1);
+
+			// The new connection subscribes normally.
+			newSocket.emitMessage(subscribeFrame("client-a", "session-1"));
+			await settle();
+			expect(transport.subscribe).toHaveBeenCalledTimes(2);
+		});
+
+		it("does not let a superseded connection's close unregister the live registration", async () => {
+			const transport = createTransport();
+			const adapter = new BrowserWebSocketHubAdapter(transport);
+			const oldSocket = createSocket();
+			const newSocket = createSocket();
+			adapter.attach(oldSocket);
+			adapter.attach(newSocket);
+
+			oldSocket.emitMessage(registerFrame("client-a", "req-1"));
+			await settle();
+			newSocket.emitMessage(registerFrame("client-a", "req-2"));
+			await settle();
+
+			const unregisterCalls = () =>
+				transport.command.mock.calls.filter(
+					([envelope]) => envelope?.command === "client.unregister",
+				);
+
+			// The superseded connection closes late: it no longer owns the
+			// clientId, so it must not clobber the live registration.
+			oldSocket.emitClose();
+			await settle();
+			expect(unregisterCalls()).toHaveLength(0);
+
+			// The owning connection's close performs the real unregister.
+			newSocket.emitClose();
+			await settle();
+			expect(unregisterCalls()).toHaveLength(1);
+		});
+
+		it("tears down delivery when the socket is dead but close never fired", async () => {
+			const transport = createTransport();
+			const adapter = new BrowserWebSocketHubAdapter(transport);
+			const socket = Object.assign(createSocket(), { readyState: 1 });
+			adapter.attach(socket);
+
+			socket.emitMessage(subscribeFrame("client-a"));
+			await settle();
+			expect(transport.subscribe).toHaveBeenCalledTimes(1);
+			const onEvent = transport.subscribe.mock.calls[0]?.[1];
+			if (!onEvent) throw new Error("subscribe listener was not captured");
+			const unsubscribe = transport.subscribe.mock.results[0]
+				?.value as ReturnType<typeof vi.fn>;
+
+			// While the socket is open, events flow.
+			onEvent({ version: "v1", event: "session.updated", payload: {} });
+			expect(
+				socket.sent.map((entry) => JSON.parse(entry) as { kind?: string }),
+			).toContainEqual(expect.objectContaining({ kind: "event" }));
+
+			// Socket dies without a close event (crashed peer, half-open
+			// connection): the next delivery detects it and tears down.
+			socket.readyState = 3;
+			const sentBefore = socket.sent.length;
+			onEvent({ version: "v1", event: "session.updated", payload: {} });
+			expect(socket.sent).toHaveLength(sentBefore);
+			expect(unsubscribe).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/sdk/packages/core/src/hub/server/browser-websocket.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.ts
@@ -135,6 +135,13 @@ export class BrowserWebSocketHubAdapter {
 		};
 
 		const onMessage = async (event: { data: string }): Promise<void> => {
+			if (closed) {
+				// Dead-socket teardown can run while frames from this connection
+				// are still queued; processing one after teardown would create
+				// delivery state (e.g. a stream.subscribe's transport
+				// subscription) that no cleanup path ever releases.
+				return;
+			}
 			try {
 				const frame = JSON.parse(event.data) as HubTransportFrame;
 				switch (frame.kind) {
@@ -143,6 +150,45 @@ export class BrowserWebSocketHubAdapter {
 						let settled = false;
 						const context = commandLogContext(frame);
 						logHubMessage("info", "command.start", context);
+						// Ownership must transfer BEFORE the command executes:
+						// handleClientRegister publishes hub.client.registered
+						// synchronously mid-command, and that delivery can trigger
+						// dead-socket teardown on the superseded connection. If it
+						// were still the recorded owner at that instant, its close
+						// path would unregister the very client being registered
+						// (and the transport-side unregister drops the clientId's
+						// listeners entirely — silent event loss).
+						let registerClientId: string | undefined;
+						let previousOwner:
+							| { connectionId: number; evict: () => void }
+							| undefined;
+						if (frame.envelope.command === "client.register") {
+							const registration = (frame.envelope.payload ??
+								{}) as unknown as HubClientRegistration;
+							registerClientId =
+								registration.clientId?.trim() ||
+								frame.envelope.clientId?.trim() ||
+								undefined;
+							if (registerClientId) {
+								const clientId = registerClientId;
+								previousOwner = this.deliveryOwnerByClientId.get(clientId);
+								if (
+									previousOwner &&
+									previousOwner.connectionId !== connectionId
+								) {
+									previousOwner.evict();
+									logHubMessage("warn", "client.superseded", {
+										clientId,
+										previousConnectionId: previousOwner.connectionId,
+										connectionId,
+									});
+								}
+								this.deliveryOwnerByClientId.set(clientId, {
+									connectionId,
+									evict: () => evictClientDelivery(clientId),
+								});
+							}
+						}
 						const slowTimer = setTimeout(() => {
 							if (settled) return;
 							logHubMessage("warn", "command.slow", {
@@ -239,29 +285,40 @@ export class BrowserWebSocketHubAdapter {
 							});
 						}
 						if (frame.envelope.command === "client.register" && reply.ok) {
-							const registration = (frame.envelope.payload ??
-								{}) as unknown as HubClientRegistration;
-							const clientId =
-								registration.clientId?.trim() ||
-								frame.envelope.clientId?.trim();
-							if (clientId) {
-								const owner = this.deliveryOwnerByClientId.get(clientId);
-								if (owner && owner.connectionId !== connectionId) {
-									// The clientId moved to this connection: tear down
-									// the previous connection's delivery for it so events
-									// are not fanned out once per historical connection.
-									owner.evict();
-									logHubMessage("warn", "client.superseded", {
-										clientId,
-										previousConnectionId: owner.connectionId,
-										connectionId,
-									});
+							if (
+								registerClientId &&
+								this.deliveryOwnerByClientId.get(registerClientId)
+									?.connectionId === connectionId
+							) {
+								// Ownership was claimed before the command ran; only
+								// arm the close-time unregister if no other connection
+								// re-registered the clientId while this command was in
+								// flight.
+								registeredClientIds.add(registerClientId);
+							}
+						} else if (
+							frame.envelope.command === "client.register" &&
+							!reply.ok
+						) {
+							// The registration failed: release the pre-claimed
+							// ownership. The previous owner's evicted subscriptions
+							// are not restored (its delivery is unrecoverable), but
+							// restoring the ownership record keeps its close-time
+							// unregister armed, matching pre-call semantics.
+							if (
+								registerClientId &&
+								!registeredClientIds.has(registerClientId) &&
+								this.deliveryOwnerByClientId.get(registerClientId)
+									?.connectionId === connectionId
+							) {
+								if (previousOwner) {
+									this.deliveryOwnerByClientId.set(
+										registerClientId,
+										previousOwner,
+									);
+								} else {
+									this.deliveryOwnerByClientId.delete(registerClientId);
 								}
-								this.deliveryOwnerByClientId.set(clientId, {
-									connectionId,
-									evict: () => evictClientDelivery(clientId),
-								});
-								registeredClientIds.add(clientId);
 							}
 						} else if (
 							frame.envelope.command === "client.unregister" &&

--- a/sdk/packages/core/src/hub/server/browser-websocket.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.ts
@@ -262,11 +262,6 @@ export class BrowserWebSocketHubAdapter {
 									evict: () => evictClientDelivery(clientId),
 								});
 								registeredClientIds.add(clientId);
-								logHubMessage("info", "client.registered", {
-									clientId,
-									clientType: registration.clientType,
-									connectionId,
-								});
 							}
 						} else if (
 							frame.envelope.command === "client.unregister" &&
@@ -279,10 +274,6 @@ export class BrowserWebSocketHubAdapter {
 								if (owner?.connectionId === connectionId) {
 									this.deliveryOwnerByClientId.delete(clientId);
 								}
-								logHubMessage("info", "client.unregistered", {
-									clientId,
-									connectionId,
-								});
 							}
 						}
 						sendFrame({

--- a/sdk/packages/core/src/hub/server/browser-websocket.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.ts
@@ -18,6 +18,13 @@ type HubCommandFrame = HubTransportFrame & { kind: "command" };
 
 export interface BrowserHubSocketLike {
 	send(data: string): void;
+	/**
+	 * Standard WebSocket readyState when the underlying socket exposes one
+	 * (0 CONNECTING / 1 OPEN / 2 CLOSING / 3 CLOSED). Lets the adapter detect
+	 * dead connections whose close event never fired instead of forwarding
+	 * events into the void forever.
+	 */
+	readonly readyState?: number;
 	addEventListener(
 		type: "message",
 		listener: (event: { data: string }) => void,
@@ -58,10 +65,30 @@ export class BrowserWebSocketHubAdapter {
 		private readonly telemetry?: ITelemetryService,
 	) {}
 
+	private connectionCounter = 0;
+
+	/**
+	 * The connection that currently owns each registered clientId's event
+	 * delivery. A clientId re-registering from a NEW connection supersedes
+	 * the previous one: the old connection's subscriptions for that clientId
+	 * are torn down and its close-time unregister is disarmed. Without this,
+	 * a client that reconnects (hub swap, transport recovery) while its old
+	 * connection lingers accumulates one delivery path per connection and
+	 * every streamed event fans out N times — rendering as duplicated
+	 * assistant text in the CLI and desktop app.
+	 */
+	private readonly deliveryOwnerByClientId = new Map<
+		string,
+		{ connectionId: number; evict: () => void }
+	>();
+
 	attach(socket: BrowserHubSocketLike): () => void {
 		const subscriptions = new Map<string, () => void>();
 		const registeredClientIds = new Set<string>();
+		const connectionId = ++this.connectionCounter;
 		let closed = false;
+
+		logHubMessage("info", "connection.open", { connectionId });
 
 		const sendFrame = (frame: HubTransportFrame): void => {
 			try {
@@ -77,7 +104,33 @@ export class BrowserWebSocketHubAdapter {
 			}
 		};
 
+		/**
+		 * Drop this connection's delivery state for a clientId: subscriptions
+		 * are unsubscribed and the close-time unregister is disarmed. Called
+		 * when a newer connection re-registers the same clientId.
+		 */
+		const evictClientDelivery = (clientId: string): void => {
+			for (const [key, unsubscribe] of subscriptions) {
+				if (key.startsWith(`${clientId}:`)) {
+					unsubscribe();
+					subscriptions.delete(key);
+				}
+			}
+			registeredClientIds.delete(clientId);
+		};
+
 		const onEvent = (envelope: HubEventEnvelope): void => {
+			if (typeof socket.readyState === "number" && socket.readyState > 1) {
+				// The socket is closing/closed but its close event never fired
+				// (crashed peer, half-open connection). Tear down instead of
+				// forwarding events into the void forever.
+				logHubMessage("warn", "connection.dead_socket_detected", {
+					connectionId,
+					readyState: socket.readyState,
+				});
+				onClose();
+				return;
+			}
 			sendFrame({ kind: "event", envelope });
 		};
 
@@ -192,7 +245,28 @@ export class BrowserWebSocketHubAdapter {
 								registration.clientId?.trim() ||
 								frame.envelope.clientId?.trim();
 							if (clientId) {
+								const owner = this.deliveryOwnerByClientId.get(clientId);
+								if (owner && owner.connectionId !== connectionId) {
+									// The clientId moved to this connection: tear down
+									// the previous connection's delivery for it so events
+									// are not fanned out once per historical connection.
+									owner.evict();
+									logHubMessage("warn", "client.superseded", {
+										clientId,
+										previousConnectionId: owner.connectionId,
+										connectionId,
+									});
+								}
+								this.deliveryOwnerByClientId.set(clientId, {
+									connectionId,
+									evict: () => evictClientDelivery(clientId),
+								});
 								registeredClientIds.add(clientId);
+								logHubMessage("info", "client.registered", {
+									clientId,
+									clientType: registration.clientType,
+									connectionId,
+								});
 							}
 						} else if (
 							frame.envelope.command === "client.unregister" &&
@@ -201,6 +275,14 @@ export class BrowserWebSocketHubAdapter {
 							const clientId = frame.envelope.clientId?.trim();
 							if (clientId) {
 								registeredClientIds.delete(clientId);
+								const owner = this.deliveryOwnerByClientId.get(clientId);
+								if (owner?.connectionId === connectionId) {
+									this.deliveryOwnerByClientId.delete(clientId);
+								}
+								logHubMessage("info", "client.unregistered", {
+									clientId,
+									connectionId,
+								});
 							}
 						}
 						sendFrame({
@@ -214,18 +296,43 @@ export class BrowserWebSocketHubAdapter {
 						if (subscriptions.has(key)) {
 							break;
 						}
+						const owner = frame.clientId
+							? this.deliveryOwnerByClientId.get(frame.clientId)
+							: undefined;
+						if (owner && owner.connectionId !== connectionId) {
+							// A newer connection owns this clientId's delivery; a
+							// late subscribe from a superseded connection must not
+							// re-create a second delivery path.
+							logHubMessage("warn", "stream.subscribe.superseded", {
+								clientId: frame.clientId,
+								sessionId: frame.sessionId,
+								connectionId,
+								owningConnectionId: owner.connectionId,
+							});
+							break;
+						}
 						const unsubscribe = await this.transport.subscribe(
 							frame.clientId,
 							onEvent,
 							{ sessionId: frame.sessionId },
 						);
 						subscriptions.set(key, unsubscribe);
+						logHubMessage("info", "stream.subscribed", {
+							clientId: frame.clientId,
+							sessionId: frame.sessionId,
+							connectionId,
+						});
 						break;
 					}
 					case "stream.unsubscribe": {
 						const key = `${frame.clientId}:${frame.sessionId ?? "*"}`;
 						subscriptions.get(key)?.();
 						subscriptions.delete(key);
+						logHubMessage("info", "stream.unsubscribed", {
+							clientId: frame.clientId,
+							sessionId: frame.sessionId,
+							connectionId,
+						});
 						break;
 					}
 					case "reply":
@@ -271,11 +378,23 @@ export class BrowserWebSocketHubAdapter {
 				return;
 			}
 			closed = true;
+			logHubMessage("info", "connection.closed", {
+				connectionId,
+				registeredClientIds: [...registeredClientIds],
+			});
 			for (const unsubscribe of subscriptions.values()) {
 				unsubscribe();
 			}
 			subscriptions.clear();
 			for (const clientId of registeredClientIds) {
+				// Generation guard: if a newer connection re-registered this
+				// clientId, unregistering here would clobber the live
+				// registration. Only unregister what this connection still owns.
+				const owner = this.deliveryOwnerByClientId.get(clientId);
+				if (owner && owner.connectionId !== connectionId) {
+					continue;
+				}
+				this.deliveryOwnerByClientId.delete(clientId);
 				void this.transport.command({
 					version: "v1",
 					command: "client.unregister",

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -49,6 +49,7 @@ export { HubServerTransport } from "./hub-server-transport";
 
 type NodeWebSocketLike = {
 	send(data: string): void;
+	readyState?: number;
 	on(event: "message", listener: (data: unknown) => void): void;
 	on(event: "close", listener: () => void): void;
 	on(event: "pong", listener: () => void): void;
@@ -87,6 +88,9 @@ function wrapWsSocket(socket: NodeWebSocketLike) {
 	return {
 		send(data: string): void {
 			socket.send(data);
+		},
+		get readyState(): number | undefined {
+			return socket.readyState;
 		},
 		addEventListener(
 			type: "message" | "close",


### PR DESCRIPTION
### Related Issue

Field incident (internal): duplicated streamed assistant text in the desktop app and CLI on a teammate's machine. Companion to #13154 (desktop dual-relay), which fixes a *different* duplication mechanism.

### Description

**The failure.** A hub client that reconnects — hub swap under it, transport recovery after a command timeout — re-registers its clientId from a new websocket connection while the old connection can linger half-open. The hub accumulated delivery state per connection with **no supersede semantics**, so every session event fanned out once per historical connection. A client process still holding more than one socket dispatched every copy, rendering as word-by-word duplicated assistant text ("Here'sHere's the full the full picture…").

**How we found it.** Forensics on the affected machine (read-only, agent-collected) showed the signature exactly:
- the CLI's hub client had **4 `client.register` entries and 0 `client.unregister`**; its visibly-doubled session started streaming at 21:11:02 and the 4th re-register landed at 21:11:06.999 — five seconds into the run, the moment doubling switched on
- hooks fired once per stale registration (4× `hook.beforeRun` for a single run, ~10k duplicate `hook.onEvent` capability responds), and a 300s `askQuestion` timeout targeted a dead registration
- canonical session stores were clean everywhere — pure delivery-layer duplication
- the trigger was daemon churn from mixed installs (CLI 3.0.53's buildId-strict hub replacement under a still-running older desktop; two daemons raced for the port in the same second and the losers never exited). #13168/#13177 fix that churn; this PR fixes the fan-out it exposed.

The reconnect-accumulation bug is reachable from *any* future reconnect (and #13177 makes prompted hub restarts routine), so it needs fixing independently of the churn fixes.

**The fix.**

Server — `BrowserWebSocketHubAdapter`:
- `client.register` now **supersedes**: an existing registration for the same clientId from another connection has its subscriptions evicted and its close-time unregister disarmed; a late `stream.subscribe` from a superseded connection is refused instead of re-creating a second delivery path
- connection close only unregisters clientIds the closing connection still **owns** — a lingering old connection closing late can no longer clobber the live registration (generation guard)
- event delivery checks the socket's `readyState` and tears the connection down when the socket died without a close event (crashed peer / half-open), instead of forwarding events into the void forever
- connection lifecycle is now logged (`connection.open/closed`, `client.registered/unregistered/superseded`, `stream.subscribed/unsubscribed`). The field diagnosis took days largely because hub-daemon.log recorded none of this churn; next time it's a five-minute grep.

Client — `NodeHubClient`:
- the message listener now ignores frames from superseded sockets (the close listener already had exactly this `this.socket !== socket` guard; the message listener didn't). During reconnect, in-flight frames on the old socket no longer double-dispatch to every listener. `close()` already rejects pending replies itself, so no command can hang from the dropped frames.

**Ordering note (found in review):** ownership transfers **before** the register command executes, not after its reply. `handleClientRegister` publishes `hub.client.registered` synchronously mid-command; that publish can reach the old connection's global subscription, and if its socket is dead, dead-socket teardown runs at that instant. If the old connection were still the recorded owner, its close path would unregister the client being registered right now — and the transport's unregister callback drops the clientId's listeners map, so the new connection's fresh subscriptions would be silently destroyed. A failed registration releases the pre-claimed ownership (restoring the previous owner's record; its evicted subscriptions are not restorable), and the close-time unregister only arms if the connection is still the owner after the reply, so a concurrent re-register from a third connection wins cleanly.

**Known edges intentionally out of scope:**
- a single connection holding both a global and a session-scoped subscription still receives session events twice (once per subscription entry, `publish()` semantics). No shipped client does this on one connection — connectors hold global-only, runtime hosts session-scoped-only.
- hub commands carry no per-connection identity binding (pre-existing), so a superseded-but-open connection can still *explicitly* `client.unregister` the live client. No shipped client sends unregister on a superseded socket; command-level ownership enforcement is a bigger change than this bug justifies.

### Test Procedure

- New adapter tests replay the field sequence: register → subscribe → re-register on a second connection **without closing the first** → assert the old connection's subscription is evicted, a late subscribe from it is refused, and its late close doesn't unregister the live registration. Plus a dead-socket (readyState=3, no close event) teardown test.
- Regression test for the mid-register interleaving above (mock transport publishes `hub.client.registered` synchronously before resolving, old socket dead without close): fails without the ownership-ordering fix, passes with it. The dead-socket test also asserts a `stream.subscribe` processed after teardown creates no new transport subscription.
- New `NodeHubClient` test: frames emitted on a superseded socket after reconnect are dropped (1 delivery, not 2).
- Full `@cline/core` unit suite: 1845 passed / 14 skipped. tsc + biome clean.
- **Live verification** against a real local hub daemon running this code: replaying the sequence (register, subscribe, re-register on a second connection, publish one session event) delivers exactly once, to the new connection only. The same replay against a pre-fix daemon delivers to both connections.
