### PR TITLE
docs: update DeepSeek V4 ClinePass pricing

### DIFF
--- a/docs/getting-started/clinepass.mdx
+++ b/docs/getting-started/clinepass.mdx
@@ -96,8 +96,8 @@ ClinePass is a flat monthly subscription, so you are not charged the individual 
 | Kimi K3 | $3.00 | $15.00 | $0.30 | - |
 | Kimi K2.7 Code | $0.95 | $4.00 | $0.19 | - |
 | Kimi K2.6 | $0.95 | $4.00 | $0.16 | - |
-| DeepSeek V4 Pro | $1.74 | $3.48 | $0.0145 | - |
-| DeepSeek V4 Flash | $0.14 | $0.28 | $0.0028 | - |
+| DeepSeek V4 Pro | $3.96 | $11.88 | $0.132 | - |
+| DeepSeek V4 Flash | $0.33 | $0.99 | $0.0105 | - |
 | MiMo-V2.5 | $0.14 | $0.28 | $0.0028 | - |
 | MiMo-V2.5-Pro | $1.74 | $3.48 | $0.0145 | - |
 | MiniMax M3 | $0.30 | $1.20 | $0.06 | - |


### PR DESCRIPTION
## Summary

- update the ClinePass reference pricing for DeepSeek V4 Pro and V4 Flash
- use the simple midpoint of DeepSeek's new off-peak and peak API rates
- preserve the existing V4 Pro reference-pricing relationship to the official direct rate

## Pricing

DeepSeek now publishes separate off-peak and peak prices. This draft uses `(off-peak + peak) / 2`:

| Model | Input | Output | Cached read |
| --- | ---: | ---: | ---: |
| DeepSeek V4 Flash midpoint | $0.33 | $0.99 | $0.0105 |
| DeepSeek V4 Pro midpoint | $0.99 | $2.97 | $0.033 |

The ClinePass reference table previously priced V4 Pro at 4x the official direct rate, so this PR preserves that relationship and publishes `$3.96 / $11.88 / $0.132`. V4 Flash continues to use the direct reference rate.

Official pricing: https://api-docs.deepseek.com/quick_start/pricing/

Reported change context and effective date: https://www.reddit.com/r/DeepSeek/comments/1vn81do/deepseek_just_massively_increased_their_api/

## Impact

Documentation only. The ClinePass pricing spreadsheet is intentionally not updated in this PR.

## Checks

- `git diff --check`
