### PR TITLE
fix(desktop-app): add white border to accent color swatches

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -656,7 +656,7 @@ function GeneralSettingsContent() {
 								aria-label={option.label}
 								aria-pressed={accent === option.id}
 								className={cn(
-									"size-7 rounded-full border border-white transition-transform hover:scale-110",
+									"size-7 rounded-full border border-foreground/10 transition-transform hover:scale-110 dark:border-white",
 									accent === option.id &&
 										"ring-2 ring-ring ring-offset-2 ring-offset-background",
 								)}

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -656,7 +656,7 @@ function GeneralSettingsContent() {
 								aria-label={option.label}
 								aria-pressed={accent === option.id}
 								className={cn(
-									"size-7 rounded-full border border-foreground/10 transition-transform hover:scale-110",
+									"size-7 rounded-full border border-white transition-transform hover:scale-110",
 									accent === option.id &&
 										"ring-2 ring-ring ring-offset-2 ring-offset-background",
 								)}


### PR DESCRIPTION
## Summary

Adds a thin white border around each accent color swatch in Settings > General > Accent color **in dark mode**, so each swatch has a clearer boundary against the dark background.

## Changes

- `apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx`: added `dark:border-white` to the swatch button.

The swatches already had a border, but at `border-foreground/10` it was almost invisible against the dark background. Light mode keeps the existing `border-foreground/10`, where a white border would wash out against the pale background.

The selected-state `ring-2 ring-ring` indicator is unchanged, so the selected swatch still reads as selected.

## Testing

- `vitest run webview/components/views/settings webview/lib/theme.test.ts` — 4 files / 16 tests passing.
- `biome check` on the touched file reports no new issues (only a pre-existing `<img>` warning elsewhere in the file).
