### PR TITLE
fix(cli): stop streaming markdown from flashing raw text on every chunk

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -640,10 +640,23 @@ export function ChatEntryView(props: {
 						)}
 					</box>
 					<box flexGrow={1}>
+						{/*
+						 * internalBlockMode="top-level" keeps each markdown block as its
+						 * own renderable. The default coalesced mode merges the whole
+						 * message into one block that is torn down and re-highlighted on
+						 * every streamed chunk, which flashes already-rendered headings
+						 * and links back to raw uncolored markdown while tree-sitter
+						 * re-highlights asynchronously. Top-level blocks are reused by
+						 * token identity, so settled content never re-renders.
+						 * tableOptions preserves the bordered table style that coalesced
+						 * mode used by default (top-level defaults to borderless columns).
+						 */}
 						<markdown
 							content={content}
 							syntaxStyle={getSyntaxStyle(theme, mode)}
 							streaming={entry.streaming}
+							internalBlockMode="top-level"
+							tableOptions={{ style: "grid" }}
 							fg={defaultFg}
 						/>
 					</box>


### PR DESCRIPTION
### Problem

Reported on macOS Terminal, Ghostty and Kitty: while an assistant response streams into the CLI TUI, already-rendered markdown (colored headings, bold text, links) keeps flashing back to raw uncolored text with visible `###` markers on every incoming chunk. The re-wraps also make settled rows jump vertically, which is what makes rows (like the user message row) look jammed right under the content above them with no padding.

### Root cause

The assistant `<markdown>` element used opentui's default `internalBlockMode: "coalesced"`, which merges the entire message (headings, paragraphs, lists) into a single `CodeRenderable` block. Every streamed chunk re-runs `applyMarkdownCodeRenderable` on that whole block with a fresh `initialStyledText` built from `Lexer.lexInline(raw)`. Since `###` is not inline syntax, that immediately replaces the tree-sitter-highlighted buffer with raw, uncolored, unconcealed markdown for the whole message until the async re-highlight lands, once per chunk. The raw text also wraps differently than the concealed text (literal `###`, `**`, full link URLs), so the transcript reflows and rows jump on each flash.

This is the same bug opencode hit after switching to the opentui markdown renderable (anomalyco/opencode#27897), and the fix matches what opencode ships in its session view: `internalBlockMode="top-level"` with `tableOptions={{ style: "grid" }}`.

### Fix

Render assistant markdown with `internalBlockMode="top-level"`. Top-level blocks are reused by token identity via opentui's incremental parser, so settled blocks are never torn down or re-highlighted while streaming; only the trailing unstable block updates per chunk, and its interim render uses the token's real inline chunks (no raw `###` markers across the message). `tableOptions={{ style: "grid" }}` preserves the bordered table style that coalesced mode used by default (top-level mode otherwise defaults to borderless columns, see anomalyco/opencode#27533).

### Before

Mid-stream frame in Kitty: settled headings flash back to raw `###`, uncolored, and rows re-wrap.

![Before: settled headings flash back to raw ### uncolored markdown mid-stream](https://cursor.com/artifacts/c/art-57de79aa-7e77-4adb-b608-8a1035c27867)

### After

Same flow: settled content stays styled and stable for the whole stream; headings, bold, links and conceal all keep rendering while chunks arrive.

![After: markdown stays styled and stable during streaming](https://cursor.com/artifacts/c/art-e18c77e2-2c24-4859-baec-b0c42dbf4398)

### Testing

- Reproduced pre-fix with tuistory snapshots (raw `### Introduction` / `### Features` frames alternating with concealed frames during a real streamed turn) and in a real Kitty terminal on a virtual display.
- Post-fix: 90 snapshots at ~110ms intervals during a streamed markdown-heavy turn show zero raw-heading frames; screen recordings reviewed frame by frame confirm settled content never flashes and rows no longer jump.
- Verified no rendering regressions for tables (grid borders), fenced code blocks, blockquotes, nested lists, headings, steer mid-stream, esc-cancel, and user message row spacing.
- `bun run test:unit` (1139 passed) and `bun run test:e2e:tuistory` (6 passed) in `apps/cli`; `bun run typecheck` clean.