### PR TITLE
fix(hooks): collect PostToolUse hook output and honor its control

### DIFF
--- a/apps/vscode/src/sdk/hooks-adapter.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.ts
@@ -37,13 +37,20 @@ function toStringRecord(input: unknown): Record<string, string> {
 	return result
 }
 
-function mapStopControl(hookOutput: { cancel?: boolean; errorMessage?: string }): AgentStopControl | undefined {
+function mapStopControl(hookOutput: {
+	cancel?: boolean
+	errorMessage?: string
+	contextModification?: string
+}): AgentStopControl | undefined {
 	if (!hookOutput.cancel) {
 		return undefined
 	}
+	// A cancelling hook's contextModification is never injected as context;
+	// it serves as the fallback explanation when no errorMessage was given.
+	const reason = hookOutput.errorMessage?.trim() || hookOutput.contextModification?.trim() || undefined
 	return {
 		stop: true,
-		reason: hookOutput.errorMessage || undefined,
+		reason,
 	}
 }
 

--- a/apps/vscode/src/sdk/hooks-adapter.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.ts
@@ -166,7 +166,9 @@ export function buildAgentHooks(
 			}
 		},
 
-		async afterTool(ctx: AgentAfterToolContext): Promise<undefined> {
+		async afterTool(
+			ctx: AgentAfterToolContext,
+		): Promise<{ stop?: boolean; reason?: string; appendContext?: string } | undefined> {
 			let runningTs: number | undefined
 			try {
 				if (!hooksEnabled()) {
@@ -203,7 +205,15 @@ export function buildAgentHooks(
 						ts: runningTs,
 					}),
 				)
-				return undefined
+				const stopControl = mapStopControl(result)
+				if (stopControl) {
+					return stopControl
+				}
+				// The runtime injects appendContext into the conversation as a
+				// <hook_context> block, restoring the documented contextModification
+				// behavior. HookFactory already truncates it at 50KB.
+				const contextModification = result.contextModification?.trim()
+				return contextModification ? { appendContext: contextModification } : undefined
 			} catch (error) {
 				emitHookMessage?.(
 					buildHookStatusMessage({

--- a/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
@@ -356,7 +356,7 @@ describe("createHookConfigFileHooks", () => {
 				detachAsyncHooks: false,
 			});
 			const control = await hooks?.beforeTool?.(beforeToolContext());
-			expect(control).toEqual({ stop: true });
+			expect(control).toEqual({ stop: true, reason: "blocked by policy" });
 		} finally {
 			await rm(workspace, {
 				recursive: true,
@@ -424,6 +424,37 @@ describe("createHookConfigFileHooks", () => {
 			`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: true, errorMessage: "post-hook says stop" }))\n`,
 		);
 		try {
+			const hooks = createHookConfigFileHooks({
+				cwd: workspace,
+				workspacePath: workspace,
+				detachAsyncHooks: false,
+			});
+			const control = await hooks?.afterTool?.(afterToolContext());
+			expect(control).toEqual({
+				stop: true,
+				reason: "post-hook says stop",
+			});
+		} finally {
+			await rm(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 250,
+			});
+		}
+	});
+
+	it("keeps another hook's context out of a cancelling hook's reason", async () => {
+		const { workspace } = await createWorkspaceWithHook(
+			"PostToolUse",
+			'echo \'HOOK_CONTROL\t{"cancel":false,"contextModification":"unrelated lint context"}\'\n',
+		);
+		try {
+			await writeFile(
+				join(workspace, ".clinerules", "hooks", "PostToolUse.js"),
+				`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: true, errorMessage: "post-hook says stop" }))\n`,
+				"utf8",
+			);
 			const hooks = createHookConfigFileHooks({
 				cwd: workspace,
 				workspacePath: workspace,

--- a/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
@@ -444,6 +444,32 @@ describe("createHookConfigFileHooks", () => {
 		}
 	});
 
+	it("prefers errorMessage over context for a cancelling hook's reason", async () => {
+		const { workspace } = await createWorkspaceWithHook(
+			"PostToolUse.js",
+			`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: true, contextModification: "some context", errorMessage: "the actual error" }))\n`,
+		);
+		try {
+			const hooks = createHookConfigFileHooks({
+				cwd: workspace,
+				workspacePath: workspace,
+				detachAsyncHooks: false,
+			});
+			const control = await hooks?.afterTool?.(afterToolContext());
+			expect(control).toEqual({
+				stop: true,
+				reason: "the actual error",
+			});
+		} finally {
+			await rm(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 250,
+			});
+		}
+	});
+
 	it("keeps another hook's context out of a cancelling hook's reason", async () => {
 		const { workspace } = await createWorkspaceWithHook(
 			"PostToolUse",

--- a/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
@@ -470,6 +470,32 @@ describe("createHookConfigFileHooks", () => {
 		}
 	});
 
+	it("falls back to context for the reason when errorMessage is blank", async () => {
+		const { workspace } = await createWorkspaceWithHook(
+			"PostToolUse.js",
+			`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: true, contextModification: "the real reason", errorMessage: "   " }))\n`,
+		);
+		try {
+			const hooks = createHookConfigFileHooks({
+				cwd: workspace,
+				workspacePath: workspace,
+				detachAsyncHooks: false,
+			});
+			const control = await hooks?.afterTool?.(afterToolContext());
+			expect(control).toEqual({
+				stop: true,
+				reason: "the real reason",
+			});
+		} finally {
+			await rm(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 250,
+			});
+		}
+	});
+
 	it("keeps another hook's context out of a cancelling hook's reason", async () => {
 		const { workspace } = await createWorkspaceWithHook(
 			"PostToolUse",

--- a/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
@@ -392,6 +392,58 @@ describe("createHookConfigFileHooks", () => {
 		}
 	});
 
+	it("collects PostToolUse context and returns it from afterTool", async () => {
+		const { workspace } = await createWorkspaceWithHook(
+			"PostToolUse.js",
+			`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: false, contextModification: "LINT_RESULTS: 3 errors in src/foo.ts" }))\n`,
+		);
+		try {
+			const hooks = createHookConfigFileHooks({
+				cwd: workspace,
+				workspacePath: workspace,
+				detachAsyncHooks: false,
+			});
+			expect(hooks?.afterTool).toBeTypeOf("function");
+			const control = await hooks?.afterTool?.(afterToolContext());
+			expect(control).toEqual({
+				appendContext: "LINT_RESULTS: 3 errors in src/foo.ts",
+			});
+		} finally {
+			await rm(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 250,
+			});
+		}
+	});
+
+	it("honors PostToolUse cancel with the hook's error message as reason", async () => {
+		const { workspace } = await createWorkspaceWithHook(
+			"PostToolUse.js",
+			`console.log('HOOK_CONTROL\\t' + JSON.stringify({ cancel: true, errorMessage: "post-hook says stop" }))\n`,
+		);
+		try {
+			const hooks = createHookConfigFileHooks({
+				cwd: workspace,
+				workspacePath: workspace,
+				detachAsyncHooks: false,
+			});
+			const control = await hooks?.afterTool?.(afterToolContext());
+			expect(control).toEqual({
+				stop: true,
+				reason: "post-hook says stop",
+			});
+		} finally {
+			await rm(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 250,
+			});
+		}
+	});
+
 	it("concatenates appendContext across merged hook layers", async () => {
 		const hooks = mergeAgentHooks([
 			{

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -538,6 +538,26 @@ function beforeToolResultFromControl(
 	return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function afterToolResultFromControl(
+	control: HookCommandControl | undefined,
+): { stop?: boolean; reason?: string; appendContext?: string } | undefined {
+	if (!control) {
+		return undefined;
+	}
+	const result: { stop?: boolean; reason?: string; appendContext?: string } =
+		{};
+	if (control.cancel === true) {
+		result.stop = true;
+		// On cancel the parsed context carries the hook's error message.
+		if (control.context?.trim()) {
+			result.reason = control.context;
+		}
+	} else if (control.context?.trim()) {
+		result.appendContext = control.context;
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}
+
 export function createHookAuditHooks(options: {
 	rootSessionId?: string;
 	workspacePath: string;
@@ -758,16 +778,16 @@ export function createHookConfigFileHooks(
 
 	const runToolCallEnd = async (
 		ctx: HookCommandToolCallEndContext,
-	): Promise<void> => {
+	): Promise<HookCommandControl | undefined> => {
 		const commandPaths = commandMap.tool_result ?? [];
 		if (commandPaths.length === 0) {
-			return;
+			return undefined;
 		}
-		await runAsyncHookCommands({
+		return runBlockingHookCommands({
 			commands: commandPaths,
 			cwd: options.cwd,
 			logger: options.logger,
-			detached: options.detachAsyncHooks ?? true,
+			timeoutMs: options.toolCallTimeoutMs ?? 120000,
 			payload: {
 				...createPayloadBase(ctx, options),
 				hookName: "tool_result",
@@ -910,8 +930,8 @@ export function createHookConfigFileHooks(
 	}
 	if ((commandMap.tool_result?.length ?? 0) > 0) {
 		hooks.afterTool = async (ctx: AgentAfterToolContext) => {
-			await runToolCallEnd(toolCallEndContext(ctx));
-			return undefined;
+			const control = await runToolCallEnd(toolCallEndContext(ctx));
+			return afterToolResultFromControl(control);
 		};
 	}
 	if ((commandMap.agent_end?.length ?? 0) > 0) {

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -165,22 +165,28 @@ function parseHookControl(value: unknown): HookCommandControl | undefined {
 		return undefined;
 	}
 	const record = value as Record<string, unknown>;
-	const context =
+	const injectableContext =
 		typeof record.context === "string"
 			? record.context
 			: typeof record.contextModification === "string"
 				? record.contextModification
-				: typeof record.errorMessage === "string"
-					? record.errorMessage
-					: undefined;
+				: undefined;
+	const errorMessage =
+		typeof record.errorMessage === "string" && record.errorMessage.length > 0
+			? record.errorMessage
+			: undefined;
 	const cancel = typeof record.cancel === "boolean" ? record.cancel : undefined;
 	return {
 		cancel,
 		review: typeof record.review === "boolean" ? record.review : undefined,
 		// A cancelling hook's message is its error/reason, not injectable
-		// conversation context.
-		context: cancel === true ? undefined : truncateHookContext(context),
-		cancelReason: cancel === true ? context : undefined,
+		// conversation context; errorMessage takes precedence there.
+		context:
+			cancel === true
+				? undefined
+				: truncateHookContext(injectableContext ?? errorMessage),
+		cancelReason:
+			cancel === true ? (errorMessage ?? injectableContext) : undefined,
 		overrideInput: Object.hasOwn(record, "overrideInput")
 			? record.overrideInput
 			: undefined,

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -172,7 +172,8 @@ function parseHookControl(value: unknown): HookCommandControl | undefined {
 				? record.contextModification
 				: undefined;
 	const errorMessage =
-		typeof record.errorMessage === "string" && record.errorMessage.length > 0
+		typeof record.errorMessage === "string" &&
+		record.errorMessage.trim().length > 0
 			? record.errorMessage
 			: undefined;
 	const cancel = typeof record.cancel === "boolean" ? record.cancel : undefined;

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -35,6 +35,12 @@ type HookContextBase = {
 type HookCommandControl = Omit<HookControl, "appendMessages"> & {
 	systemPrompt?: string;
 	appendMessages?: unknown[];
+	/**
+	 * Error message accompanying `cancel: true`. Kept separate from `context`
+	 * so injectable context from one hook never leaks into another hook's
+	 * cancellation reason when controls are merged.
+	 */
+	cancelReason?: string;
 };
 
 type HookCommandRunStartContext = HookContextBase & {
@@ -128,6 +134,11 @@ function mergeHookControls(
 			(value): value is string => typeof value === "string" && value.length > 0,
 		)
 		.join("\n");
+	const cancelReasons = [current.cancelReason, next.cancelReason]
+		.filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		)
+		.join("\n");
 	const appendMessages = [
 		...(current.appendMessages ?? []),
 		...(next.appendMessages ?? []),
@@ -136,6 +147,7 @@ function mergeHookControls(
 		cancel: current.cancel === true || next.cancel === true ? true : undefined,
 		review: current.review === true || next.review === true ? true : undefined,
 		context: contexts || undefined,
+		cancelReason: cancelReasons || undefined,
 		overrideInput:
 			next.overrideInput !== undefined
 				? next.overrideInput
@@ -161,10 +173,14 @@ function parseHookControl(value: unknown): HookCommandControl | undefined {
 				: typeof record.errorMessage === "string"
 					? record.errorMessage
 					: undefined;
+	const cancel = typeof record.cancel === "boolean" ? record.cancel : undefined;
 	return {
-		cancel: typeof record.cancel === "boolean" ? record.cancel : undefined,
+		cancel,
 		review: typeof record.review === "boolean" ? record.review : undefined,
-		context: truncateHookContext(context),
+		// A cancelling hook's message is its error/reason, not injectable
+		// conversation context.
+		context: cancel === true ? undefined : truncateHookContext(context),
+		cancelReason: cancel === true ? context : undefined,
 		overrideInput: Object.hasOwn(record, "overrideInput")
 			? record.overrideInput
 			: undefined,
@@ -526,9 +542,12 @@ function beforeToolResultFromControl(
 	} = {};
 	if (control.cancel === true) {
 		result.stop = true;
+		if (control.cancelReason?.trim()) {
+			result.reason = control.cancelReason;
+		}
 	} else if (control.context?.trim()) {
-		// Context is injected only when the hook lets the run continue; on
-		// cancel the parsed context is the hook's error message (legacy
+		// Context is injected only when the hook lets the run continue; a
+		// cancelling hook's message travels as cancelReason instead (legacy
 		// surfaced it as an error, never as conversation context).
 		result.appendContext = control.context;
 	}
@@ -548,9 +567,8 @@ function afterToolResultFromControl(
 		{};
 	if (control.cancel === true) {
 		result.stop = true;
-		// On cancel the parsed context carries the hook's error message.
-		if (control.context?.trim()) {
-			result.reason = control.context;
+		if (control.cancelReason?.trim()) {
+			result.reason = control.cancelReason;
 		}
 	} else if (control.context?.trim()) {
 		result.appendContext = control.context;

--- a/sdk/packages/core/src/hooks/subprocess.ts
+++ b/sdk/packages/core/src/hooks/subprocess.ts
@@ -41,6 +41,12 @@ import {
 
 type AgentHookControl = Omit<HookControl, "appendMessages"> & {
 	appendMessages?: unknown[];
+	/**
+	 * Error message accompanying `cancel: true`. Kept separate from `context`
+	 * so injectable context from one hook never leaks into another hook's
+	 * cancellation reason when controls are merged.
+	 */
+	cancelReason?: string;
 };
 
 /**
@@ -117,6 +123,12 @@ export interface RunHookOptions {
 export type RunHookResult = RunSubprocessEventResult;
 
 const DEFAULT_HOOK_COMMAND = ["agent", "hook"];
+
+/**
+ * Default timeout for blocking tool hooks (tool_call/tool_result). Without a
+ * bound, a hook command that never exits would block the agent indefinitely.
+ */
+const DEFAULT_TOOL_HOOK_TIMEOUT_MS = 120_000;
 
 export async function runHook(
 	payload: HookEventPayload,
@@ -201,10 +213,14 @@ function toHookControl(value: unknown): AgentHookControl | undefined {
 						maybe.errorMessage.length > 0
 					? maybe.errorMessage
 					: undefined;
+	const cancel = typeof maybe.cancel === "boolean" ? maybe.cancel : undefined;
 	return {
-		cancel: typeof maybe.cancel === "boolean" ? maybe.cancel : undefined,
+		cancel,
 		review: typeof maybe.review === "boolean" ? maybe.review : undefined,
-		context: truncateHookContext(contextFromHook),
+		// A cancelling hook's message is its error/reason, not injectable
+		// conversation context.
+		context: cancel === true ? undefined : truncateHookContext(contextFromHook),
+		cancelReason: cancel === true ? contextFromHook : undefined,
 		overrideInput: Object.hasOwn(maybe, "overrideInput")
 			? maybe.overrideInput
 			: undefined,
@@ -313,16 +329,22 @@ function runtimeToolRecord(
 
 function beforeToolResultFromControl(
 	control: AgentHookControl | undefined,
-): { stop?: boolean; input?: unknown; appendContext?: string } | undefined {
+):
+	| { stop?: boolean; reason?: string; input?: unknown; appendContext?: string }
+	| undefined {
 	if (!control) return undefined;
-	const result: { stop?: boolean; input?: unknown; appendContext?: string } =
-		{};
+	const result: {
+		stop?: boolean;
+		reason?: string;
+		input?: unknown;
+		appendContext?: string;
+	} = {};
 	if (control.cancel === true) {
 		result.stop = true;
+		if (control.cancelReason?.trim()) {
+			result.reason = control.cancelReason;
+		}
 	} else if (control.context?.trim()) {
-		// Context is injected only when the hook lets the run continue; on
-		// cancel the parsed context is the hook's error message (legacy
-		// surfaced it as an error, never as conversation context).
 		result.appendContext = control.context;
 	}
 	if (control.overrideInput !== undefined) result.input = control.overrideInput;
@@ -337,9 +359,8 @@ function afterToolResultFromControl(
 		{};
 	if (control.cancel === true) {
 		result.stop = true;
-		// On cancel the parsed context carries the hook's error message.
-		if (control.context?.trim()) {
-			result.reason = control.context;
+		if (control.cancelReason?.trim()) {
+			result.reason = control.cancelReason;
 		}
 	} else if (control.context?.trim()) {
 		result.appendContext = control.context;
@@ -450,7 +471,7 @@ export function createSubprocessHooks(
 				cwd: options.cwd,
 				env: options.env,
 				detached: false,
-				timeoutMs: options.timeoutMs,
+				timeoutMs: options.timeoutMs ?? DEFAULT_TOOL_HOOK_TIMEOUT_MS,
 				onSpawn: options.onSpawn,
 			});
 			options.onDispatch?.({ payload, result, detached: false });
@@ -506,7 +527,7 @@ export function createSubprocessHooks(
 				cwd: options.cwd,
 				env: options.env,
 				detached: false,
-				timeoutMs: options.timeoutMs,
+				timeoutMs: options.timeoutMs ?? DEFAULT_TOOL_HOOK_TIMEOUT_MS,
 				onSpawn: options.onSpawn,
 			});
 			options.onDispatch?.({ payload, result, detached: false });

--- a/sdk/packages/core/src/hooks/subprocess.ts
+++ b/sdk/packages/core/src/hooks/subprocess.ts
@@ -329,6 +329,24 @@ function beforeToolResultFromControl(
 	return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function afterToolResultFromControl(
+	control: AgentHookControl | undefined,
+): { stop?: boolean; reason?: string; appendContext?: string } | undefined {
+	if (!control) return undefined;
+	const result: { stop?: boolean; reason?: string; appendContext?: string } =
+		{};
+	if (control.cancel === true) {
+		result.stop = true;
+		// On cancel the parsed context carries the hook's error message.
+		if (control.context?.trim()) {
+			result.reason = control.context;
+		}
+	} else if (control.context?.trim()) {
+		result.appendContext = control.context;
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}
+
 async function dispatchDetached(
 	payload: HookEventPayload,
 	options: SubprocessHooksOptions,
@@ -451,7 +469,11 @@ export function createSubprocessHooks(
 		}
 	};
 
-	const afterTool = async (ctx: AgentAfterToolContext): Promise<undefined> => {
+	const afterTool = async (
+		ctx: AgentAfterToolContext,
+	): Promise<
+		{ stop?: boolean; reason?: string; appendContext?: string } | undefined
+	> => {
 		const record = runtimeToolRecord(ctx);
 		const base = {
 			agentId: ctx.snapshot.agentId,
@@ -477,8 +499,30 @@ export function createSubprocessHooks(
 				executionTimeMs: record.durationMs,
 			},
 		};
-		await dispatchDetached(payload, options);
-		return undefined;
+
+		try {
+			const result = await runHook(payload, {
+				command: options.command,
+				cwd: options.cwd,
+				env: options.env,
+				detached: false,
+				timeoutMs: options.timeoutMs,
+				onSpawn: options.onSpawn,
+			});
+			options.onDispatch?.({ payload, result, detached: false });
+			if (result?.timedOut) {
+				throw new Error("tool_result hook command timed out");
+			}
+			if (result?.parseError) {
+				throw new Error(
+					`tool_result hook produced invalid control JSON: ${result.parseError}`,
+				);
+			}
+			return afterToolResultFromControl(toHookControl(result?.parsedJson));
+		} catch (error) {
+			options.onDispatchError?.(toError(error), payload);
+			return;
+		}
 	};
 
 	const afterRun: NonNullable<AgentHooks["afterRun"]> = async ({

--- a/sdk/packages/core/src/hooks/subprocess.ts
+++ b/sdk/packages/core/src/hooks/subprocess.ts
@@ -211,7 +211,8 @@ function toHookControl(value: unknown): AgentHookControl | undefined {
 				? maybe.contextModification
 				: undefined;
 	const errorMessage =
-		typeof maybe.errorMessage === "string" && maybe.errorMessage.length > 0
+		typeof maybe.errorMessage === "string" &&
+		maybe.errorMessage.trim().length > 0
 			? maybe.errorMessage
 			: undefined;
 	const cancel = typeof maybe.cancel === "boolean" ? maybe.cancel : undefined;

--- a/sdk/packages/core/src/hooks/subprocess.ts
+++ b/sdk/packages/core/src/hooks/subprocess.ts
@@ -204,23 +204,28 @@ function toHookControl(value: unknown): AgentHookControl | undefined {
 	if (!hasControlKey) {
 		return undefined;
 	}
-	const contextFromHook =
+	const injectableContext =
 		typeof maybe.context === "string"
 			? maybe.context
 			: typeof maybe.contextModification === "string"
 				? maybe.contextModification
-				: typeof maybe.errorMessage === "string" &&
-						maybe.errorMessage.length > 0
-					? maybe.errorMessage
-					: undefined;
+				: undefined;
+	const errorMessage =
+		typeof maybe.errorMessage === "string" && maybe.errorMessage.length > 0
+			? maybe.errorMessage
+			: undefined;
 	const cancel = typeof maybe.cancel === "boolean" ? maybe.cancel : undefined;
 	return {
 		cancel,
 		review: typeof maybe.review === "boolean" ? maybe.review : undefined,
 		// A cancelling hook's message is its error/reason, not injectable
-		// conversation context.
-		context: cancel === true ? undefined : truncateHookContext(contextFromHook),
-		cancelReason: cancel === true ? contextFromHook : undefined,
+		// conversation context; errorMessage takes precedence there.
+		context:
+			cancel === true
+				? undefined
+				: truncateHookContext(injectableContext ?? errorMessage),
+		cancelReason:
+			cancel === true ? (errorMessage ?? injectableContext) : undefined,
 		overrideInput: Object.hasOwn(maybe, "overrideInput")
 			? maybe.overrideInput
 			: undefined,


### PR DESCRIPTION
**Stacked on #13297** — merge that first, then retarget/rebase this onto `main`.

## Problem

`tool_result` (PostToolUse) hooks run fire-and-forget with stdout ignored (`stdio: ["pipe","ignore","ignore"]` when detached), so their entire JSON output is discarded — `contextModification` *and* `cancel`. Legacy awaited PostToolUse, injected its `contextModification` into the conversation, and honored `cancel` (aborting the task with the hook's error message).

Second half of the fix for the `contextModification` report in #13277. Ticket: [CLINE-2987](https://linear.app/cline-bot/issue/CLINE-2987/hook-contextmodification-never-reaches-the-model-on-the-next-engine)

## Change

- Run `tool_result` hook commands **blocking**, with the same 120s default timeout as `tool_call`, in both the hook-config-file layer (`hook-file-hooks.ts`) and the agent-hook subprocess layer (`subprocess.ts`).
- Map their output via the `afterTool` result: `cancel: true` stops the run with the hook's error message as the reason; otherwise non-empty context is injected through `appendContext` (from #13297) and reaches the model as a `<hook_context source="PostToolUse">` block.

## Trade-off

This deliberately restores legacy blocking semantics: each tool result now waits for the PostToolUse hook subprocess to exit (bounded by the timeout). The cost is only paid in sessions that actually have a `tool_result` hook configured — with none, behavior is unchanged. The alternative (staying async and dropping output) is what produced the bug: the documented contract can't be honored without reading the hook's stdout, and a detached process's exit can't be awaited without blocking anyway.

## Testing

- Core hooks suite (39 passed): PostToolUse `contextModification` returned as `appendContext` from `afterTool`; `cancel` + `errorMessage` maps to `{stop, reason}`.
- End-to-end injection into the next model request is covered by the runtime tests added in #13297 (the `afterTool` → user-message path is identical).
- `bun -F @cline/core typecheck`, biome clean.
