### PR TITLE
chore(cerebras): replace GLM 4.7 with Gemma 4

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -18678,35 +18678,6 @@ export const GENERATED_PROVIDER_MODELS: {
       "releaseDate": "2026-04-02",
       "family": "gemma"
     },
-    "zai-glm-4.7": {
-      "id": "zai-glm-4.7",
-      "name": "Z.AI GLM-4.7",
-      "contextWindow": 131072,
-      "maxInputTokens": 131072,
-      "maxTokens": 40960,
-      "capabilities": [
-        "tools",
-        "reasoning",
-        "structured_output",
-        "temperature",
-        "prompt-cache"
-      ],
-      "reasoningOptions": [
-        {
-          "type": "effort",
-          "values": [
-            "none"
-          ]
-        }
-      ],
-      "pricing": {
-        "input": 2.25,
-        "output": 2.75,
-        "cacheRead": 2.25,
-        "cacheWrite": 0
-      },
-      "releaseDate": "2026-01-07"
-    },
     "gpt-oss-120b": {
       "id": "gpt-oss-120b",
       "name": "GPT OSS 120B",

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -811,7 +811,7 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "Cerebras",
 		description: "Fast inference on Cerebras wafer-scale chips",
 		family: "openai-compatible",
-		defaultModelId: "zai-glm-4.7",
+		defaultModelId: "gemma-4-31b",
 		apiKeyEnv: ["CEREBRAS_API_KEY"],
 		defaults: { baseUrl: "https://api.cerebras.ai/v1" },
 	},


### PR DESCRIPTION
## Summary
- remove GLM 4.7 from the generated Cerebras model catalog
- set Gemma 4 31B as the Cerebras default model

## Validation
- `bun -F @cline/llms typecheck`
- `bun -F @cline/llms test src/providers/builtins.test.ts` (21 tests)