### PR TITLE
fix(vscode): clear task-scoped settings overlay when task view is cleared or switched

### DIFF
--- a/.changeset/clear-task-settings-overlay.md
+++ b/.changeset/clear-task-settings-overlay.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix auto-approve checkboxes freezing after "New Task": clear the task-scoped settings overlay when the task view is cleared or switched, so stale task settings no longer shadow global settings

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -582,6 +582,7 @@ export class Controller {
 			},
 			setTurnPhase: (phase, anchorTs) => this.turnStateTracker.set(phase, anchorTs),
 			postStateToWebview: () => this.postStateToWebview(),
+			clearTaskSettings: () => this.stateManager.clearTaskSettings(),
 		})
 		this.taskStart = new SdkTaskStartCoordinator({
 			stateManager: this.stateManager,

--- a/apps/vscode/src/sdk/auto-approve-overlay-regression.test.ts
+++ b/apps/vscode/src/sdk/auto-approve-overlay-regression.test.ts
@@ -1,0 +1,170 @@
+// Regression test for #13260: auto-approve checkboxes froze after "New Task".
+//
+// Toggling an auto-approve setting while a task view is open writes
+// autoApprovalSettings into the StateManager's task-settings overlay
+// (updateAutoApprovalSettings -> setTaskSettings), and the overlay shadows
+// global settings in getGlobalSettingsKey(). If clearTask() leaves the overlay
+// behind, every later toggle RPC is accepted into global state but every
+// posted state still carries the overlay's old version — which the webview
+// rejects as not newer, so the checkboxes never move again.
+//
+// Unlike the SdkTaskControlCoordinator unit tests (which assert clearTask
+// calls clearTaskSettings), this test wires the REAL StateManager, the REAL
+// updateAutoApprovalSettings handler, and the REAL coordinator clearTask()
+// together, with the webview's version gate modeled on
+// ExtensionStateContext.tsx, so the end-to-end invariant is what's pinned:
+// after New Task, checkbox clicks must reach the webview.
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import type { Controller } from "@/core/controller"
+import { updateAutoApprovalSettings } from "@/core/controller/state/updateAutoApprovalSettings"
+import { StateManager } from "@/core/storage/StateManager"
+import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@/shared/AutoApprovalSettings"
+import { AutoApprovalSettingsRequest } from "@/shared/proto/cline/state"
+import { createStorageContext } from "@/shared/storage/storage-context"
+import { SdkTaskControlCoordinator, type SdkTaskControlCoordinatorOptions } from "./sdk-task-control-coordinator"
+import type { TaskProxy } from "./task-proxy"
+
+vi.mock("@/services/logging/distinctId", () => ({
+	initializeDistinctId: vi.fn(async () => undefined),
+}))
+
+describe("auto-approve settings after New Task (#13260)", () => {
+	let clineDir: string
+	let stateManager: StateManager
+	let task: TaskProxy | undefined
+	// What the webview last received via subscribeToState. It only accepts
+	// autoApprovalSettings whose version is strictly greater than what it holds
+	// (ExtensionStateContext.tsx).
+	let webviewSettings: typeof DEFAULT_AUTO_APPROVAL_SETTINGS
+
+	// Mirrors getStateToPostToWebview: autoApprovalSettings resolves through
+	// getGlobalSettingsKey, where the task-settings overlay shadows global state.
+	const resolveSettings = () => stateManager.getGlobalSettingsKey("autoApprovalSettings")
+
+	const postStateToWebview = async () => {
+		const incoming = resolveSettings()
+		if ((incoming.version ?? 1) > (webviewSettings.version ?? 1)) {
+			webviewSettings = incoming
+		}
+	}
+
+	const makeTaskProxy = (taskId: string): TaskProxy =>
+		({ taskId, messageStateHandler: { clear: () => {} } }) as unknown as TaskProxy
+
+	const makeCoordinator = () =>
+		new SdkTaskControlCoordinator({
+			sessions: { endActiveSession: async () => {} },
+			interactions: { clearPending: () => {} },
+			messages: { cancelPendingSave: () => {} },
+			taskHistory: {},
+			getTask: () => task,
+			setTask: (next) => {
+				task = next
+			},
+			onAskResponse: async () => {},
+			resetMessageTranslator: () => {},
+			postStateToWebview,
+			clearTaskSettings: () => stateManager.clearTaskSettings(),
+			setTurnPhase: () => {},
+		} as unknown as SdkTaskControlCoordinatorOptions)
+
+	const makeController = () =>
+		({
+			task,
+			getStateToPostToWebview: async () => ({ autoApprovalSettings: resolveSettings() }),
+			postStateToWebview,
+			stateManager,
+		}) as unknown as Controller
+
+	// What the webview's useAutoApproveActions.updateAction sends on a checkbox click.
+	const clickCheckbox = async (action: string, value: boolean) => {
+		await updateAutoApprovalSettings(
+			makeController(),
+			AutoApprovalSettingsRequest.create({
+				version: (webviewSettings.version ?? 1) + 1,
+				actions: { ...webviewSettings.actions, [action]: value },
+			}),
+		)
+	}
+
+	beforeAll(async () => {
+		clineDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-13260-regression-"))
+		await StateManager.initialize(createStorageContext({ clineDir, workspacePath: clineDir }))
+		stateManager = StateManager.get()
+	})
+
+	beforeEach(async () => {
+		await stateManager.clearTaskSettings()
+		stateManager.setGlobalState("autoApprovalSettings", { ...DEFAULT_AUTO_APPROVAL_SETTINGS })
+		task = undefined
+		webviewSettings = resolveSettings()
+	})
+
+	afterAll(async () => {
+		await StateManager.get().flushPendingState()
+		await StateManager.get().reInitialize()
+		await fs.rm(clineDir, { recursive: true, force: true })
+	})
+
+	it("keeps checkboxes working after a mid-task toggle followed by New Task", async () => {
+		// A task view is open (running or completed — the proxy stays installed
+		// either way) and the user unchecks "Edit files". The handler writes the
+		// setting to BOTH global state and the task overlay.
+		task = makeTaskProxy("task-1")
+		await clickCheckbox("editFiles", false)
+		expect(webviewSettings.actions.editFiles).toBe(false)
+
+		// User clicks "New Task" — the real coordinator path, which must drop the
+		// overlay along with the task proxy.
+		await makeCoordinator().clearTask()
+		await postStateToWebview()
+		expect(task).toBeUndefined()
+
+		// The next checkbox click must reach the webview: accepted into global
+		// state AND visible in the next posted state.
+		const versionBefore = webviewSettings.version
+		await clickCheckbox("readFiles", false)
+		expect(webviewSettings.actions.readFiles).toBe(false)
+		expect(webviewSettings.version).toBe(versionBefore + 1)
+		// The mid-task toggle survives New Task.
+		expect(webviewSettings.actions.editFiles).toBe(false)
+	})
+
+	it("freezes forever if the overlay outlives the task view (the failure mode the fix prevents)", async () => {
+		// Same start: mid-task toggle populates the overlay.
+		task = makeTaskProxy("task-1")
+		await clickCheckbox("editFiles", false)
+		const versionAfterToggle = webviewSettings.version
+
+		// Buggy New Task: task proxy dropped, overlay left behind.
+		task = undefined
+		await postStateToWebview()
+
+		// Every subsequent click is accepted into global state but never surfaces:
+		// the stale overlay version shadows global in every posted state, and the
+		// webview rejects non-newer versions. No amount of state posts recovers.
+		await clickCheckbox("readFiles", false)
+		await postStateToWebview()
+		await clickCheckbox("useBrowser", false)
+		await postStateToWebview()
+		expect(webviewSettings.actions.readFiles).toBe(true)
+		expect(webviewSettings.actions.useBrowser).toBe(true)
+		expect(webviewSettings.version).toBe(versionAfterToggle)
+	})
+
+	it("never freezes when toggles happen with no task view open", async () => {
+		// Control: with no task, only global state is written — no overlay exists,
+		// so New Task has nothing to leak.
+		await clickCheckbox("editFiles", false)
+		await makeCoordinator().clearTask()
+		await postStateToWebview()
+
+		const versionBefore = webviewSettings.version
+		await clickCheckbox("readFiles", false)
+		expect(webviewSettings.actions.readFiles).toBe(false)
+		expect(webviewSettings.version).toBe(versionBefore + 1)
+	})
+})

--- a/apps/vscode/src/sdk/auto-approve-overlay-regression.test.ts
+++ b/apps/vscode/src/sdk/auto-approve-overlay-regression.test.ts
@@ -61,7 +61,7 @@ describe("auto-approve settings after New Task (#13260)", () => {
 			messages: { cancelPendingSave: () => {} },
 			taskHistory: {},
 			getTask: () => task,
-			setTask: (next) => {
+			setTask: (next: TaskProxy | undefined) => {
 				task = next
 			},
 			onAskResponse: async () => {},

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.test.ts
@@ -87,6 +87,40 @@ describe("SdkTaskControlCoordinator", () => {
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 	})
 
+	it("drops the task-scoped settings overlay when the task is cleared (#13260)", async () => {
+		// autoApprovalSettings written via setTaskSettings while a task is open
+		// shadow global settings in getGlobalSettingsKey(). If the overlay
+		// survives "New Task", later global updates are accepted but never
+		// reach the webview (the stale overlay version wins), freezing the
+		// auto-approve checkboxes.
+		const { coordinator, options } = makeCoordinator({
+			activeSession: makeActiveSession(),
+			task: makeTask("task-1"),
+		})
+
+		await coordinator.clearTask()
+
+		expect(options.clearTaskSettings).toHaveBeenCalledOnce()
+	})
+
+	it("drops the outgoing task's settings overlay when switching to another task", async () => {
+		const { coordinator, options } = makeCoordinator({
+			activeSession: makeActiveSession(),
+			task: makeTask("old-task"),
+			hasHistoryItem: true,
+			clineMessages: [{ ts: 1, type: "say", say: "task", text: "hello" }],
+			sessionStatus: "completed",
+		})
+
+		await coordinator.showTaskWithId("task-1")
+
+		expect(options.clearTaskSettings).toHaveBeenCalledOnce()
+		// The overlay must be gone before the new proxy is installed.
+		expect(options.clearTaskSettings.mock.invocationCallOrder[0]).toBeLessThan(
+			options.setTask.mock.invocationCallOrder[0],
+		)
+	})
+
 	it("shows a task by creating a proxy, loading messages, and appending a fresh resume ask", async () => {
 		const existingTask = makeTask("old-task")
 		const activeSession = makeActiveSession()
@@ -461,6 +495,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		raiseCancelFence: vi.fn(),
 		setTurnPhase: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
+		clearTaskSettings: vi.fn().mockResolvedValue(undefined),
 	} as unknown as SdkTaskControlCoordinatorOptions & {
 		sessions: SdkTaskControlCoordinatorOptions["sessions"] & {
 			getActiveSession: ReturnType<typeof vi.fn>
@@ -484,6 +519,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		resetMessageTranslator: ReturnType<typeof vi.fn>
 		setTurnPhase: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
+		clearTaskSettings: ReturnType<typeof vi.fn>
 	}
 
 	return {

--- a/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-control-coordinator.ts
@@ -18,6 +18,17 @@ export interface SdkTaskControlCoordinatorOptions {
 	resetMessageTranslator: () => void
 	postStateToWebview: () => Promise<void>
 	/**
+	 * Drops the StateManager's task-scoped settings overlay (persisting pending
+	 * writes first). Task settings — e.g. autoApprovalSettings written by
+	 * toggling auto-approve while a task is open — shadow global settings in
+	 * getGlobalSettingsKey(). If the overlay outlives the task view, later
+	 * global updates are accepted but never surface in posted state (the stale
+	 * overlay version wins), which froze the auto-approve checkboxes after
+	 * "New Task" (#13260). Must run whenever the task view is cleared or
+	 * switched to another task.
+	 */
+	clearTaskSettings: () => Promise<void>
+	/**
 	 * Sets the authoritative turn phase. showTaskWithId must derive the phase
 	 * from the reopened conversation (resumable/completed) — leaving the
 	 * previous task's phase in place hides the Resume button for interrupted
@@ -113,6 +124,8 @@ export class SdkTaskControlCoordinator {
 			this.options.setTask(undefined)
 		}
 
+		await this.options.clearTaskSettings()
+
 		this.options.resetMessageTranslator()
 	}
 
@@ -185,6 +198,10 @@ export class SdkTaskControlCoordinator {
 			if (currentTask) {
 				currentTask.messageStateHandler.clear()
 			}
+
+			// The outgoing task's settings overlay must not apply to the newly
+			// opened task (see clearTaskSettings option doc).
+			await this.options.clearTaskSettings()
 
 			this.options.resetMessageTranslator()
 


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes #13260 ([CLINE-2965](https://linear.app/cline-bot/issue/CLINE-2965))

### Description

After clicking "New Task", the auto-approve checkboxes could freeze permanently: clicks were accepted by the extension but never reflected in the UI until a window reload.

Root cause: toggling an auto-approve setting while a task view is open (running or completed) writes `autoApprovalSettings` to both global state and the StateManager's task-settings overlay (`updateAutoApprovalSettings` → `setTaskSettings`). The SDK controller never cleared that overlay on `clearTask`/`showTaskWithId` (the legacy controller did — on `main`, `StateManager.clearTaskSettings()` has no callers). The orphaned overlay keeps shadowing global settings in `getGlobalSettingsKey()`, so after "New Task" every toggle RPC is accepted into global state, but every state post to the webview still carries the overlay's old version — which the webview rejects as not newer. The checkboxes freeze forever, while global settings silently diverge from what the UI shows. Both VS Code and JetBrains are affected since this is shared core state handling.

The fix restores legacy parity in `SdkTaskControlCoordinator`: drop the overlay (persisting pending writes first) in `clearTask()`, and before installing a different task's proxy in `showTaskWithId()`.

Note on the issue's repro steps: taken literally (unchecking before any task exists) they don't populate the overlay — the load-bearing step is that the toggle happens **while a task view is open**. The multi-line prompt is incidental.

### Test Procedure

- New unit tests in `sdk-task-control-coordinator.test.ts` assert the overlay is dropped on `clearTask()` and before the new proxy is installed on `showTaskWithId()`.
- Added an end-to-end regression test (`auto-approve-overlay-regression.test.ts`) that wires the real `StateManager`, the real `updateAutoApprovalSettings` handler, and the real `SdkTaskControlCoordinator.clearTask()` together, with the webview's version gate modeled on `ExtensionStateContext`: after a mid-task toggle followed by New Task, checkbox clicks must keep reaching the webview. It also pins the failure mode (overlay outliving the task view freezes all toggles) and a no-task control. Verified the test fails when the `clearTaskSettings()` call is removed from `clearTask()`.
- `vitest` on `sdk-task-control-coordinator.test.ts` and `updateAutoApprovalSettings.test.ts` passes; `biome lint` on the touched files is clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
