### PR TITLE
fix(llms): surface provider-executed tool activity as observational events

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -226,6 +226,50 @@ describe("AgentRuntime", () => {
 		expect(eventTypes).toContain("tool-finished");
 	});
 
+	it("keeps a turn that is only provider-executed tool activity", async () => {
+		// No trailing text: the whole turn is observational activity. The
+		// empty-content guard must not reject it — the transcript would lose
+		// the activity, which lives in metadata rather than content.
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "cli_read_1",
+					toolName: "Read",
+					execution: "provider",
+					input: { file_path: "/tmp/a.txt" },
+				},
+				{
+					type: "tool-result",
+					toolCallId: "cli_read_1",
+					toolName: "Read",
+					execution: "provider",
+					output: { content: "hello" },
+				},
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const result = await runtime.run("Read the file");
+
+		expect(result.status).toBe("completed");
+		const lastMessage = result.messages.at(-1);
+		expect(lastMessage?.role).toBe("assistant");
+		expect(lastMessage?.content).toEqual([]);
+		expect(lastMessage?.metadata).toEqual({
+			modelToolActivities: [
+				{
+					toolCallId: "cli_read_1",
+					toolName: "Read",
+					execution: "provider",
+					input: { file_path: "/tmp/a.txt" },
+					output: { content: "hello" },
+				},
+			],
+		});
+	});
+
 	it("stores generated model-tool media once and keeps activity metadata compact", async () => {
 		const data = "aGVsbG8=";
 		const model = new ScriptedModel([

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -703,11 +703,22 @@ export class AgentRuntime {
 					throw this.normalizeAbortError();
 				}
 				if (message.content.length === 0) {
-					throw new Error(
-						finishReason === "error"
-							? (this.state.lastError ?? "Model stream failed")
-							: "Model returned empty response",
-					);
+					if (finishReason === "error") {
+						throw new Error(this.state.lastError ?? "Model stream failed");
+					}
+					// Provider-executed tool activity lives in message metadata, not
+					// content (projecting it into content would replay tool_use blocks
+					// the model never gets results for). A turn that is only such
+					// activity is not empty: keep the message so the transcript and
+					// display projection retain it. Replay stays safe — the codec
+					// renders empty content as its placeholder text block.
+					const modelToolActivities = message.metadata?.modelToolActivities;
+					const hasModelToolActivity =
+						Array.isArray(modelToolActivities) &&
+						modelToolActivities.length > 0;
+					if (!hasModelToolActivity) {
+						throw new Error("Model returned empty response");
+					}
 				}
 				const toolCalls = message.content.filter(
 					(part: AgentMessagePart): part is AgentToolCallPart =>

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -1307,6 +1307,12 @@ async function* emitAiSdkEvents(
 	const projectedModelToolResults = new Map<string, ProjectedModelToolResult>();
 	const pendingProjectedModelToolOutputs = new Map<string, unknown>();
 	const projectedModelToolErrors = new Map<string, string>();
+	// Tool calls the provider executed inside this inference request (e.g. the
+	// Claude Code CLI's own tools). They surface as observational activity and
+	// must never enter AgentRuntime's local execution/approval loop. Result and
+	// error parts are matched by ID because some providers omit the
+	// providerExecuted flag on the result half of the pair.
+	const observationalProviderToolCallIds = new Set<string>();
 
 	try {
 		if (stream.fullStream) {
@@ -1425,6 +1431,22 @@ async function* emitAiSdkEvents(
 						};
 						continue;
 					}
+					if (part.providerExecuted === true) {
+						const toolCallId =
+							(part.toolCallId as string | undefined) ??
+							(part.id as string | undefined) ??
+							`provider_tool_${nanoid()}`;
+						observationalProviderToolCallIds.add(toolCallId);
+						sawVisibleContent = true;
+						yield {
+							type: "tool-call-delta",
+							toolCallId,
+							toolName,
+							execution: "provider",
+							input: part.input ?? part.args,
+						};
+						continue;
+					}
 					sawToolCalls = true;
 					sawVisibleContent = true;
 					const toolCallId =
@@ -1500,6 +1522,26 @@ async function* emitAiSdkEvents(
 						}
 						continue;
 					}
+					const toolCallId =
+						(part.toolCallId as string | undefined) ??
+						(part.id as string | undefined);
+					if (
+						part.providerExecuted === true ||
+						(toolCallId && observationalProviderToolCallIds.has(toolCallId))
+					) {
+						if (part.preliminary !== true) {
+							sawVisibleContent = true;
+							yield {
+								type: "tool-result",
+								toolCallId: toolCallId ?? `provider_tool_${nanoid()}`,
+								toolName,
+								execution: "provider",
+								input: part.input ?? part.args,
+								output: part.output ?? part.result,
+							};
+						}
+						continue;
+					}
 				}
 
 				if (part.type === "tool-error") {
@@ -1539,6 +1581,27 @@ async function* emitAiSdkEvents(
 							isError: true,
 						};
 						continue;
+					}
+					{
+						const errorToolCallId =
+							(part.toolCallId as string | undefined) ??
+							(part.id as string | undefined);
+						if (
+							part.providerExecuted === true ||
+							(errorToolCallId &&
+								observationalProviderToolCallIds.has(errorToolCallId))
+						) {
+							yield {
+								type: "tool-result",
+								toolCallId: errorToolCallId ?? `provider_tool_${nanoid()}`,
+								toolName,
+								execution: "provider",
+								input: part.input ?? part.args,
+								output: { error: extractErrorMessage(part.error) },
+								isError: true,
+							};
+							continue;
+						}
 					}
 					sawToolCalls = true;
 					const toolCallId =

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -734,7 +734,8 @@ describe("sdk-gateway", () => {
 					toolName: "Bash",
 					error: new Error("command failed"),
 				},
-				{ type: "text-delta", text: "done" },
+				// Deliberately no trailing text: a tool-only stream must still
+				// surface the activity and finish cleanly.
 				{ type: "finish", finishReason: "stop" },
 			]),
 		});

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -635,6 +635,143 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("surfaces provider-executed tool activity as observational events", async () => {
+		// Providers like the Claude Code CLI execute their own tools inside the
+		// inference request and mark every part providerExecuted. That activity
+		// must surface as execution-tagged events (visible in the transcript)
+		// without ever entering AgentRuntime's local execution/approval loop.
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{
+					type: "tool-call",
+					toolCallId: "cli_read_1",
+					toolName: "Read",
+					input: { file_path: "/tmp/a.txt" },
+					providerExecuted: true,
+				},
+				{
+					type: "tool-result",
+					toolCallId: "cli_read_1",
+					toolName: "Read",
+					input: { file_path: "/tmp/a.txt" },
+					output: { content: "hello" },
+					providerExecuted: true,
+				},
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", finishReason: "stop" },
+			]),
+		});
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "anthropic", apiKey: "anthropic-key" }],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "anthropic",
+				modelId: "claude-sonnet-4-5",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-call-delta",
+				toolCallId: "cli_read_1",
+				toolName: "Read",
+				execution: "provider",
+			}),
+		);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-result",
+				toolCallId: "cli_read_1",
+				toolName: "Read",
+				execution: "provider",
+				output: { content: "hello" },
+			}),
+		);
+		// Never the runtime-execution path: no execution-less tool events, and
+		// the turn finishes as a normal completion, not a tool-call handoff.
+		expect(
+			events.filter(
+				(event) =>
+					event.type === "tool-call-delta" && event.execution === undefined,
+			),
+		).toHaveLength(0);
+		expect(events.at(-1)).toEqual({ type: "finish", reason: "stop" });
+	});
+
+	it("matches flag-less results and errors to observational provider tool calls by ID", async () => {
+		// Some provider packages set providerExecuted only on the call half of
+		// the pair. Results and errors are matched by tool-call ID so the
+		// activity still completes observationally instead of being dropped or
+		// misread as a runtime tool call.
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{
+					type: "tool-call",
+					toolCallId: "cli_bash_1",
+					toolName: "Bash",
+					input: { command: "ls" },
+					providerExecuted: true,
+				},
+				{
+					type: "tool-result",
+					toolCallId: "cli_bash_1",
+					toolName: "Bash",
+					output: { stdout: "a.txt" },
+				},
+				{
+					type: "tool-call",
+					toolCallId: "cli_bash_2",
+					toolName: "Bash",
+					input: { command: "boom" },
+					providerExecuted: true,
+				},
+				{
+					type: "tool-error",
+					toolCallId: "cli_bash_2",
+					toolName: "Bash",
+					error: new Error("command failed"),
+				},
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", finishReason: "stop" },
+			]),
+		});
+		const gateway = createGateway({
+			providerConfigs: [{ providerId: "anthropic", apiKey: "anthropic-key" }],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "anthropic",
+				modelId: "claude-sonnet-4-5",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-result",
+				toolCallId: "cli_bash_1",
+				toolName: "Bash",
+				execution: "provider",
+				output: { stdout: "a.txt" },
+			}),
+		);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-result",
+				toolCallId: "cli_bash_2",
+				toolName: "Bash",
+				execution: "provider",
+				isError: true,
+				output: { error: "command failed" },
+			}),
+		);
+		expect(events.at(-1)).toEqual({ type: "finish", reason: "stop" });
+	});
+
 	it("rejects model tools not declared by the provider manifest", async () => {
 		const createProvider = vi.fn(() => ({
 			async *stream() {

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -293,7 +293,11 @@ export type AgentModelEvent =
 	| {
 			type: "tool-result";
 			toolCallId: string;
-			toolName: import("./llms/model-tools").ModelToolName;
+			/**
+			 * Declared model tools carry a ModelToolName; provider-executed tools
+			 * (e.g. the Claude Code CLI's own tools) carry arbitrary names.
+			 */
+			toolName: string;
 			input?: unknown;
 			output: unknown;
 			isError?: boolean;


### PR DESCRIPTION
## Problem

Since the provider-aware web search change, `emitAiSdkEvents` diverts every AI-SDK tool part with `providerExecuted: true` out of the normal pipeline — declared model tools (`web_search`, `image_generation`) are re-emitted as observational events, but **everything else is silently dropped**.

The `ai-sdk-provider-claude-code` package marks *every* tool the Claude Code CLI executes as `providerExecuted: true` (openai-codex behaves the same), so those sessions read and edit the workspace with **no tool activity at all** in runtime events, transcripts, or the UI. This is the 4.1.10 regression behind [CLINE-2988](https://linear.app/cline-bot/issue/CLINE-2988/provider-executed-tool-activity-silently-dropped-since-13075-claude) (reported as [#13277](https://github.com/cline/cline/issues/13277)).

## Fix

Route **all** provider-executed parts onto the existing observational path instead of dropping the non-model-tool ones:

- `tool-call` parts with `providerExecuted: true` (and no declared model tool) emit an execution-tagged `tool-call-delta`.
- `tool-result` / `tool-error` parts complete the activity as execution-tagged `tool-result` events. They are matched by tool-call ID as a fallback because some provider packages set `providerExecuted` only on the call half of the pair.
- They still never enter AgentRuntime's local execution/approval loop (that part of the original change is correct), so no synthesized "unknown tool" errors and no approval prompts for tools the provider already ran.
- `AgentModelEvent`'s `tool-result` variant widens `toolName` from `ModelToolName` to `string` to carry the provider's own tool names. The runtime side is already generic.

Downstream, the runtime machinery from the web-search work picks these up unchanged: `tool-started`/`tool-finished` events fire with `execution: "provider"`, the activity persists as `modelToolActivities` message metadata, and `readDisplayMessages` projects it into ordinary tool blocks.

## Out of scope

Hooks still don't fire for provider-executed tools — that needs an interception design (`canUseTool`), tracked in [CLINE-2989](https://linear.app/cline-bot/issue/CLINE-2989/design-hook-semantics-for-provider-executed-tools-claude-codecodex). The hook-output regression from the same report is [CLINE-2987](https://linear.app/cline-bot/issue/CLINE-2987/hook-contextmodification-never-reaches-the-model-on-the-next-engine).

## Testing

- Two new gateway tests: provider-executed activity surfaces as observational events (never the runtime path, finish reason stays `stop`), and flag-less results/errors match observational calls by ID.
- Full suites green: llms (724), shared (354), agents (68), core unit (1897).
- Runtime-level probe confirms `tool-started`/`tool-finished` emit with `execution: "provider"` and the activity lands in message metadata.