### PR TITLE
feat(ui): AskQuestion component redesign

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -927,10 +927,16 @@ describe("ChatMessages follow-up questions", () => {
 			},
 		);
 
-		const answer = [...container.querySelectorAll("button")].find(
-			(button) => button.textContent === "Continue",
+		const answer = [...container.querySelectorAll("button")].find((button) =>
+			button.textContent?.includes("Continue"),
 		);
 		await act(async () => answer?.click());
+		expect(onAnswerAskQuestion).not.toHaveBeenCalled();
+
+		const submit = [...container.querySelectorAll("button")].find(
+			(button) => button.textContent === "Submit",
+		);
+		await act(async () => submit?.click());
 
 		expect(onAnswerAskQuestion).toHaveBeenCalledWith("request-1", "Continue");
 	});

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -7,7 +7,7 @@ import {
 	ConversationScrollButton,
 	ConversationViewport,
 } from "@cline/ui/components/agent-chat";
-import { Clock3, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import {
 	AlertDialog,
@@ -36,7 +36,6 @@ import {
 import { ChatImageLightbox } from "./messages/image-lightbox";
 import { MessageBubble } from "./messages/message-bubble";
 import {
-	formatApprovalTimestamp,
 	ToolApprovalPanel,
 	type ToolApprovalRequestItem,
 } from "./messages/tool-approval-panel";
@@ -191,21 +190,7 @@ function ChatMessagesImpl({
 	const askQuestionItems = useMemo(
 		() =>
 			pendingAskQuestions.map((item) => ({
-				description: (
-					<>
-						Request {item.requestId}
-						{item.context?.iteration != null
-							? ` · Iteration ${item.context.iteration}`
-							: ""}
-					</>
-				),
 				id: item.requestId,
-				meta: (
-					<>
-						<Clock3 className="h-3 w-3" />
-						{formatApprovalTimestamp(item.createdAt)}
-					</>
-				),
 				options: item.options,
 				question: item.question,
 			})),

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -78,8 +78,9 @@ welcome heading and respects reduced-motion preferences.
 `AgentApprovalCard` is controlled presentation; the host owns approval state
 and submits its callbacks.
 
-`AgentAskQuestion` is controlled presentation; the host owns pending answers,
-errors, and response transport.
+`AgentAskQuestion` keeps option selection locally and submits explicitly. The
+host owns pending answers, errors, and response transport. Multiple-choice
+items set `multiple: true` and provide `onAnswers` for array submission.
 
 `AgentPromptQueue` renders queued prompts and reports edit, remove, and steer
 actions to the host.

--- a/sdk/packages/ui/components/agent-ask-question.css
+++ b/sdk/packages/ui/components/agent-ask-question.css
@@ -1,21 +1,23 @@
-.cline-ui-agent-ask-question {
-	/* Brand violet, falling back to a literal for hosts without the theme
-	 * tokens; hosts may override. */
-	--cline-ui-agent-ask-question-accent: var(
-		--brand-violet,
-		oklch(0.55 0.22 293)
-	);
-	--cline-ui-agent-ask-question-accent-border: var(
-		--brand-violet,
-		oklch(0.62 0.19 293)
-	);
-}
-
 .cline-ui-agent-ask-question,
 .cline-ui-agent-ask-question__item,
-.cline-ui-agent-ask-question__option {
+.cline-ui-agent-ask-question__option,
+.cline-ui-agent-ask-question__option-key {
 	box-sizing: border-box;
 	border-style: solid;
+}
+
+.cline-ui-agent-ask-question__item {
+	overflow: hidden;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	background: var(--background);
+	padding-top: 0.75rem;
+	-webkit-user-select: text;
+	user-select: text;
+}
+
+.cline-ui-agent-ask-question__item-header {
+	padding-inline: 1rem 0.75rem;
 }
 
 .cline-ui-agent-ask-question__option {
@@ -27,14 +29,59 @@
 	line-height: inherit;
 }
 
+.cline-ui-agent-ask-question__option:hover:not(:disabled) {
+	background: var(--surface-hover-lighter);
+}
+
+.cline-ui-agent-ask-question__option-label {
+	font-size: var(--text-md);
+	line-height: var(--text-md--line-height);
+	letter-spacing: var(--text-md--letter-spacing);
+}
+
+.cline-ui-agent-ask-question__option[aria-pressed="true"] {
+	background: var(--surface-hover);
+}
+
+.cline-ui-agent-ask-question__option[aria-pressed="true"]
+	.cline-ui-agent-ask-question__option-key {
+	border-color: var(--neutral-6);
+	background: var(--neutral-5);
+}
+
+.cline-ui-agent-ask-question__option-key {
+	display: inline-flex;
+	height: 1.375rem;
+	width: 1.375rem;
+	flex: none;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-md);
+	background: var(--surface-hover-lighter);
+	color: var(--muted-foreground);
+	font-family: var(--font-mono);
+	font-size: var(--text-xs);
+	font-weight: var(--font-weight-medium);
+	line-height: var(--text-xs--line-height);
+}
+
 .cline-ui-agent-ask-question__spinner {
 	animation: cline-ui-agent-ask-question-spin 1s linear infinite;
 }
 
-.cline-ui-agent-ask-question__option:has(
-		> .cline-ui-agent-ask-question__spinner
-	) {
-	padding-inline: 0.625rem;
+.cline-ui-agent-ask-question__footer {
+	border-style: solid;
+	border-width: 1px 0 0;
+}
+
+.cline-ui-agent-ask-question__submit:not(:disabled) {
+	background: var(--foreground);
+	color: var(--background);
+}
+
+.cline-ui-agent-ask-question__submit:hover:not(:disabled) {
+	opacity: 0.9;
 }
 
 @keyframes cline-ui-agent-ask-question-spin {

--- a/sdk/packages/ui/components/agent-ask-question.tsx
+++ b/sdk/packages/ui/components/agent-ask-question.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import type { ReactNode } from "react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	type ReactNode,
+	useState,
+} from "react";
+import { Badge } from "./badge.js";
+import { Button } from "./button.js";
 
 export interface AgentAskQuestionItem {
 	description?: ReactNode;
 	id: string;
 	meta?: ReactNode;
+	multiple?: boolean;
 	options: readonly string[];
 	question: ReactNode;
 }
@@ -14,27 +21,30 @@ export interface AgentAskQuestionProps {
 	errors?: Readonly<Record<string, ReactNode>>;
 	items: readonly AgentAskQuestionItem[];
 	onAnswer: (id: string, answer: string) => void;
-	pendingAnswers?: Readonly<Record<string, string | undefined>>;
+	onAnswers?: (id: string, answers: readonly string[]) => void;
+	pendingAnswers?: Readonly<
+		Record<string, string | readonly string[] | undefined>
+	>;
 }
 
-function QuestionIcon() {
-	return (
-		<svg
-			aria-hidden="true"
-			className="cline-ui-agent-ask-question__icon size-4 fill-none stroke-[var(--cline-ui-agent-ask-question-accent)] [stroke-linecap:round] [stroke-linejoin:round] [stroke-width:2]"
-			viewBox="0 0 24 24"
-		>
-			<path d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-			<path d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1" />
-		</svg>
-	);
+function optionLabel(index: number) {
+	let value = index + 1;
+	let label = "";
+
+	while (value > 0) {
+		value -= 1;
+		label = String.fromCharCode(65 + (value % 26)) + label;
+		value = Math.floor(value / 26);
+	}
+
+	return label;
 }
 
 function Spinner() {
 	return (
 		<svg
 			aria-hidden="true"
-			className="cline-ui-agent-ask-question__spinner mr-1 size-3.5 flex-none fill-none stroke-current [stroke-linecap:round] [stroke-linejoin:round] [stroke-width:2]"
+			className="cline-ui-agent-ask-question__spinner mr-1 size-3.5 flex-none fill-none stroke-current [stroke-linecap:round] [stroke-linejoin:round] stroke-2"
 			viewBox="0 0 24 24"
 		>
 			<path d="M21 12a9 9 0 1 1-6.219-8.56" />
@@ -46,68 +56,192 @@ export function AgentAskQuestion({
 	errors = {},
 	items,
 	onAnswer,
+	onAnswers,
 	pendingAnswers = {},
 }: AgentAskQuestionProps) {
+	const [selections, setSelections] = useState<
+		Readonly<Record<string, readonly string[]>>
+	>({});
+
 	return (
 		<section
 			aria-label="Follow-up question"
 			className="cline-ui-agent-ask-question flex flex-col gap-2"
 		>
-			{items.map((item) => {
+			{items.map((item, itemIndex) => {
 				const pendingAnswer = pendingAnswers[item.id];
-				const isPending = Boolean(pendingAnswer);
+				const isPending = Array.isArray(pendingAnswer)
+					? pendingAnswer.length > 0
+					: Boolean(pendingAnswer);
 				const error = errors[item.id];
+				const options = [...new Set(item.options)];
+				const pendingSelection = (
+					Array.isArray(pendingAnswer)
+						? pendingAnswer
+						: pendingAnswer
+							? [pendingAnswer]
+							: []
+				).filter((option) => options.includes(option));
+				const validSelection = (
+					isPending ? pendingSelection : (selections[item.id] ?? [])
+				).filter((option) => options.includes(option));
+				const selected = item.multiple
+					? validSelection
+					: validSelection.slice(-1);
+				const canSubmit =
+					selected.length > 0 && (!item.multiple || Boolean(onAnswers));
+				const selectOption = (option: string) => {
+					setSelections((current) => {
+						const currentSelection = current[item.id] ?? [];
+						const nextSelection = item.multiple
+							? currentSelection.includes(option)
+								? currentSelection.filter((value) => value !== option)
+								: [...currentSelection, option]
+							: [option];
+
+						return { ...current, [item.id]: nextSelection };
+					});
+				};
+				const submit = () => {
+					if (!canSubmit) return;
+					if (item.multiple) onAnswers?.(item.id, selected);
+					else onAnswer(item.id, selected[0] as string);
+				};
+				const handleOptionKeyDown = (
+					event: ReactKeyboardEvent<HTMLFieldSetElement>,
+				) => {
+					if (isPending || event.altKey || event.ctrlKey || event.metaKey)
+						return;
+
+					const optionButtons = Array.from(
+						event.currentTarget.querySelectorAll<HTMLButtonElement>(
+							".cline-ui-agent-ask-question__option:not(:disabled)",
+						),
+					);
+					const activeIndex = optionButtons.indexOf(
+						document.activeElement as HTMLButtonElement,
+					);
+
+					if (event.key === "Enter" && canSubmit && !event.repeat) {
+						event.preventDefault();
+						submit();
+						return;
+					}
+
+					if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+						event.preventDefault();
+						optionButtons[(activeIndex + 1) % optionButtons.length]?.focus();
+						return;
+					}
+					if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+						event.preventDefault();
+						optionButtons[
+							(activeIndex - 1 + optionButtons.length) % optionButtons.length
+						]?.focus();
+						return;
+					}
+
+					if (/^[a-z]$/i.test(event.key)) {
+						const optionIndex = event.key.toUpperCase().charCodeAt(0) - 65;
+						const option = options[optionIndex];
+						if (option) {
+							event.preventDefault();
+							selectOption(option);
+							optionButtons[optionIndex]?.focus();
+						}
+					}
+				};
 
 				return (
 					<div
 						aria-busy={isPending || undefined}
-						className="cline-ui-agent-ask-question__item rounded-cline-ui-xl border border-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent-border)_40%,transparent)] bg-[color-mix(in_oklab,var(--cline-ui-agent-ask-question-accent)_5%,transparent)] p-3"
+						className="cline-ui-agent-ask-question__item"
 						key={item.id}
 					>
-						<div className="cline-ui-agent-ask-question__item-header flex items-start justify-between gap-2">
-							<div className="cline-ui-agent-ask-question__question flex items-center gap-2 font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm">
-								<QuestionIcon />
-								{item.question}
-							</div>
-							{item.meta ? (
-								<div className="cline-ui-agent-ask-question__meta inline-flex items-center gap-1 text-[11px] text-cline-ui-muted-foreground">
-									{item.meta}
+						<div className="cline-ui-agent-ask-question__item-header flex items-start justify-between gap-3">
+							<div className="min-w-0 flex-1 mt-1 w-full flex">
+								<div className="flex justify-between gap-1 w-full flex-col">
+									<h5 className="cline-ui-agent-ask-question__question font-cline-ui-medium text-cline-ui-foreground text-cline-ui-base w-full">
+										{item.question}
+									</h5>
+
+									{item.multiple ? (
+										<div className="cline-ui-agent-ask-question__multiple-hint text-cline-ui-sm text-cline-ui-muted-foreground">
+											Select all that apply.
+										</div>
+									) : null}
+									{item.description ? (
+										<div className="cline-ui-agent-ask-question__description text-cline-ui-sm text-cline-ui-muted-foreground">
+											{item.description}
+										</div>
+									) : null}
 								</div>
-							) : null}
+								{item.meta ? (
+									<Badge className="cline-ui-agent-ask-question__meta h-fit -mt-1">
+										{item.meta}
+									</Badge>
+								) : null}
+							</div>
 						</div>
-						{item.description ? (
-							<div className="cline-ui-agent-ask-question__description mt-1 pl-6 text-[11px] text-cline-ui-muted-foreground">
-								{item.description}
-							</div>
-						) : null}
-						{error ? (
-							<div
-								className="cline-ui-agent-ask-question__error mt-2 pl-6 text-cline-ui-destructive text-cline-ui-xs"
-								role="alert"
-							>
-								{error}
-							</div>
-						) : null}
-						<div className="cline-ui-agent-ask-question__options mt-2.5 flex flex-wrap items-center gap-2 pl-6">
+
+						<fieldset
+							aria-label="Answer options"
+							className="cline-ui-agent-ask-question__options m-0 flex min-w-0 flex-col border-0 px-1 py-4"
+							onKeyDown={handleOptionKeyDown}
+						>
 							{/* Options are model-supplied and may repeat; repeats submit the same answer. */}
-							{[...new Set(item.options)].map((option) => (
-								<button
-									className="cline-ui-agent-ask-question__option inline-flex min-h-8 max-w-full flex-none cursor-pointer items-center justify-center gap-1.5 whitespace-normal rounded-cline-ui-md border border-cline-ui-border bg-cline-ui-background px-3 py-0 font-cline-ui-medium text-cline-ui-foreground shadow-xs transition-[color,background-color,border-color,box-shadow] duration-150 ease-[ease] [overflow-wrap:anywhere] [&:hover]:bg-cline-ui-accent [&:hover]:text-cline-ui-accent-foreground focus-visible:outline-3 focus-visible:outline-cline-ui-ring/50 focus-visible:outline-offset-0 disabled:pointer-events-none disabled:opacity-50 cline-ui-dark:border-cline-ui-input cline-ui-dark:bg-cline-ui-input/30 cline-ui-dark:[&:hover]:bg-cline-ui-input/50"
+							{options.map((option, index) => (
+								<Button
+									aria-pressed={selected.includes(option)}
+									autoFocus={itemIndex === 0 && index === 0 && !isPending}
+									className="cline-ui-agent-ask-question__option h-auto min-h-9.5 w-full max-w-full justify-start gap-3 whitespace-normal rounded-cline-ui-md p-2 text-left text-cline-ui-sm wrap-anywhere"
 									disabled={isPending}
 									key={option}
-									onClick={() => onAnswer(item.id, option)}
-									type="button"
+									onClick={() => selectOption(option)}
+									size="sm"
+									tone="neutral"
+									variant="ghost"
 								>
-									{pendingAnswer === option ? (
-										<>
-											<Spinner />
-											Sending…
-										</>
-									) : (
-										option
-									)}
-								</button>
+									{index < 26 ? (
+										<span
+											aria-hidden="true"
+											className="cline-ui-agent-ask-question__option-key"
+										>
+											{optionLabel(index)}
+										</span>
+									) : null}
+									<span className="cline-ui-agent-ask-question__option-label min-w-0 flex-1 font-cline-ui-medium text-cline-ui-foreground">
+										{option}
+									</span>
+								</Button>
 							))}
+						</fieldset>
+						<div className="cline-ui-agent-ask-question__footer flex justify-end border-cline-ui-border border-t px-2 py-2 items-baseline">
+							{error ? (
+								<div
+									className="cline-ui-agent-ask-question__error mt-2 text-cline-ui-destructive text-cline-ui-xs w-full px-2"
+									role="alert"
+								>
+									{error}
+								</div>
+							) : null}
+							<Button
+								className="cline-ui-agent-ask-question__submit"
+								disabled={!canSubmit || isPending}
+								onClick={submit}
+								size="sm"
+								tone="neutral"
+								variant="fill"
+							>
+								{isPending ? (
+									<>
+										<Spinner />
+										Sending…
+									</>
+								) : (
+									"Submit"
+								)}
+							</Button>
 						</div>
 					</div>
 				);

--- a/sdk/packages/ui/components/agent-ask-question.tsx
+++ b/sdk/packages/ui/components/agent-ask-question.tsx
@@ -122,12 +122,6 @@ export function AgentAskQuestion({
 						document.activeElement as HTMLButtonElement,
 					);
 
-					if (event.key === "Enter" && canSubmit && !event.repeat) {
-						event.preventDefault();
-						submit();
-						return;
-					}
-
 					if (event.key === "ArrowDown" || event.key === "ArrowRight") {
 						event.preventDefault();
 						optionButtons[(activeIndex + 1) % optionButtons.length]?.focus();

--- a/sdk/packages/ui/components/badge.tsx
+++ b/sdk/packages/ui/components/badge.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { clsx } from "clsx";
+import { forwardRef, type HTMLAttributes } from "react";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {}
+
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+	({ className, ...props }, ref) => (
+		<span
+			{...props}
+			className={clsx(
+				"inline-flex shrink-0 items-center rounded-cline-ui-sm border border-cline-ui-border bg-cline-ui-surface-hover-lighter px-1.5 pt-[0.3rem] pb-[0.2rem] text-cline-ui-muted-foreground text-cline-ui-xs",
+				className,
+			)}
+			data-slot="badge"
+			ref={ref}
+		/>
+	),
+);
+Badge.displayName = "Badge";

--- a/sdk/packages/ui/components/index.ts
+++ b/sdk/packages/ui/components/index.ts
@@ -1,5 +1,6 @@
 "use client";
 
+export { Badge, type BadgeProps } from "./badge.js";
 export {
 	type AgentApprovalAction,
 	AgentApprovalCard,

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -43,6 +43,7 @@
 	},
 	"files": [
 		"components.css",
+		"components/badge.tsx",
 		"components/button.tsx",
 		"components/generated-media.tsx",
 		"components/agent-chat/agent-chat.css",

--- a/sdk/packages/ui/stories/agent-ask-question.stories.tsx
+++ b/sdk/packages/ui/stories/agent-ask-question.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+	AgentAskQuestion,
+	type AgentAskQuestionItem,
+} from "../components/agent-ask-question";
+
+const questions: AgentAskQuestionItem[] = [
+	{
+		description: "This controls where the new settings entry point appears.",
+		id: "location",
+		meta: "Required",
+		options: ["Sidebar", "Command palette", "Both"],
+		question: "Where should users open this feature?",
+	},
+	{
+		id: "scope",
+		options: ["Current workspace", "All workspaces"],
+		question: "Should the preference apply globally?",
+	},
+];
+
+const meta: Meta<typeof AgentAskQuestion> = {
+	title: "Agent/Ask question",
+	component: AgentAskQuestion,
+	tags: ["autodocs"],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"Presents one or more model-supplied follow-up questions with explicit submission. Set an item to multiple and provide onAnswers to allow more than one selection. Hosts own pending and error state for each question.",
+			},
+		},
+	},
+	args: {
+		items: questions,
+		onAnswer: () => {},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentAskQuestion>;
+
+export const Default: Story = {
+	render: (args) => (
+		<div className="mx-auto max-w-2xl p-6">
+			<AgentAskQuestion {...args} />
+		</div>
+	),
+};
+
+export const SendingAnswer: Story = {
+	args: {
+		pendingAnswers: { location: "Both" },
+	},
+	render: Default.render,
+};
+
+export const ErrorState: Story = {
+	args: {
+		errors: { location: "The answer could not be sent. Please try again." },
+	},
+	render: Default.render,
+};
+
+export const LongOptions: Story = {
+	args: {
+		items: [
+			{
+				id: "strategy",
+				options: [
+					"Keep the existing behavior and only update the visual presentation",
+					"Replace the existing flow with the new shared component",
+				],
+				question: "Which implementation strategy should Cline use?",
+			},
+		],
+	},
+	render: Default.render,
+};
+
+export const MultipleChoice: Story = {
+	args: {
+		items: [
+			{
+				id: "surfaces",
+				multiple: true,
+				options: ["Desktop", "VS Code", "CLI"],
+				question: "Where should this feature be available?",
+			},
+		],
+		onAnswers: () => {},
+	},
+	render: Default.render,
+};

--- a/sdk/packages/ui/stories/badge.stories.tsx
+++ b/sdk/packages/ui/stories/badge.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Badge } from "../components/badge";
+
+const meta: Meta<typeof Badge> = {
+	title: "Components/Badge",
+	component: Badge,
+	tags: ["autodocs"],
+	args: {
+		children: "Required",
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+
+export const Customized: Story = {
+	args: {
+		"aria-label": "Current status",
+		children: "In progress",
+		className: "uppercase",
+	},
+};

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -372,9 +372,15 @@ describe("AgentAskQuestion", () => {
 			cancelable: true,
 			key: "Enter",
 		});
-		await act(async () => buttons[1]?.dispatchEvent(enter));
+		await act(async () => {
+			if (buttons[1]?.dispatchEvent(enter)) buttons[1].click();
+		});
 
 		expect(enter.defaultPrevented).toBe(false);
-		expect(onAnswer).not.toHaveBeenCalled();
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("false");
+		expect(buttons[1]?.getAttribute("aria-pressed")).toBe("true");
+
+		await act(async () => buttons[2]?.click());
+		expect(onAnswer).toHaveBeenCalledWith("request-1", "Second");
 	});
 });

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -42,7 +42,12 @@ describe("AgentAskQuestion", () => {
 		);
 
 		const buttons = container.querySelectorAll("button");
+		expect(
+			[...buttons].every((button) => button.dataset.slot === "button"),
+		).toBe(true);
 		await act(async () => buttons[1]?.click());
+		expect(onAnswer).not.toHaveBeenCalled();
+		await act(async () => buttons[2]?.click());
 
 		// The element carries no visible heading — the question itself leads —
 		// but stays labelled for assistive tech.
@@ -52,6 +57,10 @@ describe("AgentAskQuestion", () => {
 		expect(container.textContent).toContain("Continue this task?");
 		expect(onAnswer).toHaveBeenCalledWith("request-1", "Stop");
 		expect(container.textContent).toContain("Request request-1 · Iteration 2");
+		const meta = container.querySelector<HTMLElement>(
+			".cline-ui-agent-ask-question__meta",
+		);
+		expect(meta?.dataset.slot).toBe("badge");
 	});
 
 	it("shows controlled pending and error states", async () => {
@@ -74,7 +83,8 @@ describe("AgentAskQuestion", () => {
 
 		const buttons = container.querySelectorAll("button");
 		expect([...buttons].every((button) => button.disabled)).toBe(true);
-		expect(buttons[0]?.textContent).toContain("Sending…");
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("true");
+		expect(buttons[2]?.textContent).toContain("Sending…");
 		expect(container.textContent).toContain("Could not send answer");
 		expect(container.querySelector('[role="alert"]')?.textContent).toBe(
 			"Could not send answer",
@@ -84,6 +94,31 @@ describe("AgentAskQuestion", () => {
 				.querySelector(".cline-ui-agent-ask-question__item")
 				?.getAttribute("aria-busy"),
 		).toBe("true");
+	});
+
+	it("shows every controlled pending answer for a multiple-choice item", async () => {
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							multiple: true,
+							options: ["First", "Second", "Third"],
+							question: "Choose",
+						},
+					]}
+					onAnswer={() => {}}
+					onAnswers={() => {}}
+					pendingAnswers={{ "request-1": ["First", "Third"] }}
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("true");
+		expect(buttons[1]?.getAttribute("aria-pressed")).toBe("false");
+		expect(buttons[2]?.getAttribute("aria-pressed")).toBe("true");
 	});
 
 	it("deduplicates repeated model-supplied options", async () => {
@@ -105,6 +140,206 @@ describe("AgentAskQuestion", () => {
 		const labels = [...container.querySelectorAll("button")].map(
 			(button) => button.textContent,
 		);
-		expect(labels).toEqual(["Yes", "No"]);
+		expect(labels).toEqual(["AYes", "BNo", "Submit"]);
+	});
+
+	it("labels choices alphabetically without changing the submitted answer", async () => {
+		const onAnswer = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							options: ["First", "Second"],
+							question: "Choose",
+						},
+					]}
+					onAnswer={onAnswer}
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(buttons[0]?.textContent).toBe("AFirst");
+		expect(buttons[1]?.textContent).toBe("BSecond");
+		expect(buttons[0]?.querySelector("[aria-hidden='true']")?.textContent).toBe(
+			"A",
+		);
+
+		await act(async () => buttons[1]?.click());
+		expect(onAnswer).not.toHaveBeenCalled();
+		await act(async () => buttons[2]?.click());
+		expect(onAnswer).toHaveBeenCalledWith("request-1", "Second");
+	});
+
+	it("does not advertise unsupported shortcuts after Z", async () => {
+		const options = Array.from(
+			{ length: 27 },
+			(_, index) => `Option ${index + 1}`,
+		);
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[{ id: "request-1", options, question: "Choose" }]}
+					onAnswer={() => {}}
+				/>,
+			),
+		);
+
+		const optionButtons = container.querySelectorAll<HTMLButtonElement>(
+			".cline-ui-agent-ask-question__option",
+		);
+		expect(
+			optionButtons[25]?.querySelector(
+				".cline-ui-agent-ask-question__option-key",
+			)?.textContent,
+		).toBe("Z");
+		expect(
+			optionButtons[26]?.querySelector(
+				".cline-ui-agent-ask-question__option-key",
+			),
+		).toBeNull();
+	});
+
+	it("submits all selected answers for a multiple-choice item", async () => {
+		const onAnswer = vi.fn();
+		const onAnswers = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							multiple: true,
+							options: ["First", "Second", "Third"],
+							question: "Choose",
+						},
+					]}
+					onAnswer={onAnswer}
+					onAnswers={onAnswers}
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(buttons[3]?.disabled).toBe(true);
+		await act(async () => {
+			buttons[0]?.click();
+			buttons[2]?.click();
+		});
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("true");
+		expect(buttons[2]?.getAttribute("aria-pressed")).toBe("true");
+		expect(buttons[3]?.disabled).toBe(false);
+
+		await act(async () => buttons[3]?.click());
+		expect(onAnswer).not.toHaveBeenCalled();
+		expect(onAnswers).toHaveBeenCalledWith("request-1", ["First", "Third"]);
+		expect(container.textContent).toContain("Select all that apply.");
+	});
+
+	it("replaces a single choice and toggles a multiple choice off", async () => {
+		const onAnswer = vi.fn();
+		const onAnswers = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "single",
+							options: ["First", "Second"],
+							question: "Choose one",
+						},
+						{
+							id: "multiple",
+							multiple: true,
+							options: ["Third", "Fourth"],
+							question: "Choose any",
+						},
+					]}
+					onAnswer={onAnswer}
+					onAnswers={onAnswers}
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		await act(async () => {
+			buttons[0]?.click();
+			buttons[1]?.click();
+		});
+		expect(buttons[0]?.getAttribute("aria-pressed")).toBe("false");
+		expect(buttons[1]?.getAttribute("aria-pressed")).toBe("true");
+		await act(async () => buttons[2]?.click());
+		expect(onAnswer).toHaveBeenCalledWith("single", "Second");
+
+		await act(async () => {
+			buttons[3]?.click();
+			buttons[3]?.click();
+		});
+		expect(buttons[3]?.getAttribute("aria-pressed")).toBe("false");
+		expect(buttons[5]?.disabled).toBe(true);
+	});
+
+	it("does not submit a selection removed by an item update", async () => {
+		const onAnswer = vi.fn();
+		const renderItem = (options: readonly string[]) => (
+			<AgentAskQuestion
+				items={[{ id: "request-1", options, question: "Choose" }]}
+				onAnswer={onAnswer}
+			/>
+		);
+
+		await act(async () => root.render(renderItem(["First", "Second"])));
+		await act(async () => container.querySelectorAll("button")[1]?.click());
+		await act(async () => root.render(renderItem(["First", "Third"])));
+
+		const buttons = container.querySelectorAll("button");
+		expect(buttons[2]?.disabled).toBe(true);
+		await act(async () => buttons[2]?.click());
+		expect(onAnswer).not.toHaveBeenCalled();
+	});
+
+	it("focuses the first choice and supports letter and arrow-key selection", async () => {
+		const onAnswer = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							options: ["First", "Second", "Third"],
+							question: "Choose",
+						},
+					]}
+					onAnswer={onAnswer}
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(document.activeElement).toBe(buttons[0]);
+
+		await act(async () =>
+			buttons[0]?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }),
+			),
+		);
+		expect(document.activeElement).toBe(buttons[1]);
+
+		await act(async () =>
+			buttons[1]?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, key: "c" }),
+			),
+		);
+		expect(document.activeElement).toBe(buttons[2]);
+		expect(buttons[2]?.getAttribute("aria-pressed")).toBe("true");
+
+		await act(async () =>
+			buttons[2]?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+			),
+		);
+		expect(onAnswer).toHaveBeenCalledWith("request-1", "Third");
 	});
 });

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -335,11 +335,46 @@ describe("AgentAskQuestion", () => {
 		expect(document.activeElement).toBe(buttons[2]);
 		expect(buttons[2]?.getAttribute("aria-pressed")).toBe("true");
 
+		expect(onAnswer).not.toHaveBeenCalled();
+	});
+
+	it("lets Enter activate the focused option instead of submitting another selection", async () => {
+		const onAnswer = vi.fn();
 		await act(async () =>
-			buttons[2]?.dispatchEvent(
-				new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							options: ["First", "Second"],
+							question: "Choose",
+						},
+					]}
+					onAnswer={onAnswer}
+				/>,
 			),
 		);
-		expect(onAnswer).toHaveBeenCalledWith("request-1", "Third");
+
+		const buttons = container.querySelectorAll("button");
+		await act(async () => buttons[0]?.click());
+		await act(async () =>
+			buttons[0]?.dispatchEvent(
+				new KeyboardEvent("keydown", {
+					bubbles: true,
+					key: "ArrowDown",
+				}),
+			),
+		);
+		expect(document.activeElement).toBe(buttons[1]);
+
+		const enter = new KeyboardEvent("keydown", {
+			bubbles: true,
+			cancelable: true,
+			key: "Enter",
+		});
+		await act(async () => buttons[1]?.dispatchEvent(enter));
+
+		expect(enter.defaultPrevented).toBe(false);
+		expect(onAnswer).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/ui/tests/badge.test.tsx
+++ b/sdk/packages/ui/tests/badge.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Badge } from "../components/index.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+});
+
+async function render(node: ReactNode) {
+	await act(async () => root.render(node));
+}
+
+describe("Badge", () => {
+	it("renders its content with the default styling", async () => {
+		await render(<Badge>Required</Badge>);
+		const badge = container.querySelector("span");
+		expect(badge?.textContent).toBe("Required");
+		expect(badge?.dataset.slot).toBe("badge");
+		expect(badge?.className).toContain("border-cline-ui-border");
+		expect(badge?.className).toContain("bg-cline-ui-surface-hover-lighter");
+	});
+
+	it("forwards native props, refs, and custom classes", async () => {
+		let forwardedRef: HTMLSpanElement | null = null;
+		await render(
+			<Badge
+				aria-label="Status"
+				className="consumer-class"
+				ref={(node) => {
+					forwardedRef = node;
+				}}
+				title="Current status"
+			>
+				Active
+			</Badge>,
+		);
+		const badge = container.querySelector<HTMLSpanElement>("span");
+		expect(forwardedRef).toBe(badge);
+		expect(badge?.className).toContain("consumer-class");
+		expect(badge?.getAttribute("aria-label")).toBe("Status");
+		expect(badge?.title).toBe("Current status");
+	});
+});

--- a/sdk/packages/ui/tests/theme.test.ts
+++ b/sdk/packages/ui/tests/theme.test.ts
@@ -298,6 +298,7 @@ describe("@cline/ui theme contract", () => {
 		for (const size of [
 			"xs",
 			"sm",
+			"md",
 			"base",
 			"lg",
 			"xl",
@@ -327,6 +328,7 @@ describe("@cline/ui theme contract", () => {
 			"--font-weight-cline-ui-medium: var(--font-weight-medium);",
 		);
 		expect(componentTheme).toContain("--text-cline-ui-xs: var(--text-xs);");
+		expect(componentTheme).toContain("--text-cline-ui-md: var(--text-md);");
 		expect(componentTheme).toContain("--radius-cline-ui-lg: var(--radius-lg);");
 		expect(componentTheme).not.toMatch(
 			/--color-cline-ui-(?:neutral|accent|error|success|warning|info)-(?:a)?\d+:/,

--- a/sdk/packages/ui/theme/component-theme.css
+++ b/sdk/packages/ui/theme/component-theme.css
@@ -94,6 +94,9 @@
 	--text-cline-ui-sm: var(--text-sm);
 	--text-cline-ui-sm--line-height: var(--text-sm--line-height);
 	--text-cline-ui-sm--letter-spacing: var(--text-sm--letter-spacing);
+	--text-cline-ui-md: var(--text-md);
+	--text-cline-ui-md--line-height: var(--text-md--line-height);
+	--text-cline-ui-md--letter-spacing: var(--text-md--letter-spacing);
 	--text-cline-ui-base: var(--text-base);
 	--text-cline-ui-base--line-height: var(--text-base--line-height);
 	--text-cline-ui-base--letter-spacing: var(--text-base--letter-spacing);

--- a/sdk/packages/ui/theme/scoped-tokens.css
+++ b/sdk/packages/ui/theme/scoped-tokens.css
@@ -374,6 +374,10 @@
 	--text-sm: 0.86667rem;
 	--text-sm--line-height: 1.25rem;
 	--text-sm--letter-spacing: 0em;
+	/* 14px at 15px root */
+	--text-md: 0.93333rem;
+	--text-md--line-height: 1.4rem;
+	--text-md--letter-spacing: 0em;
 	--text-base: 1rem;
 	--text-base--line-height: 1.5rem;
 	--text-base--letter-spacing: 0em;

--- a/sdk/packages/ui/theme/theme.css
+++ b/sdk/packages/ui/theme/theme.css
@@ -4,6 +4,7 @@
 	/* Register non-default typography companions for standard text utilities. */
 	--text-xs--letter-spacing: var(--text-xs--letter-spacing);
 	--text-sm--letter-spacing: var(--text-sm--letter-spacing);
+	--text-md--letter-spacing: var(--text-md--letter-spacing);
 	--text-base--letter-spacing: var(--text-base--letter-spacing);
 	--text-lg--letter-spacing: var(--text-lg--letter-spacing);
 	--text-xl--letter-spacing: var(--text-xl--letter-spacing);

--- a/sdk/packages/ui/theme/tokens.css
+++ b/sdk/packages/ui/theme/tokens.css
@@ -38,6 +38,10 @@
 	--text-sm: 0.86667rem;
 	--text-sm--line-height: 1.25rem;
 	--text-sm--letter-spacing: 0em;
+	/* 14px at 15px root */
+	--text-md: 0.93333rem;
+	--text-md--line-height: 1.4rem;
+	--text-md--letter-spacing: 0em;
 	--text-base: 1rem;
 	--text-base--line-height: 1.5rem;
 	--text-base--letter-spacing: 0em;


### PR DESCRIPTION
### Related Issue

(N/A)

### Description

Redesigns follow-up questions
- updated to explicit submission button (this is to accommodate multiple-choice answers)
- added keyboard navigation and A–Z shortcuts, synchronizes controlled pending selections
- removes request id, timestamp, and iteration count from the UI
- also introduces a reusable Badge component
- also adds the medium text token used by the updated presentation and keeps internal request IDs, iteration counts, and timestamps out of the user-facing card.

### Test Procedure

1. Open Storybook (`bun run build:sdk`, then `bun -F @cline/ui storybook`)
2. Open **Agent / Ask question / Default** in Storybook
3. Confirm question and option text can be selected with the pointer.
4. Select an option and confirm it is highlighted but is not sent until **Submit** is activated.
5. Use the arrow keys to move between options, press an A–Z shortcut to select its matching option, and press Enter to submit the selection.
6. Open **Multiple Choice**, select more than one option, and confirm **Submit** becomes enabled and preserves every selected option.
7. Check **Sending Answer**, **Error State**, and **Long Options** for their pending, error, and wrapping states.
8. Run the desktop app, trigger an `ask_question`, and confirm the card does not display its internal request ID, iteration count, or timestamp.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
    - `bun test` currently fails in unchanged CLI/Vitest suites (including ClinePass TUI timing, raw Bun/Vitest incompatibilities, and missing generated VS Code modules). `bun run format` reports existing diagnostics outside this PR. Focused unit/integration tests, typechecks, builds, and lint pass.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before**

<img width="1280" height="720" alt="ask-question-before" src="https://github.com/user-attachments/assets/8179cb9b-439b-4bf0-94e7-33d0e3d33754" />

**After**

<img width="1280" height="720" alt="ask-question-after" src="https://github.com/user-attachments/assets/5c45d9e4-a94f-41c9-972a-24304b31783b" />

### Additional Notes

The API remains backward-compatible for single-answer hosts, but the interaction changes from immediate submission to explicit submission.
