### PR TITLE
fix(vscode): SDK remote-config parity — refresh coordination, session gating, and fail-closed opt-out

### DIFF
--- a/apps/vscode/proto/cline/remote_config.proto
+++ b/apps/vscode/proto/cline/remote_config.proto
@@ -26,7 +26,13 @@ message RemoteConfigSettingsResponse {
   repeated RemoteConfigSetting settings = 1;
 }
 
+message ToggleRemoteConfigSettingRequest {
+  RemoteConfigType type = 1;
+  string name = 2;
+  bool enabled = 3;
+}
+
 service RemoteConfigService {
   rpc getRemoteConfigSettings(Empty) returns (RemoteConfigSettingsResponse);
-  rpc toggleRemoteConfigSetting(StringRequest) returns (RemoteConfigSetting);
+  rpc toggleRemoteConfigSetting(ToggleRemoteConfigSettingRequest) returns (RemoteConfigSetting);
 }

--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -116,6 +116,7 @@ message Settings {
   reserved "custom_prompt";
   reserved 139; // was max_consecutive_mistakes (removed; the SDK owns the mistake limit)
   reserved "max_consecutive_mistakes";
+  reserved 142; // was yolo_mode_toggled (removed; migrated into auto_approval_settings)
   optional string lite_llm_base_url = 1;
   optional bool lite_llm_use_prompt_cache = 2;
   optional string anthropic_base_url = 4;
@@ -252,7 +253,6 @@ message Settings {
   optional bool enable_checkpoints_setting = 135;
   optional int32 shell_integration_timeout = 136;
   optional string default_terminal_profile = 137;
-  reserved 142; // was yolo_mode_toggled (removed; migrated into auto_approval_settings)
   optional bool use_auto_condense = 143;
   optional string preferred_language = 145;
   optional PlanActMode mode = 147;
@@ -276,7 +276,6 @@ message Settings {
   optional int32 open_telemetry_log_batch_timeout = 170;
   optional int32 open_telemetry_log_max_queue_size = 171;
   optional bool worktrees_enabled = 172;
-  optional bool auto_approve_all_toggled = 174;
   map<string, string> open_ai_headers = 177;
   optional string plan_mode_cline_model_id = 178;
   optional OpenRouterModelInfo plan_mode_cline_model_info = 179;

--- a/apps/vscode/src/core/controller/account/setUserOrganization.test.ts
+++ b/apps/vscode/src/core/controller/account/setUserOrganization.test.ts
@@ -1,0 +1,20 @@
+import { UserOrganizationUpdateRequest } from "@shared/proto/cline/account"
+import { describe, expect, it, vi } from "vitest"
+import { setUserOrganization } from "./setUserOrganization"
+
+describe("setUserOrganization", () => {
+	it("refreshes through the authoritative SDK path after switching organizations", async () => {
+		const switchAccount = vi.fn().mockResolvedValue(undefined)
+		const refreshRemoteConfig = vi.fn().mockResolvedValue(undefined)
+		const controller = {
+			accountService: { switchAccount },
+			refreshRemoteConfig,
+		}
+
+		await setUserOrganization(controller as never, UserOrganizationUpdateRequest.create({ organizationId: "org-new" }))
+
+		expect(switchAccount).toHaveBeenCalledWith("org-new")
+		expect(refreshRemoteConfig).toHaveBeenCalledOnce()
+		expect(switchAccount.mock.invocationCallOrder[0]).toBeLessThan(refreshRemoteConfig.mock.invocationCallOrder[0])
+	})
+})

--- a/apps/vscode/src/core/controller/account/setUserOrganization.ts
+++ b/apps/vscode/src/core/controller/account/setUserOrganization.ts
@@ -1,6 +1,5 @@
 import { UserOrganizationUpdateRequest } from "@shared/proto/cline/account"
 import { Empty } from "@shared/proto/cline/common"
-import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
 import type { Controller } from "../index"
 
 /**
@@ -16,7 +15,7 @@ export async function setUserOrganization(controller: Controller, request: UserO
 		}
 		// Switch to the specified organization using the account service
 		await controller.accountService.switchAccount(request.organizationId)
-		await fetchRemoteConfig(controller)
+		await controller.refreshRemoteConfig()
 		return {}
 	} catch (error) {
 		throw error

--- a/apps/vscode/src/core/controller/remoteConfig/getRemoteConfigSettings.test.ts
+++ b/apps/vscode/src/core/controller/remoteConfig/getRemoteConfigSettings.test.ts
@@ -1,0 +1,89 @@
+import { Empty } from "@shared/proto/cline/common"
+import { RemoteConfigType } from "@shared/proto/cline/remote_config"
+import { describe, expect, it, vi } from "vitest"
+import { getRemoteConfigSettings } from "./getRemoteConfigSettings"
+
+function deferred() {
+	let resolve!: () => void
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+function makeStateManager(remoteConfig: Record<string, unknown>, toggles: Record<string, Record<string, boolean>> = {}) {
+	return {
+		getRemoteConfigSettings: () => remoteConfig,
+		getGlobalStateKey: (key: string) => toggles[key] ?? {},
+	}
+}
+
+describe("getRemoteConfigSettings", () => {
+	it("maps rules, workflows, and skills with persisted per-type enabled state", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			stateManager: makeStateManager(
+				{
+					remoteGlobalRules: [{ name: "Security", contents: "Use secure defaults", alwaysEnabled: true }],
+					remoteGlobalWorkflows: [{ name: "Release", contents: "Run release checks", alwaysEnabled: false }],
+					remoteGlobalSkills: [{ name: "Review", contents: "Review changes", alwaysEnabled: false }],
+				},
+				{
+					remoteWorkflowToggles: { Release: false },
+				},
+			),
+		}
+
+		const response = await getRemoteConfigSettings(controller as never, Empty.create())
+
+		expect(response.settings).toEqual([
+			{
+				type: RemoteConfigType.RULE,
+				name: "Security",
+				content: "Use secure defaults",
+				enabled: true,
+				locked: true,
+			},
+			{
+				type: RemoteConfigType.WORKFLOW,
+				name: "Release",
+				content: "Run release checks",
+				enabled: false,
+				locked: false,
+			},
+			{
+				type: RemoteConfigType.SKILL,
+				name: "Review",
+				content: "Review changes",
+				enabled: true,
+				locked: false,
+			},
+		])
+	})
+
+	it("waits for initial remote config readiness before reading compatibility state", async () => {
+		const readiness = deferred()
+		let remoteConfig: Record<string, unknown> = {}
+		const controller = {
+			waitForInitialRemoteConfig: () => readiness.promise,
+			stateManager: {
+				getRemoteConfigSettings: () => remoteConfig,
+				getGlobalStateKey: () => ({}),
+			},
+		}
+
+		let settled = false
+		const read = getRemoteConfigSettings(controller as never, Empty.create()).then((response) => {
+			settled = true
+			return response
+		})
+		await Promise.resolve()
+		expect(settled).toBe(false)
+
+		remoteConfig = { remoteGlobalRules: [{ name: "Loaded before read", contents: "Policy" }] }
+		readiness.resolve()
+
+		const response = await read
+		expect(response.settings.map((setting) => setting.name)).toEqual(["Loaded before read"])
+	})
+})

--- a/apps/vscode/src/core/controller/remoteConfig/getRemoteConfigSettings.ts
+++ b/apps/vscode/src/core/controller/remoteConfig/getRemoteConfigSettings.ts
@@ -1,30 +1,8 @@
 import { Controller } from "@/sdk"
-import { Empty, RemoteConfigSetting, RemoteConfigSettingsResponse, RemoteConfigType } from "@/shared/proto/index.cline"
+import { Empty, RemoteConfigSettingsResponse } from "@/shared/proto/index.cline"
+import { getAllRemoteConfigSettings } from "./settings"
 
 export async function getRemoteConfigSettings(controller: Controller, _request: Empty): Promise<RemoteConfigSettingsResponse> {
-	const globalRules: RemoteConfigSetting[] = (controller.remoteConfig?.globalRules || []).map((rule) => ({
-		type: RemoteConfigType.RULE,
-		name: rule.name,
-		content: rule.contents,
-		enabled: true, // TODO: Implement actual enabled state when toggle support is wired up
-		locked: Boolean(rule.alwaysEnabled),
-	}))
-	const globalWorkflows: RemoteConfigSetting[] = (controller.remoteConfig?.globalWorkflows || []).map((workflow) => ({
-		type: RemoteConfigType.WORKFLOW,
-		name: workflow.name,
-		content: workflow.contents,
-		enabled: true, // TODO: Implement actual enabled state when toggle support is wired up
-		locked: Boolean(workflow.alwaysEnabled),
-	}))
-	const managedSkills: RemoteConfigSetting[] = (controller.remoteConfigBundle?.managedInstructions || [])
-		.filter((instruction) => instruction.kind === "skill")
-		.map((skill) => ({
-			type: RemoteConfigType.SKILL,
-			name: skill.name,
-			content: skill.contents,
-			enabled: true, // TODO: Implement actual enabled state when toggle support is wired up
-			locked: Boolean(skill.alwaysEnabled),
-		}))
-
-	return RemoteConfigSettingsResponse.create({ settings: [...globalRules, ...globalWorkflows, ...managedSkills] })
+	await controller.waitForInitialRemoteConfig()
+	return RemoteConfigSettingsResponse.create({ settings: getAllRemoteConfigSettings(controller) })
 }

--- a/apps/vscode/src/core/controller/remoteConfig/settings.ts
+++ b/apps/vscode/src/core/controller/remoteConfig/settings.ts
@@ -1,0 +1,51 @@
+import type { Controller } from "@/sdk"
+import { RemoteConfigSetting, RemoteConfigType } from "@/shared/proto/index.cline"
+
+function getToggles(controller: Controller, type: RemoteConfigType): Record<string, boolean> {
+	switch (type) {
+		case RemoteConfigType.RULE:
+			return controller.stateManager.getGlobalStateKey("remoteRulesToggles") || {}
+		case RemoteConfigType.WORKFLOW:
+			return controller.stateManager.getGlobalStateKey("remoteWorkflowToggles") || {}
+		case RemoteConfigType.SKILL:
+			return controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+		default:
+			throw new Error(`Invalid remote config type: ${type}`)
+	}
+}
+
+function getInstructions(controller: Controller, type: RemoteConfigType) {
+	const remoteConfig = controller.stateManager.getRemoteConfigSettings()
+	switch (type) {
+		case RemoteConfigType.RULE:
+			return remoteConfig.remoteGlobalRules ?? []
+		case RemoteConfigType.WORKFLOW:
+			return remoteConfig.remoteGlobalWorkflows ?? []
+		case RemoteConfigType.SKILL:
+			return remoteConfig.remoteGlobalSkills ?? []
+		default:
+			throw new Error(`Invalid remote config type: ${type}`)
+	}
+}
+
+export function getRemoteConfigSetting(controller: Controller, type: RemoteConfigType, name: string): RemoteConfigSetting {
+	const instruction = getInstructions(controller, type).find((entry) => entry.name === name)
+	if (!instruction) {
+		throw new Error(`Managed ${RemoteConfigType[type]?.toLowerCase() ?? "setting"} not found: ${name}`)
+	}
+
+	const locked = Boolean(instruction.alwaysEnabled)
+	return RemoteConfigSetting.create({
+		type,
+		name: instruction.name,
+		content: instruction.contents,
+		enabled: locked || getToggles(controller, type)[name] !== false,
+		locked,
+	})
+}
+
+export function getAllRemoteConfigSettings(controller: Controller): RemoteConfigSetting[] {
+	return [RemoteConfigType.RULE, RemoteConfigType.WORKFLOW, RemoteConfigType.SKILL].flatMap((type) =>
+		getInstructions(controller, type).map((entry) => getRemoteConfigSetting(controller, type, entry.name)),
+	)
+}

--- a/apps/vscode/src/core/controller/remoteConfig/toggleRemoteConfigSetting.test.ts
+++ b/apps/vscode/src/core/controller/remoteConfig/toggleRemoteConfigSetting.test.ts
@@ -1,0 +1,72 @@
+import { RemoteConfigType, ToggleRemoteConfigSettingRequest } from "@shared/proto/cline/remote_config"
+import { describe, expect, it, vi } from "vitest"
+import { toggleRemoteConfigSetting } from "./toggleRemoteConfigSetting"
+
+function makeController(options: { locked?: boolean } = {}) {
+	const stores: Record<string, Record<string, boolean>> = {
+		remoteRulesToggles: {},
+		remoteWorkflowToggles: {},
+		remoteSkillsToggles: {},
+	}
+	const controller = {
+		stateManager: {
+			getRemoteConfigSettings: () => ({
+				remoteGlobalRules: [{ name: "Shared", contents: "rule", alwaysEnabled: options.locked }],
+				remoteGlobalWorkflows: [{ name: "Shared", contents: "workflow", alwaysEnabled: false }],
+				remoteGlobalSkills: [{ name: "Shared", contents: "skill", alwaysEnabled: false }],
+			}),
+			getGlobalStateKey: (key: string) => stores[key],
+			setGlobalState: vi.fn((key: string, value: Record<string, boolean>) => {
+				stores[key] = value
+			}),
+		},
+		rematerializeRemoteConfig: vi.fn().mockResolvedValue(undefined),
+	}
+	return { controller, stores }
+}
+
+describe("toggleRemoteConfigSetting", () => {
+	it.each([
+		[RemoteConfigType.RULE, "remoteRulesToggles"],
+		[RemoteConfigType.WORKFLOW, "remoteWorkflowToggles"],
+		[RemoteConfigType.SKILL, "remoteSkillsToggles"],
+	] as const)("persists and rematerializes type %s", async (type, key) => {
+		const { controller, stores } = makeController()
+
+		const response = await toggleRemoteConfigSetting(
+			controller as never,
+			ToggleRemoteConfigSettingRequest.create({ type, name: "Shared", enabled: false }),
+		)
+
+		expect(stores[key]).toEqual({ Shared: false })
+		expect(response.enabled).toBe(false)
+		expect(controller.rematerializeRemoteConfig).toHaveBeenCalledOnce()
+	})
+
+	it("keeps duplicate names isolated by instruction type", async () => {
+		const { controller, stores } = makeController()
+
+		await toggleRemoteConfigSetting(
+			controller as never,
+			ToggleRemoteConfigSettingRequest.create({ type: RemoteConfigType.RULE, name: "Shared", enabled: false }),
+		)
+
+		expect(stores.remoteRulesToggles).toEqual({ Shared: false })
+		expect(stores.remoteWorkflowToggles).toEqual({})
+		expect(stores.remoteSkillsToggles).toEqual({})
+	})
+
+	it("rejects disabling a locked instruction without changing state", async () => {
+		const { controller, stores } = makeController({ locked: true })
+
+		await expect(
+			toggleRemoteConfigSetting(
+				controller as never,
+				ToggleRemoteConfigSettingRequest.create({ type: RemoteConfigType.RULE, name: "Shared", enabled: false }),
+			),
+		).rejects.toThrow("locked")
+
+		expect(stores.remoteRulesToggles).toEqual({})
+		expect(controller.rematerializeRemoteConfig).not.toHaveBeenCalled()
+	})
+})

--- a/apps/vscode/src/core/controller/remoteConfig/toggleRemoteConfigSetting.ts
+++ b/apps/vscode/src/core/controller/remoteConfig/toggleRemoteConfigSetting.ts
@@ -1,12 +1,37 @@
 import { Controller } from "@/sdk"
-import { RemoteConfigSetting, StringRequest } from "@/shared/proto/index.cline"
+import { RemoteConfigSetting, RemoteConfigType, ToggleRemoteConfigSettingRequest } from "@/shared/proto/index.cline"
+import { getRemoteConfigSetting } from "./settings"
 
-export async function toggleRemoteConfigSetting(_controller: Controller, _request: StringRequest): Promise<RemoteConfigSetting> {
-	// TODO(ENG): Toggling remote config settings is not implemented yet. The
-	// `enabled` flag is currently hardcoded to `true` in getRemoteConfigSettings,
-	// so there is no per-setting enabled state to flip. When this is wired up,
-	// look up the setting by name, persist the new enabled state, and return the
-	// updated RemoteConfigSetting. Until then, reject so the caller's request
-	// completes instead of hanging forever.
-	throw new Error("toggleRemoteConfigSetting is not implemented")
+function toggleKey(type: RemoteConfigType): "remoteRulesToggles" | "remoteWorkflowToggles" | "remoteSkillsToggles" {
+	switch (type) {
+		case RemoteConfigType.RULE:
+			return "remoteRulesToggles"
+		case RemoteConfigType.WORKFLOW:
+			return "remoteWorkflowToggles"
+		case RemoteConfigType.SKILL:
+			return "remoteSkillsToggles"
+		default:
+			throw new Error(`Invalid remote config type: ${type}`)
+	}
+}
+
+export async function toggleRemoteConfigSetting(
+	controller: Controller,
+	request: ToggleRemoteConfigSettingRequest,
+): Promise<RemoteConfigSetting> {
+	if (!request.name) {
+		throw new Error("Managed setting name is required")
+	}
+
+	const current = getRemoteConfigSetting(controller, request.type, request.name)
+	if (current.locked && !request.enabled) {
+		throw new Error(`Managed setting is locked and cannot be disabled: ${request.name}`)
+	}
+
+	const key = toggleKey(request.type)
+	const toggles = controller.stateManager.getGlobalStateKey(key) || {}
+	controller.stateManager.setGlobalState(key, { ...toggles, [request.name]: request.enabled })
+	await controller.rematerializeRemoteConfig()
+
+	return getRemoteConfigSetting(controller, request.type, request.name)
 }

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -29,6 +29,8 @@ export async function getStateToPostToWebview(controller: {
 	foregroundCommandRunning?: boolean
 	workspaceManager?: any
 	checkpointRestoreInput?: ExtensionState["checkpointRestoreInput"]
+	isRemoteConfigAvailable?: boolean
+	currentRemoteConfigRevision?: number
 }): Promise<ExtensionState> {
 	const stateManager = controller.stateManager
 
@@ -172,10 +174,12 @@ export async function getStateToPostToWebview(controller: {
 		lastDismissedInfoBannerVersion,
 		lastDismissedModelBannerVersion,
 		remoteConfigSettings: stateManager.getRemoteConfigSettings?.(),
+		remoteConfigRevision: controller.currentRemoteConfigRevision ?? 0,
 		lastDismissedCliBannerVersion,
 		dismissedBanners,
 		backgroundEditEnabled: stateManager.getGlobalSettingsKey("backgroundEditEnabled"),
 		optOutOfRemoteConfig: stateManager.getGlobalSettingsKey("optOutOfRemoteConfig"),
+		remoteConfigAvailable: controller.isRemoteConfigAvailable ?? false,
 		showFeatureTips,
 		banners,
 		welcomeBanners,

--- a/apps/vscode/src/core/controller/state/refreshRemoteConfig.ts
+++ b/apps/vscode/src/core/controller/state/refreshRemoteConfig.ts
@@ -1,5 +1,4 @@
 import { Empty, EmptyRequest } from "@shared/proto/cline/common"
-import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
 import { Controller } from ".."
 
 /**
@@ -9,7 +8,7 @@ import { Controller } from ".."
  * @returns Empty response
  */
 export async function refreshRemoteConfig(controller: Controller, _: EmptyRequest): Promise<Empty> {
-	await fetchRemoteConfig(controller)
+	await controller.refreshRemoteConfig()
 
 	return Empty.create()
 }

--- a/apps/vscode/src/core/controller/state/remoteConfigRefresh.characterization.test.ts
+++ b/apps/vscode/src/core/controller/state/remoteConfigRefresh.characterization.test.ts
@@ -1,0 +1,41 @@
+import { Empty } from "@shared/proto/cline/common"
+import { UpdateSettingsRequest } from "@shared/proto/cline/state"
+import { describe, expect, it, vi } from "vitest"
+import { refreshRemoteConfig } from "./refreshRemoteConfig"
+import { updateSettings } from "./updateSettings"
+
+describe("SDK remote-config refresh handlers", () => {
+	it("uses the authoritative SDK path for manual refresh", async () => {
+		const sdkRefresh = vi.fn().mockResolvedValue(undefined)
+		const controller = { refreshRemoteConfig: sdkRefresh }
+
+		await refreshRemoteConfig(controller as never, Empty.create())
+
+		expect(sdkRefresh).toHaveBeenCalledOnce()
+	})
+
+	it.each([
+		{ previousValue: true, requestedValue: false, description: "re-enabling" },
+		{ previousValue: false, requestedValue: true, description: "opting out" },
+	])("awaits the authoritative SDK path when $description remote config", async ({ previousValue, requestedValue }) => {
+		const sdkRefresh = vi.fn().mockResolvedValue(undefined)
+		const controller = {
+			refreshRemoteConfig: sdkRefresh,
+			stateManager: {
+				getGlobalSettingsKey: vi.fn((key: string) => (key === "optOutOfRemoteConfig" ? previousValue : undefined)),
+				setGlobalState: vi.fn(),
+			},
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+		}
+
+		await updateSettings(
+			controller as never,
+			UpdateSettingsRequest.create({
+				optOutOfRemoteConfig: requestedValue,
+			}),
+		)
+
+		expect(controller.stateManager.setGlobalState).toHaveBeenCalledWith("optOutOfRemoteConfig", requestedValue)
+		expect(sdkRefresh).toHaveBeenCalledOnce()
+	})
+})

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -245,7 +245,9 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			// Update first so the authoritative refresh evaluates the new preference.
 			controller.stateManager.setGlobalState("optOutOfRemoteConfig", isOptingOut)
 			if (isOptingOut !== hadOptedOut) {
-				await controller.refreshRemoteConfig()
+				// force: never coalesce onto an in-flight refresh that already
+				// evaluated the pre-change opt-out preference.
+				await controller.refreshRemoteConfig({ force: true })
 			}
 		}
 

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -5,8 +5,6 @@ import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-
 import { OpenaiReasoningEffort } from "@shared/storage/types"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { ClineEnv } from "@/config"
-import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
-import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
 import { McpDisplayMode } from "@/shared/McpDisplayMode"
 import { Logger } from "@/shared/services/Logger"
 import { telemetryService } from "../../../services/telemetry"
@@ -241,21 +239,13 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 		}
 
 		if (request.optOutOfRemoteConfig !== undefined) {
-			const hadOptedOut = controller.stateManager.getGlobalSettingsKey("optOutOfRemoteConfig")
+			const hadOptedOut = !!controller.stateManager.getGlobalSettingsKey("optOutOfRemoteConfig")
 			const isOptingOut = !!request.optOutOfRemoteConfig
-			const isReenablingRemoteConfig = !isOptingOut && hadOptedOut
 
-			// Update now so any subsequent function can access the updated value
+			// Update first so the authoritative refresh evaluates the new preference.
 			controller.stateManager.setGlobalState("optOutOfRemoteConfig", isOptingOut)
-
-			if (isOptingOut && !hadOptedOut) {
-				clearRemoteConfig()
-			} else if (isReenablingRemoteConfig) {
-				// Fire-and-forget: We don't need to await here
-				// The function catches any errors and posts the updated state to the webview
-				// The immediate state update below shows the user's intent (opted-in),
-				// and we apply the actual config afterwards without blocking the settings update
-				fetchRemoteConfig(controller)
+			if (isOptingOut !== hadOptedOut) {
+				await controller.refreshRemoteConfig()
 			}
 		}
 

--- a/apps/vscode/src/core/storage/remote-config/contracts.test.ts
+++ b/apps/vscode/src/core/storage/remote-config/contracts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { parseOrganizationRemoteConfigResponse, parseRemoteConfigDiscovery, parseRemoteConfigValue } from "./contracts"
+import organizationResponseFixture from "./fixtures/organization-remote-config-response.json"
+import discoveryFixture from "./fixtures/user-remote-config-discovery.json"
+
+describe("remote-config API contracts", () => {
+	it("parses discovery and preserves all managed instruction types", () => {
+		const discovery = parseRemoteConfigDiscovery(discoveryFixture)
+		const config = parseRemoteConfigValue(discovery.value)
+
+		expect(discovery.organizationId).toBe("org-contract")
+		expect(config.globalRules?.[0]?.name).toBe("Contract Rule")
+		expect(config.globalWorkflows?.[0]?.name).toBe("Contract Workflow")
+		expect(config.globalSkills?.[0]?.name).toBe("Contract Skill")
+		expect(config.allowedMCPServers?.[0]?.id).toBe("https://github.com/example/contract-mcp")
+		expect(config.openTelemetryEnabled).toBe(true)
+	})
+
+	it("parses the organization response envelope and preserves host policy fields", () => {
+		const result = parseOrganizationRemoteConfigResponse(organizationResponseFixture)
+
+		expect(result.enabled).toBe(true)
+		expect(result.remoteConfig?.version).toBe("contract-v2")
+		expect(result.remoteConfig?.globalRules?.[0]?.name).toBe("Fetched Rule")
+		expect(result.remoteConfig?.globalWorkflows?.[0]?.name).toBe("Fetched Workflow")
+		expect(result.remoteConfig?.globalSkills?.[0]?.name).toBe("Fetched Skill")
+		expect(result.remoteConfig?.blockPersonalRemoteMCPServers).toBe(true)
+		expect(result.remoteConfig?.remoteMCPServers?.[0]?.name).toBe("managed")
+	})
+
+	it("rejects malformed discovery instead of silently dropping it", () => {
+		expect(() => parseRemoteConfigDiscovery({ organizationId: "", value: "{}" })).toThrow()
+	})
+})

--- a/apps/vscode/src/core/storage/remote-config/contracts.ts
+++ b/apps/vscode/src/core/storage/remote-config/contracts.ts
@@ -1,0 +1,43 @@
+import { z } from "zod"
+import type { UserRemoteConfigDiscoveryResponse } from "@/shared/ClineAccount"
+import { type RemoteConfig, RemoteConfigSchema } from "@/shared/remote-config/schema"
+
+const RemoteConfigDiscoverySchema = z.object({
+	organizationId: z.string().min(1),
+	value: z.string(),
+	organizations: z
+		.array(
+			z.object({
+				organizationId: z.string().min(1),
+				name: z.string(),
+			}),
+		)
+		.optional(),
+})
+
+const OrganizationRemoteConfigDataSchema = z.object({
+	enabled: z.boolean(),
+	value: z.string(),
+})
+
+const OrganizationRemoteConfigResponseSchema = z.object({
+	success: z.literal(true),
+	error: z.string().optional(),
+	data: OrganizationRemoteConfigDataSchema,
+})
+
+export function parseRemoteConfigDiscovery(value: unknown): UserRemoteConfigDiscoveryResponse {
+	return RemoteConfigDiscoverySchema.parse(value)
+}
+
+export function parseRemoteConfigValue(value: string): RemoteConfig {
+	return RemoteConfigSchema.parse(JSON.parse(value))
+}
+
+export function parseOrganizationRemoteConfigResponse(value: unknown): { enabled: boolean; remoteConfig?: RemoteConfig } {
+	const response = OrganizationRemoteConfigResponseSchema.parse(value)
+	return {
+		enabled: response.data.enabled,
+		remoteConfig: response.data.enabled ? parseRemoteConfigValue(response.data.value) : undefined,
+	}
+}

--- a/apps/vscode/src/core/storage/remote-config/fixtures/organization-remote-config-response.json
+++ b/apps/vscode/src/core/storage/remote-config/fixtures/organization-remote-config-response.json
@@ -1,0 +1,8 @@
+{
+	"success": true,
+	"error": "",
+	"data": {
+		"enabled": true,
+		"value": "{\"version\":\"contract-v2\",\"globalRules\":[{\"alwaysEnabled\":false,\"name\":\"Fetched Rule\",\"contents\":\"Fetched rule contents.\"}],\"globalWorkflows\":[{\"alwaysEnabled\":true,\"name\":\"Fetched Workflow\",\"contents\":\"Fetched workflow contents.\"}],\"globalSkills\":[{\"alwaysEnabled\":true,\"name\":\"Fetched Skill\",\"contents\":\"---\\nname: Fetched Skill\\n---\\nFetched skill contents.\"}],\"blockPersonalRemoteMCPServers\":true,\"remoteMCPServers\":[{\"name\":\"managed\",\"url\":\"https://mcp.example.test\",\"alwaysEnabled\":true}],\"openTelemetryOtlpEndpoint\":\"https://otel.example.test\"}"
+	}
+}

--- a/apps/vscode/src/core/storage/remote-config/fixtures/user-remote-config-discovery.json
+++ b/apps/vscode/src/core/storage/remote-config/fixtures/user-remote-config-discovery.json
@@ -1,0 +1,10 @@
+{
+	"organizationId": "org-contract",
+	"value": "{\"version\":\"contract-v1\",\"globalRules\":[{\"alwaysEnabled\":true,\"name\":\"Contract Rule\",\"contents\":\"Always follow the contract rule.\"}],\"globalWorkflows\":[{\"alwaysEnabled\":false,\"name\":\"Contract Workflow\",\"contents\":\"Run the contract workflow.\"}],\"globalSkills\":[{\"alwaysEnabled\":false,\"name\":\"Contract Skill\",\"contents\":\"---\\nname: Contract Skill\\n---\\nUse the contract skill.\"}],\"allowedMCPServers\":[{\"id\":\"https://github.com/example/contract-mcp\"}],\"openTelemetryEnabled\":true}",
+	"organizations": [
+		{
+			"organizationId": "org-contract",
+			"name": "Contract Organization"
+		}
+	]
+}

--- a/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
@@ -15,7 +15,7 @@ import { isRemoteConfigEnabled } from "./utils"
 export interface SdkRemoteConfigControlPlaneController {
 	accountService: {
 		switchAccount(organizationId: string): Promise<unknown>
-		fetchUserRemoteConfig(): Promise<import("@/shared/ClineAccount").UserRemoteConfigDiscoveryResponse | undefined>
+		fetchUserRemoteConfig(): Promise<import("@/shared/ClineAccount").UserRemoteConfigDiscoveryResponse | null | undefined>
 	}
 	stateManager: {
 		setSecret(key: "remoteLiteLlmApiKey", value: string | undefined): unknown
@@ -103,7 +103,10 @@ async function fetchRemoteConfigForOrganization(organizationId: string): Promise
 				Logger.error(`Cached config validation failed for organization ${organizationId}:`, validationError)
 			}
 		}
-		return undefined
+		// A transient failure with no usable cache must NOT be reported as "no
+		// config" — the caller would clear the org's policy and report success.
+		// Rethrow so the refresh preserves the last known-good state instead.
+		throw error
 	}
 }
 
@@ -219,13 +222,34 @@ export class SdkRemoteConfigControlPlane {
 	}
 
 	private async discoverRemoteConfigOrg(): Promise<{ organizationId: string; discoveredValue?: string } | undefined> {
+		const activeOrganizationId = AuthService.getInstance().getActiveOrganizationId()
+
+		// Opt-out is a local, admin-gated preference. Evaluate it before any
+		// network call so opting out clears remote config even while offline.
+		if (activeOrganizationId && !isRemoteConfigEnabled(activeOrganizationId)) {
+			// The org still distributes config; keep availability so the account
+			// UI keeps offering the opt-in toggle to the opted-out admin.
+			this.remoteConfigAvailable = true
+			return undefined
+		}
+
 		const response = await this.controller.accountService.fetchUserRemoteConfig()
-		if (!response) {
+		if (response === undefined) {
+			// No auth token was available. A user with an active organization is
+			// signed in, so this is auth/network trouble (e.g. token refresh
+			// failed offline), not an org without config. Treating it as explicit
+			// no-config would wipe the enforced policy.
+			if (activeOrganizationId) {
+				throw new Error("Remote config discovery returned no response for the active organization")
+			}
+			return undefined
+		}
+		if (response === null) {
+			// The server answered and distributes no remote config for this user.
 			return undefined
 		}
 
 		const discovery = parseRemoteConfigDiscovery(response)
-		const activeOrganizationId = AuthService.getInstance().getActiveOrganizationId()
 		if (activeOrganizationId) {
 			return {
 				organizationId: activeOrganizationId,

--- a/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
@@ -1,7 +1,6 @@
-import type { RemoteConfigBundle } from "@cline/shared"
+import type { RemoteConfigBundle, RemoteConfigManagedInstructionFile } from "@cline/shared"
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
 import { ClineEnv } from "@/config"
-import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 import { buildBasicClineHeaders } from "@/services/EnvUtils"
 import { CLINE_API_ENDPOINT } from "@/shared/cline/api"
@@ -10,11 +9,18 @@ import { APIKeySchema, type APIKeySettings, type RemoteConfig, RemoteConfigSchem
 import { Logger } from "@/shared/services/Logger"
 import type { ConfiguredAPIKeys } from "@/shared/storage/state-keys"
 import { deleteRemoteConfigFromCache, readRemoteConfigFromCache, writeRemoteConfigToCache } from "../disk"
+import { parseRemoteConfigDiscovery, parseRemoteConfigValue } from "./contracts"
 import { isRemoteConfigEnabled } from "./utils"
 
 export interface SdkRemoteConfigControlPlaneController {
-	accountService: { switchAccount(organizationId: string): Promise<unknown> }
-	stateManager: { setSecret(key: "remoteLiteLlmApiKey", value: string | undefined): unknown }
+	accountService: {
+		switchAccount(organizationId: string): Promise<unknown>
+		fetchUserRemoteConfig(): Promise<import("@/shared/ClineAccount").UserRemoteConfigDiscoveryResponse | undefined>
+	}
+	stateManager: {
+		setSecret(key: "remoteLiteLlmApiKey", value: string | undefined): unknown
+		getGlobalStateKey(key: "remoteRulesToggles" | "remoteWorkflowToggles" | "remoteSkillsToggles"): Record<string, boolean>
+	}
 }
 
 interface RemoteConfigControlPlaneFetchInput {
@@ -26,17 +32,7 @@ interface RemoteConfigControlPlaneFetchInput {
 	now?: number
 }
 
-interface RemoteConfigManagedInstructionFile {
-	id: string
-	name: string
-	kind: "skill"
-	contents: string
-	alwaysEnabled?: boolean
-}
-
-export interface SdkRemoteConfigBundle extends RemoteConfigBundle {
-	remoteConfig?: RemoteConfigBundle["remoteConfig"] & RemoteConfig
-}
+export type SdkRemoteConfigBundle = RemoteConfigBundle
 
 function parseApiKeys(value: string): APIKeySettings {
 	try {
@@ -96,7 +92,7 @@ async function fetchRemoteConfigForOrganization(organizationId: string): Promise
 			await deleteRemoteConfigFromCache(organizationId)
 			return undefined
 		}
-		return RemoteConfigSchema.parse(JSON.parse(configData.value))
+		return parseRemoteConfigValue(configData.value)
 	} catch (error) {
 		Logger.error(`Failed to fetch remote config for organization ${organizationId}:`, error)
 		const cachedConfig = await readRemoteConfigFromCache(organizationId)
@@ -123,7 +119,7 @@ async function fetchApiKeysForOrganization(organizationId: string): Promise<APIK
 
 function parseDiscoveredConfig(value: string, organizationId: string): RemoteConfig | undefined {
 	try {
-		return RemoteConfigSchema.parse(JSON.parse(value))
+		return parseRemoteConfigValue(value)
 	} catch (error) {
 		Logger.warn(`Failed to parse discovered config for org ${organizationId}, will re-fetch`, error)
 		return undefined
@@ -140,10 +136,15 @@ function skillsToManagedInstructions(remoteConfig: RemoteConfig): RemoteConfigMa
 	}))
 }
 
+function isInstructionEnabled(entry: { name: string; alwaysEnabled?: boolean }, toggles: Record<string, boolean>): boolean {
+	return Boolean(entry.alwaysEnabled) || toggles[entry.name] !== false
+}
+
 export class SdkRemoteConfigControlPlane {
 	readonly name = "cline-extension-remote-config"
 	private lastConfiguredKeys: ConfiguredAPIKeys = {}
 	private lastRemoteConfig: RemoteConfig | undefined
+	private remoteConfigAvailable = false
 	private explicitNoConfig = false
 
 	constructor(private readonly controller: SdkRemoteConfigControlPlaneController) {}
@@ -160,10 +161,15 @@ export class SdkRemoteConfigControlPlane {
 		return this.explicitNoConfig
 	}
 
+	isRemoteConfigAvailable(): boolean {
+		return this.remoteConfigAvailable
+	}
+
 	async fetchBundle(_input: RemoteConfigControlPlaneFetchInput): Promise<SdkRemoteConfigBundle | undefined> {
 		this.explicitNoConfig = false
 		this.lastConfiguredKeys = {}
 		this.lastRemoteConfig = undefined
+		this.remoteConfigAvailable = false
 
 		const discovered = await this.discoverRemoteConfigOrg()
 		if (!discovered) {
@@ -173,7 +179,8 @@ export class SdkRemoteConfigControlPlane {
 
 		const { organizationId, discoveredValue } = discovered
 		const remoteConfig = await this.resolveRemoteConfig(organizationId, discoveredValue)
-		if (!remoteConfig) {
+		this.remoteConfigAvailable = Boolean(remoteConfig)
+		if (!remoteConfig || !isRemoteConfigEnabled(organizationId)) {
 			this.explicitNoConfig = true
 			return undefined
 		}
@@ -187,20 +194,43 @@ export class SdkRemoteConfigControlPlane {
 		await writeRemoteConfigToCache(organizationId, remoteConfig)
 		this.lastRemoteConfig = remoteConfig
 
+		const ruleToggles = this.controller.stateManager.getGlobalStateKey("remoteRulesToggles") || {}
+		const workflowToggles = this.controller.stateManager.getGlobalStateKey("remoteWorkflowToggles") || {}
+		const skillToggles = this.controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+		// Explicit host-to-SDK boundary: skills are not part of the SDK RemoteConfig
+		// schema and are adapted into managedInstructions below. The assignment keeps
+		// the remaining runtime config structurally checked without an unsafe cast.
+		const { globalSkills: _globalSkills, ...sdkRemoteConfig } = remoteConfig
+		const effectiveRemoteConfig: NonNullable<RemoteConfigBundle["remoteConfig"]> = {
+			...sdkRemoteConfig,
+			globalRules: remoteConfig.globalRules?.filter((entry) => isInstructionEnabled(entry, ruleToggles)),
+			globalWorkflows: remoteConfig.globalWorkflows?.filter((entry) => isInstructionEnabled(entry, workflowToggles)),
+		}
+
 		return {
 			source: this.name,
 			version: remoteConfig.version,
-			remoteConfig: remoteConfig as SdkRemoteConfigBundle["remoteConfig"],
-			managedInstructions: skillsToManagedInstructions(remoteConfig),
+			remoteConfig: effectiveRemoteConfig,
+			managedInstructions: skillsToManagedInstructions(remoteConfig).filter((entry) =>
+				isInstructionEnabled(entry, skillToggles),
+			),
 			metadata: { organizationId },
 		}
 	}
 
 	private async discoverRemoteConfigOrg(): Promise<{ organizationId: string; discoveredValue?: string } | undefined> {
-		const accountService = ClineAccountService.getInstance()
-		const discovery = await accountService.fetchUserRemoteConfig()
-		if (!discovery) {
+		const response = await this.controller.accountService.fetchUserRemoteConfig()
+		if (!response) {
 			return undefined
+		}
+
+		const discovery = parseRemoteConfigDiscovery(response)
+		const activeOrganizationId = AuthService.getInstance().getActiveOrganizationId()
+		if (activeOrganizationId) {
+			return {
+				organizationId: activeOrganizationId,
+				discoveredValue: activeOrganizationId === discovery.organizationId ? discovery.value : undefined,
+			}
 		}
 
 		if (isRemoteConfigEnabled(discovery.organizationId)) {

--- a/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-control-plane.ts
@@ -20,6 +20,7 @@ export interface SdkRemoteConfigControlPlaneController {
 	stateManager: {
 		setSecret(key: "remoteLiteLlmApiKey", value: string | undefined): unknown
 		getGlobalStateKey(key: "remoteRulesToggles" | "remoteWorkflowToggles" | "remoteSkillsToggles"): Record<string, boolean>
+		getGlobalStateKey(key: "lastManagedOrganizationId"): string | undefined
 	}
 }
 
@@ -235,12 +236,16 @@ export class SdkRemoteConfigControlPlane {
 
 		const response = await this.controller.accountService.fetchUserRemoteConfig()
 		if (response === undefined) {
-			// No auth token was available. A user with an active organization is
-			// signed in, so this is auth/network trouble (e.g. token refresh
-			// failed offline), not an org without config. Treating it as explicit
-			// no-config would wipe the enforced policy.
-			if (activeOrganizationId) {
-				throw new Error("Remote config discovery returned no response for the active organization")
+			// No auth token was available. An active organization means the user
+			// is signed in, so this is auth/network trouble (e.g. token refresh
+			// failed offline), not an org without config. The persisted marker
+			// covers the offline cold start where identity restore fails and BOTH
+			// token and org come back null: this install last ran under org
+			// policy, so reporting no-config here would wipe the policy — and the
+			// marker itself — permanently disarming the fail-closed session gate.
+			// A real sign-out clears the marker directly, so it never gets stuck.
+			if (activeOrganizationId || this.controller.stateManager.getGlobalStateKey("lastManagedOrganizationId")) {
+				throw new Error("Remote config discovery returned no response for a managed install")
 			}
 			return undefined
 		}

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
@@ -48,7 +48,7 @@ vi.mock("./sdk-control-plane", () => ({
 	},
 }))
 
-import { refreshSdkRemoteConfig } from "./sdk-refresh"
+import { clearSdkRemoteConfig, refreshSdkRemoteConfig } from "./sdk-refresh"
 
 function deferred<T>() {
 	let resolve!: (value: T) => void
@@ -267,5 +267,29 @@ describe("refreshSdkRemoteConfig", () => {
 		expect(setRemoteConfigCoreIntegration).toHaveBeenCalledWith(undefined)
 		expect(getCurrentIntegration()).toBeUndefined()
 		expect(controller.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("still clears state and reports success when file cleanup fails on the cleared path", async () => {
+		scenarios.push({ preparation: Promise.reject(new Error("no bundle")), explicitNoConfig: true })
+		clearMaterializedRemoteConfigRuntime.mockRejectedValueOnce(new Error("EACCES: permission denied"))
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController()
+
+		const refreshed = await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(refreshed).toBe(true)
+		expect(clearRemoteConfig).toHaveBeenCalledOnce()
+		expect(setRemoteConfigCoreIntegration).toHaveBeenCalledWith(undefined)
+		expect(getCurrentIntegration()).toBeUndefined()
+	})
+
+	it("clearSdkRemoteConfig clears state and integration even when file cleanup fails", async () => {
+		clearMaterializedRemoteConfigRuntime.mockRejectedValueOnce(new Error("EACCES: permission denied"))
+		const { controller, getCurrentIntegration } = makeController("signed-in")
+
+		await clearSdkRemoteConfig(controller as never, { workspacePath: "/workspace", organizationId: "org-current" })
+
+		expect(clearRemoteConfig).toHaveBeenCalledWith("org-current")
+		expect(getCurrentIntegration()).toBeUndefined()
+		expect(controller.setRemoteConfigAvailable).toHaveBeenCalledWith(false)
 	})
 })

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
@@ -76,6 +76,7 @@ function makeController(initialVersion = "existing") {
 		controller: {
 			authService: { getActiveOrganizationId: () => "org-current" },
 			mcpHub: {},
+			stateManager: { setGlobalState: vi.fn() },
 			setRemoteConfigAvailable: vi.fn(),
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			setRemoteConfigCoreIntegration,
@@ -140,6 +141,7 @@ describe("refreshSdkRemoteConfig", () => {
 		expect(captureRemoteConfigRefresh).toHaveBeenCalledWith(
 			expect.objectContaining({ outcome: "applied", managed: true, configVersion: "current" }),
 		)
+		expect(controller.stateManager.setGlobalState).toHaveBeenCalledWith("lastManagedOrganizationId", "org-current")
 	})
 
 	it("preserves the previous integration and disposes the candidate when compatibility application fails", async () => {

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+interface Scenario {
+	preparation: Promise<unknown>
+	remoteConfig?: { version: string }
+	explicitNoConfig?: boolean
+}
+
+const {
+	scenarios,
+	prepareRemoteConfigCoreIntegration,
+	clearMaterializedRemoteConfigRuntime,
+	applyRemoteConfig,
+	clearRemoteConfig,
+	captureRemoteConfigRefresh,
+} = vi.hoisted(() => ({
+	scenarios: [] as Scenario[],
+	prepareRemoteConfigCoreIntegration: vi.fn(),
+	clearMaterializedRemoteConfigRuntime: vi.fn(),
+	applyRemoteConfig: vi.fn(),
+	clearRemoteConfig: vi.fn(),
+	captureRemoteConfigRefresh: vi.fn(),
+}))
+
+vi.mock("@cline/core", () => ({ prepareRemoteConfigCoreIntegration }))
+vi.mock("@cline/shared", () => ({ clearMaterializedRemoteConfigRuntime }))
+vi.mock("@/services/telemetry", () => ({ telemetryService: { captureRemoteConfigRefresh } }))
+vi.mock("./utils", () => ({ applyRemoteConfig, clearRemoteConfig }))
+vi.mock("./sdk-control-plane", () => ({
+	SdkRemoteConfigControlPlane: class {
+		readonly scenario = scenarios.shift()
+
+		getLastRemoteConfig() {
+			return this.scenario?.remoteConfig
+		}
+
+		getLastConfiguredKeys() {
+			return {}
+		}
+
+		wasExplicitNoConfig() {
+			return this.scenario?.explicitNoConfig ?? false
+		}
+
+		isRemoteConfigAvailable() {
+			return Boolean(this.scenario?.remoteConfig)
+		}
+	},
+}))
+
+import { refreshSdkRemoteConfig } from "./sdk-refresh"
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise
+		reject = rejectPromise
+	})
+	return { promise, resolve, reject }
+}
+
+function integration(version: string) {
+	return {
+		prepared: { bundle: { version, remoteConfig: { version } } },
+		dispose: vi.fn().mockResolvedValue(undefined),
+	}
+}
+
+function makeController(initialVersion = "existing") {
+	let currentIntegration: unknown = integration(initialVersion)
+	const setRemoteConfigCoreIntegration = vi.fn(async (next: unknown) => {
+		currentIntegration = next
+	})
+	return {
+		controller: {
+			authService: { getActiveOrganizationId: () => "org-current" },
+			mcpHub: {},
+			setRemoteConfigAvailable: vi.fn(),
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			setRemoteConfigCoreIntegration,
+		},
+		setRemoteConfigCoreIntegration,
+		getCurrentIntegration: () => currentIntegration,
+	}
+}
+
+describe("refreshSdkRemoteConfig", () => {
+	beforeEach(() => {
+		scenarios.length = 0
+		prepareRemoteConfigCoreIntegration.mockReset().mockImplementation(({ controlPlane }) => controlPlane.scenario.preparation)
+		applyRemoteConfig.mockReset().mockResolvedValue(undefined)
+		clearRemoteConfig.mockReset()
+		clearMaterializedRemoteConfigRuntime.mockReset().mockResolvedValue(undefined)
+		captureRemoteConfigRefresh.mockReset()
+	})
+
+	it("does not let an older response overwrite a newer published integration", async () => {
+		const older = deferred<unknown>()
+		const newer = deferred<unknown>()
+		scenarios.push(
+			{ preparation: older.promise, remoteConfig: { version: "older" } },
+			{ preparation: newer.promise, remoteConfig: { version: "newer" } },
+		)
+		const { controller, getCurrentIntegration } = makeController()
+		let currentGeneration = 1
+
+		const firstRefresh = refreshSdkRemoteConfig(controller as never, {
+			workspacePath: "/workspace",
+			isCurrent: () => currentGeneration === 1,
+		})
+		currentGeneration = 2
+		const secondRefresh = refreshSdkRemoteConfig(controller as never, {
+			workspacePath: "/workspace",
+			isCurrent: () => currentGeneration === 2,
+		})
+		const newerIntegration = integration("newer")
+		newer.resolve(newerIntegration)
+		await secondRefresh
+		const olderIntegration = integration("older")
+		older.resolve(olderIntegration)
+		await firstRefresh
+
+		expect(olderIntegration.dispose).toHaveBeenCalledOnce()
+		expect(getCurrentIntegration()).toBe(newerIntegration)
+	})
+
+	it("applies compatibility state before publishing the SDK integration", async () => {
+		const candidate = integration("current")
+		scenarios.push({ preparation: Promise.resolve(candidate), remoteConfig: { version: "current" } })
+		const { controller, setRemoteConfigCoreIntegration } = makeController()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(applyRemoteConfig).toHaveBeenCalledOnce()
+		expect(setRemoteConfigCoreIntegration).toHaveBeenCalledWith(candidate)
+		expect(applyRemoteConfig.mock.invocationCallOrder[0]).toBeLessThan(
+			setRemoteConfigCoreIntegration.mock.invocationCallOrder[0],
+		)
+		expect(captureRemoteConfigRefresh).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "applied", managed: true, configVersion: "current" }),
+		)
+	})
+
+	it("preserves the previous integration and disposes the candidate when compatibility application fails", async () => {
+		const candidate = integration("candidate")
+		scenarios.push({ preparation: Promise.resolve(candidate), remoteConfig: { version: "candidate" } })
+		applyRemoteConfig.mockRejectedValueOnce(new Error("compatibility bridge failed"))
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController("last-known-good")
+		const previous = getCurrentIntegration()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(getCurrentIntegration()).toBe(previous)
+		expect(setRemoteConfigCoreIntegration).not.toHaveBeenCalled()
+		expect(candidate.dispose).toHaveBeenCalledOnce()
+		expect(controller.postStateToWebview).not.toHaveBeenCalled()
+	})
+
+	it("serializes compatibility application so a newer generation leaves the final state", async () => {
+		const olderApplyStarted = deferred<void>()
+		const finishOlderApply = deferred<void>()
+		applyRemoteConfig.mockImplementation(async (remoteConfig: { version: string }) => {
+			if (remoteConfig.version === "older") {
+				olderApplyStarted.resolve()
+				await finishOlderApply.promise
+			}
+		})
+		const olderIntegration = integration("older")
+		const newerIntegration = integration("newer")
+		scenarios.push(
+			{ preparation: Promise.resolve(olderIntegration), remoteConfig: { version: "older" } },
+			{ preparation: Promise.resolve(newerIntegration), remoteConfig: { version: "newer" } },
+		)
+		const { controller, getCurrentIntegration } = makeController("initial")
+		let currentGeneration = 1
+
+		const olderRefresh = refreshSdkRemoteConfig(controller as never, {
+			workspacePath: "/workspace",
+			isCurrent: () => currentGeneration === 1,
+		})
+		await olderApplyStarted.promise
+		currentGeneration = 2
+		const newerRefresh = refreshSdkRemoteConfig(controller as never, {
+			workspacePath: "/workspace",
+			isCurrent: () => currentGeneration === 2,
+		})
+		await Promise.resolve()
+		expect(applyRemoteConfig).toHaveBeenCalledTimes(1)
+
+		finishOlderApply.resolve()
+		await Promise.all([olderRefresh, newerRefresh])
+
+		expect(applyRemoteConfig.mock.calls.map(([config]) => config.version)).toEqual(["older", "newer"])
+		expect(olderIntegration.dispose).toHaveBeenCalledOnce()
+		expect(getCurrentIntegration()).toBe(newerIntegration)
+	})
+
+	it("disposes a superseded candidate without publishing either state", async () => {
+		const candidate = integration("stale")
+		scenarios.push({ preparation: Promise.resolve(candidate), remoteConfig: { version: "stale" } })
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController("current")
+		const previous = getCurrentIntegration()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace", isCurrent: () => false })
+
+		expect(candidate.dispose).toHaveBeenCalledOnce()
+		expect(applyRemoteConfig).not.toHaveBeenCalled()
+		expect(setRemoteConfigCoreIntegration).not.toHaveBeenCalled()
+		expect(getCurrentIntegration()).toBe(previous)
+		expect(controller.postStateToWebview).not.toHaveBeenCalled()
+	})
+
+	it("does not clear current state when a superseded request reports no config", async () => {
+		scenarios.push({ preparation: Promise.reject(new Error("stale no-config")), explicitNoConfig: true })
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController("current")
+		const previous = getCurrentIntegration()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace", isCurrent: () => false })
+
+		expect(clearRemoteConfig).not.toHaveBeenCalled()
+		expect(setRemoteConfigCoreIntegration).not.toHaveBeenCalled()
+		expect(getCurrentIntegration()).toBe(previous)
+	})
+
+	it("preserves the previous integration after a transient preparation failure", async () => {
+		scenarios.push({ preparation: Promise.reject(new Error("temporary network failure")) })
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController("last-known-good")
+		const previous = getCurrentIntegration()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(getCurrentIntegration()).toBe(previous)
+		expect(setRemoteConfigCoreIntegration).not.toHaveBeenCalled()
+		expect(clearRemoteConfig).not.toHaveBeenCalled()
+		expect(clearMaterializedRemoteConfigRuntime).not.toHaveBeenCalled()
+	})
+
+	it("disposes an empty prepared candidate and clears both states", async () => {
+		const candidate = integration("empty")
+		scenarios.push({ preparation: Promise.resolve(candidate) })
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(candidate.dispose).toHaveBeenCalledOnce()
+		expect(clearRemoteConfig).toHaveBeenCalledOnce()
+		expect(clearMaterializedRemoteConfigRuntime).toHaveBeenCalledWith({ workspacePath: "/workspace" })
+		expect(setRemoteConfigCoreIntegration).toHaveBeenCalledWith(undefined)
+		expect(getCurrentIntegration()).toBeUndefined()
+		expect(controller.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("clears SDK and compatibility state after explicit no-config", async () => {
+		scenarios.push({
+			preparation: Promise.reject(new Error("no bundle")),
+			explicitNoConfig: true,
+		})
+		const { controller, setRemoteConfigCoreIntegration, getCurrentIntegration } = makeController()
+
+		await refreshSdkRemoteConfig(controller as never, { workspacePath: "/workspace" })
+
+		expect(clearRemoteConfig).toHaveBeenCalledOnce()
+		expect(clearMaterializedRemoteConfigRuntime).toHaveBeenCalledWith({ workspacePath: "/workspace" })
+		expect(setRemoteConfigCoreIntegration).toHaveBeenCalledWith(undefined)
+		expect(getCurrentIntegration()).toBeUndefined()
+		expect(controller.postStateToWebview).toHaveBeenCalledOnce()
+	})
+})

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
@@ -37,6 +37,39 @@ async function withPublicationLock<T>(controller: object, operation: () => Promi
 	}
 }
 
+/**
+ * File cleanup is best-effort: a filesystem error (e.g. EACCES on the
+ * remote-config workspace) must not reject the refresh, or every session
+ * start — including for personal users with no org — fails with a raw fs
+ * error. State and integration clearing still proceed.
+ */
+async function clearMaterializedRuntimeBestEffort(workspacePath: string): Promise<void> {
+	try {
+		await clearMaterializedRemoteConfigRuntime({ workspacePath })
+	} catch (error) {
+		Logger.error("[RemoteConfig] Failed to remove materialized remote config files; continuing with state clear:", error)
+	}
+}
+
+/**
+ * Authoritative local clear (sign-out): runs under the same publication lock
+ * as refreshes so an in-flight refresh cannot interleave with the clear.
+ * Callers must also invalidate the refresh coordinator first so a refresh
+ * that already fetched under the old identity cannot republish afterward.
+ */
+export async function clearSdkRemoteConfig(
+	controller: Controller,
+	options: { workspacePath?: string; organizationId?: string } = {},
+): Promise<void> {
+	const workspacePath = await getRemoteConfigWorkspacePath(options.workspacePath)
+	await withPublicationLock(controller, async () => {
+		await clearMaterializedRuntimeBestEffort(workspacePath)
+		clearRemoteConfig(options.organizationId)
+		controller.setRemoteConfigAvailable(false)
+		await controller.setRemoteConfigCoreIntegration(undefined)
+	})
+}
+
 async function ensureGlobalRemoteConfigWorkspacePath(): Promise<string> {
 	const clineDir = process.env.CLINE_DIR || path.join(os.homedir(), ".cline")
 	const workspacePath = path.join(clineDir, "data", "remote-config-workspace")
@@ -93,7 +126,7 @@ export async function refreshSdkRemoteConfig(
 				if (!remoteConfig) {
 					await candidateIntegration?.dispose()
 					candidateIntegration = undefined
-					await clearMaterializedRemoteConfigRuntime({ workspacePath })
+					await clearMaterializedRuntimeBestEffort(workspacePath)
 					clearRemoteConfig()
 					await controller.setRemoteConfigCoreIntegration(undefined)
 					shouldPostState = true
@@ -138,7 +171,7 @@ export async function refreshSdkRemoteConfig(
 						return
 					}
 					controller.setRemoteConfigAvailable(controlPlane.isRemoteConfigAvailable())
-					await clearMaterializedRemoteConfigRuntime({ workspacePath })
+					await clearMaterializedRuntimeBestEffort(workspacePath)
 					clearRemoteConfig()
 					await controller.setRemoteConfigCoreIntegration(undefined)
 					shouldPostState = true

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
@@ -112,8 +112,15 @@ export async function refreshSdkRemoteConfig(
 					outcome = "superseded"
 					return
 				}
+				const publishedOrganizationId = candidateIntegration?.prepared.bundle?.metadata?.organizationId as
+					| string
+					| undefined
 				await controller.setRemoteConfigCoreIntegration(candidateIntegration)
 				candidateIntegration = undefined // Ownership transferred to the controller.
+				controller.stateManager.setGlobalState(
+					"lastManagedOrganizationId",
+					publishedOrganizationId ?? controller.authService.getActiveOrganizationId() ?? undefined,
+				)
 				shouldPostState = true
 				outcome = "applied"
 				configVersion = remoteConfig.version

--- a/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
+++ b/apps/vscode/src/core/storage/remote-config/sdk-refresh.ts
@@ -2,7 +2,9 @@ import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
 import { prepareRemoteConfigCoreIntegration } from "@cline/core"
+import { clearMaterializedRemoteConfigRuntime } from "@cline/shared"
 import { Controller } from "@/sdk/SdkController"
+import { telemetryService } from "@/services/telemetry"
 import { Logger } from "@/shared/services/Logger"
 import type { ConfiguredAPIKeys } from "@/shared/storage/state-keys"
 import { SdkRemoteConfigControlPlane } from "./sdk-control-plane"
@@ -11,6 +13,28 @@ import { applyRemoteConfig, clearRemoteConfig } from "./utils"
 export interface RefreshSdkRemoteConfigOptions {
 	workspacePath?: string
 	rootPath?: string
+	isCurrent?: () => boolean
+}
+
+const publicationTails = new WeakMap<object, Promise<void>>()
+
+async function withPublicationLock<T>(controller: object, operation: () => Promise<T>): Promise<T> {
+	const previous = publicationTails.get(controller) ?? Promise.resolve()
+	let release!: () => void
+	const current = new Promise<void>((resolve) => {
+		release = resolve
+	})
+	publicationTails.set(controller, current)
+
+	await previous
+	try {
+		return await operation()
+	} finally {
+		release()
+		if (publicationTails.get(controller) === current) {
+			publicationTails.delete(controller)
+		}
+	}
 }
 
 async function ensureGlobalRemoteConfigWorkspacePath(): Promise<string> {
@@ -28,43 +52,107 @@ async function getRemoteConfigWorkspacePath(workspacePath?: string): Promise<str
 	return ensureGlobalRemoteConfigWorkspacePath()
 }
 
-export async function refreshSdkRemoteConfig(controller: Controller, options: RefreshSdkRemoteConfigOptions = {}): Promise<void> {
+export async function refreshSdkRemoteConfig(
+	controller: Controller,
+	options: RefreshSdkRemoteConfigOptions = {},
+): Promise<boolean> {
 	const controlPlane = new SdkRemoteConfigControlPlane(controller)
 	const workspacePath = await getRemoteConfigWorkspacePath(options.workspacePath)
+	let candidateIntegration: Awaited<ReturnType<typeof prepareRemoteConfigCoreIntegration>> | undefined
+	let shouldPostState = false
+	let outcome: "applied" | "cleared" | "failed" | "superseded" = "failed"
+	let configVersion: string | undefined
+	const startedAt = Date.now()
+	const isCurrent = options.isCurrent ?? (() => true)
 
 	try {
-		const integration = await prepareRemoteConfigCoreIntegration({
-			workspacePath,
-			rootPath: options.rootPath,
-			controlPlane,
-			useCachedBundle: false,
-		})
-
-		const remoteConfig = controlPlane.getLastRemoteConfig()
-		if (!remoteConfig) {
-			clearRemoteConfig()
-			await controller.setRemoteConfigCoreIntegration(undefined)
-			await controller.postStateToWebview()
-			return
-		}
-
-		await controller.setRemoteConfigCoreIntegration(integration)
-
 		try {
-			const configuredKeys: ConfiguredAPIKeys = controlPlane.getLastConfiguredKeys()
-			await applyRemoteConfig(remoteConfig, configuredKeys, controller.mcpHub)
-		} catch (bridgeError) {
-			Logger.error("[RemoteConfig] SDK refresh succeeded but classic bridge application failed:", bridgeError)
+			candidateIntegration = await prepareRemoteConfigCoreIntegration({
+				workspacePath,
+				rootPath: options.rootPath,
+				controlPlane,
+				useCachedBundle: false,
+			})
+
+			if (!isCurrent()) {
+				await candidateIntegration.dispose()
+				outcome = "superseded"
+				return false
+			}
+
+			const remoteConfig = controlPlane.getLastRemoteConfig()
+			await withPublicationLock(controller, async () => {
+				if (!isCurrent()) {
+					await candidateIntegration?.dispose()
+					candidateIntegration = undefined
+					outcome = "superseded"
+					return
+				}
+				controller.setRemoteConfigAvailable(controlPlane.isRemoteConfigAvailable())
+
+				if (!remoteConfig) {
+					await candidateIntegration?.dispose()
+					candidateIntegration = undefined
+					await clearMaterializedRemoteConfigRuntime({ workspacePath })
+					clearRemoteConfig()
+					await controller.setRemoteConfigCoreIntegration(undefined)
+					shouldPostState = true
+					outcome = "cleared"
+					return
+				}
+
+				// Compatibility application and SDK publication are serialized. If this
+				// generation becomes stale during application, the newer generation runs
+				// next and is guaranteed to leave the final shared state authoritative.
+				const configuredKeys: ConfiguredAPIKeys = controlPlane.getLastConfiguredKeys()
+				await applyRemoteConfig(remoteConfig, configuredKeys, controller.mcpHub)
+				if (!isCurrent()) {
+					await candidateIntegration?.dispose()
+					candidateIntegration = undefined
+					outcome = "superseded"
+					return
+				}
+				await controller.setRemoteConfigCoreIntegration(candidateIntegration)
+				candidateIntegration = undefined // Ownership transferred to the controller.
+				shouldPostState = true
+				outcome = "applied"
+				configVersion = remoteConfig.version
+			})
+		} catch (error) {
+			if (candidateIntegration) {
+				await candidateIntegration.dispose().catch((disposeError) => {
+					Logger.error("[RemoteConfig] Failed to dispose unpublished SDK remote config integration:", disposeError)
+				})
+			}
+			if (controlPlane.wasExplicitNoConfig()) {
+				await withPublicationLock(controller, async () => {
+					if (!isCurrent()) {
+						outcome = "superseded"
+						return
+					}
+					controller.setRemoteConfigAvailable(controlPlane.isRemoteConfigAvailable())
+					await clearMaterializedRemoteConfigRuntime({ workspacePath })
+					clearRemoteConfig()
+					await controller.setRemoteConfigCoreIntegration(undefined)
+					shouldPostState = true
+					outcome = "cleared"
+				})
+			} else {
+				Logger.error("[RemoteConfig] Failed to refresh SDK remote config; keeping previous config:", error)
+				return false
+			}
 		}
 
-		await controller.postStateToWebview()
-	} catch (error) {
-		if (controlPlane.wasExplicitNoConfig()) {
-			clearRemoteConfig()
-			await controller.setRemoteConfigCoreIntegration(undefined)
+		if (shouldPostState) {
 			await controller.postStateToWebview()
-			return
 		}
-		Logger.error("[RemoteConfig] Failed to refresh SDK remote config; keeping previous config:", error)
+		return isCurrent()
+	} finally {
+		void telemetryService.captureRemoteConfigRefresh({
+			outcome,
+			durationMs: Date.now() - startedAt,
+			managed: Boolean(controller.authService.getActiveOrganizationId()),
+			configVersion,
+		})
 	}
 }

--- a/apps/vscode/src/core/storage/remote-config/utils.ts
+++ b/apps/vscode/src/core/storage/remote-config/utils.ts
@@ -14,6 +14,7 @@ import { isOpenTelemetryConfigValid, remoteConfigToOtelConfig } from "@/shared/s
 import { Logger } from "@/shared/services/Logger"
 import { syncWorker } from "@/shared/services/worker/sync"
 import { BlobStoreSettings } from "@/shared/storage"
+import { deleteRemoteConfigFromCache } from "../disk"
 import { StateManager } from "../StateManager"
 import { syncRemoteMcpServersToSettings } from "./syncRemoteMcpServers"
 
@@ -269,7 +270,7 @@ async function applyRemoteSyncQueueConfig(transformed: Partial<RemoteConfigField
 	}
 }
 
-export function clearRemoteConfig() {
+export function clearRemoteConfig(organizationId?: string) {
 	try {
 		const stateManager = StateManager.get()
 
@@ -279,9 +280,22 @@ export function clearRemoteConfig() {
 		stateManager.setGlobalState("remoteRulesToggles", {})
 		stateManager.setGlobalState("remoteWorkflowToggles", {})
 		stateManager.setGlobalState("remoteSkillsToggles", {})
+		stateManager.setGlobalState("lastManagedOrganizationId", undefined)
 
 		// clear secrets
 		stateManager.setSecret("remoteLiteLlmApiKey", undefined)
+
+		// The per-org disk cache holds the full config, including any
+		// enterprise blob-store secrets, and would otherwise resurrect the
+		// cleared policy via the offline fallback. Best-effort async removal.
+		// Sign-out deauths before clearing, so callers that know the org must
+		// pass it explicitly; otherwise fall back to the live lookup.
+		const cachedOrganizationId = organizationId ?? AuthService.getInstance().getActiveOrganizationId()
+		if (cachedOrganizationId) {
+			void deleteRemoteConfigFromCache(cachedOrganizationId).catch((err) =>
+				Logger.error("[REMOTE CONFIG] Failed to delete cached remote config", err),
+			)
+		}
 	} catch (err) {
 		Logger.error("[REMOTE CONFIG] Failed to clear remote config", err)
 	}

--- a/apps/vscode/src/sdk/SdkController.test.ts
+++ b/apps/vscode/src/sdk/SdkController.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+import { telemetryService } from "@/services/telemetry"
 import { isClineManagedProvider } from "@/shared/utils/cline"
+import { Controller as SdkController } from "./SdkController"
 import { resolveWorkspaceManagerPaths, resolveWorkspaceRootPath } from "./workspace-root"
 
 describe("isClineManagedProvider", () => {
@@ -18,6 +20,160 @@ describe("resolveWorkspaceRootPath", () => {
 
 	it("falls back to Desktop when no workspace folder is open", () => {
 		expect(resolveWorkspaceRootPath([], "/Users/tester/Desktop")).toBe("/Users/tester/Desktop")
+	})
+})
+
+vi.mock("@/services/telemetry", () => ({
+	telemetryService: {
+		captureRemoteConfigSessionGate: vi.fn(),
+	},
+}))
+
+describe("SDK remote-config coordination", () => {
+	it("keys refreshes by the current user and organization", async () => {
+		const refresh = vi.fn().mockResolvedValue(true)
+		const controller = {
+			authService: {
+				getInfo: () => ({ user: { uid: "user-1" } }),
+				getActiveOrganizationId: () => "org-1",
+			},
+			remoteConfigRefreshCoordinator: { refresh },
+		}
+
+		await SdkController.prototype.refreshRemoteConfig.call(controller as never)
+
+		expect(refresh).toHaveBeenCalledWith("user-1:org-1")
+	})
+
+	it("uses a stable signed-out identity so startup refresh can settle", async () => {
+		const refresh = vi.fn().mockResolvedValue(true)
+		const controller = {
+			authService: {
+				getInfo: () => ({}),
+				getActiveOrganizationId: () => null,
+			},
+			remoteConfigRefreshCoordinator: { refresh },
+		}
+
+		await SdkController.prototype.refreshRemoteConfig.call(controller as never)
+
+		expect(refresh).toHaveBeenCalledWith("signed-out:no-org")
+	})
+
+	it("refreshes remote config after login before posting authenticated state", async () => {
+		const events: string[] = []
+		const controller = {
+			authService: { handleAuthCallback: vi.fn(async () => events.push("auth")) },
+			refreshRemoteConfig: vi.fn(async () => {
+				events.push("refresh")
+				return true
+			}),
+			postStateToWebview: vi.fn(async () => events.push("post")),
+		}
+
+		await SdkController.prototype.handleAuthCallback.call(controller as never, "token", "cline")
+
+		expect(events).toEqual(["auth", "refresh", "post"])
+	})
+
+	it("rematerializes policy and ends the active session after a managed toggle", async () => {
+		const events: string[] = []
+		const controller = {
+			refreshRemoteConfig: vi.fn(async () => {
+				events.push("refresh")
+				return true
+			}),
+			sessions: {
+				endActiveSession: vi.fn(async () => {
+					events.push("end")
+				}),
+			},
+			postStateToWebview: vi.fn(async () => events.push("post")),
+		}
+
+		await SdkController.prototype.rematerializeRemoteConfig.call(controller as never)
+
+		expect(events).toEqual(["refresh", "end", "post"])
+		expect(controller.sessions.endActiveSession).toHaveBeenCalledWith("remoteConfigToggle", { awaitStop: true })
+	})
+
+	it("allows the current organization to start with its last known-good policy after a transient failure", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			refreshRemoteConfig: vi.fn().mockResolvedValue(false),
+			authService: { getActiveOrganizationId: () => "org-current" },
+			remoteConfigBundle: { metadata: { organizationId: "org-current" } },
+		}
+
+		await expect(
+			SdkController.prototype["ensureRemoteConfigForSessionStart"].call(controller as never),
+		).resolves.toBeUndefined()
+		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "last_known_good", managed: true }),
+		)
+	})
+
+	it("blocks session start when current organization policy cannot be verified", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			refreshRemoteConfig: vi.fn().mockResolvedValue(false),
+			authService: { getActiveOrganizationId: () => "org-new" },
+			remoteConfigBundle: { metadata: { organizationId: "org-old" } },
+		}
+
+		await expect(SdkController.prototype["ensureRemoteConfigForSessionStart"].call(controller as never)).rejects.toThrow(
+			"Could not verify organization policy",
+		)
+		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "blocked", managed: true }),
+		)
+	})
+
+	it("does not enter task startup until initial remote config is ready", async () => {
+		let finishPolicyCheck!: () => void
+		const policyReady = new Promise<void>((resolve) => {
+			finishPolicyCheck = resolve
+		})
+		const events: string[] = []
+		const initTask = vi.fn(async () => {
+			events.push("task")
+			return "task-id"
+		})
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn(async () => {
+				await policyReady
+				events.push("policy")
+			}),
+			turnStateTracker: { set: vi.fn() },
+			messageTranslatorState: { clearTurnOutcome: vi.fn() },
+			taskStart: { initTask },
+		}
+
+		const taskPromise = SdkController.prototype.initTask.call(controller as never, "start immediately")
+		await Promise.resolve()
+		expect(initTask).not.toHaveBeenCalled()
+		expect(controller.turnStateTracker.set).not.toHaveBeenCalled()
+
+		finishPolicyCheck()
+		const taskId = await taskPromise
+
+		expect(taskId).toBe("task-id")
+		expect(events).toEqual(["policy", "task"])
+		expect(initTask).toHaveBeenCalledWith("start immediately", undefined, undefined, undefined, undefined)
+	})
+
+	it("waits for initial remote config before resuming an existing task", async () => {
+		const events: string[] = []
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn(async () => events.push("policy")),
+			turnStateTracker: { set: vi.fn() },
+			messageTranslatorState: { clearTurnOutcome: vi.fn() },
+			taskStart: { reinitExistingTaskFromId: vi.fn(async () => events.push("resume")) },
+		}
+
+		await SdkController.prototype.reinitExistingTaskFromId.call(controller as never, "task-id")
+
+		expect(events).toEqual(["policy", "resume"])
 	})
 })
 

--- a/apps/vscode/src/sdk/SdkController.test.ts
+++ b/apps/vscode/src/sdk/SdkController.test.ts
@@ -29,7 +29,40 @@ vi.mock("@/services/telemetry", () => ({
 	},
 }))
 
+const { buildBaseStateMock } = vi.hoisted(() => ({
+	buildBaseStateMock: vi.fn(async () => ({ taskHistory: [] })),
+}))
+vi.mock("@core/controller/state/getStateToPostToWebview", () => ({
+	getStateToPostToWebview: buildBaseStateMock,
+}))
+
 describe("SDK remote-config coordination", () => {
+	it("posts the current remote-config revision to the webview", async () => {
+		const controller = {
+			stateManager: {
+				getGlobalSettingsKey: () => undefined,
+				getRemoteConfigSettings: () => ({}),
+				setGlobalState: vi.fn(),
+			},
+			backgroundCommandRunning: false,
+			backgroundCommandTaskId: undefined,
+			foregroundCommands: { isRunning: false },
+			isRemoteConfigAvailable: true,
+			currentRemoteConfigRevision: 7,
+			ensureWorkspaceManager: async () => undefined,
+			taskHistory: { listHistory: async () => [] },
+			sessions: { getActiveSession: () => undefined },
+			turnStateTracker: { get: () => undefined },
+			messageTranslatorState: { getMinter: () => ({ epoch: 1, nextSeq: () => 1 }) },
+		}
+
+		await SdkController.prototype.getStateToPostToWebview.call(controller as never)
+
+		expect(buildBaseStateMock).toHaveBeenCalledWith(
+			expect.objectContaining({ isRemoteConfigAvailable: true, currentRemoteConfigRevision: 7 }),
+		)
+	})
+
 	it("keys refreshes by the current user and organization", async () => {
 		const refresh = vi.fn().mockResolvedValue(true)
 		const controller = {
@@ -110,6 +143,40 @@ describe("SDK remote-config coordination", () => {
 		).resolves.toBeUndefined()
 		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
 			expect.objectContaining({ outcome: "last_known_good", managed: true }),
+		)
+	})
+
+	it("does not block session start for users without an active organization when refresh fails", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			refreshRemoteConfig: vi.fn().mockResolvedValue(false),
+			authService: { getActiveOrganizationId: () => null },
+			stateManager: { getGlobalStateKey: () => undefined },
+			remoteConfigBundle: undefined,
+		}
+
+		await expect(
+			SdkController.prototype["ensureRemoteConfigForSessionStart"].call(controller as never),
+		).resolves.toBeUndefined()
+		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "unmanaged", managed: false }),
+		)
+	})
+
+	it("blocks session start when the install was managed but the identity cannot be resolved", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			refreshRemoteConfig: vi.fn().mockResolvedValue(false),
+			authService: { getActiveOrganizationId: () => null },
+			stateManager: { getGlobalStateKey: () => "org-previous" },
+			remoteConfigBundle: undefined,
+		}
+
+		await expect(SdkController.prototype["ensureRemoteConfigForSessionStart"].call(controller as never)).rejects.toThrow(
+			"Could not verify organization policy",
+		)
+		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "blocked", managed: true }),
 		)
 	})
 

--- a/apps/vscode/src/sdk/SdkController.test.ts
+++ b/apps/vscode/src/sdk/SdkController.test.ts
@@ -75,7 +75,7 @@ describe("SDK remote-config coordination", () => {
 
 		await SdkController.prototype.refreshRemoteConfig.call(controller as never)
 
-		expect(refresh).toHaveBeenCalledWith("user-1:org-1")
+		expect(refresh).toHaveBeenCalledWith("user-1:org-1", {})
 	})
 
 	it("uses a stable signed-out identity so startup refresh can settle", async () => {
@@ -90,7 +90,7 @@ describe("SDK remote-config coordination", () => {
 
 		await SdkController.prototype.refreshRemoteConfig.call(controller as never)
 
-		expect(refresh).toHaveBeenCalledWith("signed-out:no-org")
+		expect(refresh).toHaveBeenCalledWith("signed-out:no-org", {})
 	})
 
 	it("refreshes remote config after login before posting authenticated state", async () => {
@@ -150,6 +150,23 @@ describe("SDK remote-config coordination", () => {
 		const controller = {
 			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
 			refreshRemoteConfig: vi.fn().mockResolvedValue(false),
+			authService: { getActiveOrganizationId: () => null },
+			stateManager: { getGlobalStateKey: () => undefined },
+			remoteConfigBundle: undefined,
+		}
+
+		await expect(
+			SdkController.prototype["ensureRemoteConfigForSessionStart"].call(controller as never),
+		).resolves.toBeUndefined()
+		expect(telemetryService.captureRemoteConfigSessionGate).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "unmanaged", managed: false }),
+		)
+	})
+
+	it("does not block unmanaged session start when the refresh rejects instead of returning false", async () => {
+		const controller = {
+			waitForInitialRemoteConfig: vi.fn().mockResolvedValue(undefined),
+			refreshRemoteConfig: vi.fn().mockRejectedValue(new Error("EACCES: permission denied")),
 			authService: { getActiveOrganizationId: () => null },
 			stateManager: { getGlobalStateKey: () => undefined },
 			remoteConfigBundle: undefined,

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -66,6 +66,7 @@ import {
 	type ProviderFailureTelemetry,
 	ProviderFailureTelemetryTurnGate,
 } from "./provider-failure-telemetry"
+import { RemoteConfigRefreshCoordinator } from "./remote-config-refresh-coordinator"
 import {
 	findVisibleCheckpointUserMessageByRun,
 	getCheckpointRunCountForMessage,
@@ -232,6 +233,15 @@ export class Controller {
 	// Timer for periodic remote config fetching (enterprise policy enforcement)
 	private remoteConfigTimer?: NodeJS.Timeout
 	private remoteConfigCoreIntegration?: PreparedRemoteConfigCoreIntegration
+	private remoteConfigRevision = 0
+	private remoteConfigAvailable = false
+	private readonly remoteConfigRefreshCoordinator = new RemoteConfigRefreshCoordinator<boolean>((isCurrent) =>
+		this.performRemoteConfigRefresh(isCurrent),
+	)
+	private resolveInitialRemoteConfigReady!: () => void
+	private readonly initialRemoteConfigReady = new Promise<void>((resolve) => {
+		this.resolveInitialRemoteConfigReady = resolve
+	})
 
 	// Watches user-instruction files (workflows/skills/rules), including those
 	// materialized by remote config under `.cline/remote-config/`. Used to expand
@@ -256,6 +266,14 @@ export class Controller {
 
 	get remoteConfigBundle(): RemoteConfigBundle | undefined {
 		return this.remoteConfigCoreIntegration?.prepared.bundle
+	}
+
+	get isRemoteConfigAvailable(): boolean {
+		return this.remoteConfigAvailable
+	}
+
+	get currentRemoteConfigRevision(): number {
+		return this.remoteConfigRevision
 	}
 
 	constructor(readonly context: ClineExtensionContext) {
@@ -371,6 +389,7 @@ export class Controller {
 				})
 			},
 			onDidBecomeIdle: () => this.handleSessionBecameIdle(),
+			beforeStartSession: () => this.ensureRemoteConfigForSessionStart(),
 			getRemoteConfigIntegration: () => this.remoteConfigCoreIntegration,
 			foregroundCommands: this.foregroundCommands,
 			getTerminalManager: () => {
@@ -542,7 +561,7 @@ export class Controller {
 			},
 			runExclusive: (operation) => this.sessionRebuilds.runExclusive(operation),
 			getTask: () => this.task,
-			createTempSessionHost: () => VscodeSessionHost.create({ mcpHub: this.mcpHub }),
+			createTempSessionHost: () => this.createRemoteConfigAwareSessionHost(),
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
 			loadInitialMessages: (sessionHost, taskId) => this.sessionHistory.loadInitialMessages(sessionHost, taskId),
 			buildStartSessionInput,
@@ -601,7 +620,7 @@ export class Controller {
 			onAskResponse: (text, images, files) => this.askResponse(text, images, files),
 			onCancelTask: () => this.cancelTask(),
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
-			createTempSessionHost: () => VscodeSessionHost.create({ mcpHub: this.mcpHub }),
+			createTempSessionHost: () => this.createRemoteConfigAwareSessionHost(),
 			loadInitialMessages: (reader, taskId) => this.sessionHistory.loadInitialMessages(reader, taskId),
 			resolveContextMentions: (text) => this.resolveContextMentions(text),
 			isClineManagedProviderActive: () => this.isClineManagedProviderActive(),
@@ -617,7 +636,7 @@ export class Controller {
 			taskHistory: this.taskHistory,
 			sessionConfigBuilder: this.sessionConfigBuilder,
 			getDisplayedTaskId: () => this.task?.taskId,
-			createTempSessionHost: () => VscodeSessionHost.create({ mcpHub: this.mcpHub }),
+			createTempSessionHost: () => this.createRemoteConfigAwareSessionHost(),
 			loadInitialMessages: (reader, taskId) => this.sessionHistory.loadInitialMessages(reader, taskId),
 			getWorkspaceRoot: () => this.getWorkspaceRoot(),
 			postStateToWebview: () => this.postStateToWebview(),
@@ -656,11 +675,19 @@ export class Controller {
 		// organization and apply org-level policies.
 		this.authService
 			.restoreRefreshTokenAndRetrieveAuthInfo()
-			.then(() => {
+			.then(async () => {
+				try {
+					await this.refreshRemoteConfig()
+				} catch (err) {
+					Logger.error("[SdkController] Initial remote config refresh failed:", err)
+				}
 				this.startRemoteConfigTimer()
 			})
 			.catch((err) => {
 				Logger.error("[SdkController] Failed to restore auth state:", err)
+			})
+			.finally(() => {
+				this.resolveInitialRemoteConfigReady()
 			})
 
 		Logger.log("[SdkController] Initialized with SDK adapter layer + gRPC bridge + auth services")
@@ -743,27 +770,96 @@ export class Controller {
 	 * MCP server management, OpenTelemetry, etc.).
 	 */
 	private startRemoteConfigTimer(): void {
-		// Initial fetch
-		this.refreshRemoteConfig().catch((err) => Logger.error("[SdkController] Initial remote config refresh failed:", err))
 		// Set up 1-hour interval
 		this.remoteConfigTimer = setInterval(() => {
 			this.refreshRemoteConfig().catch((err) => Logger.error("[SdkController] Remote config timer failed:", err))
 		}, 3600000) // 1 hour
 	}
 
-	private async refreshRemoteConfig(): Promise<void> {
-		await refreshSdkRemoteConfig(this, {
-			workspacePath: await this.getRemoteConfigWorkspacePath(),
+	async refreshRemoteConfig(): Promise<boolean> {
+		const userId = this.authService.getInfo().user?.uid ?? "signed-out"
+		const organizationId = this.authService.getActiveOrganizationId() ?? "no-org"
+		return this.remoteConfigRefreshCoordinator.refresh(`${userId}:${organizationId}`)
+	}
+
+	async waitForInitialRemoteConfig(): Promise<void> {
+		await this.initialRemoteConfigReady
+	}
+
+	async rematerializeRemoteConfig(): Promise<void> {
+		const refreshed = await this.refreshRemoteConfig()
+		if (!refreshed) {
+			throw new Error("Could not apply managed configuration change. Check your connection and try again.")
+		}
+		await this.sessions.endActiveSession("remoteConfigToggle", { awaitStop: true })
+		await this.postStateToWebview()
+	}
+
+	private async ensureRemoteConfigForSessionStart(): Promise<void> {
+		const startedAt = Date.now()
+		await this.waitForInitialRemoteConfig()
+		const refreshed = await this.refreshRemoteConfig()
+		const activeOrganizationId = this.authService.getActiveOrganizationId()
+		if (refreshed) {
+			void telemetryService.captureRemoteConfigSessionGate({
+				outcome: "refreshed",
+				durationMs: Date.now() - startedAt,
+				managed: Boolean(activeOrganizationId),
+			})
+			return
+		}
+
+		const bundleOrganizationId = this.remoteConfigBundle?.metadata?.organizationId
+		if (activeOrganizationId && bundleOrganizationId === activeOrganizationId) {
+			Logger.warn("[SdkController] Remote config refresh failed; starting with last known-good organization policy")
+			void telemetryService.captureRemoteConfigSessionGate({
+				outcome: "last_known_good",
+				durationMs: Date.now() - startedAt,
+				managed: true,
+			})
+			return
+		}
+		void telemetryService.captureRemoteConfigSessionGate({
+			outcome: "blocked",
+			durationMs: Date.now() - startedAt,
+			managed: Boolean(activeOrganizationId),
 		})
+		throw new Error("Could not verify organization policy. Check your connection and try again.")
+	}
+
+	private createRemoteConfigAwareSessionHost(): Promise<VscodeSessionHost> {
+		return VscodeSessionHost.create({
+			mcpHub: this.mcpHub,
+			beforeStartSession: () => this.ensureRemoteConfigForSessionStart(),
+			getRemoteConfigIntegration: () => this.remoteConfigCoreIntegration,
+		})
+	}
+
+	private async performRemoteConfigRefresh(isCurrent: () => boolean): Promise<boolean> {
+		const refreshed = await refreshSdkRemoteConfig(this, {
+			workspacePath: await this.getRemoteConfigWorkspacePath(),
+			isCurrent,
+		})
+		if (!isCurrent()) {
+			return false
+		}
 		// Remote config may have materialized new workflows/skills/rules under
 		// `.cline/remote-config/`. Refresh the watcher so slash-command expansion
 		// sees them without waiting on filesystem events.
 		await this.refreshUserInstructionWatchers()
+		return refreshed
+	}
+
+	setRemoteConfigAvailable(available: boolean): void {
+		this.remoteConfigAvailable = available
 	}
 
 	async setRemoteConfigCoreIntegration(integration: PreparedRemoteConfigCoreIntegration | undefined): Promise<void> {
 		const previous = this.remoteConfigCoreIntegration
 		this.remoteConfigCoreIntegration = integration
+		if (previous !== integration) {
+			this.remoteConfigRevision += 1
+		}
 		if (previous && previous !== integration) {
 			try {
 				await previous.dispose()
@@ -1257,10 +1353,7 @@ export class Controller {
 		historyItem?: HistoryItem,
 		taskSettings?: Partial<Settings>,
 	): Promise<string | undefined> {
-		// Fire-and-forget: ensure we have the latest remote config (enterprise
-		// policies like allowedMCPServers, provider lockdown, etc.) without
-		// blocking the UI.
-		this.refreshRemoteConfig().catch((err) => Logger.error("[SdkController] Remote config refresh before task failed:", err))
+		await this.waitForInitialRemoteConfig()
 		// A new task is starting — the agent is about to stream.
 		this.turnStateTracker.set("streaming")
 		// Clear the previous turn's completion signal so this turn's phase is computed fresh.
@@ -1269,6 +1362,7 @@ export class Controller {
 	}
 
 	async reinitExistingTaskFromId(taskId: string): Promise<void> {
+		await this.waitForInitialRemoteConfig()
 		this.turnStateTracker.set("streaming")
 		this.messageTranslatorState.clearTurnOutcome()
 		await this.taskStart.reinitExistingTaskFromId(taskId)
@@ -1417,7 +1511,7 @@ export class Controller {
 		const sourceSessionId = activeSession?.sessionId ?? currentTask.taskId
 		let sdkMessages: SdkUserMessage[]
 		let tempHost: VscodeSessionHost | undefined
-		const sessionHost = activeSession?.sdkHost ?? (tempHost = await VscodeSessionHost.create({ mcpHub: this.mcpHub }))
+		const sessionHost = activeSession?.sdkHost ?? (tempHost = await this.createRemoteConfigAwareSessionHost())
 		try {
 			sdkMessages = (await sessionHost.readMessages(sourceSessionId)) as SdkUserMessage[]
 			const sdkTargetIndex = findSdkUserMessageIndexByOrdinal(sdkMessages, userOrdinal)
@@ -1638,7 +1732,7 @@ export class Controller {
 		// After a window reload the latest task is shown from history without a
 		// live session, so fall back to a temporary host for the comparison.
 		let tempHost: VscodeSessionHost | undefined
-		const sessionHost = activeSession?.sdkHost ?? (tempHost = await VscodeSessionHost.create({ mcpHub: this.mcpHub }))
+		const sessionHost = activeSession?.sdkHost ?? (tempHost = await this.createRemoteConfigAwareSessionHost())
 		try {
 			if (!sessionHost.compareCheckpoint) {
 				throw new Error("This session host does not support checkpoint comparison")
@@ -2088,6 +2182,7 @@ export class Controller {
 				backgroundCommandRunning: this.backgroundCommandRunning,
 				backgroundCommandTaskId: this.backgroundCommandTaskId,
 				foregroundCommandRunning: this.foregroundCommands.isRunning,
+				isRemoteConfigAvailable: this.isRemoteConfigAvailable,
 				// Without this the webview always receives workspaceRoots: [] on the
 				// SDK path (classic Controller exposes a public workspaceManager;
 				// SdkController builds one lazily). The task-header working-directory

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -809,8 +809,31 @@ export class Controller {
 			return
 		}
 
+		if (!activeOrganizationId) {
+			if (this.stateManager.getGlobalStateKey("lastManagedOrganizationId")) {
+				// This install last ran under organization policy, but the current
+				// identity could not be resolved (refresh failed and no org was
+				// restored — e.g. the API is unreachable). Fail closed rather than
+				// starting an unpoliced session.
+				void telemetryService.captureRemoteConfigSessionGate({
+					outcome: "blocked",
+					durationMs: Date.now() - startedAt,
+					managed: true,
+				})
+				throw new Error("Could not verify organization policy. Check your connection and try again.")
+			}
+			// No organization policy applies to personal or signed-out use; a
+			// failed refresh must not block local work.
+			void telemetryService.captureRemoteConfigSessionGate({
+				outcome: "unmanaged",
+				durationMs: Date.now() - startedAt,
+				managed: false,
+			})
+			return
+		}
+
 		const bundleOrganizationId = this.remoteConfigBundle?.metadata?.organizationId
-		if (activeOrganizationId && bundleOrganizationId === activeOrganizationId) {
+		if (bundleOrganizationId === activeOrganizationId) {
 			Logger.warn("[SdkController] Remote config refresh failed; starting with last known-good organization policy")
 			void telemetryService.captureRemoteConfigSessionGate({
 				outcome: "last_known_good",
@@ -822,7 +845,7 @@ export class Controller {
 		void telemetryService.captureRemoteConfigSessionGate({
 			outcome: "blocked",
 			durationMs: Date.now() - startedAt,
-			managed: Boolean(activeOrganizationId),
+			managed: true,
 		})
 		throw new Error("Could not verify organization policy. Check your connection and try again.")
 	}
@@ -1854,9 +1877,12 @@ export class Controller {
 
 	async handleSignOut(): Promise<void> {
 		const sessionProviderId = this.getSessionProviderId() ?? this.getActiveProviderId()
+		// Capture before deauth nulls the auth info, so the per-org config cache
+		// (which can hold enterprise secrets) is actually deleted on sign-out.
+		const organizationId = this.authService.getActiveOrganizationId() ?? undefined
 		await this.taskControl.cancelClineTaskOnSignOut(isClineManagedProvider(sessionProviderId))
 		await this.authService.handleDeauth(LogoutReason.USER_INITIATED)
-		clearRemoteConfig()
+		clearRemoteConfig(organizationId)
 		await this.setRemoteConfigCoreIntegration(undefined)
 		await this.postStateToWebview()
 	}
@@ -2183,6 +2209,7 @@ export class Controller {
 				backgroundCommandTaskId: this.backgroundCommandTaskId,
 				foregroundCommandRunning: this.foregroundCommands.isRunning,
 				isRemoteConfigAvailable: this.isRemoteConfigAvailable,
+				currentRemoteConfigRevision: this.currentRemoteConfigRevision,
 				// Without this the webview always receives workspaceRoots: [] on the
 				// SDK path (classic Controller exposes a public workspaceManager;
 				// SdkController builds one lazily). The task-header working-directory

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -33,8 +33,7 @@ import type { TelemetrySetting } from "@shared/TelemetrySetting"
 import type { ClineCheckpointRestore } from "@shared/WebviewMessage"
 import { parseMentions } from "@/core/mentions"
 import { ensureMcpServersDirectoryExists } from "@/core/storage/disk"
-import { refreshSdkRemoteConfig } from "@/core/storage/remote-config/sdk-refresh"
-import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
+import { clearSdkRemoteConfig, refreshSdkRemoteConfig } from "@/core/storage/remote-config/sdk-refresh"
 import { StateManager } from "@/core/storage/StateManager"
 import { WorkspaceRootManager } from "@/core/workspace/WorkspaceRootManager"
 import { HostProvider } from "@/hosts/host-provider"
@@ -776,10 +775,10 @@ export class Controller {
 		}, 3600000) // 1 hour
 	}
 
-	async refreshRemoteConfig(): Promise<boolean> {
+	async refreshRemoteConfig(options: { force?: boolean } = {}): Promise<boolean> {
 		const userId = this.authService.getInfo().user?.uid ?? "signed-out"
 		const organizationId = this.authService.getActiveOrganizationId() ?? "no-org"
-		return this.remoteConfigRefreshCoordinator.refresh(`${userId}:${organizationId}`)
+		return this.remoteConfigRefreshCoordinator.refresh(`${userId}:${organizationId}`, options)
 	}
 
 	async waitForInitialRemoteConfig(): Promise<void> {
@@ -787,7 +786,10 @@ export class Controller {
 	}
 
 	async rematerializeRemoteConfig(): Promise<void> {
-		const refreshed = await this.refreshRemoteConfig()
+		// force: this runs right after a toggle/opt-out mutation; coalescing onto
+		// an in-flight refresh that sampled the pre-mutation state would report
+		// success while applying the old configuration.
+		const refreshed = await this.refreshRemoteConfig({ force: true })
 		if (!refreshed) {
 			throw new Error("Could not apply managed configuration change. Check your connection and try again.")
 		}
@@ -798,7 +800,16 @@ export class Controller {
 	private async ensureRemoteConfigForSessionStart(): Promise<void> {
 		const startedAt = Date.now()
 		await this.waitForInitialRemoteConfig()
-		const refreshed = await this.refreshRemoteConfig()
+		let refreshed = false
+		try {
+			refreshed = await this.refreshRemoteConfig()
+		} catch (error) {
+			// A rejected refresh must degrade to the same fallback logic as a
+			// false return: otherwise a filesystem error on the clear path (e.g.
+			// EACCES on the remote-config workspace) blocks even unmanaged users
+			// from starting sessions with a raw fs error.
+			Logger.error("[SdkController] Remote config refresh threw during session gate:", error)
+		}
 		const activeOrganizationId = this.authService.getActiveOrganizationId()
 		if (refreshed) {
 			void telemetryService.captureRemoteConfigSessionGate({
@@ -1882,8 +1893,15 @@ export class Controller {
 		const organizationId = this.authService.getActiveOrganizationId() ?? undefined
 		await this.taskControl.cancelClineTaskOnSignOut(isClineManagedProvider(sessionProviderId))
 		await this.authService.handleDeauth(LogoutReason.USER_INITIATED)
-		clearRemoteConfig(organizationId)
-		await this.setRemoteConfigCoreIntegration(undefined)
+		// Invalidate BEFORE clearing: a refresh that already fetched under the
+		// signed-in identity must not republish the policy (and re-create the
+		// secret-bearing caches) after the clear. The clear itself runs under the
+		// same publication lock refreshes use, so it cannot interleave either.
+		this.remoteConfigRefreshCoordinator.invalidate()
+		await clearSdkRemoteConfig(this, {
+			workspacePath: await this.getRemoteConfigWorkspacePath(),
+			organizationId,
+		})
 		await this.postStateToWebview()
 	}
 

--- a/apps/vscode/src/sdk/account-service.ts
+++ b/apps/vscode/src/sdk/account-service.ts
@@ -9,6 +9,7 @@ import type {
 	OrganizationUsageTransaction,
 	PaymentTransaction,
 	UsageTransaction,
+	UserRemoteConfigDiscoveryResponse,
 	UserResponse,
 } from "@shared/ClineAccount"
 import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios"
@@ -48,10 +49,14 @@ export class ClineAccountService {
 	 * Helper function to make authenticated requests to the Cline API.
 	 * Uses the SDK-backed AuthService for token management.
 	 */
-	private async authenticatedRequest<T>(endpoint: string, config: AxiosRequestConfig = {}): Promise<T> {
+	private async authenticatedRequest<T>(
+		endpoint: string,
+		config: AxiosRequestConfig = {},
+		options?: { allowNullData?: boolean; authToken?: string },
+	): Promise<T> {
 		const url = new URL(endpoint, this.baseUrl).toString()
 		// IMPORTANT: Prefixed with 'workos:' so backend can route verification to WorkOS provider
-		const clineAccountAuthToken = await this._authService.getAuthToken()
+		const clineAccountAuthToken = options?.authToken ?? (await this._authService.getAuthToken())
 		if (!clineAccountAuthToken) {
 			throw new Error("No Cline account auth token found")
 		}
@@ -65,7 +70,7 @@ export class ClineAccountService {
 			},
 			...getAxiosSettings(),
 		}
-		const response: AxiosResponse<{ data?: T; error: string; success: boolean }> = await axios.request({
+		const response: AxiosResponse<{ data?: T | null; error: string; success: boolean }> = await axios.request({
 			url,
 			method: "GET",
 			...requestConfig,
@@ -74,16 +79,21 @@ export class ClineAccountService {
 		if (status < 200 || status >= 300) {
 			throw new Error(`Request to ${endpoint} failed with status ${status}`)
 		}
-		if (response.statusText !== "No Content" && (!response.data || !response.data.data)) {
-			throw new Error(`Invalid response from ${endpoint} API`)
-		}
 		if (typeof response.data === "object" && !response.data.success) {
 			throw new Error(`API error: ${response.data.error}`)
 		}
 		if (response.statusText === "No Content") {
 			return {} as T
 		}
-		return response.data.data as T
+
+		const payload = response.data?.data
+		if (!response.data || typeof payload === "undefined") {
+			throw new Error(`Invalid response from ${endpoint} API`)
+		}
+		if (payload === null && !options?.allowNullData) {
+			throw new Error(`Invalid response from ${endpoint} API`)
+		}
+		return payload as T
 	}
 
 	/**
@@ -210,6 +220,20 @@ export class ClineAccountService {
 			Logger.error("Failed to fetch organization transactions (RPC):", error)
 			return undefined
 		}
+	}
+
+	async fetchUserRemoteConfig(): Promise<UserRemoteConfigDiscoveryResponse | undefined> {
+		const token = await this._authService.getAuthToken()
+		if (!token) {
+			return undefined
+		}
+
+		const data = await this.authenticatedRequest<UserRemoteConfigDiscoveryResponse | null>(
+			CLINE_API_ENDPOINT.USER_REMOTE_CONFIG,
+			{},
+			{ allowNullData: true, authToken: token },
+		)
+		return data ?? undefined
 	}
 
 	/**

--- a/apps/vscode/src/sdk/account-service.ts
+++ b/apps/vscode/src/sdk/account-service.ts
@@ -222,18 +222,23 @@ export class ClineAccountService {
 		}
 	}
 
-	async fetchUserRemoteConfig(): Promise<UserRemoteConfigDiscoveryResponse | undefined> {
+	/**
+	 * Returns undefined when no auth token is available (signed out or token
+	 * refresh failed), and null when the server answered but distributes no
+	 * remote config for this user. Callers rely on the distinction: only the
+	 * server's answer may be treated as "explicitly no config".
+	 */
+	async fetchUserRemoteConfig(): Promise<UserRemoteConfigDiscoveryResponse | null | undefined> {
 		const token = await this._authService.getAuthToken()
 		if (!token) {
 			return undefined
 		}
 
-		const data = await this.authenticatedRequest<UserRemoteConfigDiscoveryResponse | null>(
+		return await this.authenticatedRequest<UserRemoteConfigDiscoveryResponse | null>(
 			CLINE_API_ENDPOINT.USER_REMOTE_CONFIG,
 			{},
 			{ allowNullData: true, authToken: token },
 		)
-		return data ?? undefined
 	}
 
 	/**

--- a/apps/vscode/src/sdk/remote-config-refresh-coordinator.test.ts
+++ b/apps/vscode/src/sdk/remote-config-refresh-coordinator.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest"
+import { RemoteConfigRefreshCoordinator } from "./remote-config-refresh-coordinator"
+
+function deferred() {
+	let resolve!: () => void
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+describe("RemoteConfigRefreshCoordinator", () => {
+	it("coalesces concurrent refreshes for the same identity", async () => {
+		const pending = deferred()
+		const performRefresh = vi.fn(() => pending.promise)
+		const coordinator = new RemoteConfigRefreshCoordinator(performRefresh)
+
+		const timerRefresh = coordinator.refresh("user:org")
+		const manualRefresh = coordinator.refresh("user:org")
+
+		expect(manualRefresh).toBe(timerRefresh)
+		expect(performRefresh).toHaveBeenCalledOnce()
+		pending.resolve()
+		await timerRefresh
+	})
+
+	it("supersedes an older refresh when account identity changes", async () => {
+		const checks: (() => boolean)[] = []
+		const pending = [deferred(), deferred()]
+		const performRefresh = vi.fn((isCurrent: () => boolean) => {
+			checks.push(isCurrent)
+			return pending[checks.length - 1].promise
+		})
+		const coordinator = new RemoteConfigRefreshCoordinator(performRefresh)
+
+		const oldAccountRefresh = coordinator.refresh("user-a:org-a")
+		const newAccountRefresh = coordinator.refresh("user-b:org-b")
+
+		expect(performRefresh).toHaveBeenCalledTimes(2)
+		expect(checks[0]()).toBe(false)
+		expect(checks[1]()).toBe(true)
+		pending[1].resolve()
+		await newAccountRefresh
+		pending[0].resolve()
+		await oldAccountRefresh
+	})
+
+	it("starts a new refresh after the current one settles", async () => {
+		const performRefresh = vi.fn().mockResolvedValue(undefined)
+		const coordinator = new RemoteConfigRefreshCoordinator(performRefresh)
+
+		await coordinator.refresh("user:org")
+		await coordinator.refresh("user:org")
+
+		expect(performRefresh).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/vscode/src/sdk/remote-config-refresh-coordinator.test.ts
+++ b/apps/vscode/src/sdk/remote-config-refresh-coordinator.test.ts
@@ -54,4 +54,45 @@ describe("RemoteConfigRefreshCoordinator", () => {
 
 		expect(performRefresh).toHaveBeenCalledTimes(2)
 	})
+
+	it("forces a fresh run instead of coalescing when refresh inputs were mutated", async () => {
+		const checks: (() => boolean)[] = []
+		const pending = [deferred(), deferred()]
+		const performRefresh = vi.fn((isCurrent: () => boolean) => {
+			checks.push(isCurrent)
+			return pending[checks.length - 1].promise
+		})
+		const coordinator = new RemoteConfigRefreshCoordinator(performRefresh)
+
+		const staleRefresh = coordinator.refresh("user:org")
+		const forcedRefresh = coordinator.refresh("user:org", { force: true })
+
+		expect(forcedRefresh).not.toBe(staleRefresh)
+		expect(performRefresh).toHaveBeenCalledTimes(2)
+		expect(checks[0]()).toBe(false)
+		expect(checks[1]()).toBe(true)
+		pending[0].resolve()
+		pending[1].resolve()
+		await Promise.all([staleRefresh, forcedRefresh])
+	})
+
+	it("invalidate marks the in-flight refresh stale without starting a new one", async () => {
+		const checks: (() => boolean)[] = []
+		const pending = deferred()
+		const performRefresh = vi.fn((isCurrent: () => boolean) => {
+			checks.push(isCurrent)
+			return pending.promise
+		})
+		const coordinator = new RemoteConfigRefreshCoordinator(performRefresh)
+
+		const inFlight = coordinator.refresh("user:org")
+		expect(checks[0]()).toBe(true)
+
+		coordinator.invalidate()
+
+		expect(checks[0]()).toBe(false)
+		expect(performRefresh).toHaveBeenCalledTimes(1)
+		pending.resolve()
+		await inFlight
+	})
 })

--- a/apps/vscode/src/sdk/remote-config-refresh-coordinator.ts
+++ b/apps/vscode/src/sdk/remote-config-refresh-coordinator.ts
@@ -1,0 +1,21 @@
+export class RemoteConfigRefreshCoordinator<Result = void> {
+	private generation = 0
+	private inFlight?: { identity: string; promise: Promise<Result> }
+
+	constructor(private readonly performRefresh: (isCurrent: () => boolean) => Promise<Result>) {}
+
+	refresh(identity: string): Promise<Result> {
+		if (this.inFlight?.identity === identity) {
+			return this.inFlight.promise
+		}
+
+		const generation = ++this.generation
+		const promise = this.performRefresh(() => generation === this.generation).finally(() => {
+			if (this.inFlight?.promise === promise) {
+				this.inFlight = undefined
+			}
+		})
+		this.inFlight = { identity, promise }
+		return promise
+	}
+}

--- a/apps/vscode/src/sdk/remote-config-refresh-coordinator.ts
+++ b/apps/vscode/src/sdk/remote-config-refresh-coordinator.ts
@@ -4,8 +4,10 @@ export class RemoteConfigRefreshCoordinator<Result = void> {
 
 	constructor(private readonly performRefresh: (isCurrent: () => boolean) => Promise<Result>) {}
 
-	refresh(identity: string): Promise<Result> {
-		if (this.inFlight?.identity === identity) {
+	refresh(identity: string, options: { force?: boolean } = {}): Promise<Result> {
+		// force: callers that just mutated refresh inputs (toggles, opt-out) must
+		// not coalesce onto an in-flight run that already sampled the old values.
+		if (!options.force && this.inFlight?.identity === identity) {
 			return this.inFlight.promise
 		}
 
@@ -17,5 +19,15 @@ export class RemoteConfigRefreshCoordinator<Result = void> {
 		})
 		this.inFlight = { identity, promise }
 		return promise
+	}
+
+	/**
+	 * Marks any in-flight refresh stale without starting a new one. Used by
+	 * authoritative local clears (sign-out) so a refresh that already fetched
+	 * under the old identity cannot republish the state being cleared.
+	 */
+	invalidate(): void {
+		this.generation += 1
+		this.inFlight = undefined
 	}
 }

--- a/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
+++ b/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import discoveryFixture from "@/core/storage/remote-config/fixtures/user-remote-config-discovery.json"
 
 const {
 	fetchUserRemoteConfig,
@@ -7,6 +8,8 @@ const {
 	isRemoteConfigEnabled,
 	writeRemoteConfigToCache,
 	readRemoteConfigFromCache,
+	activeOrganization,
+	axiosRequest,
 } = vi.hoisted(() => ({
 	fetchUserRemoteConfig: vi.fn(),
 	switchAccount: vi.fn(),
@@ -14,18 +17,14 @@ const {
 	isRemoteConfigEnabled: vi.fn(),
 	writeRemoteConfigToCache: vi.fn(),
 	readRemoteConfigFromCache: vi.fn(),
-}))
-
-vi.mock("@/services/account/ClineAccountService", () => ({
-	ClineAccountService: {
-		getInstance: () => ({ fetchUserRemoteConfig }),
-	},
+	activeOrganization: { id: "org-current" as string | null },
+	axiosRequest: vi.fn(),
 }))
 
 vi.mock("@/services/auth/AuthService", () => ({
 	AuthService: {
 		getInstance: () => ({
-			getActiveOrganizationId: () => "org-current",
+			getActiveOrganizationId: () => activeOrganization.id,
 			getAuthToken: async () => "token",
 		}),
 	},
@@ -43,7 +42,7 @@ vi.mock("@/core/storage/remote-config/utils", () => ({
 
 vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: async () => ({}) }))
 vi.mock("@/shared/net", () => ({ getAxiosSettings: () => ({}) }))
-vi.mock("axios", () => ({ default: { request: vi.fn() } }))
+vi.mock("axios", () => ({ default: { request: axiosRequest } }))
 
 import { SdkRemoteConfigControlPlane } from "@/core/storage/remote-config/sdk-control-plane"
 
@@ -55,14 +54,31 @@ describe("SdkRemoteConfigControlPlane", () => {
 		isRemoteConfigEnabled.mockReset().mockReturnValue(true)
 		writeRemoteConfigToCache.mockReset().mockResolvedValue(undefined)
 		readRemoteConfigFromCache.mockReset().mockResolvedValue({ version: "v1" })
+		activeOrganization.id = "org-current"
+		axiosRequest.mockReset().mockRejectedValue(new Error("offline"))
 	})
 
 	function makeControlPlane() {
 		return new SdkRemoteConfigControlPlane({
-			accountService: { switchAccount },
-			stateManager: { setSecret },
+			accountService: { switchAccount, fetchUserRemoteConfig },
+			stateManager: { setSecret, getGlobalStateKey: () => ({}) },
 		})
 	}
+
+	it("adapts the discovery API contract without dropping rules, workflows, skills, or policy fields", async () => {
+		activeOrganization.id = null
+		fetchUserRemoteConfig.mockResolvedValue(discoveryFixture)
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle?.metadata?.organizationId).toBe("org-contract")
+		expect(bundle?.remoteConfig?.globalRules?.[0]?.name).toBe("Contract Rule")
+		expect(bundle?.remoteConfig?.globalWorkflows?.[0]?.name).toBe("Contract Workflow")
+		expect(bundle?.managedInstructions?.[0]?.name).toBe("Contract Skill")
+		expect(bundle?.remoteConfig?.allowedMCPServers?.[0]?.id).toBe("https://github.com/example/contract-mcp")
+		expect(bundle?.remoteConfig?.openTelemetryEnabled).toBe(true)
+	})
 
 	it("returns undefined and marks explicit no-config when discovery returns nothing", async () => {
 		fetchUserRemoteConfig.mockResolvedValue(undefined)
@@ -74,7 +90,8 @@ describe("SdkRemoteConfigControlPlane", () => {
 		expect(controlPlane.wasExplicitNoConfig()).toBe(true)
 	})
 
-	it("wraps discovered remote config in a bundle", async () => {
+	it("wraps discovered remote config in a bundle when no organization is active", async () => {
+		activeOrganization.id = null
 		fetchUserRemoteConfig.mockResolvedValue({
 			organizationId: "org-target",
 			value: JSON.stringify({ version: "v1" }),
@@ -92,7 +109,103 @@ describe("SdkRemoteConfigControlPlane", () => {
 		expect(writeRemoteConfigToCache).toHaveBeenCalledWith("org-target", { version: "v1" })
 	})
 
+	it("prefers the active organization even when discovery only lists another organization", async () => {
+		activeOrganization.id = "org-b"
+		fetchUserRemoteConfig.mockResolvedValue({
+			organizationId: "org-a",
+			value: JSON.stringify({ version: "org-a" }),
+			organizations: [{ organizationId: "org-a", name: "A" }],
+		})
+		readRemoteConfigFromCache.mockResolvedValue({ version: "org-b" })
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle?.metadata?.organizationId).toBe("org-b")
+		expect(bundle?.remoteConfig?.version).toBe("org-b")
+		expect(switchAccount).not.toHaveBeenCalled()
+		expect(writeRemoteConfigToCache).toHaveBeenCalledWith("org-b", { version: "org-b" })
+	})
+
+	it("does not fall back to another organization when the active org is opted out", async () => {
+		activeOrganization.id = "org-b"
+		isRemoteConfigEnabled.mockImplementation((orgId: string) => orgId !== "org-b")
+		fetchUserRemoteConfig.mockResolvedValue({
+			organizationId: "org-a",
+			value: JSON.stringify({ version: "org-a" }),
+			organizations: [
+				{ organizationId: "org-a", name: "A" },
+				{ organizationId: "org-b", name: "B" },
+			],
+		})
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle).toBeUndefined()
+		expect(controlPlane.wasExplicitNoConfig()).toBe(true)
+		expect(controlPlane.isRemoteConfigAvailable()).toBe(true)
+		expect(switchAccount).not.toHaveBeenCalled()
+	})
+
+	it("reports unavailable when the active organization's remote config is disabled", async () => {
+		activeOrganization.id = "org-b"
+		fetchUserRemoteConfig.mockResolvedValue({
+			organizationId: "org-a",
+			value: JSON.stringify({ version: "org-a" }),
+			organizations: [{ organizationId: "org-a", name: "A" }],
+		})
+		axiosRequest.mockResolvedValue({
+			status: 200,
+			data: { success: true, data: { enabled: false, value: "" } },
+		})
+		readRemoteConfigFromCache.mockResolvedValue(undefined)
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle).toBeUndefined()
+		expect(controlPlane.isRemoteConfigAvailable()).toBe(false)
+		expect(switchAccount).not.toHaveBeenCalled()
+	})
+
+	it("filters disabled optional instructions from the effective SDK bundle", async () => {
+		activeOrganization.id = null
+		fetchUserRemoteConfig.mockResolvedValue({
+			organizationId: "org-target",
+			value: JSON.stringify({
+				version: "v1",
+				globalRules: [
+					{ name: "Optional rule", alwaysEnabled: false, contents: "optional" },
+					{ name: "Locked rule", alwaysEnabled: true, contents: "locked" },
+				],
+				globalWorkflows: [{ name: "Optional workflow", alwaysEnabled: false, contents: "workflow" }],
+				globalSkills: [{ name: "Optional skill", alwaysEnabled: false, contents: "skill" }],
+			}),
+			organizations: [{ organizationId: "org-target", name: "Target" }],
+		})
+		const controlPlane = new SdkRemoteConfigControlPlane({
+			accountService: { switchAccount, fetchUserRemoteConfig },
+			stateManager: {
+				setSecret,
+				getGlobalStateKey: (key): Record<string, boolean> =>
+					key === "remoteRulesToggles"
+						? { "Optional rule": false, "Locked rule": false }
+						: key === "remoteWorkflowToggles"
+							? { "Optional workflow": false }
+							: { "Optional skill": false },
+			},
+		})
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle?.remoteConfig?.globalRules?.map((entry) => entry.name)).toEqual(["Locked rule"])
+		expect(bundle?.remoteConfig?.globalWorkflows).toEqual([])
+		expect(bundle?.managedInstructions).toEqual([])
+	})
+
 	it("converts globalSkills to managed skill instructions", async () => {
+		activeOrganization.id = "org-target"
 		fetchUserRemoteConfig.mockResolvedValue({
 			organizationId: "org-target",
 			value: JSON.stringify({
@@ -116,7 +229,8 @@ describe("SdkRemoteConfigControlPlane", () => {
 		])
 	})
 
-	it("skips disabled active org and selects an enabled fallback org", async () => {
+	it("selects an enabled fallback org when no organization is active", async () => {
+		activeOrganization.id = null
 		isRemoteConfigEnabled.mockImplementation((orgId: string) => orgId === "org-fallback")
 		fetchUserRemoteConfig.mockResolvedValue({
 			organizationId: "org-disabled",

--- a/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
+++ b/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/core/storage/remote-config/utils", () => ({
 	isRemoteConfigEnabled,
 }))
 
+vi.mock("@/config", () => ({ ClineEnv: { config: () => ({ apiBaseUrl: "https://api.example.test" }) } }))
 vi.mock("@/services/EnvUtils", () => ({ buildBasicClineHeaders: async () => ({}) }))
 vi.mock("@/shared/net", () => ({ getAxiosSettings: () => ({}) }))
 vi.mock("axios", () => ({ default: { request: axiosRequest } }))
@@ -80,8 +81,44 @@ describe("SdkRemoteConfigControlPlane", () => {
 		expect(bundle?.remoteConfig?.openTelemetryEnabled).toBe(true)
 	})
 
-	it("returns undefined and marks explicit no-config when discovery returns nothing", async () => {
+	it("returns undefined and marks explicit no-config when discovery returns nothing while signed out", async () => {
+		activeOrganization.id = null
 		fetchUserRemoteConfig.mockResolvedValue(undefined)
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle).toBeUndefined()
+		expect(controlPlane.wasExplicitNoConfig()).toBe(true)
+	})
+
+	it("reports explicit no-config for a locally opted-out organization without any network call", async () => {
+		activeOrganization.id = "org-current"
+		isRemoteConfigEnabled.mockReturnValue(false)
+		const controlPlane = makeControlPlane()
+
+		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
+
+		expect(bundle).toBeUndefined()
+		expect(controlPlane.wasExplicitNoConfig()).toBe(true)
+		expect(controlPlane.isRemoteConfigAvailable()).toBe(true)
+		expect(fetchUserRemoteConfig).not.toHaveBeenCalled()
+	})
+
+	it("throws instead of reporting no-config when no auth token is available for an active organization", async () => {
+		activeOrganization.id = "org-current"
+		fetchUserRemoteConfig.mockResolvedValue(undefined)
+		const controlPlane = makeControlPlane()
+
+		await expect(controlPlane.fetchBundle({ workspacePath: "/workspace" })).rejects.toThrow(
+			"Remote config discovery returned no response",
+		)
+		expect(controlPlane.wasExplicitNoConfig()).toBe(false)
+	})
+
+	it("reports explicit no-config when the server answers null for an active organization", async () => {
+		activeOrganization.id = "org-current"
+		fetchUserRemoteConfig.mockResolvedValue(null)
 		const controlPlane = makeControlPlane()
 
 		const bundle = await controlPlane.fetchBundle({ workspacePath: "/workspace" })
@@ -167,6 +204,20 @@ describe("SdkRemoteConfigControlPlane", () => {
 		expect(bundle).toBeUndefined()
 		expect(controlPlane.isRemoteConfigAvailable()).toBe(false)
 		expect(switchAccount).not.toHaveBeenCalled()
+	})
+
+	it("throws instead of reporting no-config when the fetch fails and no cache exists", async () => {
+		activeOrganization.id = "org-current"
+		fetchUserRemoteConfig.mockResolvedValue({
+			organizationId: "org-other",
+			value: JSON.stringify({ version: "other" }),
+		})
+		axiosRequest.mockRejectedValue(new Error("network down"))
+		readRemoteConfigFromCache.mockResolvedValue(undefined)
+		const controlPlane = makeControlPlane()
+
+		await expect(controlPlane.fetchBundle({ workspacePath: "/workspace" })).rejects.toThrow("network down")
+		expect(controlPlane.wasExplicitNoConfig()).toBe(false)
 	})
 
 	it("filters disabled optional instructions from the effective SDK bundle", async () => {

--- a/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
+++ b/apps/vscode/src/sdk/sdk-remote-config-control-plane.test.ts
@@ -56,13 +56,20 @@ describe("SdkRemoteConfigControlPlane", () => {
 		writeRemoteConfigToCache.mockReset().mockResolvedValue(undefined)
 		readRemoteConfigFromCache.mockReset().mockResolvedValue({ version: "v1" })
 		activeOrganization.id = "org-current"
+		lastManagedOrganization.id = undefined
 		axiosRequest.mockReset().mockRejectedValue(new Error("offline"))
 	})
+
+	const lastManagedOrganization = { id: undefined as string | undefined }
 
 	function makeControlPlane() {
 		return new SdkRemoteConfigControlPlane({
 			accountService: { switchAccount, fetchUserRemoteConfig },
-			stateManager: { setSecret, getGlobalStateKey: () => ({}) },
+			stateManager: {
+				setSecret,
+				getGlobalStateKey: ((key: string) =>
+					key === "lastManagedOrganizationId" ? lastManagedOrganization.id : {}) as never,
+			},
 		})
 	}
 
@@ -107,6 +114,22 @@ describe("SdkRemoteConfigControlPlane", () => {
 
 	it("throws instead of reporting no-config when no auth token is available for an active organization", async () => {
 		activeOrganization.id = "org-current"
+		fetchUserRemoteConfig.mockResolvedValue(undefined)
+		const controlPlane = makeControlPlane()
+
+		await expect(controlPlane.fetchBundle({ workspacePath: "/workspace" })).rejects.toThrow(
+			"Remote config discovery returned no response",
+		)
+		expect(controlPlane.wasExplicitNoConfig()).toBe(false)
+	})
+
+	it("throws instead of reporting no-config when identity restore fails on a previously managed install", async () => {
+		// Offline cold start: auth restore failed, so BOTH the token and the
+		// active org are gone — but the persisted marker says this install runs
+		// under org policy. Reporting no-config would wipe the policy and the
+		// marker, permanently disarming the fail-closed session gate.
+		activeOrganization.id = null
+		lastManagedOrganization.id = "org-previous"
 		fetchUserRemoteConfig.mockResolvedValue(undefined)
 		const controlPlane = makeControlPlane()
 
@@ -239,12 +262,14 @@ describe("SdkRemoteConfigControlPlane", () => {
 			accountService: { switchAccount, fetchUserRemoteConfig },
 			stateManager: {
 				setSecret,
-				getGlobalStateKey: (key): Record<string, boolean> =>
-					key === "remoteRulesToggles"
-						? { "Optional rule": false, "Locked rule": false }
-						: key === "remoteWorkflowToggles"
-							? { "Optional workflow": false }
-							: { "Optional skill": false },
+				getGlobalStateKey: ((key: string) =>
+					key === "lastManagedOrganizationId"
+						? undefined
+						: key === "remoteRulesToggles"
+							? { "Optional rule": false, "Locked rule": false }
+							: key === "remoteWorkflowToggles"
+								? { "Optional workflow": false }
+								: { "Optional skill": false }) as never,
 			},
 		})
 

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
@@ -137,6 +137,17 @@ describe("SdkSessionLifecycle", () => {
 		expect(lifecycle.getActiveSession()).toBeUndefined()
 	})
 
+	it("passes the policy readiness gate to the shared session host", async () => {
+		const beforeStartSession = vi.fn().mockResolvedValue(undefined)
+		const sdkHost = makeSdkHost({ startResult: { sessionId: "session-123" } })
+		mockCreateSessionHost.mockResolvedValueOnce(sdkHost)
+		const lifecycle = makeLifecycle({ beforeStartSession })
+
+		await lifecycle.startNewSession({} as StartInput)
+
+		expect(mockCreateSessionHost).toHaveBeenCalledWith(expect.objectContaining({ beforeStartSession }))
+	})
+
 	it("passes shared telemetry to the VSCode session host", async () => {
 		const telemetry = { capture: vi.fn() }
 		const sdkHost = makeSdkHost({ startResult: { sessionId: "session-123" } })

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -38,6 +38,8 @@ export interface SdkSessionLifecycleOptions {
 	getTerminalManager?: () => VscodeTerminalManager
 	/** Registry of in-flight foreground executions for "Proceed While Running". */
 	foregroundCommands?: SdkForegroundCommandCoordinator
+	/** Resolves once the applicable remote config is ready for a new SDK session. */
+	beforeStartSession?: () => Promise<void>
 	/** Returns the latest prepared remote-config integration, if remote config is active. */
 	getRemoteConfigIntegration?: () => PreparedRemoteConfigCoreIntegration | undefined
 	/** Shared SDK telemetry service owned by SdkController. */
@@ -341,6 +343,7 @@ export class SdkSessionLifecycle {
 				readFileExecutor: this.options.readFileExecutor,
 				getTerminalManager: this.options.getTerminalManager,
 				foregroundCommands: this.options.foregroundCommands,
+				beforeStartSession: this.options.beforeStartSession,
 				getRemoteConfigIntegration: this.options.getRemoteConfigIntegration,
 				telemetry: this.options.telemetry,
 			})

--- a/apps/vscode/src/sdk/vscode-session-host.test.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.test.ts
@@ -130,6 +130,33 @@ describe("VscodeSessionHost telemetry wiring", () => {
 		expect(capabilities.toolExecutors).toBeUndefined()
 	})
 
+	it("waits for policy readiness before selecting and applying remote config", async () => {
+		const events: string[] = []
+		const beforeStartSession = vi.fn(async () => {
+			events.push("ready")
+		})
+		const applyToStartSessionInput = vi.fn(async (input: ClineCoreStartInput) => {
+			events.push("apply")
+			return input
+		})
+		await VscodeSessionHost.create({
+			// biome-ignore lint/suspicious/noExplicitAny: focused host unit test
+			mcpHub: {} as any,
+			beforeStartSession,
+			getRemoteConfigIntegration: () =>
+				({
+					applyToStartSessionInput,
+					dispose: vi.fn(),
+				}) as never,
+		})
+
+		const prepare = mockClineCoreCreate.mock.calls[0][0].prepare
+		const bootstrap = await prepare()
+		await bootstrap.applyToStartSessionInput({ config: { cwd: "/workspace" } })
+
+		expect(events).toEqual(["ready", "apply"])
+	})
+
 	it("applies remote config before appending VS Code extra tools", async () => {
 		mockCreateVscodeExtraTools.mockResolvedValueOnce([{ name: "vscode-tool" }] as never)
 		const applyToStartSessionInput = vi.fn(async (input: ClineCoreStartInput) => ({

--- a/apps/vscode/src/sdk/vscode-session-host.test.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.test.ts
@@ -191,6 +191,54 @@ describe("VscodeSessionHost telemetry wiring", () => {
 		expect(result.config.extensions).toEqual([{ name: "remote-config" }])
 		expect(result.config.extraTools).toEqual([{ name: "remote-tool" }, { name: "vscode-tool" }])
 	})
+
+	it("runs the session gate and remote-config integration on a checkpoint restore with a replacement session", async () => {
+		const events: string[] = []
+		const innerRestore = vi.fn(async (_input: unknown) => ({ checkpoint: {} }))
+		mockClineCoreCreate.mockResolvedValue({ runtimeAddress: undefined, restore: innerRestore })
+		const host = await VscodeSessionHost.create({
+			// biome-ignore lint/suspicious/noExplicitAny: focused host unit test
+			mcpHub: {} as any,
+			beforeStartSession: async () => {
+				events.push("gate")
+			},
+			getRemoteConfigIntegration: () =>
+				({
+					applyToStartSessionInput: (input: ClineCoreStartInput) => {
+						events.push("integration")
+						return input
+					},
+				}) as never,
+		})
+
+		await host.restore({
+			sessionId: "session-1",
+			checkpointRunCount: 1,
+			start: { config: { cwd: "/workspace", extraTools: [] } } as never,
+		})
+
+		// The gate must resolve before the integration is read; ClineCore.restore
+		// does not run the prepare hook, so the host must apply it itself.
+		expect(events).toEqual(["gate", "integration"])
+		const restoredInput = innerRestore.mock.calls[0][0] as { start: ClineCoreStartInput }
+		expect(restoredInput.start.source).toBe("vscode")
+	})
+
+	it("does not gate a workspace-only restore that starts no replacement session", async () => {
+		const innerRestore = vi.fn(async () => ({ checkpoint: {} }))
+		const beforeStartSession = vi.fn()
+		mockClineCoreCreate.mockResolvedValue({ runtimeAddress: undefined, restore: innerRestore })
+		const host = await VscodeSessionHost.create({
+			// biome-ignore lint/suspicious/noExplicitAny: focused host unit test
+			mcpHub: {} as any,
+			beforeStartSession,
+		})
+
+		await host.restore({ sessionId: "session-1", checkpointRunCount: 1 })
+
+		expect(beforeStartSession).not.toHaveBeenCalled()
+		expect(innerRestore).toHaveBeenCalledWith({ sessionId: "session-1", checkpointRunCount: 1 })
+	})
 })
 
 function makeTelemetry(): ITelemetryService {

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -92,10 +92,15 @@ export interface VscodeSessionHostOptions {
 export class VscodeSessionHost implements SdkSessionHost {
 	readonly runtimeAddress: string | undefined
 	private readonly inner: ClineCore
+	private readonly prepareStartSessionInput?: (input: ClineCoreStartInput) => Promise<ClineCoreStartInput>
 
-	private constructor(inner: ClineCore) {
+	private constructor(
+		inner: ClineCore,
+		prepareStartSessionInput?: (input: ClineCoreStartInput) => Promise<ClineCoreStartInput>,
+	) {
 		this.inner = inner
 		this.runtimeAddress = inner.runtimeAddress
+		this.prepareStartSessionInput = prepareStartSessionInput
 	}
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void> {
 		return this.inner.updateSessionModel(sessionId, modelId)
@@ -126,6 +131,37 @@ export class VscodeSessionHost implements SdkSessionHost {
 			;(toolExecutors as Record<string, unknown>).bash = undefined
 		}
 
+		// Single funnel for session-start preparation: waits on the remote-config
+		// readiness/policy gate, applies the remote-config integration, and adds
+		// the VSCode extra tools. Used by ClineCore's prepare hook for normal
+		// starts AND by restore() for checkpoint-restore replacement sessions,
+		// which ClineCore starts without running the prepare hook.
+		const prepareStartSessionInput = async (input: ClineCoreStartInput): Promise<ClineCoreStartInput> => {
+			await options.beforeStartSession?.()
+			// Read only after the readiness gate: it may have atomically replaced
+			// the integration that must be captured by this session.
+			const remoteConfigIntegration = options.getRemoteConfigIntegration?.()
+			const inputWithRemoteConfig = remoteConfigIntegration
+				? await remoteConfigIntegration.applyToStartSessionInput(input)
+				: input
+			const requestedTerminalExecutionMode = StateManager.get().getGlobalStateKey("vscodeTerminalExecutionMode")
+			const extraTools = await createVscodeExtraTools(options.mcpHub, {
+				cwd: inputWithRemoteConfig.config.cwd,
+				getTerminalManager: options.getTerminalManager,
+				vscodeTerminalExecutionMode: getEffectiveTerminalExecutionMode(requestedTerminalExecutionMode),
+				foregroundCommands: options.foregroundCommands,
+			})
+			return {
+				...inputWithRemoteConfig,
+				source: inputWithRemoteConfig.source ?? "vscode",
+				config: {
+					...inputWithRemoteConfig.config,
+					telemetry: inputWithRemoteConfig.config.telemetry ?? options.telemetry,
+					extraTools: [...(inputWithRemoteConfig.config.extraTools ?? []), ...extraTools],
+				},
+			}
+		}
+
 		const inner = await ClineCore.create({
 			backendMode: "local",
 			capabilities: {
@@ -138,31 +174,7 @@ export class VscodeSessionHost implements SdkSessionHost {
 			telemetry: options.telemetry,
 			distinctId: getDistinctId() || undefined,
 			prepare: async () => ({
-				applyToStartSessionInput: async (input: ClineCoreStartInput): Promise<ClineCoreStartInput> => {
-					await options.beforeStartSession?.()
-					// Read only after the readiness gate: it may have atomically replaced
-					// the integration that must be captured by this session.
-					const remoteConfigIntegration = options.getRemoteConfigIntegration?.()
-					const inputWithRemoteConfig = remoteConfigIntegration
-						? await remoteConfigIntegration.applyToStartSessionInput(input)
-						: input
-					const requestedTerminalExecutionMode = StateManager.get().getGlobalStateKey("vscodeTerminalExecutionMode")
-					const extraTools = await createVscodeExtraTools(options.mcpHub, {
-						cwd: inputWithRemoteConfig.config.cwd,
-						getTerminalManager: options.getTerminalManager,
-						vscodeTerminalExecutionMode: getEffectiveTerminalExecutionMode(requestedTerminalExecutionMode),
-						foregroundCommands: options.foregroundCommands,
-					})
-					return {
-						...inputWithRemoteConfig,
-						source: inputWithRemoteConfig.source ?? "vscode",
-						config: {
-							...inputWithRemoteConfig.config,
-							telemetry: inputWithRemoteConfig.config.telemetry ?? options.telemetry,
-							extraTools: [...(inputWithRemoteConfig.config.extraTools ?? []), ...extraTools],
-						},
-					}
-				},
+				applyToStartSessionInput: prepareStartSessionInput,
 			}),
 		})
 
@@ -170,7 +182,7 @@ export class VscodeSessionHost implements SdkSessionHost {
 		if (options.getTerminalManager) {
 			Logger.log("[VscodeSessionHost] SDK run_commands suppressed; using custom foreground/background terminal tool")
 		}
-		return new VscodeSessionHost(inner)
+		return new VscodeSessionHost(inner, prepareStartSessionInput)
 	}
 
 	async start(input: StartSessionInput): Promise<StartSessionResult>
@@ -250,6 +262,12 @@ export class VscodeSessionHost implements SdkSessionHost {
 	}
 
 	async restore(input: RestoreInput): Promise<RestoreResult> {
+		// ClineCore.restore starts the checkpoint-restore replacement session
+		// WITHOUT running the prepare hook, which would bypass the remote-config
+		// session gate and integration. Run the same preparation here.
+		if (input.start && this.prepareStartSessionInput) {
+			input = { ...input, start: await this.prepareStartSessionInput(input.start) }
+		}
 		return this.inner.restore(input)
 	}
 

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -75,6 +75,8 @@ export interface VscodeSessionHostOptions {
 	toolPolicies?: Record<string, ToolPolicy>
 	/** Shared SDK telemetry service owned by SdkController. */
 	telemetry?: ITelemetryService
+	/** Resolves once the applicable remote config is ready for a new SDK session. */
+	beforeStartSession?: () => Promise<void>
 	/** Returns the latest prepared remote-config integration, if remote config is active. */
 	getRemoteConfigIntegration?: () => PreparedRemoteConfigCoreIntegration | undefined
 	/**
@@ -137,6 +139,9 @@ export class VscodeSessionHost implements SdkSessionHost {
 			distinctId: getDistinctId() || undefined,
 			prepare: async () => ({
 				applyToStartSessionInput: async (input: ClineCoreStartInput): Promise<ClineCoreStartInput> => {
+					await options.beforeStartSession?.()
+					// Read only after the readiness gate: it may have atomically replaced
+					// the integration that must be captured by this session.
 					const remoteConfigIntegration = options.getRemoteConfigIntegration?.()
 					const inputWithRemoteConfig = remoteConfigIntegration
 						? await remoteConfigIntegration.applyToStartSessionInput(input)

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -13,8 +13,6 @@ import type { ITelemetryProvider, TelemetryProperties } from "./providers/ITelem
 import {
 	getRolloutErrorProperties,
 	getRolloutTelemetryMetadata,
-	REMOTE_CONFIG_REFRESH_EVENT,
-	REMOTE_CONFIG_SESSION_GATE_EVENT,
 	ROLLOUT_BUNDLE_ACTIVATED_EVENT,
 	type RolloutBundleActivation,
 	type RolloutTelemetryMetadata,
@@ -252,6 +250,13 @@ export class TelemetryService {
 		WORKSPACE: {
 			// Track multi-root checkpoint operations
 			MULTI_ROOT_CHECKPOINT: "workspace.multi_root_checkpoint",
+		},
+		// Organization remote-config lifecycle events
+		REMOTE_CONFIG: {
+			// Tracks the outcome of every remote-config refresh attempt
+			REFRESH: "remote_config.refresh",
+			// Tracks the session-start policy gate decision
+			SESSION_GATE: "remote_config.session_gate",
 		},
 		TASK: {
 			// Tracks user feedback on completed tasks
@@ -595,7 +600,7 @@ export class TelemetryService {
 		configVersion?: string
 	}): void {
 		this.capture({
-			event: REMOTE_CONFIG_REFRESH_EVENT,
+			event: TelemetryService.EVENTS.REMOTE_CONFIG.REFRESH,
 			properties: {
 				outcome: input.outcome,
 				duration_ms: Math.max(0, Math.round(input.durationMs)),
@@ -611,7 +616,7 @@ export class TelemetryService {
 		managed: boolean
 	}): void {
 		this.capture({
-			event: REMOTE_CONFIG_SESSION_GATE_EVENT,
+			event: TelemetryService.EVENTS.REMOTE_CONFIG.SESSION_GATE,
 			properties: {
 				outcome: input.outcome,
 				duration_ms: Math.max(0, Math.round(input.durationMs)),

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -593,12 +593,25 @@ export class TelemetryService {
 		})
 	}
 
+	/**
+	 * Volume guard for the remote-config events: they fire on every session
+	 * start and refresh for ALL users, but the signal is managed-org behavior
+	 * and failures. The unmanaged happy path ("nothing to enforce, allowed")
+	 * would dominate event volume with no informational value, so it is dropped.
+	 */
+	private static shouldCaptureRemoteConfigEvent(managed: boolean, outcome: string): boolean {
+		return managed || outcome === "failed" || outcome === "blocked" || outcome === "last_known_good"
+	}
+
 	public captureRemoteConfigRefresh(input: {
 		outcome: "applied" | "cleared" | "failed" | "superseded"
 		durationMs: number
 		managed: boolean
 		configVersion?: string
 	}): void {
+		if (!TelemetryService.shouldCaptureRemoteConfigEvent(input.managed, input.outcome)) {
+			return
+		}
 		this.capture({
 			event: TelemetryService.EVENTS.REMOTE_CONFIG.REFRESH,
 			properties: {
@@ -615,6 +628,9 @@ export class TelemetryService {
 		durationMs: number
 		managed: boolean
 	}): void {
+		if (!TelemetryService.shouldCaptureRemoteConfigEvent(input.managed, input.outcome)) {
+			return
+		}
 		this.capture({
 			event: TelemetryService.EVENTS.REMOTE_CONFIG.SESSION_GATE,
 			properties: {

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -13,6 +13,8 @@ import type { ITelemetryProvider, TelemetryProperties } from "./providers/ITelem
 import {
 	getRolloutErrorProperties,
 	getRolloutTelemetryMetadata,
+	REMOTE_CONFIG_REFRESH_EVENT,
+	REMOTE_CONFIG_SESSION_GATE_EVENT,
 	ROLLOUT_BUNDLE_ACTIVATED_EVENT,
 	type RolloutBundleActivation,
 	type RolloutTelemetryMetadata,
@@ -582,6 +584,38 @@ export class TelemetryService {
 				actual_bundle: input.actualBundle,
 				fallback: input.fallback,
 				...(input.fallback ? getRolloutErrorProperties(input.error) : {}),
+			},
+		})
+	}
+
+	public captureRemoteConfigRefresh(input: {
+		outcome: "applied" | "cleared" | "failed" | "superseded"
+		durationMs: number
+		managed: boolean
+		configVersion?: string
+	}): void {
+		this.capture({
+			event: REMOTE_CONFIG_REFRESH_EVENT,
+			properties: {
+				outcome: input.outcome,
+				duration_ms: Math.max(0, Math.round(input.durationMs)),
+				managed: input.managed,
+				...(input.configVersion ? { config_version: input.configVersion.slice(0, 100) } : {}),
+			},
+		})
+	}
+
+	public captureRemoteConfigSessionGate(input: {
+		outcome: "refreshed" | "last_known_good" | "blocked"
+		durationMs: number
+		managed: boolean
+	}): void {
+		this.capture({
+			event: REMOTE_CONFIG_SESSION_GATE_EVENT,
+			properties: {
+				outcome: input.outcome,
+				duration_ms: Math.max(0, Math.round(input.durationMs)),
+				managed: input.managed,
 			},
 		})
 	}

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -606,7 +606,7 @@ export class TelemetryService {
 	}
 
 	public captureRemoteConfigSessionGate(input: {
-		outcome: "refreshed" | "last_known_good" | "blocked"
+		outcome: "refreshed" | "last_known_good" | "unmanaged" | "blocked"
 		durationMs: number
 		managed: boolean
 	}): void {

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -2,12 +2,7 @@ import { describe, it } from "bun:test"
 import * as assert from "assert"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE } from "../../../sdk/provider-failure-telemetry"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
-import {
-	REMOTE_CONFIG_REFRESH_EVENT,
-	REMOTE_CONFIG_SESSION_GATE_EVENT,
-	ROLLOUT_BUNDLE_ACTIVATED_EVENT,
-	ROLLOUT_ERROR_MESSAGE_LIMIT,
-} from "../rollout-metadata"
+import { ROLLOUT_BUNDLE_ACTIVATED_EVENT, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
 import { TelemetryMetadata, TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
@@ -143,13 +138,13 @@ describe("TelemetryService metrics", () => {
 		})
 		service.captureRemoteConfigSessionGate({ outcome: "last_known_good", durationMs: 4.2, managed: true })
 
-		const refresh = provider.logs.find((entry) => entry.event === REMOTE_CONFIG_REFRESH_EVENT)
+		const refresh = provider.logs.find((entry) => entry.event === "remote_config.refresh")
 		assert.strictEqual(refresh?.properties?.outcome, "applied")
 		assert.strictEqual(refresh?.properties?.duration_ms, 13)
 		assert.strictEqual((refresh?.properties?.config_version as string).length, 100)
 		assert.strictEqual(refresh?.properties?.extension_variant, "next")
 		assert.strictEqual(refresh?.properties?.organization_id, undefined)
-		const gate = provider.logs.find((entry) => entry.event === REMOTE_CONFIG_SESSION_GATE_EVENT)
+		const gate = provider.logs.find((entry) => entry.event === "remote_config.session_gate")
 		assert.strictEqual(gate?.properties?.outcome, "last_known_good")
 		assert.strictEqual(gate?.properties?.duration_ms, 4)
 		assert.strictEqual(gate?.properties?.extension_variant, "next")

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -2,7 +2,12 @@ import { describe, it } from "bun:test"
 import * as assert from "assert"
 import { PROVIDER_FAILURE_ERROR_TYPE, PROVIDER_FAILURE_PHASE } from "../../../sdk/provider-failure-telemetry"
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "../providers/ITelemetryProvider"
-import { ROLLOUT_BUNDLE_ACTIVATED_EVENT, ROLLOUT_ERROR_MESSAGE_LIMIT } from "../rollout-metadata"
+import {
+	REMOTE_CONFIG_REFRESH_EVENT,
+	REMOTE_CONFIG_SESSION_GATE_EVENT,
+	ROLLOUT_BUNDLE_ACTIVATED_EVENT,
+	ROLLOUT_ERROR_MESSAGE_LIMIT,
+} from "../rollout-metadata"
 import { TelemetryMetadata, TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
@@ -124,6 +129,30 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(events[0].properties?.error_type, "TypeError")
 		assert.strictEqual((events[0].properties?.error_message as string).length, ROLLOUT_ERROR_MESSAGE_LIMIT)
 		assert.strictEqual(events[0].properties?.extension_variant, "legacy")
+	})
+
+	it("captures bounded, content-free remote-config rollout signals", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider, { extension_variant: "next" })
+
+		service.captureRemoteConfigRefresh({
+			outcome: "applied",
+			durationMs: 12.6,
+			managed: true,
+			configVersion: "v".repeat(120),
+		})
+		service.captureRemoteConfigSessionGate({ outcome: "last_known_good", durationMs: 4.2, managed: true })
+
+		const refresh = provider.logs.find((entry) => entry.event === REMOTE_CONFIG_REFRESH_EVENT)
+		assert.strictEqual(refresh?.properties?.outcome, "applied")
+		assert.strictEqual(refresh?.properties?.duration_ms, 13)
+		assert.strictEqual((refresh?.properties?.config_version as string).length, 100)
+		assert.strictEqual(refresh?.properties?.extension_variant, "next")
+		assert.strictEqual(refresh?.properties?.organization_id, undefined)
+		const gate = provider.logs.find((entry) => entry.event === REMOTE_CONFIG_SESSION_GATE_EVENT)
+		assert.strictEqual(gate?.properties?.outcome, "last_known_good")
+		assert.strictEqual(gate?.properties?.duration_ms, 4)
+		assert.strictEqual(gate?.properties?.extension_variant, "next")
 	})
 
 	it("does not capture rollout activation events for ordinary builds", () => {

--- a/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/apps/vscode/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -150,6 +150,25 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(gate?.properties?.extension_variant, "next")
 	})
 
+	it("drops unmanaged happy-path remote-config events but keeps failures", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+		const remoteConfigEvents = () => provider.logs.filter((entry) => entry.event.startsWith("remote_config."))
+
+		// Unmanaged happy path: the overwhelming majority of installs, no signal.
+		service.captureRemoteConfigRefresh({ outcome: "applied", durationMs: 1, managed: false })
+		service.captureRemoteConfigRefresh({ outcome: "cleared", durationMs: 1, managed: false })
+		service.captureRemoteConfigSessionGate({ outcome: "unmanaged", durationMs: 1, managed: false })
+		service.captureRemoteConfigSessionGate({ outcome: "refreshed", durationMs: 1, managed: false })
+		assert.strictEqual(remoteConfigEvents().length, 0)
+
+		// Failures and managed-org events are the signal and must still be sent.
+		service.captureRemoteConfigRefresh({ outcome: "failed", durationMs: 1, managed: false })
+		service.captureRemoteConfigRefresh({ outcome: "cleared", durationMs: 1, managed: true })
+		service.captureRemoteConfigSessionGate({ outcome: "blocked", durationMs: 1, managed: true })
+		assert.strictEqual(remoteConfigEvents().length, 3)
+	})
+
 	it("does not capture rollout activation events for ordinary builds", () => {
 		const provider = new FakeProvider()
 		const service = createTelemetryService(provider)

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -12,8 +12,6 @@ export interface RolloutBundleActivation {
 }
 
 export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
-export const REMOTE_CONFIG_REFRESH_EVENT = "remote_config.refresh"
-export const REMOTE_CONFIG_SESSION_GATE_EVENT = "remote_config.session_gate"
 export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
 
 /**

--- a/apps/vscode/src/services/telemetry/rollout-metadata.ts
+++ b/apps/vscode/src/services/telemetry/rollout-metadata.ts
@@ -12,6 +12,8 @@ export interface RolloutBundleActivation {
 }
 
 export const ROLLOUT_BUNDLE_ACTIVATED_EVENT = "extension.rollout.bundle_activated"
+export const REMOTE_CONFIG_REFRESH_EVENT = "remote_config.refresh"
+export const REMOTE_CONFIG_SESSION_GATE_EVENT = "remote_config.session_gate"
 export const ROLLOUT_ERROR_MESSAGE_LIMIT = 500
 
 /**

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -134,10 +134,12 @@ export interface ExtensionState {
 	dismissedBanners?: Array<{ bannerId: string; dismissedAt: number }>
 	hooksEnabled?: boolean
 	remoteConfigSettings?: Partial<RemoteConfigFields>
+	remoteConfigRevision?: number
 	globalSkillsToggles?: Record<string, boolean>
 	localSkillsToggles?: Record<string, boolean>
 	backgroundEditEnabled?: boolean
 	optOutOfRemoteConfig?: boolean
+	remoteConfigAvailable?: boolean
 	showFeatureTips?: boolean
 	banners?: BannerCardData[]
 	welcomeBanners?: BannerCardData[]

--- a/apps/vscode/src/shared/storage/state-keys.ts
+++ b/apps/vscode/src/shared/storage/state-keys.ts
@@ -89,6 +89,11 @@ const GLOBAL_STATE_FIELDS = {
 	lastDismissedInfoBannerVersion: { default: 0 as number },
 	lastDismissedModelBannerVersion: { default: 0 as number },
 	lastDismissedCliBannerVersion: { default: 0 as number },
+	// Organization id of the last successful managed remote-config publish.
+	// Persistent evidence that this install is managed: the session gate uses it
+	// to fail closed when the user's identity cannot be resolved (API unreachable)
+	// instead of starting an unpoliced session. Cleared on explicit no-config.
+	lastManagedOrganizationId: { default: undefined as string | undefined },
 	remoteRulesToggles: { default: {} as ClineRulesToggles },
 	remoteWorkflowToggles: { default: {} as ClineRulesToggles },
 	remoteSkillsToggles: { default: {} as ClineRulesToggles },

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
 			"src/shared/vsCodeSelectorUtils.test.ts",
 			"src/shared/proto-conversions/models/**/*.test.ts",
 			"src/core/storage/remote-config/**/*.test.ts",
+			"src/core/controller/account/setUserOrganization.test.ts",
+			"src/core/controller/remoteConfig/**/*.test.ts",
 			"src/core/controller/state/**/*.test.ts",
 			"src/core/controller/slash/**/*.test.ts",
 			"src/services/mcp/__tests__/settingsLock.test.ts",

--- a/apps/vscode/webview-ui/src/components/account/RemoteConfigToggle.test.tsx
+++ b/apps/vscode/webview-ui/src/components/account/RemoteConfigToggle.test.tsx
@@ -1,0 +1,85 @@
+import type { UserOrganization } from "@shared/proto/index.cline"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { RemoteConfigToggle } from "./RemoteConfigToggle"
+
+const mocks = vi.hoisted(() => ({
+	updateSettings: vi.fn(),
+	state: {
+		optOutOfRemoteConfig: false,
+		remoteConfigAvailable: false,
+	},
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => mocks.state,
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	StateServiceClient: { updateSettings: mocks.updateSettings },
+}))
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeCheckbox: ({ checked, children, onChange }: any) => (
+		<label>
+			<input checked={checked} onChange={onChange} type="checkbox" />
+			{children}
+		</label>
+	),
+}))
+
+function organization(roles = ["admin"]): UserOrganization {
+	return {
+		active: true,
+		memberId: "member-1",
+		name: "Organization",
+		organizationId: "org-1",
+		roles,
+	}
+}
+
+describe("RemoteConfigToggle", () => {
+	beforeEach(() => {
+		mocks.updateSettings.mockReset().mockResolvedValue(undefined)
+		mocks.state.optOutOfRemoteConfig = false
+		mocks.state.remoteConfigAvailable = false
+	})
+
+	it("hides the toggle when the active organization has no remote config", () => {
+		render(<RemoteConfigToggle activeOrganization={organization()} />)
+
+		expect(screen.queryByRole("checkbox")).toBeNull()
+	})
+
+	it("shows the toggle for an admin when remote config is available", () => {
+		mocks.state.remoteConfigAvailable = true
+		render(<RemoteConfigToggle activeOrganization={organization()} />)
+
+		expect(screen.getByRole("checkbox", { name: "Opt out of remote config" })).toBeDefined()
+	})
+
+	it("keeps the toggle available while opted out so the org can opt back in", () => {
+		mocks.state.remoteConfigAvailable = true
+		mocks.state.optOutOfRemoteConfig = true
+		render(<RemoteConfigToggle activeOrganization={organization()} />)
+
+		expect(screen.getByRole("checkbox")).toBeChecked()
+	})
+
+	it("hides the toggle for members who cannot opt out", () => {
+		mocks.state.remoteConfigAvailable = true
+		render(<RemoteConfigToggle activeOrganization={organization(["member"])} />)
+
+		expect(screen.queryByRole("checkbox")).toBeNull()
+	})
+
+	it("updates the opt-out setting", () => {
+		mocks.state.remoteConfigAvailable = true
+		render(<RemoteConfigToggle activeOrganization={organization()} />)
+
+		fireEvent.click(screen.getByRole("checkbox"))
+
+		expect(mocks.updateSettings).toHaveBeenCalledOnce()
+		expect(mocks.updateSettings.mock.calls[0][0].optOutOfRemoteConfig).toBe(true)
+	})
+})

--- a/apps/vscode/webview-ui/src/components/account/RemoteConfigToggle.tsx
+++ b/apps/vscode/webview-ui/src/components/account/RemoteConfigToggle.tsx
@@ -1,16 +1,13 @@
 import { UpdateSettingsRequest, UserOrganization } from "@shared/proto/index.cline"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { useRef } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { StateServiceClient } from "@/services/grpc-client"
 import { isAdminOrOwner } from "./helpers"
 
 export function RemoteConfigToggle({ activeOrganization }: { activeOrganization: UserOrganization | null }) {
-	const { optOutOfRemoteConfig } = useExtensionState()
-	const hadOptedOutOfRemoteConfig = useRef(optOutOfRemoteConfig)
+	const { optOutOfRemoteConfig, remoteConfigAvailable } = useExtensionState()
 
-	// If there is no active org but the user had already opted out, keep displaying the toggle
-	if (!hadOptedOutOfRemoteConfig.current && activeOrganization && !isAdminOrOwner(activeOrganization)) {
+	if (!activeOrganization || !isAdminOrOwner(activeOrganization) || !remoteConfigAvailable) {
 		return null
 	}
 

--- a/apps/vscode/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/apps/vscode/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -216,7 +216,11 @@ const ClineRulesToggleModal: React.FC = () => {
 		.map(([path, enabled]): [string, boolean] => [path, enabled as boolean])
 		.sort(([a], [b]) => a.localeCompare(b))
 
-	const remoteConfigSettings = useRemoteConfigSettings(isVisible)
+	const {
+		settings: remoteConfigSettings,
+		isLoading: isRemoteConfigLoading,
+		error: remoteConfigError,
+	} = useRemoteConfigSettings(isVisible)
 	const remoteRules = remoteConfigSettings.filter((s) => s.type === "rule")
 	const remoteWorkflows = remoteConfigSettings.filter((s) => s.type === "workflow")
 	const remoteSkills = remoteConfigSettings.filter((s) => s.type === "skill")
@@ -500,6 +504,17 @@ const ClineRulesToggleModal: React.FC = () => {
 
 					{/* Scrollable content area */}
 					<div className="flex-1 overflow-y-auto px-3 pb-3" style={{ minHeight: 0 }}>
+						{isRemoteConfigLoading && remoteConfigSettings.length === 0 && (
+							<div className="text-xs text-description mb-3" role="status">
+								Loading managed configuration…
+							</div>
+						)}
+						{remoteConfigError && (
+							<div className="text-xs text-vscode-errorForeground mb-3" role="alert">
+								Could not refresh managed configuration: {remoteConfigError}
+								{remoteConfigSettings.length > 0 ? " Showing the last loaded configuration." : ""}
+							</div>
+						)}
 						{currentView === "rules" ? (
 							<>
 								{/* Remote Rules Section */}
@@ -518,7 +533,7 @@ const ClineRulesToggleModal: React.FC = () => {
 														key={rule.name}
 														rulePath={rule.name}
 														ruleType="cline"
-														toggleRule={rule.toggle}
+														toggleRule={(_path, enabled) => rule.toggle(enabled)}
 													/>
 												)
 											})}
@@ -617,7 +632,7 @@ const ClineRulesToggleModal: React.FC = () => {
 															key={workflow.name}
 															rulePath={workflow.name}
 															ruleType="workflow"
-															toggleRule={workflow.toggle}
+															toggleRule={(_path, enabled) => workflow.toggle(enabled)}
 														/>
 													)
 												})}
@@ -773,7 +788,7 @@ const ClineRulesToggleModal: React.FC = () => {
 															key={skill.name}
 															rulePath={skill.name}
 															ruleType="skill"
-															toggleRule={skill.toggle}
+															toggleRule={(_path, enabled) => skill.toggle(enabled)}
 														/>
 													)
 												})}

--- a/apps/vscode/webview-ui/src/components/settings/sections/RemoteConfigSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/RemoteConfigSection.tsx
@@ -24,6 +24,7 @@ const AUTOMATIC_DELAY_MS = 30000
 
 function RefreshButton() {
 	const [isLoading, setIsLoading] = useState(false)
+	const [error, setError] = useState<string>()
 	const [retryIn, setRetryIn] = useState<number | null>(null)
 	const intervalRef = useRef<NodeJS.Timeout>()
 
@@ -37,28 +38,40 @@ function RefreshButton() {
 
 	const onRefresh = () => {
 		setIsLoading(true)
-		StateServiceClient.refreshRemoteConfig(EmptyRequest.create()).finally(() => {
-			setIsLoading(false)
-			setRetryIn(AUTOMATIC_DELAY_MS / 1000)
+		setError(undefined)
+		StateServiceClient.refreshRemoteConfig(EmptyRequest.create())
+			.catch((refreshError) => {
+				setError(refreshError instanceof Error ? refreshError.message : "Failed to refresh managed configuration")
+			})
+			.finally(() => {
+				setIsLoading(false)
+				setRetryIn(AUTOMATIC_DELAY_MS / 1000)
 
-			intervalRef.current = setInterval(() => {
-				setRetryIn((old) => {
-					if (old && old > 0) return old - 1
+				intervalRef.current = setInterval(() => {
+					setRetryIn((old) => {
+						if (old && old > 0) return old - 1
 
-					intervalRef.current && clearInterval(intervalRef.current)
-					return null
-				})
-			}, 1000)
-		})
+						intervalRef.current && clearInterval(intervalRef.current)
+						return null
+					})
+				}, 1000)
+			})
 	}
 
 	return (
-		<VSCodeButton
-			className={`w-full rounded-xs ${isLoading ? "animate-pulse" : ""}`}
-			disabled={isLoading || (retryIn !== null && retryIn > 0)}
-			onClick={() => onRefresh()}>
-			Refresh {retryIn && retryIn > 0 && <>(Retry in: {retryIn} seconds)</>}
-		</VSCodeButton>
+		<div>
+			<VSCodeButton
+				className={`w-full rounded-xs ${isLoading ? "animate-pulse" : ""}`}
+				disabled={isLoading || (retryIn !== null && retryIn > 0)}
+				onClick={() => onRefresh()}>
+				Refresh {retryIn && retryIn > 0 && <>(Retry in: {retryIn} seconds)</>}
+			</VSCodeButton>
+			{error && (
+				<div className="text-xs text-vscode-errorForeground mt-2" role="alert">
+					Could not refresh managed configuration: {error}
+				</div>
+			)}
+		</div>
 	)
 }
 
@@ -269,10 +282,10 @@ function PromptUploadingSection() {
 }
 
 export function RemoteConfigSection({ renderSectionHeader }: RemoteConfigSectionProps) {
-	const { remoteConfigSettings, optOutOfRemoteConfig } = useExtensionState()
+	const { remoteConfigSettings, optOutOfRemoteConfig, remoteConfigAvailable } = useExtensionState()
 	const { activeOrganization } = useClineAuth()
 
-	if (optOutOfRemoteConfig) {
+	if (optOutOfRemoteConfig && remoteConfigAvailable) {
 		return (
 			<BaseRemoteConfigSection renderSectionHeader={renderSectionHeader}>
 				<div className="flex flex-col justify-center gap-4">

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -306,6 +306,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		lastDismissedInfoBannerVersion: 0,
 		lastDismissedModelBannerVersion: 0,
 		optOutOfRemoteConfig: false,
+		remoteConfigAvailable: false,
 		remoteConfigSettings: {},
 		backgroundCommandRunning: false,
 		backgroundCommandTaskId: undefined,

--- a/apps/vscode/webview-ui/src/hooks/useRemoteConfigSettings.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useRemoteConfigSettings.test.ts
@@ -1,0 +1,134 @@
+import type { RemoteConfigSettingsResponse } from "@shared/proto/cline/remote_config"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { RemoteConfigServiceClient } from "@/services/grpc-client"
+import useRemoteConfigSettings from "./useRemoteConfigSettings"
+
+vi.mock("@/context/ExtensionStateContext", () => ({ useExtensionState: vi.fn() }))
+vi.mock("@/services/grpc-client", () => ({
+	RemoteConfigServiceClient: {
+		getRemoteConfigSettings: vi.fn(),
+		toggleRemoteConfigSetting: vi.fn(),
+	},
+}))
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise
+		reject = rejectPromise
+	})
+	return { promise, resolve, reject }
+}
+
+const useExtensionStateMock = vi.mocked(useExtensionState)
+const getSettingsMock = vi.mocked(RemoteConfigServiceClient.getRemoteConfigSettings)
+const toggleSettingMock = vi.mocked(RemoteConfigServiceClient.toggleRemoteConfigSetting)
+
+describe("useRemoteConfigSettings", () => {
+	let revision = 0
+
+	beforeEach(() => {
+		revision = 0
+		useExtensionStateMock.mockImplementation(
+			() => ({ remoteConfigRevision: revision }) as ReturnType<typeof useExtensionState>,
+		)
+		getSettingsMock.mockReset()
+		toggleSettingMock.mockReset()
+	})
+
+	it("reports loading and then the authoritative settings", async () => {
+		const request = deferred<RemoteConfigSettingsResponse>()
+		getSettingsMock.mockReturnValue(request.promise as never)
+		const { result } = renderHook(() => useRemoteConfigSettings(true))
+
+		expect(result.current).toEqual({ settings: [], isLoading: true, error: undefined })
+
+		request.resolve({
+			settings: [{ type: 0, name: "Security", content: "Policy", enabled: true, locked: true }],
+		})
+		await waitFor(() => expect(result.current.isLoading).toBe(false))
+		expect(result.current.settings[0]).toMatchObject({ type: "rule", name: "Security", locked: true })
+	})
+
+	it("refetches when the extension publishes a new remote-config revision", async () => {
+		getSettingsMock.mockResolvedValueOnce({ settings: [] } as never).mockResolvedValueOnce({
+			settings: [{ type: 1, name: "Release", content: "Steps", enabled: true, locked: false }],
+		} as never)
+		const { result, rerender } = renderHook(() => useRemoteConfigSettings(true))
+		await waitFor(() => expect(getSettingsMock).toHaveBeenCalledTimes(1))
+
+		revision = 1
+		rerender()
+
+		await waitFor(() => expect(getSettingsMock).toHaveBeenCalledTimes(2))
+		await waitFor(() => expect(result.current.settings[0]?.name).toBe("Release"))
+	})
+
+	it("retains stale settings and reports an error when refresh fails", async () => {
+		getSettingsMock.mockResolvedValueOnce({
+			settings: [{ type: 2, name: "Review", content: "Skill", enabled: true, locked: false }],
+		} as never)
+		const { result, rerender } = renderHook(() => useRemoteConfigSettings(true))
+		await waitFor(() => expect(result.current.settings[0]?.name).toBe("Review"))
+
+		getSettingsMock.mockRejectedValueOnce(new Error("transport failed"))
+		revision = 1
+		rerender()
+
+		await waitFor(() => expect(result.current.error).toBe("transport failed"))
+		expect(result.current.settings[0]?.name).toBe("Review")
+	})
+
+	it("updates from the authoritative toggle response", async () => {
+		getSettingsMock.mockResolvedValue({
+			settings: [{ type: 0, name: "Optional", content: "Policy", enabled: true, locked: false }],
+		} as never)
+		toggleSettingMock.mockResolvedValue({
+			type: 0,
+			name: "Optional",
+			content: "Policy",
+			enabled: false,
+			locked: false,
+		} as never)
+		const { result } = renderHook(() => useRemoteConfigSettings(true))
+		await waitFor(() => expect(result.current.settings[0]?.name).toBe("Optional"))
+
+		act(() => result.current.settings[0].toggle(false))
+
+		await waitFor(() => expect(result.current.settings[0].enabled).toBe(false))
+		expect(toggleSettingMock).toHaveBeenCalledWith({ type: 0, name: "Optional", enabled: false })
+	})
+
+	it("surfaces toggle failures and retains the authoritative previous value", async () => {
+		getSettingsMock.mockResolvedValue({
+			settings: [{ type: 0, name: "Optional", content: "Policy", enabled: true, locked: false }],
+		} as never)
+		toggleSettingMock.mockRejectedValue(new Error("toggle failed"))
+		const { result } = renderHook(() => useRemoteConfigSettings(true))
+		await waitFor(() => expect(result.current.settings[0]?.name).toBe("Optional"))
+
+		act(() => result.current.settings[0].toggle(false))
+
+		await waitFor(() => expect(result.current.error).toBe("toggle failed"))
+		expect(result.current.settings[0].enabled).toBe(true)
+	})
+
+	it("ignores a response after the modal becomes hidden", async () => {
+		const request = deferred<RemoteConfigSettingsResponse>()
+		getSettingsMock.mockReturnValue(request.promise as never)
+		const { result, rerender } = renderHook(({ visible }) => useRemoteConfigSettings(visible), {
+			initialProps: { visible: true },
+		})
+
+		rerender({ visible: false })
+		await act(async () => {
+			request.resolve({ settings: [{ type: 0, name: "Late", content: "", enabled: true, locked: false }] })
+			await request.promise
+		})
+
+		expect(result.current.settings).toEqual([])
+	})
+})

--- a/apps/vscode/webview-ui/src/hooks/useRemoteConfigSettings.ts
+++ b/apps/vscode/webview-ui/src/hooks/useRemoteConfigSettings.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { RemoteConfigServiceClient } from "@/services/grpc-client"
 
 export interface RemoteConfigSetting {
@@ -7,19 +8,49 @@ export interface RemoteConfigSetting {
 	content: string
 	enabled: boolean
 	locked: boolean
-	toggle: () => void
+	toggle: (enabled: boolean) => void
 }
 
-function toggleRemoteConfigSetting(settingName: string) {
-	// TODO(ENG): The backend handler is not implemented yet and currently
-	// rejects. Handle the result (e.g. update UI state) once toggling is wired
-	// up; for now swallow the rejection so it doesn't surface as an unhandled
-	// promise rejection.
-	RemoteConfigServiceClient.toggleRemoteConfigSetting({ value: settingName }).catch(() => {})
+export interface RemoteConfigSettingsState {
+	settings: RemoteConfigSetting[]
+	isLoading: boolean
+	error?: string
 }
 
-export default function useRemoteConfigSettings(isVisible: boolean): RemoteConfigSetting[] {
-	const [remoteConfigSettings, setRemoteConfigSettings] = useState<RemoteConfigSetting[]>([])
+type ProtoSetting = Awaited<ReturnType<typeof RemoteConfigServiceClient.getRemoteConfigSettings>>["settings"][number]
+
+function settingType(type: ProtoSetting["type"]): RemoteConfigSetting["type"] {
+	return type === 0 ? "rule" : type === 1 ? "workflow" : "skill"
+}
+
+export default function useRemoteConfigSettings(isVisible: boolean): RemoteConfigSettingsState {
+	const { remoteConfigRevision } = useExtensionState()
+	const [state, setState] = useState<Omit<RemoteConfigSettingsState, "settings"> & { settings: ProtoSetting[] }>({
+		settings: [],
+		isLoading: false,
+	})
+
+	const toggle = useCallback(async (setting: ProtoSetting, enabled: boolean) => {
+		setState((current) => ({ ...current, error: undefined }))
+		try {
+			const updated = await RemoteConfigServiceClient.toggleRemoteConfigSetting({
+				type: setting.type,
+				name: setting.name,
+				enabled,
+			})
+			setState((current) => ({
+				...current,
+				settings: current.settings.map((entry) =>
+					entry.type === updated.type && entry.name === updated.name ? updated : entry,
+				),
+			}))
+		} catch (error) {
+			setState((current) => ({
+				...current,
+				error: error instanceof Error ? error.message : "Failed to update managed configuration",
+			}))
+		}
+	}, [])
 
 	useEffect(() => {
 		if (!isVisible) {
@@ -27,32 +58,38 @@ export default function useRemoteConfigSettings(isVisible: boolean): RemoteConfi
 		}
 
 		let isCancelled = false
+		setState((current) => ({ ...current, isLoading: true, error: undefined }))
 
-		RemoteConfigServiceClient.getRemoteConfigSettings({}).then((response) => {
-			if (isCancelled) {
-				return
-			}
-
-			const settings = response.settings.map(
-				(setting) =>
-					({
-						type: setting.type === 0 ? "rule" : setting.type === 1 ? "workflow" : "skill",
-						name: setting.name,
-						content: setting.content,
-						enabled: setting.enabled,
-						locked: setting.locked,
-						toggle: () => {
-							toggleRemoteConfigSetting(setting.name)
-						},
-					}) as RemoteConfigSetting,
-			)
-			setRemoteConfigSettings(settings)
-		})
+		RemoteConfigServiceClient.getRemoteConfigSettings({})
+			.then((response) => {
+				if (!isCancelled) {
+					setState({ settings: response.settings, isLoading: false })
+				}
+			})
+			.catch((error) => {
+				if (!isCancelled) {
+					setState((current) => ({
+						...current,
+						isLoading: false,
+						error: error instanceof Error ? error.message : "Failed to load managed configuration",
+					}))
+				}
+			})
 
 		return () => {
 			isCancelled = true
 		}
-	}, [isVisible])
+	}, [isVisible, remoteConfigRevision])
 
-	return remoteConfigSettings
+	return {
+		...state,
+		settings: state.settings.map((setting) => ({
+			type: settingType(setting.type),
+			name: setting.name,
+			content: setting.content,
+			enabled: setting.enabled,
+			locked: setting.locked,
+			toggle: (enabled) => void toggle(setting, enabled),
+		})),
+	}
 }

--- a/sdk/packages/llms/src/providers/vendors/google.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/google.test.ts
@@ -27,7 +27,7 @@ describe("createGoogleProviderModule", () => {
 			context(),
 		);
 
-		provider.model("gemini-2.5-pro");
+		provider.operations.language("gemini-2.5-pro");
 
 		expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -330,6 +330,7 @@ export { CLINE_DEFAULT_MODEL_ID } from "./providers/defaults";
 export { isClineProvider } from "./providers/utils";
 export {
 	buildRemoteConfigSessionBlobUploadMetadata,
+	clearMaterializedRemoteConfigRuntime,
 	clearRemoteConfigSessionBlobUpload,
 	createRemoteConfigSessionMessagesArtifactUploader,
 	prepareRemoteConfigRuntime,
@@ -341,6 +342,7 @@ export type {
 	PreparedRemoteConfigRuntime,
 	PrepareRemoteConfigRuntimeOptions,
 	RemoteConfigBundle,
+	RemoteConfigManagedInstructionFile,
 } from "./remote-config/bundle";
 export { REMOTE_URI_SCHEME } from "./remote-config/constants";
 export type {

--- a/sdk/packages/shared/src/remote-config/runtime.test.ts
+++ b/sdk/packages/shared/src/remote-config/runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	buildRemoteConfigSessionBlobUploadMetadata,
+	clearMaterializedRemoteConfigRuntime,
 	prepareRemoteConfigRuntime,
 	REMOTE_CONFIG_SESSION_BLOB_UPLOAD_METADATA_KEY,
 	readRemoteConfigSessionBlobUploadMetadata,
@@ -61,6 +62,41 @@ describe("remote-config runtime", () => {
 		expect(prepared.workflowsDirectories).toEqual([
 			prepared.paths.workflowsPath,
 		]);
+	});
+
+	it("removes materialized instructions when an authoritative refresh returns no bundle", async () => {
+		const workspacePath = await createTempWorkspace();
+		const initial = await prepareRemoteConfigRuntime({
+			workspacePath,
+			controlPlane: {
+				name: "test",
+				async fetchBundle() {
+					return {
+						source: "test",
+						version: "1",
+						remoteConfig: {
+							version: "v1",
+							globalRules: [{ name: "rule", contents: "stale rule" }],
+							globalWorkflows: [{ name: "workflow", contents: "stale workflow" }],
+						},
+						managedInstructions: [{ id: "skill", kind: "skill", name: "skill", contents: "stale skill" }],
+					};
+				},
+			},
+		});
+
+		await expect(fs.stat(initial.paths.rulesFilePath)).resolves.toBeDefined();
+		await expect(fs.stat(initial.paths.manifestPath)).resolves.toBeDefined();
+		await expect(fs.readdir(initial.paths.workflowsPath)).resolves.toHaveLength(1);
+		await expect(fs.readdir(initial.paths.skillsPath)).resolves.toHaveLength(1);
+
+		await clearMaterializedRemoteConfigRuntime({ workspacePath });
+
+		await expect(fs.stat(initial.paths.rulesFilePath)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(fs.stat(initial.paths.manifestPath)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(fs.readdir(initial.paths.workflowsPath)).resolves.toEqual([]);
+		await expect(fs.readdir(initial.paths.skillsPath)).resolves.toEqual([]);
+		await expect(fs.stat(initial.paths.bundleCachePath)).resolves.toBeDefined();
 	});
 
 	it("builds and reads non-secret blob upload metadata", () => {

--- a/sdk/packages/shared/src/remote-config/runtime.test.ts
+++ b/sdk/packages/shared/src/remote-config/runtime.test.ts
@@ -77,9 +77,18 @@ describe("remote-config runtime", () => {
 						remoteConfig: {
 							version: "v1",
 							globalRules: [{ name: "rule", contents: "stale rule" }],
-							globalWorkflows: [{ name: "workflow", contents: "stale workflow" }],
+							globalWorkflows: [
+								{ name: "workflow", contents: "stale workflow" },
+							],
 						},
-						managedInstructions: [{ id: "skill", kind: "skill", name: "skill", contents: "stale skill" }],
+						managedInstructions: [
+							{
+								id: "skill",
+								kind: "skill",
+								name: "skill",
+								contents: "stale skill",
+							},
+						],
 					};
 				},
 			},
@@ -87,16 +96,24 @@ describe("remote-config runtime", () => {
 
 		await expect(fs.stat(initial.paths.rulesFilePath)).resolves.toBeDefined();
 		await expect(fs.stat(initial.paths.manifestPath)).resolves.toBeDefined();
-		await expect(fs.readdir(initial.paths.workflowsPath)).resolves.toHaveLength(1);
+		await expect(fs.readdir(initial.paths.workflowsPath)).resolves.toHaveLength(
+			1,
+		);
 		await expect(fs.readdir(initial.paths.skillsPath)).resolves.toHaveLength(1);
 
 		await clearMaterializedRemoteConfigRuntime({ workspacePath });
 
-		await expect(fs.stat(initial.paths.rulesFilePath)).rejects.toMatchObject({ code: "ENOENT" });
-		await expect(fs.stat(initial.paths.manifestPath)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(fs.stat(initial.paths.rulesFilePath)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+		await expect(fs.stat(initial.paths.manifestPath)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 		await expect(fs.readdir(initial.paths.workflowsPath)).resolves.toEqual([]);
 		await expect(fs.readdir(initial.paths.skillsPath)).resolves.toEqual([]);
-		await expect(fs.stat(initial.paths.bundleCachePath)).resolves.toBeDefined();
+		await expect(fs.stat(initial.paths.bundleCachePath)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 	});
 
 	it("builds and reads non-secret blob upload metadata", () => {

--- a/sdk/packages/shared/src/remote-config/runtime.ts
+++ b/sdk/packages/shared/src/remote-config/runtime.ts
@@ -20,6 +20,19 @@ import {
 } from "./paths";
 import { DefaultRemoteConfigTelemetryAdapter } from "./telemetry";
 
+export async function clearMaterializedRemoteConfigRuntime(options: {
+	workspacePath: string;
+	pluginName?: string;
+	artifactStore?: RemoteConfigManagedArtifactStore;
+}): Promise<void> {
+	const paths = resolveRemoteConfigPaths(options);
+	const artifactStore = options.artifactStore ?? new FileSystemRemoteConfigManagedArtifactStore();
+	await artifactStore.removeChildren(paths.workflowsPath);
+	await artifactStore.removeChildren(paths.skillsPath);
+	await artifactStore.remove(paths.rulesFilePath);
+	await artifactStore.remove(paths.manifestPath);
+}
+
 function deriveClaims(
 	bundle: RemoteConfigBundle | undefined,
 ): RemoteConfigSyncResult["claims"] {

--- a/sdk/packages/shared/src/remote-config/runtime.ts
+++ b/sdk/packages/shared/src/remote-config/runtime.ts
@@ -26,11 +26,16 @@ export async function clearMaterializedRemoteConfigRuntime(options: {
 	artifactStore?: RemoteConfigManagedArtifactStore;
 }): Promise<void> {
 	const paths = resolveRemoteConfigPaths(options);
-	const artifactStore = options.artifactStore ?? new FileSystemRemoteConfigManagedArtifactStore();
+	const artifactStore =
+		options.artifactStore ?? new FileSystemRemoteConfigManagedArtifactStore();
 	await artifactStore.removeChildren(paths.workflowsPath);
 	await artifactStore.removeChildren(paths.skillsPath);
 	await artifactStore.remove(paths.rulesFilePath);
 	await artifactStore.remove(paths.manifestPath);
+	// The cached bundle can carry secrets (e.g. blob-store access keys) and is
+	// used as an offline fallback; an authoritative clear must remove it so the
+	// policy cannot be resurrected after opt-out or explicit no-config.
+	await artifactStore.remove(paths.bundleCachePath);
 }
 
 function deriveClaims(


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — internal remote-config parity work.

### Description

Test Lines Changed: 1,361
Prod Lines Changed: 949

**What is this?** Organizations can push rules, skills, and workflows down to everyone's Cline ("remote config"). This PR makes that pipeline behave correctly when things go wrong — bad network, opting out, signing out.

**What was broken:**

- **The UI never noticed updates.** When the config changed, the settings modal was supposed to refetch — but the "something changed" counter was never passed along, so it always read 0. Now it's wired through, and the modal refreshes.
- **A network hiccup could delete company policy.** If the server returned an error and there was no saved copy, the code concluded "guess there's no config" and wiped everything — while reporting success. Now a failed fetch keeps the last good config and reports failure.
- **Offline users got locked out (or let through wrongly).** Personal users with no organization could be blocked from starting tasks by a server blip. Meanwhile a company user whose identity couldn't be verified could slip through with no policy at all. Now: no org → never blocked; previously-managed install with unresolvable identity → blocked until it can verify.
- **"Opt out" only worked online.** Opting out used to ask the server first; offline, it silently did nothing while the UI said "opted out." Now the opt-out is checked locally before any network call, so it always clears the rules/skills/workflows — and it also shreds the two cache files on disk that could contain embedded credentials.

**One deliberate tradeoff:** a company user who cold-starts with no internet is blocked until they're back online. We chose strict fail-closed over an offline-cache fallback to keep this change small.

### Test Procedure

Automated: full `apps/vscode` suite (1,092 tests) and `sdk/packages/shared` (338 tests) pass; `tsc --noEmit` clean. Each fix has a test pinning it.

Manual verification, if you want to poke at it:

1. **UI refresh:** In an org with remote config, open Settings → manage remote rules. In another window, toggle a rule off and back on. The modal should reflect changes without reopening the extension.
2. **Network blip doesn't wipe policy:** With remote config applied, block api.cline.bot (hosts file or offline), trigger a refresh (or wait for the hourly one). Rules/skills/workflows under `.cline/remote-config/` should remain, and the agent should still receive them.
3. **Opt-out while offline:** As an org admin, go offline, then opt out of remote config in Account settings. The materialized files under `.cline/remote-config/` should be gone immediately and the agent should stop receiving org rules. Check that `remote_config_<org>.json` and `remote-config/cache/bundle.json` are deleted too.
4. **Personal accounts never blocked:** Sign in with a personal account (no org), go offline, start a task. It should start normally.
5. **Managed install fails closed:** In an org account, block only api.cline.bot, reload the window, and try to start a task. It should refuse with "Could not verify organization policy."

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/controller changes; webview changes covered by hook/component tests.

### Additional Notes

- Three commits, split by file: implementation → tests → review fixes. The implementation commit alone isn't CI-green (its updated tests land in the next commit); the branch tip is green.
- Known follow-ups deliberately left out: legacy REMOTE-scope toggle branches that bypass lock enforcement, refresh coalescing that can sample stale toggle state, toggle persist-without-rollback, request timeouts, and stricter validation of server-supplied org IDs used in file paths.