### PR TITLE
docs: fix links to the retired cline/sdk repository and moved docs

### DIFF
--- a/apps/examples/vscode/src/webview/README.md
+++ b/apps/examples/vscode/src/webview/README.md
@@ -43,7 +43,7 @@ export default defineConfig([
 ])
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://www.npmjs.com/package/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://www.npmjs.com/package/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js

--- a/docs/cli/samples/github-issue-rca.mdx
+++ b/docs/cli/samples/github-issue-rca.mdx
@@ -55,7 +55,7 @@ gh auth login
 # Install GitHub CLI (Debian/Ubuntu)
 sudo apt install gh
 
-# Or for other Linux distributions, see: https://cli.github.com/manual/installation
+# Or for other Linux distributions, see: https://cli.github.com/manual/
 
 # Install jq (Debian/Ubuntu)
 sudo apt install jq

--- a/sdk/packages/agents/README.md
+++ b/sdk/packages/agents/README.md
@@ -301,10 +301,8 @@ mailboxes, task management, and outcome convergence.
 ## More Examples
 
 - Repo examples:
-  [examples/plugins](https://github.com/cline/sdk/tree/main/examples/plugins),
-  [examples/hooks](https://github.com/cline/sdk/tree/main/examples/hooks),
-  [examples/cron](https://github.com/cline/sdk/tree/main/examples/cron)
-- Workspace overview: [README.md](https://github.com/cline/sdk/blob/main/README.md)
+  [sdk/examples](https://github.com/cline/cline/tree/main/sdk/examples),
+  [apps/examples](https://github.com/cline/cline/tree/main/apps/examples)
+- Workspace overview: [README.md](https://github.com/cline/cline/blob/main/sdk/README.md)
 - API and architecture references:
-  [DOC.md](https://github.com/cline/sdk/blob/main/DOC.md),
-  [ARCHITECTURE.md](https://github.com/cline/sdk/blob/main/ARCHITECTURE.md)
+  [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/sdk/ARCHITECTURE.md)

--- a/sdk/packages/core/README.md
+++ b/sdk/packages/core/README.md
@@ -117,6 +117,6 @@ The package also exports storage and settings helpers such as:
 
 ## More Examples
 
-- Repo examples: [examples](https://github.com/cline/sdk/tree/main/examples), [apps/examples](https://github.com/cline/sdk/tree/main/apps/examples)
+- Repo examples: [examples](https://github.com/cline/cline/tree/main/sdk/examples), [apps/examples](https://github.com/cline/cline/tree/main/apps/examples)
 - Workspace overview: [README.md](https://github.com/cline/cline/blob/main/README.md)
-- API and architecture references: [DOC.md](https://github.com/cline/cline/blob/main/DOC.md), [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/ARCHITECTURE.md)
+- API and architecture references: [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/sdk/ARCHITECTURE.md)

--- a/sdk/packages/llms/README.md
+++ b/sdk/packages/llms/README.md
@@ -130,7 +130,7 @@ Batch models continue to use `transcribeAudio`.
 ## More Examples
 
 - Workspace overview: [README.md](https://github.com/cline/cline/blob/main/README.md)
-- API and architecture references: [DOC.md](https://github.com/cline/cline/blob/main/DOC.md), [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/ARCHITECTURE.md)
+- API and architecture references: [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/sdk/ARCHITECTURE.md)
 
 ## Live Provider Smoke Test
 


### PR DESCRIPTION
The standalone `cline/sdk` repository no longer exists (the SDK now lives in this repo under `sdk/`), so every link pointing at `github.com/cline/sdk/...` is dead. Found by a docs audit; fixed 5 files:

1. **sdk/packages/agents/README.md** - "More Examples" section: `examples/plugins`, `examples/hooks`, `examples/cron` no longer exist; replaced with the live `sdk/examples` and `apps/examples` roots. Workspace `README.md` and `ARCHITECTURE.md` links moved to `cline/cline/blob/main/sdk/...`. Dropped the `DOC.md` link (file removed everywhere).
2. **sdk/packages/core/README.md** and **sdk/packages/llms/README.md** - repo examples links moved to `cline/cline/tree/main/sdk/examples` + `apps/examples`; root `DOC.md`/`ARCHITECTURE.md` links updated (`ARCHITECTURE.md` now at `sdk/ARCHITECTURE.md`, `DOC.md` removed).
3. **docs/cli/samples/github-issue-rca.mdx** - `cli.github.com/manual/installation` is 404; pointed to the live `cli.github.com/manual/`.
4. **apps/examples/vscode/src/webview/README.md** - links into `Rel1cx/eslint-react/tree/main/packages/plugins/...` are 404 (repo restructured); pointed at the stable npm package pages for `eslint-plugin-react-x` / `eslint-plugin-react-dom`.

All replacement targets verified live (200).