### PR TITLE
feat(desktop): add app font size bootstrap script

### DIFF
--- a/apps/examples/desktop-app/src-tauri/Cargo.toml
+++ b/apps/examples/desktop-app/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ rfd = "0.15"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSResponder"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSEvent", "NSImage", "NSMenu", "NSMenuItem", "NSResponder"] }
 objc2-foundation = { version = "0.3", features = ["NSString"] }
 
 [features]

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -9,6 +9,8 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+#[cfg(target_os = "macos")]
+use tauri::menu::{Menu, MenuItemKind, PredefinedMenuItem, Submenu};
 use tauri::{
     menu::{MenuBuilder, MenuItem},
     tray::TrayIconBuilder,
@@ -24,6 +26,12 @@ const TRAY_OPEN_MENU_ID: &str = "tray-open";
 const TRAY_NEW_SESSION_MENU_ID: &str = "tray-new-session";
 const TRAY_SETTINGS_MENU_ID: &str = "tray-settings";
 const TRAY_QUIT_MENU_ID: &str = "tray-quit";
+#[cfg(any(target_os = "macos", test))]
+const VIEW_ZOOM_IN_MENU_ID: &str = "view-zoom-in";
+#[cfg(any(target_os = "macos", test))]
+const VIEW_ZOOM_OUT_MENU_ID: &str = "view-zoom-out";
+#[cfg(any(target_os = "macos", test))]
+const VIEW_ZOOM_RESET_MENU_ID: &str = "view-zoom-reset";
 const DESKTOP_MENU_ACTION_PENDING_EVENT: &str = "desktop-menu-action-pending";
 
 #[derive(Default)]
@@ -808,6 +816,101 @@ fn queue_desktop_menu_action(app: &tauri::AppHandle, action: &str) {
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
+fn application_menu_action(menu_id: &str) -> Option<&'static str> {
+    match menu_id {
+        VIEW_ZOOM_IN_MENU_ID => Some("zoom-in"),
+        VIEW_ZOOM_OUT_MENU_ID => Some("zoom-out"),
+        VIEW_ZOOM_RESET_MENU_ID => Some("zoom-reset"),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn setup_application_menu(app: &tauri::App) -> tauri::Result<()> {
+    let menu = Menu::default(app.handle())?;
+    let zoom_in = MenuItem::with_id(app, VIEW_ZOOM_IN_MENU_ID, "Zoom In", true, None::<&str>)?;
+    let zoom_out = MenuItem::with_id(
+        app,
+        VIEW_ZOOM_OUT_MENU_ID,
+        "Zoom Out",
+        true,
+        Some("CmdOrCtrl+-"),
+    )?;
+    let zoom_reset = MenuItem::with_id(
+        app,
+        VIEW_ZOOM_RESET_MENU_ID,
+        "Actual Size",
+        true,
+        Some("CmdOrCtrl+0"),
+    )?;
+    let separator = PredefinedMenuItem::separator(app)?;
+
+    let mut view_menu = None;
+    for item in menu.items()? {
+        if let MenuItemKind::Submenu(submenu) = item {
+            if submenu.text()? == "View" {
+                view_menu = Some(submenu);
+                break;
+            }
+        }
+    }
+
+    if let Some(view_menu) = view_menu {
+        view_menu.prepend_items(&[&zoom_in, &zoom_out, &zoom_reset, &separator])?;
+    } else {
+        let view_menu =
+            Submenu::with_items(app, "View", true, &[&zoom_in, &zoom_out, &zoom_reset])?;
+        menu.append(&view_menu)?;
+    }
+
+    app.set_menu(menu)?;
+    set_macos_menu_key_equivalent("View", "Zoom In", "+")?;
+    app.on_menu_event(|app, event| {
+        if let Some(action) = application_menu_action(event.id().as_ref()) {
+            queue_desktop_menu_action(app, action);
+        }
+    });
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn set_macos_menu_key_equivalent(
+    menu_title: &str,
+    item_title: &str,
+    key_equivalent: &str,
+) -> tauri::Result<()> {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSEventModifierFlags};
+    use objc2_foundation::NSString;
+
+    let missing = |description: &str| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("native menu item not found: {description}"),
+        )
+    };
+    let mtm = MainThreadMarker::new()
+        .ok_or_else(|| std::io::Error::other("native menu setup must run on the main thread"))?;
+    let app = NSApplication::sharedApplication(mtm);
+    let main_menu = app.mainMenu().ok_or_else(|| missing("main menu"))?;
+    let menu_item = main_menu
+        .itemWithTitle(&NSString::from_str(menu_title))
+        .ok_or_else(|| missing(menu_title))?;
+    let submenu = menu_item
+        .submenu()
+        .ok_or_else(|| missing(&format!("{menu_title} submenu")))?;
+    let item = submenu
+        .itemWithTitle(&NSString::from_str(item_title))
+        .ok_or_else(|| missing(item_title))?;
+
+    // Tauri 2.11's accelerator parser cannot represent the `+` character.
+    // Set the AppKit key equivalent directly so the menu displays and handles ⌘+.
+    item.setKeyEquivalent(&NSString::from_str(key_equivalent));
+    item.setKeyEquivalentModifierMask(NSEventModifierFlags::Command);
+    Ok(())
+}
+
 fn setup_tray_icon(app: &tauri::App) -> tauri::Result<()> {
     let status = MenuItem::new(app, "Status: Healthy", false, None::<&str>)?;
     let running_sessions = MenuItem::new(app, "0 sessions running", false, None::<&str>)?;
@@ -906,6 +1009,8 @@ fn main() {
         .manage(Arc::new(UpdateState::default()))
         .manage(DesktopMenuActionState::default())
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            setup_application_menu(app)?;
             setup_tray_icon(app)?;
             let app_context = app.state::<AppContext>().inner().clone();
             let backend_state = app.state::<Arc<DesktopBackendState>>().inner().clone();
@@ -982,6 +1087,23 @@ mod tests {
 
         assert_eq!(state.drain(), vec!["new-session", "open-settings"]);
         assert!(state.drain().is_empty());
+    }
+
+    #[test]
+    fn application_menu_ids_map_to_zoom_actions() {
+        assert_eq!(
+            application_menu_action(VIEW_ZOOM_IN_MENU_ID),
+            Some("zoom-in")
+        );
+        assert_eq!(
+            application_menu_action(VIEW_ZOOM_OUT_MENU_ID),
+            Some("zoom-out")
+        );
+        assert_eq!(
+            application_menu_action(VIEW_ZOOM_RESET_MENU_ID),
+            Some("zoom-reset")
+        );
+        assert_eq!(application_menu_action("unknown"), None);
     }
 
     #[test]

--- a/apps/examples/desktop-app/webview/app/layout.tsx
+++ b/apps/examples/desktop-app/webview/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { DesktopErrorTelemetry } from "@/components/desktop-error-telemetry";
 import { NativeShell } from "@/components/native-shell";
 import { Toaster } from "@/components/ui/toaster";
+import { APP_FONT_SIZE_BOOTSTRAP_SCRIPT } from "@/lib/app-font-size";
 import { HUB_THEME_BOOTSTRAP_SCRIPT } from "@/lib/theme";
 import "./globals.css";
 
@@ -40,6 +41,13 @@ export default function RootLayout({
 			suppressHydrationWarning
 		>
 			<head>
+				<script
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: static bootstrap must run before the first paint
+					dangerouslySetInnerHTML={{
+						__html: APP_FONT_SIZE_BOOTSTRAP_SCRIPT,
+					}}
+					id="cline-app-font-size-bootstrap"
+				/>
 				<script
 					// biome-ignore lint/security/noDangerouslySetInnerHtml: static bootstrap must run before the first paint
 					dangerouslySetInnerHTML={{ __html: HUB_THEME_BOOTSTRAP_SCRIPT }}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -43,6 +43,7 @@ import { useChatSession } from "@/hooks/use-chat-session";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
+import { syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
 import {
@@ -199,6 +200,7 @@ export default function Home() {
 	useEffect(() => {
 		syncHubTheme();
 		syncHubAccent();
+		syncAppFontSize();
 		return watchSystemHubTheme();
 	}, []);
 

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -43,7 +43,7 @@ import { useChatSession } from "@/hooks/use-chat-session";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
-import { syncAppFontSize } from "@/lib/app-font-size";
+import { applyAppZoomAction, syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
 import {
@@ -309,6 +309,11 @@ export default function Home() {
 						break;
 					case "open-settings":
 						handleViewChange("settings");
+						break;
+					case "zoom-in":
+					case "zoom-out":
+					case "zoom-reset":
+						applyAppZoomAction(action);
 						break;
 				}
 			}),

--- a/apps/examples/desktop-app/webview/components/ui/slider.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/slider.tsx
@@ -6,6 +6,10 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 function Slider({
+	"aria-describedby": ariaDescribedBy,
+	"aria-label": ariaLabel,
+	"aria-labelledby": ariaLabelledBy,
+	"aria-valuetext": ariaValueText,
 	className,
 	defaultValue,
 	value,
@@ -22,10 +26,18 @@ function Slider({
 					: [min, max],
 		[value, defaultValue, min, max],
 	);
-	const thumbKeyCounts = new Map<string, number>();
+	const thumbKeyPrefix = React.useId();
+	const thumbKeys = Array.from(
+		{ length: _values.length },
+		(_, index) => `${thumbKeyPrefix}-${index}`,
+	);
 
 	return (
 		<SliderPrimitive.Root
+			aria-describedby={ariaDescribedBy}
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabelledBy}
+			aria-valuetext={ariaValueText}
 			data-interactive=""
 			data-slot="slider"
 			defaultValue={defaultValue}
@@ -51,18 +63,17 @@ function Slider({
 					}
 				/>
 			</SliderPrimitive.Track>
-			{_values.map((thumbValue) => {
-				const valueKey = String(thumbValue);
-				const occurrence = (thumbKeyCounts.get(valueKey) ?? 0) + 1;
-				thumbKeyCounts.set(valueKey, occurrence);
-				return (
-					<SliderPrimitive.Thumb
-						data-slot="slider-thumb"
-						key={`${valueKey}-${occurrence}`}
-						className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
-					/>
-				);
-			})}
+			{thumbKeys.map((thumbKey) => (
+				<SliderPrimitive.Thumb
+					aria-describedby={ariaDescribedBy}
+					aria-label={ariaLabel}
+					aria-labelledby={ariaLabelledBy}
+					aria-valuetext={ariaValueText}
+					data-slot="slider-thumb"
+					key={thumbKey}
+					className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+				/>
+			))}
 		</SliderPrimitive.Root>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.test.tsx
@@ -3,7 +3,10 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { APP_FONT_SIZE_STORAGE_KEY } from "@/lib/app-font-size";
+import {
+	APP_FONT_SIZE_STORAGE_KEY,
+	applyAppZoomAction,
+} from "@/lib/app-font-size";
 import { SettingsView } from "./settings-view";
 
 const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
@@ -88,5 +91,14 @@ describe("SettingsView font size", () => {
 		expect(window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY)).toBe("19");
 		expect(document.documentElement.style.fontSize).toBe("19px");
 		expect(updatedSlider?.getAttribute("aria-valuenow")).toBe("19");
+
+		await act(async () => {
+			applyAppZoomAction("zoom-in");
+		});
+
+		expect(window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY)).toBe("20");
+		expect(container.textContent).toContain("20px");
+		expect(updatedSlider?.getAttribute("aria-valuenow")).toBe("20");
+		expect(increaseButton?.disabled).toBe(true);
 	});
 });

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { APP_FONT_SIZE_STORAGE_KEY } from "@/lib/app-font-size";
+import { SettingsView } from "./settings-view";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@/lib/desktop-client", () => ({
+	desktopClient: { invoke },
+	isTauriAvailable: vi.fn(() => false),
+	openExternalUrl: vi.fn(),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+class ResizeObserverStub {
+	disconnect() {}
+	observe() {}
+	unobserve() {}
+}
+
+beforeEach(() => {
+	Object.assign(globalThis, {
+		IS_REACT_ACT_ENVIRONMENT: true,
+		ResizeObserver: ResizeObserverStub,
+	});
+	window.localStorage.clear();
+	document.documentElement.style.removeProperty("font-size");
+	delete document.documentElement.dataset.clineFontSize;
+	invoke.mockReset();
+	invoke.mockResolvedValue({
+		telemetryOptOut: false,
+		autoUpdateEnabled: true,
+	});
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+});
+
+describe("SettingsView font size", () => {
+	it("loads the saved size and updates it from the General settings controls", async () => {
+		window.localStorage.setItem(APP_FONT_SIZE_STORAGE_KEY, "17");
+
+		await act(async () => {
+			root.render(
+				<SettingsView onNavigateSection={vi.fn()} section="General" />,
+			);
+		});
+
+		const slider = container.querySelector<HTMLElement>(
+			'[role="slider"][aria-label="Font size"]',
+		);
+		const increaseButton = container.querySelector<HTMLButtonElement>(
+			'button[aria-label="Increase font size"]',
+		);
+		expect(slider?.getAttribute("aria-valuenow")).toBe("17");
+		expect(increaseButton).not.toBeNull();
+		expect(increaseButton?.disabled).toBe(false);
+		expect(container.textContent).toContain("17px");
+
+		await act(async () => {
+			increaseButton?.click();
+		});
+
+		expect(window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY)).toBe("18");
+		expect(document.documentElement.style.fontSize).toBe("18px");
+		const updatedSlider = container.querySelector<HTMLElement>(
+			'[role="slider"][aria-label="Font size"]',
+		);
+		expect(updatedSlider).toBe(slider);
+		expect(updatedSlider?.getAttribute("aria-valuenow")).toBe("18");
+
+		await act(async () => {
+			updatedSlider?.focus();
+			updatedSlider?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, key: "ArrowRight" }),
+			);
+		});
+
+		expect(window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY)).toBe("19");
+		expect(document.documentElement.style.fontSize).toBe("19px");
+		expect(updatedSlider?.getAttribute("aria-valuenow")).toBe("19");
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -1,7 +1,16 @@
-import { RotateCcw } from "lucide-react";
+import { Minus, Plus, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import {
+	DEFAULT_APP_FONT_SIZE,
+	isAppFontSize,
+	MAX_APP_FONT_SIZE,
+	MIN_APP_FONT_SIZE,
+	readStoredAppFontSize,
+	setStoredAppFontSize,
+} from "@/lib/app-font-size";
 import {
 	APP_ICONS,
 	type AppIconId,
@@ -502,6 +511,10 @@ function GeneralSettingsContent() {
 		if (typeof window === "undefined") return "violet";
 		return readStoredHubAccent();
 	});
+	const [fontSize, setFontSize] = useState(() => {
+		if (typeof window === "undefined") return DEFAULT_APP_FONT_SIZE;
+		return readStoredAppFontSize();
+	});
 	const [appIcon, setAppIcon] = useState<AppIconId>(() => {
 		if (typeof window === "undefined") return DEFAULT_APP_ICON;
 		return readStoredAppIcon();
@@ -594,6 +607,16 @@ function GeneralSettingsContent() {
 		setAccent(setStoredHubAccent(nextAccent));
 	};
 
+	const updateFontSizePreference = (nextFontSize: number) => {
+		if (isAppFontSize(nextFontSize)) {
+			setFontSize(setStoredAppFontSize(nextFontSize));
+		}
+	};
+
+	const updateFontSize = ([nextFontSize]: number[]) => {
+		updateFontSizePreference(nextFontSize);
+	};
+
 	const updateAppIcon = async (nextIcon: AppIconId) => {
 		const requestId = ++appIconRequestRef.current;
 		const previousIcon = appIcon;
@@ -640,6 +663,53 @@ function GeneralSettingsContent() {
 						checked={theme === "dark"}
 						onCheckedChange={updateTheme}
 					/>
+				</div>
+				<div className="flex items-center justify-between gap-5 border-b py-4 max-[720px]:flex-col max-[720px]:items-stretch">
+					<div className="flex flex-col gap-1">
+						<p className="text-base font-semibold text-foreground">Font size</p>
+						<p className="text-sm text-muted-foreground">
+							Adjust the size of text and interface elements throughout the app.
+						</p>
+					</div>
+					<div className="flex w-64 shrink-0 items-center gap-3 max-[720px]:w-full">
+						<Button
+							aria-label="Decrease font size"
+							className="size-7"
+							disabled={fontSize === MIN_APP_FONT_SIZE}
+							onClick={() => updateFontSizePreference(fontSize - 1)}
+							size="icon"
+							type="button"
+							variant="outline"
+						>
+							<Minus />
+						</Button>
+						<Slider
+							aria-label="Font size"
+							aria-valuetext={`${fontSize} pixels`}
+							max={MAX_APP_FONT_SIZE}
+							min={MIN_APP_FONT_SIZE}
+							onValueChange={updateFontSize}
+							step={1}
+							value={[fontSize]}
+						/>
+						<Button
+							aria-label="Increase font size"
+							className="size-7"
+							disabled={fontSize === MAX_APP_FONT_SIZE}
+							onClick={() => updateFontSizePreference(fontSize + 1)}
+							size="icon"
+							type="button"
+							variant="outline"
+						>
+							<Plus />
+						</Button>
+						<output
+							aria-label="Selected font size"
+							className="w-10 shrink-0 text-right font-mono text-sm tabular-nums text-foreground"
+						>
+							{fontSize}px
+						</output>
+					</div>
 				</div>
 				<div className="flex py-4 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
 					<div className="flex flex-col gap-1">

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -10,6 +10,7 @@ import {
 	MIN_APP_FONT_SIZE,
 	readStoredAppFontSize,
 	setStoredAppFontSize,
+	subscribeToAppFontSize,
 } from "@/lib/app-font-size";
 import {
 	APP_ICONS,
@@ -529,6 +530,8 @@ function GeneralSettingsContent() {
 	const [autoUpdateLoading, setAutoUpdateLoading] = useState(true);
 	const [autoUpdateSaving, setAutoUpdateSaving] = useState(false);
 	const [autoUpdateError, setAutoUpdateError] = useState<string | null>(null);
+
+	useEffect(() => subscribeToAppFontSize(setFontSize), []);
 
 	const loadGlobalSettings = useCallback(async () => {
 		setTelemetryLoading(true);

--- a/apps/examples/desktop-app/webview/lib/app-font-size.test.ts
+++ b/apps/examples/desktop-app/webview/lib/app-font-size.test.ts
@@ -1,14 +1,16 @@
 // @vitest-environment jsdom
 
 import { runInNewContext } from "node:vm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	APP_FONT_SIZE_BOOTSTRAP_SCRIPT,
 	APP_FONT_SIZE_STORAGE_KEY,
+	applyAppZoomAction,
 	DEFAULT_APP_FONT_SIZE,
 	isAppFontSize,
 	readStoredAppFontSize,
 	setStoredAppFontSize,
+	subscribeToAppFontSize,
 	syncAppFontSize,
 } from "./app-font-size";
 
@@ -43,6 +45,33 @@ describe("app font size", () => {
 		document.documentElement.style.removeProperty("font-size");
 		expect(syncAppFontSize()).toBe(18);
 		expect(document.documentElement.style.fontSize).toBe("18px");
+	});
+
+	it("applies zoom actions, clamps the range, and notifies subscribers", () => {
+		const onChange = vi.fn();
+		const unsubscribe = subscribeToAppFontSize(onChange);
+		setStoredAppFontSize(19);
+		onChange.mockClear();
+
+		expect(applyAppZoomAction("zoom-in")).toBe(20);
+		expect(onChange).toHaveBeenLastCalledWith(20);
+
+		onChange.mockClear();
+		expect(applyAppZoomAction("zoom-in")).toBe(20);
+		expect(onChange).toHaveBeenLastCalledWith(20);
+
+		onChange.mockClear();
+		expect(applyAppZoomAction("zoom-out")).toBe(19);
+		expect(onChange).toHaveBeenLastCalledWith(19);
+
+		onChange.mockClear();
+		expect(applyAppZoomAction("zoom-reset")).toBe(DEFAULT_APP_FONT_SIZE);
+		expect(onChange).toHaveBeenLastCalledWith(DEFAULT_APP_FONT_SIZE);
+
+		unsubscribe();
+		onChange.mockClear();
+		applyAppZoomAction("zoom-out");
+		expect(onChange).not.toHaveBeenCalled();
 	});
 
 	it("restores the saved size before the first paint", () => {

--- a/apps/examples/desktop-app/webview/lib/app-font-size.test.ts
+++ b/apps/examples/desktop-app/webview/lib/app-font-size.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { runInNewContext } from "node:vm";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	APP_FONT_SIZE_BOOTSTRAP_SCRIPT,
+	APP_FONT_SIZE_STORAGE_KEY,
+	DEFAULT_APP_FONT_SIZE,
+	isAppFontSize,
+	readStoredAppFontSize,
+	setStoredAppFontSize,
+	syncAppFontSize,
+} from "./app-font-size";
+
+afterEach(() => {
+	window.localStorage.clear();
+	document.documentElement.style.removeProperty("font-size");
+	delete document.documentElement.dataset.clineFontSize;
+});
+
+function runFontSizeBootstrap(): void {
+	runInNewContext(APP_FONT_SIZE_BOOTSTRAP_SCRIPT, { document, window });
+}
+
+describe("app font size", () => {
+	it("defaults invalid and missing preferences to 15px", () => {
+		expect(readStoredAppFontSize()).toBe(DEFAULT_APP_FONT_SIZE);
+		expect(isAppFontSize(12)).toBe(true);
+		expect(isAppFontSize(20)).toBe(true);
+		expect(isAppFontSize(11)).toBe(false);
+		expect(isAppFontSize(15.5)).toBe(false);
+
+		window.localStorage.setItem(APP_FONT_SIZE_STORAGE_KEY, "large");
+		expect(readStoredAppFontSize()).toBe(DEFAULT_APP_FONT_SIZE);
+	});
+
+	it("persists and applies the selected size", () => {
+		expect(setStoredAppFontSize(18)).toBe(18);
+		expect(window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY)).toBe("18");
+		expect(document.documentElement.style.fontSize).toBe("18px");
+		expect(document.documentElement.dataset.clineFontSize).toBe("18");
+
+		document.documentElement.style.removeProperty("font-size");
+		expect(syncAppFontSize()).toBe(18);
+		expect(document.documentElement.style.fontSize).toBe("18px");
+	});
+
+	it("restores the saved size before the first paint", () => {
+		window.localStorage.setItem(APP_FONT_SIZE_STORAGE_KEY, "19");
+
+		runFontSizeBootstrap();
+
+		expect(document.documentElement.style.fontSize).toBe("19px");
+		expect(document.documentElement.dataset.clineFontSize).toBe("19");
+	});
+
+	it("uses the default before paint when storage is invalid", () => {
+		window.localStorage.setItem(APP_FONT_SIZE_STORAGE_KEY, "21");
+
+		runFontSizeBootstrap();
+
+		expect(document.documentElement.style.fontSize).toBe("15px");
+		expect(document.documentElement.dataset.clineFontSize).toBe("15");
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/app-font-size.ts
+++ b/apps/examples/desktop-app/webview/lib/app-font-size.ts
@@ -1,0 +1,82 @@
+export const APP_FONT_SIZE_STORAGE_KEY = "cline.code.font-size.v1";
+
+export const APP_FONT_SIZES = [12, 13, 14, 15, 16, 17, 18, 19, 20] as const;
+
+export type AppFontSize = (typeof APP_FONT_SIZES)[number];
+
+export const DEFAULT_APP_FONT_SIZE: AppFontSize = 15;
+export const MIN_APP_FONT_SIZE: AppFontSize = APP_FONT_SIZES[0];
+export const MAX_APP_FONT_SIZE: AppFontSize =
+	APP_FONT_SIZES[APP_FONT_SIZES.length - 1];
+
+export function isAppFontSize(value: unknown): value is AppFontSize {
+	return (
+		typeof value === "number" &&
+		(APP_FONT_SIZES as readonly number[]).includes(value)
+	);
+}
+
+function parseAppFontSize(value: string | null): AppFontSize | null {
+	if (value === null || value.trim() === "") {
+		return null;
+	}
+	const parsed = Number(value);
+	return isAppFontSize(parsed) ? parsed : null;
+}
+
+/**
+ * Runs from the document head before the webview paints. Keep this
+ * self-contained: the browser executes it before the client bundle loads.
+ */
+export const APP_FONT_SIZE_BOOTSTRAP_SCRIPT = `(() => {
+	const root = document.documentElement;
+	let fontSize = ${JSON.stringify(DEFAULT_APP_FONT_SIZE)};
+
+	try {
+		const stored = window.localStorage.getItem(${JSON.stringify(APP_FONT_SIZE_STORAGE_KEY)});
+		const parsed = Number(stored);
+		if (
+			stored !== null &&
+			stored.trim() !== "" &&
+			Number.isInteger(parsed) &&
+			parsed >= ${JSON.stringify(MIN_APP_FONT_SIZE)} &&
+			parsed <= ${JSON.stringify(MAX_APP_FONT_SIZE)}
+		) {
+			fontSize = parsed;
+		}
+	} catch {}
+
+	root.style.fontSize = fontSize + "px";
+	root.dataset.clineFontSize = String(fontSize);
+})();`;
+
+export function readStoredAppFontSize(): AppFontSize {
+	try {
+		return (
+			parseAppFontSize(
+				window.localStorage.getItem(APP_FONT_SIZE_STORAGE_KEY),
+			) ?? DEFAULT_APP_FONT_SIZE
+		);
+	} catch {
+		return DEFAULT_APP_FONT_SIZE;
+	}
+}
+
+export function applyAppFontSize(fontSize: AppFontSize): AppFontSize {
+	document.documentElement.style.fontSize = `${fontSize}px`;
+	document.documentElement.dataset.clineFontSize = String(fontSize);
+	return fontSize;
+}
+
+export function syncAppFontSize(): AppFontSize {
+	return applyAppFontSize(readStoredAppFontSize());
+}
+
+export function setStoredAppFontSize(fontSize: AppFontSize): AppFontSize {
+	try {
+		window.localStorage.setItem(APP_FONT_SIZE_STORAGE_KEY, String(fontSize));
+	} catch {
+		// Applying still works for this session when persistence is unavailable.
+	}
+	return applyAppFontSize(fontSize);
+}

--- a/apps/examples/desktop-app/webview/lib/app-font-size.ts
+++ b/apps/examples/desktop-app/webview/lib/app-font-size.ts
@@ -1,4 +1,5 @@
 export const APP_FONT_SIZE_STORAGE_KEY = "cline.code.font-size.v1";
+export const APP_FONT_SIZE_CHANGE_EVENT = "cline-app-font-size-change";
 
 export const APP_FONT_SIZES = [12, 13, 14, 15, 16, 17, 18, 19, 20] as const;
 
@@ -9,10 +10,21 @@ export const MIN_APP_FONT_SIZE: AppFontSize = APP_FONT_SIZES[0];
 export const MAX_APP_FONT_SIZE: AppFontSize =
 	APP_FONT_SIZES[APP_FONT_SIZES.length - 1];
 
+export const APP_ZOOM_ACTIONS = ["zoom-in", "zoom-out", "zoom-reset"] as const;
+
+export type AppZoomAction = (typeof APP_ZOOM_ACTIONS)[number];
+
 export function isAppFontSize(value: unknown): value is AppFontSize {
 	return (
 		typeof value === "number" &&
 		(APP_FONT_SIZES as readonly number[]).includes(value)
+	);
+}
+
+export function isAppZoomAction(value: unknown): value is AppZoomAction {
+	return (
+		typeof value === "string" &&
+		(APP_ZOOM_ACTIONS as readonly string[]).includes(value)
 	);
 }
 
@@ -65,6 +77,11 @@ export function readStoredAppFontSize(): AppFontSize {
 export function applyAppFontSize(fontSize: AppFontSize): AppFontSize {
 	document.documentElement.style.fontSize = `${fontSize}px`;
 	document.documentElement.dataset.clineFontSize = String(fontSize);
+	window.dispatchEvent(
+		new CustomEvent<AppFontSize>(APP_FONT_SIZE_CHANGE_EVENT, {
+			detail: fontSize,
+		}),
+	);
 	return fontSize;
 }
 
@@ -79,4 +96,31 @@ export function setStoredAppFontSize(fontSize: AppFontSize): AppFontSize {
 		// Applying still works for this session when persistence is unavailable.
 	}
 	return applyAppFontSize(fontSize);
+}
+
+export function applyAppZoomAction(action: AppZoomAction): AppFontSize {
+	if (action === "zoom-reset") {
+		return setStoredAppFontSize(DEFAULT_APP_FONT_SIZE);
+	}
+
+	const currentIndex = APP_FONT_SIZES.indexOf(readStoredAppFontSize());
+	const offset = action === "zoom-in" ? 1 : -1;
+	const nextIndex = Math.min(
+		APP_FONT_SIZES.length - 1,
+		Math.max(0, currentIndex + offset),
+	);
+	return setStoredAppFontSize(APP_FONT_SIZES[nextIndex]);
+}
+
+export function subscribeToAppFontSize(
+	onChange: (fontSize: AppFontSize) => void,
+): () => void {
+	const handleChange = (event: Event) => {
+		if (event instanceof CustomEvent && isAppFontSize(event.detail)) {
+			onChange(event.detail);
+		}
+	};
+	window.addEventListener(APP_FONT_SIZE_CHANGE_EVENT, handleChange);
+	return () =>
+		window.removeEventListener(APP_FONT_SIZE_CHANGE_EVENT, handleChange);
 }

--- a/apps/examples/desktop-app/webview/lib/desktop-tray.test.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-tray.test.ts
@@ -46,7 +46,7 @@ describe("desktop tray", () => {
 		let eventHandler: MenuEventHandler | undefined;
 		const pendingBatches: unknown[][] = [
 			["new-session", "unexpected"],
-			["open-settings"],
+			["open-settings", "zoom-in", "zoom-out", "zoom-reset"],
 		];
 		mocks.listen.mockImplementation(
 			async (_eventName: string, handler: MenuEventHandler) => {
@@ -78,7 +78,13 @@ describe("desktop tray", () => {
 		eventHandler?.({ payload: undefined });
 
 		await vi.waitFor(() =>
-			expect(onAction.mock.calls).toEqual([["new-session"], ["open-settings"]]),
+			expect(onAction.mock.calls).toEqual([
+				["new-session"],
+				["open-settings"],
+				["zoom-in"],
+				["zoom-out"],
+				["zoom-reset"],
+			]),
 		);
 		unsubscribe();
 		expect(mocks.unlisten).toHaveBeenCalledOnce();

--- a/apps/examples/desktop-app/webview/lib/desktop-tray.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-tray.ts
@@ -1,11 +1,12 @@
 "use client";
 
+import { type AppZoomAction, isAppZoomAction } from "@/lib/app-font-size";
 import { desktopClient, isTauriAvailable } from "@/lib/desktop-client";
 
 export const DESKTOP_MENU_ACTION_PENDING_EVENT = "desktop-menu-action-pending";
 const TRAY_STATUS_REFRESH_INTERVAL_MS = 5_000;
 
-export type DesktopMenuAction = "new-session" | "open-settings";
+export type DesktopMenuAction = "new-session" | "open-settings" | AppZoomAction;
 
 type ProcessContext = {
 	runningSessionCount?: unknown;
@@ -15,7 +16,11 @@ type ProcessContext = {
 };
 
 function isDesktopMenuAction(value: unknown): value is DesktopMenuAction {
-	return value === "new-session" || value === "open-settings";
+	return (
+		value === "new-session" ||
+		value === "open-settings" ||
+		isAppZoomAction(value)
+	);
 }
 
 export function subscribeToDesktopMenuActions(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Adds a persisted font-size preference to the desktop app and exposes it through both Settings and the native macOS View menu.

- Adds an accessible 12–20px font-size slider with decrease/increase controls under General settings.
- Persists the preference in local storage and restores it before first paint to avoid a visible layout shift.
- Uses the root font size so Tailwind's existing `rem`-based typography scales consistently.
- Adds native View → Zoom In, Zoom Out, and Actual Size commands with `Cmd++`, `Cmd+-`, and `Cmd+0` shortcuts.
- Routes native menu commands through the existing desktop action bridge and keeps the open Settings controls synchronized.
- Improves Slider ARIA propagation and keeps its thumb identity stable during controlled updates.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Automated verification from `apps/examples/desktop-app`:

1. `bun run typecheck`
2. `bunx vitest run webview/lib/app-font-size.test.ts webview/lib/desktop-tray.test.ts webview/components/views/settings/settings-view.test.tsx` (10 tests)
3. `bunx next build webview`
4. `cargo test` from `src-tauri` (6 tests)
5. `cargo fmt --check` and focused Biome checks

Manual verification:

1. Open Settings → General and adjust the Font size slider and +/- controls.
2. Confirm the selected size applies immediately and persists after reopening the app.
3. Open the native macOS View menu and confirm the zoom commands and shortcut glyphs are present.
4. Confirm `Cmd++` changes the font size in the running Tauri app.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test the branch first.
-->

<img width="1495" height="983" alt="Desktop app font-size setting" src="https://github.com/user-attachments/assets/26638596-27d4-41bc-ac95-143026a0506a" />

<img width="1495" height="974" alt="Desktop app with adjusted font size" src="https://github.com/user-attachments/assets/d2f2ee2d-ba8e-450d-87e9-b09b3b097d2c" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

- Tauri 2.11 cannot represent `+` through its current accelerator parser, so the macOS Zoom In item uses the equivalent native AppKit key equivalent while retaining Tauri's menu event handling.
- A user-editable JSON keybinding map is intentionally deferred to a follow-up PR.
