### PR TITLE
fix(vscode): extend background run_commands timeout

### DIFF
--- a/apps/vscode/src/sdk/vscode-run-commands-tool.background.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.background.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+	createShellExecutor: vi.fn(() => vi.fn(async () => "background-ok")),
+	getGlobalSettingsKey: vi.fn(() => "default"),
+}))
+
+vi.mock("@cline/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@cline/core")>()
+	return {
+		...actual,
+		createShellExecutor: mocks.createShellExecutor,
+	}
+})
+
+vi.mock("@/core/storage/StateManager", () => ({
+	StateManager: {
+		get: () => ({ getGlobalSettingsKey: mocks.getGlobalSettingsKey }),
+	},
+}))
+
+vi.mock("@services/telemetry", () => ({
+	TerminalUserInterventionAction: { PROCESS_WHILE_RUNNING: "process_while_running" },
+	telemetryService: {
+		captureTerminalUserIntervention: () => {},
+		captureTerminalExecution: () => {},
+	},
+}))
+
+import { createVscodeRunCommandsTool, VSCODE_RUN_COMMANDS_TIMEOUT_MS } from "./vscode-run-commands-tool"
+
+afterEach(() => {
+	mocks.createShellExecutor.mockReset()
+	mocks.createShellExecutor.mockReturnValue(vi.fn(async () => "background-ok"))
+	mocks.getGlobalSettingsKey.mockReset()
+	mocks.getGlobalSettingsKey.mockReturnValue("default")
+})
+
+describe("createVscodeRunCommandsTool background mode", () => {
+	it("passes the configured timeout to the SDK shell executor", async () => {
+		const backgroundExecutor = vi.fn(async () => "background-ok")
+		mocks.createShellExecutor.mockReturnValue(backgroundExecutor)
+		const tool = createVscodeRunCommandsTool({
+			cwd: "/workspace",
+			getTerminalManager: () => {
+				throw new Error("terminal manager should not be created for background execution")
+			},
+			bashTimeoutMs: VSCODE_RUN_COMMANDS_TIMEOUT_MS,
+			vscodeTerminalExecutionMode: "backgroundExec",
+		})
+
+		const result = await tool.execute(
+			{ commands: ["echo ok"] },
+			{ agentId: "agent-1", conversationId: "conversation-1", iteration: 1 },
+		)
+
+		expect(mocks.createShellExecutor).toHaveBeenCalledWith(
+			expect.objectContaining({
+				timeoutMs: VSCODE_RUN_COMMANDS_TIMEOUT_MS,
+				shell: expect.any(String),
+				env: expect.objectContaining({
+					SHELL: expect.any(String),
+				}),
+			}),
+		)
+		expect(backgroundExecutor).toHaveBeenCalledWith("echo ok", "/workspace", expect.any(Object))
+		expect(result).toEqual([expect.objectContaining({ result: "background-ok", success: true })])
+	})
+})

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -43,8 +43,11 @@ import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-c
 type ShellCommand = string | StructuredCommandInput
 type VscodeTerminalExecutionMode = "vscodeTerminal" | "backgroundExec"
 
-/** Foreground VS Code terminals cannot be forcibly terminated; give long-running commands room to finish. */
-export const VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS = 60 * 60 * 1000
+/** VS Code run_commands can run longer IDE tasks, in both foreground and background modes. */
+export const VSCODE_RUN_COMMANDS_TIMEOUT_MS = 60 * 60 * 1000
+
+/** @deprecated Use VSCODE_RUN_COMMANDS_TIMEOUT_MS. */
+export const VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS = VSCODE_RUN_COMMANDS_TIMEOUT_MS
 
 /** Release the agent turn if a foreground command is still running after 300 seconds. */
 export const FOREGROUND_COMMAND_AUTO_PROCEED_MS = 300 * 1000
@@ -64,7 +67,7 @@ export interface VscodeRunCommandsToolOptions {
 	cwd: string
 	/** Lazy factory for the VscodeTerminalManager. Called once on first foreground use. */
 	getTerminalManager: () => VscodeTerminalManager
-	/** Timeout passed to the SDK shell tool wrapper and timeout telemetry. */
+	/** Timeout passed to the SDK shell tool wrapper, executor, and timeout telemetry. */
 	bashTimeoutMs?: number
 	/** Terminal execution mode captured when this session's tool set is built. */
 	vscodeTerminalExecutionMode?: VscodeTerminalExecutionMode
@@ -563,6 +566,7 @@ function createVscodeShellExecutor(options: VscodeRunCommandsToolOptions, state:
 				bgExecutorShell = shell
 				bgExecutor = createShellExecutor({
 					shell,
+					timeoutMs: options.bashTimeoutMs,
 					// Set SHELL env to match the shell we're spawning so child
 					// processes see the correct value instead of the inherited parent's.
 					env: { SHELL: shell },

--- a/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.test.ts
@@ -1,6 +1,16 @@
 import sinon from "sinon"
-import { describe, expect, it } from "vitest"
-import { McpHubToolProvider } from "./vscode-runtime-builder"
+import { describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+	createVscodeRunCommandsTool: vi.fn(() => ({ name: "run_commands" })),
+}))
+
+vi.mock("./vscode-run-commands-tool", () => ({
+	createVscodeRunCommandsTool: mocks.createVscodeRunCommandsTool,
+	VSCODE_RUN_COMMANDS_TIMEOUT_MS: 60 * 60 * 1000,
+}))
+
+import { createVscodeExtraTools, McpHubToolProvider } from "./vscode-runtime-builder"
 
 describe("McpHubToolProvider", () => {
 	it("forwards the agent abort signal to McpHub", async () => {
@@ -20,5 +30,30 @@ describe("McpHubToolProvider", () => {
 
 		expect(callTool.calledOnce).toBe(true)
 		expect(callTool.firstCall.args[4]).toBe(controller.signal)
+	})
+})
+
+describe("createVscodeExtraTools", () => {
+	it("uses the VS Code run_commands timeout in background mode", async () => {
+		await createVscodeExtraTools(
+			{
+				getServers: () => [],
+			} as never,
+			{
+				cwd: "/workspace",
+				getTerminalManager: () => {
+					throw new Error("terminal manager should not be created during tool construction")
+				},
+				vscodeTerminalExecutionMode: "backgroundExec",
+			},
+		)
+
+		expect(mocks.createVscodeRunCommandsTool).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cwd: "/workspace",
+				bashTimeoutMs: 60 * 60 * 1000,
+				vscodeTerminalExecutionMode: "backgroundExec",
+			}),
+		)
 	})
 })

--- a/apps/vscode/src/sdk/vscode-runtime-builder.ts
+++ b/apps/vscode/src/sdk/vscode-runtime-builder.ts
@@ -5,7 +5,7 @@ import type { McpHub } from "@/services/mcp/McpHub"
 import { resolveMcpServerTimeoutMs } from "@/services/mcp/timeout"
 import { Logger } from "@/shared/services/Logger"
 import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
-import { createVscodeRunCommandsTool, VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS } from "./vscode-run-commands-tool"
+import { createVscodeRunCommandsTool, VSCODE_RUN_COMMANDS_TIMEOUT_MS } from "./vscode-run-commands-tool"
 
 interface McpToolDescriptor {
 	name: string
@@ -96,13 +96,13 @@ export async function createVscodeExtraTools(mcpHub: McpHub, options?: VscodeExt
 			createVscodeRunCommandsTool({
 				cwd: options.cwd ?? process.cwd(),
 				getTerminalManager: options.getTerminalManager,
-				bashTimeoutMs: executionMode === "vscodeTerminal" ? VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS : undefined,
+				bashTimeoutMs: VSCODE_RUN_COMMANDS_TIMEOUT_MS,
 				vscodeTerminalExecutionMode: executionMode,
 				foregroundCommands: options.foregroundCommands,
 			}),
 		)
 		Logger.log(
-			`[VscodeRuntimeTools] Added custom run_commands tool (mode=${executionMode}, timeoutMs=${executionMode === "vscodeTerminal" ? VSCODE_FOREGROUND_RUN_COMMANDS_TIMEOUT_MS : "default"})`,
+			`[VscodeRuntimeTools] Added custom run_commands tool (mode=${executionMode}, timeoutMs=${VSCODE_RUN_COMMANDS_TIMEOUT_MS})`,
 		)
 	}
 


### PR DESCRIPTION
### Related Issue

**Issue:** #13246

### Description

Background `run_commands` now uses the same one-hour VS Code timeout as foreground terminal execution. The timeout is passed to both the shell tool wrapper and the SDK background shell executor, so background commands no longer keep the SDK's 30-second default.

### Test Procedure

Added regression coverage for background timeout wiring: `createVscodeExtraTools` passes the VS Code timeout in `backgroundExec` mode, and `createVscodeRunCommandsTool` passes that timeout into `createShellExecutor`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable.

### Additional Notes

No UI change.
