### PR TITLE
fix(core): respect explicit command sequencing

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -510,6 +510,31 @@ describe("run_commands tool description", () => {
 		expect(onUnix).toContain("grep/head/tail");
 	});
 
+	it("preserves explicit command sequencing and shell-safe arguments", () => {
+		const descriptions = [
+			buildRunCommandsDescription("powershell", true),
+			buildRunCommandsDescription("cmd", true),
+			buildRunCommandsDescription("wsl", true),
+			buildRunCommandsDescription("posix", true),
+			buildRunCommandsDescription("posix", false),
+		];
+
+		for (const description of descriptions) {
+			const sequencingInstruction =
+				"If the user asks for commands separately or one at a time, do not combine commands or merge their argument lists.";
+			expect(description).toContain(sequencingInstruction);
+			expect(description).toContain(
+				"Commands that mutate the same shared state, such as the Git index, are not independent and must not run concurrently.",
+			);
+			expect(description).toContain(
+				"Quote paths and arguments containing whitespace or shell metacharacters for the active shell, including parentheses.",
+			);
+			expect(description.indexOf(sequencingInstruction)).toBeLessThan(
+				description.indexOf("Include multiple commands"),
+			);
+		}
+	});
+
 	it("derives the createShellTool description from config.shell", () => {
 		const posixTool = createShellTool(async () => "ok", {
 			shell: "/bin/bash",

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -401,6 +401,12 @@ const RUN_COMMANDS_SHARED_INSTRUCTIONS =
 	"Use for listing files, checking git status, running builds, executing tests, etc. " +
 	"Commands must be non-interactive. Commands that require follow-up input like pagers should be skipped or used with supported flags/env (e.g. git --no-pager, --non-interactive) to bypass the interaction steps. ";
 
+const RUN_COMMANDS_EXECUTION_INSTRUCTIONS =
+	"Follow explicit user instructions about command grouping and order. " +
+	"If the user asks for commands separately or one at a time, do not combine commands or merge their argument lists. " +
+	"Commands that mutate the same shared state, such as the Git index, are not independent and must not run concurrently. " +
+	"Quote paths and arguments containing whitespace or shell metacharacters for the active shell, including parentheses. ";
+
 /**
  * Build the run_commands tool description for the shell that will actually
  * execute the commands. The shell kind decides the syntax guidance (quoting,
@@ -418,7 +424,8 @@ export function buildRunCommandsDescription(
 			"Run non-interactive shell commands from the root of the workspace in Windows environment. " +
 			RUN_COMMANDS_SHARED_INSTRUCTIONS +
 			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
-			`Commands run through ${shellName}; quote paths and arguments for ${shellName} and use ${sequencingOperator} to sequence commands. ` +
+			`Commands run through ${shellName}; use ${sequencingOperator} to sequence commands. ` +
+			RUN_COMMANDS_EXECUTION_INSTRUCTIONS +
 			"Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."
 		);
 	}
@@ -433,7 +440,8 @@ export function buildRunCommandsDescription(
 		"Run non-interactive shell commands from the root of the workspace. " +
 		RUN_COMMANDS_SHARED_INSTRUCTIONS +
 		environmentNote +
-		"Commands should be properly shell-escaped and targeted to avoid error or timeout. Include multiple commands in the same call when they are independent complete shell commands and safe to run concurrently; multiline scripts and heredocs must be a single command string. When independent reads, searches, or edits are also needed, call those tools in the same response. " +
+		RUN_COMMANDS_EXECUTION_INSTRUCTIONS +
+		"Commands should be targeted to avoid error or timeout. Include multiple commands in the same call when they are independent complete shell commands and safe to run concurrently; multiline scripts and heredocs must be a single command string. When independent reads, searches, or edits are also needed, call those tools in the same response. " +
 		`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); pipe through grep/head/tail when you need specific sections of large output. ` +
 		"For long-running commands, run them in background and redirect output to a tmp file that you can read from later."
 	);


### PR DESCRIPTION
### Related Issue

**Issue:** #13294

### Description

The shared shell-tool guidance encouraged batching commands that appeared independent, but did not state that a user's requested grouping and order takes precedence. Its escaping guidance was also generic enough that shell-significant paths, such as SvelteKit route groups containing parentheses, could still be emitted unquoted for Git Bash.

This change makes the execution contract explicit for every supported shell family:

- Do not combine commands or merge argument lists when the user asks to run commands separately or one at a time.
- Treat commands that mutate the same shared state, such as the Git index, as dependent rather than safe to run concurrently.
- Quote paths and arguments containing whitespace or shell metacharacters for the active shell, including parentheses.

The scope is limited to preventing the unsafe command construction trigger. It does not change terminal-failure recovery.

### Test Procedure

- Added contract coverage for PowerShell, cmd.exe, WSL, POSIX shells on Windows (including Git Bash), and POSIX shells on Unix.
- The new regression failed before the implementation change while the other 62 focused tests passed; after the change, all 63 focused tests passed.
- The focused regression is collected by the core unit-test configuration.
- Formatting and lint checks pass for both changed files, and the committed diff has no whitespace errors.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this change updates command-generation guidance and has no visual UI changes.

### Additional Notes

No executor, public API, terminal lifecycle, dependency, or generated-file changes are included in this patch.
