### PR TITLE
fix(vscode,cli): render overflow-recovery compactions as compaction d…

### DIFF
--- a/apps/cli/src/tui/utils/compaction-status.test.ts
+++ b/apps/cli/src/tui/utils/compaction-status.test.ts
@@ -36,6 +36,42 @@ describe("parseCompactionNoticeMetadata", () => {
 		).toEqual({ compactionMode: "auto", status: "started" });
 	});
 
+	it("extracts a divider entry from an overflow-recovery compaction notice", () => {
+		expect(
+			parseCompactionNoticeMetadata({
+				kind: "overflow_recovery_compaction",
+				reason: "overflow_recovery_compaction",
+				phase: "completed",
+				tokensBefore: 25_101,
+				tokensAfter: 6_300,
+				messagesBefore: 142,
+				messagesAfter: 9,
+			}),
+		).toEqual({
+			compactionMode: "auto",
+			status: "completed",
+			tokensBefore: 25_101,
+			tokensAfter: 6_300,
+			messagesBefore: 142,
+			messagesAfter: 9,
+		});
+	});
+
+	it("maps every overflow-recovery phase to a divider entry", () => {
+		expect(
+			parseCompactionNoticeMetadata({
+				kind: "overflow_recovery_compaction",
+				phase: "started",
+			}),
+		).toEqual({ compactionMode: "auto", status: "started" });
+		expect(
+			parseCompactionNoticeMetadata({
+				kind: "overflow_recovery_compaction",
+				phase: "skipped",
+			}),
+		).toEqual({ compactionMode: "auto", status: "skipped" });
+	});
+
 	it("maps manual compaction notices to manual mode", () => {
 		expect(
 			parseCompactionNoticeMetadata({

--- a/apps/cli/src/tui/utils/compaction-status.ts
+++ b/apps/cli/src/tui/utils/compaction-status.ts
@@ -30,7 +30,11 @@ export function parseCompactionNoticeMetadata(
 		return undefined;
 	}
 	const kind = metadata.kind ?? metadata.reason;
-	if (kind !== "auto_compaction" && kind !== "manual_compaction") {
+	if (
+		kind !== "auto_compaction" &&
+		kind !== "manual_compaction" &&
+		kind !== "overflow_recovery_compaction"
+	) {
 		return undefined;
 	}
 	const compactionMode = kind === "manual_compaction" ? "manual" : "auto";

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -2048,6 +2048,41 @@ describe("translateSessionEvent — agent_event notice", () => {
 		})
 	})
 
+	it("translates overflow-recovery compaction notices into a divider row", () => {
+		const state = new MessageTranslatorState()
+
+		const started = translateSessionEvent(
+			noticeEvent("overflow-recovery-compacting", { kind: "overflow_recovery_compaction", phase: "started" }),
+			state,
+		).messages
+		expect(started).toHaveLength(1)
+		expect(started[0].say).toBe("compaction")
+		expect(JSON.parse(started[0].text ?? "{}")).toMatchObject({ status: "started", mode: "auto" })
+
+		const completed = translateSessionEvent(
+			noticeEvent("overflow-recovery-compacted", {
+				kind: "overflow_recovery_compaction",
+				phase: "completed",
+				tokensBefore: 120_000,
+				tokensAfter: 40_000,
+				messagesBefore: 80,
+				messagesAfter: 12,
+			}),
+			state,
+		).messages
+		expect(completed).toHaveLength(1)
+		expect(completed[0].say).toBe("compaction")
+		expect(completed[0].ts).toBe(started[0].ts)
+		expect(JSON.parse(completed[0].text ?? "{}")).toMatchObject({
+			status: "completed",
+			mode: "auto",
+			tokensBefore: 120_000,
+			tokensAfter: 40_000,
+			messagesBefore: 80,
+			messagesAfter: 12,
+		})
+	})
+
 	it("suppresses known-internal status notices instead of rendering raw slugs", () => {
 		const state = new MessageTranslatorState()
 		const result = translateSessionEvent(

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -1198,7 +1198,7 @@ export function parseCompactionNoticeMetadata(metadata: Record<string, unknown> 
 		return undefined
 	}
 	const kind = metadata.kind ?? metadata.reason
-	if (kind !== "auto_compaction" && kind !== "manual_compaction") {
+	if (kind !== "auto_compaction" && kind !== "manual_compaction" && kind !== "overflow_recovery_compaction") {
 		return undefined
 	}
 	const mode = kind === "manual_compaction" ? "manual" : "auto"


### PR DESCRIPTION
### Related Issue

**Issue:** N/A - small bug fix. Spotted while triaging #10637 (not a fix for it; see Additional Notes).

### Description

#12804 added a third compaction status-notice kind, `overflow_recovery_compaction` (`sdk/packages/core/src/extensions/context/compaction.ts:397-402`), emitted for all three phases with the usual `tokensBefore`/`tokensAfter`/`messagesBefore`/`messagesAfter` payload. The two notice parsers were written earlier, in #12137 (CLI, 2026-07-15) and #12487 (webview, 2026-07-23), and still allowlist only `auto_compaction` and `manual_compaction`.

So an overflow-recovery compaction, which really does delete messages, never reaches the divider path:

- `apps/vscode/src/sdk/message-translator.ts:1201`
- `apps/cli/src/tui/utils/compaction-status.ts:33`

Both return `undefined`, the notice falls past `INTERNAL_STATUS_NOTICES` and renders as a generic `say:"info"` row printing the raw internal slug (`overflow-recovery-compacting` / `-compacted` / `-compaction-skipped`). Two consequences: the counters are discarded, and the VS Code context-usage header never rescales, because `apps/vscode/src/shared/getApiMetrics.ts:104-116` only accumulates `shrinkFraction` on a `say:"compaction"` row. The user sees the pre-compaction number persist after a real compaction.

The fix widens both allowlists. Both parsers already funnel every non-manual kind into `"auto"`, so nothing else changes.

**What did not change:** no type change (`ClineCompactionInfo.mode` stays `"auto" | "manual"`, `CompactionDividerEntry.compactionMode` stays as-is), no proto change, no webview change, no change to auto or manual compaction behaviour, and no change to when compaction fires. Only notices carrying `kind: "overflow_recovery_compaction"` are affected.

**Alternative considered:** giving overflow recovery its own `mode` with a distinct label such as "Recovering from context overflow". I went with `"auto"` because `ClineCompactionInfo` is serialised into persisted message text, so a new `mode` value is a history-compat surface, and the completed row users actually read ("Context compacted · 120k → 40k tokens · 80 → 12 messages") is already accurate either way. Happy to switch if you'd rather keep the distinction visible.

### Test Procedure

Regression tests in both hosts. Each fails on `main` and passes with this change.

    cd apps/vscode && bun run test:vitest -- src/sdk/message-translator.test.ts
    bun -F @cline/cli test:unit -- src/tui/utils/compaction-status.test.ts

Before: VS Code `AssertionError: expected 'info' to be 'compaction'`; CLI `expected undefined to deeply equal { compactionMode: 'auto', ... }`.
After: VS Code 157/157 in that file, CLI 15/15.

Wider runs on this branch:

    cd apps/vscode && bun run test:vitest        # 79 files, 1057 tests, all pass
    cd apps/vscode && bun run check-types        # clean
    cd apps/vscode && bun run lint               # clean

Coverage: VS Code asserts `started` then `completed`, including that the completed row reuses the started row's `ts` so the spinner updates in place. CLI asserts `completed` with full counters plus `started` and `skipped`.

One unrelated pre-existing failure on `main`, untouched by this PR: `apps/cli/src/utils/events.test.ts > saves generated images and prints an openable path`. It fails identically on a clean checkout of the base commit.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

No visual change beyond the row itself: the raw-slug info row becomes the existing compaction divider.

### Additional Notes

There is a third enumeration of this vocabulary, `resolveStatusNoticeReason` at `sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts:73-84`, with its type union at `sdk/packages/shared/src/agents/types.ts:184-192`. Both omit the new kind, so `AgentEvent.reason` comes through `undefined` for these notices. I left it alone deliberately: `metadata` is passed through verbatim at `:254` and both parsers read `metadata.kind` first, so the divider works without touching it, and the only reader of that `reason` is `resolveNonCompactionStatusLabel`, which both CLI call sites now short-circuit past. Happy to widen it in a follow-up if you'd prefer the vocabulary consistent.

This is not a fix for #10637. That report is about compaction running with the setting disabled, and this path requires it enabled.