### PR TITLE
fix: resolve provider model lists independently so one hung provider cannot block the rest

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -645,6 +645,59 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("resolves bundled models promptly when the live catalog host hangs", async () => {
+		vi.useFakeTimers();
+		try {
+			// Simulate a DNS-blackholed catalog host: the request never settles
+			// on its own and only rejects once the caller aborts it, like a real
+			// fetch would. A hanging catalog request must not block unrelated
+			// providers from resolving their bundled models.
+			const fetchMock = vi.fn(
+				(_input: string, init?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () =>
+							reject(
+								new DOMException("This operation was aborted", "AbortError"),
+							),
+						);
+					}),
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
+			// Two unrelated providers resolving concurrently with the host
+			// app's default catalog config. Neither should stay stuck behind
+			// the unreachable catalog host.
+			const resolving = Promise.all([
+				resolveProviderConfig("openrouter", {
+					loadLatestOnInit: true,
+					failOnError: false,
+					cacheTtlMs: 0,
+				}),
+				resolveProviderConfig("groq", {
+					loadLatestOnInit: true,
+					failOnError: false,
+					cacheTtlMs: 0,
+				}),
+			]);
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			const pending = Symbol("pending");
+			const outcome = await Promise.race([resolving, Promise.resolve(pending)]);
+			expect(outcome).not.toBe(pending);
+			if (!Array.isArray(outcome)) {
+				throw new Error("expected provider resolution to have settled");
+			}
+
+			const [openrouter, groq] = outcome;
+			expect(Object.keys(openrouter?.knownModels ?? {}).length).toBeGreaterThan(
+				0,
+			);
+			expect(Object.keys(groq?.knownModels ?? {}).length).toBeGreaterThan(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("resolves ChatGPT OAuth models from the filtered catalog", async () => {
 		const resolved = await resolveProviderConfig(
 			"openai-codex",

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -798,7 +798,14 @@ async function getPrivateProviderModels(
 async function fetchLiveModelsCatalog(
 	url: string,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
-	return Llms.fetchLiveProviderModels(url, globalThis.fetch);
+	// Route the shared catalog fetches through the same abortable timeout as
+	// the per-provider model fetchers. Every provider's resolveProviderConfig
+	// awaits this shared request, so a hanging catalog host (e.g. blackholed
+	// DNS) must fail fast instead of stalling model resolution for providers
+	// that never talk to that host.
+	return Llms.fetchLiveProviderModels(url, (input, init) =>
+		fetchWithTimeout(String(input), init ?? {}),
+	);
 }
 
 export async function getLiveModelsCatalog(

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -1,6 +1,17 @@
 import { getClineEnvironmentConfig } from "@cline/shared";
 import type { ModelInfo } from "./types";
 
+/**
+ * The minimal fetch capability the catalog needs. Callers may pass the global
+ * fetch or any compatible wrapper (for example one that adds a timeout); only
+ * the call signature is required, so Bun- and DOM-typed environments both
+ * satisfy it.
+ */
+export type CatalogFetcher = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
+
 export interface ClineRecommendedModelEntry {
 	id: string;
 	name?: string;
@@ -140,7 +151,7 @@ export function normalizeClineRecommendedProviderModels(
 }
 
 export async function fetchClineRecommendedModelsPayload(
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 ): Promise<ClineRecommendedModelsPayload> {
 	const url = `${getClineEnvironmentConfig().apiBaseUrl}/api/v1/ai/cline/recommended-models`;
 	const response = await fetcher(url);
@@ -154,7 +165,7 @@ export async function fetchClineRecommendedModelsPayload(
 }
 
 export async function fetchClineRecommendedProviderModels(
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 	openRouterModels: Record<string, ModelInfo>,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
 	const payload = await fetchClineRecommendedModelsPayload(fetcher);

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -480,7 +480,10 @@ export function normalizeModelsDevProviderSpecs(
  * the call signature is required, so Bun- and DOM-typed environments both
  * satisfy it.
  */
-export type CatalogFetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+export type CatalogFetcher = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
 
 async function fetchModelsDevPayload(
 	url: string,

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -474,9 +474,17 @@ export function normalizeModelsDevProviderSpecs(
 	return providerSpecs;
 }
 
+/**
+ * The minimal fetch capability the catalog needs. Callers may pass the global
+ * fetch or any compatible wrapper (for example one that adds a timeout); only
+ * the call signature is required, so Bun- and DOM-typed environments both
+ * satisfy it.
+ */
+export type CatalogFetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
 async function fetchModelsDevPayload(
 	url: string,
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 ): Promise<ModelsDevPayload> {
 	const response = await fetcher(url);
 	if (!response.ok) {
@@ -490,7 +498,7 @@ async function fetchModelsDevPayload(
 
 export async function fetchModelsDevProviderModels(
 	url: string,
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
 	return normalizeModelsDevProviderModels(
 		await fetchModelsDevPayload(url, fetcher),
@@ -499,7 +507,7 @@ export async function fetchModelsDevProviderModels(
 
 export async function fetchModelsDevCatalog(
 	url: string,
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 ): Promise<{
 	providerModels: Record<string, Record<string, ModelInfo>>;
 	providerSpecs: Record<string, ModelsDevGeneratedProviderSpec>;
@@ -514,7 +522,7 @@ export async function fetchModelsDevCatalog(
 
 export async function fetchLiveProviderModels(
 	modelsDevUrl: string,
-	fetcher: typeof fetch = fetch,
+	fetcher: CatalogFetcher = fetch,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
 	const emptyProviderModels: Record<string, Record<string, ModelInfo>> = {};
 	// Promise.allSettled keeps the catalog sources independent: one failing

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -12,6 +12,10 @@ import {
 	fetchClineRecommendedModelsPayload,
 	normalizeClineRecommendedProviderModels,
 } from "./catalog-cline-recommended";
+
+export type { CatalogFetcher } from "./catalog-cline-recommended";
+
+import type { CatalogFetcher } from "./catalog-cline-recommended";
 import {
 	resolveCatalogModelOperation,
 	resolveCatalogModelOperationModes,
@@ -473,17 +477,6 @@ export function normalizeModelsDevProviderSpecs(
 
 	return providerSpecs;
 }
-
-/**
- * The minimal fetch capability the catalog needs. Callers may pass the global
- * fetch or any compatible wrapper (for example one that adds a timeout); only
- * the call signature is required, so Bun- and DOM-typed environments both
- * satisfy it.
- */
-export type CatalogFetcher = (
-	input: string | URL | Request,
-	init?: RequestInit,
-) => Promise<Response>;
 
 async function fetchModelsDevPayload(
 	url: string,

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -517,12 +517,21 @@ export async function fetchLiveProviderModels(
 	fetcher: typeof fetch = fetch,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
 	const emptyProviderModels: Record<string, Record<string, ModelInfo>> = {};
-	const [providerModels, clineRecommendedPayload] = await Promise.all([
-		fetchModelsDevProviderModels(modelsDevUrl, fetcher).catch(
-			() => emptyProviderModels,
-		),
-		fetchClineRecommendedModelsPayload(fetcher).catch(() => undefined),
-	]);
+	// Promise.allSettled keeps the catalog sources independent: one failing
+	// source degrades to its fallback without discarding the other's result.
+	const [providerModelsResult, clineRecommendedResult] =
+		await Promise.allSettled([
+			fetchModelsDevProviderModels(modelsDevUrl, fetcher),
+			fetchClineRecommendedModelsPayload(fetcher),
+		]);
+	const providerModels =
+		providerModelsResult.status === "fulfilled"
+			? providerModelsResult.value
+			: emptyProviderModels;
+	const clineRecommendedPayload =
+		clineRecommendedResult.status === "fulfilled"
+			? clineRecommendedResult.value
+			: undefined;
 	const clineRecommended = clineRecommendedPayload
 		? normalizeClineRecommendedProviderModels(
 				clineRecommendedPayload,


### PR DESCRIPTION
### Related Issue

**Issue:** #9561

### Description

One unreachable catalog host currently stalls model lists for every provider. The mechanism moved since the issue was filed: per-provider fetchers already have timeouts and graceful degradation, but every provider's `resolveProviderConfig` awaits the shared live-catalog promise, and that path fetched with a bare `fetch` and aggregated its two sources with `Promise.all`. A DNS-blackholed host (the repro in the issue) leaves that shared promise pending forever, so openai/ollama/groq/openrouter model lists all hang together.

Two minimal changes, following the approach suggested in the issue thread:

- `fetchLiveModelsCatalog` now injects the module's existing `fetchWithTimeout` (same 5s budget as the per-provider fetchers) instead of `globalThis.fetch`, so a hung host aborts and the existing fallback paths return bundled/generated catalogs.
- `fetchLiveProviderModels` aggregates its two sources with `Promise.allSettled` instead of `Promise.all` with per-promise catches, keeping the sources structurally independent. Behavior for rejected fetches is unchanged.

### Test Procedure

What could break: model list resolution for all providers, since every provider's catalog resolution flows through the shared live-catalog fetch this change wraps in a timeout; and the merge of models.dev models with Cline recommended models, whose aggregation changed to `Promise.allSettled`.

How I verified it doesn't:

1. Added a regression test in `sdk/packages/core/src/services/llms/provider-defaults.test.ts` simulating the issue's repro: a catalog host whose requests never complete (as with a DNS blackhole). Before the fix, `resolveProviderConfig` for openrouter and groq never settles; after the fix, both resolve promptly with their bundled catalogs. The fetch mock only fails when aborted, so the test also proves the abort signal now reaches the request.
2. Ran the full `@cline/llms` suite (722 passed) and the full `@cline/core` unit suite (1898 passed, 0 failed). The existing catalog-live tests covering one source failing while the other succeeds still pass unchanged, confirming the `allSettled` swap preserves the degradation behavior for rejected fetches.
3. Typechecked both packages and ran Biome on the changed files (clean; remaining sdk-wide diagnostics are pre-existing and identical without this change).
4. Fallback-path check: on timeout the two source fetchers reject with AbortError, `allSettled` maps them to the same empty-catalog fallbacks the old catch handlers produced, and `resolveProviderConfig`'s existing non-strict error handling returns bundled defaults. A slow catalog host now degrades to bundled/stale model lists within the existing 5-second budget instead of blocking every provider.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend-only change. Red/green evidence: the new regression test fails on `main` (`expected Symbol(pending) not to be Symbol(pending)`, 1 failed | 17 passed) and passes with this change (18/18), alongside the full-suite runs above.

### Additional Notes

The issue thread's file references predate the monorepo restructure; the equivalent code now lives in `sdk/packages/llms/src/catalog/catalog-live.ts` and `sdk/packages/core/src/services/llms/provider-defaults.ts`.
