### PR TITLE
fix(llms): catch container-level tool-call truncation left open by #13001

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -706,6 +706,7 @@
         "dify-ai-provider": "^1.1.0",
         "nanoid": "^5.1.7",
         "ollama-ai-provider-v2": "^4",
+        "prefix-safe-json": "0.0.1-alpha.3",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -4342,6 +4343,8 @@
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
+    "prefix-safe-json": ["prefix-safe-json@0.0.1-alpha.3", "", { "dependencies": { "ajv": "^8.20.0" } }, "sha512-Yzc0ubKw6TnFA14TrZa4DdWLSAxT/f3sRrorgoWgODAYZ8R7opV3fttv9j51+jPJ9Uq/42c9iblFjRzjPkNdPw=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
@@ -5990,6 +5993,8 @@
 
     "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
+    "prefix-safe-json/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
@@ -6861,6 +6866,8 @@
     "ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "pkg-up/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
+    "prefix-safe-json/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "radix-ui/@radix-ui/react-navigation-menu/@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -710,6 +710,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@cline/agents": "workspace:*",
         "ai-sdk-provider-claude-code": "^4",
         "ai-sdk-provider-codex-cli": "^2",
       },

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -74,6 +74,7 @@
 		"dify-ai-provider": "^1.1.0",
 		"nanoid": "^5.1.7",
 		"ollama-ai-provider-v2": "^4",
+		"prefix-safe-json": "0.0.1-alpha.3",
 		"zod": "^4.3.6"
 	},
 	"peerDependencies": {

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -83,6 +83,7 @@
 		"ai-sdk-provider-codex-cli": "^2"
 	},
 	"devDependencies": {
+		"@cline/agents": "workspace:*",
 		"ai-sdk-provider-claude-code": "^4",
 		"ai-sdk-provider-codex-cli": "^2"
 	}

--- a/sdk/packages/llms/src/providers/ai-sdk-execution-dispatch.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-execution-dispatch.test.ts
@@ -1,0 +1,379 @@
+import { AgentRuntime } from "@cline/agents";
+import type {
+	AgentModel,
+	AgentModelRequest,
+	AgentTool,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { createOpenAICompatibleProvider } from "./ai-sdk";
+
+/**
+ * Execution-level dispatch-safety tests for the prefix-safe-json truncation
+ * side-channel added in ai-sdk.ts.
+ *
+ * ai-sdk.tool-calls.test.ts proves the *emitted event* carries corrective
+ * metadata (`metadata.inputParseError`). It does not prove a tool is never
+ * actually invoked before that event becomes available - the concern this
+ * file exists to settle: does prepareToolExecution() ever see a tool call
+ * *before* the stream-end-driven correction has been merged into it?
+ *
+ * This drives this package's real provider (createOpenAICompatibleProvider,
+ * unmodified from ai-sdk.tool-calls.test.ts's own harness) all the way
+ * through @cline/agents' real dispatch path - AgentRuntime.run() ->
+ * executeToolCalls() -> prepareToolExecution() -> tool.execute() - with an
+ * instrumented tool that counts real invocations, not emitted events.
+ *
+ * @cline/agents is a devDependency declared for this file only; @cline/llms
+ * has no runtime dependency on it and nothing in src/index.ts changes.
+ */
+
+function sseChunk(delta: unknown, finish: string | null = null): string {
+	return `data: ${JSON.stringify({
+		id: "cmpl-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "test-model",
+		choices: [{ index: 0, delta, finish_reason: finish }],
+	})}\n\n`;
+}
+
+/** Same shape as ai-sdk.tool-calls.test.ts's sseToolCalls, duplicated here
+ * deliberately - this file has no import relationship to that one. */
+function toolCallsSse(
+	calls: ReadonlyArray<{ name: string; args: string }>,
+	finishReason: string,
+): string {
+	let body = sseChunk({
+		role: "assistant",
+		tool_calls: calls.map((call, index) => ({
+			index,
+			id: `call_${index}`,
+			type: "function",
+			function: { name: call.name, arguments: "" },
+		})),
+	});
+	for (const [index, call] of calls.entries()) {
+		body += sseChunk({
+			tool_calls: [{ index, function: { arguments: call.args } }],
+		});
+	}
+	body += sseChunk({}, finishReason);
+	body += "data: [DONE]\n\n";
+	return body;
+}
+
+/** A plain text-only completion turn with no tool calls - used as the
+ * follow-up turn so the agent loop can terminate cleanly after processing
+ * whatever happened (executed, skipped, or errored) on the first turn. */
+function textOnlySse(text: string): string {
+	return (
+		sseChunk({ role: "assistant", content: text }) +
+		sseChunk({}, "stop") +
+		"data: [DONE]\n\n"
+	);
+}
+
+/** Real network failure before any streaming starts at all - closest
+ * approximation of a provider/connection error for this harness. */
+function createFailingFetch(): typeof fetch {
+	return (async () => {
+		throw new Error("simulated network failure");
+	}) as unknown as typeof fetch;
+}
+
+function createScriptedModel(
+	steps: ReadonlyArray<{ sseBody: string } | { fetchOverride: typeof fetch }>,
+): AgentModel {
+	let stepIndex = 0;
+	return {
+		async stream(request: AgentModelRequest) {
+			const step = steps[stepIndex];
+			stepIndex += 1;
+			if (!step) throw new Error("No scripted step available");
+			const fetchImpl: typeof fetch =
+				"fetchOverride" in step
+					? step.fetchOverride
+					: ((async () =>
+							new Response(step.sseBody, {
+								status: 200,
+								headers: { "content-type": "text/event-stream" },
+							})) as unknown as typeof fetch);
+			const config = {
+				providerId: "openai-compatible",
+				apiKey: "test-key",
+				baseUrl: "http://fake.local/v1",
+				fetch: fetchImpl,
+			};
+			const provider = await createOpenAICompatibleProvider(config);
+			const model = {
+				id: "test-model",
+				providerId: "openai-compatible",
+				name: "test-model",
+			};
+			const context = {
+				provider: {
+					id: "openai-compatible",
+					name: "OpenAI Compatible",
+					defaultModelId: "test-model",
+					models: [model],
+				},
+				model,
+				config,
+			} as unknown as GatewayProviderContext;
+			// AgentRuntime's own request construction (see generateAssistantMessage
+			// in agent-runtime.ts) is provider-agnostic and doesn't set
+			// providerId/modelId - it defers provider selection entirely to
+			// whatever AgentModel wraps it. This adapter is the thing supplying
+			// that, so it fills them in here the same way ai-sdk.tool-calls.test.ts's
+			// own hand-built request does.
+			return provider.stream(
+				{
+					...request,
+					providerId: "openai-compatible",
+					modelId: "test-model",
+				} as unknown as GatewayStreamRequest,
+				context,
+			);
+		},
+	};
+}
+
+function createInstrumentedTool(name: string): {
+	tool: AgentTool;
+	executions: () => number;
+} {
+	let count = 0;
+	return {
+		tool: {
+			name,
+			description: `Instrumented test tool ${name}`,
+			inputSchema: { type: "object" },
+			async execute() {
+				count += 1;
+				return { ok: true };
+			},
+		},
+		executions: () => count,
+	};
+}
+
+describe("execution-level dispatch safety (prefix-safe-json truncation side-channel)", () => {
+	it("1. complete call: tool executes exactly once", async () => {
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[
+						{
+							name: "run_commands",
+							args: '{"commands":["npm install","npm test"]}',
+						},
+					],
+					"tool_calls",
+				),
+			},
+			{ sseBody: textOnlySse("done") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		const result = await runtime.run("run the tests");
+
+		expect(result.status).toBe("completed");
+		expect(executions()).toBe(1);
+	});
+
+	it("2. mid-string truncated (#13015's existing case): tool executes zero times", async () => {
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[{ name: "run_commands", args: '{"commands": ["npm install' }],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		await runtime.run("run the tests");
+
+		expect(executions()).toBe(0);
+	});
+
+	it("3. container-level truncated (#13001 residual, literal repro): tool executes zero times", async () => {
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[
+						{
+							name: "run_commands",
+							args: '{"commands":["npm install","npm test"',
+						},
+					],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		await runtime.run("run the tests");
+
+		expect(executions()).toBe(0);
+	});
+
+	it("4. syntactically-complete repaired JSON but finish_reason: length: tool executes zero times", async () => {
+		// No repair even needed here - the JSON is already fully valid on its
+		// own - but the stream itself says it was cut short. Exercises the
+		// "complete status, but not executable" branch (reason mismatch)
+		// rather than the "root never closed" branch scenario 3 exercises.
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[
+						{
+							name: "run_commands",
+							args: '{"commands":["npm install","npm test"]}',
+						},
+					],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		await runtime.run("run the tests");
+
+		expect(executions()).toBe(0);
+	});
+
+	it("5. parallel complete + truncated calls under one length-terminated stream: truncated call never executes", async () => {
+		const readFiles = createInstrumentedTool("read_files");
+		const runCommands = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[
+						{ name: "read_files", args: '{"files":[{"path":"/tmp/a.txt"}]}' },
+						{
+							name: "run_commands",
+							args: '{"commands":["npm install","npm test"',
+						},
+					],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [readFiles.tool, runCommands.tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		await runtime.run("read a file and run the tests");
+
+		// The safety requirement: the truncated call must never execute.
+		expect(runCommands.executions()).toBe(0);
+		// Disclosed, conservative side effect (not a bug in this integration):
+		// prefix-safe-json's coordinator applies one shared stream-level end
+		// reason to every call it tracked, not a per-call one, so the
+		// genuinely-complete read_files call is held back too rather than
+		// silently allowed through alongside a truncated sibling.
+		expect(readFiles.executions()).toBe(0);
+	});
+
+	it("6. existing #13015 mid-string test keeps its original event-level message (no double-correction)", async () => {
+		const { tool } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[{ name: "run_commands", args: '{"commands": ["npm install' }],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		const result = await runtime.run("run the tests");
+		const toolResultMessages = result.messages.filter((m) => m.role === "tool");
+
+		// Exactly one tool-result for the one tool call - never two, which
+		// would indicate the existing tool-error path and the new side-channel
+		// both independently produced a dispatch-affecting signal.
+		expect(toolResultMessages).toHaveLength(1);
+	});
+
+	it("7. no duplicate corrective/error dispatch: exactly one tool-result message for the truncated call", async () => {
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{
+				sseBody: toolCallsSse(
+					[
+						{
+							name: "run_commands",
+							args: '{"commands":["npm install","npm test"',
+						},
+					],
+					"length",
+				),
+			},
+			{ sseBody: textOnlySse("stopping") },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		const result = await runtime.run("run the tests");
+		const toolResultMessages = result.messages.filter((m) => m.role === "tool");
+
+		expect(toolResultMessages).toHaveLength(1);
+		expect(executions()).toBe(0);
+	});
+
+	it("8. provider/network error before any tool call starts: tool executes zero times", async () => {
+		const { tool, executions } = createInstrumentedTool("run_commands");
+		const model = createScriptedModel([
+			{ fetchOverride: createFailingFetch() },
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			tools: [tool],
+			toolPolicies: { "*": { autoApprove: true } },
+		});
+
+		// AgentRuntime.run() reports failure via result.status rather than a
+		// rejected promise (see AgentRunResult).
+		const result = await runtime.run("run the tests");
+		expect(result.status).toBe("failed");
+		expect(executions()).toBe(0);
+	});
+});

--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -111,7 +111,9 @@ function sseToolCalls(
 		})),
 	});
 	for (const [index, call] of calls.entries()) {
-		body += chunk({ tool_calls: [{ index, function: { arguments: call.args } }] });
+		body += chunk({
+			tool_calls: [{ index, function: { arguments: call.args } }],
+		});
 	}
 	body += chunk({}, finishReason);
 	body += "data: [DONE]\n\n";
@@ -238,7 +240,12 @@ describe("ai-sdk adapter malformed tool calls", () => {
 		// tell you the model didn't actually finish.
 		const events = await streamToolCallEvents(
 			sseToolCalls(
-				[{ name: "run_commands", args: '{"commands":["npm install","npm test"' }],
+				[
+					{
+						name: "run_commands",
+						args: '{"commands":["npm install","npm test"',
+					},
+				],
 				"length",
 			),
 			[RUN_COMMANDS_TOOL],
@@ -263,7 +270,10 @@ describe("ai-sdk adapter malformed tool calls", () => {
 			sseToolCalls(
 				[
 					{ name: "read_files", args: '{"files": [{"path": "/tmp/a.txt"}]}' },
-					{ name: "run_commands", args: '{"commands":["npm install","npm test"' },
+					{
+						name: "run_commands",
+						args: '{"commands":["npm install","npm test"',
+					},
 				],
 				"length",
 			),
@@ -271,13 +281,26 @@ describe("ai-sdk adapter malformed tool calls", () => {
 		);
 
 		const parseErrors = events
-			.filter((event): event is Extract<AgentModelEvent, { type: "tool-call-delta" }> => event.type === "tool-call-delta")
-			.map((event) => (event.metadata as Record<string, unknown> | undefined)?.inputParseError)
+			.filter(
+				(
+					event,
+				): event is Extract<AgentModelEvent, { type: "tool-call-delta" }> =>
+					event.type === "tool-call-delta",
+			)
+			.map(
+				(event) =>
+					(event.metadata as Record<string, unknown> | undefined)
+						?.inputParseError,
+			)
 			.filter((message): message is string => typeof message === "string");
 
 		expect(parseErrors).toHaveLength(2);
-		expect(parseErrors.some((message) => message.includes("read_files"))).toBe(true);
-		expect(parseErrors.some((message) => message.includes("run_commands"))).toBe(true);
+		expect(parseErrors.some((message) => message.includes("read_files"))).toBe(
+			true,
+		);
+		expect(
+			parseErrors.some((message) => message.includes("run_commands")),
+		).toBe(true);
 	});
 
 	it("surfaces parse error for truncated JSON with unterminated string value", async () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.tool-calls.test.ts
@@ -82,6 +82,42 @@ function sseToolCall(toolName: string, args: string): string {
 	);
 }
 
+/**
+ * Same shape as sseToolCall, generalized to N concurrent tool calls and an
+ * explicit finish_reason - used for the truncation side-channel tests below,
+ * which specifically need finish_reason: "length" (a real max-output-tokens
+ * cutoff, not the "tool_calls" clean-finish every other test in this file
+ * uses).
+ */
+function sseToolCalls(
+	calls: ReadonlyArray<{ name: string; args: string }>,
+	finishReason: string,
+): string {
+	const chunk = (delta: unknown, finish: string | null = null) =>
+		`data: ${JSON.stringify({
+			id: "cmpl-1",
+			object: "chat.completion.chunk",
+			created: 1,
+			model: "test-model",
+			choices: [{ index: 0, delta, finish_reason: finish }],
+		})}\n\n`;
+	let body = chunk({
+		role: "assistant",
+		tool_calls: calls.map((call, index) => ({
+			index,
+			id: `call_${index}`,
+			type: "function",
+			function: { name: call.name, arguments: "" },
+		})),
+	});
+	for (const [index, call] of calls.entries()) {
+		body += chunk({ tool_calls: [{ index, function: { arguments: call.args } }] });
+	}
+	body += chunk({}, finishReason);
+	body += "data: [DONE]\n\n";
+	return body;
+}
+
 async function streamToolCallEvents(
 	sseBody: string,
 	tools: AgentToolDefinition[],
@@ -176,14 +212,72 @@ describe("ai-sdk adapter malformed tool calls", () => {
 		expect(findToolInput(events)).toEqual({ commands: ["ls", "pwd"] });
 	});
 
-	it("repairs unclosed container brackets with complete string values", async () => {
+	it("no longer treats a syntactically-repaired unclosed container as safe to execute", async () => {
+		// jsonrepair still mechanically closes the missing brace here - this
+		// is unchanged, see the "repairs unclosed containers" case in the
+		// repairMalformedToolCall describe block below. What changed is that
+		// the adapter no longer treats *that* success as proof the model was
+		// actually done: prefix-safe-json's own independent tracking of the
+		// raw, unrepaired argument text sees the same root object never
+		// closed, and flags it - regardless of jsonrepair's guess.
 		const events = await streamToolCallEvents(
 			sseToolCall("read_files", '{"files": [{"path": "/tmp/a.txt"}]'),
 			[READ_FILES_TOOL],
 		);
 
-		expect(findParseError(events)).toBeUndefined();
-		expect(findToolInput(events)).toEqual({ files: [{ path: "/tmp/a.txt" }] });
+		expect(findParseError(events)).toContain("were not confirmed complete");
+	});
+
+	it("container-level truncation cut short by max_tokens (finish_reason: length) is never executed", async () => {
+		// The exact repro from cline/cline#13001's still-open residual: no
+		// unterminated string anywhere in the raw text (both list elements
+		// are complete), so #13015's hasUnterminatedString guard does not
+		// apply and jsonrepair happily closes the array. Only provider
+		// stream metadata - finish_reason: "length" here - or (as in this
+		// case) the fact that the outer container never closed at all can
+		// tell you the model didn't actually finish.
+		const events = await streamToolCallEvents(
+			sseToolCalls(
+				[{ name: "run_commands", args: '{"commands":["npm install","npm test"' }],
+				"length",
+			),
+			[RUN_COMMANDS_TOOL],
+		);
+
+		expect(findParseError(events)).toContain("were not confirmed complete");
+	});
+
+	it("parallel calls: a complete tool call and a truncated one in the same length-terminated stream both fail closed", async () => {
+		// Deliberately verifies the more conservative of two possible
+		// behaviors: prefix-safe-json's coordinator applies one shared
+		// stream-level end reason to every call it tracked (see its own
+		// docs/EXECUTION_GATE.md limitations section) - it does not currently
+		// distinguish "this call's own JSON closed cleanly before the cutoff"
+		// from "the whole response was cut short by length". A call whose
+		// own JSON is genuinely complete (read_files here) is still flagged
+		// alongside the one that's actually truncated (run_commands), not
+		// silently allowed through. Tracked as a possible follow-up in
+		// prefix-safe-json itself, not something this integration papers
+		// over.
+		const events = await streamToolCallEvents(
+			sseToolCalls(
+				[
+					{ name: "read_files", args: '{"files": [{"path": "/tmp/a.txt"}]}' },
+					{ name: "run_commands", args: '{"commands":["npm install","npm test"' },
+				],
+				"length",
+			),
+			[READ_FILES_TOOL, RUN_COMMANDS_TOOL],
+		);
+
+		const parseErrors = events
+			.filter((event): event is Extract<AgentModelEvent, { type: "tool-call-delta" }> => event.type === "tool-call-delta")
+			.map((event) => (event.metadata as Record<string, unknown> | undefined)?.inputParseError)
+			.filter((message): message is string => typeof message === "string");
+
+		expect(parseErrors).toHaveLength(2);
+		expect(parseErrors.some((message) => message.includes("read_files"))).toBe(true);
+		expect(parseErrors.some((message) => message.includes("run_commands"))).toBe(true);
 	});
 
 	it("surfaces parse error for truncated JSON with unterminated string value", async () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -43,6 +43,10 @@ import {
 	wrapLanguageModel,
 } from "ai";
 import { nanoid } from "nanoid";
+import {
+	AiSdkStreamAdapter,
+	createToolCallExecutionGate,
+} from "prefix-safe-json";
 import { classifyProviderError } from "./error-classification";
 import { extractErrorMessage } from "./format";
 import { createRetryEmptyResponseMiddleware } from "./middleware/retry-empty-response";
@@ -1292,6 +1296,16 @@ async function* emitAiSdkEvents(
 ): AsyncIterable<AgentModelEvent> {
 	let sawToolCalls = false;
 	const emittedToolCallIds = new Set<string>();
+	// Tool calls the *existing* tool-error path (below) already corrected -
+	// excluded from the truncation side-channel's own corrective yield so a
+	// call isn't flagged twice through two different mechanisms.
+	const toolErrorHandledIds = new Set<string>();
+	// Side-channel truncation check, independent of experimental_repairToolCall:
+	// tracks raw tool-input-delta text directly (never trusts an already-
+	// repaired "tool-call" part's `input`) and cross-references the stream's
+	// own finishReason once known, once the loop below ends.
+	const truncationAdapter = new AiSdkStreamAdapter();
+	const truncationGate = createToolCallExecutionGate();
 	let finishReason: unknown;
 	let streamError: CapturedStreamError | undefined;
 	let finishUsage: unknown;
@@ -1311,6 +1325,14 @@ async function* emitAiSdkEvents(
 	try {
 		if (stream.fullStream) {
 			for await (const part of stream.fullStream) {
+				// Side-channel only - observes every part (including the
+				// tool-input-start/-delta/-end parts nothing below handles) and
+				// never affects what this loop yields on its own. Decisions are
+				// read after the loop, once finishReason is known.
+				for (const normalized of truncationAdapter.push(part)) {
+					truncationGate.push(normalized);
+				}
+
 				if (part.type === "text-delta") {
 					const text =
 						(part.textDelta as string | undefined) ??
@@ -1547,6 +1569,7 @@ async function* emitAiSdkEvents(
 						`tool_${nanoid()}`;
 					const alreadyEmitted = emittedToolCallIds.has(toolCallId);
 					emittedToolCallIds.add(toolCallId);
+					toolErrorHandledIds.add(toolCallId);
 					const input = (part.input ?? part.args ?? {}) as unknown;
 					const inputText =
 						typeof input === "string" ? input : JSON.stringify(input);
@@ -1602,6 +1625,48 @@ async function* emitAiSdkEvents(
 		// Prefer the real provider error from onError over the generic
 		// NoOutputGeneratedError the AI SDK throws when 0 steps are recorded.
 		streamError = capturedError?.current ?? captureStreamError(error);
+	}
+
+	// Truncation side-channel: finishReason is only known now that the loop
+	// above has ended, so this is the first point a tool call already
+	// yielded as "tool-call-delta" (line ~1438) can be checked against it.
+	// experimental_repairToolCall / parseJsonStream are untouched - this
+	// never changes what was already streamed, it only appends a correction
+	// (same inputParseError/aiSdkToolError metadata shape the existing
+	// tool-error path above already uses) when the *stream itself* says a
+	// tool call's arguments never definitively finished, regardless of
+	// whether jsonrepair produced something that happens to parse. A
+	// streamError already short-circuits the whole turn via the existing
+	// error path below, so this only runs when there isn't one.
+	if (!streamError) {
+		const { decisions: truncationDecisions } = truncationGate.finish(
+			streamAborted ? { reason: "cancelled" } : undefined,
+		);
+		for (const decision of truncationDecisions) {
+			if (
+				decision.action === "execute" ||
+				(decision.reason !== "truncated" &&
+					decision.reason !== "stream_incomplete") ||
+				!decision.toolCallId ||
+				!emittedToolCallIds.has(decision.toolCallId) ||
+				toolErrorHandledIds.has(decision.toolCallId)
+			) {
+				continue;
+			}
+			yield {
+				type: "tool-call-delta",
+				toolCallId: decision.toolCallId,
+				toolName: decision.name,
+				metadata: buildToolCallMetadata({
+					metadata: {
+						inputParseError: `Tool call ${decision.name ?? decision.toolCallId} arguments were not confirmed complete before the stream ended (${decision.reason}); the previously streamed input must not be treated as final`,
+						aiSdkToolError: `prefix-safe-json: ${decision.reason}`,
+					},
+					request,
+					context,
+				}),
+			};
+		}
 	}
 
 	if (!streamError) {


### PR DESCRIPTION
### Related Issue

**Issue:** #13001

### Description

This closes the container-level truncation case left outside the scope of #13015.

On current `main`, an argument stream such as:

```json
{"commands":["npm install","npm test"
```

contains no unterminated string, because both string values themselves are complete. The existing `hasUnterminatedString()` guard therefore does not reject it, and `jsonrepair` can close the remaining container into:

```json
{"commands":["npm install","npm test"]}
```

without preserving any signal that the model's output was actually truncated.

This change keeps the existing `experimental_repairToolCall` path unchanged and tracks the raw AI SDK tool-input stream (`tool-input-start` / `tool-input-delta` / `tool-input-end`) alongside it, using `prefix-safe-json`'s `AiSdkStreamAdapter` + `createToolCallExecutionGate` as a side-channel - it never reads the SDK's already-resolved/repaired `tool-call.input` as the source of truth. Once the actual stream finish reason is known, calls whose arguments were not confirmed complete are marked through Cline's existing `inputParseError` / `aiSdkToolError` metadata path before tool dispatch - no new error subsystem.

**Why the later correction is safe:**

`AgentRuntime.generateAssistantMessage()` fully drains the model event stream (`for await` over the whole stream) before returning the assembled assistant message. Events for the same `toolCallId` are merged during that assembly, not raced. Only after the stream has fully completed does `AgentRuntime.run()` extract tool calls and pass them to `executeToolCalls()`. So the corrective metadata is already present in the merged assembly before `prepareToolExecution()` decides whether a tool may execute - there's no window where a partially-drained stream reaches the dispatcher.

### Test Procedure

Verified using instrumented tool implementations (real invocation counts), not only emitted-event assertions, driving the real provider through `@cline/agents`' real `AgentRuntime`:

- complete tool call → executes exactly once
- mid-string truncated call (#13015's existing case) → executes zero times
- container-level truncated call (this PR's case) → executes zero times
- syntactically complete-looking call with `finishReason: length` → executes zero times
- provider error before a call starts → executes zero times
- existing #13015 behavior is unchanged (its own test still passes as-is)
- no duplicate correction/dispatch occurs (exactly one `tool-result` per call)

**Parallel-call tradeoff (disclosed, not hidden):** the execution gate currently applies the stream-level finish reason to every tool call tracked during that turn. So when a turn ends with `length`, a genuinely complete parallel call is conservatively withheld together with a truncated one, rather than being allowed through. This is intentionally fail-closed - no truncated tool call is ever allowed through - but it means a sibling call that finished cleanly earlier in the same turn can also be held back. Covered by its own test.

Validation:

```
@cline/llms typecheck: PASS
targeted AI SDK tool-call tests: PASS - 15/15
@cline/llms full test suite: PASS - 732 passed, 4 skipped (pre-existing), 0 failed
@cline/agents test suite: PASS - 68/68
biome lint (sdk/, apps/cli/, apps/cline-hub/, apps/examples/): PASS, 0 errors on changed files
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - backend change only, no UI surface.

### Additional Notes

Adds one new dependency to `sdk/packages/llms`: `prefix-safe-json` (implements the raw-stream truncation tracking this PR relies on). `@cline/agents` is also added as a devDependency of `sdk/packages/llms`, scoped to the new execution-dispatch test file only - it lets that test drive a real `AgentRuntime` to prove dispatch is actually gated, not just that an event is emitted. Neither addition touches `sdk/packages/llms`'s public `src/index.ts`.
