### PR TITLE
fix(core): warn when frontmatter is not at byte 0

### DIFF
--- a/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
+++ b/sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts
@@ -37,6 +37,7 @@ export interface ParseMarkdownFrontmatterResult {
 	body: string;
 	hadFrontmatter: boolean;
 	parseError?: string;
+	warning?: string;
 }
 
 export interface SkillConfig {
@@ -195,6 +196,25 @@ async function discoverManagedPluginRoots(
 	}
 }
 
+/**
+ * Detects a YAML frontmatter block whose opening `---` delimiter is not at byte 0.
+ * The parser only recognizes frontmatter that begins at the very first byte; any
+ * leading whitespace, blank line, or prose makes it silently fall through to the
+ * body. Requiring both an opening and closing delimiter line avoids flagging
+ * ordinary markdown horizontal rules.
+ */
+function hasMisplacedFrontmatterDelimiter(content: string): boolean {
+	if (content.startsWith("---")) {
+		return false;
+	}
+	const lines = content.split(/\r?\n/);
+	const openingIndex = lines.findIndex((line) => line.trim() === "---");
+	if (openingIndex < 0) {
+		return false;
+	}
+	return lines.slice(openingIndex + 1).some((line) => line.trim() === "---");
+}
+
 function parseMarkdownFrontmatter(
 	content: string,
 ): ParseMarkdownFrontmatterResult {
@@ -206,7 +226,18 @@ function parseMarkdownFrontmatter(
 	const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 	const match = normalizedContent.match(frontmatterRegex);
 	if (!match) {
-		return { data: {}, body: normalizedContent, hadFrontmatter: false };
+		const warning = hasMisplacedFrontmatterDelimiter(normalizedContent)
+			? "Markdown frontmatter was not parsed because the opening '---' delimiter is not at the start of the file."
+			: undefined;
+		if (warning) {
+			console.warn(`[cline] ${warning}`);
+		}
+		return {
+			data: {},
+			body: normalizedContent,
+			hadFrontmatter: false,
+			warning,
+		};
 	}
 
 	const [, yamlContent, body] = match;


### PR DESCRIPTION
## Summary

Frontmatter in rules/skills/workflows files is currently skipped silently when the
opening `---` delimiter is not at byte 0. The parser only matches
`/^---\r?\n/`, so a leading blank line, whitespace, or prose turns the frontmatter
into body content with no signal to the user.

This PR emits a warning when that happens.

## Why

The "frontmatter trap" is a common footgun: a user adds YAML frontmatter, a leading
blank line (or an editor/formatting quirk) displaces the opening `---`, and the
config is silently ignored. That is hard to debug because the file looks correct.

## Changes

- `sdk/packages/core/src/extensions/config/user-instruction-config-loader.ts`
  - Add `warning?: string` to `ParseMarkdownFrontmatterResult`.
  - Add `hasMisplacedFrontmatterDelimiter()` to detect a frontmatter block (opening
    `---` line plus a closing `---` line) whose opening delimiter is not at byte 0.
    Requiring both delimiters avoids flagging ordinary markdown horizontal rules.
  - In `parseMarkdownFrontmatter()`, emit `console.warn("[cline] ...")` and return
    the warning when the trap is detected.

## Scope / behavior notes

- The parser behavior is unchanged: misplaced frontmatter is still treated as body
  content. This PR only adds a diagnostic.
- Files with valid byte-0 frontmatter and files with no frontmatter are unaffected.
