### PR TITLE
feat(llms, core): gate provider-executed tools through PreToolUse hooks

### DIFF
--- a/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
@@ -147,6 +147,32 @@ describe("createProviderToolPermission", () => {
 		expect(seenBySecond).toHaveBeenCalled();
 	});
 
+	it("keeps an earlier valid rewrite when a later layer returns a non-object input", async () => {
+		const log = vi.fn();
+		const gate = createProviderToolPermission({
+			hooks: [
+				{ beforeTool: async () => ({ input: { command: "ls -la" } }) },
+				{ beforeTool: async () => ({ input: "not-an-object" }) },
+			],
+			sessionId: "s1",
+			logger: { log, debug: vi.fn() },
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "allow",
+			updatedInput: { command: "ls -la" },
+		});
+		expect(log).toHaveBeenCalled();
+	});
+
+	it("ignores a non-object rewrite when no valid rewrite preceded it", async () => {
+		const gate = createProviderToolPermission({
+			hooks: [{ beforeTool: async () => ({ input: 42 }) }],
+			sessionId: "s1",
+			logger: { log: vi.fn(), debug: vi.fn() },
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({ behavior: "allow" });
+	});
+
 	it("fails open when a hook throws", async () => {
 		const log = vi.fn();
 		const gate = createProviderToolPermission({

--- a/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
@@ -173,6 +173,27 @@ describe("createProviderToolPermission", () => {
 		await expect(gate?.(REQUEST)).resolves.toEqual({ behavior: "allow" });
 	});
 
+	it("supplies a tool descriptor so contract-conformant hooks keep gating", async () => {
+		// The runtime contract guarantees ctx.tool is defined in beforeTool;
+		// a hook reading ctx.tool.name must gate, not throw into fail-open.
+		const gate = createProviderToolPermission({
+			hooks: [
+				{
+					beforeTool: async (ctx: AgentBeforeToolContext) =>
+						ctx.tool.name === "Bash"
+							? { skip: true, reason: `no ${ctx.tool.name}` }
+							: undefined,
+				},
+			],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: "no Bash",
+			interrupt: false,
+		});
+	});
+
 	it("fails open when a hook throws", async () => {
 		const log = vi.fn();
 		const gate = createProviderToolPermission({

--- a/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
@@ -19,9 +19,7 @@ describe("createProviderToolPermission", () => {
 	});
 
 	it("allows when hooks return no control", async () => {
-		const beforeTool = vi.fn(
-			async (_ctx: AgentBeforeToolContext) => undefined,
-		);
+		const beforeTool = vi.fn(async (_ctx: AgentBeforeToolContext) => undefined);
 		const gate = createProviderToolPermission({
 			hooks: [{ beforeTool }],
 			sessionId: "s1",
@@ -89,6 +87,64 @@ describe("createProviderToolPermission", () => {
 			message: "layer two says no",
 			interrupt: false,
 		});
+	});
+
+	it("stops at the first denial: later layers are never consulted and cannot erase it", async () => {
+		const later = vi.fn(async () => {
+			throw new Error("boom");
+		});
+		const gate = createProviderToolPermission({
+			hooks: [
+				{ beforeTool: async () => ({ skip: true, reason: "denied first" }) },
+				{ beforeTool: later },
+			],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: "denied first",
+			interrupt: false,
+		});
+		expect(later).not.toHaveBeenCalled();
+	});
+
+	it("lets later layers deny after an earlier layer throws", async () => {
+		const gate = createProviderToolPermission({
+			hooks: [
+				{
+					beforeTool: async () => {
+						throw new Error("boom");
+					},
+				},
+				{ beforeTool: async () => ({ stop: true, reason: "still denied" }) },
+			],
+			sessionId: "s1",
+			logger: { log: vi.fn(), debug: vi.fn() },
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: "still denied",
+			interrupt: true,
+		});
+	});
+
+	it("threads input overrides through subsequent layers", async () => {
+		const seenBySecond = vi.fn(async (ctx: AgentBeforeToolContext) => {
+			expect(ctx.input).toEqual({ command: "ls -la" });
+			return undefined;
+		});
+		const gate = createProviderToolPermission({
+			hooks: [
+				{ beforeTool: async () => ({ input: { command: "ls -la" } }) },
+				{ beforeTool: seenBySecond },
+			],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "allow",
+			updatedInput: { command: "ls -la" },
+		});
+		expect(seenBySecond).toHaveBeenCalled();
 	});
 
 	it("fails open when a hook throws", async () => {

--- a/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.test.ts
@@ -1,0 +1,110 @@
+import type { AgentBeforeToolContext, AgentHooks } from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createProviderToolPermission } from "./provider-tool-permission";
+
+const REQUEST = {
+	toolName: "Bash",
+	toolCallId: "cli_bash_1",
+	input: { command: "ls" },
+};
+
+describe("createProviderToolPermission", () => {
+	it("returns undefined when no layer has a beforeTool hook", () => {
+		expect(
+			createProviderToolPermission({
+				hooks: [undefined, { afterRun: async () => {} }],
+				sessionId: "s1",
+			}),
+		).toBeUndefined();
+	});
+
+	it("allows when hooks return no control", async () => {
+		const beforeTool = vi.fn(
+			async (_ctx: AgentBeforeToolContext) => undefined,
+		);
+		const gate = createProviderToolPermission({
+			hooks: [{ beforeTool }],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({ behavior: "allow" });
+		const ctx = beforeTool.mock.calls[0][0];
+		expect(ctx.toolCall).toMatchObject({
+			toolCallId: "cli_bash_1",
+			toolName: "Bash",
+			execution: "provider",
+		});
+		expect(ctx.input).toEqual({ command: "ls" });
+		expect(ctx.snapshot).toMatchObject({
+			agentId: "s1",
+			conversationId: "s1",
+		});
+	});
+
+	it("maps stop to an interrupting deny with the hook's reason", async () => {
+		const gate = createProviderToolPermission({
+			hooks: [{ beforeTool: async () => ({ stop: true, reason: "nope" }) }],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: "nope",
+			interrupt: true,
+		});
+	});
+
+	it("maps skip to a non-interrupting deny with a default message", async () => {
+		const gate = createProviderToolPermission({
+			hooks: [{ beforeTool: async () => ({ skip: true }) }],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: 'Tool "Bash" was blocked by a Cline hook',
+			interrupt: false,
+		});
+	});
+
+	it("maps an input override to allow with updatedInput", async () => {
+		const gate = createProviderToolPermission({
+			hooks: [{ beforeTool: async () => ({ input: { command: "ls -la" } }) }],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "allow",
+			updatedInput: { command: "ls -la" },
+		});
+	});
+
+	it("consults every layer and lets any of them deny", async () => {
+		const first: AgentHooks = { beforeTool: async () => undefined };
+		const second: AgentHooks = {
+			beforeTool: async () => ({ skip: true, reason: "layer two says no" }),
+		};
+		const gate = createProviderToolPermission({
+			hooks: [first, second],
+			sessionId: "s1",
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({
+			behavior: "deny",
+			message: "layer two says no",
+			interrupt: false,
+		});
+	});
+
+	it("fails open when a hook throws", async () => {
+		const log = vi.fn();
+		const gate = createProviderToolPermission({
+			hooks: [
+				{
+					beforeTool: async () => {
+						throw new Error("boom");
+					},
+				},
+			],
+			sessionId: "s1",
+			logger: { log, debug: vi.fn() },
+		});
+		await expect(gate?.(REQUEST)).resolves.toEqual({ behavior: "allow" });
+		expect(log).toHaveBeenCalled();
+	});
+});

--- a/sdk/packages/core/src/hooks/provider-tool-permission.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.ts
@@ -70,6 +70,23 @@ function toUpdatedInput(value: unknown): Record<string, unknown> | undefined {
 		: undefined;
 }
 
+// A throwing host logger must never escape the gate's control flow (a logging
+// failure inside the fail-open catch would otherwise reject the whole gate).
+function safeWarn(
+	logger: BasicLogger | undefined,
+	message: string,
+	error?: unknown,
+): void {
+	try {
+		logger?.log?.(message, {
+			severity: "warn",
+			...(error !== undefined ? { error } : {}),
+		});
+	} catch {
+		// Logging failures must not affect gating.
+	}
+}
+
 export function createProviderToolPermission(options: {
 	hooks: ReadonlyArray<AgentHooks | undefined>;
 	sessionId: string;
@@ -105,9 +122,10 @@ export function createProviderToolPermission(options: {
 			} catch (error) {
 				// Fail open per layer: a broken hook must not brick the provider
 				// session, but the remaining layers still get their say.
-				options.logger?.log?.(
+				safeWarn(
+					options.logger,
 					`provider tool permission hook failed for "${request.toolName}"; skipping that hook layer`,
-					{ severity: "warn", ...(error !== undefined ? { error } : {}) },
+					error,
 				);
 				continue;
 			}
@@ -129,9 +147,9 @@ export function createProviderToolPermission(options: {
 					input = rewrite;
 					inputUpdated = true;
 				} else {
-					options.logger?.log?.(
+					safeWarn(
+						options.logger,
 						`provider tool permission hook returned a non-object input rewrite for "${request.toolName}"; ignoring it`,
-						{ severity: "warn" },
 					);
 				}
 			}

--- a/sdk/packages/core/src/hooks/provider-tool-permission.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.ts
@@ -107,14 +107,26 @@ export function createProviderToolPermission(options: {
 				};
 			}
 			if (result?.input !== undefined && result.input !== input) {
-				input = result.input;
-				inputUpdated = true;
+				// Provider tool inputs are object-shaped on the wire; a rewrite
+				// that is not an object cannot be represented and must not
+				// displace a valid rewrite an earlier layer already made.
+				const rewrite = toUpdatedInput(result.input);
+				if (rewrite) {
+					input = rewrite;
+					inputUpdated = true;
+				} else {
+					options.logger?.log?.(
+						`provider tool permission hook returned a non-object input rewrite for "${request.toolName}"; ignoring it`,
+						{ severity: "warn" },
+					);
+				}
 			}
 		}
-		const updatedInput = inputUpdated ? toUpdatedInput(input) : undefined;
 		return {
 			behavior: "allow",
-			...(updatedInput ? { updatedInput } : {}),
+			...(inputUpdated
+				? { updatedInput: input as Record<string, unknown> }
+				: {}),
 		};
 	};
 }

--- a/sdk/packages/core/src/hooks/provider-tool-permission.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.ts
@@ -37,8 +37,22 @@ function syntheticBeforeToolContext(
 			iteration: 0,
 			messages: [],
 		} as unknown as AgentBeforeToolContext["snapshot"],
-		// Provider-executed tools have no local AgentTool registration.
-		tool: undefined as unknown as AgentTool,
+		// Provider-executed tools have no local AgentTool registration, but the
+		// runtime contract guarantees `tool` is defined whenever beforeTool
+		// runs — hooks legitimately read `ctx.tool.name`. Supply an honest
+		// stub so such hooks keep gating instead of throwing into the
+		// per-layer fail-open.
+		tool: {
+			name: request.toolName,
+			description:
+				"Provider-executed tool (runs inside the provider's own session)",
+			inputSchema: {},
+			execute: () => {
+				throw new Error(
+					`Tool "${request.toolName}" is executed by the model provider and cannot be run locally`,
+				);
+			},
+		} satisfies AgentTool,
 		toolCall: {
 			type: "tool-call",
 			toolCallId,

--- a/sdk/packages/core/src/hooks/provider-tool-permission.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.ts
@@ -17,7 +17,6 @@ import type {
 	ProviderToolPermissionCallback,
 	ProviderToolPermissionRequest,
 } from "@cline/shared";
-import { mergeAgentHooks } from "./hook-file-hooks";
 
 function syntheticBeforeToolContext(
 	sessionId: string,
@@ -62,15 +61,42 @@ export function createProviderToolPermission(options: {
 	sessionId: string;
 	logger?: BasicLogger;
 }): ProviderToolPermissionCallback | undefined {
-	const beforeTool = mergeAgentHooks([...options.hooks])?.beforeTool;
-	if (!beforeTool) {
+	// Layers run with the runtime pipeline's beforeTool semantics (see
+	// mergeRuntimeHooks in session-runtime-orchestrator.ts), NOT the
+	// mergeAgentHooks aggregation: the first stop/skip wins immediately and
+	// later layers never see the call, and a layer that throws fails open by
+	// itself — it must not erase a denial another layer already issued or
+	// prevent later layers from being consulted.
+	const layers = options.hooks
+		.map((layer) => layer?.beforeTool)
+		.filter(
+			(handler): handler is NonNullable<AgentHooks["beforeTool"]> =>
+				typeof handler === "function",
+		);
+	if (layers.length === 0) {
 		return undefined;
 	}
 	return async (request) => {
-		try {
-			const result = await beforeTool(
-				syntheticBeforeToolContext(options.sessionId, request),
-			);
+		let input = request.input;
+		let inputUpdated = false;
+		for (const handler of layers) {
+			let result: Awaited<ReturnType<(typeof layers)[number]>>;
+			try {
+				result = await handler(
+					syntheticBeforeToolContext(options.sessionId, {
+						...request,
+						input,
+					}),
+				);
+			} catch (error) {
+				// Fail open per layer: a broken hook must not brick the provider
+				// session, but the remaining layers still get their say.
+				options.logger?.log?.(
+					`provider tool permission hook failed for "${request.toolName}"; skipping that hook layer`,
+					{ severity: "warn", ...(error !== undefined ? { error } : {}) },
+				);
+				continue;
+			}
 			if (result?.stop || result?.skip) {
 				return {
 					behavior: "deny",
@@ -80,21 +106,15 @@ export function createProviderToolPermission(options: {
 					interrupt: result.stop === true,
 				};
 			}
-			const updatedInput =
-				result?.input !== undefined && result.input !== request.input
-					? toUpdatedInput(result.input)
-					: undefined;
-			return {
-				behavior: "allow",
-				...(updatedInput ? { updatedInput } : {}),
-			};
-		} catch (error) {
-			// Fail open: a broken hook must not brick the provider session.
-			options.logger?.log?.(
-				`provider tool permission hook failed for "${request.toolName}"; allowing`,
-				{ severity: "warn", ...(error !== undefined ? { error } : {}) },
-			);
-			return { behavior: "allow" };
+			if (result?.input !== undefined && result.input !== input) {
+				input = result.input;
+				inputUpdated = true;
+			}
 		}
+		const updatedInput = inputUpdated ? toUpdatedInput(input) : undefined;
+		return {
+			behavior: "allow",
+			...(updatedInput ? { updatedInput } : {}),
+		};
 	};
 }

--- a/sdk/packages/core/src/hooks/provider-tool-permission.ts
+++ b/sdk/packages/core/src/hooks/provider-tool-permission.ts
@@ -1,0 +1,100 @@
+// Adapts the session's beforeTool hook chain into a pre-execution gate for
+// provider-executed tools (providers with the `provider-tools` capability,
+// e.g. the Claude Code CLI, run tools inside their own session — those calls
+// never reach AgentRuntime's tool pipeline where hooks normally attach).
+//
+// The gate is consulted from inside the provider's inference request, before
+// the provider runs the tool. Hook semantics mirror the runtime pipeline:
+// `stop`/`cancel` aborts the provider's turn, `skip` blocks just this tool
+// call, an `input` override rewrites the tool input. Hook failures fail open,
+// consistent with hook error handling elsewhere.
+
+import type {
+	AgentBeforeToolContext,
+	AgentHooks,
+	AgentTool,
+	BasicLogger,
+	ProviderToolPermissionCallback,
+	ProviderToolPermissionRequest,
+} from "@cline/shared";
+import { mergeAgentHooks } from "./hook-file-hooks";
+
+function syntheticBeforeToolContext(
+	sessionId: string,
+	request: ProviderToolPermissionRequest,
+): AgentBeforeToolContext {
+	const toolCallId =
+		request.toolCallId ??
+		`provider_tool_${Math.random().toString(36).slice(2)}`;
+	return {
+		// The provider executes mid-request: there is no live runtime snapshot
+		// yet. Hooks only read identity fields and the iteration counter from
+		// it, so a minimal session-scoped snapshot is provided.
+		snapshot: {
+			agentId: sessionId,
+			conversationId: sessionId,
+			runId: sessionId,
+			parentAgentId: undefined,
+			iteration: 0,
+			messages: [],
+		} as unknown as AgentBeforeToolContext["snapshot"],
+		// Provider-executed tools have no local AgentTool registration.
+		tool: undefined as unknown as AgentTool,
+		toolCall: {
+			type: "tool-call",
+			toolCallId,
+			toolName: request.toolName,
+			input: request.input,
+			execution: "provider",
+		},
+		input: request.input,
+	};
+}
+
+function toUpdatedInput(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+export function createProviderToolPermission(options: {
+	hooks: ReadonlyArray<AgentHooks | undefined>;
+	sessionId: string;
+	logger?: BasicLogger;
+}): ProviderToolPermissionCallback | undefined {
+	const beforeTool = mergeAgentHooks([...options.hooks])?.beforeTool;
+	if (!beforeTool) {
+		return undefined;
+	}
+	return async (request) => {
+		try {
+			const result = await beforeTool(
+				syntheticBeforeToolContext(options.sessionId, request),
+			);
+			if (result?.stop || result?.skip) {
+				return {
+					behavior: "deny",
+					message:
+						result.reason ??
+						`Tool "${request.toolName}" was blocked by a Cline hook`,
+					interrupt: result.stop === true,
+				};
+			}
+			const updatedInput =
+				result?.input !== undefined && result.input !== request.input
+					? toUpdatedInput(result.input)
+					: undefined;
+			return {
+				behavior: "allow",
+				...(updatedInput ? { updatedInput } : {}),
+			};
+		} catch (error) {
+			// Fail open: a broken hook must not brick the provider session.
+			options.logger?.log?.(
+				`provider tool permission hook failed for "${request.toolName}"; allowing`,
+				{ severity: "warn", ...(error !== undefined ? { error } : {}) },
+			);
+			return { behavior: "allow" };
+		}
+	};
+}

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -82,6 +82,9 @@ function buildGatewayProviderOptions(
 		const workspace = config.extensionContext?.workspace;
 		Object.assign(options, {
 			cwd: workspace?.cwd ?? workspace?.rootPath,
+			// Gate the CLI's own tool executions through the session's
+			// PreToolUse hooks (a live function; in-process only).
+			onToolPermission: config.onProviderToolPermission,
 		});
 	}
 

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -80,6 +80,49 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 	});
 
+	it("consults extension-contributed beforeTool hooks in the provider tool gate", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input: createStartInput(),
+			localRuntime: {
+				extensions: [
+					{
+						name: "test.policy_extension",
+						manifest: { capabilities: ["hooks"] },
+						hooks: {
+							beforeTool: async () => ({
+								skip: true,
+								reason: "extension policy says no",
+							}),
+						},
+					},
+				],
+			},
+			sessionId: "sess-ext-gate",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		const gate = bootstrap.providerConfig.onProviderToolPermission;
+		expect(gate).toBeTypeOf("function");
+		await expect(
+			gate?.({ toolName: "Bash", toolCallId: "t1", input: { command: "ls" } }),
+		).resolves.toEqual({
+			behavior: "deny",
+			message: "extension policy says no",
+			interrupt: false,
+		});
+	});
+
 	it("lets stored provider model catalog settings override hub defaults", async () => {
 		const { prepareLocalRuntimeBootstrap } = await import(
 			"./local-runtime-bootstrap"

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -400,8 +400,7 @@ export async function prepareLocalRuntimeBootstrap(
 		modelCatalogDefaults,
 		defaultFetch,
 	);
-	const hooks = mergeAgentHooks([
-		baseConfig.hooks,
+	const checkpointHooks =
 		baseConfig.checkpoint?.enabled === true
 			? createCheckpointHooks({
 					cwd: baseConfig.cwd,
@@ -411,15 +410,23 @@ export async function prepareLocalRuntimeBootstrap(
 					readSessionMetadata,
 					writeSessionMetadata,
 				})
-			: undefined,
-	]);
+			: undefined;
+	const hooks = mergeAgentHooks([baseConfig.hooks, checkpointHooks]);
 	// Provider-executed tools (claude-code and friends) never reach the
 	// runtime tool pipeline, so gate them at the provider boundary with the
-	// same hook layers: session hooks (host adapters, checkpoints) plus the
-	// workspace's file-based hooks. Attached unconditionally; the handler
-	// factory forwards it only to providers that execute their own tools.
+	// same hook layers: host adapter hooks, audit hooks, checkpoint hooks,
+	// and the workspace's file-based hooks. Passed unmerged so a denial from
+	// one layer survives a later layer failing (the gate runs them with the
+	// runtime pipeline's first-deny-wins semantics). Attached unconditionally;
+	// the handler factory forwards it only to providers that execute their
+	// own tools.
 	providerConfig.onProviderToolPermission = createProviderToolPermission({
-		hooks: [hooks, fileHookExtension?.hooks],
+		hooks: [
+			localConfig?.hooks,
+			auditHooks,
+			checkpointHooks,
+			fileHookExtension?.hooks,
+		],
 		sessionId,
 		logger: baseConfig.logger,
 	});

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -414,18 +414,21 @@ export async function prepareLocalRuntimeBootstrap(
 	const hooks = mergeAgentHooks([baseConfig.hooks, checkpointHooks]);
 	// Provider-executed tools (claude-code and friends) never reach the
 	// runtime tool pipeline, so gate them at the provider boundary with the
-	// same hook layers: host adapter hooks, audit hooks, checkpoint hooks,
-	// and the workspace's file-based hooks. Passed unmerged so a denial from
-	// one layer survives a later layer failing (the gate runs them with the
-	// runtime pipeline's first-deny-wins semantics). Attached unconditionally;
-	// the handler factory forwards it only to providers that execute their
-	// own tools.
+	// same hook layers the runtime would consult: host adapter hooks, audit
+	// hooks, checkpoint hooks, and every extension's hooks — the file-based
+	// workspace hooks plus host- and plugin-contributed extensions (the
+	// runtime merges config hooks with all registered extension hooks; see
+	// createRuntimeHooks in session-runtime-orchestrator.ts). Passed unmerged
+	// so a denial from one layer survives a later layer failing (the gate
+	// runs them with the runtime pipeline's first-deny-wins semantics).
+	// Attached unconditionally; the handler factory forwards it only to
+	// providers that execute their own tools.
 	providerConfig.onProviderToolPermission = createProviderToolPermission({
 		hooks: [
 			localConfig?.hooks,
 			auditHooks,
 			checkpointHooks,
-			fileHookExtension?.hooks,
+			...(extensions ?? []).map((extension) => extension.hooks),
 		],
 		sessionId,
 		logger: baseConfig.logger,

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -33,6 +33,7 @@ import {
 	createHookConfigFileExtension,
 	mergeAgentHooks,
 } from "../hooks/hook-file-hooks";
+import { createProviderToolPermission } from "../hooks/provider-tool-permission";
 import type { RuntimeCapabilities } from "../runtime/capabilities";
 import { normalizeRuntimeCapabilities } from "../runtime/capabilities";
 import type {
@@ -412,6 +413,16 @@ export async function prepareLocalRuntimeBootstrap(
 				})
 			: undefined,
 	]);
+	// Provider-executed tools (claude-code and friends) never reach the
+	// runtime tool pipeline, so gate them at the provider boundary with the
+	// same hook layers: session hooks (host adapters, checkpoints) plus the
+	// workspace's file-based hooks. Attached unconditionally; the handler
+	// factory forwards it only to providers that execute their own tools.
+	providerConfig.onProviderToolPermission = createProviderToolPermission({
+		hooks: [hooks, fileHookExtension?.hooks],
+		sessionId,
+		logger: baseConfig.logger,
+	});
 	const config: CoreSessionConfig = {
 		...baseConfig,
 		providerConfig,

--- a/sdk/packages/llms/src/providers/config.ts
+++ b/sdk/packages/llms/src/providers/config.ts
@@ -8,6 +8,7 @@
 import type {
 	BasicLogger,
 	ExtensionContext,
+	ProviderToolPermissionCallback,
 	ReasoningEffort,
 } from "@cline/shared";
 import type { ModelInfo, ProviderClient } from "../catalog/types";
@@ -332,6 +333,14 @@ export interface ProviderConfig
 
 	/** Claude Code-specific options */
 	claudeCode?: ClaudeCodeConfig;
+
+	/**
+	 * Pre-execution gate for provider-executed tools (providers with the
+	 * `provider-tools` capability run tools inside their own session). Hosts
+	 * derive this from their hook layers; it is a live function and only
+	 * works in-process.
+	 */
+	onProviderToolPermission?: ProviderToolPermissionCallback;
 
 	/** OpenCode-specific options */
 	opencode?: OpenCodeConfig;

--- a/sdk/packages/llms/src/providers/vendors/community-claude-code.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community-claude-code.test.ts
@@ -1,0 +1,136 @@
+import type { GatewayResolvedProviderConfig } from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createClaudeCode = vi.fn(() => (modelId: string) => ({ modelId }));
+
+vi.mock("ai-sdk-provider-claude-code", () => ({
+	createClaudeCode,
+}));
+
+import { createClaudeCodeProviderModule } from "./community";
+
+type SdkHookCallback = (...args: unknown[]) => Promise<Record<string, unknown>>;
+
+function capturedSettings(): Record<string, unknown> {
+	const call = createClaudeCode.mock.calls.at(-1) as unknown[] | undefined;
+	const options = call?.[0] as { defaultSettings?: Record<string, unknown> };
+	return options?.defaultSettings ?? {};
+}
+
+function capturedPreToolUseHook(): SdkHookCallback {
+	const hooks = capturedSettings().hooks as
+		| Record<string, Array<{ hooks: SdkHookCallback[] }>>
+		| undefined;
+	const callback = hooks?.PreToolUse?.[0]?.hooks?.[0];
+	if (!callback) {
+		throw new Error("expected a wired PreToolUse hook");
+	}
+	return callback;
+}
+
+function makeConfig(
+	options: Record<string, unknown>,
+): GatewayResolvedProviderConfig {
+	return { providerId: "claude-code", options };
+}
+
+describe("createClaudeCodeProviderModule PreToolUse gating", () => {
+	beforeEach(() => {
+		createClaudeCode.mockClear();
+	});
+
+	it("wires no hooks when the host provides no permission callback", async () => {
+		await createClaudeCodeProviderModule(makeConfig({}));
+		expect(capturedSettings().hooks).toBeUndefined();
+	});
+
+	it("never clobbers hooks the caller configured explicitly", async () => {
+		const userHooks = { PreToolUse: [] };
+		await createClaudeCodeProviderModule(
+			makeConfig({
+				onToolPermission: vi.fn(),
+				defaultSettings: { hooks: userHooks },
+			}),
+		);
+		expect(capturedSettings().hooks).toBe(userHooks);
+	});
+
+	it("translates the SDK hook payload into a permission request", async () => {
+		const onToolPermission = vi.fn(async () => ({ behavior: "allow" }));
+		await createClaudeCodeProviderModule(makeConfig({ onToolPermission }));
+
+		const output = await capturedPreToolUseHook()({
+			hook_event_name: "PreToolUse",
+			tool_name: "Read",
+			tool_input: { file_path: "/tmp/a.txt" },
+			tool_use_id: "cli_read_1",
+		});
+
+		expect(onToolPermission).toHaveBeenCalledWith({
+			toolName: "Read",
+			toolCallId: "cli_read_1",
+			input: { file_path: "/tmp/a.txt" },
+		});
+		// Allow must NOT force a permission decision: the CLI's own permission
+		// flow (user settings, permission mode) still applies.
+		expect(output).toEqual({
+			hookSpecificOutput: { hookEventName: "PreToolUse" },
+		});
+	});
+
+	it("passes an input override through as updatedInput", async () => {
+		const onToolPermission = vi.fn(async () => ({
+			behavior: "allow",
+			updatedInput: { file_path: "/tmp/b.txt" },
+		}));
+		await createClaudeCodeProviderModule(makeConfig({ onToolPermission }));
+
+		const output = await capturedPreToolUseHook()({
+			tool_name: "Read",
+			tool_input: { file_path: "/tmp/a.txt" },
+			tool_use_id: "cli_read_1",
+		});
+
+		expect(output).toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				updatedInput: { file_path: "/tmp/b.txt" },
+			},
+		});
+	});
+
+	it("maps deny to a permission denial, and interrupt to a turn stop", async () => {
+		const onToolPermission = vi
+			.fn()
+			.mockResolvedValueOnce({ behavior: "deny", message: "not this file" })
+			.mockResolvedValueOnce({
+				behavior: "deny",
+				message: "stop everything",
+				interrupt: true,
+			});
+		await createClaudeCodeProviderModule(makeConfig({ onToolPermission }));
+		const hook = capturedPreToolUseHook();
+
+		await expect(
+			hook({ tool_name: "Read", tool_input: {}, tool_use_id: "t1" }),
+		).resolves.toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: "not this file",
+			},
+		});
+
+		await expect(
+			hook({ tool_name: "Bash", tool_input: {}, tool_use_id: "t2" }),
+		).resolves.toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: "stop everything",
+			},
+			continue: false,
+			stopReason: "stop everything",
+		});
+	});
+});

--- a/sdk/packages/llms/src/providers/vendors/community-claude-code.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community-claude-code.test.ts
@@ -44,15 +44,29 @@ describe("createClaudeCodeProviderModule PreToolUse gating", () => {
 		expect(capturedSettings().hooks).toBeUndefined();
 	});
 
-	it("never clobbers hooks the caller configured explicitly", async () => {
-		const userHooks = { PreToolUse: [] };
+	it("appends the gate alongside caller-configured hooks instead of yielding", async () => {
+		// Configuring an unrelated hook (or even other PreToolUse matchers)
+		// must never silently disable the policy gate.
+		const userPreToolUse = { matcher: "Bash", hooks: [vi.fn()] };
+		const userNotification = [{ hooks: [vi.fn()] }];
 		await createClaudeCodeProviderModule(
 			makeConfig({
 				onToolPermission: vi.fn(),
-				defaultSettings: { hooks: userHooks },
+				defaultSettings: {
+					hooks: {
+						PreToolUse: [userPreToolUse],
+						Notification: userNotification,
+					},
+				},
 			}),
 		);
-		expect(capturedSettings().hooks).toBe(userHooks);
+		const hooks = capturedSettings().hooks as Record<string, unknown[]>;
+		expect(hooks.Notification).toBe(userNotification);
+		expect(hooks.PreToolUse).toHaveLength(2);
+		expect(hooks.PreToolUse[0]).toBe(userPreToolUse);
+		expect(
+			(hooks.PreToolUse[1] as { hooks: unknown[] }).hooks[0],
+		).toBeInstanceOf(Function);
 	});
 
 	it("translates the SDK hook payload into a permission request", async () => {

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -1,7 +1,10 @@
 import { accessSync, existsSync, constants as fsConstants } from "node:fs";
 import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
-import type { GatewayResolvedProviderConfig } from "@cline/shared";
+import type {
+	GatewayResolvedProviderConfig,
+	ProviderToolPermissionCallback,
+} from "@cline/shared";
 // Keep this import static so the VS Code extension bundle includes the SAP
 // provider. Hiding it behind a computed dynamic import leaves the published
 // extension trying to load @jerome-benoit/sap-ai-provider from node_modules at
@@ -97,10 +100,76 @@ export async function createClaudeCodeProviderModule(
 			{ cause: error },
 		);
 	}
-	const { cwd: workspaceCwd, ...options } = readOptions(config);
+	const {
+		cwd: workspaceCwd,
+		onToolPermission,
+		...options
+	} = readOptions(config);
 	const defaultSettings: Record<string, unknown> = {
 		...((options.defaultSettings as Record<string, unknown> | undefined) ?? {}),
 	};
+	// Bridge the host's provider-tool gate into the agent session as a native
+	// PreToolUse hook. Hooks (unlike canUseTool) fire for every tool use,
+	// including tools the CLI would allow without prompting, so the host's
+	// PreToolUse hooks observe and can veto all of them.
+	if (
+		typeof onToolPermission === "function" &&
+		defaultSettings.hooks === undefined
+	) {
+		const permission = onToolPermission as ProviderToolPermissionCallback;
+		defaultSettings.hooks = {
+			PreToolUse: [
+				{
+					hooks: [
+						async (...args: unknown[]) => {
+							const payload =
+								args[0] && typeof args[0] === "object"
+									? (args[0] as Record<string, unknown>)
+									: {};
+							const result = await permission({
+								toolName:
+									typeof payload.tool_name === "string"
+										? payload.tool_name
+										: "tool",
+								toolCallId:
+									typeof payload.tool_use_id === "string"
+										? payload.tool_use_id
+										: undefined,
+								input: payload.tool_input,
+							});
+							if (result.behavior === "deny") {
+								const message =
+									result.message ?? "Tool call was blocked by a Cline hook";
+								return {
+									hookSpecificOutput: {
+										hookEventName: "PreToolUse",
+										permissionDecision: "deny",
+										permissionDecisionReason: message,
+									},
+									// interrupt stops the whole agent turn (a hook `cancel`),
+									// a plain deny only blocks this tool call.
+									...(result.interrupt
+										? { continue: false, stopReason: message }
+										: {}),
+								};
+							}
+							// Allow: return no permissionDecision so the CLI's own
+							// permission flow (user settings, permission mode) still
+							// applies — the gate must never widen what the user allowed.
+							return {
+								hookSpecificOutput: {
+									hookEventName: "PreToolUse",
+									...(result.updatedInput
+										? { updatedInput: result.updatedInput }
+										: {}),
+								},
+							};
+						},
+					],
+				},
+			],
+		};
+	}
 	if (defaultSettings.pathToClaudeCodeExecutable === undefined) {
 		const executable = resolveClaudeExecutable();
 		if (executable !== undefined) {

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -111,14 +111,25 @@ export async function createClaudeCodeProviderModule(
 	// Bridge the host's provider-tool gate into the agent session as a native
 	// PreToolUse hook. Hooks (unlike canUseTool) fire for every tool use,
 	// including tools the CLI would allow without prompting, so the host's
-	// PreToolUse hooks observe and can veto all of them.
-	if (
-		typeof onToolPermission === "function" &&
-		defaultSettings.hooks === undefined
-	) {
+	// PreToolUse hooks observe and can veto all of them. Caller-configured
+	// hooks are preserved and the gate is appended alongside them (the SDK
+	// runs every matcher) — configuring an unrelated hook must never silently
+	// disable the policy gate.
+	if (typeof onToolPermission === "function") {
 		const permission = onToolPermission as ProviderToolPermissionCallback;
+		const configuredHooks =
+			defaultSettings.hooks &&
+			typeof defaultSettings.hooks === "object" &&
+			!Array.isArray(defaultSettings.hooks)
+				? (defaultSettings.hooks as Record<string, unknown>)
+				: undefined;
+		const configuredPreToolUse = Array.isArray(configuredHooks?.PreToolUse)
+			? (configuredHooks.PreToolUse as unknown[])
+			: [];
 		defaultSettings.hooks = {
+			...(configuredHooks ?? {}),
 			PreToolUse: [
+				...configuredPreToolUse,
 				{
 					hooks: [
 						async (...args: unknown[]) => {

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -183,6 +183,39 @@ export interface GatewayProviderManifest {
 	metadata?: GatewayProviderMetadata;
 }
 
+/**
+ * A tool call a provider is about to execute inside its own session (e.g. the
+ * Claude Code CLI's native tools), offered to the host for gating before it
+ * runs.
+ */
+export interface ProviderToolPermissionRequest {
+	toolName: string;
+	toolCallId?: string;
+	input: unknown;
+}
+
+export type ProviderToolPermissionResult =
+	| {
+			behavior: "allow";
+			/** Replacement input for the tool call, when a hook rewrote it. */
+			updatedInput?: Record<string, unknown>;
+	  }
+	| {
+			behavior: "deny";
+			message?: string;
+			/** Stop the provider's whole turn instead of just this tool call. */
+			interrupt?: boolean;
+	  };
+
+/**
+ * Pre-execution gate for provider-executed tools. Lives only in-process (it is
+ * a function and never serializes across a transport); hosts construct it
+ * where their hook layers live.
+ */
+export type ProviderToolPermissionCallback = (
+	request: ProviderToolPermissionRequest,
+) => Promise<ProviderToolPermissionResult>;
+
 export interface GatewayProviderSettings {
 	apiKey?: string;
 	apiKeyResolver?: () => string | undefined | Promise<string | undefined>;


### PR DESCRIPTION
Independent of #13300 (no shared files; based on main). The two complement each other for claude-code sessions: #13300 makes the CLI's tool activity visible, this PR makes it gateable. The live e2e below was run with both applied — a denial renders as a visible tool block only once #13300 is in.

## Problem

For providers with the `provider-tools` capability (claude-code, openai-codex) the CLI executes tools inside its own session, so Cline's `PreToolUse`/`PostToolUse` hooks never fire — there is no interception point in the runtime tool pipeline. This is the remaining half of [#13277](https://github.com/cline/cline/issues/13277), tracked in [CLINE-2989](https://linear.app/cline-bot/issue/CLINE-2989/design-hook-semantics-for-provider-executed-tools-claude-codecodex). It is a regression vs the legacy extension, which ran these CLIs as plain text models and executed all tools itself.

## Approach

Give the session's `beforeTool` hook chain a seat *inside* the provider's loop:

- **core**: `createProviderToolPermission` (new) adapts the merged hook layers — host adapter hooks plus the workspace's `.clinerules/hooks` file hooks — into a `ProviderToolPermissionCallback`. The bootstrap attaches it to the provider config (a live function, in-process only — same pattern as the existing `fetch` threading; it works in both the extension host and the hub daemon because the callback is constructed where the hooks live).
- **llms**: the claude-code provider module wires the callback into the agent session as a **native SDK `PreToolUse` hook** rather than `canUseTool`. Hooks fire for *every* tool use — including tools the CLI allows without prompting (`Read`, `Glob`), which `canUseTool` would never see. The ticket sketched `canUseTool`; this is the same interception idea with strictly better coverage.

Semantics mirror the runtime pipeline (tightened during review — thanks to the three findings below, each of which was a real gate-weakening bug):
- hook `cancel` (stop) → deny + interrupt: aborts the provider's turn
- hook `skip` → deny: blocks just that tool call, the session continues
- hook input override → `updatedInput`
- hook failure → fail open (a broken hook must not brick the session)
- **an allow never returns a permission decision** — the CLI's own permission rules and mode still apply, so the gate can only narrow, never widen, what the user allowed
- **first deny wins**: hook layers run unmerged with the runtime pipeline's `beforeTool` semantics — the first `stop`/`skip` returns immediately and later layers are never consulted, so nothing (including a later layer throwing) can erase a denial; a throwing layer fails open by itself while the rest still get their say
- **rewrites are validated per layer**: provider tool inputs are object-shaped on the wire, so a non-object `input` rewrite is ignored with a warning instead of displacing an earlier approved rewrite
- **caller-configured `defaultSettings.hooks` are merged, not a bypass**: the gate's `PreToolUse` matcher is appended alongside the caller's hooks (the SDK runs every matcher) — configuring an unrelated hook can never silently disable the gate, and caller entries are preserved untouched

## Testing

- Unit: hook-chain → permission mapping incl. deny-preservation and rewrite-validation edge cases (12 cases, core) and SDK hook payload/output translation incl. hook merging (5 cases, llms, package mocked). Full suites green: llms 740, shared 354, core unit 2022.
- Semi-manual TUI pass (re-run after the review fixes): a denial renders as an error-styled tool block with the hook's message, the turn stops per interrupt semantics with the spinner cleared and input usable, the session survives the interrupt (follow-up turn completes), and a cold resume replays the denial identically. The blocked file's contents appear nowhere in the raw terminal stream.
- Live e2e with the real Claude Code CLI (headless cline session, local backend):
  - a `.clinerules/hooks/PreToolUse` script **fires** on the CLI's `Read` (payload `hookName: tool_call`, tool `Read`) — the original reporter's exact scenario;
  - a denying hook **blocks** the read: the tool block renders the denial, the file's contents never reach the model or output, and `cancel` stops the turn.

## Notes for review

- A file hook's `errorMessage` currently surfaces as the generic deny message, not verbatim — `parseHookControl` maps `errorMessage` into `context`, which `beforeToolResultFromControl` doesn't forward as `reason`. That is the [CLINE-2987](https://linear.app/cline-bot/issue/CLINE-2987/hook-contextmodification-never-reaches-the-model-on-the-next-engine) plumbing area; once its `appendContext`/reason work lands, the message flows through here unchanged.
- `PostToolUse` dispatch for provider tools is intentionally not in this PR — it wants the observational `tool-result` events from #13300 as its source and is follow-up work on CLINE-2989.
- openai-codex is not wired (its provider package has no equivalent hook bridge); the handler factory only forwards the callback for claude-code.

