### PR TITLE
style(desktop): refine session hover cards

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -240,8 +240,6 @@ describe("AgentSidebar session organization", () => {
 			["Model", "test-model"],
 			["Tokens", "3009k"],
 			["Cost", "$3.06"],
-			["ID", "cline-5"],
-			["Updated", "5m"],
 		]);
 		expect(getSessionOverviewItems(makeThread("cline", 5))).not.toContainEqual([
 			"Branch",

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -12,7 +12,9 @@ import {
 	Code,
 	FileText,
 	Filter,
+	Folder,
 	FolderTree,
+	GitBranch,
 	GitFork,
 	Loader2,
 	PanelLeftOpen,
@@ -1108,7 +1110,7 @@ function ThreadItem({
 
 	return (
 		<ContextMenu>
-			<HoverCard openDelay={250} closeDelay={100}>
+			<HoverCard openDelay={0} closeDelay={100}>
 				<ContextMenuTrigger asChild>
 					<HoverCardTrigger asChild>
 						<button
@@ -1153,12 +1155,20 @@ function ThreadItem({
 						<div className="wrap-break-word text-sm font-medium">
 							{overviewTitle}
 						</div>
-						<div className="grid grid-cols-[72px_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs">
+						<div className="grid grid-cols-[72px_minmax(0,1fr)] gap-x-2 gap-y-1.5 text-xs">
 							{infoItems.map(([label, value, fullValue]) => (
 								<div className="contents" key={label}>
-									<span className="text-muted-foreground">{label}</span>
+									<span className="text-muted-foreground" title={label}>
+										{label === "Workspace" ? (
+											<Folder aria-label={label} className="size-3.5" />
+										) : label === "Branch" ? (
+											<GitBranch aria-label={label} className="size-3.5" />
+										) : (
+											label
+										)}
+									</span>
 									<span
-										className="min-w-0 truncate font-mono font-thin text-foreground"
+										className="min-w-0 truncate font-mono text-foreground"
 										title={fullValue}
 									>
 										{value}
@@ -1201,9 +1211,9 @@ export function getSessionOverviewItems(
 		["Model", thread.model],
 		["Tokens", formatTokenCount(thread.inputTokens, thread.outputTokens)],
 		["Cost", formatCostUsd(thread.totalCostUsd)],
-		["ID", thread.id],
+		// ["ID", thread.id],
 		["Source", thread.source],
-		["Updated", thread.time],
+		// ["Updated", thread.time], // Removed because updated time is visible in the sidebar item.
 	];
 	return items.filter((item): item is [string, string, string?] =>
 		Boolean(item[1]),

--- a/apps/examples/desktop-app/webview/components/ui/hover-card.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/hover-card.tsx
@@ -32,7 +32,7 @@ function HoverCardContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+					"bg-popover text-popover-foreground z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Refines desktop session hover cards with immediate opening, workspace and branch icons, simplified metadata, and a static presentation without hover-card transition animations.

### Test Procedure

- `bun run build:sdk` — passed.
- `NODE_OPTIONS=--localstorage-file=/private/tmp/cline-sidebar-localstorage bun --cwd apps/examples/desktop-app vitest run webview/components/agent-sidebar.test.tsx --config vitest.config.ts` — 14 tests passed.
- `bun -F @cline/code typecheck` — passed.
- `bun run lint` — passed with existing warnings.
- `bun test` — failed in unchanged repository-wide CLI/Vitest suites. Failures included ClinePass TUI timeouts, raw Bun runner incompatibilities with Vitest globals, and missing generated VS Code modules.
- `bun run format` — failed on existing formatting diagnostics outside this PR.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
    - `bun test` and `bun run format` currently fail on unchanged repository-wide tests/files as documented above; focused tests, typecheck, and lint pass.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No deterministic screenshot is available: the desktop sidecar cannot start in this environment without a compatible Hub runtime, and the hover card requires populated session data.

### Additional Notes

The removal of hover-card animations is intentional.
