### PR TITLE
docs: rename Nebius AI Studio to Token Factory

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1065,7 +1065,7 @@
 		},
 		{
 			"source": "/provider-config/nebius",
-			"destination": "/provider-config/other-30-plus-providers#nebius-ai-studio"
+			"destination": "/provider-config/other-30-plus-providers#nebius-token-factory"
 		},
 		{
 			"source": "/provider-config/nousresearch",

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -23,7 +23,7 @@ Use this page for providers that follow the same setup pattern.
   - [Hugging Face](#hugging-face)
   - [Mistral](#mistral)
   - [Moonshot](#moonshot)
-  - [Nebius AI Studio](#nebius-ai-studio)
+  - [Nebius Token Factory](#nebius-token-factory)
   - [Nous Research](#nous-research)
   - [Oracle Code Assist](#oracle-code-assist)
   - [Qwen Code](#qwen-code)
@@ -200,16 +200,21 @@ Moonshot provides API access to Kimi model families.
 2. Create an API key in account settings.
 3. In Cline, select **Moonshot** and enter the key.
 
-### Nebius AI Studio
-Nebius AI Studio offers managed hosted model APIs.
+### Nebius Token Factory
 
-**Website:** [https://studio.nebius.com/](https://studio.nebius.com/)
+Nebius Token Factory provides OpenAI-compatible hosted inference for models available to your project. Cline uses its existing Nebius provider and Chat Completions integration; no custom base URL is required.
+
+**Website:** [https://tokenfactory.nebius.com/](https://tokenfactory.nebius.com/)
+
+**Integration guide:** [Cline with Nebius Token Factory](https://docs.tokenfactory.nebius.com/integrations/coding/cline)
 
 #### Basic Setup
 
-1. Create/sign in to Nebius AI Studio.
-2. Generate API credentials.
-3. In Cline, choose **Nebius AI Studio** and provide the credential.
+1. [Create a Token Factory API key](https://tokenfactory.nebius.com/project/api-keys).
+2. In Cline, choose **Nebius Token Factory** and paste the key.
+3. Choose a model from Cline's model picker.
+
+Cline's Nebius provider and model catalog are generated from [models.dev](https://models.dev/). Because model availability can change, avoid copying a static model list from this page. Use Cline's current picker and, when you need to confirm project-specific availability, consult Token Factory's [`GET /v1/models`](https://docs.tokenfactory.nebius.com/api-reference/models/list-models) endpoint.
 
 ### Nous Research
 Nous Research provides access to Hermes-family model offerings.


### PR DESCRIPTION
## Summary

- rename the public provider guide from Nebius AI Studio to Nebius Token Factory
- replace the retired Studio website with the Token Factory UI, API-key page, and current Cline integration guide
- direct readers to Cline's models.dev-generated picker and Token Factory's live `/v1/models` endpoint instead of maintaining a static model list
- update the legacy `/provider-config/nebius` redirect to the renamed section anchor

## Scope

This is documentation-only. It deliberately does not modify the generated Models.dev provider, provider IDs, runtime configuration, or model catalog. Cline's existing generic OpenAI Chat Completions path remains unchanged; this does not switch Nebius to Responses.

## Validation

- `bun x mintlify@4.2.338 broken-links` — no broken links found (Bun 1.3.13)
- `jq empty docs/docs.json`
- all five referenced external URLs returned HTTP 200
- repository search confirms no retired `Nebius AI Studio` or `studio.nebius.com` reference remains under `docs/`
- `git diff --check`

No issue is linked because CONTRIBUTING exempts minor wording/documentation corrections from the issue-first requirement.
