### PR TITLE
fix(core): make doctor and the build-mismatch watcher shield-aware

### DIFF
--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -72,7 +72,7 @@ vi.mock("@cline/core", () => ({
 	resolveSharedHubOwnerContext: mockResolveSharedHubOwnerContext,
 	clearHubDiscovery: mockClearHubDiscovery,
 	probeHubServer: mockProbeHubServer,
-	readHubDiscovery: mockReadHubDiscovery,
+	readHubDiscoveryIncludingSuperseded: mockReadHubDiscovery,
 	stopLocalHubServerGracefully: mockStopLocalHubServerGracefully,
 	ensureFileExists: mockEnsureFileExists,
 	listActiveConnectors: mockListActiveConnectors,

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -6,7 +6,7 @@ import {
 	ensureFileExists,
 	listActiveConnectors,
 	probeHubServer,
-	readHubDiscovery,
+	readHubDiscoveryIncludingSuperseded,
 	resolveClineDataDir,
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
@@ -411,7 +411,14 @@ function resolveCliHubOwnerContext() {
 
 async function collectDoctorStatus(cwd: string): Promise<DoctorStatus> {
 	const owner = resolveCliHubOwnerContext();
-	const discovery = await readHubDiscovery(owner.discoveryPath);
+	// Fall back to the postinstall shield's set-aside record: during a
+	// self-update the live hub keeps serving sessions while its discovery
+	// record is hidden from pre-3.0.55 updaters. Without this, doctor reads no
+	// record, reports the still-live hub as a stale daemon, and recommends
+	// `doctor fix` — which would kill the hub out from under an attached session.
+	const discovery = await readHubDiscoveryIncludingSuperseded(
+		owner.discoveryPath,
+	);
 	const health = discovery?.url
 		? await probeHubServer(discovery.url, { authToken: discovery.authToken })
 		: undefined;

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
@@ -23,7 +23,7 @@ function mockDiscovery(options: DiscoveryMockOptions): void {
 		return {
 			...actual,
 			resolveHubBuildId: () => options.expectedBuildId ?? "current-build",
-			readHubDiscovery: vi.fn(async () => options.record),
+			readHubDiscoveryIncludingSuperseded: vi.fn(async () => options.record),
 			probeHubServer: vi.fn(async () => options.probe),
 		};
 	});
@@ -215,7 +215,7 @@ describe("watchManagedHubBuildMismatch", () => {
 			return {
 				...actual,
 				resolveHubBuildId: () => "current-build",
-				readHubDiscovery: vi.fn(async () => liveRecord),
+				readHubDiscoveryIncludingSuperseded: vi.fn(async () => liveRecord),
 				probeHubServer: vi.fn(async () => probeResult),
 			};
 		});
@@ -271,7 +271,7 @@ describe("watchManagedHubBuildMismatch", () => {
 			return {
 				...actual,
 				resolveHubBuildId: () => "current-build",
-				readHubDiscovery: vi.fn(async () => liveRecord),
+				readHubDiscoveryIncludingSuperseded: vi.fn(async () => liveRecord),
 				probeHubServer: vi.fn(async () => probeResult),
 			};
 		});
@@ -328,7 +328,7 @@ describe("watchManagedHubBuildMismatch", () => {
 			return {
 				...actual,
 				resolveHubBuildId: () => "current-build",
-				readHubDiscovery: vi.fn(async () => liveRecord),
+				readHubDiscoveryIncludingSuperseded: vi.fn(async () => liveRecord),
 				probeHubServer: vi.fn(async () => probeResult),
 			};
 		});

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -5,7 +5,7 @@ import {
 	getManagedHubCompatibility,
 	type HubOwnerContext,
 	probeHubServer,
-	readHubDiscovery,
+	readHubDiscoveryIncludingSuperseded,
 	resolveHubBuildId,
 	resolveHubBuildIdentity,
 } from "../discovery";
@@ -79,9 +79,14 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	if (isHubStartupLockHeld(owner.discoveryPath)) {
 		return undefined;
 	}
-	const record = await readHubDiscovery(owner.discoveryPath).catch(
-		() => undefined,
-	);
+	// Fall back to the postinstall shield's set-aside record. After a self-update
+	// shields the record, an older hub left running because it is serving live
+	// sessions is exactly the `outdated_hub` case this watcher reports - but the
+	// hidden record would otherwise make the notice unreachable in the one window
+	// it exists for.
+	const record = await readHubDiscoveryIncludingSuperseded(
+		owner.discoveryPath,
+	).catch(() => undefined);
 	if (!record?.url) {
 		return undefined;
 	}

--- a/sdk/packages/core/src/hub/discovery/index.test.ts
+++ b/sdk/packages/core/src/hub/discovery/index.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -8,9 +8,11 @@ import {
 	isManagedHubReusable,
 	probeHubServer,
 	readHubDiscovery,
+	readHubDiscoveryIncludingSuperseded,
 	resolveHubBuildEpochMs,
 	resolveHubBuildId,
 	resolveHubOwnerContext,
+	SUPERSEDED_HUB_DISCOVERY_SUFFIX,
 	writeHubDiscovery,
 } from ".";
 
@@ -324,5 +326,58 @@ describe("hub discovery", () => {
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
+	});
+
+	it("prefers the live record and falls back to the set-aside superseded copy", async () => {
+		snapshot = captureEnv();
+		delete process.env.CLINE_HUB_DISCOVERY_PATH;
+		process.env.CLINE_DATA_DIR = "/tmp/cline-data";
+
+		const discoveryPath = resolveHubOwnerContext(
+			"superseded-fallback",
+		).discoveryPath;
+		const supersededPath = `${discoveryPath}${SUPERSEDED_HUB_DISCOVERY_SUFFIX}`;
+		const baseRecord = {
+			protocolVersion: "v1",
+			authToken: "test-token",
+			host: "127.0.0.1",
+			port: 25463,
+			url: "ws://127.0.0.1:25463/hub",
+			startedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+
+		await mkdir(dirname(discoveryPath), { recursive: true });
+		await rm(supersededPath, { force: true });
+
+		// No record at all: nothing to return.
+		await clearHubDiscovery(discoveryPath);
+		await expect(
+			readHubDiscoveryIncludingSuperseded(discoveryPath),
+		).resolves.toBeUndefined();
+
+		// Shielded window: the live record has been set aside (exactly what the
+		// postinstall does with renameSync), so the fallback must find it.
+		await writeHubDiscovery(discoveryPath, {
+			...baseRecord,
+			hubId: "shielded-hub",
+		});
+		await rename(discoveryPath, supersededPath);
+		await expect(readHubDiscovery(discoveryPath)).resolves.toBeUndefined();
+		expect(
+			(await readHubDiscoveryIncludingSuperseded(discoveryPath))?.hubId,
+		).toBe("shielded-hub");
+
+		// The live record always wins over a stale set-aside copy.
+		await writeHubDiscovery(discoveryPath, {
+			...baseRecord,
+			hubId: "live-hub",
+		});
+		expect(
+			(await readHubDiscoveryIncludingSuperseded(discoveryPath))?.hubId,
+		).toBe("live-hub");
+
+		await clearHubDiscovery(discoveryPath);
+		await rm(supersededPath, { force: true });
 	});
 });

--- a/sdk/packages/core/src/hub/discovery/index.ts
+++ b/sdk/packages/core/src/hub/discovery/index.ts
@@ -399,6 +399,39 @@ export async function readHubDiscovery(
 	}
 }
 
+/**
+ * Filename suffix the npm postinstall shield uses to set the discovery record
+ * aside during a self-update (see apps/cli/script/postinstall.mjs). Centralized
+ * so every shield-aware reader agrees on where the set-aside record lives.
+ */
+export const SUPERSEDED_HUB_DISCOVERY_SUFFIX = ".superseded";
+
+/**
+ * Read the discovery record, falling back to the set-aside `.superseded` copy
+ * the postinstall shield leaves behind.
+ *
+ * The shield hides the live record from pre-3.0.55 updaters (which would
+ * otherwise restart a hub that is still serving sessions), but the hub itself
+ * keeps running. Read-only consumers on the current build — `cline doctor` and
+ * the build-mismatch watcher — must still be able to see that hub, or they
+ * mistake a live daemon for a stale one (and recommend killing it) and miss the
+ * outdated-hub notice during the exact window it exists for.
+ *
+ * The main record always wins when present; `.superseded` is consulted only
+ * during the shielded window. This never resurrects the record on disk, so the
+ * shield's protection against pre-3.0.55 updaters is preserved.
+ */
+export async function readHubDiscoveryIncludingSuperseded(
+	discoveryPath: string,
+): Promise<HubServerDiscoveryRecord | undefined> {
+	return (
+		(await readHubDiscovery(discoveryPath)) ??
+		(await readHubDiscovery(
+			`${discoveryPath}${SUPERSEDED_HUB_DISCOVERY_SUFFIX}`,
+		))
+	);
+}
+
 export async function writeHubDiscovery(
 	discoveryPath: string,
 	record: HubServerDiscoveryRecord,


### PR DESCRIPTION
### Related Issue

Follow-up hardening for the hub-lifecycle stack. Stacks on #13231 (`bee/hub-lifecycle`, which contains #13230) and completes the postinstall shield introduced in #13233 (`saoudrizwan/deferred-cli-update`). The bugs below only appear when the shield (#13233) and the defer/dialog/doctor code (#13230/#13231) are both present, so this targets the converged stack.

### Description

The CLI self-update shield in `apps/cli/script/postinstall.mjs` sets the hub discovery record aside (`production.json` -> `production.json.superseded`) so a pre-3.0.55 updater cannot restart a hub that is still serving live sessions. The ensure path already reads the set-aside record back (`readSupersededHubDiscovery`), but two other read-only consumers read `production.json` directly with no fallback. During the shielded window - which lasts as long as the displaced hub keeps serving a session, potentially hours - that gap produces two user-facing problems:

1. `cline doctor` sees no record, so it reports the still-live hub as a `stale hub daemon` and prints `Run 'cline doctor fix' to kill all stale local processes`. A user who follows that advice kills the hub out from under an attached session - reproducing the exact `Hub connection closed (code=1006)` the shield exists to prevent.
2. The build-mismatch watcher (`checkManagedHubBuildMismatch`) sees no record and returns `undefined`, so the `outdated_hub` informational dialog is unreachable in the one situation it was built for: a freshly updated CLI running beside an older hub that was deliberately left in place because it is busy.

**Fix:** add `readHubDiscoveryIncludingSuperseded` (and a shared `SUPERSEDED_HUB_DISCOVERY_SUFFIX` constant) that prefers the live record and falls back to the set-aside `.superseded` copy, and use it in both consumers. The record is never resurrected on disk, so the shield's protection against pre-3.0.55 updaters is preserved - only current-build read-only consumers gain visibility.

Out of scope, deliberately: during the shielded window the interactive CLI runs its own session on a local runtime host rather than sharing the older busy hub. That follows from `resolveCompatibleLocalHubUrl` requiring the current build (an older hub is never reused for a current-build client), which is the intended "don't spawn a rival daemon on the fixed port" behavior of #13231, not a regression the shield introduced. Left unchanged here.

### Test Procedure

New/updated unit tests:
- `discovery/index.test.ts` - `readHubDiscoveryIncludingSuperseded` prefers the live record, falls back to the set-aside copy (created via `rename`, exactly as the postinstall does), and returns `undefined` when neither exists.
- `managed-hub-build-watcher.test.ts` and `doctor.test.ts` - updated the discovery mocks to the shield-aware reader; existing behavior is unchanged.

Suites: `@cline/core` hub suite 267/267; `@cline/cli` doctor suite 21/21. `tsc --noEmit` clean for `@cline/core` and `apps/cli`; biome clean. All green both on this base and against the full converged stack.

End-to-end, against a real busy older hub with the record shielded (`production.json` moved to `.superseded`), using a compiled binary of the converged stack:
- Before: `hub healthy no`, `stale hub daemons 26589` (the live hub), no dialog.
- After: `hub healthy yes (pid=30883)`, `stale hub daemons 0`, and the `outdated_hub` dialog fires while the busy hub is left running.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

- The `.superseded` suffix is now a single exported constant (`SUPERSEDED_HUB_DISCOVERY_SUFFIX`) rather than a magic string; `apps/cli/script/postinstall.mjs` still hardcodes the literal because it runs standalone under Node with no `@cline/*` imports, so the value is duplicated there by necessity.
- This is a clean stack on `bee/hub-lifecycle`: the three touched source files (`discovery/index.ts`, `managed-hub-build-watcher.ts`, `doctor.ts`) are not modified by #13233, so the diff applies without conflict. The fallback is inert until #13233's shield is present, at which point it becomes active.