### PR TITLE
feat(prompts): Enforce strict file editing tool constraints

### DIFF
--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -19,7 +19,7 @@ Remember:
 - Be explicit about any assumptions or limitations in your solution.
 - Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
 - Always use absolute paths when referring to files.
-- NEVER use raw terminal commands (like `sed`, `awk`, `cat`, or `echo`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
+- NEVER use raw terminal commands (like \`sed\`, \`awk\`, \`cat\`, or \`echo\`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
 - You can call multiple tools in a single response. Before using tools, identify every independent read, search, command, or edit needed for the next step and emit all of those tool calls now, either as multiple tool calls or as one batched input for tools that accept arrays. Do not wait for one independent result before requesting another. Do not split independent reads, searches, checks, or edits across separate turns.
 - Good parallelism examples: read all known relevant files in one read_files call; run independent inspection commands in one run_commands call; emit independent read_files, search_codebase, and run_commands calls together in one response; emit multiple editor calls together when editing different files or non-overlapping regions.
 - Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
@@ -46,7 +46,7 @@ RULES:
 - Provide complete and functional code without omissions or placeholders.
 - Always show your planning process without repeating yourself before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's request.
 - Always use absolute paths when referring to files.
-- NEVER use raw terminal commands (like `sed`, `awk`, `cat`, or `echo`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
+- NEVER use raw terminal commands (like \`sed\`, \`awk\`, \`cat\`, or \`echo\`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
 - You can call multiple tools in a single response. Before using tools, identify every independent read, search, command, or edit needed for the next step and emit all of those tool calls now, either as multiple tool calls or as one batched input for tools that accept arrays. Do not wait for one independent result before requesting another. Do not split independent reads, searches, checks, or edits across separate turns.
 - Good parallelism examples: read all known relevant files in one read_files call; run independent inspection commands in one run_commands call; emit independent read_files, search_codebase, and run_commands calls together in one response; emit multiple editor calls together when editing different files or non-overlapping regions.
 - Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.

--- a/sdk/packages/shared/src/prompt/system.ts
+++ b/sdk/packages/shared/src/prompt/system.ts
@@ -19,6 +19,7 @@ Remember:
 - Be explicit about any assumptions or limitations in your solution.
 - Always show your planning process before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's needs.
 - Always use absolute paths when referring to files.
+- NEVER use raw terminal commands (like `sed`, `awk`, `cat`, or `echo`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
 - You can call multiple tools in a single response. Before using tools, identify every independent read, search, command, or edit needed for the next step and emit all of those tool calls now, either as multiple tool calls or as one batched input for tools that accept arrays. Do not wait for one independent result before requesting another. Do not split independent reads, searches, checks, or edits across separate turns.
 - Good parallelism examples: read all known relevant files in one read_files call; run independent inspection commands in one run_commands call; emit independent read_files, search_codebase, and run_commands calls together in one response; emit multiple editor calls together when editing different files or non-overlapping regions.
 - Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.
@@ -45,6 +46,7 @@ RULES:
 - Provide complete and functional code without omissions or placeholders.
 - Always show your planning process without repeating yourself before executing any task. This will help ensure that you have a clear understanding of the requirements and that your approach aligns with the user's request.
 - Always use absolute paths when referring to files.
+- NEVER use raw terminal commands (like `sed`, `awk`, `cat`, or `echo`) to modify or create files. You must ALWAYS use your dedicated file editing tools for code modifications to ensure the user can review the visual diff.
 - You can call multiple tools in a single response. Before using tools, identify every independent read, search, command, or edit needed for the next step and emit all of those tool calls now, either as multiple tool calls or as one batched input for tools that accept arrays. Do not wait for one independent result before requesting another. Do not split independent reads, searches, checks, or edits across separate turns.
 - Good parallelism examples: read all known relevant files in one read_files call; run independent inspection commands in one run_commands call; emit independent read_files, search_codebase, and run_commands calls together in one response; emit multiple editor calls together when editing different files or non-overlapping regions.
 - Always verify the files you have edited or created at the end of the task to ensure they are completed and working as expected.


### PR DESCRIPTION
Cline occasionally bypasses its dedicated file editing tools by utilizing raw bash commands (e.g. \sed\, \cat\, \echo >\) to modify source code. This bypasses the visual diff UI in VS Code, preventing the user from reviewing changes before they are applied, and often leads to syntax mutilation. This PR explicitly injects a constraint into the system prompt to forbid raw terminal file modifications, forcing the LLM to use the proper toolchain.