### PR TITLE
style(ui): refine dark typography and button focus

### DIFF
--- a/sdk/packages/ui/components/button.tsx
+++ b/sdk/packages/ui/components/button.tsx
@@ -17,7 +17,7 @@ const BASE =
 	"inline-flex items-center justify-center whitespace-nowrap rounded-cline-ui-md font-cline-ui-medium cursor-pointer " +
 	"disabled:pointer-events-none disabled:opacity-50 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 " +
 	"[&_svg]:pointer-events-none [&_svg]:shrink-0 shrink-0 " +
-	"outline-none focus-visible:ring-2 focus-visible:ring-cline-ui-ring/60 transition-colors";
+	"outline-none focus-visible:ring-1 focus-visible:ring-cline-ui-ring/60";
 
 // ─── Button ───────────────────────────────────────────────────────────────────
 
@@ -127,7 +127,12 @@ const preventDisabledActivation: MouseEventHandler<HTMLElement> = (event) => {
 };
 
 function disableComposedChild(children: ReactNode) {
-	if (!isValidElement<{ onClick?: MouseEventHandler; onClickCapture?: MouseEventHandler }>(children)) {
+	if (
+		!isValidElement<{
+			onClick?: MouseEventHandler;
+			onClickCapture?: MouseEventHandler;
+		}>(children)
+	) {
 		return children;
 	}
 

--- a/sdk/packages/ui/tests/theme.test.ts
+++ b/sdk/packages/ui/tests/theme.test.ts
@@ -220,13 +220,13 @@ describe("@cline/ui theme contract", () => {
 			expect(root).toContain(`--font-weight-${token}: ${value};`);
 		}
 		for (const [token, value] of [
-			["normal", 400],
-			["medium", 500],
-			["semibold", 600],
-			["bold", 600],
+			["normal", 380],
+			["medium", 480],
+			["semibold", 560],
 		] as const) {
 			expect(dark).toContain(`--font-weight-${token}: ${value};`);
 		}
+		expect(dark).toContain("--font-weight-bold: var(--font-weight-semibold);");
 		for (const token of [
 			"--font-sans:",
 			"--font-mono:",

--- a/sdk/packages/ui/theme/scoped-tokens.css
+++ b/sdk/packages/ui/theme/scoped-tokens.css
@@ -407,10 +407,11 @@
 	--brand-periwinkle: oklch(0.63 0.16 275);
 	--brand-cyan: oklch(0.72 0.09 210);
 	--card-surface: var(--neutral-3);
-	--font-weight-normal: 400;
-	--font-weight-medium: 500;
-	--font-weight-semibold: 600;
-	--font-weight-bold: 600;
+	/* adjustment for optical weight: bright text appear thicker over dark background */
+	--font-weight-normal: 380;
+	--font-weight-medium: 480;
+	--font-weight-semibold: 560;
+	--font-weight-bold: var(--font-weight-semibold);
 }
 
 .cline-ui-theme,

--- a/sdk/packages/ui/theme/tokens.css
+++ b/sdk/packages/ui/theme/tokens.css
@@ -70,10 +70,11 @@
 	--brand-periwinkle: oklch(0.63 0.16 275);
 	--brand-cyan: oklch(0.72 0.09 210);
 	--card-surface: var(--neutral-3);
-	--font-weight-normal: 400;
-	--font-weight-medium: 500;
-	--font-weight-semibold: 600;
-	--font-weight-bold: 600;
+	/* adjustment for optical weight: bright text appear thicker over dark background */
+	--font-weight-normal: 380;
+	--font-weight-medium: 480;
+	--font-weight-semibold: 560;
+	--font-weight-bold: var(--font-weight-semibold);
 }
 
 :root,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adjusts dark-theme font weights for optical balance and refines the shared Button focus ring. Color transitions are intentionally removed so button state changes are immediate.

### Test Procedure

- `bun run build:sdk` — passed.
- `bun -F @cline/ui test` — 102 tests passed.
- `bun -F @cline/ui typecheck` and `bun -F @cline/ui build` — passed.
- `bun -F @cline/ui build-storybook` — passed.
- `bun run lint` — passed with existing warnings.
- `bun test` — failed in unchanged repository-wide CLI/Vitest suites. Failures included ClinePass TUI timeouts, raw Bun runner incompatibilities with Vitest globals, and missing generated VS Code modules.
- `bun run format` — failed on existing formatting diagnostics outside this PR.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
    - `bun test` and `bun run format` currently fail on unchanged repository-wide tests/files as documented above; focused tests, typecheck, build, Storybook build, and lint pass.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before**

<img width="1280" height="720" alt="button-theme-before" src="https://github.com/user-attachments/assets/8bcdc4f7-ec7e-4000-8072-c5a2de353a45" />

**After**

Captured during Storybook verification; the local artifact is retained as `button-theme-after.png` because GitHub's attachment upload did not complete reliably.

### Additional Notes

Removing `transition-colors` is intentional.
