### PR TITLE
fix(cli): say nothing when the Hub is only finishing an update

### DIFF
--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -585,12 +585,15 @@ function App(props: TuiProps) {
 		setHubBuildMismatch(null);
 		const hubCoreVersion = hubBuildMismatch.hubCoreVersion;
 		if (hubBuildMismatch.reason === "outdated_hub") {
-			// Nothing is wrong and nothing is asked of the user, so a modal
-			// would interrupt only to say "ignore me". One quiet note instead.
-			showToast(
-				"Update finishes the next time Cline starts. No action needed.",
-				"info",
-			);
+			// This CLI is already the newer build. The Hub is behind only because
+			// retiring it would kill the sessions it is serving, and it is
+			// replaced on its own at the next launch. Nothing is wrong, nothing is
+			// asked, and nothing the user can act on differs - so say nothing, the
+			// same conclusion the desktop surface reached.
+			//
+			// The classification still earns its keep here: it is what stops the
+			// update-and-restart prompt below from firing at someone who has
+			// nothing to update.
 			return;
 		}
 		void dialog


### PR DESCRIPTION
### Related Issue

Follow-up to #13231 (merged), whose f51d7c0 replaced the `outdated_hub` modal with a toast. This removes the remaining toast.

### Description

`outdated_hub` describes a state the user cannot act on. This CLI is already the newer build; the Hub is behind only because retiring it would kill the sessions it is serving, and it is replaced on its own at the next launch. Nothing is wrong, nothing is asked, and nothing they can change differs. A toast that interrupts to say "no action needed" is still an interruption, and f51d7c0 already reached exactly this conclusion for the desktop surface, which renders nothing for this reason. This makes the CLI agree.

**It also could not deliver the message it existed for.** `Toast` caps at `maxWidth = Math.min(44, width - 4)`, and after the rounded border and `paddingX={1}` that leaves roughly 38 columns. The string is 61 characters and did not wrap despite `wrapMode="word"`, so what actually rendered was:

> Update finishes the next time Cline

A sentence cut off before the reassuring half. "No action needed", the entire payload, never reached the screen. I confirmed this is not terminal width by capturing the same toast at 200 columns: byte-identical truncation. Screenshot below.

**What stays.** The classification is untouched in core, and it still earns its keep at this call site: `outdated_hub` is precisely what stops the update-and-restart prompt below from firing at someone who has nothing to update. Removing the reason would send that case through `build_mismatch` and show a misleading, actionless "Update and restart" dialog to a user already on the newest build. So the reason keeps doing load-bearing work; only the rendering goes.

The `build_mismatch` direction, where the user genuinely has something to do, is not touched by this PR.

### Test Procedure

Both directions driven by hand against real hub daemons, with build identities forced through `CLINE_HUB_BUILD_ID` / `CLINE_HUB_BUILD_EPOCH_MS` in an isolated `CLINE_DATA_DIR`, using the compiled binary with `CLINE_BUILD_ENV=production`. A second old-identity CLI stays attached so the Hub is genuinely busy, which is what produces the deferral and the `outdated_hub` classification in the first place.

Core still classifies it correctly, so this is a surface-only change:

```
checkManagedHubBuildMismatch() ->
  {"reason":"outdated_hub","hubBuildId":"qa-old-build",
   "hubCoreVersion":"0.0.74","expectedBuildId":"qa-new-build"}
```

**Newer CLI on a busy older Hub**, screen polled every 400ms for 120s (the toast only lives 1800ms, so slower sampling misses it):

- before: `toast episodes=1, modal sightings=0`
- after: `toast episodes=0, modal sightings=0`
- the Hub was not retired during the run, so the deferral is intact: `{'buildId': 'qa-old-build', 'pid': 752533}` before and after.

**Older CLI on a newer Hub**, the direction that must not regress. Dialog still appears about 10s in with the "Update and restart" button:

- Enter: TUI exits and runs the update path. `The shared Cline Hub was updated by another Cline installation. Updating this CLI… / Checking for updates… / Already on the latest version / Start cline again to reconnect to the updated Hub.`
- Esc: dismisses and shows its follow-up toast, `Hub still differs from this CLI. Run …`

Suites: `apps/cli` `bun run test:unit` 133 files / 1138 tests passed; `@cline/core` `managed-hub-build-watcher.test.ts` 11 passed; `tsc --noEmit` clean for `apps/cli`; biome clean. No test asserted the toast string, so nothing needed updating.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- drag outdated_hub_toast.png in here -->

Before: the toast, truncated mid-sentence at "Update finishes the next time Cline". After is the absence of it, which does not screenshot usefully; the polled counts above are the evidence.

### Additional Notes

**This deliberately leaves no proactive surface for the deferral.** `cline doctor` already prints the running Hub's core version and pid next to the CLI's own version, so the information is reachable on demand, but nothing volunteers it. That is the intent: the state is transient, self-correcting, and outside the user's control. If we later decide it should be discoverable, `doctor` naming the mismatch explicitly is a better home than an 1800ms toast, and it is a separate change.

Worth knowing: the toast was largely unreachable in the shipping flow anyway. After a shielded background auto-update, postinstall sets `production.json` aside and `checkManagedHubBuildMismatch` returns early when there is no discovery record, so neither the toast nor the dialog could fire there. The notice only ever surfaced in the two-install case, which is the configuration tested above.

The truncation itself is a pre-existing `Toast` limitation rather than something f51d7c0 introduced. The dismiss toast on the `build_mismatch` path clips the same way (`Hub still differs from this CLI. Run `). That one is not fixed here since it is a hint attached to a dialog the user has already read, but it is the same underlying bug and worth its own look.