### PR TITLE
fix(vscode): restore Gemini custom base URL

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -35,6 +35,10 @@ describe("providerSettingsRegistry", () => {
 			),
 		).toEqual({
 			allowsCustomIds: false,
+			baseUrlField: {
+				label: "Use custom base URL",
+				placeholder: "Default: https://generativelanguage.googleapis.com",
+			},
 			providerId: "gemini",
 			providerName: "Google Gemini",
 			signupUrl: "https://aistudio.google.com/apikey",
@@ -156,6 +160,16 @@ describe("providerSettingsRegistry", () => {
 			providerId: "deepseek",
 			providerName: "DeepSeek",
 			signupUrl: "https://www.deepseek.com/",
+		})
+		expect(getFallbackGenericProviderSettings("gemini")).toEqual({
+			allowsCustomIds: false,
+			baseUrlField: {
+				label: "Use custom base URL",
+				placeholder: "Default: https://generativelanguage.googleapis.com",
+			},
+			providerId: "gemini",
+			providerName: "Gemini",
+			signupUrl: "https://aistudio.google.com/apikey",
 		})
 		expect(getFallbackGenericProviderSettings("minimax")).toEqual({
 			allowsCustomIds: false,

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -57,6 +57,10 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	},
 	gemini: {
 		signupUrl: "https://aistudio.google.com/apikey",
+		baseUrlField: {
+			label: "Use custom base URL",
+			placeholder: "Default: https://generativelanguage.googleapis.com",
+		},
 	},
 	huggingface: {
 		signupUrl: "https://huggingface.co/settings/tokens",

--- a/sdk/packages/llms/src/providers/vendors/google.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/google.test.ts
@@ -1,0 +1,78 @@
+import type {
+	GatewayProviderContext,
+	GatewayResolvedProviderConfig,
+} from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGoogleProviderModule } from "./google";
+
+const createGoogleGenerativeAIMock = vi.hoisted(() => vi.fn());
+const googleModelMock = vi.hoisted(() =>
+	vi.fn((modelId: string) => ({ provider: "google", modelId })),
+);
+
+vi.mock("@ai-sdk/google", () => ({
+	createGoogleGenerativeAI: createGoogleGenerativeAIMock,
+}));
+
+describe("createGoogleProviderModule", () => {
+	beforeEach(() => {
+		createGoogleGenerativeAIMock.mockReset();
+		createGoogleGenerativeAIMock.mockReturnValue(googleModelMock);
+		googleModelMock.mockClear();
+	});
+
+	it("passes custom base URLs to the Google provider", async () => {
+		const provider = await createGoogleProviderModule(
+			config({ baseUrl: "https://gemini-proxy.example.com/v1beta" }),
+			context(),
+		);
+
+		provider.model("gemini-2.5-pro");
+
+		expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				apiKey: "test-api-key",
+				baseURL: "https://gemini-proxy.example.com/v1beta",
+				name: "gemini",
+			}),
+		);
+		expect(googleModelMock).toHaveBeenCalledWith("gemini-2.5-pro");
+	});
+
+	it("keeps the Google provider default when no base URL is configured", async () => {
+		await createGoogleProviderModule(config(), context());
+
+		expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				baseURL: undefined,
+			}),
+		);
+	});
+});
+
+function config(
+	overrides: Partial<GatewayResolvedProviderConfig> = {},
+): GatewayResolvedProviderConfig {
+	return {
+		providerId: "gemini",
+		apiKey: "test-api-key",
+		...overrides,
+	};
+}
+
+function context(): GatewayProviderContext {
+	return {
+		provider: {
+			id: "gemini",
+			name: "Google Gemini",
+			defaultModelId: "gemini-2.5-pro",
+			models: [],
+		},
+		model: {
+			providerId: "gemini",
+			id: "gemini-2.5-pro",
+			name: "Gemini 2.5 Pro",
+		},
+		config: config(),
+	};
+}

--- a/sdk/packages/llms/src/providers/vendors/google.ts
+++ b/sdk/packages/llms/src/providers/vendors/google.ts
@@ -14,6 +14,7 @@ export async function createGoogleProviderModule(
 	const apiKey = await resolveApiKey(config);
 	const provider = createGoogleGenerativeAI({
 		apiKey,
+		baseURL: config.baseUrl,
 		headers: config.headers,
 		fetch: config.fetch,
 		name: context.provider.id,


### PR DESCRIPTION
### Related Issue

**Issue:** #13243

### Description

Restores Gemini custom base URL support that was lost during the SDK migration.

- Exposes the existing base URL field in Gemini's generic provider settings, including the fallback rendered before provider listings load.
- Passes the resolved `config.baseUrl` to the native Google AI SDK provider.
- Adds focused regression coverage for the UI metadata and transport configuration.

The existing configuration store and legacy migration already map `geminiBaseUrl`, so no new storage key or migration is needed.

### Test Procedure

- `cd apps/vscode/webview-ui && bunx vitest run src/components/settings/providers/providerSettingsRegistry.test.ts`
- `cd sdk/packages/llms && bunx vitest run src/providers/vendors/google.test.ts`
- `cd sdk && bun -F @cline/llms typecheck`
- Targeted Biome checks for all four changed files

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature which causes existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed the contributor guidelines

### Screenshots

N/A — this restores the existing generic `BaseUrlField`; its label and placeholder are covered by registry/component tests, and request routing is covered by the Google provider factory test.

### Additional Notes

No changelog entry is included; the contribution guide states that maintainers handle release notes.
