### PR TITLE
feat(hub): route cline deep links through hub

### DIFF
--- a/apps/cli/src/commands/deep-link.test.ts
+++ b/apps/cli/src/commands/deep-link.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleDeepLink } from "./deep-link";
+
+describe("handleDeepLink", () => {
+	it("forwards a normalized link to Hub", async () => {
+		const writeln = vi.fn();
+		const openInHub = vi.fn(async () => ({
+			type: "new_session" as const,
+			prompt: "fix it",
+		}));
+		const result = await handleDeepLink({
+			url: "cline://new-session?prompt=fix%20it",
+			cwd: "/tmp/project",
+			io: { writeln, writeErr: vi.fn() },
+			openInHub,
+		});
+		expect(result).toBe(0);
+		expect(openInHub).toHaveBeenCalledWith(
+			"cline://new-session?prompt=fix%20it",
+			"/tmp/project",
+		);
+		expect(writeln).toHaveBeenCalledWith(
+			"Forwarded Cline link to Hub (new_session).",
+		);
+	});
+
+	it("rejects invalid URLs without starting Hub", async () => {
+		const openInHub = vi.fn();
+		const writeErr = vi.fn();
+		expect(
+			await handleDeepLink({
+				url: "https://example.com",
+				io: { writeln: vi.fn(), writeErr },
+				openInHub,
+			}),
+		).toBe(1);
+		expect(openInHub).not.toHaveBeenCalled();
+		expect(writeErr).toHaveBeenCalled();
+	});
+});

--- a/apps/cli/src/commands/deep-link.ts
+++ b/apps/cli/src/commands/deep-link.ts
@@ -1,0 +1,64 @@
+import { ensureDetachedHubServer, HubUIClient } from "@cline/core";
+import { type ClineDeepLinkAction, parseClineDeepLink } from "@cline/shared";
+import { resolveWorkspaceRoot } from "../utils/helpers";
+
+export interface DeepLinkCommandIo {
+	writeln: (text?: string) => void;
+	writeErr: (text: string) => void;
+}
+
+export interface HandleDeepLinkOptions {
+	url: string;
+	cwd?: string;
+	io: DeepLinkCommandIo;
+	openInHub?: (
+		url: string,
+		workspaceRoot: string,
+	) => Promise<ClineDeepLinkAction>;
+}
+
+async function openInDefaultHub(
+	url: string,
+	workspaceRoot: string,
+): Promise<ClineDeepLinkAction> {
+	const hub = await ensureDetachedHubServer(workspaceRoot);
+	const client = new HubUIClient({
+		address: hub.url,
+		authToken: hub.authToken,
+		clientType: "cline-deep-link",
+		displayName: "Cline URL Handler",
+	});
+	try {
+		await client.connect();
+		return await client.openDeepLink(url);
+	} finally {
+		await client.dispose();
+	}
+}
+
+export async function handleDeepLink(
+	options: HandleDeepLinkOptions,
+): Promise<number> {
+	const url = options.url.trim();
+	if (!parseClineDeepLink(url)) {
+		options.io.writeErr("Unsupported or invalid cline:// link.");
+		return 1;
+	}
+	const cwd = options.cwd?.trim() || process.cwd();
+	const workspaceRoot = resolveWorkspaceRoot(cwd);
+	try {
+		const action = await (options.openInHub ?? openInDefaultHub)(
+			url,
+			workspaceRoot,
+		);
+		options.io.writeln(`Forwarded Cline link to Hub (${action.type}).`);
+		return 0;
+	} catch (error) {
+		options.io.writeErr(
+			`Failed to forward Cline link to Hub: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return 1;
+	}
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -172,6 +172,15 @@ export async function runCli(): Promise<void> {
 		startupTarget?: TuiStartupTarget;
 	} = {};
 	const io = { writeln, writeErr };
+	const launchedDeepLink = cliArgs.find((arg) => arg.startsWith("cline://"));
+	if (launchedDeepLink) {
+		const { handleDeepLink } = await import("./commands/deep-link");
+		process.exitCode = await handleDeepLink({
+			url: launchedDeepLink,
+			io,
+		});
+		return;
+	}
 	const program = createProgram();
 	// Re-enable built-in help/version output for the routing program
 	program.configureOutput({
@@ -604,6 +613,20 @@ export async function runCli(): Promise<void> {
 		.action(async (_opts: unknown, cmd: Command) => {
 			const hubCmd = await createHubRuntimeCommand();
 			await hubCmd.parseAsync(cmd.args, { from: "user" });
+		});
+
+	const deepLinkCmd = program
+		.command("deeplink")
+		.description("Forward a cline:// URL to the local Hub")
+		.argument("<url>", "Cline deep link URL")
+		.option("-c, --cwd <path>", "Workspace used to discover or start Hub")
+		.action(async (url: string) => {
+			const { handleDeepLink } = await import("./commands/deep-link");
+			ctx.exitCode = await handleDeepLink({
+				url,
+				cwd: deepLinkCmd.opts<{ cwd?: string }>().cwd,
+				io,
+			});
 		});
 
 	const dashboardCmd = program

--- a/apps/cline-hub/src/server/hub.ts
+++ b/apps/cline-hub/src/server/hub.ts
@@ -121,6 +121,15 @@ export async function attachHub(ctx: HubContext): Promise<void> {
 	await ctx.uiClient.connect();
 
 	ctx.uiClient.subscribeUI({
+		onDeepLink(action) {
+			ctx.pushEvent(
+				"Deep link opened",
+				`Routing ${action.type.replaceAll("_", " ")}`,
+				"info",
+			);
+			ctx.broadcast({ type: "deep_link", action });
+			broadcastHubState(ctx);
+		},
 		onNotify(payload: HubUINotifyPayload) {
 			ctx.pushEvent(
 				payload.title,

--- a/apps/cline-hub/src/server/hub.ts
+++ b/apps/cline-hub/src/server/hub.ts
@@ -14,6 +14,7 @@ import {
 } from "./approvals";
 import { configureConnectorCliLaunch } from "./connectors";
 import { workspaceRoot } from "./deps";
+import { loadProviders, sendProviderCatalog } from "./providers";
 import {
 	formatClientName,
 	formatSessionCreator,
@@ -129,6 +130,24 @@ export async function attachHub(ctx: HubContext): Promise<void> {
 			);
 			ctx.broadcast({ type: "deep_link", action });
 			broadcastHubState(ctx);
+			if (action.type === "auth" && action.provider) {
+				for (const peer of ctx.peers) {
+					ctx.send(peer, {
+						type: "provider_oauth_login_done",
+						providerId: action.provider,
+						accessTokenPresent: true,
+					});
+					void Promise.all([
+						sendProviderCatalog(ctx, peer),
+						loadProviders(ctx, peer),
+					]).catch((error) => {
+						console.warn(
+							"Failed to refresh providers after deep-link OAuth:",
+							error,
+						);
+					});
+				}
+			}
 		},
 		onNotify(payload: HubUINotifyPayload) {
 			ctx.pushEvent(

--- a/apps/cline-hub/src/server/providers.ts
+++ b/apps/cline-hub/src/server/providers.ts
@@ -136,6 +136,16 @@ export async function runProviderOAuthLogin(
 	providerId: string,
 ): Promise<void> {
 	const normalized = normalizeOAuthProvider(providerId);
+	if (normalized === "cline" || normalized === "cline-pass") {
+		if (!ctx.uiClient) throw new Error("Hub UI client is not connected.");
+		const flow = await ctx.uiClient.beginDeepLinkOAuth(normalized);
+		await openExternalUrl(flow.authorizationUrl);
+		ctx.send(peer, {
+			type: "status",
+			text: `Waiting for ${normalized} authentication in your browser...`,
+		});
+		return;
+	}
 	const saved = await loginAndSaveLocalProviderOAuthCredentials(
 		providerSettingsManager,
 		normalized,

--- a/apps/cline-hub/src/webview-protocol.ts
+++ b/apps/cline-hub/src/webview-protocol.ts
@@ -3,7 +3,7 @@ import type {
 	ProviderListItem,
 	ProviderModel,
 } from "@cline/core";
-import type { GeneratedMedia } from "@cline/shared";
+import type { ClineDeepLinkAction, GeneratedMedia } from "@cline/shared";
 
 export type WebviewUsage = {
 	inputTokens?: number;
@@ -68,6 +68,8 @@ export type WebviewChatMessage = Omit<
 };
 
 export type WebviewConfig = {
+	workspaceRoot?: string;
+	cwd?: string;
 	provider?: string;
 	model?: string;
 	mode?: "act" | "plan";
@@ -274,6 +276,7 @@ export type WebviewInboundMessage =
 
 export type WebviewOutboundMessage =
 	| { type: "status"; text: string }
+	| { type: "deep_link"; action: ClineDeepLinkAction }
 	/**
 	 * `recoverable: true` marks an in-run notice (e.g. a MistakeTracker
 	 * mistake such as a plan-mode guard-blocked command) — the run continues,

--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -1170,6 +1170,10 @@ function App() {
 			if (message.type === "deep_link") {
 				const { action } = message;
 				if (action.type === "open_session") {
+					setDeepLinkDraft((current) => ({
+						prompt: action.prompt,
+						version: current.version + 1,
+					}));
 					setSelectedSessionId(action.sessionId);
 					window.history.pushState(null, "", chatPath(action.sessionId));
 					setView("chat");
@@ -1177,11 +1181,11 @@ function App() {
 					action.type === "new_session" ||
 					action.type === "open_project"
 				) {
-					setDeepLinkDraft({
+					setDeepLinkDraft((current) => ({
 						prompt: action.prompt,
 						workspacePath: action.path,
-						version: Date.now(),
-					});
+						version: current.version + 1,
+					}));
 					setSelectedSessionId(undefined);
 					window.history.pushState(null, "", chatPath());
 					setView("chat");

--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -1125,6 +1125,11 @@ function App() {
 	const [recentSessions, setRecentSessions] = useState<WebviewSessionSummary[]>(
 		[],
 	);
+	const [deepLinkDraft, setDeepLinkDraft] = useState<{
+		prompt?: string;
+		workspacePath?: string;
+		version: number;
+	}>({ version: 0 });
 
 	useEffect(() => {
 		syncHubTheme();
@@ -1160,6 +1165,31 @@ function App() {
 			}
 			if (message.type === "sessions") {
 				setRecentSessions(message.sessions);
+				return;
+			}
+			if (message.type === "deep_link") {
+				const { action } = message;
+				if (action.type === "open_session") {
+					setSelectedSessionId(action.sessionId);
+					window.history.pushState(null, "", chatPath(action.sessionId));
+					setView("chat");
+				} else if (
+					action.type === "new_session" ||
+					action.type === "open_project"
+				) {
+					setDeepLinkDraft({
+						prompt: action.prompt,
+						workspacePath: action.path,
+						version: Date.now(),
+					});
+					setSelectedSessionId(undefined);
+					window.history.pushState(null, "", chatPath());
+					setView("chat");
+				} else if (action.type === "auth") {
+					window.history.pushState(null, "", VIEW_PATHS.account);
+					setSettingsSection("Account");
+					setView("account");
+				}
 			}
 		};
 		window.addEventListener("message", handleMessage);
@@ -1230,7 +1260,10 @@ function App() {
 		if (view === "chat") {
 			return (
 				<Chat
+					initialPrompt={deepLinkDraft.prompt}
 					initialSessionId={selectedSessionId}
+					initialWorkspacePath={deepLinkDraft.workspacePath}
+					key={`chat-${deepLinkDraft.version}`}
 					onSessionSelected={updateChatSessionRoute}
 				/>
 			);
@@ -1337,6 +1370,7 @@ function App() {
 			/>
 		);
 	}, [
+		deepLinkDraft,
 		hubState,
 		deleteSession,
 		navigate,

--- a/apps/cline-hub/src/webview/src/Chat.tsx
+++ b/apps/cline-hub/src/webview/src/Chat.tsx
@@ -734,12 +734,16 @@ function formatCheckpointTime(createdAt: number): string {
 }
 
 type ChatProps = {
+	initialPrompt?: string;
 	initialSessionId?: string;
+	initialWorkspacePath?: string;
 	onSessionSelected?: (sessionId?: string) => void;
 };
 
 export default function Chat({
+	initialPrompt,
 	initialSessionId,
+	initialWorkspacePath,
 	onSessionSelected,
 }: ChatProps) {
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -752,8 +756,8 @@ export default function Chat({
 		Record<string, WebviewProviderModel[]>
 	>({});
 	const [defaults, setDefaults] = useState<WebviewDefaults>({
-		workspaceRoot: "",
-		cwd: "",
+		workspaceRoot: initialWorkspacePath ?? "",
+		cwd: initialWorkspacePath ?? "",
 	});
 	const [sessions, setSessions] = useState<WebviewSessionSummary[]>([]);
 	const [sessionTitleDraft, setSessionTitleDraft] = useState("");
@@ -873,7 +877,15 @@ export default function Chat({
 					});
 					return;
 				case "defaults":
-					setDefaults(message.defaults);
+					setDefaults(
+						initialWorkspacePath
+							? {
+									...message.defaults,
+									workspaceRoot: initialWorkspacePath,
+									cwd: initialWorkspacePath,
+								}
+							: message.defaults,
+					);
 					if (message.defaults.provider) {
 						setProvider(message.defaults.provider);
 					}
@@ -1095,7 +1107,7 @@ export default function Chat({
 		return () => {
 			window.removeEventListener("message", handleMessage);
 		};
-	}, []);
+	}, [initialWorkspacePath]);
 
 	useEffect(() => {
 		if (!initialSessionId || initialSessionIdRef.current === initialSessionId) {
@@ -1423,6 +1435,7 @@ export default function Chat({
 				) : null}
 				<Composer
 					autoApproveTools={autoApproveTools}
+					initialPrompt={initialPrompt}
 					disabled={isHydrating}
 					enableSpawn={enableSpawn}
 					enableTeams={enableTeams}
@@ -1478,6 +1491,8 @@ export default function Chat({
 							prompt,
 							attachments,
 							config: {
+								workspaceRoot: defaults.workspaceRoot || undefined,
+								cwd: defaults.cwd || undefined,
 								autoApproveTools,
 								enableSpawn,
 								enableTeams,

--- a/apps/cline-hub/src/webview/src/components/Composer.tsx
+++ b/apps/cline-hub/src/webview/src/components/Composer.tsx
@@ -8,7 +8,7 @@ import {
 	SignalLow,
 	SignalMedium,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
 	Attachment,
@@ -298,6 +298,7 @@ const reasonLevels = [
 
 export function Composer({
 	autoApproveTools,
+	initialPrompt,
 	disabled = false,
 	enableSpawn,
 	enableTeams,
@@ -329,6 +330,7 @@ export function Composer({
 	workspaceRoot,
 }: {
 	autoApproveTools: boolean;
+	initialPrompt?: string;
 	disabled?: boolean;
 	enableSpawn: boolean;
 	enableTeams: boolean;
@@ -369,6 +371,11 @@ export function Composer({
 	const selectedModel = models.find((item) => item.id === model);
 	const thinkingSupported = selectedModel?.supportsThinking === true;
 	const activeReasonLevel = thinkingSupported ? reasonLevel : ReasonLevel.None;
+	useEffect(() => {
+		if (initialPrompt !== undefined) {
+			controller.textInput.setInput(initialPrompt);
+		}
+	}, [controller.textInput, initialPrompt]);
 	const reasonLevelOption = Math.max(
 		reasonLevels.findIndex((item) => item.value === activeReasonLevel),
 		0,

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -149,6 +149,22 @@ event payload and `source` field.
 8. Hub client adapters exported from `@cline/core/hub` (`NodeHubClient`, `HubSessionClient`, `HubUIClient`, `connectToHub`) translate command/reply and event streams into host-facing APIs.
 9. Hub `session.get` records include both canonical root-session usage and explicit aggregate usage from the hub-owned `RuntimeHost`, so attached clients can intentionally render either root-only or root-plus-teammate costs without replaying event streams.
 
+The CLI and other registered protocol handlers forward `cline://` URLs to the
+shared hub with `deep_link.open`. The hub validates and normalizes each URL,
+publishes `deep_link.opened` together with `ui.show_window`, and leaves view
+routing and draft prompt state to the attached host UI. Project, new-session,
+and existing-session links therefore share one authority path without coupling
+the runtime to a particular window implementation.
+
+OAuth deep links must originate from `deep_link.oauth.begin`. The hub creates a
+cryptographically random, short-lived, single-use transaction whose state is
+embedded in the exact `cline://auth` redirect URI sent to the authorization
+server. A callback is rejected unless it consumes that pending transaction;
+the transaction is consumed before the asynchronous code exchange so retries
+and replays cannot reuse it. The hub persists the resulting credentials and
+publishes only the normalized provider action, never the authorization code or
+transaction state.
+
 ### Generated Media Operation and Event Flow
 
 Model modalities and provider operations are separate facts. Modalities describe

--- a/sdk/packages/core/src/auth/cline.ts
+++ b/sdk/packages/core/src/auth/cline.ts
@@ -514,6 +514,23 @@ async function exchangeAuthorizationCode(
 	);
 }
 
+/** Complete a code flow whose redirect was delivered by an embedding host. */
+export async function completeClineAuthorizationCode(options: {
+	code: string;
+	redirectUri: string;
+	apiBaseUrl: string;
+	provider?: string;
+	headers?: HeaderInput;
+	requestTimeoutMs?: number;
+}): Promise<ClineOAuthCredentials> {
+	return exchangeAuthorizationCode(
+		options.code,
+		options.redirectUri,
+		options,
+		options.provider,
+	);
+}
+
 export async function loginClineOAuth(
 	options: ClineOAuthProviderOptions & {
 		callbacks: OAuthLoginCallbacks;

--- a/sdk/packages/core/src/hub/client/ui-client.ts
+++ b/sdk/packages/core/src/hub/client/ui-client.ts
@@ -1,4 +1,5 @@
 import type {
+	ClineDeepLinkAction,
 	HubClientRecord,
 	HubEventEnvelope,
 	HubUINotifyPayload,
@@ -74,6 +75,14 @@ export class HubUIClient {
 		);
 	}
 
+	async openDeepLink(url: string): Promise<ClineDeepLinkAction> {
+		const reply = await this.client.command("deep_link.open", { url });
+		if (!reply.ok) {
+			throw new Error(reply.error?.message ?? "deep_link.open failed");
+		}
+		return reply.payload?.action as unknown as ClineDeepLinkAction;
+	}
+
 	async listClients(): Promise<HubClientRecord[]> {
 		const reply = await this.client.command("client.list");
 		return Array.isArray(reply.payload?.clients)
@@ -108,6 +117,7 @@ export class HubUIClient {
 	subscribeUI(handlers: {
 		onNotify?: (payload: HubUINotifyPayload) => void;
 		onShowWindow?: (payload: HubUIShowWindowPayload) => void;
+		onDeepLink?: (payload: ClineDeepLinkAction) => void;
 		onClientRegistered?: (payload: Record<string, unknown>) => void;
 		onClientDisconnected?: (payload: Record<string, unknown>) => void;
 		onSessionCreated?: (payload: Record<string, unknown>) => void;
@@ -122,6 +132,11 @@ export class HubUIClient {
 				case "ui.show_window":
 					handlers.onShowWindow?.(
 						event.payload as unknown as HubUIShowWindowPayload,
+					);
+					break;
+				case "deep_link.opened":
+					handlers.onDeepLink?.(
+						event.payload as unknown as ClineDeepLinkAction,
 					);
 					break;
 				case "hub.client.registered":

--- a/sdk/packages/core/src/hub/client/ui-client.ts
+++ b/sdk/packages/core/src/hub/client/ui-client.ts
@@ -83,6 +83,27 @@ export class HubUIClient {
 		return reply.payload?.action as unknown as ClineDeepLinkAction;
 	}
 
+	async beginDeepLinkOAuth(providerId: string): Promise<{
+		providerId: string;
+		authorizationUrl: string;
+	}> {
+		const reply = await this.client.command("deep_link.oauth.begin", {
+			providerId,
+		});
+		if (!reply.ok) {
+			throw new Error(reply.error?.message ?? "deep_link.oauth.begin failed");
+		}
+		const resolvedProviderId = reply.payload?.providerId;
+		const authorizationUrl = reply.payload?.authorizationUrl;
+		if (
+			typeof resolvedProviderId !== "string" ||
+			typeof authorizationUrl !== "string"
+		) {
+			throw new Error("Hub returned an invalid deep-link OAuth response.");
+		}
+		return { providerId: resolvedProviderId, authorizationUrl };
+	}
+
 	async listClients(): Promise<HubClientRecord[]> {
 		const reply = await this.client.command("client.list");
 		return Array.isArray(reply.payload?.clients)

--- a/sdk/packages/core/src/hub/server/deep-link-oauth.test.ts
+++ b/sdk/packages/core/src/hub/server/deep-link-oauth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DeepLinkOAuthTransactionStore } from "./deep-link-oauth";
+
+describe("DeepLinkOAuthTransactionStore", () => {
+	it("binds a callback to its provider and exact redirect URI", () => {
+		const store = new DeepLinkOAuthTransactionStore(
+			() => 1_000,
+			() => "state-1",
+		);
+		const { transaction } = store.begin("cline");
+		expect(transaction.redirectUri).toBe("cline://auth?state=state-1");
+		expect(
+			store.consume(
+				new URL("cline://auth?state=state-1&code=code&provider=cline"),
+			),
+		).toEqual(transaction);
+	});
+
+	it("rejects callbacks without a pending transaction and replay attempts", () => {
+		const store = new DeepLinkOAuthTransactionStore(
+			() => 1_000,
+			() => "state-1",
+		);
+		store.begin("cline");
+		const callback = new URL("cline://auth?state=state-1&code=code");
+		store.consume(callback);
+		expect(() => store.consume(callback)).toThrow(
+			"does not match a pending login",
+		);
+		expect(() => store.consume(new URL("cline://auth?code=code"))).toThrow(
+			"missing transaction state",
+		);
+	});
+
+	it("rejects expired callbacks", () => {
+		let now = 1_000;
+		const store = new DeepLinkOAuthTransactionStore(
+			() => now,
+			() => "state-1",
+		);
+		store.begin("cline");
+		now += 10 * 60 * 1000;
+		expect(() =>
+			store.consume(new URL("cline://auth?state=state-1&provider=cline")),
+		).toThrow("expired");
+	});
+});

--- a/sdk/packages/core/src/hub/server/deep-link-oauth.ts
+++ b/sdk/packages/core/src/hub/server/deep-link-oauth.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+
+const DEEP_LINK_OAUTH_TRANSACTION_TTL_MS = 10 * 60 * 1000;
+
+export type DeepLinkOAuthTransaction = {
+	providerId: string;
+	redirectUri: string;
+	expiresAt: number;
+};
+
+export class DeepLinkOAuthTransactionStore {
+	private readonly pending = new Map<string, DeepLinkOAuthTransaction>();
+
+	constructor(
+		private readonly now: () => number = Date.now,
+		private readonly createState: () => string = randomUUID,
+	) {}
+
+	begin(providerId: string): {
+		state: string;
+		transaction: DeepLinkOAuthTransaction;
+	} {
+		this.deleteExpired();
+		const state = this.createState();
+		const redirect = new URL("cline://auth");
+		redirect.searchParams.set("state", state);
+		const transaction = {
+			providerId,
+			redirectUri: redirect.toString(),
+			expiresAt: this.now() + DEEP_LINK_OAUTH_TRANSACTION_TTL_MS,
+		};
+		this.pending.set(state, transaction);
+		return { state, transaction };
+	}
+
+	consume(callback: URL): DeepLinkOAuthTransaction {
+		const state = callback.searchParams.get("state")?.trim();
+		if (!state) {
+			throw new Error("OAuth callback is missing transaction state.");
+		}
+		const transaction = this.pending.get(state);
+		// Consume before any asynchronous exchange so callbacks are single-use,
+		// including when the exchange itself fails.
+		this.pending.delete(state);
+		if (!transaction) {
+			throw new Error("OAuth callback does not match a pending login.");
+		}
+		if (transaction.expiresAt <= this.now()) {
+			throw new Error("OAuth login has expired. Start sign-in again.");
+		}
+		return transaction;
+	}
+
+	private deleteExpired(): void {
+		const now = this.now();
+		for (const [state, transaction] of this.pending) {
+			if (transaction.expiresAt <= now) this.pending.delete(state);
+		}
+	}
+}

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -18,7 +18,11 @@ import type {
 	PendingPromptsRuntimeService,
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
-import { completeLocalProviderOAuthCallback } from "../../services/providers/local-provider-service";
+import {
+	completeLocalProviderOAuthCallback,
+	createLocalProviderDeepLinkOAuthAuthorization,
+	normalizeOAuthProvider,
+} from "../../services/providers/local-provider-service";
 import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
 import { CoreSessionService } from "../../session/services/session-service";
@@ -29,6 +33,10 @@ import {
 	type CoreSettingsType,
 } from "../../settings";
 import type { CoreSessionEvent } from "../../types/events";
+import {
+	type DeepLinkOAuthTransaction,
+	DeepLinkOAuthTransactionStore,
+} from "./deep-link-oauth";
 import {
 	handleApprovalRespond,
 	requestToolApproval as requestToolApprovalHandler,
@@ -190,6 +198,7 @@ export class HubServerTransport implements NativeHubTransport {
 	private readonly sessionHost: RuntimeHost &
 		Partial<PendingPromptsRuntimeService>;
 	private readonly hubId = createSessionId("hub_");
+	private readonly deepLinkOAuth = new DeepLinkOAuthTransactionStore();
 	private readonly ctx: HubTransportContext;
 
 	constructor(readonly options: HubWebSocketServerOptions) {
@@ -427,8 +436,19 @@ export class HubServerTransport implements NativeHubTransport {
 						"Expected a supported cline:// deep link.",
 					);
 				}
+				let routedAction = action;
 				if (action.type === "auth") {
 					const callback = new URL(rawUrl);
+					let transaction: DeepLinkOAuthTransaction;
+					try {
+						transaction = this.deepLinkOAuth.consume(callback);
+					} catch (error) {
+						return errorReply(
+							envelope,
+							"invalid_oauth_transaction",
+							error instanceof Error ? error.message : String(error),
+						);
+					}
 					const code = callback.searchParams.get("code")?.trim();
 					if (!code) {
 						return errorReply(
@@ -440,27 +460,65 @@ export class HubServerTransport implements NativeHubTransport {
 					await completeLocalProviderOAuthCallback(
 						new ProviderSettingsManager(),
 						{
-							providerId: action.provider ?? "cline",
+							providerId: transaction.providerId,
 							code,
-							redirectUri: "cline://auth",
+							redirectUri: transaction.redirectUri,
+							authProvider: callback.searchParams.get("provider")?.trim(),
 						},
 					);
+					routedAction = { type: "auth", provider: transaction.providerId };
 				}
 				this.publish(
 					buildHubEvent(
 						"deep_link.opened",
-						action as unknown as Record<string, unknown>,
+						routedAction as unknown as Record<string, unknown>,
 					),
 				);
 				this.publish(
 					buildHubEvent("ui.show_window", {
 						reason: "deep_link",
-						action: action as unknown as Record<string, unknown>,
+						action: routedAction as unknown as Record<string, unknown>,
 					}),
 				);
 				return okReply(envelope, {
-					action: action as unknown as Record<string, unknown>,
+					action: routedAction as unknown as Record<string, unknown>,
 				});
+			}
+			case "deep_link.oauth.begin": {
+				const providerId =
+					typeof envelope.payload?.providerId === "string"
+						? envelope.payload.providerId.trim()
+						: "";
+				if (!providerId) {
+					return errorReply(
+						envelope,
+						"invalid_provider",
+						"deep_link.oauth.begin requires a providerId.",
+					);
+				}
+				try {
+					const normalizedProviderId = normalizeOAuthProvider(providerId);
+					const { state, transaction } =
+						this.deepLinkOAuth.begin(normalizedProviderId);
+					const authorization = createLocalProviderDeepLinkOAuthAuthorization(
+						new ProviderSettingsManager(),
+						{
+							providerId: normalizedProviderId,
+							redirectUri: transaction.redirectUri,
+							state,
+						},
+					);
+					return okReply(envelope, {
+						providerId: authorization.providerId,
+						authorizationUrl: authorization.authorizationUrl,
+					});
+				} catch (error) {
+					return errorReply(
+						envelope,
+						"oauth_not_supported",
+						error instanceof Error ? error.message : String(error),
+					);
+				}
 			}
 			case "settings.list":
 				return await this.handleSettingsList(envelope);

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -5,7 +5,11 @@ import type {
 	HubReplyEnvelope,
 	ToolApprovalRequest,
 } from "@cline/shared";
-import { captureSdkError, createSessionId } from "@cline/shared";
+import {
+	captureSdkError,
+	createSessionId,
+	parseClineDeepLink,
+} from "@cline/shared";
 import { CronService } from "../../cron/service/cron-service";
 import { HubScheduleCommandService } from "../../cron/service/schedule-command-service";
 import { HubScheduleService } from "../../cron/service/schedule-service";
@@ -14,6 +18,8 @@ import type {
 	PendingPromptsRuntimeService,
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
+import { completeLocalProviderOAuthCallback } from "../../services/providers/local-provider-service";
+import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
 import { CoreSessionService } from "../../session/services/session-service";
 import {
@@ -44,6 +50,7 @@ import {
 import { handleConnectorCommand } from "./handlers/connector-handlers";
 import {
 	buildHubEvent,
+	errorReply,
 	type HubTransportContext,
 	okReply,
 	type PendingApproval,
@@ -407,6 +414,54 @@ export class HubServerTransport implements NativeHubTransport {
 			case "ui.show_window":
 				this.publish(buildHubEvent("ui.show_window", envelope.payload ?? {}));
 				return okReply(envelope);
+			case "deep_link.open": {
+				const rawUrl =
+					typeof envelope.payload?.url === "string"
+						? envelope.payload.url.trim()
+						: "";
+				const action = parseClineDeepLink(rawUrl);
+				if (!action) {
+					return errorReply(
+						envelope,
+						"invalid_deep_link",
+						"Expected a supported cline:// deep link.",
+					);
+				}
+				if (action.type === "auth") {
+					const callback = new URL(rawUrl);
+					const code = callback.searchParams.get("code")?.trim();
+					if (!code) {
+						return errorReply(
+							envelope,
+							"invalid_oauth_callback",
+							"OAuth callback is missing the authorization code.",
+						);
+					}
+					await completeLocalProviderOAuthCallback(
+						new ProviderSettingsManager(),
+						{
+							providerId: action.provider ?? "cline",
+							code,
+							redirectUri: "cline://auth",
+						},
+					);
+				}
+				this.publish(
+					buildHubEvent(
+						"deep_link.opened",
+						action as unknown as Record<string, unknown>,
+					),
+				);
+				this.publish(
+					buildHubEvent("ui.show_window", {
+						reason: "deep_link",
+						action: action as unknown as Record<string, unknown>,
+					}),
+				);
+				return okReply(envelope, {
+					action: action as unknown as Record<string, unknown>,
+				});
+			}
 			case "settings.list":
 				return await this.handleSettingsList(envelope);
 			case "settings.toggle":

--- a/sdk/packages/core/src/hub/server/ui-events.test.ts
+++ b/sdk/packages/core/src/hub/server/ui-events.test.ts
@@ -1,4 +1,4 @@
-import type { HubUINotifyPayload } from "@cline/shared";
+import type { ClineDeepLinkAction, HubUINotifyPayload } from "@cline/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { SessionSource } from "../../types/common";
 import { HubUIClient } from "../client/ui-client";
@@ -103,6 +103,46 @@ describe("hub UI events", () => {
 		await sender.sendShowWindow({ focus: true });
 
 		await expect(received).resolves.toEqual({ focus: true });
+		sender.close();
+		receiver.close();
+	}, 10_000);
+
+	it("validates and broadcasts normalized deep links", async () => {
+		const server = await startHubServer({
+			port: 0,
+			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+		});
+		servers.push(server);
+		const sender = new HubUIClient({
+			address: server.url,
+			authToken: server.authToken,
+			clientType: "test-sender",
+		});
+		const receiver = new HubUIClient({
+			address: server.url,
+			authToken: server.authToken,
+			clientType: "test-receiver",
+		});
+		await sender.connect();
+		await receiver.connect();
+		const received = waitForEvent<ClineDeepLinkAction>((resolve) =>
+			receiver.subscribeUI({ onDeepLink: resolve }),
+		);
+		await expect(
+			sender.openDeepLink("cline://new-session?prompt=fix%20it"),
+		).resolves.toEqual({
+			type: "new_session",
+			path: undefined,
+			prompt: "fix it",
+		});
+		await expect(received).resolves.toEqual({
+			type: "new_session",
+			path: undefined,
+			prompt: "fix it",
+		});
+		await expect(sender.openDeepLink("https://example.com")).rejects.toThrow(
+			"Expected a supported cline:// deep link",
+		);
 		sender.close();
 		receiver.close();
 	}, 10_000);

--- a/sdk/packages/core/src/hub/server/ui-events.test.ts
+++ b/sdk/packages/core/src/hub/server/ui-events.test.ts
@@ -147,6 +147,34 @@ describe("hub UI events", () => {
 		receiver.close();
 	}, 10_000);
 
+	it("requires a pending transaction for OAuth deep links", async () => {
+		const server = await startHubServer({
+			port: 0,
+			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+		});
+		servers.push(server);
+		const sender = new HubUIClient({
+			address: server.url,
+			authToken: server.authToken,
+			clientType: "test-sender",
+		});
+		await sender.connect();
+
+		await expect(
+			sender.openDeepLink("cline://auth?code=untrusted&state=unknown"),
+		).rejects.toThrow("does not match a pending login");
+
+		const flow = await sender.beginDeepLinkOAuth("cline");
+		const authorizationUrl = new URL(flow.authorizationUrl);
+		const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+		expect(flow.providerId).toBe("cline");
+		expect(authorizationUrl.searchParams.get("callback_url")).toBe(redirectUri);
+		expect(authorizationUrl.searchParams.get("state")).toBeTruthy();
+		expect(redirectUri).toMatch(/^cline:\/\/auth\?state=.+/);
+
+		sender.close();
+	}, 10_000);
+
 	it("receives hub.client.registered events when clients connect", async () => {
 		const server = await startHubServer({
 			port: 0,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -656,6 +656,7 @@ export {
 export {
 	addLocalProvider,
 	type CreateConfiguredStreamingTranscriptionSessionRequest,
+	completeLocalProviderOAuthCallback,
 	createConfiguredStreamingTranscriptionSession,
 	type DeleteLocalProviderRequest,
 	deleteLocalProvider,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -658,6 +658,7 @@ export {
 	type CreateConfiguredStreamingTranscriptionSessionRequest,
 	completeLocalProviderOAuthCallback,
 	createConfiguredStreamingTranscriptionSession,
+	createLocalProviderDeepLinkOAuthAuthorization,
 	type DeleteLocalProviderRequest,
 	deleteLocalProvider,
 	ensureCustomProvidersLoaded,

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -10,9 +10,12 @@ import type {
 	SaveProviderSettingsActionRequest,
 	VoiceInputSelection,
 } from "@cline/shared";
+import { getClineEnvironmentConfig } from "@cline/shared";
 import { createOAuthClientCallbacks } from "../../auth/client";
+import { completeClineAuthorizationCode } from "../../auth/cline";
 import {
 	getProviderAuthHandler,
+	getProviderAuthStorageId,
 	loginAndSaveProviderOAuthCredentials,
 	type ProviderOAuthCredentials,
 	saveProviderOAuthCredentials,
@@ -1106,6 +1109,33 @@ export async function loginLocalProvider(
 		},
 	});
 	return handler.login({ settings: existing, callbacks, telemetry });
+}
+
+export async function completeLocalProviderOAuthCallback(
+	manager: ProviderSettingsManager,
+	input: { providerId: string; code: string; redirectUri: string },
+): Promise<ProviderSettings> {
+	const providerId = normalizeOAuthProvider(input.providerId);
+	if (providerId !== "cline" && providerId !== "cline-pass") {
+		throw new Error(
+			`deep-link OAuth callbacks are not supported for "${providerId}"`,
+		);
+	}
+	const storageProviderId = getProviderAuthStorageId(providerId) ?? providerId;
+	const existing = manager.getProviderSettings(storageProviderId);
+	const credentials = await completeClineAuthorizationCode({
+		code: input.code,
+		redirectUri: input.redirectUri,
+		apiBaseUrl:
+			existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+		provider: providerId,
+	});
+	return saveLocalProviderOAuthCredentials(
+		manager,
+		providerId,
+		existing,
+		credentials,
+	);
 }
 
 export function saveLocalProviderOAuthCredentials(

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -1113,7 +1113,12 @@ export async function loginLocalProvider(
 
 export async function completeLocalProviderOAuthCallback(
 	manager: ProviderSettingsManager,
-	input: { providerId: string; code: string; redirectUri: string },
+	input: {
+		providerId: string;
+		code: string;
+		redirectUri: string;
+		authProvider?: string;
+	},
 ): Promise<ProviderSettings> {
 	const providerId = normalizeOAuthProvider(input.providerId);
 	if (providerId !== "cline" && providerId !== "cline-pass") {
@@ -1128,7 +1133,7 @@ export async function completeLocalProviderOAuthCallback(
 		redirectUri: input.redirectUri,
 		apiBaseUrl:
 			existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
-		provider: providerId,
+		provider: input.authProvider,
 	});
 	return saveLocalProviderOAuthCredentials(
 		manager,
@@ -1136,6 +1141,29 @@ export async function completeLocalProviderOAuthCallback(
 		existing,
 		credentials,
 	);
+}
+
+export function createLocalProviderDeepLinkOAuthAuthorization(
+	manager: ProviderSettingsManager,
+	input: { providerId: string; redirectUri: string; state: string },
+): { providerId: string; authorizationUrl: string } {
+	const providerId = normalizeOAuthProvider(input.providerId);
+	if (providerId !== "cline" && providerId !== "cline-pass") {
+		throw new Error(
+			`deep-link OAuth callbacks are not supported for "${providerId}"`,
+		);
+	}
+	const storageProviderId = getProviderAuthStorageId(providerId) ?? providerId;
+	const existing = manager.getProviderSettings(storageProviderId);
+	const authorizationUrl = new URL(
+		"/api/v1/auth/authorize",
+		existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+	);
+	authorizationUrl.searchParams.set("client_type", "extension");
+	authorizationUrl.searchParams.set("callback_url", input.redirectUri);
+	authorizationUrl.searchParams.set("redirect_uri", input.redirectUri);
+	authorizationUrl.searchParams.set("state", input.state);
+	return { providerId, authorizationUrl: authorizationUrl.toString() };
 }
 
 export function saveLocalProviderOAuthCredentials(

--- a/sdk/packages/shared/src/hub-deep-link.test.ts
+++ b/sdk/packages/shared/src/hub-deep-link.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseClineDeepLink } from "./hub";
+
+describe("parseClineDeepLink", () => {
+	it("parses project, new-session, and existing-session actions", () => {
+		expect(
+			parseClineDeepLink("cline://open-project?path=%2Ftmp%2Frepo"),
+		).toEqual({
+			type: "open_project",
+			path: "/tmp/repo",
+			prompt: undefined,
+		});
+		expect(parseClineDeepLink("cline:///new-session?prompt=fix%20it")).toEqual({
+			type: "new_session",
+			path: undefined,
+			prompt: "fix it",
+		});
+		expect(parseClineDeepLink("cline://session?id=s_1")).toEqual({
+			type: "open_session",
+			sessionId: "s_1",
+			prompt: undefined,
+		});
+	});
+
+	it("returns a sanitized auth action", () => {
+		expect(
+			parseClineDeepLink("cline://auth?code=secret&provider=cline"),
+		).toEqual({
+			type: "auth",
+			provider: "cline",
+		});
+	});
+
+	it("rejects untrusted, unsupported, and incomplete URLs", () => {
+		expect(parseClineDeepLink("https://example.com/new-session")).toBeNull();
+		expect(parseClineDeepLink("cline://unknown")).toBeNull();
+		expect(parseClineDeepLink("cline://open-project")).toBeNull();
+	});
+});

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -468,7 +468,57 @@ export type HubCommandName =
 	| "cron.event.list"
 	| "cron.event.get"
 	| "ui.notify"
-	| "ui.show_window";
+	| "ui.show_window"
+	| "deep_link.open";
+
+export type ClineDeepLinkAction =
+	| { type: "auth"; provider?: string }
+	| { type: "open_project"; path: string; prompt?: string }
+	| { type: "new_session"; path?: string; prompt?: string }
+	| { type: "open_session"; sessionId: string; prompt?: string };
+
+function clineDeepLinkRoute(url: URL): string {
+	const path = url.pathname.replace(/^\/+/, "");
+	return (
+		url.hostname ? [url.hostname, path].filter(Boolean).join("/") : path
+	).toLowerCase();
+}
+
+/** Parse and validate a URL before it crosses the trusted local Hub boundary. */
+export function parseClineDeepLink(rawUrl: string): ClineDeepLinkAction | null {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== "cline:") return null;
+	const route = clineDeepLinkRoute(url);
+	const prompt = url.searchParams.get("prompt")?.trim() || undefined;
+	const path =
+		url.searchParams.get("path")?.trim() ||
+		url.searchParams.get("project")?.trim() ||
+		undefined;
+	if (route === "auth" || route.startsWith("auth/")) {
+		return {
+			type: "auth",
+			provider: url.searchParams.get("provider")?.trim() || undefined,
+		};
+	}
+	if (route === "open-project" && path) {
+		return { type: "open_project", path, prompt };
+	}
+	if (route === "new-session" || route === "task") {
+		return { type: "new_session", path, prompt };
+	}
+	if (route === "open-session" || route === "session") {
+		const sessionId =
+			url.searchParams.get("id")?.trim() ||
+			url.searchParams.get("sessionId")?.trim();
+		return sessionId ? { type: "open_session", sessionId, prompt } : null;
+	}
+	return null;
+}
 
 export const HUB_DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
 export const HUB_COMMAND_SLOW_LOG_MS = 5_000;
@@ -566,6 +616,7 @@ export type HubEventName =
 	| "settings.changed"
 	| "ui.notify"
 	| "ui.show_window"
+	| "deep_link.opened"
 	| "hub.client.updated";
 
 export interface HubEventEnvelope {

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -469,7 +469,8 @@ export type HubCommandName =
 	| "cron.event.get"
 	| "ui.notify"
 	| "ui.show_window"
-	| "deep_link.open";
+	| "deep_link.open"
+	| "deep_link.oauth.begin";
 
 export type ClineDeepLinkAction =
 	| { type: "auth"; provider?: string }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds first-class `cline://` deep-link routing through the local Cline Hub and CLI.

- accepts raw `cline://` URLs through the CLI or the explicit `cline deeplink` command
- discovers or starts the local Hub, validates and normalizes the URL, forwards it, and exits
- broadcasts typed deep-link actions and window-focus requests to connected Hub UI clients
- routes open-project, new-session/task, and open-session actions in the Hub dashboard, including prompt and workspace drafts
- completes Cline OAuth callbacks inside Hub and persists credentials without broadcasting authorization codes to UI subscribers
- supports host-style and path-style URL forms through a shared parser

CLI-only OS protocol registration remains separate packaging work; this PR provides the Hub and CLI handling path that an OS registration can target.

### Test Procedure

- Ran the full SDK build with `bun run build:sdk`.
- Ran `bun -F @cline/cli typecheck`.
- Ran `bun -F @cline/cline-hub typecheck`.
- Ran the shared deep-link parser tests: 3 passed.
- Ran the Hub UI event integration tests: 5 passed.
- Ran the CLI deep-link forwarding tests: 2 passed.
- Ran Biome on every changed TypeScript file and `git diff --check`.
- Verified the Hub integration test rejects non-`cline://` URLs and delivers normalized actions between real Hub UI clients.

Potentially affected areas are the shared Hub protocol command/event unions, Hub UI subscriptions, CLI startup routing, provider OAuth persistence, and Hub dashboard chat initialization. Focused build, typecheck, parser, CLI, and real Hub transport tests cover those boundaries.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The UI change is navigation/draft routing triggered by a deep-link event; the behavior is covered by typechecking and Hub transport tests.

### Additional Notes

This intentionally centralizes validation and OAuth completion at the trusted Hub boundary. OAuth authorization codes are consumed by Hub and omitted from published UI event payloads.