### PR TITLE
fix(cli): stop background auto-update from killing live hub sessions

### DIFF
--- a/apps/cli/script/postinstall.mjs
+++ b/apps/cli/script/postinstall.mjs
@@ -17,6 +17,35 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
+// CLI versions <= 3.0.54 restart the hub daemon after a background
+// auto-update even while it is serving live sessions, killing those sessions
+// mid-turn — and their build-fingerprint check then rejects every replacement
+// hub, bricking the running TUI. That restart code is the *old* version's, so
+// it cannot be patched here; but it bails out harmlessly when no hub
+// discovery record exists, and it runs only after this install (and this
+// script) completes. Setting the record aside protects any attached clients:
+// a running hub keeps serving its established connections, clients that share
+// its build fingerprint rebuild the record from a port probe, and the next
+// fresh launch retires stale hubs regardless of the record.
+function shieldRunningHubDiscovery() {
+	const explicitPath = process.env.CLINE_HUB_DISCOVERY_PATH?.trim();
+	const dataDir =
+		process.env.CLINE_DATA_DIR?.trim() ||
+		path.join(
+			process.env.CLINE_DIR?.trim() || path.join(os.homedir(), ".cline"),
+			"data",
+		);
+	const recordPath =
+		explicitPath || path.join(dataDir, "locks", "hub", "production.json");
+	if (!fs.existsSync(recordPath)) {
+		return;
+	}
+	const asidePath = `${recordPath}.superseded`;
+	fs.rmSync(asidePath, { force: true });
+	fs.renameSync(recordPath, asidePath);
+	console.log("Set aside hub discovery record for the updated CLI");
+}
+
 function main() {
 	if (os.platform() === "win32") {
 		// On Windows, npm creates .cmd shims from the bin field.
@@ -77,6 +106,14 @@ function main() {
 
 	fs.chmodSync(target, 0o755);
 	console.log(`Cached cline binary at ${target}`);
+}
+
+try {
+	shieldRunningHubDiscovery();
+} catch (error) {
+	// Best-effort: without the shield the worst case is the pre-3.0.55
+	// restart-while-busy behavior, never a broken install.
+	console.error(`postinstall: hub discovery shield skipped: ${error.message}`);
 }
 
 try {

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import {
 	clearHubDiscovery,
 	isAutoUpdateEnabledGlobally,
+	localHubHasNoActiveSessions,
 	probeHubServer,
 	readHubDiscovery,
 	resolveProductionHubOwnerContext,
@@ -359,6 +360,17 @@ async function restartHubServerIfRunning(): Promise<void> {
 			}).catch(() => undefined)
 		: undefined;
 	if (!discovery || !health?.url) return;
+
+	// Clients attached to the hub cannot survive a restart under them: the
+	// replacement hub comes up with the new build's fingerprint, which their
+	// compatibility check rejects. Leave a busy hub alone; the next fresh
+	// launch retires it once its sessions are gone.
+	if (!(await localHubHasNoActiveSessions(health.url, discovery.authToken))) {
+		writeln(
+			`${c.dim}[hub] update installed; hub has active sessions, deferring restart to the next launch${c.reset}`,
+		);
+		return;
+	}
 
 	const pid = discovery?.pid;
 	writeln(`${c.dim}[hub] restarting server…${c.reset}`);

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -955,7 +955,7 @@ function hasActiveHubSessions(payload: unknown): boolean {
 	});
 }
 
-async function localHubHasNoActiveSessions(
+export async function localHubHasNoActiveSessions(
 	url: string,
 	authToken?: string,
 	options?: Pick<HubClientOptions, "workspaceRoot" | "cwd">,

--- a/sdk/packages/core/src/hub/daemon/entry.ts
+++ b/sdk/packages/core/src/hub/daemon/entry.ts
@@ -37,6 +37,34 @@ export const hubDaemonReady = new Promise<void>((resolve, reject) => {
 // readiness promise. Keep startup failures handled by the fatal path below.
 void hubDaemonReady.catch(() => undefined);
 
+const HUB_STARTUP_BIND_RETRY_WINDOW_MS = 5_000;
+const HUB_STARTUP_BIND_RETRY_DELAY_MS = 250;
+
+function isAddressInUseError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error as Error & { code?: string }).code === "EADDRINUSE"
+	);
+}
+
+async function startHubWebSocketServerWithBindRetry(
+	bindDeadline: number,
+	options: Parameters<typeof startHubWebSocketServer>[0],
+): Promise<Awaited<ReturnType<typeof startHubWebSocketServer>>> {
+	for (;;) {
+		try {
+			return await startHubWebSocketServer(options);
+		} catch (error) {
+			if (!isAddressInUseError(error) || Date.now() >= bindDeadline) {
+				throw error;
+			}
+			await new Promise((resolve) =>
+				setTimeout(resolve, HUB_STARTUP_BIND_RETRY_DELAY_MS),
+			);
+		}
+	}
+}
+
 function parseArgs(argv: string[]): {
 	cwd: string;
 	host?: string;
@@ -198,9 +226,14 @@ async function main(): Promise<void> {
 		shutdownFatal("unhandledRejection", reason);
 	});
 
+	// A hub being retired can keep the port bound for a couple of seconds
+	// after acking shutdown (its watchdog force-exits below the 3s retire
+	// poll). Spawning into that window must wait the port out instead of
+	// dying with EADDRINUSE and leaving clients with no hub at all.
+	const bindDeadline = Date.now() + HUB_STARTUP_BIND_RETRY_WINDOW_MS;
 	let server: Awaited<ReturnType<typeof startHubWebSocketServer>>;
 	try {
-		server = await startHubWebSocketServer({
+		server = await startHubWebSocketServerWithBindRetry(bindDeadline, {
 			onShutdownRequested: () => {
 				void requestOrQueueShutdown({
 					reason: "authenticated HTTP shutdown request",

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -71,6 +71,30 @@ function resolveDefaultHubOwnerContext() {
 
 function isReusableHubRecord(record: HubServerProbeRecord): boolean {
 	return isManagedHubReusable(record, { expectedBuildId: resolveHubBuildId() });
+}
+
+/**
+ * Reads the discovery record the npm postinstall set aside (see
+ * apps/cli/script/postinstall.mjs). Deliberately bypasses readHubDiscovery —
+ * the file is best-effort recovery metadata, not a live record — and stays
+ * synchronous so it adds no async boundary to the ensure flow.
+ */
+function readSupersededHubDiscovery(
+	discoveryPath: string,
+): { url?: string; authToken?: string; pid?: number } | undefined {
+	try {
+		const raw = JSON.parse(
+			readFileSync(`${discoveryPath}.superseded`, "utf8"),
+		) as { url?: unknown; authToken?: unknown; pid?: unknown };
+		return {
+			url: typeof raw.url === "string" ? raw.url : undefined,
+			authToken:
+				typeof raw.authToken === "string" ? raw.authToken : undefined,
+			pid: typeof raw.pid === "number" ? raw.pid : undefined,
+		};
+	} catch {
+		return undefined;
+	}
 }
 
 function withMatchingDiscoveryRetirementMetadata(
@@ -308,6 +332,13 @@ async function ensureDetachedHubServerLocked(
 	};
 	await retireLegacySharedHub(owner).catch(() => undefined);
 	const discovered = await readHubDiscovery(owner.discoveryPath);
+	// The npm package's postinstall sets the discovery record aside (same
+	// ".superseded" suffix) so pre-3.0.55 updaters cannot restart a busy hub.
+	// Without it, a hub displaced that way could never be retired here: the
+	// port probe alone carries no auth token or pid.
+	const superseded = discovered?.url
+		? undefined
+		: readSupersededHubDiscovery(owner.discoveryPath);
 	let retiredUnusableDiscovery = false;
 	if (discovered?.url) {
 		const discoveredAuthToken = discovered.authToken;
@@ -345,7 +376,7 @@ async function ensureDetachedHubServerLocked(
 	if (expected?.url) {
 		const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
 			expected,
-			discovered,
+			discovered ?? superseded,
 			expectedUrl,
 		);
 		if (isReusableHubRecord(expected)) {
@@ -355,6 +386,7 @@ async function ensureDetachedHubServerLocked(
 			const candidateTokens = [
 				expected.authToken,
 				discovered?.authToken,
+				superseded?.authToken,
 			].filter(
 				(token): token is string =>
 					typeof token === "string" && token.trim().length > 0,
@@ -379,7 +411,7 @@ async function ensureDetachedHubServerLocked(
 					host: expected.host,
 					port: expected.port,
 					url: expected.url,
-					pid: expected.pid ?? discovered?.pid,
+					pid: expected.pid ?? discovered?.pid ?? superseded?.pid,
 					startedAt: expected.startedAt ?? new Date().toISOString(),
 					updatedAt: new Date().toISOString(),
 				};
@@ -446,7 +478,7 @@ async function ensureDetachedHubServerLocked(
 		if (nextExpected?.url && !isReusableHubRecord(nextExpected)) {
 			const expectedForRetirement = withMatchingDiscoveryRetirementMetadata(
 				nextExpected,
-				nextDiscovery,
+				nextDiscovery ?? superseded,
 				expectedUrl,
 			);
 			const retiredExpected = await retireIncompatibleHub(


### PR DESCRIPTION
### Related Issue

Internal incident — no tracked issue. Two team members hit this in two days during the 3.0.53 → 3.0.54 transition; any future release re-triggers it for every user with a live session.

### Description

**The incident.** Launch `cline` while a newer version exists on npm, start a turn, and ~60–90s later the turn dies with `Error: Hub connection closed (code=1006, reason=Connection ended)`. Retrying then fails with `WebSocket connection to 'ws://127.0.0.1:25463/hub' failed: Failed to connect`, and the TUI is dead until restarted. A second report (Bee) showed the nastier follow-on: `hub-daemon.log` full of a kill loop — hub starts, `client.register ok`, `shutdown deadline exceeded after authenticated HTTP shutdown request; forcing process exit`, repeat.

**Root cause chain** (three bugs stacking):

1. **The updater kills its own hub.** `autoUpdateOnStartup()` background-installs the new version and, on success, calls `restartHubServerIfRunning()` — which unconditionally sends the authenticated `/shutdown` (escalating to SIGTERM/SIGKILL) with **zero check for whether the hub is serving live sessions**. The session whose startup triggered the update check gets its own hub executed mid-turn. The guarded pattern already existed next door (`restartLocalHubIfIdleAfterStartupTimeout` checks `localHubHasNoActiveSessions`); the updater path just never got it. The `#13145` shutdown watchdog then force-exits the busy hub (graceful close stalls on the active session), producing the abrupt 1006.

2. **The old client can never recover.** After the install, the dist on disk is the *new* version. The old client's `ensureDetachedHubServerLocked` spawns a replacement daemon from those new files → it comes up with the new build fingerprint → the old client's own `isReusableHubRecord` check rejects it, and the post-spawn poll loop even *retires the hub it just spawned* and spawns another. Bee's kill loop is exactly this: the `client.register ok` before each kill is the old client's verify-probe connecting (protocol v1 is compatible; the fingerprint rejection is a client-side decision after connecting). Net effect: any hub swap under an attached pre-#13177 client bricks that client.

3. **The replacement daemon races the dying one for the port.** A retired hub's watchdog can hold the fixed port for ~2s after acking shutdown, while the retire poll clears the discovery record and the replacement spawns immediately. The new daemon died with a fatal `EADDRINUSE` (our `hub-daemon.log` had a long history of these), leaving **no hub at all** — which is why the original incident ended in `Failed to connect` rather than recovery.

**The fixes:**

1. **Guard the updater restart** (`apps/cli/src/commands/update.ts`): after a successful install, check `localHubHasNoActiveSessions` (now exported from core); if the hub is busy, print a note and defer — the next fresh launch retires it once idle. There is no urgency to restart: the running session is happily served by the old hub, and hub freshness is enforced at next launch anyway.

2. **Postinstall shield for versions ≤ 3.0.54** (`apps/cli/script/postinstall.mjs`): the unguarded restart is baked into binaries already on users' machines, so fix (1) alone means every existing user eats one more mid-session kill on their next upgrade. But their update flow *awaits* `npm update -g cline`, and the newly installed package's postinstall (which already exists — `node ./postinstall.mjs || true`) runs inside that install, **before** their restart code fires. The old `restartHubServerIfRunning()` bails out harmlessly when `readHubDiscovery` finds nothing — so the shield simply renames the hub discovery record aside (`production.json` → `production.json.superseded`). Every path self-heals from a missing record:
   - The running old TUI keeps its established WS connection untouched; if it ever needs to re-ensure, it finds its own same-fingerprint hub on the port probe and *republishes* the record (the existing repair path).
   - The next fresh launch of the new binary probes the port, retires the now-idle incompatible hub, and starts cleanly. The retire needs the old hub's auth token and pid, which the port probe alone doesn't carry — so ensure falls back to reading `<discoveryPath>.superseded` (the very file the shield wrote) for retirement credentials. Without this, new-binary launches after a shielded update errored with "incompatible hub could not be retired automatically" and stranded — caught by the live upgrade test below.
   - Same-version reinstalls likewise repair the record from the probe.

   Deliberately **unconditional** (no session check in postinstall): checking would require a WS protocol handshake in a dependency-free lifecycle script, and hiding the record for an *idle* hub costs only a deferred restart. Worst case of the shield failing (`ignore-scripts`, bun's untrusted-lifecycle default) is exactly today's behavior — it can only improve things, never regress.

3. **Bind retry in the daemon** (`sdk/packages/core/src/hub/daemon/entry.ts`): retry `EADDRINUSE` for up to 5s (250ms interval) so a replacement daemon waits out a retiring hub's watchdog window instead of dying fatally. This is what turns any remaining hub swap from "no hub at all" into a few hundred ms of delay.

**What this does *not* fix (deliberately, hotfix scope):** the fingerprint-retire behavior itself (a newer client starting alongside a still-attached older TUI will still retire the old hub). That's the #13177 directional-upgrade stack's job (older clients attach to newer hubs + get an update prompt), which lands separately on `bee/hub-improve`. A busy-aware ensure (spawn on port 0 + record takeover instead of retiring a busy hub) is a natural follow-up there — same decision sites that stack rewrites.

**Release note:** the shield only protects users upgrading **to** a version that carries it — every release published before this ships burns the ≤3.0.54 population's live sessions again. Worth cutting as 3.0.55 ahead of other queued releases.

### Test Procedure

- `tsc --noEmit` clean in `apps/cli` and `sdk/packages/core` (dev + smoke configs).
- `apps/cli` update tests: 11/11. Core hub unit tests: 244/244. Daemon shutdown e2e: 2/2. Biome clean on all four files.
- **Live guard check:** started a real daemon from source, called `localHubHasNoActiveSessions` against it — idle hub → `true` (restart proceeds, current behavior preserved); after `session.create` → `false` (restart deferred).
- **Live bind-retry check:** occupied the daemon's port with a plain TCP listener, spawned the daemon, released the port after 2s — daemon retried, bound, and published its discovery record; zero `EADDRINUSE` fatals (previously an immediate fatal exit).
- **Live shield check:** ran `postinstall.mjs` with `CLINE_DATA_DIR` pointing at a fixture — discovery record renamed to `.superseded`, binary-cache step still runs, exit 0. No-record case is a no-op.
- **Live upgrade e2e (real released artifacts):** installed actual `cline@3.0.53` from npm into an isolated prefix, started its real hub daemon, attached a client holding an active session, then ran the old binary's own `cline update` (its genuine updater code path) with the install redirected to a package built from this PR. Result: shield renamed the record mid-install, the old updater's restart bailed (no `[hub] restarting server…`), the old daemon stayed up, and the held session polled through the entire update without a single error. Zero shutdown requests in the hub log.
- **Live convergence test:** hub on default port with `CLINE_HUB_BUILD_ID=buildA`, record renamed to `.superseded` (as the shield leaves it), then `ensureDetachedHubServer` under `buildB` — retired the old hub via the set-aside credentials and came up with a fresh `buildB` record on the same port. This exact sequence failed with the stranded-client error before the fallback commit.
- Confidence in the shield's interaction with *old* code comes from reading the shipped `cli-v3.0.53`/`cli-v3.0.54` tags: their `restartHubServerIfRunning` returns before any kill/ensure when the record is absent, and their ensure repair path rebuilds the record from a same-fingerprint port probe.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend). Evidence of the incident and fixes is in the Test Procedure section; the original `hub-daemon.log` tail ends with `[hub-daemon] shutdown deadline exceeded after authenticated HTTP shutdown request; forcing process exit` immediately after healthy hook traffic from the live session.

### Additional Notes

npm's newer `allow-scripts` gate (observed on npm 11.18: warns; npm 12 may hard-block) can suppress the postinstall for global installs — in that case the shield silently degrades to today's behavior, never worse. Same applies to `ignore-scripts` configs and bun's untrusted-lifecycle default.

Registry note: `latest` is currently dist-tagged back to 3.0.53 to freeze the auto-update trigger while this bakes; publishing the release containing this PR re-points it.

The postinstall shield also fires when `cline` is installed as a *dependency* of another project (npm runs lifecycle scripts for deps) — the global discovery record gets set aside, costing at most one record-repair probe on the next hub interaction. Accepted as harmless; noting it so it doesn't surprise anyone debugging discovery-record churn.
