### PR TITLE
fix(core): stop concurrent Hub installs from retiring each other

### DIFF
--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -624,3 +624,42 @@ describe("doctor supervision reporting", () => {
 		);
 	});
 });
+
+describe("describeProcessesStartedDuringFix", () => {
+	const { describeProcessesStartedDuringFix } = __test__;
+	const liveParents = new Map([
+		[100, 10],
+		[200, 20],
+	]);
+	const resolveLiveParent = (pid: number) => liveParents.get(pid);
+
+	it("says nothing when no process started during the fix", () => {
+		expect(
+			describeProcessesStartedDuringFix([], resolveLiveParent),
+		).toBeUndefined();
+	});
+
+	it("blames the parent only when every process has a live one", () => {
+		expect(
+			describeProcessesStartedDuringFix([100, 200], resolveLiveParent),
+		).toBe(
+			"\nThese processes were respawned by a live parent. Stop the parent process listed above, then re-run.",
+		);
+	});
+
+	// A process can start on its own mid-repair - a user opening a new session,
+	// say - and telling them to go kill an unrelated parent would be wrong.
+	it("states the facts when no process has a live parent", () => {
+		expect(describeProcessesStartedDuringFix([777], resolveLiveParent)).toBe(
+			"\nThese processes started after the fix began, so they were not targeted. Re-run to see whether they persist.",
+		);
+	});
+
+	it("separates respawns from independent starts in a mixed batch", () => {
+		expect(
+			describeProcessesStartedDuringFix([100, 777], resolveLiveParent),
+		).toBe(
+			"\nSome of these were respawned by a live parent (100); stop the parent process listed above, then re-run. The rest started after the fix began and were not targeted.",
+		);
+	});
+});

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -461,6 +461,11 @@ function readParentPid(pid: number): number | undefined {
 	}
 }
 
+function liveParentPid(pid: number): number | undefined {
+	const parent = readParentPid(pid);
+	return parent && isProcessRunning(parent) ? parent : undefined;
+}
+
 /**
  * A daemon whose parent is still running was almost certainly just spawned by
  * that parent, and killing it only invites the parent to spawn another. Naming
@@ -471,12 +476,33 @@ function formatDaemonPidList(label: string, pids: number[]): string {
 		return `${label} ${c.dim}0${c.reset}`;
 	}
 	const described = pids.map((pid) => {
-		const parent = readParentPid(pid);
-		return parent && isProcessRunning(parent)
-			? `${pid} (spawned by ${parent})`
-			: String(pid);
+		const parent = liveParentPid(pid);
+		return parent ? `${pid} (spawned by ${parent})` : String(pid);
 	});
 	return `${label} ${c.dim}${described.join(", ")}${c.reset}`;
+}
+
+/**
+ * Advice for processes first seen during the fix. Only a process with a live
+ * parent is known to have been respawned by it; anything else may have been
+ * started independently (a user opening a new session mid-repair), so it gets
+ * a statement of fact rather than an instruction to go kill something.
+ */
+export function describeProcessesStartedDuringFix(
+	pids: number[],
+	resolveLiveParent: (pid: number) => number | undefined,
+): string | undefined {
+	if (pids.length === 0) {
+		return undefined;
+	}
+	const respawned = pids.filter((pid) => resolveLiveParent(pid) !== undefined);
+	if (respawned.length === 0) {
+		return "\nThese processes started after the fix began, so they were not targeted. Re-run to see whether they persist.";
+	}
+	if (respawned.length === pids.length) {
+		return "\nThese processes were respawned by a live parent. Stop the parent process listed above, then re-run.";
+	}
+	return `\nSome of these were respawned by a live parent (${respawned.join(", ")}); stop the parent process listed above, then re-run. The rest started after the fix began and were not targeted.`;
 }
 
 function formatStartupLockList(
@@ -579,6 +605,7 @@ function killPids(pids: number[]): number {
 export const __test__ = {
 	decideForeignContainer,
 	CONTAINER_CGROUP_PATTERN,
+	describeProcessesStartedDuringFix,
 	formatSupervisedConnector,
 };
 
@@ -758,9 +785,13 @@ export async function runDoctorCommand(
 	];
 	if (spawnedDuringFix.length > 0) {
 		writeln(formatDaemonPidList("started during fix", spawnedDuringFix));
-		io.writeln(
-			"\nProcesses started while the fix ran are respawns from a live parent. Stop the parent process listed above, then re-run.",
+		const advice = describeProcessesStartedDuringFix(
+			spawnedDuringFix,
+			liveParentPid,
 		);
+		if (advice) {
+			io.writeln(advice);
+		}
 	}
 	return 0;
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -449,6 +449,54 @@ function formatPidList(label: string, pids: number[]): string {
 	return `${label} ${c.dim}${pids.join(", ")}${c.reset}`;
 }
 
+function readParentPid(pid: number): number | undefined {
+	try {
+		const output = spawnSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+			encoding: "utf8",
+		});
+		const parsed = Number(output.stdout?.trim());
+		return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * A daemon whose parent is still running was almost certainly just spawned by
+ * that parent, and killing it only invites the parent to spawn another. Naming
+ * the parent points at the process the user actually has to stop.
+ */
+function formatDaemonPidList(label: string, pids: number[]): string {
+	if (pids.length === 0) {
+		return `${label} ${c.dim}0${c.reset}`;
+	}
+	const described = pids.map((pid) => {
+		const parent = readParentPid(pid);
+		return parent && isProcessRunning(parent)
+			? `${pid} (spawned by ${parent})`
+			: String(pid);
+	});
+	return `${label} ${c.dim}${described.join(", ")}${c.reset}`;
+}
+
+function formatStartupLockList(
+	label: string,
+	locks: StartupArtifact[],
+): string {
+	const described = locks
+		.map((lock) => {
+			if (lock.pid === undefined) {
+				return "unreadable";
+			}
+			return lock.stale ? `${lock.pid} (stale)` : `${lock.pid} (held, live)`;
+		})
+		.filter((entry) => entry.length > 0);
+	if (described.length === 0) {
+		return `${label} ${c.dim}0${c.reset}`;
+	}
+	return `${label} ${c.dim}${described.join(", ")}${c.reset}`;
+}
+
 function formatRecentSpawnedProcess(record: SpawnedProcessRecord): string {
 	const pieces = [
 		record.timestamp ?? "unknown-time",
@@ -556,13 +604,8 @@ export async function runDoctorCommand(
 		);
 		writeln(`hub uptime ${c.dim}${before.hubUptime ?? "n/a"}${c.reset}`);
 		writeln(formatPidList("hub listeners", before.listeningPids));
-		writeln(formatPidList("stale hub daemons", before.staleHubPids));
-		writeln(
-			formatPidList(
-				"hub startup locks",
-				before.hubStartupLocks.map((a) => a.pid ?? -1).filter((pid) => pid > 0),
-			),
-		);
+		writeln(formatDaemonPidList("stale hub daemons", before.staleHubPids));
+		writeln(formatStartupLockList("hub startup locks", before.hubStartupLocks));
 		writeln(formatPidList("cli processes", before.staleCliPids));
 		writeln(formatPidList("sidecar processes", before.staleSidecarPids));
 		if (before.activeConnectors.length === 0) {
@@ -673,16 +716,52 @@ export async function runDoctorCommand(
 		`cleared hub discovery records ${c.dim}${clearedArtifacts.discovery}${c.reset}`,
 	);
 	writeln(`hub healthy after fix: ${after.hubHealthy ? "yes" : "no"}`);
-	writeln(formatPidList("remaining hub listeners", after.listeningPids));
-	writeln(formatPidList("remaining stale hub daemons", after.staleHubPids));
+	// "Remaining" means a process this run tried to kill and failed to. A
+	// re-scan alone cannot tell that apart from a process that appeared while
+	// the fix was running, and reporting the two together reads as a failure
+	// to kill something that was never targeted.
+	const survived = (targets: number[], remaining: number[]) =>
+		remaining.filter((pid) => targets.includes(pid));
+	const appeared = (targets: number[], remaining: number[]) =>
+		remaining.filter((pid) => !targets.includes(pid));
 	writeln(
 		formatPidList(
-			"remaining hub startup locks",
-			after.hubStartupLocks.map((a) => a.pid ?? -1).filter((pid) => pid > 0),
+			"remaining hub listeners",
+			survived(refreshedAfterGracefulStop.listeningPids, after.listeningPids),
 		),
 	);
-	writeln(formatPidList("remaining cli processes", after.staleCliPids));
-	writeln(formatPidList("remaining sidecar processes", after.staleSidecarPids));
+	writeln(
+		formatDaemonPidList(
+			"remaining stale hub daemons",
+			survived(staleHubTargets, after.staleHubPids),
+		),
+	);
+	writeln(
+		formatStartupLockList("remaining hub startup locks", after.hubStartupLocks),
+	);
+	writeln(
+		formatPidList(
+			"remaining cli processes",
+			survived(staleCliTargets, after.staleCliPids),
+		),
+	);
+	writeln(
+		formatPidList(
+			"remaining sidecar processes",
+			survived(staleSidecarTargets, after.staleSidecarPids),
+		),
+	);
+	const spawnedDuringFix = [
+		...appeared(staleHubTargets, after.staleHubPids),
+		...appeared(staleCliTargets, after.staleCliPids),
+		...appeared(staleSidecarTargets, after.staleSidecarPids),
+	];
+	if (spawnedDuringFix.length > 0) {
+		writeln(formatDaemonPidList("started during fix", spawnedDuringFix));
+		io.writeln(
+			"\nProcesses started while the fix ran are respawns from a live parent. Stop the parent process listed above, then re-run.",
+		);
+	}
 	return 0;
 }
 

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -967,7 +967,7 @@ describe("resolveCompatibleLocalHubUrl", () => {
 		expect(readHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 
-	it("returns undefined and keeps discovery when build metadata is missing", async () => {
+	it("attaches and keeps discovery when build metadata is missing", async () => {
 		const clearHubDiscoveryMock = vi.fn();
 		vi.doMock("../discovery/workspace", () => ({
 			resolveProductionHubOwnerContext: () => ({
@@ -1011,7 +1011,13 @@ describe("resolveCompatibleLocalHubUrl", () => {
 
 		const { resolveCompatibleLocalHubUrl } = await import(".");
 
-		await expect(resolveCompatibleLocalHubUrl()).resolves.toBeUndefined();
+		// A Hub carrying no build metadata cannot be ordered against this
+		// build, so it is attached over the compatible wire protocol rather
+		// than retired. Retiring an unorderable peer is what let two installs
+		// shut each other's daemon down in a loop.
+		await expect(resolveCompatibleLocalHubUrl()).resolves.toBe(
+			"ws://127.0.0.1:59999/hub",
+		);
 		expect(clearHubDiscoveryMock).not.toHaveBeenCalled();
 	});
 

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -865,15 +865,13 @@ async function probeCompatibleHubUrl(
 		};
 	}
 	if (options?.requireCurrentBuild) {
-		// Managed Hubs: reusable when the build matches or the Hub is a newer
-		// build (another installation upgraded it - attach and let the
-		// build-mismatch watcher prompt the user instead of downgrading it).
+		// Managed Hubs: reusable unless this build is strictly newer than the
+		// Hub's. A Hub that is newer or unorderable is attached over the
+		// compatible wire protocol and left to the build-mismatch watcher to
+		// prompt about, so two installations can never retire each other.
 		const expectedBuildId = resolveHubBuildId();
 		const compatibility = getManagedHubCompatibility(record, expectedBuildId);
-		if (
-			!compatibility.compatible &&
-			!isManagedHubReusable(record, { expectedBuildId })
-		) {
+		if (!compatibility.compatible && !isManagedHubReusable(record)) {
 			return {
 				status:
 					compatibility.reason === "unsupported_protocol"

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -105,7 +105,7 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	}
 	if (
 		compatibility.reason === "build_mismatch" &&
-		isManagedHubReusable(healthy, { expectedBuildId })
+		isManagedHubReusable(healthy)
 	) {
 		return report("build_mismatch");
 	}

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -122,7 +122,11 @@ vi.mock("../discovery", () => ({
 describe("ensureDetachedHubServer", () => {
 	const fetchMock = vi.fn(async () => ({ ok: true }));
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		// The retire circuit breaker is module state keyed by Hub URL, and these
+		// cases all retire the same URL.
+		const { __test__ } = await import(".");
+		__test__.resetRetireAttempts();
 		delete process.env[CLINE_RUN_AS_HUB_DAEMON_ENV];
 		spawn.mockReset();
 		spawn.mockImplementation(() => ({ unref: vi.fn() }));

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -23,7 +23,6 @@ import {
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
-	resolveHubBuildId,
 	withHubStartupLock,
 	writeHubDiscovery,
 } from "../discovery";
@@ -42,6 +41,40 @@ const HUB_RETIRE_TIMEOUT_MS = 3_000;
 const HUB_RETIRE_POLL_MS = 100;
 const HUB_SPAWN_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000];
 const COMPILED_BUN_HUB_DAEMON_ARG = "--cline-hub-daemon";
+const HUB_RETIRE_ATTEMPT_LIMIT = 3;
+const HUB_RETIRE_ATTEMPT_WINDOW_MS = 60_000;
+
+const retireAttemptsByUrl = new Map<
+	string,
+	{ count: number; windowStartedAt: number }
+>();
+
+/**
+ * Circuit breaker on repeated retirements of the same Hub URL.
+ *
+ * Build ordering already guarantees that only one side of a pair can decide to
+ * retire, so a healthy install retires a given URL once. Retiring the same URL
+ * over and over means something upstream is wrong, and the failure mode is
+ * severe: long-lived clients (sidecars, interactive CLI sessions) tear each
+ * other's daemon down in a tight loop and every session dies with an abnormal
+ * socket close. Backing off after a few attempts keeps a future ordering bug to
+ * a stale-build prompt instead of an unusable Hub.
+ */
+export const __test__ = {
+	resetRetireAttempts(): void {
+		retireAttemptsByUrl.clear();
+	},
+};
+
+function shouldAttemptRetire(url: string, now = Date.now()): boolean {
+	const entry = retireAttemptsByUrl.get(url);
+	if (!entry || now - entry.windowStartedAt > HUB_RETIRE_ATTEMPT_WINDOW_MS) {
+		retireAttemptsByUrl.set(url, { count: 1, windowStartedAt: now });
+		return true;
+	}
+	entry.count += 1;
+	return entry.count <= HUB_RETIRE_ATTEMPT_LIMIT;
+}
 
 function endpointArgs(endpoint: HubEndpointOverrides): string[] {
 	return [
@@ -70,7 +103,7 @@ function resolveDefaultHubOwnerContext() {
 }
 
 function isReusableHubRecord(record: HubServerProbeRecord): boolean {
-	return isManagedHubReusable(record, { expectedBuildId: resolveHubBuildId() });
+	return isManagedHubReusable(record);
 }
 
 function withMatchingDiscoveryRetirementMetadata(
@@ -118,6 +151,9 @@ async function retireDiscoveredHub(
 	record: { url: string; authToken?: string; pid?: number },
 	discoveryPath: string,
 ): Promise<boolean> {
+	if (!shouldAttemptRetire(record.url)) {
+		return false;
+	}
 	await requestHubShutdown(record.url, record.authToken).catch(() => false);
 	if (record.pid) {
 		try {

--- a/sdk/packages/core/src/hub/discovery/build-order.test.ts
+++ b/sdk/packages/core/src/hub/discovery/build-order.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+	compareHubBuilds,
+	type HubBuildIdentity,
+	isManagedHubReusable,
+} from ".";
+
+/**
+ * Every shape a discovered Hub record has taken across releases, including the
+ * ones that caused the mutual-retire loop: pre-fingerprint daemons with no
+ * build metadata at all, and fingerprinted daemons from before build epochs
+ * were embedded.
+ */
+const BUILD_CORPUS: HubBuildIdentity[] = [
+	{},
+	{ buildId: "0.0.54" },
+	{ buildId: "0.0.64" },
+	{ buildId: "0.0.74" },
+	{ coreVersion: "0.0.64" },
+	{ coreVersion: "0.0.74" },
+	{ buildId: "0.0.64", coreVersion: "0.0.64" },
+	{ buildId: "0.0.74", coreVersion: "0.0.74" },
+	{ buildId: "abc123", coreVersion: "0.0.74" },
+	{ buildId: "def456", coreVersion: "0.0.74" },
+	{ buildId: "0.0.74", buildEpochMs: 1_000 },
+	{ buildId: "0.0.75", buildEpochMs: 2_000 },
+	{ buildId: "0.0.75", buildEpochMs: 2_000, coreVersion: "0.0.75" },
+	{ buildId: "source-0.0.74", coreVersion: "0.0.74" },
+	{ buildId: "0.0.74", buildEpochMs: Number.NaN },
+	{ buildId: "0.0.74", buildEpochMs: 0 },
+	{ buildId: " ", coreVersion: "not-a-version" },
+	{ coreVersion: "3.0.50-nightly.1785933782" },
+	{ coreVersion: "3.0.50" },
+];
+
+/**
+ * The subset a healthy daemon actually publishes: build id, epoch, and core
+ * version all present.
+ */
+const FULL_BUILD_CORPUS: HubBuildIdentity[] = [
+	{ buildId: "a", buildEpochMs: 1_000, coreVersion: "0.0.64" },
+	{ buildId: "b", buildEpochMs: 2_000, coreVersion: "0.0.74" },
+	{ buildId: "c", buildEpochMs: 2_000, coreVersion: "0.0.75" },
+	{ buildId: "d", buildEpochMs: 3_000, coreVersion: "0.0.64" },
+	{ buildId: "e", buildEpochMs: 3_000, coreVersion: "0.0.64" },
+];
+
+const PROTOCOL = { protocolVersion: "v1" } as const;
+
+function retires(mine: HubBuildIdentity, theirs: HubBuildIdentity): boolean {
+	return !isManagedHubReusable({ ...PROTOCOL, ...theirs }, { self: mine });
+}
+
+describe("compareHubBuilds", () => {
+	it("is reflexive over the corpus", () => {
+		for (const build of BUILD_CORPUS) {
+			expect(compareHubBuilds(build, build)).toBe(0);
+		}
+	});
+
+	it("is antisymmetric over every pair in the corpus", () => {
+		for (const a of BUILD_CORPUS) {
+			for (const b of BUILD_CORPUS) {
+				expect(
+					Math.sign(compareHubBuilds(a, b)) + Math.sign(compareHubBuilds(b, a)),
+				).toBe(0);
+			}
+		}
+	});
+
+	/**
+	 * Transitivity only holds where every record carries the same fields: a
+	 * tier is skipped when either side lacks it, so partial metadata makes
+	 * "indistinguishable" a non-transitive relation. Antisymmetry - the
+	 * property that actually prevents the retire loop - holds regardless, and
+	 * is asserted over the full corpus above.
+	 */
+	it("is transitive over fully populated identities", () => {
+		for (const a of FULL_BUILD_CORPUS) {
+			for (const b of FULL_BUILD_CORPUS) {
+				for (const c of FULL_BUILD_CORPUS) {
+					if (compareHubBuilds(a, b) < 0 && compareHubBuilds(b, c) < 0) {
+						expect(compareHubBuilds(a, c)).toBeLessThan(0);
+					}
+				}
+			}
+		}
+	});
+
+	it("orders by build epoch before core version", () => {
+		expect(
+			compareHubBuilds(
+				{ buildId: "a", buildEpochMs: 1_000, coreVersion: "9.9.9" },
+				{ buildId: "b", buildEpochMs: 2_000, coreVersion: "0.0.1" },
+			),
+		).toBeLessThan(0);
+	});
+
+	it("falls back to core version when epochs are absent or tied", () => {
+		expect(
+			compareHubBuilds({ coreVersion: "0.0.64" }, { coreVersion: "0.0.74" }),
+		).toBeLessThan(0);
+		expect(
+			compareHubBuilds(
+				{ buildId: "a", buildEpochMs: 5, coreVersion: "0.0.64" },
+				{ buildId: "b", buildEpochMs: 5, coreVersion: "0.0.74" },
+			),
+		).toBeLessThan(0);
+	});
+
+	it("treats records with no comparable metadata as indistinguishable", () => {
+		expect(compareHubBuilds({}, {})).toBe(0);
+		expect(compareHubBuilds({}, { buildId: "0.0.74" })).toBe(0);
+	});
+});
+
+describe("isManagedHubReusable", () => {
+	/**
+	 * The regression guard for the mutual-retire loop: two installations, each
+	 * evaluating the other's Hub, must never both decide to retire.
+	 */
+	it("never lets two builds retire each other", () => {
+		for (const a of BUILD_CORPUS) {
+			for (const b of BUILD_CORPUS) {
+				expect(retires(a, b) && retires(b, a)).toBe(false);
+			}
+		}
+	});
+
+	it("reuses a Hub built from the same build id", () => {
+		const build = { buildId: "0.0.74", coreVersion: "0.0.74" };
+		expect(retires(build, build)).toBe(false);
+	});
+
+	it("retires a strictly older Hub", () => {
+		expect(
+			retires(
+				{ buildId: "0.0.74", coreVersion: "0.0.74" },
+				{ buildId: "0.0.64", coreVersion: "0.0.64" },
+			),
+		).toBe(true);
+	});
+
+	it("attaches to a strictly newer Hub instead of downgrading it", () => {
+		expect(
+			retires(
+				{ buildId: "0.0.64", coreVersion: "0.0.64" },
+				{ buildId: "0.0.74", coreVersion: "0.0.74" },
+			),
+		).toBe(false);
+	});
+
+	it("attaches to a Hub with no build metadata rather than retiring it", () => {
+		expect(retires({ buildId: "0.0.74" }, {})).toBe(false);
+	});
+
+	it("still replaces a protocol-incompatible Hub", () => {
+		expect(
+			isManagedHubReusable(
+				{ protocolVersion: "v99", buildId: "0.0.64" },
+				{ self: { buildId: "0.0.74" } },
+			),
+		).toBe(false);
+	});
+});

--- a/sdk/packages/core/src/hub/discovery/index.test.ts
+++ b/sdk/packages/core/src/hub/discovery/index.test.ts
@@ -111,18 +111,19 @@ describe("hub discovery", () => {
 		expect(resolveHubBuildEpochMs()).toBe(12345);
 	});
 
-	it("reuses managed Hubs only for the same build or a strictly newer one", () => {
+	it("retires a managed Hub only when this build is strictly newer", () => {
 		snapshot = captureEnv();
 		delete process.env.CLINE_HUB_BUILD_EPOCH_MS;
-		const reuseOptions = {
-			expectedBuildId: "current-build",
-			expectedBuildEpochMs: 1_000,
+		const self = {
+			buildId: "current-build",
+			buildEpochMs: 1_000,
+			coreVersion: "0.0.70",
 		};
 		// Same build: reusable regardless of epoch.
 		expect(
 			isManagedHubReusable(
 				{ protocolVersion: "v1", buildId: "current-build" },
-				reuseOptions,
+				{ self },
 			),
 		).toBe(true);
 		// Different build with a newer epoch: another install upgraded the Hub.
@@ -133,24 +134,37 @@ describe("hub discovery", () => {
 					buildId: "other-build",
 					buildEpochMs: 2_000,
 				},
-				reuseOptions,
+				{ self },
 			),
 		).toBe(true);
 		// Different build that is older: retire and replace.
 		expect(
 			isManagedHubReusable(
 				{ protocolVersion: "v1", buildId: "other-build", buildEpochMs: 500 },
-				reuseOptions,
+				{ self },
 			),
 		).toBe(false);
-		// Different build with no ordering information: replace (safe default).
+		// No epoch, but an older core version still orders the two builds.
+		expect(
+			isManagedHubReusable(
+				{
+					protocolVersion: "v1",
+					buildId: "other-build",
+					coreVersion: "0.0.64",
+				},
+				{ self },
+			),
+		).toBe(false);
+		// Different build with no ordering information at all: attach rather
+		// than replace. Retiring an unordered peer is what let two installs
+		// shut each other's daemon down in a loop.
 		expect(
 			isManagedHubReusable(
 				{ protocolVersion: "v1", buildId: "other-build" },
-				reuseOptions,
+				{ self },
 			),
-		).toBe(false);
-		// Own epoch unknown (unbundled sources): replace.
+		).toBe(true);
+		// Own epoch unknown (unbundled sources): attach, never downgrade.
 		expect(
 			isManagedHubReusable(
 				{
@@ -158,12 +172,13 @@ describe("hub discovery", () => {
 					buildId: "other-build",
 					buildEpochMs: 2_000,
 				},
-				{ expectedBuildId: "current-build" },
+				{ self: { buildId: "current-build" } },
 			),
-		).toBe(false);
-		// Legacy hub without build metadata: replace.
-		expect(isManagedHubReusable({ protocolVersion: "v1" }, reuseOptions)).toBe(
-			false,
+		).toBe(true);
+		// Legacy hub without build metadata: attach and let the build-mismatch
+		// watcher prompt instead of killing a daemon we cannot order.
+		expect(isManagedHubReusable({ protocolVersion: "v1" }, { self })).toBe(
+			true,
 		);
 		// Protocol mismatch is never reusable, newer or not.
 		expect(
@@ -173,7 +188,7 @@ describe("hub discovery", () => {
 					buildId: "other-build",
 					buildEpochMs: 2_000,
 				},
-				reuseOptions,
+				{ self },
 			),
 		).toBe(false);
 	});

--- a/sdk/packages/core/src/hub/discovery/index.ts
+++ b/sdk/packages/core/src/hub/discovery/index.ts
@@ -182,41 +182,143 @@ export function getManagedHubCompatibility(
 	return { compatible: true };
 }
 
+export interface HubBuildIdentity {
+	buildId?: string;
+	buildEpochMs?: number;
+	coreVersion?: string;
+}
+
+function finiteEpochMs(value: number | undefined): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? value
+		: undefined;
+}
+
+/**
+ * Numeric release components of a semver-ish version, ignoring any prerelease
+ * or build suffix. Undefined when the value carries no comparable release.
+ */
+function parseReleaseComponents(
+	version: string | undefined,
+): number[] | undefined {
+	const release = version?.trim().split(/[-+]/, 1)[0];
+	if (!release) {
+		return undefined;
+	}
+	const components = release.split(".").map((part) => Number(part));
+	if (
+		components.length === 0 ||
+		components.some((part) => !Number.isInteger(part) || part < 0)
+	) {
+		return undefined;
+	}
+	return components;
+}
+
+function compareReleaseComponents(a: number[], b: number[]): number {
+	for (let index = 0; index < Math.max(a.length, b.length); index++) {
+		const left = a[index] ?? 0;
+		const right = b[index] ?? 0;
+		if (left !== right) {
+			return left < right ? -1 : 1;
+		}
+	}
+	return 0;
+}
+
+/**
+ * Total order over Hub builds: negative when `a` is older than `b`, positive
+ * when newer, zero when the two are indistinguishable.
+ *
+ * The ordering is what keeps concurrent installations from replacing each
+ * other's daemons. A one-sided "may I reuse this?" predicate lets both sides
+ * answer no, and two clients then retire each other's Hub forever; a total
+ * order is antisymmetric by construction, so at most one side can ever decide
+ * to retire. Every tier below preserves that: a field decides only when both
+ * records carry it, and the final fallback is "equal", which means reuse.
+ *
+ * Tiers, in order: identical build, embedded build epoch, core release
+ * version, then build id as a deterministic tiebreak.
+ */
+export function compareHubBuilds(
+	a: HubBuildIdentity,
+	b: HubBuildIdentity,
+): number {
+	const buildIdA = a.buildId?.trim();
+	const buildIdB = b.buildId?.trim();
+	if (buildIdA && buildIdB && buildIdA === buildIdB) {
+		return 0;
+	}
+
+	const epochA = finiteEpochMs(a.buildEpochMs);
+	const epochB = finiteEpochMs(b.buildEpochMs);
+	if (epochA !== undefined && epochB !== undefined && epochA !== epochB) {
+		return epochA < epochB ? -1 : 1;
+	}
+
+	const releaseA = parseReleaseComponents(a.coreVersion);
+	const releaseB = parseReleaseComponents(b.coreVersion);
+	if (releaseA && releaseB) {
+		const release = compareReleaseComponents(releaseA, releaseB);
+		if (release !== 0) {
+			return release;
+		}
+	}
+
+	if (buildIdA && buildIdB && buildIdA !== buildIdB) {
+		return buildIdA < buildIdB ? -1 : 1;
+	}
+
+	return 0;
+}
+
+/**
+ * This build's own identity, in the same shape a daemon publishes into its
+ * discovery record.
+ *
+ * Self and peer identities must be built from the same fields. Enriching only
+ * the local side - filling in a `coreVersion` the wire record can omit, say -
+ * makes a build's identity depend on which role it is playing, and two
+ * installations then decide the comparison on different tiers and each
+ * conclude that it is the newer one. Callers that need a synthetic identity
+ * pass it verbatim rather than layering overrides onto this.
+ */
+export function resolveHubBuildIdentity(): HubBuildIdentity {
+	return {
+		buildId: resolveHubBuildId(),
+		buildEpochMs: resolveHubBuildEpochMs(),
+		coreVersion: String(corePackage.version),
+	};
+}
+
 /**
  * Whether a client may keep using a managed local Hub instead of retiring it.
  *
- * Same build: always reusable. Different build: reusable only when the Hub
- * was produced *after* this client's own build (another installation
- * upgraded the shared Hub) - the daemon is then running newer code, so
- * replacing it would be a downgrade; the client attaches over the compatible
- * wire protocol and the build-mismatch watcher prompts the user to update.
- * A Hub that is older, unordered, or missing build metadata is not reusable
- * and gets retired and replaced, preserving the stale-daemon fix.
+ * A Hub is retired only when this client's build is *strictly newer* by
+ * {@link compareHubBuilds}. Same build, newer Hub, and indistinguishable
+ * builds all attach over the compatible wire protocol and let the
+ * build-mismatch watcher prompt the user to update. Because the decision is
+ * derived from a total order, two installations can never retire each other.
+ *
+ * Genuine protocol incompatibility is unaffected: those Hubs cannot be spoken
+ * to at all and are still replaced.
  */
 export function isManagedHubReusable(
-	record: HubProtocolMetadata & { buildId?: string; buildEpochMs?: number },
-	options?: { expectedBuildId?: string; expectedBuildEpochMs?: number },
+	record: HubProtocolMetadata & HubBuildIdentity,
+	options?: { self?: HubBuildIdentity },
 ): boolean {
-	const compatibility = getManagedHubCompatibility(
-		record,
-		options?.expectedBuildId ?? resolveHubBuildId(),
-	);
+	const self = options?.self ?? resolveHubBuildIdentity();
+	const compatibility = getManagedHubCompatibility(record, self.buildId ?? "");
 	if (compatibility.compatible) {
 		return true;
 	}
-	if (compatibility.reason !== "build_mismatch") {
+	if (
+		compatibility.reason !== "build_mismatch" &&
+		compatibility.reason !== "missing_build"
+	) {
 		return false;
 	}
-	const hubEpochMs = record.buildEpochMs;
-	const expectedEpochMs =
-		options?.expectedBuildEpochMs ?? resolveHubBuildEpochMs();
-	return (
-		typeof hubEpochMs === "number" &&
-		Number.isFinite(hubEpochMs) &&
-		typeof expectedEpochMs === "number" &&
-		Number.isFinite(expectedEpochMs) &&
-		hubEpochMs > expectedEpochMs
-	);
+	return compareHubBuilds(self, record) <= 0;
 }
 
 export function resolveHubOwnerContext(

--- a/sdk/packages/core/src/hub/discovery/workspace.ts
+++ b/sdk/packages/core/src/hub/discovery/workspace.ts
@@ -3,6 +3,7 @@ import { normalizeWorkspacePath } from "../../services/workspace/workspace-manif
 import {
 	type HubOwnerContext,
 	resolveClineDataDir,
+	resolveHubBuildId,
 	resolveHubOwnerContext,
 } from ".";
 
@@ -19,10 +20,19 @@ export function resolveWorkspaceHubOwnerContext(
 	);
 }
 
+/**
+ * Development builds change on every compile, so a single shared owner record
+ * puts every checkout and every rebuild in contention for one daemon - and the
+ * loser of that contention gets shut down mid-session. Scoping the owner by
+ * build id lets differing dev builds run their own Hub side by side instead of
+ * arbitrating over one. Production keeps a single owner (see
+ * {@link resolveProductionHubOwnerContext}), where the singleton matters and
+ * builds are ordered.
+ */
 export function resolveSharedHubOwnerContext(
 	label = DEFAULT_SHARED_HUB_OWNER_LABEL,
 ): HubOwnerContext {
-	return resolveHubOwnerContext(label);
+	return resolveHubOwnerContext(`${label}@${resolveHubBuildId()}`);
 }
 
 export function resolveProductionHubOwnerContext(): HubOwnerContext {

--- a/sdk/packages/core/src/hub/server/index.test.ts
+++ b/sdk/packages/core/src/hub/server/index.test.ts
@@ -455,9 +455,10 @@ describe("hub server startup", () => {
 		expect(payload.buildId).toBe(resolveHubBuildId());
 	});
 
-	it("does not reuse managed discovery from a different build", async () => {
+	it("does not reuse managed discovery from an older build", async () => {
 		const owner = createInMemoryHubOwnerContext("hub-server-test-stale-build");
 		vi.stubEnv("CLINE_HUB_BUILD_ID", "old-build");
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
 		try {
 			const stale = await startHubWebSocketServer({
 				owner,
@@ -469,6 +470,7 @@ describe("hub server startup", () => {
 			servers.add(stale);
 
 			vi.stubEnv("CLINE_HUB_BUILD_ID", "new-build");
+			vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "2000");
 			const result = await ensureHubWebSocketServer({
 				owner,
 				host: "127.0.0.1",
@@ -481,6 +483,43 @@ describe("hub server startup", () => {
 			expect(result.action).toBe("started");
 			expect(result.url).not.toBe(stale.url);
 			servers.add(requireServer(result.server));
+		} finally {
+			vi.unstubAllEnvs();
+			await clearHubDiscovery(owner.discoveryPath);
+		}
+	});
+
+	/**
+	 * Two builds that differ only by an opaque id carry nothing that says which
+	 * came first. Retiring on that basis is what let two installations shut each
+	 * other's Hub down in a loop, so an unorderable peer is attached to and the
+	 * build-mismatch watcher raises it with the user instead.
+	 */
+	it("reuses managed discovery from a build it cannot order itself against", async () => {
+		const owner = createInMemoryHubOwnerContext("hub-server-test-unordered");
+		vi.stubEnv("CLINE_HUB_BUILD_ID", "other-build");
+		try {
+			const other = await startHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+			servers.add(other);
+
+			vi.stubEnv("CLINE_HUB_BUILD_ID", "current-build");
+			const result = await ensureHubWebSocketServer({
+				owner,
+				host: "127.0.0.1",
+				port: 0,
+				pathname: "/hub",
+				allowPortFallback: true,
+				runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+			});
+
+			expect(result.action).toBe("reuse");
+			expect(result.url).toBe(other.url);
 		} finally {
 			vi.unstubAllEnvs();
 			await clearHubDiscovery(owner.discoveryPath);


### PR DESCRIPTION
### Related Issue

Follow-up to #13145, which introduced the behavior, and #13177, which partially mitigated it.

### Description

Two Cline installations on different builds shut each other's Hub daemon down in a loop. Every new session died as its daemon was killed mid-handshake:

```
Hub connection closed (code=1006, reason=Connection ended)
```

`~/.cline/data/logs/hub-daemon.log` shows the loop at roughly 700ms per cycle, alternating between two builds' shutdown paths:

```
[hub] command.end  client.register  ok
[hub-daemon] shutdown deadline exceeded after authenticated HTTP shutdown request; forcing process exit
[hub] command.end  client.register  ok
[hub-daemon] graceful shutdown stalled; forcing exit
```

(Those two messages come from different builds — #13168 replaced the second with the first — so the log itself shows two generations of daemon taking turns.)

#### Root cause

The retire decision was a **one-sided predicate**. Each client independently asked "may I reuse this Hub?", and two clients on differing builds both answered no, so each retired the other's daemon forever. #13177 added build-epoch ordering to break the tie, but left every unordered case — missing epoch, missing build id — retiring as before, so any pair involving a pre-epoch build still looped.

Transcribing `origin/main`'s predicate and running it over the two builds actually present on the affected machine:

```
a retires b: true
b retires a: true
MUTUAL RETIRE (loop): true
```

There was also a second, independent route to the same loop: identity was read from **different fields depending on role**. A build filled in its own `coreVersion` from `package.json`, but appeared as a peer without it whenever the wire record omitted it. The two directions of a pair were then decided by different tiers, and both concluded they were the newer one.

#### Fix

Derive the decision from a **total order**. `compareHubBuilds` orders two builds by embedded epoch, then core release version, then build id as a deterministic tiebreak. It is antisymmetric by construction, so at most one side of a pair can ever decide to retire — whatever the metadata looks like. A Hub that is newer or cannot be ordered is attached over the compatible wire protocol and left to the build-mismatch watcher to prompt about. Genuine protocol incompatibility still replaces, unchanged.

Self and peer identities are now built from the same fields, so a build's identity no longer depends on which role it is playing.

Also in this PR:

- **Dev owner scoping.** Development builds change on every compile, so one shared owner record put every checkout and rebuild in contention for a single daemon. The dev owner is now scoped by build id — differing dev builds run their own Hub side by side instead of arbitrating. Production keeps its singleton.
- **Retire circuit breaker.** After repeated retirements of the same URL, back off. Bounds any future ordering bug to a stale-build prompt rather than an unusable Hub.
- **Honest `cline doctor fix` output.** It previously printed `killed stale hub daemons 0` next to `remaining stale hub daemons 29958, 32607`, which reads as a failure to kill processes it had never targeted — they were spawned by a live parent *while the fix ran*. It now separates survivors from processes that appeared during the fix, names the live parent respawning a daemon, and marks a startup lock held by a running process as held rather than leaked.

### Test Procedure

New property test, `sdk/packages/core/src/hub/discovery/build-order.test.ts`, over a corpus of every record shape shipped across releases — including metadata-less pre-fingerprint daemons and fingerprinted-but-epoch-less ones:

- `compareHubBuilds` is reflexive and antisymmetric over every pair, and transitive over fully populated identities
- **`isManagedHubReusable` never lets two builds retire each other** — the regression guard for this class of bug

Verified the guard fails against `origin/main` and passes here.

Suites: `src/hub` (excluding `runtime-host`) — 149 passed, 6 failed; those 6 fail identically on `origin/main` without these changes (`LocalRuntimeHost` forwarding / yolo runtime builder, environmental). `apps/cli` doctor tests: 17 passed. `tsc --noEmit` clean for both `sdk/packages/core` and `apps/cli`; biome clean.

Not covered by automated tests: the multi-install scenario itself (needs two differing builds installed side by side).

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix, or chore
- [x] Tests added for the core behavior, and the guard verified to fail on the buggy code
- [x] No changeset — `.changeset/` targets `claude-dev` only; prior Hub PRs (#13145, #13168, #13177) added none

### Behavior change to be aware of

A Hub that cannot be ordered against the current build (no build metadata at all) is now **attached** rather than retired. That is the deliberate safe direction: it is what makes the mutual-retire case impossible, and the build-mismatch watcher still prompts the user to update. The previous behavior — kill anything unorderable — is precisely what made mixed installs unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
