### PR TITLE
feat: add web search settings toggle to VS Code extension and desktop app

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -36,6 +36,7 @@ import {
 	saveLocalProviderSettings,
 	setAutoUpdateEnabledGlobally,
 	setMcpServerDisabled,
+	setModelToolEnabledGlobally,
 	setTelemetryOptOutGlobally,
 	updateLocalProvider,
 	updateMcpSettingsFileSync,
@@ -1523,6 +1524,13 @@ export async function handleCommand(
 			throw new Error("auto_update_enabled must be a boolean");
 		}
 		setAutoUpdateEnabledGlobally(args.auto_update_enabled);
+		return readGlobalSettings();
+	}
+	if (command === "set_web_search_enabled") {
+		if (typeof args?.web_search_enabled !== "boolean") {
+			throw new Error("web_search_enabled must be a boolean");
+		}
+		setModelToolEnabledGlobally("web_search", args.web_search_enabled);
 		return readGlobalSettings();
 	}
 

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -67,6 +67,7 @@ export {
 type GlobalSettingsResponse = {
 	telemetryOptOut: boolean;
 	autoUpdateEnabled: boolean;
+	tools?: Partial<Record<"web_search", { enabled: boolean }>>;
 };
 
 const PROVIDER_CATALOG_CACHE_TTL_MS = 60_000;
@@ -530,6 +531,10 @@ function GeneralSettingsContent() {
 	const [autoUpdateLoading, setAutoUpdateLoading] = useState(true);
 	const [autoUpdateSaving, setAutoUpdateSaving] = useState(false);
 	const [autoUpdateError, setAutoUpdateError] = useState<string | null>(null);
+	const [webSearchEnabled, setWebSearchEnabled] = useState(false);
+	const [webSearchLoading, setWebSearchLoading] = useState(true);
+	const [webSearchSaving, setWebSearchSaving] = useState(false);
+	const [webSearchError, setWebSearchError] = useState<string | null>(null);
 
 	useEffect(() => subscribeToAppFontSize(setFontSize), []);
 
@@ -538,19 +543,24 @@ function GeneralSettingsContent() {
 		setTelemetryError(null);
 		setAutoUpdateLoading(true);
 		setAutoUpdateError(null);
+		setWebSearchLoading(true);
+		setWebSearchError(null);
 		try {
 			const settings = await desktopClient.invoke<GlobalSettingsResponse>(
 				"get_global_settings",
 			);
 			setTelemetryOptOut(settings.telemetryOptOut);
 			setAutoUpdateEnabled(settings.autoUpdateEnabled);
+			setWebSearchEnabled(settings.tools?.web_search?.enabled === true);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			setTelemetryError(message);
 			setAutoUpdateError(message);
+			setWebSearchError(message);
 		} finally {
 			setTelemetryLoading(false);
 			setAutoUpdateLoading(false);
+			setWebSearchLoading(false);
 		}
 	}, []);
 
@@ -598,6 +608,26 @@ function GeneralSettingsContent() {
 			setAutoUpdateError(message);
 		} finally {
 			setAutoUpdateSaving(false);
+		}
+	};
+
+	const updateWebSearchEnabled = async (nextValue: boolean) => {
+		const previousValue = webSearchEnabled;
+		setWebSearchEnabled(nextValue);
+		setWebSearchSaving(true);
+		setWebSearchError(null);
+		try {
+			const settings = await desktopClient.invoke<GlobalSettingsResponse>(
+				"set_web_search_enabled",
+				{ web_search_enabled: nextValue },
+			);
+			setWebSearchEnabled(settings.tools?.web_search?.enabled === true);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			setWebSearchEnabled(previousValue);
+			setWebSearchError(message);
+		} finally {
+			setWebSearchSaving(false);
 		}
 	};
 
@@ -789,6 +819,28 @@ function GeneralSettingsContent() {
 							</button>
 						))}
 					</div>
+				</div>
+				<div className="flex py-4 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
+					<div className="flex flex-col gap-1">
+						<p className="text-base font-semibold text-foreground">
+							Web search
+						</p>
+						<p className="text-sm text-muted-foreground">
+							Let the model search the web when the selected provider and model
+							support it. Applies to new sessions.
+						</p>
+						{webSearchError ? (
+							<p className="mt-2 text-xs text-destructive" role="alert">
+								Failed to update web search setting: {webSearchError}
+							</p>
+						) : null}
+					</div>
+					<Switch
+						aria-label="Web search"
+						checked={webSearchEnabled}
+						disabled={webSearchLoading || webSearchSaving}
+						onCheckedChange={(checked) => void updateWebSearchEnabled(checked)}
+					/>
 				</div>
 				<div className="flex py-4 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
 					<div className="flex flex-col gap-1">

--- a/apps/vscode/proto/cline/state.proto
+++ b/apps/vscode/proto/cline/state.proto
@@ -429,6 +429,7 @@ message UpdateSettingsRequest {
   optional bool worktrees_enabled = 40;
   optional bool show_feature_tips = 42;
   optional string compaction_strategy = 44;
+  optional bool web_search_enabled = 45;
 }
 
 message UpdateTerminalConnectionTimeoutRequest {

--- a/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
+++ b/apps/vscode/src/core/controller/state/getStateToPostToWebview.ts
@@ -4,7 +4,7 @@
 // This allows the SdkController to reuse the classic state-building logic
 // without inheriting the entire classic Controller implementation.
 
-import { readCompactionStrategyGlobally } from "@cline/core"
+import { isModelToolEnabledGlobally, readCompactionStrategyGlobally } from "@cline/core"
 import { getHooksEnabledSafe } from "@core/hooks/hooks-utils"
 import type { ExtensionState, Platform } from "@shared/ExtensionMessage"
 import { ClineEnv } from "@/config"
@@ -43,6 +43,7 @@ export async function getStateToPostToWebview(controller: {
 	const mode = stateManager.getGlobalSettingsKey("mode")
 	const useAutoCondense = stateManager.getGlobalSettingsKey("useAutoCondense")
 	const compactionStrategy = readCompactionStrategyGlobally()
+	const webSearchEnabled = isModelToolEnabledGlobally("web_search")
 	const subagentsEnabled = stateManager.getGlobalSettingsKey("subagentsEnabled")
 	const userInfo = stateManager.getGlobalStateKey("userInfo")
 	const mcpMarketplaceEnabled = stateManager.getGlobalStateKey("mcpMarketplaceEnabled")
@@ -120,6 +121,7 @@ export async function getStateToPostToWebview(controller: {
 		mode,
 		useAutoCondense,
 		compactionStrategy,
+		webSearchEnabled,
 		subagentsEnabled,
 		userInfo,
 		mcpMarketplaceEnabled,

--- a/apps/vscode/src/core/controller/state/updateSettings.ts
+++ b/apps/vscode/src/core/controller/state/updateSettings.ts
@@ -1,4 +1,4 @@
-import { setCompactionStrategyGlobally } from "@cline/core"
+import { setCompactionStrategyGlobally, setModelToolEnabledGlobally } from "@cline/core"
 import { Empty } from "@shared/proto/cline/common"
 import { PlanActMode, McpDisplayMode as ProtoMcpDisplayMode, UpdateSettingsRequest } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
@@ -165,6 +165,11 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 				)
 			}
 			controller.stateManager.setGlobalState("useAutoCondense", request.useAutoCondense)
+		}
+
+		// Update web search setting (stored in the SDK global settings file; applied when the next session is built)
+		if (request.webSearchEnabled !== undefined) {
+			setModelToolEnabledGlobally("web_search", !!request.webSearchEnabled)
 		}
 
 		if (request.compactionStrategy !== undefined) {

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -118,6 +118,7 @@ export interface ExtensionState {
 	mcpResponsesCollapsed?: boolean
 	useAutoCondense?: boolean
 	compactionStrategy?: string
+	webSearchEnabled?: boolean
 	subagentsEnabled?: boolean
 	worktreesEnabled?: ClineFeatureSetting
 	favoritedModelIds: string[]

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -84,6 +84,28 @@ export function setCompactionStrategyGlobally(compactionStrategy: GlobalCompacti
 	}
 }
 
+export type ModelToolName = "web_search"
+
+export function isModelToolEnabledGlobally(name: ModelToolName): boolean {
+	try {
+		const settings = JSON.parse(readFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH ?? "", "utf8"))
+		return settings.tools?.[name]?.enabled === true
+	} catch {
+		return false
+	}
+}
+
+export function setModelToolEnabledGlobally(name: ModelToolName, enabled: boolean): void {
+	const filePath = process.env.CLINE_GLOBAL_SETTINGS_PATH
+	if (filePath) {
+		let settings: { tools?: Record<string, { enabled: boolean }> } = {}
+		try {
+			settings = JSON.parse(readFileSync(filePath, "utf8"))
+		} catch {}
+		writeFileSync(filePath, JSON.stringify({ ...settings, tools: { ...settings.tools, [name]: { enabled } } }))
+	}
+}
+
 export function truncateCommandOutput(output: string): string {
 	return output
 }

--- a/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -143,6 +143,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		mcpDisplayMode,
 		useAutoCondense,
 		compactionStrategy,
+		webSearchEnabled,
 		subagentsEnabled,
 		worktreesEnabled,
 		backgroundEditEnabled,
@@ -202,6 +203,12 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 									</SelectContent>
 								</Select>
 							</div>
+							<FeatureRow
+								checked={webSearchEnabled}
+								description="Let the model search the web when the selected provider and model support it. Applies to new tasks."
+								label="Web Search"
+								onChange={(checked) => updateSetting("webSearchEnabled", checked)}
+							/>
 						</div>
 					</div>
 
@@ -223,7 +230,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 							))}
 						</div>
 					</div>
-
 				</div>
 
 				{/* Advanced */}

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -299,6 +299,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		mcpResponsesCollapsed: false, // Default value (expanded), will be overwritten by extension state
 		useAutoCondense: true,
 		compactionStrategy: "basic",
+		webSearchEnabled: false,
 		subagentsEnabled: false,
 		worktreesEnabled: { user: true, featureFlag: false },
 		favoritedModelIds: [],


### PR DESCRIPTION
### Related Issue

Follow-up to #13075, which added provider-aware web search (disabled by default). The CLI already exposes a way to enable it via the config Tools tab, but the VS Code extension and desktop app had no way to turn it on.

### Description

Adds a Web Search toggle to both the VS Code extension and the desktop app. Both write the same SDK global setting (`tools.web_search.enabled` in `~/.cline/data/settings/global-settings.json`) via `setModelToolEnabledGlobally("web_search", ...)` from `@cline/core`, so the CLI, extension, and desktop app all share one source of truth. The runtime already picks the flag up when building the next session (`DefaultRuntimeBuilder`), gated on provider/model support, so no session wiring was needed.

**VS Code extension** (mirrors the existing `compactionStrategy` global-settings bridge):
- New `web_search_enabled` field on `UpdateSettingsRequest` in `proto/cline/state.proto`
- `updateSettings.ts` writes the global setting; `getStateToPostToWebview.ts` reads it via `isModelToolEnabledGlobally("web_search")`
- New "Web Search" switch in Settings > Features under the Agent group
- Vitest `@cline/core` stub extended with the two new functions

**Desktop app** (mirrors the existing telemetry/auto-update pattern):
- New `set_web_search_enabled` sidecar command; `get_global_settings` already returns the `tools` map so the webview reads the current value from it
- New "Web search" switch on the General settings page with optimistic update and rollback on error

### Test Procedure

- `bun run test:unit` in `apps/vscode` (1067 tests pass)
- Webview vitest suite in `apps/vscode/webview-ui` (431 tests pass)
- `bun run check-types` in `apps/vscode` and `bun run typecheck` + `bun run test:chat-ui` in `apps/examples/desktop-app` all pass
- Manual, VS Code: toggled the new switch ON in the extension dev host and confirmed via the integrated terminal that `~/.cline/data/settings/global-settings.json` gained `"tools": { "web_search": { "enabled": true } }`
- Manual, desktop app: with the setting already enabled from the VS Code test, the General settings page loaded with the switch ON (validating the shared read path), then toggled it OFF and back ON while watching the settings file, which transitioned `true` to `false` to `true` accordingly with no errors

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

VS Code extension, Settings > Features > Agent, with the toggle ON and the settings file shown in the integrated terminal:

![VS Code Web Search toggle](https://cursor.com/artifacts/c/art-55603f47-528d-4d98-bf56-bf4f2fc9f78b)

Desktop app, Settings > General, with the toggle ON:

![Desktop app Web search toggle](https://cursor.com/artifacts/c/art-da89bd3c-ee4c-459c-80ff-781e9ea75151)