### PR TITLE
fix(cli): resolve workspace root via CLINE_WORKSPACE and .clinerules boundary

### DIFF
--- a/apps/cli/src/utils/helpers.test.ts
+++ b/apps/cli/src/utils/helpers.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import {
 	isCliHookPayload,
 	normalizeAutoApproveArgs,
 	parseArgs,
+	resolveWorkspaceRoot,
 	truncate,
 } from "./helpers";
 
@@ -602,3 +603,45 @@ describe("sandbox environment", () => {
 		}
 	});
 });
+
+describe("resolveWorkspaceRoot", () => {
+	it("honors CLINE_WORKSPACE when set", () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), "cli-workspace-root-"));
+		const cwd = path.join(root, "project", "nested");
+		mkdirSync(cwd, { recursive: true });
+		const explicit = path.join(root, "explicit-workspace");
+		const previous = process.env.CLINE_WORKSPACE;
+		try {
+			process.env.CLINE_WORKSPACE = explicit;
+			expect(resolveWorkspaceRoot(cwd)).toBe(explicit);
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CLINE_WORKSPACE;
+			} else {
+				process.env.CLINE_WORKSPACE = previous;
+			}
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("walks up to the nearest .clinerules directory", () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), "cli-workspace-root-"));
+		const project = path.join(root, "project");
+		const cwd = path.join(project, "src", "nested");
+		mkdirSync(path.join(project, ".clinerules"), { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		const previous = process.env.CLINE_WORKSPACE;
+		try {
+			delete process.env.CLINE_WORKSPACE;
+			expect(resolveWorkspaceRoot(cwd)).toBe(project);
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CLINE_WORKSPACE;
+			} else {
+				process.env.CLINE_WORKSPACE = previous;
+			}
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+

--- a/apps/cli/src/utils/helpers.ts
+++ b/apps/cli/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, unlinkSync } from "node:fs";
+import { appendFileSync, existsSync, statSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { type HookEventPayload, parseHookEventPayload } from "@cline/shared";
 import { ensureHookLogDir } from "@cline/shared/storage";
 import { nanoid } from "nanoid";
@@ -41,6 +41,16 @@ export function randomSessionId(): string {
 }
 
 export function resolveWorkspaceRoot(cwd: string): string {
+	const envWorkspace = process.env.CLINE_WORKSPACE?.trim();
+	if (envWorkspace) {
+		return resolve(cwd, envWorkspace);
+	}
+
+	const clinerulesRoot = findClinerulesDirectoryRoot(cwd);
+	if (clinerulesRoot) {
+		return clinerulesRoot;
+	}
+
 	const result = spawnSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
 		encoding: "utf8",
 	});
@@ -51,6 +61,29 @@ export function resolveWorkspaceRoot(cwd: string): string {
 		}
 	}
 	return cwd;
+}
+
+/**
+ * Walks up from `cwd` to the nearest ancestor that contains a `.clinerules`
+ * directory. A `.clinerules` directory marks the project boundary even when the
+ * current directory is not inside a git worktree (or `git` is unavailable).
+ */
+function findClinerulesDirectoryRoot(cwd: string): string | undefined {
+	let current = resolve(cwd);
+	for (;;) {
+		try {
+			if (statSync(join(current, ".clinerules")).isDirectory()) {
+				return current;
+			}
+		} catch {
+			// `.clinerules` does not exist here; keep walking up.
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			return undefined;
+		}
+		current = parent;
+	}
 }
 
 function safeJsonStringify(value: unknown): string {


### PR DESCRIPTION
## Summary

Fixes workspace-root resolution in the CLI. Today `resolveWorkspaceRoot()` only
runs `git rev-parse --show-toplevel` and otherwise falls back to the raw `cwd`,
which breaks projects that are not inside a git worktree (or when `git` is not on
`PATH`).

This PR:

1. Honors `CLINE_WORKSPACE` when set (resolved relative to `cwd`, matching the
   existing `resolveSandboxDataDir` convention).
2. Walks up from `cwd` until it finds a `.clinerules` directory and treats its
   parent as the workspace root.
3. Keeps the existing git fallback and final `cwd` fallback as-is.

## Why

`.clinerules` is the project-boundary marker the config system already uses, but
workspace-root resolution never consulted it. Without this, a CLI session started
in a non-git directory reports `cwd` as the workspace root and misses any
`.clinerules` boundary above it.

## Changes

- `apps/cli/src/utils/helpers.ts`
  - `resolveWorkspaceRoot()`: add `CLINE_WORKSPACE` env handling and a
    `.clinerules` directory boundary walk before the git fallback.
  - Add `findClinerulesDirectoryRoot()` helper.
- `apps/cli/src/utils/helpers.test.ts`
  - Add tests for `CLINE_WORKSPACE` precedence and the `.clinerules` boundary walk.

## Test plan

```sh
cd apps/cli
bun test src/utils/helpers.test.ts
```

New cases:

- `resolveWorkspaceRoot` returns `CLINE_WORKSPACE` when set.
- `resolveWorkspaceRoot` returns the nearest ancestor containing `.clinerules`
  when running from a nested non-git directory.
