### PR TITLE
fix(desktop): show Core scheduled jobs in Schedules filter CLINE-2948

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -31,6 +31,7 @@ function makeThread(project: string, index: number): SessionThread {
 		provider: "cline",
 		model: "test-model",
 		status: "completed",
+		isScheduled: false,
 	};
 }
 
@@ -142,9 +143,10 @@ describe("AgentSidebar session organization", () => {
 	it("filters scheduled sessions without changing their titles", async () => {
 		const scheduled = {
 			...makeThread("scheduled", 1),
-			source: "hub-schedule",
+			source: "core",
+			isScheduled: true,
 		};
-		const regular = makeThread("regular", 1);
+		const regular = { ...makeThread("regular", 1), source: "core" };
 
 		await act(async () => {
 			root.render(

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -90,7 +90,6 @@ import {
 	filterSessionsBySource,
 	getSessionSourceLabel,
 	getSessionSources,
-	SCHEDULED_SESSION_SOURCE,
 } from "@/lib/session-history";
 import {
 	groupThreadsByProject,
@@ -339,7 +338,7 @@ export function AgentSidebar({
 			case "Running":
 				return filtered.filter((t) => t.status === "running");
 			case "Schedules":
-				return filtered.filter((t) => t.source === SCHEDULED_SESSION_SOURCE);
+				return filtered.filter((t) => t.isScheduled);
 			case "Favorites":
 				return filtered.filter((t) => t.pinned);
 			default:

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.test.tsx
@@ -25,6 +25,7 @@ const thread: SessionThread = {
 	inputTokens: 13_837_938,
 	outputTokens: 132_579,
 	status: "completed",
+	isScheduled: false,
 };
 
 const session: SessionHistoryItem = {

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -83,6 +83,43 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 });
 
+describe("useSessionHistory session mapping", () => {
+	it("maps nested Core schedule provenance onto sidebar threads", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+
+		await act(async () => {
+			pendingLists[0].resolve([
+				{
+					...sessionRow("scheduled-session"),
+					source: "core",
+					metadata: {
+						sessionHistoryOrigin: {
+							mode: "automation",
+							trigger: "hub-schedule",
+						},
+					},
+				},
+				{
+					...sessionRow("regular-session"),
+					source: "core",
+					metadata: { sessionHistoryOrigin: { mode: "user" } },
+				},
+			]);
+			await Promise.resolve();
+		});
+
+		expect(
+			current.threads.find((thread) => thread.id === "scheduled-session"),
+		).toMatchObject({ source: "core", isScheduled: true });
+		expect(
+			current.threads.find((thread) => thread.id === "regular-session"),
+		).toMatchObject({ source: "core", isScheduled: false });
+	});
+});
+
 describe("useSessionHistory refresh coalescing", () => {
 	it("reuses an in-flight refresh that already covers the requested limit", async () => {
 		await act(async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/lib/session-history";
 import {
 	getSessionMetadataGitBranch,
+	getSessionMetadataIsScheduled,
 	getSessionMetadataPinned,
 	getSessionMetadataTitle,
 	getSessionSource,
@@ -37,6 +38,7 @@ export interface SessionThread {
 	totalCostUsd?: number;
 	status: SessionHistoryStatus;
 	pinned?: boolean;
+	isScheduled: boolean;
 }
 
 type SessionHookEvent = {
@@ -261,6 +263,7 @@ function toThread(session: SessionHistoryItem): SessionThread {
 		gitBranch: getSessionMetadataGitBranch(session.metadata) || undefined,
 		status: normalizeDiscoveredStatus(session.status, session.prompt),
 		pinned: getSessionMetadataPinned(session.metadata),
+		isScheduled: getSessionMetadataIsScheduled(session.metadata),
 	};
 }
 
@@ -358,6 +361,8 @@ function areSessionsEquivalent(
 			a.startedAt !== b.startedAt ||
 			a.endedAt !== b.endedAt ||
 			a.prompt !== b.prompt ||
+			getSessionMetadataIsScheduled(a.metadata) !==
+				getSessionMetadataIsScheduled(b.metadata) ||
 			getSessionMetadataGitBranch(a.metadata) !==
 				getSessionMetadataGitBranch(b.metadata) ||
 			getSessionMetadataTitle(a.metadata) !==
@@ -399,7 +404,8 @@ function areThreadsEquivalent(
 			a.outputTokens !== b.outputTokens ||
 			a.totalCostUsd !== b.totalCostUsd ||
 			a.status !== b.status ||
-			a.pinned !== b.pinned
+			a.pinned !== b.pinned ||
+			a.isScheduled !== b.isScheduled
 		) {
 			return false;
 		}

--- a/apps/examples/desktop-app/webview/lib/session-history.ts
+++ b/apps/examples/desktop-app/webview/lib/session-history.ts
@@ -16,6 +16,11 @@ export type SessionMetadata = {
 		url?: string;
 		branch?: string;
 	};
+	sessionHistoryOrigin?: {
+		mode?: string;
+		version?: string;
+		trigger?: string;
+	};
 	[key: string]: unknown;
 };
 
@@ -101,6 +106,19 @@ export function getSessionMetadataTitle(metadata?: SessionMetadata): string {
 
 export function getSessionMetadataPinned(metadata?: SessionMetadata): boolean {
 	return metadata?.[PINNED_METADATA_KEY] === true;
+}
+
+export function getSessionMetadataIsScheduled(
+	metadata?: SessionMetadata,
+): boolean {
+	const origin = metadata?.sessionHistoryOrigin;
+	if (!origin || typeof origin !== "object" || Array.isArray(origin)) {
+		return false;
+	}
+	return (
+		typeof origin.trigger === "string" &&
+		origin.trigger.trim() === SCHEDULED_SESSION_SOURCE
+	);
 }
 
 export function getSessionMetadataGitBranch(

--- a/apps/examples/desktop-app/webview/lib/sidebar-session-organization.test.ts
+++ b/apps/examples/desktop-app/webview/lib/sidebar-session-organization.test.ts
@@ -19,6 +19,7 @@ function thread(
 		provider: "cline",
 		model: "test-model",
 		status: "completed",
+		isScheduled: false,
 		...overrides,
 	};
 }


### PR DESCRIPTION
### Related Issue

**Issue:**  CLINE-2948

### Description

The desktop sidebar's **Schedules** filter compared the session's top-level client source with `hub-schedule`. Scheduled jobs launched by Core intentionally keep `source: "core"`; their scheduler provenance is stored at `metadata.sessionHistoryOrigin.trigger`. As a result, those jobs appeared under the Core source but disappeared when the Schedules filter was selected.

This change derives an `isScheduled` flag from `metadata.sessionHistoryOrigin.trigger === "hub-schedule"` while preserving the Core client source. The sidebar now filters on that normalized flag, and history/thread equivalence checks include it so background refreshes cannot retain stale classification.

### Test Procedure

- Ran the focused desktop suite covering the sidebar, session-history mapping, session organization, and sessions view: 38 tests passed.
- Ran `bun run typecheck` from `apps/examples/desktop-app`.
- Ran Biome checks on all seven changed files with no diagnostics.
- Verified a scheduled Core session remains labeled with source `core` while the Schedules filter includes it and excludes a regular Core session.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This changes session filtering behavior without changing the sidebar's visual design; automated interaction coverage verifies the result.

### Additional Notes

The top-level session source remains `core` by design. Schedule classification uses the existing nested history-origin provenance rather than reinterpreting client-source data.