### PR TITLE
fix(cli): keep --id headless with prompt/json/piped stdin and resume …

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -576,6 +576,106 @@ describe("runCli lightweight command dispatch", () => {
 		expect(mockState.runInteractiveImports).toBe(0);
 	});
 
+	it("keeps --id with a positional prompt in headless json mode", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+
+		runtimeMocks.runAgent.mockClear();
+		runtimeMocks.runInteractive.mockClear();
+		mockState.runAgentImports = 0;
+		mockState.runInteractiveImports = 0;
+		process.exitCode = undefined;
+
+		process.argv = [
+			"bun",
+			"src/index.ts",
+			"--json",
+			"--id",
+			"session-123",
+			"Continue the previous task",
+		];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+
+		expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+		expect(runtimeMocks.runAgent).toHaveBeenCalledTimes(1);
+
+		const call = runtimeMocks.runAgent.mock.calls[0];
+
+		expect(call[0]).toBe("Continue the previous task");
+		expect(call[1]).toEqual(
+			expect.objectContaining({
+				outputMode: "json",
+			}),
+		);
+		expect(call[2]).toBeDefined();
+		expect(call[3]).toEqual({
+			resumeSessionId: "session-123",
+		});
+	});
+
+	it("keeps --id with piped stdin headless and resumes the session", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+
+		runtimeMocks.runAgent.mockClear();
+		runtimeMocks.runInteractive.mockClear();
+		mockState.runAgentImports = 0;
+		mockState.runInteractiveImports = 0;
+		process.exitCode = undefined;
+
+		vi.mocked(fstatSync).mockReturnValue({
+			isFIFO: () => true,
+			isFile: () => false,
+		} as ReturnType<typeof fstatSync>);
+
+		vi.spyOn(process.stdin, Symbol.asyncIterator).mockImplementation(
+			async function* (): AsyncGenerator<Buffer, undefined> {
+				yield Buffer.from("Continue the previous task");
+			},
+		);
+
+		process.argv = ["bun", "src/index.ts", "--json", "--id", "session-123"];
+
+		try {
+			const { runCli } = await import("./main");
+
+			await expect(runCli()).resolves.toBeUndefined();
+
+			expect(runtimeMocks.runInteractive).not.toHaveBeenCalled();
+			expect(runtimeMocks.runAgent).toHaveBeenCalledTimes(1);
+
+			const call = runtimeMocks.runAgent.mock.calls[0];
+
+			expect(call[0]).toBe("Continue the previous task");
+			expect(call[1]).toEqual(
+				expect.objectContaining({
+					outputMode: "json",
+				}),
+			);
+			expect(call[2]).toBeDefined();
+			expect(call[3]).toEqual({
+				resumeSessionId: "session-123",
+			});
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("rejects a single bare positional prompt token", async () => {
 		const consoleError = vi
 			.spyOn(console, "error")

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -738,19 +738,38 @@ export async function runCli(): Promise<void> {
 
 	let startupTarget = ctx.startupTarget;
 	let resumeSessionId: string | undefined;
+
 	if (args.id !== undefined) {
 		const sessionId = args.id.trim();
+
 		if (!sessionId) {
 			writeErr("--id requires <session-id>");
 			process.exitCode = 1;
 			return;
 		}
+
 		resumeSessionId = sessionId;
-		startupTarget = "chat";
+
+		const hasHeadlessInput =
+			Boolean(args.prompt) ||
+			args.outputMode === "json" ||
+			stdinHasPipedInput();
+
+		if (hasHeadlessInput) {
+			startupTarget = undefined;
+			args = {
+				...args,
+				interactive: false,
+			};
+		} else {
+			startupTarget = "chat";
+		}
+
 		process.env.CLINE_HOOK_AGENT_RESUME = "1";
 	} else {
 		delete process.env.CLINE_HOOK_AGENT_RESUME;
 	}
+
 	if (startupTarget) {
 		args = {
 			...args,
@@ -804,7 +823,12 @@ export async function runCli(): Promise<void> {
 	}
 	setCurrentOutputMode(args.outputMode);
 
-	if (args.outputMode === "json" && (args.interactive || !args.prompt)) {
+	const hasPipedInput = stdinHasPipedInput();
+
+	if (
+		args.outputMode === "json" &&
+		(args.interactive || (!args.prompt && !hasPipedInput))
+	) {
 		writeErr(
 			"JSON output mode requires a prompt argument or piped stdin (interactive mode is unsupported)",
 		);
@@ -1157,7 +1181,13 @@ export async function runCli(): Promise<void> {
 					await runZen(pipedEffectivePrompt, config, userInstructionService);
 					return;
 				}
-				await runAgent(pipedEffectivePrompt, config, userInstructionService);
+				if (resumeSessionId) {
+					await runAgent(pipedEffectivePrompt, config, userInstructionService, {
+						resumeSessionId,
+					});
+				} else {
+					await runAgent(pipedEffectivePrompt, config, userInstructionService);
+				}
 				return;
 			}
 		}
@@ -1232,7 +1262,13 @@ export async function runCli(): Promise<void> {
 			return;
 		}
 
-		await runAgent(effectivePrompt, config, userInstructionService);
+		if (resumeSessionId) {
+			await runAgent(effectivePrompt, config, userInstructionService, {
+				resumeSessionId,
+			});
+		} else {
+			await runAgent(effectivePrompt, config, userInstructionService);
+		}
 		// Exit once agent is done in non-interactive mode
 		return;
 	} finally {

--- a/apps/cli/src/runtime/run-agent.test.ts
+++ b/apps/cli/src/runtime/run-agent.test.ts
@@ -7,6 +7,7 @@ const sessionManagerMocks = vi.hoisted(() => ({
 	stop: vi.fn(),
 	dispose: vi.fn(),
 	abort: vi.fn(),
+	readMessages: vi.fn(),
 	getAccumulatedUsage: vi.fn(),
 }));
 
@@ -152,6 +153,8 @@ describe("runAgent", () => {
 		sessionManagerMocks.dispose.mockResolvedValue(undefined);
 		sessionManagerMocks.abort.mockReset();
 		sessionManagerMocks.abort.mockResolvedValue(undefined);
+		sessionManagerMocks.readMessages.mockReset();
+		sessionManagerMocks.readMessages.mockResolvedValue([]);
 		sessionManagerMocks.getAccumulatedUsage.mockReset();
 		hookMocks.runtimeHooks.shutdown.mockReset();
 		hookMocks.runtimeHooks.shutdown.mockResolvedValue(undefined);
@@ -246,6 +249,87 @@ describe("runAgent", () => {
 		);
 		expect(startInput?.localRuntime).not.toHaveProperty(
 			"userInstructionService",
+		);
+	});
+
+	it("loads prior messages when resuming a headless session", async () => {
+		const startedAt = new Date("2026-03-22T00:00:00.000Z");
+		const endedAt = new Date("2026-03-22T00:00:01.000Z");
+		const priorMessages = [
+			{ role: "user", content: [{ type: "text", text: "previous" }] },
+		];
+		sessionManagerMocks.readMessages.mockResolvedValue(priorMessages);
+		sessionManagerMocks.start.mockResolvedValue({
+			sessionId: "session-123",
+			manifestPath: "/tmp/manifest.json",
+			messagesPath: "/tmp/messages.json",
+			manifest: {
+				session_id: "session-123",
+			},
+			result: {
+				text: "ok",
+				usage: {
+					inputTokens: 1,
+					outputTokens: 1,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+					totalCost: undefined,
+				},
+				messages: [],
+				toolCalls: [],
+				iterations: 1,
+				finishReason: "completed",
+				model: {
+					id: "gemini",
+					provider: "openrouter",
+					info: {},
+				},
+				startedAt,
+				endedAt,
+				durationMs: 1000,
+			},
+		});
+
+		const { runAgent } = await import("./run-agent");
+
+		await expect(
+			runAgent(
+				"Continue the previous task",
+				{
+					cwd: process.cwd(),
+					enableAgentTeams: false,
+					enableSpawnAgent: false,
+					enableTools: [],
+					execution: {
+						maxConsecutiveMistakes: 3,
+					},
+					logger: undefined,
+					mode: "act",
+					modelId: "google/gemini-3-flash-preview",
+					outputMode: "json",
+					providerId: "openrouter",
+					systemPrompt: "system",
+					thinking: false,
+					toolPolicies: { "*": { autoApprove: true } },
+					verbose: false,
+					workspaceRoot: process.cwd(),
+				} as never,
+				undefined,
+				{ resumeSessionId: "session-123" },
+			),
+		).resolves.toBeUndefined();
+
+		expect(sessionManagerMocks.readMessages).toHaveBeenCalledWith(
+			"session-123",
+		);
+		expect(sessionManagerMocks.start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				initialMessages: priorMessages,
+				prompt: "prompt",
+				config: expect.objectContaining({
+					sessionId: "session-123",
+				}),
+			}),
 		);
 	});
 

--- a/apps/cli/src/runtime/run-agent.ts
+++ b/apps/cli/src/runtime/run-agent.ts
@@ -33,6 +33,7 @@ import {
 	writeErr,
 	writeln,
 } from "../utils/output";
+import { loadInteractiveResumeMessages } from "../utils/resume";
 import type { Config } from "../utils/types";
 import { shouldShowCliUsageCost } from "../utils/usage-cost-display";
 import { setActiveRuntimeAbort } from "./active-runtime";
@@ -138,6 +139,7 @@ export async function runAgent(
 	options?: {
 		clineApiBaseUrl?: string;
 		clineProviderSettings?: ProviderSettings;
+		resumeSessionId?: string;
 	},
 ): Promise<void> {
 	// A clean one-shot run should not inherit a stale nonzero process exit code
@@ -212,7 +214,9 @@ export async function runAgent(
 		}
 		handleEvent(event, config);
 	};
-	const plannedSessionId = createSessionId();
+	const plannedSessionId =
+		options?.resumeSessionId?.trim() || createSessionId();
+
 	const unsubscribe = subscribeToAgentEvents(sessionManager, onAgentEvent, {
 		sessionId: plannedSessionId,
 	});
@@ -278,6 +282,12 @@ export async function runAgent(
 			userImages,
 			userFiles,
 		} = await buildUserInputMessage(prompt, userInstructionService);
+		const initialMessages = options?.resumeSessionId?.trim()
+			? await loadInteractiveResumeMessages(
+					sessionManager,
+					options.resumeSessionId,
+				)
+			: undefined;
 		const started = await sessionManager.start({
 			source: SessionSource.CLI,
 			config: {
@@ -296,6 +306,7 @@ export async function runAgent(
 				) => resolveMistakeLimitDecision(config, context),
 			},
 			prompt: userInput,
+			initialMessages,
 			userImages: userImages.length > 0 ? userImages : undefined,
 			userFiles: userFiles.length > 0 ? userFiles : undefined,
 			interactive: false,


### PR DESCRIPTION

### Related Issue

 
**Issue:** #13239 #10856

### Description

Headless/no-TTY invocations that resume an existing session with `--id` were force-routed into interactive mode. `cline --json --id <session-id> "<prompt>"` (and the piped-stdin variant) failed with:

```
JSON output mode requires a prompt argument or piped stdin (interactive mode is unsupported)
```

Root cause: the `--id` routing in `apps/cli/src/main.ts` unconditionally set `startupTarget = "chat"`, which flipped `args.interactive = true` and cleared `args.prompt` — so the JSON-mode validation rejected the run before the agent ever started.

This PR:

- keeps `--id` headless whenever a positional prompt, `--json`, or piped stdin is present; interactive `--id` on a real TTY without a prompt is unchanged (still opens the chat TUI),
- allows JSON mode with piped stdin in the validation guard,
- propagates `resumeSessionId` into `runAgent()` for both the positional-prompt and piped-stdin paths (the historical 3-argument `runAgent(...)` call shape is preserved when no resume ID exists),
- makes `runAgent()` actually resume: it loads the prior session messages (`loadInteractiveResumeMessages`) and passes them as `initialMessages` together with the supplied session ID to `sessionManager.start()`, instead of minting a new session ID.

### Test Procedure

- New regression tests in `apps/cli/src/main.test.ts`:
  - `keeps --id with a positional prompt in headless json mode` — asserts `runAgent` is called with the prompt and `{ resumeSessionId: "session-123" }`, and `runInteractive` is never loaded.
  - `keeps --id with piped stdin headless and resumes the session` — same assertions for the stdin-piped form.
- New regression test in `apps/cli/src/runtime/run-agent.test.ts`:
  - `loads prior messages when resuming a headless session` — asserts `readMessages(<id>)` is called and `sessionManager.start()` receives `initialMessages` plus `config.sessionId = <id>` (written red first, then implemented).
- Full suites: `cd apps/cli && bunx vitest run src/main.test.ts src/runtime/run-agent.test.ts` — 102/102 pass, including the pre-existing lazy-import accounting tests (`does not load interactive runtime for single-prompt mode` etc.), which is why the 3-arg call shape is kept for non-resume runs.
- Manual no-TTY verification (Docker, `-T`, both source via `bun src/index.ts` and a compiled `bun build --compile` linux-x64 binary):
  - `cline --json --id "$SESSION_ID" "Continue the previous task"`
  - `printf '%s\n' "Continue the previous task" | cline --json --id "$SESSION_ID"`
  - Both run headless (no TUI), emit JSON event lines including an `agent_resume` hook event, and create/use session artifacts under `~/.cline/data/sessions/<session-id>/` with the supplied ID. The only failure in the sandbox was a provider `Unauthorized` (no credentials in the container), which is downstream of the fixed routing.
- Code formatted with biome; only the four touched files changed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal evidence (no-TTY, piped stdin against a compiled binary):

```
{"ts":"...","type":"hook_event","hookEventName":"agent_resume","agentId":"agent_...","taskId":"conv_...","parentAgentId":null}
{"ts":"...","type":"agent_event","event":{"type":"iteration_start","iteration":1}}
...
~/.cline/data/sessions/session-e2e-13239/session-e2e-13239.json
~/.cline/data/sessions/session-e2e-13239/session-e2e-13239.messages.json
```

### Additional Notes

- Files touched: `apps/cli/src/main.ts`, `apps/cli/src/main.test.ts`, `apps/cli/src/runtime/run-agent.ts`, `apps/cli/src/runtime/run-agent.test.ts` (~+236/−5).
- The resume-message loading reuses the existing `loadInteractiveResumeMessages` helper from the interactive resume path, so headless and interactive resume share the same semantics.
- Hub-runtime resume was not separately exercised; the local runtime path treats a requested `config.sessionId` with `initialMessages` as a resume (same contract the interactive TUI uses).
