### PR TITLE
fix(vscode): preserve LiteLLM input token limits

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -279,6 +279,80 @@ describe("provider model catalog handlers", () => {
 		expect(stateManager.flushPendingState).toHaveBeenCalledTimes(1)
 	})
 
+	it("commitModelSelection carries cached dynamic model metadata into the host store", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("litellm")
+		const store = makeStore({ providerId, apiKey: "litellm-key" })
+		const catalog = makeCatalog()
+		const modelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+		vi.mocked(catalog.peekModels).mockReturnValue({
+			ok: true,
+			providerId,
+			configFingerprint: computeConfigFingerprint(providerId, { providerId, apiKey: "litellm-key" }),
+			models: new Map([["openai/grok-4.6", modelInfo]]),
+			defaultModelId: "openai/grok-4.6",
+			source: "sdk-dynamic",
+			fetchedAt: 99,
+		})
+		const controller = makeController(store, catalog)
+
+		await commitModelSelection(controller, {
+			providerId: "litellm",
+			mode: "act",
+			modelId: "openai/grok-4.6",
+		})
+
+		expect(catalog.peekModels).toHaveBeenCalledWith(providerId)
+		expect(store.commitSelection).toHaveBeenCalledWith(
+			providerId,
+			"act",
+			{
+				providerId,
+				modelId: "openai/grok-4.6",
+				overrides: undefined,
+			},
+			modelInfo,
+		)
+	})
+
+	it("commitModelSelection does not substitute a different cached model when the selected ID has no metadata", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("litellm")
+		const store = makeStore({ providerId, apiKey: "litellm-key" })
+		const catalog = makeCatalog()
+		vi.mocked(catalog.peekModels).mockReturnValue({
+			ok: true,
+			providerId,
+			configFingerprint: computeConfigFingerprint(providerId, { providerId, apiKey: "litellm-key" }),
+			models: new Map([
+				["openai/other-model", { name: "Other model", maxInputTokens: 200_000, supportsPromptCache: false }],
+			]),
+			defaultModelId: "openai/other-model",
+			source: "sdk-dynamic",
+			fetchedAt: 99,
+		})
+		const controller = makeController(store, catalog)
+
+		await commitModelSelection(controller, {
+			providerId: "litellm",
+			mode: "act",
+			modelId: "custom/no-metadata",
+		})
+
+		expect(catalog.peekModels).toHaveBeenCalledWith(providerId)
+		expect(store.commitSelection).toHaveBeenCalledWith(providerId, "act", {
+			providerId,
+			modelId: "custom/no-metadata",
+			overrides: undefined,
+		})
+	})
+
 	// The settings UI sources provider ids from the SDK catalog, whose OpenAI
 	// Compatible built-in is spelled `openai-compatible`. Committing under that
 	// spelling must land on the legacy `openai` state keys

--- a/apps/vscode/src/core/controller/models/commitModelSelection.ts
+++ b/apps/vscode/src/core/controller/models/commitModelSelection.ts
@@ -20,7 +20,13 @@ export async function commitModelSelection(
 	const previousApiConfiguration = hasProviderCatalogStateController(controller)
 		? controller.stateManager.getApiConfiguration?.()
 		: undefined
-	controller.getProviderConfigStore().commitSelection(providerId, mode, selection)
+	const cachedModels = controller.getProviderCatalog().peekModels(providerId)
+	const baseModelInfoHint = cachedModels?.ok ? cachedModels.models.get(selection.modelId) : undefined
+	if (baseModelInfoHint) {
+		controller.getProviderConfigStore().commitSelection(providerId, mode, selection, baseModelInfoHint)
+	} else {
+		controller.getProviderConfigStore().commitSelection(providerId, mode, selection)
+	}
 
 	if (hasProviderCatalogStateController(controller)) {
 		controller.stateManager.setGlobalStateBatch({

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -713,6 +713,80 @@ describe("buildSessionConfig", () => {
 		expect(knownModel.family).toBe(expectedModel.family)
 	})
 
+	it("injects cached LiteLLM max input tokens when the dynamic model is absent from the SDK registry", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: "openai/grok-4.6",
+			liteLlmApiKey: "litellm-key",
+			actModeLiteLlmModelInfo: {
+				name: "xai/grok-4.6",
+				contextWindow: 500_000,
+				maxInputTokens: 500_000,
+				maxTokens: 64_000,
+				supportsPromptCache: false,
+			},
+		} as any)
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["openai/grok-4.6"]
+
+		expect(config.providerId).toBe("litellm")
+		expect(knownModel).toMatchObject({
+			id: "openai/grok-4.6",
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+		})
+		expect(config.knownModels?.["openai/grok-4.6"]).toEqual(knownModel)
+		getModelsSpy.mockRestore()
+	})
+
+	it("keeps an explicit max-input override ahead of cached LiteLLM metadata", async () => {
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: modelId,
+			liteLlmApiKey: "litellm-key",
+			actModeLiteLlmModelInfo: {
+				name: "xai/grok-4.6",
+				contextWindow: 500_000,
+				maxInputTokens: 500_000,
+				supportsPromptCache: false,
+			},
+		} as any)
+		createProviderConfigStore().commitSelection(providerId, "act", {
+			providerId,
+			modelId,
+			overrides: { maxInputTokens: 300_000 },
+		})
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels[modelId]
+
+		expect(knownModel.contextWindow).toBe(500_000)
+		expect(knownModel.maxInputTokens).toBe(300_000)
+		getModelsSpy.mockRestore()
+	})
+
+	it("does not inject fabricated max input metadata for an unknown LiteLLM model", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: "custom/no-metadata",
+			liteLlmApiKey: "litellm-key",
+		} as any)
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.knownModels).toBeUndefined()
+		expect(config.providerConfig).not.toHaveProperty("knownModels")
+		getModelsSpy.mockRestore()
+	})
+
 	it("keeps session creation non-fatal when known-model lookup fails", async () => {
 		const lookupError = new Error("registry unavailable")
 		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockRejectedValueOnce(lookupError)

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -271,7 +271,8 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 
 	const maxTokens = positiveFiniteNumber(modelInfo.maxTokens)
 	const contextWindow = positiveFiniteNumber(modelInfo.contextWindow)
-	const maxInputTokens = positiveFiniteNumber(selection.overrides?.maxInputTokens)
+	const maxInputTokens =
+		positiveFiniteNumber(selection.overrides?.maxInputTokens) ?? positiveFiniteNumber(modelInfo.maxInputTokens)
 	const temperature = nonNegativeFiniteNumber(modelInfo.temperature)
 	const inputPrice = nonNegativeFiniteNumber(modelInfo.inputPrice)
 	const outputPrice = nonNegativeFiniteNumber(modelInfo.outputPrice)

--- a/apps/vscode/src/sdk/model-catalog/contracts.ts
+++ b/apps/vscode/src/sdk/model-catalog/contracts.ts
@@ -404,9 +404,10 @@ export interface ProviderConfigStore extends ProviderConfigReader {
 	 * Supplying overrides replaces that model's stored override entry; omitting
 	 * them leaves the existing entry unchanged.
 	 *
-	 * `baseModelInfoHint` is host-resolved catalog metadata for dynamic models
-	 * that are absent from the static SDK registry. It is not user-authored and
-	 * must never be persisted as an override.
+	 * `baseModelInfoHint` is the exact host-resolved catalog metadata selected
+	 * by the user. It is authoritative for that commit, including when a
+	 * private/dynamic provider reuses an id from the static SDK registry. It is
+	 * not user-authored and must never be persisted as an override.
 	 *
 	 * I2: refresh handlers do not have access to this method by type, since
 	 * `ProviderCatalog` holds only a `ProviderConfigReader`.

--- a/apps/vscode/src/sdk/model-catalog/contracts.ts
+++ b/apps/vscode/src/sdk/model-catalog/contracts.ts
@@ -201,9 +201,9 @@ export interface ResolvedModelSelection extends ModelSelection {
 	/**
 	 * Where the base `modelInfo` came from, before overrides were applied:
 	 *
-	 *  - "catalog"  — SDK catalog metadata (generated snapshot or registry).
+	 *  - "catalog"  — SDK catalog metadata (generated snapshot, registry, or live host cache).
 	 *  - "state"    — the mode-specific `*ModeModelInfo` snapshot persisted by
-	 *    the picker at selection time. Authoritative for dynamic-list providers
+	 *    the host at selection time. Authoritative for dynamic-list providers
 	 *    (openrouter, litellm, requesty, …) whose models are not in the static
 	 *    catalog.
 	 *  - "fallback" — provider-safe defaults fabricated because nothing better
@@ -404,10 +404,14 @@ export interface ProviderConfigStore extends ProviderConfigReader {
 	 * Supplying overrides replaces that model's stored override entry; omitting
 	 * them leaves the existing entry unchanged.
 	 *
+	 * `baseModelInfoHint` is host-resolved catalog metadata for dynamic models
+	 * that are absent from the static SDK registry. It is not user-authored and
+	 * must never be persisted as an override.
+	 *
 	 * I2: refresh handlers do not have access to this method by type, since
 	 * `ProviderCatalog` holds only a `ProviderConfigReader`.
 	 */
-	commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection): void
+	commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection, baseModelInfoHint?: ModelInfo): void
 }
 
 /**

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
@@ -20,6 +20,9 @@ describe("adaptSdkModelInfo", () => {
 
 		it("throws CatalogShapeError when optional scalar fields are malformed", () => {
 			expect(() => adaptSdkModelInfo({ id: "m", contextWindow: "big" })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: "huge" })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: Number.NaN })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: Number.POSITIVE_INFINITY })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", maxTokens: "huge" })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", name: 1 })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", description: 1 })).toThrow(CatalogShapeError)
@@ -172,10 +175,34 @@ describe("adaptSdkModelInfo", () => {
 			expect(model.description).toBeUndefined()
 		})
 
-		it("treats null contextWindow/maxTokens as missing (live LiteLLM /model/info reports unknown limits as null)", () => {
-			const model = adaptSdkModelInfo({ id: "claude-opus-5", contextWindow: null, maxTokens: null })
+		it("treats null token limits as missing (live LiteLLM /model/info reports unknown limits as null)", () => {
+			const model = adaptSdkModelInfo({
+				id: "claude-opus-5",
+				contextWindow: null,
+				maxInputTokens: null,
+				maxTokens: null,
+			})
 			expect(model.contextWindow).toBe(openAiModelInfoSafeDefaults.contextWindow)
+			expect(model.maxInputTokens).toBeUndefined()
 			expect(model.maxTokens).toBe(openAiModelInfoSafeDefaults.maxTokens)
+		})
+
+		it("uses a reported input limit when LiteLLM omits the context window", () => {
+			const model = adaptSdkModelInfo({ id: "openai/grok-4.6", maxInputTokens: 500_000 })
+
+			expect(model.contextWindow).toBe(500_000)
+			expect(model.maxInputTokens).toBe(500_000)
+		})
+
+		it("keeps distinct context and input limits when both are reported", () => {
+			const model = adaptSdkModelInfo({
+				id: "openai/grok-4.6",
+				contextWindow: 600_000,
+				maxInputTokens: 500_000,
+			})
+
+			expect(model.contextWindow).toBe(600_000)
+			expect(model.maxInputTokens).toBe(500_000)
 		})
 
 		it("falls back to id when name is omitted and passes through description", () => {
@@ -199,6 +226,7 @@ describe("adaptSdkModelInfo", () => {
 			id: "deepseek-v4-flash",
 			name: "DeepSeek V4 Flash",
 			contextWindow: 200_000,
+			maxInputTokens: 180_000,
 			maxTokens: 8192,
 			capabilities: ["tools", "reasoning", "structured_output", "temperature", "prompt-cache", "images"],
 			pricing: { input: 0.5, output: 1.5, cacheRead: 0.05, cacheWrite: 0.1 },
@@ -210,6 +238,7 @@ describe("adaptSdkModelInfo", () => {
 		expect(model).toMatchObject({
 			name: "DeepSeek V4 Flash",
 			contextWindow: 200_000,
+			maxInputTokens: 180_000,
 			maxTokens: 8192,
 			supportsImages: true,
 			supportsPromptCache: true,
@@ -229,6 +258,7 @@ describe("adaptSdkModelInfo", () => {
 			id: "m",
 			name: "M",
 			contextWindow: 32_000,
+			maxInputTokens: 30_000,
 			maxTokens: 4096,
 			capabilities: ["tools", "reasoning"],
 			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
@@ -11,6 +11,7 @@
  *   id: string,                  // only consistently-required field
  *   name?: string,
  *   contextWindow?: number,
+ *   maxInputTokens?: number,
  *   maxTokens?: number,
  *   capabilities?: string[],     // e.g. ["tools", "reasoning", "prompt-cache", "images"]
  *   modalities?: { input: string[], output: string[] },
@@ -28,7 +29,8 @@
  * | extension ModelInfo field | source | default if missing |
  * | --- | --- | --- |
  * | name | `sdk.name ?? sdk.id` | n/a (id is required) |
- * | contextWindow | `sdk.contextWindow` if finite number (null = missing) | safe default: 128_000 |
+ * | contextWindow | `sdk.contextWindow`, or positive `sdk.maxInputTokens` for legacy display compatibility | safe default: 128_000 |
+ * | maxInputTokens | `sdk.maxInputTokens` if finite number (null = missing) | omitted (undefined) |
  * | maxTokens | `sdk.maxTokens` if finite number (null = missing) | safe default: -1 |
  * | supportsImages | capabilities includes `images` or `vision` | safe default: true when capabilities absent |
  * | supportsPromptCache | capabilities includes `prompt-cache` | safe default: false when capabilities absent |
@@ -226,6 +228,13 @@ export function adaptSdkModelInfo(input: unknown): ModelInfo {
 		})
 	}
 
+	const rawMaxInputTokens = input.maxInputTokens
+	if (rawMaxInputTokens !== undefined && rawMaxInputTokens !== null && !isFiniteNumber(rawMaxInputTokens)) {
+		throw new CatalogShapeError("SDK model-info `maxInputTokens` must be a finite number when present.", {
+			details: { receivedType: typeof rawMaxInputTokens },
+		})
+	}
+
 	const rawMaxTokens = input.maxTokens
 	if (rawMaxTokens !== undefined && rawMaxTokens !== null && !isFiniteNumber(rawMaxTokens)) {
 		throw new CatalogShapeError("SDK model-info `maxTokens` must be a finite number when present.", {
@@ -249,15 +258,29 @@ export function adaptSdkModelInfo(input: unknown): ModelInfo {
 		})
 	}
 
+	const maxInputTokens = isFiniteNumber(rawMaxInputTokens) ? rawMaxInputTokens : undefined
+	// Legacy extension consumers display and budget exclusively from
+	// `contextWindow`. When a provider reports only a positive prompt limit,
+	// use it as a conservative compatibility proxy while still preserving the
+	// authoritative `maxInputTokens` field independently for the SDK runtime.
+	const contextWindow = isFiniteNumber(rawContextWindow)
+		? rawContextWindow
+		: maxInputTokens !== undefined && maxInputTokens > 0
+			? maxInputTokens
+			: openAiModelInfoSafeDefaults.contextWindow
+
 	const result: ModelInfo = {
 		name: rawName ?? id,
-		contextWindow: isFiniteNumber(rawContextWindow) ? rawContextWindow : openAiModelInfoSafeDefaults.contextWindow,
+		contextWindow,
 		maxTokens: isFiniteNumber(rawMaxTokens) ? rawMaxTokens : openAiModelInfoSafeDefaults.maxTokens,
 		supportsPromptCache: capabilities
 			? capabilities.includes(PROMPT_CACHE_CAPABILITY)
 			: openAiModelInfoSafeDefaults.supportsPromptCache,
 		inputPrice: pricing?.input ?? openAiModelInfoSafeDefaults.inputPrice,
 		outputPrice: pricing?.output ?? openAiModelInfoSafeDefaults.outputPrice,
+	}
+	if (maxInputTokens !== undefined) {
+		result.maxInputTokens = maxInputTokens
 	}
 
 	if (capabilities) {

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -221,6 +221,73 @@ describe("createProviderConfigStore", () => {
 		})
 	})
 
+	it("persists host catalog metadata for a dynamic LiteLLM model without turning it into an override", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		const liveModelInfo: ModelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+			supportsReasoning: true,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			providerId,
+			modelId,
+			overrides: undefined,
+			modelInfoSource: "state",
+			baseModelInfo: liveModelInfo,
+			modelInfo: liveModelInfo,
+		})
+		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
+	})
+
+	it("keeps a LiteLLM max-input override ahead of cached catalog metadata without baking it into the base", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		const liveModelInfo: ModelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId, overrides: { maxInputTokens: 300_000 } }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			baseModelInfo: liveModelInfo,
+			overrides: { maxInputTokens: 300_000 },
+			modelInfo: { maxInputTokens: 300_000 },
+		})
+	})
+
+	it("does not fabricate maxInputTokens or a metadata snapshot when a dynamic model has no catalog metadata", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "custom/no-metadata"
+
+		store.commitSelection(providerId, "act", { providerId, modelId })
+
+		expect(mocks.getApiConfiguration()).toMatchObject({ actModeLiteLlmModelId: modelId })
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toBeUndefined()
+		const resolved = store.readSelection(providerId, "act")
+		expect(resolved?.modelInfoSource).toBe("fallback")
+		expect(resolved?.modelInfo.maxInputTokens).toBeUndefined()
+		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
+	})
+
 	it("round-trips generic provider selections using the in-process modelInfo envelope", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -249,6 +249,37 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
 	})
 
+	it("prefers live LiteLLM catalog metadata when its model id overlaps the static registry", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "gpt-5.4"
+		const staticModelInfo: ModelInfo = {
+			name: "SDK fallback gpt-5.4",
+			contextWindow: 128_000,
+			maxInputTokens: 128_000,
+			maxTokens: 16_384,
+			supportsPromptCache: true,
+		}
+		const liveModelInfo: ModelInfo = {
+			name: "Private gpt-5.4 deployment",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+		mocks.setGeneratedModels("litellm", { [modelId]: staticModelInfo })
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			modelInfoSource: "state",
+			baseModelInfo: liveModelInfo,
+			modelInfo: liveModelInfo,
+		})
+	})
+
 	it("keeps a LiteLLM max-input override ahead of cached catalog metadata without baking it into the base", async () => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -91,6 +91,7 @@ vi.mock("../provider-migration", () => ({
 }))
 
 vi.mock("@cline/core", () => ({
+	isPrivateModelCatalogProvider: (providerId: string) => ["baseten", "hicap", "litellm", "poolside"].includes(providerId),
 	syncStoredProviderRegistration: vi.fn(),
 	readModelsFileSync: vi.fn(() => mocks.getModelsFile()),
 	resolveModelsRegistryPath: vi.fn(() => "/tmp/models.json"),
@@ -249,34 +250,73 @@ describe("createProviderConfigStore", () => {
 		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
 	})
 
-	it("prefers live LiteLLM catalog metadata when its model id overlaps the static registry", async () => {
+	it.each([
+		["litellm", "actModeLiteLlmModelInfo"],
+		["baseten", "actModeBasetenModelInfo"],
+		["hicap", "actModeHicapModelInfo"],
+	] as const)("keeps a persisted %s private-catalog snapshot authoritative after reload", async (provider, modelInfoKey) => {
 		const { createProviderConfigStore } = await import("./store")
 		const store = createProviderConfigStore()
-		const providerId = parseProviderId("litellm")
-		const modelId = "gpt-5.4"
+		const providerId = parseProviderId(provider)
+		const modelId = "shared-private-model"
 		const staticModelInfo: ModelInfo = {
-			name: "SDK fallback gpt-5.4",
+			name: "SDK fallback model",
 			contextWindow: 128_000,
 			maxInputTokens: 128_000,
 			maxTokens: 16_384,
 			supportsPromptCache: true,
 		}
 		const liveModelInfo: ModelInfo = {
-			name: "Private gpt-5.4 deployment",
+			name: "Private endpoint deployment",
 			contextWindow: 500_000,
 			maxInputTokens: 500_000,
 			maxTokens: 64_000,
 			supportsPromptCache: false,
 		}
-		mocks.setGeneratedModels("litellm", { [modelId]: staticModelInfo })
+		mocks.setGeneratedModels(provider, { [modelId]: staticModelInfo })
 
 		store.commitSelection(providerId, "act", { providerId, modelId }, liveModelInfo)
 
-		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
-		expect(store.readSelection(providerId, "act")).toMatchObject({
+		expect(mocks.getApiConfiguration()[modelInfoKey]).toEqual(liveModelInfo)
+
+		// A window reload clears the in-process catalog and selection envelope;
+		// the durable provider snapshot must still beat the same-id static entry.
+		vi.resetModules()
+		const { createProviderConfigStore: createReloadedStore } = await import("./store")
+		expect(createReloadedStore().readSelection(providerId, "act")).toMatchObject({
 			modelInfoSource: "state",
 			baseModelInfo: liveModelInfo,
 			modelInfo: liveModelInfo,
+		})
+	})
+
+	it("lets a public catalog update supersede an older persisted snapshot after reload", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openrouter")
+		const modelId = "shared-public-model"
+		const refreshedModelInfo: ModelInfo = {
+			name: "Refreshed public catalog model",
+			contextWindow: 256_000,
+			maxTokens: 32_000,
+			supportsPromptCache: true,
+		}
+		const selectedModelInfo: ModelInfo = {
+			name: "Catalog model at selection time",
+			contextWindow: 128_000,
+			maxTokens: 16_000,
+			supportsPromptCache: false,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, selectedModelInfo)
+		mocks.setGeneratedModels("openrouter", { [modelId]: refreshedModelInfo })
+
+		vi.resetModules()
+		const { createProviderConfigStore: createReloadedStore } = await import("./store")
+		expect(createReloadedStore().readSelection(providerId, "act")).toMatchObject({
+			modelInfoSource: "catalog",
+			baseModelInfo: refreshedModelInfo,
+			modelInfo: refreshedModelInfo,
 		})
 	})
 

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -1,4 +1,5 @@
 import {
+	isPrivateModelCatalogProvider,
 	readModelsFileSync,
 	resolveModelsRegistryPath,
 	type StoredModelEntry,
@@ -417,37 +418,52 @@ interface BaseModelInfoHint {
 	source: "catalog" | "state"
 }
 
+interface BaseModelInfoCandidate {
+	modelInfo: ModelInfo
+	source: "catalog" | "state" | "fallback"
+}
+
 function resolveSelection(selection: ModelSelection, baseModelInfoHint?: BaseModelInfoHint): ResolvedModelSelection {
 	const overrides = normalizeModelSelectionOverrides(
 		selection.overrides ?? readModelOverrides(selection.providerId, selection.modelId),
 	)
 	// A host catalog hint is the exact live entry the user selected, so it must
 	// win even when a private/dynamic provider reuses an id from the static SDK
-	// catalog. Persisted state is weaker: static metadata should supersede an
-	// older snapshot when no live catalog entry accompanies the commit.
+	// catalog. Persisted state is weaker by default; the private-catalog
+	// exception is applied below.
 	const catalogModelInfo = readBaseModelInfoForProvider(selection.providerId, selection.modelId)
 	const liveCatalogHint = baseModelInfoHint?.source === "catalog" ? baseModelInfoHint.modelInfo : undefined
 	const stateModelInfoHint = baseModelInfoHint?.source === "state" ? baseModelInfoHint.modelInfo : undefined
-	// LiteLLM's catalog belongs to the configured self-hosted endpoint. Its
+	const liveCatalogCandidate: BaseModelInfoCandidate | undefined = liveCatalogHint
+		? { modelInfo: liveCatalogHint, source: "catalog" }
+		: undefined
+	const staticCatalogCandidate: BaseModelInfoCandidate | undefined = catalogModelInfo
+		? { modelInfo: catalogModelInfo, source: "catalog" }
+		: undefined
+	const stateCandidate: BaseModelInfoCandidate | undefined = stateModelInfoHint
+		? { modelInfo: stateModelInfoHint, source: "state" }
+		: undefined
+
+	// Private catalogs belong to the customer's configured endpoint. Their
 	// persisted snapshot therefore remains authoritative after the live cache
-	// is gone, including when the endpoint reuses the built-in fallback model
-	// id. Other providers retain static-catalog-over-snapshot semantics so SDK
-	// catalog updates can refresh an existing selection.
-	const authoritativeStateHint = providerKey(selection.providerId) === "litellm" ? stateModelInfoHint : undefined
-	const baseModelInfo =
-		liveCatalogHint ??
-		authoritativeStateHint ??
-		catalogModelInfo ??
-		stateModelInfoHint ??
-		fallbackModelInfo(selection.modelId)
-	const modelInfoSource =
-		liveCatalogHint || (catalogModelInfo && !authoritativeStateHint) ? "catalog" : stateModelInfoHint ? "state" : "fallback"
+	// is gone, including when that endpoint reuses an id from the static SDK
+	// catalog. Public providers retain static-catalog-over-snapshot semantics so
+	// SDK catalog updates can refresh an existing selection.
+	const authoritativeStateCandidate = isPrivateModelCatalogProvider(providerKey(selection.providerId))
+		? stateCandidate
+		: undefined
+	const base =
+		liveCatalogCandidate ??
+		authoritativeStateCandidate ??
+		staticCatalogCandidate ??
+		stateCandidate ??
+		({ modelInfo: fallbackModelInfo(selection.modelId), source: "fallback" } satisfies BaseModelInfoCandidate)
 	return {
 		...selection,
 		overrides,
-		modelInfoSource,
-		baseModelInfo,
-		modelInfo: sanitizeResolvedModelInfo(applyModelOverrides(baseModelInfo, overrides)),
+		modelInfoSource: base.source,
+		baseModelInfo: base.modelInfo,
+		modelInfo: sanitizeResolvedModelInfo(applyModelOverrides(base.modelInfo, overrides)),
 	}
 }
 

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -421,12 +421,27 @@ function resolveSelection(selection: ModelSelection, baseModelInfoHint?: BaseMod
 	const overrides = normalizeModelSelectionOverrides(
 		selection.overrides ?? readModelOverrides(selection.providerId, selection.modelId),
 	)
-	// Base resolution order: static SDK catalog, then host-resolved/persisted
-	// metadata for dynamic-list models the static catalog does not know, then
-	// provider-safe fallback defaults.
+	// A host catalog hint is the exact live entry the user selected, so it must
+	// win even when a private/dynamic provider reuses an id from the static SDK
+	// catalog. Persisted state is weaker: static metadata should supersede an
+	// older snapshot when no live catalog entry accompanies the commit.
 	const catalogModelInfo = readBaseModelInfoForProvider(selection.providerId, selection.modelId)
-	const baseModelInfo = catalogModelInfo ?? baseModelInfoHint?.modelInfo ?? fallbackModelInfo(selection.modelId)
-	const modelInfoSource = catalogModelInfo ? "catalog" : (baseModelInfoHint?.source ?? "fallback")
+	const liveCatalogHint = baseModelInfoHint?.source === "catalog" ? baseModelInfoHint.modelInfo : undefined
+	const stateModelInfoHint = baseModelInfoHint?.source === "state" ? baseModelInfoHint.modelInfo : undefined
+	// LiteLLM's catalog belongs to the configured self-hosted endpoint. Its
+	// persisted snapshot therefore remains authoritative after the live cache
+	// is gone, including when the endpoint reuses the built-in fallback model
+	// id. Other providers retain static-catalog-over-snapshot semantics so SDK
+	// catalog updates can refresh an existing selection.
+	const authoritativeStateHint = providerKey(selection.providerId) === "litellm" ? stateModelInfoHint : undefined
+	const baseModelInfo =
+		liveCatalogHint ??
+		authoritativeStateHint ??
+		catalogModelInfo ??
+		stateModelInfoHint ??
+		fallbackModelInfo(selection.modelId)
+	const modelInfoSource =
+		liveCatalogHint || (catalogModelInfo && !authoritativeStateHint) ? "catalog" : stateModelInfoHint ? "state" : "fallback"
 	return {
 		...selection,
 		overrides,

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -352,8 +352,7 @@ function applyModelOverrides(modelInfo: ModelInfo, overrides: ModelSelectionOver
 	if (overrides.name !== undefined) next.name = overrides.name
 	if (overrides.maxTokens !== undefined) next.maxTokens = overrides.maxTokens
 	if (overrides.contextWindow !== undefined) next.contextWindow = overrides.contextWindow
-	if (overrides.maxInputTokens !== undefined)
-		(next as ModelInfo & { maxInputTokens?: number }).maxInputTokens = overrides.maxInputTokens
+	if (overrides.maxInputTokens !== undefined) next.maxInputTokens = overrides.maxInputTokens
 	if (overrides.inputPrice !== undefined) next.inputPrice = overrides.inputPrice
 	if (overrides.outputPrice !== undefined) next.outputPrice = overrides.outputPrice
 	if (overrides.cacheReadsPrice !== undefined) next.cacheReadsPrice = overrides.cacheReadsPrice
@@ -413,16 +412,21 @@ function readBaseModelInfoForProvider(providerId: ProviderId, modelId: string): 
 	return undefined
 }
 
-function resolveSelection(selection: ModelSelection, stateModelInfoHint?: ModelInfo): ResolvedModelSelection {
+interface BaseModelInfoHint {
+	modelInfo: ModelInfo
+	source: "catalog" | "state"
+}
+
+function resolveSelection(selection: ModelSelection, baseModelInfoHint?: BaseModelInfoHint): ResolvedModelSelection {
 	const overrides = normalizeModelSelectionOverrides(
 		selection.overrides ?? readModelOverrides(selection.providerId, selection.modelId),
 	)
-	// Base resolution order: SDK catalog, then the picker's persisted state
-	// snapshot (the only accurate data for dynamic-list models the static
-	// catalog does not know), then provider-safe fallback defaults.
+	// Base resolution order: static SDK catalog, then host-resolved/persisted
+	// metadata for dynamic-list models the static catalog does not know, then
+	// provider-safe fallback defaults.
 	const catalogModelInfo = readBaseModelInfoForProvider(selection.providerId, selection.modelId)
-	const baseModelInfo = catalogModelInfo ?? stateModelInfoHint ?? fallbackModelInfo(selection.modelId)
-	const modelInfoSource = catalogModelInfo ? "catalog" : stateModelInfoHint ? "state" : "fallback"
+	const baseModelInfo = catalogModelInfo ?? baseModelInfoHint?.modelInfo ?? fallbackModelInfo(selection.modelId)
+	const modelInfoSource = catalogModelInfo ? "catalog" : (baseModelInfoHint?.source ?? "fallback")
 	return {
 		...selection,
 		overrides,
@@ -680,17 +684,15 @@ function writeSelectionToProviderSettings(providerId: ProviderId, selection: Mod
 	saveProviderSettings(providerId, next)
 }
 
-type LegacyModelInfo = ModelInfo & { maxInputTokens?: number }
 type MutableModelSelectionOverrides = { -readonly [Key in keyof ModelSelectionOverrides]: ModelSelectionOverrides[Key] }
 
-function legacyModelInfoToOverrides(modelInfo: LegacyModelInfo, fallback: ModelInfo): ModelSelectionOverrides | undefined {
-	const fallbackInfo = fallback as LegacyModelInfo
+function legacyModelInfoToOverrides(modelInfo: ModelInfo, fallback: ModelInfo): ModelSelectionOverrides | undefined {
 	const overrides: MutableModelSelectionOverrides = {}
 	if (modelInfo.name !== undefined && modelInfo.name !== fallback.name) overrides.name = modelInfo.name
 	if (modelInfo.maxTokens !== undefined && modelInfo.maxTokens !== fallback.maxTokens) overrides.maxTokens = modelInfo.maxTokens
 	if (modelInfo.contextWindow !== undefined && modelInfo.contextWindow !== fallback.contextWindow)
 		overrides.contextWindow = modelInfo.contextWindow
-	if (modelInfo.maxInputTokens !== undefined && modelInfo.maxInputTokens !== fallbackInfo.maxInputTokens)
+	if (modelInfo.maxInputTokens !== undefined && modelInfo.maxInputTokens !== fallback.maxInputTokens)
 		overrides.maxInputTokens = modelInfo.maxInputTokens
 
 	const supportsVision = modelInfo.supportsImages ?? fallback.supportsImages
@@ -740,7 +742,7 @@ function migrateLegacyModelOverridesIfNeeded(providerId: ProviderId, modelId: st
 	if (readBaseModelInfoForProvider(providerId, modelId) !== undefined) {
 		return
 	}
-	const overrides = legacyModelInfoToOverrides(modelInfo as LegacyModelInfo, fallbackModelInfo(modelId))
+	const overrides = legacyModelInfoToOverrides(modelInfo, fallbackModelInfo(modelId))
 	if (overrides) {
 		try {
 			writeModelOverrides(providerId, modelId, overrides)
@@ -757,10 +759,11 @@ function migrateLegacyModelOverridesIfNeeded(providerId: ProviderId, modelId: st
 }
 
 /**
- * The picker writes the live model metadata to the mode-specific
- * `*ModeModelInfo` state key before committing. When the state still refers to
- * the model being resolved, that snapshot is the best available base for
- * dynamic-list models the static catalog does not know.
+ * The host persists live model metadata to the mode-specific `*ModeModelInfo`
+ * state key when a selection is committed. When the state still refers to the
+ * model being resolved, that snapshot is the best available base for
+ * dynamic-list models the static catalog does not know. Pre-existing snapshots
+ * from older picker flows remain valid inputs here.
  *
  * openai-compatible is excluded: its legacy state snapshot is user-authored
  * metadata that {@link migrateLegacyModelOverridesIfNeeded} converts into
@@ -822,7 +825,11 @@ function readSelectionFromState(providerId: ProviderId, mode: Mode): ResolvedMod
 		if (isModelInfo(modelInfo)) {
 			migrateLegacyModelOverridesIfNeeded(providerId, modelId, modelInfo)
 		}
-		return resolveSelection({ providerId, modelId }, readStateModelInfoHint(providerId, mode, modelId))
+		const stateModelInfoHint = readStateModelInfoHint(providerId, mode, modelId)
+		return resolveSelection(
+			{ providerId, modelId },
+			stateModelInfoHint ? { modelInfo: stateModelInfoHint, source: "state" } : undefined,
+		)
 	}
 
 	const providerSettingsSelection = readSelectionFromProviderSettings(providerId)
@@ -881,16 +888,23 @@ export function createProviderConfigStore(): ProviderConfigStore {
 			return config
 		},
 
-		commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection): void {
+		commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection, baseModelInfoHint?: ModelInfo): void {
 			writeSelectionToProviderSettings(providerId, selection)
 			if (selection.overrides !== undefined) {
 				writeModelOverrides(providerId, selection.modelId, selection.overrides)
 			}
-			// Read the picker-written state snapshot before writeSelectionToState
-			// replaces it, so dynamic-list models keep their live metadata instead
-			// of being re-resolved to fallback defaults.
+			// Prefer metadata resolved by the host catalog for this commit. Fall
+			// back to an existing state snapshot for legacy callers, then persist
+			// the genuine base so dynamic-list models survive future reads.
 			const stateModelInfoHint = readStateModelInfoHint(providerId, mode, selection.modelId)
-			const resolvedSelection = resolveSelection({ providerId, modelId: selection.modelId }, stateModelInfoHint)
+			const resolvedSelection = resolveSelection(
+				{ providerId, modelId: selection.modelId },
+				baseModelInfoHint
+					? { modelInfo: baseModelInfoHint, source: "catalog" }
+					: stateModelInfoHint
+						? { modelInfo: stateModelInfoHint, source: "state" }
+						: undefined,
+			)
 			writeSelectionToState(providerId, mode, resolvedSelection)
 			emit({ kind: "selection", providerId, mode, selection: resolvedSelection })
 		},

--- a/apps/vscode/src/sdk/vscode-lm/register-vscode-lm.test.ts
+++ b/apps/vscode/src/sdk/vscode-lm/register-vscode-lm.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const registerHandler = vi.fn()
 const registerProvider = vi.fn()
-vi.mock("@cline/llms", () => ({ registerHandler, registerProvider }))
+vi.mock("@cline/llms", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cline/llms")>()),
+	registerHandler,
+	registerProvider,
+}))
 vi.mock("@/shared/services/Logger", () => ({ Logger: { debug: vi.fn() } }))
 
 // `vscode.lm` presence is the gate. Use a mutable mock so each test controls it.

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -72,6 +72,8 @@ export interface ModelInfo {
 	name?: string
 	maxTokens?: number
 	contextWindow?: number
+	/** Prompt/input token budget reported by the provider. Kept separate from the total context window. */
+	maxInputTokens?: number
 	supportsImages?: boolean
 	supportsPromptCache: boolean // this value is hardcoded for now
 	supportsReasoning?: boolean // Whether the model supports reasoning/thinking mode

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -53,6 +53,7 @@ export function resolveModelsRegistryPath(): string {
 
 export function ensureCustomProvidersLoadedSync(): void {}
 
+export { isPrivateModelCatalogProvider } from "../../../../sdk/packages/core/src/services/llms/provider-defaults"
 // Real implementation re-exported from the sdk source (same pattern as the
 // apply-patch executors below) so store writes are reflected in the live
 // @cline/llms registry exactly as in production. Tests that touch it must

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -951,6 +951,7 @@ export {
 	DEFAULT_MODELS_CATALOG_URL,
 	getLiveModelsCatalog,
 	getProviderConfig,
+	isPrivateModelCatalogProvider,
 	OPENAI_COMPATIBLE_PROVIDERS,
 	resolveProviderConfig,
 } from "./services/llms/provider-defaults";

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -513,6 +513,8 @@ describe("resolveProviderConfig", () => {
 								model_name: "private-proxy-model",
 								litellm_params: { model: "openai/gpt-4o-mini" },
 								model_info: {
+									max_output_tokens: 64_000,
+									max_input_tokens: 500_000,
 									supports_vision: true,
 									supports_reasoning: true,
 								},
@@ -543,12 +545,16 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["openai/gpt-4o-mini"]).toEqual(
 			expect.objectContaining({
 				name: "private-proxy-model",
+				maxTokens: 64_000,
+				maxInputTokens: 500_000,
 				capabilities: expect.arrayContaining(["images", "reasoning"]),
 			}),
 		);
 		expect(resolved?.knownModels?.["private-proxy-model"]).toEqual(
 			expect.objectContaining({
 				name: "private-proxy-model",
+				maxTokens: 64_000,
+				maxInputTokens: 500_000,
 				capabilities: expect.arrayContaining(["images", "reasoning"]),
 			}),
 		);

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	clearLiveModelsCatalogCache,
 	clearPrivateModelsCatalogCache,
+	isPrivateModelCatalogProvider,
 	resolveProviderConfig,
 } from "./provider-defaults";
 
@@ -10,6 +11,25 @@ afterEach(() => {
 	clearPrivateModelsCatalogCache();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+});
+
+describe("isPrivateModelCatalogProvider", () => {
+	it.each([
+		"baseten",
+		"hicap",
+		"litellm",
+		"poolside",
+	])("recognizes %s as an endpoint-specific catalog provider", (providerId) => {
+		expect(isPrivateModelCatalogProvider(providerId)).toBe(true);
+	});
+
+	it.each([
+		"openrouter",
+		"requesty",
+		"anthropic",
+	])("does not classify %s as endpoint-specific", (providerId) => {
+		expect(isPrivateModelCatalogProvider(providerId)).toBe(false);
+	});
 });
 
 describe("resolveProviderConfig", () => {

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -654,6 +654,17 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	poolside: fetchPoolsidePrivateModels,
 };
 
+/**
+ * Whether a provider's model catalog comes from the customer's configured
+ * endpoint rather than a shared public catalog.
+ *
+ * Keep this derived from the fetcher registry so host consumers cannot drift
+ * from the providers whose live metadata is endpoint-specific.
+ */
+export function isPrivateModelCatalogProvider(providerId: string): boolean {
+	return Object.hasOwn(PRIVATE_PROVIDER_MODEL_FETCHERS, providerId);
+}
+
 const PUBLIC_MODELS_CACHE = new Map<
 	string,
 	{ data: Record<string, ModelInfo>; expiresAt: number }


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes #13274

### Description

LiteLLM already reports max_input_tokens, but the VS Code model boundary discarded it and substituted the 128K safe default. This change:

- preserves maxInputTokens independently from contextWindow and maxTokens;
- uses a positive input limit as the legacy context-window fallback only when the provider omits contextWindow;
- carries the selected dynamic catalog entry into the host store so private LiteLLM metadata survives selection and session reconstruction;
- keeps catalog metadata separate from user overrides, with explicit overrides retaining precedence; and
- avoids fabricating maxInputTokens when no provider metadata exists.

The separate LiteLLM alias-selection behavior mentioned in the issue is intentionally out of scope.

### Test Procedure

- VS Code focused Vitest: shape adapter, catalog store, provider catalog handlers, and session factory — 158 tests passed.
- SDK Core LiteLLM provider-defaults suite — 17 tests passed.
- VS Code TypeScript no-emit check passed.
- SDK Core TypeScript no-emit check passed.
- VS Code full lint and protobuf lint passed.
- Biome checks passed for all 11 changed files.
- Pre-commit gitleaks and lint-staged checks passed.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Relevant tests are passing and changed code is formatted and linted
- [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable; this changes model metadata propagation without changing UI structure.