### PR TITLE
docs(ui): expand agent component stories

### DIFF
--- a/sdk/packages/ui/stories/agent-approval-card.stories.tsx
+++ b/sdk/packages/ui/stories/agent-approval-card.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AgentApprovalCard } from "../components/agent-approval-card";
+
+const meta: Meta<typeof AgentApprovalCard> = {
+	title: "Agent/Approval card",
+	component: AgentApprovalCard,
+	tags: ["autodocs"],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Presents an agent action that requires explicit approval. Hosts provide the action details and own approval, rejection, pending, and error state.",
+			},
+		},
+	},
+	args: {
+		description: "Cline wants to run a command in the current workspace.",
+		detail: "bun run test:unit",
+		meta: "Terminal",
+		onApprove: () => {},
+		onReject: () => {},
+		title: "Run command?",
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentApprovalCard>;
+
+export const Default: Story = {
+	render: (args) => (
+		<div className="mx-auto max-w-xl p-6">
+			<AgentApprovalCard {...args} />
+		</div>
+	),
+};
+
+export const Approving: Story = {
+	args: {
+		responding: "approve",
+	},
+	render: Default.render,
+};
+
+export const Rejecting: Story = {
+	args: {
+		responding: "reject",
+	},
+	render: Default.render,
+};
+
+export const ErrorState: Story = {
+	args: {
+		error: "The command could not be approved. Check your workspace permissions.",
+	},
+	render: Default.render,
+};

--- a/sdk/packages/ui/stories/agent-prompt-queue.stories.tsx
+++ b/sdk/packages/ui/stories/agent-prompt-queue.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import {
+	AgentPromptQueue,
+	type AgentPromptQueueItem,
+	type AgentPromptQueueProps,
+} from "../components/agent-prompt-queue";
+
+const queuedPrompts: AgentPromptQueueItem[] = [
+	{
+		attachmentCount: 2,
+		id: "tests",
+		prompt: "Add tests for the new authentication flow",
+		steer: true,
+	},
+	{
+		id: "docs",
+		prompt: "Update the contributor documentation with the new setup steps",
+		steer: false,
+	},
+	{
+		attachmentCount: 1,
+		id: "review",
+		prompt: "Review the final diff for accessibility issues",
+		steer: false,
+	},
+];
+
+const meta: Meta<typeof AgentPromptQueue> = {
+	title: "Agent/Prompt queue",
+	component: AgentPromptQueue,
+	tags: ["autodocs"],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Shows prompts waiting behind the active agent turn. Expand the queue to steer, edit, or remove items; hosts persist each change through callbacks.",
+			},
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentPromptQueue>;
+
+function InteractiveQueue({ initialItems }: { initialItems: AgentPromptQueueItem[] }) {
+	const [items, setItems] = useState(initialItems);
+
+	const props: AgentPromptQueueProps = {
+		items,
+		onEdit: (id, prompt) => {
+			setItems((current) =>
+				current.map((item) => (item.id === id ? { ...item, prompt } : item)),
+			);
+		},
+		onRemove: (id) => {
+			setItems((current) => current.filter((item) => item.id !== id));
+		},
+		onSteer: (id) => {
+			setItems((current) =>
+				current.map((item) => ({ ...item, steer: item.id === id })),
+			);
+		},
+	};
+
+	return <AgentPromptQueue {...props} />;
+}
+
+export const Interactive: Story = {
+	render: () => (
+		<div className="mx-auto max-w-2xl p-6">
+			<InteractiveQueue initialItems={queuedPrompts} />
+		</div>
+	),
+};
+
+export const SinglePrompt: Story = {
+	render: () => (
+		<div className="mx-auto max-w-2xl p-6">
+			<InteractiveQueue initialItems={[queuedPrompts[1]]} />
+		</div>
+	),
+};

--- a/sdk/packages/ui/stories/agent-quick-actions.stories.tsx
+++ b/sdk/packages/ui/stories/agent-quick-actions.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+	AgentQuickActions,
+	type AgentQuickAction,
+} from "../components/agent-quick-actions";
+
+const actions: AgentQuickAction[] = [
+	{
+		description: "Create a focused implementation plan before editing files",
+		id: "plan",
+		label: "Plan this task",
+		value: "Create an implementation plan for this task.",
+	},
+	{
+		description: "Find the files and symbols most relevant to the request",
+		id: "explore",
+		label: "Explore the codebase",
+		value: "Explore the codebase and identify the relevant files.",
+	},
+	{
+		description: "Start implementing and verify the result with tests",
+		id: "implement",
+		label: "Implement the change",
+		value: "Implement this change and run the relevant tests.",
+	},
+];
+
+const meta: Meta<typeof AgentQuickActions> = {
+	title: "Agent/Quick actions",
+	component: AgentQuickActions,
+	tags: ["autodocs"],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Displays a compact list of suggested prompts. The host receives the selected action and decides how to populate or submit it.",
+			},
+		},
+	},
+	args: {
+		actions,
+		onSelect: () => {},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentQuickActions>;
+
+export const Default: Story = {
+	render: (args) => (
+		<div className="mx-auto max-w-xl p-6">
+			<AgentQuickActions {...args} />
+		</div>
+	),
+};
+
+export const Disabled: Story = {
+	args: {
+		disabled: true,
+	},
+	render: Default.render,
+};
+
+export const SingleAction: Story = {
+	args: {
+		actions: [actions[0]],
+	},
+	render: Default.render,
+};


### PR DESCRIPTION
### Related Issue

(N/A)

### Description

Adds Storybook documentation and representative states for the approval card, prompt queue, and quick-action components.

### Test Procedure

1. Open Storybook (`bun run build:sdk`, then `bun -F @cline/ui storybook`)
2. Open **Agent / Approval card** and inspect the Default, Approving, Rejecting, and Error State stories. Confirm the action details and approve/reject states are represented clearly.
3. Open **Agent / Prompt queue / Interactive**. Expand the queue, then edit, remove, and steer queued prompts and confirm each interaction updates the displayed queue. Check **Single Prompt** as well.
4. Open **Agent / Quick actions**. Confirm the Default actions render correctly, Disabled actions cannot be activated, and Single Action renders without layout issues.
5. Switch between light and dark backgrounds and resize the preview to confirm the new stories remain readable and do not overflow.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
    - `bun test` currently fails in unchanged CLI/Vitest suites (including ClinePass TUI timing, raw Bun/Vitest incompatibilities, and missing generated VS Code modules). `bun run format` reports existing diagnostics outside this PR. Focused tests, typecheck, Storybook build, and lint pass.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="1327" height="742" alt="image" src="https://github.com/user-attachments/assets/59f6d586-1cc3-4084-a9e4-40fa41d87ff4" />

### Additional Notes

This PR adds documentation-only stories and does not change component runtime behavior.
