### PR TITLE
fix(clients): filter non-chat models from chat pickers

### DIFF
--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -70,6 +70,10 @@ import {
 	sendSessionInfoUpdate,
 } from "./session-updates";
 
+const CHAT_MODEL_QUERY_OPTIONS = {
+	filter: "chat",
+} satisfies Llms.GetModelsForProviderOptions;
+
 interface SessionState {
 	id: string;
 	cwd: string;
@@ -185,7 +189,10 @@ export class AcpAgent implements Agent {
 		const providerId =
 			process.env.CLINE_PROVIDER ?? this.authResult?.providerId ?? "cline";
 
-		const providerModels = await Llms.getModelsForProvider(providerId);
+		const providerModels = await Llms.getModelsForProvider(
+			providerId,
+			CHAT_MODEL_QUERY_OPTIONS,
+		);
 		// Model ids are provider-scoped, so the default must come from the
 		// provider's own catalog: `cline-pass` uses `cline-pass/…` ids that mean
 		// nothing to `cline`, and vice versa.
@@ -256,7 +263,10 @@ export class AcpAgent implements Agent {
 				// provider's own catalog just like newSession.
 				const providerId =
 					process.env.CLINE_PROVIDER ?? this.authResult?.providerId ?? "cline";
-				const providerModels = await Llms.getModelsForProvider(providerId);
+				const providerModels = await Llms.getModelsForProvider(
+					providerId,
+					CHAT_MODEL_QUERY_OPTIONS,
+				);
 				session = {
 					id: params.sessionId,
 					cwd: params.cwd,
@@ -289,6 +299,7 @@ export class AcpAgent implements Agent {
 
 		const providerModels = await Llms.getModelsForProvider(
 			session.currentProviderId,
+			CHAT_MODEL_QUERY_OPTIONS,
 		);
 		const availableModels = Object.entries(providerModels).map(
 			([availableModelId, info]) => ({
@@ -473,7 +484,10 @@ export class AcpAgent implements Agent {
 				// current one when it's offered there too, otherwise fall back to the
 				// provider's declared default rather than whichever model happens to
 				// be listed first (for cline-pass that is an unrelated free model).
-				const providerModels = await Llms.getModelsForProvider(value);
+				const providerModels = await Llms.getModelsForProvider(
+					value,
+					CHAT_MODEL_QUERY_OPTIONS,
+				);
 				session.currentModelId = await resolveDefaultModelId(
 					value,
 					session.currentModelId,
@@ -907,7 +921,10 @@ async function buildAllConfigOptions(
 ): Promise<SessionConfigOption[]> {
 	const [providerOption, providerModels] = await Promise.all([
 		buildProviderConfigOption(session.currentProviderId),
-		Llms.getModelsForProvider(session.currentProviderId),
+		Llms.getModelsForProvider(
+			session.currentProviderId,
+			CHAT_MODEL_QUERY_OPTIONS,
+		),
 	]);
 	return [
 		providerOption,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from "./commands/update";
 import { CLI_DEFAULT_CHECKPOINT_CONFIG } from "./runtime/defaults";
 import type { TuiStartupTarget } from "./tui/types";
+import { filterChatModels } from "./utils/chat-models";
 import { getCliBuildInfo } from "./utils/common";
 import {
 	buildCliCompactionConfig,
@@ -1029,7 +1030,9 @@ export async function runCli(): Promise<void> {
 				`${c.dim}[model-catalog] catalog resolution failed (${message})${c.reset}`,
 			);
 		}
-		const knownModelIds = knownModels ? Object.keys(knownModels) : [];
+		const knownModelIds = knownModels
+			? Object.keys(filterChatModels(knownModels))
+			: [];
 		const resolvedReasoning = resolveCliReasoning({
 			thinking: args.thinking,
 			thinkingExplicitlySet: args.thinkingExplicitlySet,

--- a/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/apps/cli/src/tui/views/onboarding/controller.ts
@@ -11,6 +11,7 @@ import {
 } from "@cline/core";
 import { isClineProvider } from "@cline/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { isChatProviderModel } from "../../../utils/chat-models";
 import {
 	getCliSubscriptionUrl,
 	getIndividualPlanFeatures,
@@ -233,7 +234,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			const ids = new Set<string>();
 			for (const result of results) {
 				if (result.status !== "fulfilled") continue;
-				for (const m of result.value.models) {
+				for (const m of result.value.models.filter(isChatProviderModel)) {
 					if (m.supportsReasoning) ids.add(m.id);
 				}
 			}
@@ -283,7 +284,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 						providerId,
 						providerConfig,
 					);
-					return models.map(toModelEntry);
+					return models.filter(isChatProviderModel).map(toModelEntry);
 				})
 				.then((models) => {
 					setModelEntries(models);

--- a/apps/cli/src/tui/views/onboarding/model.test.ts
+++ b/apps/cli/src/tui/views/onboarding/model.test.ts
@@ -128,6 +128,27 @@ describe("onboarding model helpers", () => {
 		]);
 	});
 
+	it("keeps non-chat models out of the onboarding model picker", () => {
+		expect(
+			toModelEntriesFromKnownModels({
+				"whisper-large-v3": {
+					name: "Whisper Large V3",
+					modalities: { input: ["audio"], output: ["text"] },
+				},
+				"llama-chat": {
+					name: "Llama Chat",
+					modalities: { input: ["text"], output: ["text"] },
+				},
+			}),
+		).toEqual([
+			{
+				id: "llama-chat",
+				name: "Llama Chat",
+				supportsReasoning: false,
+			},
+		]);
+	});
+
 	it("formats OAuth provider labels for onboarding status views", () => {
 		expect(getOAuthProviderLabel("cline")).toBe("Cline");
 		expect(getOAuthProviderLabel("cline-pass")).toBe("ClinePass");

--- a/apps/cli/src/tui/views/onboarding/model.test.ts
+++ b/apps/cli/src/tui/views/onboarding/model.test.ts
@@ -131,6 +131,10 @@ describe("onboarding model helpers", () => {
 	it("keeps non-chat models out of the onboarding model picker", () => {
 		expect(
 			toModelEntriesFromKnownModels({
+				"operation-only-whisper": {
+					name: "Operation-only Whisper",
+					operation: "transcription",
+				},
 				"whisper-large-v3": {
 					name: "Whisper Large V3",
 					modalities: { input: ["audio"], output: ["text"] },

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -1,4 +1,8 @@
-import type { ChatModelModalities, ModelModality } from "@cline/shared";
+import type {
+	ChatModelModalities,
+	ModelModality,
+	ModelOperation,
+} from "@cline/shared";
 import { isChatProviderModel } from "../../../utils/chat-models";
 import { isOpenAICodexCliProvider } from "../../../utils/codex-cli";
 import { isOAuthProvider } from "../../../utils/provider-auth";
@@ -153,6 +157,7 @@ export interface ProviderModelItem {
 	id: string;
 	name?: string;
 	supportsReasoning?: boolean;
+	operation?: ModelOperation;
 	inputModalities?: ModelModality[];
 	outputModalities?: ModelModality[];
 }
@@ -160,6 +165,7 @@ export interface ProviderModelItem {
 export interface KnownModelInfo {
 	name?: string;
 	capabilities?: string[];
+	operation?: ModelOperation;
 	modalities?: ChatModelModalities;
 }
 
@@ -192,6 +198,7 @@ export function toModelEntriesFromKnownModels(
 	return Object.entries(knownModels)
 		.filter(([, info]) =>
 			isChatProviderModel({
+				operation: info.operation,
 				inputModalities: info.modalities?.input,
 				outputModalities: info.modalities?.output,
 			}),

--- a/apps/cli/src/tui/views/onboarding/model.ts
+++ b/apps/cli/src/tui/views/onboarding/model.ts
@@ -1,3 +1,5 @@
+import type { ChatModelModalities, ModelModality } from "@cline/shared";
+import { isChatProviderModel } from "../../../utils/chat-models";
 import { isOpenAICodexCliProvider } from "../../../utils/codex-cli";
 import { isOAuthProvider } from "../../../utils/provider-auth";
 
@@ -151,11 +153,14 @@ export interface ProviderModelItem {
 	id: string;
 	name?: string;
 	supportsReasoning?: boolean;
+	inputModalities?: ModelModality[];
+	outputModalities?: ModelModality[];
 }
 
 export interface KnownModelInfo {
 	name?: string;
 	capabilities?: string[];
+	modalities?: ChatModelModalities;
 }
 
 export function toProviderEntry(provider: ProviderCatalogItem): ProviderEntry {
@@ -185,6 +190,12 @@ export function toModelEntriesFromKnownModels(
 ): ModelEntry[] {
 	if (!knownModels) return [];
 	return Object.entries(knownModels)
+		.filter(([, info]) =>
+			isChatProviderModel({
+				inputModalities: info.modalities?.input,
+				outputModalities: info.modalities?.output,
+			}),
+		)
 		.map(([id, info]) => ({
 			id,
 			name: info.name || id,

--- a/apps/cli/src/utils/chat-models.test.ts
+++ b/apps/cli/src/utils/chat-models.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { filterChatModels, isChatProviderModel } from "./chat-models";
+
+describe("chat model filtering", () => {
+	it("keeps unknown and text-capable catalog models", () => {
+		const models = {
+			legacy: { name: "Legacy" },
+			chat: {
+				name: "Chat",
+				modalities: { input: ["text"] as const, output: ["text"] as const },
+			},
+			mixed: {
+				name: "Mixed",
+				modalities: {
+					input: ["text", "image"] as const,
+					output: ["text", "image"] as const,
+				},
+			},
+		};
+
+		expect(Object.keys(filterChatModels(models))).toEqual([
+			"legacy",
+			"chat",
+			"mixed",
+		]);
+	});
+
+	it("removes dedicated transcription and media-generation models", () => {
+		const models = {
+			whisper: {
+				modalities: { input: ["audio"] as const, output: ["text"] as const },
+			},
+			tts: {
+				modalities: { input: ["text"] as const, output: ["audio"] as const },
+			},
+		};
+
+		expect(filterChatModels(models)).toEqual({});
+	});
+
+	it("filters flattened provider model responses with the same rule", () => {
+		expect(
+			isChatProviderModel({
+				inputModalities: ["audio"],
+				outputModalities: ["text"],
+			}),
+		).toBe(false);
+		expect(
+			isChatProviderModel({
+				inputModalities: ["text", "image"],
+				outputModalities: ["text"],
+			}),
+		).toBe(true);
+		expect(isChatProviderModel({})).toBe(true);
+	});
+});

--- a/apps/cli/src/utils/chat-models.test.ts
+++ b/apps/cli/src/utils/chat-models.test.ts
@@ -27,6 +27,7 @@ describe("chat model filtering", () => {
 
 	it("removes dedicated transcription and media-generation models", () => {
 		const models = {
+			operationOnly: { operation: "speech-generation" as const },
 			whisper: {
 				modalities: { input: ["audio"] as const, output: ["text"] as const },
 			},
@@ -39,6 +40,7 @@ describe("chat model filtering", () => {
 	});
 
 	it("filters flattened provider model responses with the same rule", () => {
+		expect(isChatProviderModel({ operation: "transcription" })).toBe(false);
 		expect(
 			isChatProviderModel({
 				inputModalities: ["audio"],

--- a/apps/cli/src/utils/chat-models.ts
+++ b/apps/cli/src/utils/chat-models.ts
@@ -1,0 +1,30 @@
+import {
+	type ChatModelModalities,
+	type ModelModality,
+	supportsChatModalities,
+} from "@cline/shared";
+
+export type ChatCatalogModel = {
+	readonly modalities?: ChatModelModalities;
+	readonly [key: string]: unknown;
+};
+
+export function filterChatModels<T extends ChatCatalogModel>(
+	models: Readonly<Record<string, T>>,
+): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(models).filter(([, model]) =>
+			supportsChatModalities(model.modalities),
+		),
+	);
+}
+
+export function isChatProviderModel(model: {
+	readonly inputModalities?: readonly ModelModality[];
+	readonly outputModalities?: readonly ModelModality[];
+}): boolean {
+	return supportsChatModalities({
+		input: model.inputModalities,
+		output: model.outputModalities,
+	});
+}

--- a/apps/cli/src/utils/chat-models.ts
+++ b/apps/cli/src/utils/chat-models.ts
@@ -1,10 +1,12 @@
 import {
 	type ChatModelModalities,
+	isChatCompatibleModel,
 	type ModelModality,
-	supportsChatModalities,
+	type ModelOperation,
 } from "@cline/shared";
 
 export type ChatCatalogModel = {
+	readonly operation?: ModelOperation;
 	readonly modalities?: ChatModelModalities;
 	readonly [key: string]: unknown;
 };
@@ -13,18 +15,20 @@ export function filterChatModels<T extends ChatCatalogModel>(
 	models: Readonly<Record<string, T>>,
 ): Record<string, T> {
 	return Object.fromEntries(
-		Object.entries(models).filter(([, model]) =>
-			supportsChatModalities(model.modalities),
-		),
+		Object.entries(models).filter(([, model]) => isChatCompatibleModel(model)),
 	);
 }
 
 export function isChatProviderModel(model: {
+	readonly operation?: ModelOperation;
 	readonly inputModalities?: readonly ModelModality[];
 	readonly outputModalities?: readonly ModelModality[];
 }): boolean {
-	return supportsChatModalities({
-		input: model.inputModalities,
-		output: model.outputModalities,
+	return isChatCompatibleModel({
+		operation: model.operation,
+		modalities: {
+			input: model.inputModalities,
+			output: model.outputModalities,
+		},
 	});
 }

--- a/apps/cline-hub/src/server/providers.ts
+++ b/apps/cline-hub/src/server/providers.ts
@@ -9,7 +9,7 @@ import {
 	normalizeOAuthProvider,
 	saveLocalProviderSettings,
 } from "@cline/core";
-import { supportsChatModalities } from "@cline/shared";
+import { isChatCompatibleModel } from "@cline/shared";
 import type {
 	WebviewInboundMessage,
 	WebviewProviderModel,
@@ -89,14 +89,18 @@ export async function loadModels(
 	);
 	const models: WebviewProviderModel[] = payload.models
 		.filter((model) =>
-			supportsChatModalities({
-				input: model.inputModalities,
-				output: model.outputModalities,
+			isChatCompatibleModel({
+				operation: model.operation,
+				modalities: {
+					input: model.inputModalities,
+					output: model.outputModalities,
+				},
 			}),
 		)
 		.map((model) => ({
 			id: model.id,
 			name: model.name,
+			operation: model.operation,
 			supportsReasoning: model.supportsReasoning,
 			supportsThinking: model.supportsReasoning,
 			inputModalities: model.inputModalities,

--- a/apps/cline-hub/src/server/providers.ts
+++ b/apps/cline-hub/src/server/providers.ts
@@ -9,6 +9,7 @@ import {
 	normalizeOAuthProvider,
 	saveLocalProviderSettings,
 } from "@cline/core";
+import { supportsChatModalities } from "@cline/shared";
 import type {
 	WebviewInboundMessage,
 	WebviewProviderModel,
@@ -86,12 +87,21 @@ export async function loadModels(
 		provider,
 		providerSettingsManager.getProviderConfig(provider),
 	);
-	const models: WebviewProviderModel[] = payload.models.map((model) => ({
-		id: model.id,
-		name: model.name,
-		supportsReasoning: model.supportsReasoning,
-		supportsThinking: model.supportsReasoning,
-	}));
+	const models: WebviewProviderModel[] = payload.models
+		.filter((model) =>
+			supportsChatModalities({
+				input: model.inputModalities,
+				output: model.outputModalities,
+			}),
+		)
+		.map((model) => ({
+			id: model.id,
+			name: model.name,
+			supportsReasoning: model.supportsReasoning,
+			supportsThinking: model.supportsReasoning,
+			inputModalities: model.inputModalities,
+			outputModalities: model.outputModalities,
+		}));
 	ctx.send(peer, { type: "models", providerId: provider, models });
 }
 

--- a/apps/cline-hub/src/webview-protocol.ts
+++ b/apps/cline-hub/src/webview-protocol.ts
@@ -15,7 +15,7 @@ export type WebviewUsage = {
 
 export type WebviewProviderModel = Pick<
 	ProviderModel,
-	"id" | "name" | "supportsReasoning"
+	"id" | "name" | "supportsReasoning" | "inputModalities" | "outputModalities"
 > & {
 	supportsThinking?: boolean;
 };

--- a/apps/cline-hub/src/webview-protocol.ts
+++ b/apps/cline-hub/src/webview-protocol.ts
@@ -15,7 +15,12 @@ export type WebviewUsage = {
 
 export type WebviewProviderModel = Pick<
 	ProviderModel,
-	"id" | "name" | "supportsReasoning" | "inputModalities" | "outputModalities"
+	| "id"
+	| "name"
+	| "operation"
+	| "supportsReasoning"
+	| "inputModalities"
+	| "outputModalities"
 > & {
 	supportsThinking?: boolean;
 };

--- a/apps/cline-hub/src/webview/src/lib/provider-model-catalog.test.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-model-catalog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildProviderModelCatalog } from "./provider-model-catalog";
+import type { Provider } from "./provider-schema";
+
+function provider(modelList: NonNullable<Provider["modelList"]>): Provider {
+	return {
+		id: "test",
+		name: "Test",
+		models: modelList.length,
+		color: "#000000",
+		letter: "T",
+		enabled: true,
+		modelList,
+	};
+}
+
+describe("buildProviderModelCatalog", () => {
+	it("keeps legacy and mixed chat models while excluding dedicated media endpoints", () => {
+		const catalog = buildProviderModelCatalog([
+			provider([
+				{ id: "legacy", name: "Legacy" },
+				{
+					id: "mixed",
+					name: "Mixed",
+					inputModalities: ["text", "image"],
+					outputModalities: ["text", "image"],
+					supportsReasoning: true,
+				},
+				{
+					id: "transcription",
+					name: "Transcription",
+					inputModalities: ["audio"],
+					outputModalities: ["text"],
+				},
+				{
+					id: "image",
+					name: "Image",
+					inputModalities: ["text"],
+					outputModalities: ["image"],
+				},
+			]),
+		]);
+
+		expect(catalog.enabledProviderIds).toEqual(["test"]);
+		expect(catalog.providerModels.test).toEqual(["legacy", "mixed"]);
+		expect(catalog.providerReasoningModels.test).toEqual(["mixed"]);
+	});
+
+	it("omits enabled providers with no chat-compatible models", () => {
+		const catalog = buildProviderModelCatalog([
+			provider([
+				{
+					id: "speech",
+					name: "Speech",
+					inputModalities: ["text"],
+					outputModalities: ["audio"],
+				},
+			]),
+		]);
+
+		expect(catalog.enabledProviderIds).toEqual([]);
+		expect(catalog.providerModels.test).toEqual([]);
+	});
+});

--- a/apps/cline-hub/src/webview/src/lib/provider-model-catalog.test.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-model-catalog.test.ts
@@ -20,6 +20,11 @@ describe("buildProviderModelCatalog", () => {
 			provider([
 				{ id: "legacy", name: "Legacy" },
 				{
+					id: "operation-only-transcription",
+					name: "Operation-only Transcription",
+					operation: "transcription",
+				},
+				{
 					id: "mixed",
 					name: "Mixed",
 					inputModalities: ["text", "image"],
@@ -37,6 +42,11 @@ describe("buildProviderModelCatalog", () => {
 					name: "Image",
 					inputModalities: ["text"],
 					outputModalities: ["image"],
+				},
+				{
+					id: "image-operation",
+					name: "Image Operation",
+					operation: "image-generation",
 				},
 			]),
 		]);

--- a/apps/cline-hub/src/webview/src/lib/provider-model-catalog.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-model-catalog.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { supportsChatModalities } from "@cline/shared";
 import { desktopClient } from "@/lib/desktop-client";
 import type {
 	Provider,
@@ -16,12 +17,26 @@ export type ProviderModelCatalog = {
 };
 
 function toModelIds(models: ProviderModel[] | undefined): string[] {
-	return (models ?? []).map((model) => model.id);
+	return (models ?? [])
+		.filter((model) =>
+			supportsChatModalities({
+				input: model.inputModalities,
+				output: model.outputModalities,
+			}),
+		)
+		.map((model) => model.id);
 }
 
 function toReasoningModelIds(models: ProviderModel[] | undefined): string[] {
 	return (models ?? [])
-		.filter((model) => model.supportsReasoning)
+		.filter(
+			(model) =>
+				model.supportsReasoning &&
+				supportsChatModalities({
+					input: model.inputModalities,
+					output: model.outputModalities,
+				}),
+		)
 		.map((model) => model.id);
 }
 
@@ -31,7 +46,10 @@ export function buildProviderModelCatalog(
 	return {
 		providers,
 		enabledProviderIds: providers
-			.filter((provider) => provider.enabled)
+			.filter(
+				(provider) =>
+					provider.enabled && toModelIds(provider.modelList).length > 0,
+			)
 			.map((provider) => provider.id),
 		providerModels: Object.fromEntries(
 			providers.map((provider) => [

--- a/apps/cline-hub/src/webview/src/lib/provider-model-catalog.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-model-catalog.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { supportsChatModalities } from "@cline/shared";
+import { isChatCompatibleModel } from "@cline/shared";
 import { desktopClient } from "@/lib/desktop-client";
 import type {
 	Provider,
@@ -19,9 +19,12 @@ export type ProviderModelCatalog = {
 function toModelIds(models: ProviderModel[] | undefined): string[] {
 	return (models ?? [])
 		.filter((model) =>
-			supportsChatModalities({
-				input: model.inputModalities,
-				output: model.outputModalities,
+			isChatCompatibleModel({
+				operation: model.operation,
+				modalities: {
+					input: model.inputModalities,
+					output: model.outputModalities,
+				},
 			}),
 		)
 		.map((model) => model.id);
@@ -32,9 +35,12 @@ function toReasoningModelIds(models: ProviderModel[] | undefined): string[] {
 		.filter(
 			(model) =>
 				model.supportsReasoning &&
-				supportsChatModalities({
-					input: model.inputModalities,
-					output: model.outputModalities,
+				isChatCompatibleModel({
+					operation: model.operation,
+					modalities: {
+						input: model.inputModalities,
+						output: model.outputModalities,
+					},
 				}),
 		)
 		.map((model) => model.id);

--- a/apps/cline-hub/src/webview/src/lib/provider-schema.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-schema.ts
@@ -1,14 +1,15 @@
+import type { ModelModality, ModelOperation } from "@cline/shared";
+
 export interface ProviderModel {
 	id: string;
 	name: string;
 	supportsAttachments?: boolean;
 	supportsVision?: boolean;
 	supportsReasoning?: boolean;
+	operation?: ModelOperation;
 	inputModalities?: ModelModality[];
 	outputModalities?: ModelModality[];
 }
-
-export type ModelModality = "text" | "image" | "audio" | "video" | "pdf";
 
 export type ProviderConfigFieldType =
 	| "text"

--- a/apps/cline-hub/src/webview/src/lib/provider-schema.ts
+++ b/apps/cline-hub/src/webview/src/lib/provider-schema.ts
@@ -4,7 +4,11 @@ export interface ProviderModel {
 	supportsAttachments?: boolean;
 	supportsVision?: boolean;
 	supportsReasoning?: boolean;
+	inputModalities?: ModelModality[];
+	outputModalities?: ModelModality[];
 }
+
+export type ModelModality = "text" | "image" | "audio" | "video" | "pdf";
 
 export type ProviderConfigFieldType =
 	| "text"

--- a/apps/cline-hub/vitest.config.ts
+++ b/apps/cline-hub/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
 	resolve: {
 		alias: [
 			{
+				find: /^@\/(.+)$/,
+				replacement: resolve(rootDir, "src/webview/src/$1"),
+			},
+			{
 				find: /^@cline\/core$/,
 				replacement: resolve(rootDir, "../../sdk/packages/core/src/index.ts"),
 			},

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	buildProviderModelCatalog,
 	filterChatModels,
+	isChatModel,
 	isDedicatedTranscriptionModel,
 	publishProviderModels,
 	selectTranscriptionModel,
@@ -66,6 +67,50 @@ describe("transcription model selection", () => {
 		).toBe(false);
 	});
 
+	it("keeps chat and image-generation models in the composer", () => {
+		expect(
+			isChatModel({
+				id: "chat",
+				name: "Chat",
+				inputModalities: ["text", "audio"],
+				outputModalities: ["text"],
+			}),
+		).toBe(true);
+		expect(
+			isChatModel({
+				id: "legacy",
+				name: "Legacy",
+			}),
+		).toBe(true);
+		expect(
+			isChatModel({
+				id: "image",
+				name: "Image",
+				operation: "image-generation",
+				inputModalities: ["text", "image"],
+				outputModalities: ["image"],
+			}),
+		).toBe(true);
+		expect(
+			isChatModel({
+				id: "whisper",
+				name: "Whisper",
+				operation: "transcription",
+				inputModalities: ["audio"],
+				outputModalities: ["text"],
+			}),
+		).toBe(false);
+		expect(
+			isChatModel({
+				id: "tts",
+				name: "TTS",
+				operation: "speech-generation",
+				inputModalities: ["text"],
+				outputModalities: ["audio"],
+			}),
+		).toBe(false);
+	});
+
 	it("selects only the explicitly configured enabled model", () => {
 		const providers: Provider[] = [
 			{
@@ -119,7 +164,7 @@ describe("transcription model selection", () => {
 		expect(selectTranscriptionModel(providers, undefined)).toBeNull();
 	});
 
-	it("keeps voice selection in the provider catalog", () => {
+	it("keeps an enabled audio-only provider out of chat without losing voice selection", () => {
 		const elevenLabs: Provider = {
 			id: "elevenlabs",
 			name: "ElevenLabs",
@@ -143,6 +188,7 @@ describe("transcription model selection", () => {
 			modelId: "scribe_v2",
 		};
 		const catalog = buildProviderModelCatalog([elevenLabs], selection);
+		expect(catalog.enabledProviderIds).toEqual([]);
 		expect(catalog.providerModels.elevenlabs).toEqual([]);
 		expect(catalog.voiceInput).toMatchObject({
 			providerId: "elevenlabs",

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
@@ -102,6 +102,13 @@ describe("transcription model selection", () => {
 		).toBe(false);
 		expect(
 			isChatModel({
+				id: "operation-only-whisper",
+				name: "Operation-only Whisper",
+				operation: "transcription",
+			}),
+		).toBe(false);
+		expect(
+			isChatModel({
 				id: "tts",
 				name: "TTS",
 				operation: "speech-generation",

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { supportsChatModalities } from "@cline/shared/browser";
 import { desktopClient } from "@/lib/desktop-client";
 import type {
 	Provider,
@@ -39,8 +40,16 @@ export function supportsAudio(model: ProviderModel): boolean {
 export function filterChatModels(
 	models: ProviderModel[] | undefined,
 ): ProviderModel[] {
-	return (models ?? []).filter(
-		(model) => !isDedicatedTranscriptionModel(model),
+	return (models ?? []).filter(isChatModel);
+}
+
+export function isChatModel(model: ProviderModel): boolean {
+	return (
+		model.operation === "image-generation" ||
+		supportsChatModalities({
+			input: model.inputModalities,
+			output: model.outputModalities,
+		})
 	);
 }
 
@@ -85,7 +94,10 @@ export function buildProviderModelCatalog(
 	return {
 		providers,
 		enabledProviderIds: providers
-			.filter((provider) => provider.enabled)
+			.filter(
+				(provider) =>
+					provider.enabled && toModelIds(provider.modelList).length > 0,
+			)
 			.map((provider) => provider.id),
 		providerModels: Object.fromEntries(
 			providers.map((provider) => [

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { supportsChatModalities } from "@cline/shared/browser";
+import { isChatCompatibleModel } from "@cline/shared/browser";
 import { desktopClient } from "@/lib/desktop-client";
 import type {
 	Provider,
@@ -45,10 +45,16 @@ export function filterChatModels(
 
 export function isChatModel(model: ProviderModel): boolean {
 	return (
+		// Desktop supports image generation directly from its composer. Other
+		// chat-only clients intentionally use isChatCompatibleModel without this
+		// operation-specific exception.
 		model.operation === "image-generation" ||
-		supportsChatModalities({
-			input: model.inputModalities,
-			output: model.outputModalities,
+		isChatCompatibleModel({
+			operation: model.operation,
+			modalities: {
+				input: model.inputModalities,
+				output: model.outputModalities,
+			},
 		})
 	);
 }

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -116,8 +116,16 @@ describe("provider model catalog handlers", () => {
 						apiFormat: ApiFormat.OPENAI_CHAT,
 					},
 				],
+				[
+					"whisper-large-v3",
+					{
+						name: "Whisper Large V3",
+						supportsPromptCache: false,
+						modalities: { input: ["audio"], output: ["text"] },
+					},
+				],
 			]),
-			defaultModelId: "deepseek-v4-flash",
+			defaultModelId: "whisper-large-v3",
 			source: "sdk-dynamic",
 			fetchedAt: 99,
 		})
@@ -141,6 +149,8 @@ describe("provider model catalog handlers", () => {
 			temperature: 0.2,
 			apiFormat: ApiFormat.OPENAI_CHAT,
 		})
+		expect(response.models["whisper-large-v3"]).toBeUndefined()
+		expect(response.defaultModelId).toBe("deepseek-v4-flash")
 		expect(catalog.resolveModels).toHaveBeenCalledWith(providerId, { forceRefresh: true })
 	})
 

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -150,7 +150,9 @@ describe("provider model catalog handlers", () => {
 			apiFormat: ApiFormat.OPENAI_CHAT,
 		})
 		expect(response.models["whisper-large-v3"]).toBeUndefined()
-		expect(response.defaultModelId).toBe("deepseek-v4-flash")
+		// Do not invent an order-dependent default when the declared default is
+		// filtered out. The picker can leave the selection unset instead.
+		expect(response.defaultModelId).toBeUndefined()
 		expect(catalog.resolveModels).toHaveBeenCalledWith(providerId, { forceRefresh: true })
 	})
 

--- a/apps/vscode/src/core/controller/models/providerCatalogShared.ts
+++ b/apps/vscode/src/core/controller/models/providerCatalogShared.ts
@@ -1,4 +1,5 @@
 import type { ApiConfiguration, ModelInfo } from "@shared/api"
+import { filterChatModelMap, resolveChatModelDefault } from "@/sdk/model-catalog/chat-models"
 import type {
 	EffectiveProviderConfig,
 	Mode,
@@ -195,16 +196,30 @@ export function toProviderModelsResponse(
 	requestId: string,
 	result: ProviderModelsResult,
 ): ProviderModelsResponse {
+	if (!result.ok) {
+		return ProviderModelsResponse.create({
+			providerId,
+			requestId,
+			configFingerprint: result.configFingerprint,
+			fetchedAt: result.fetchedAt,
+			ok: false,
+			models: {},
+			error: toCatalogErrorInfo(result.error),
+		})
+	}
+
+	const chatModels = filterChatModelMap(result.models)
+	const defaultModelId = resolveChatModelDefault(result.defaultModelId, chatModels)
+
 	return ProviderModelsResponse.create({
 		providerId,
 		requestId,
 		configFingerprint: result.configFingerprint,
 		fetchedAt: result.fetchedAt,
-		ok: result.ok,
-		models: result.ok ? toProtobufModels(result.models) : {},
-		defaultModelId: result.ok ? result.defaultModelId : undefined,
-		source: result.ok ? result.source : undefined,
-		error: result.ok ? undefined : toCatalogErrorInfo(result.error),
+		ok: true,
+		models: toProtobufModels(chatModels),
+		defaultModelId,
+		source: result.source,
 	})
 }
 

--- a/apps/vscode/src/sdk/model-catalog/chat-models.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/chat-models.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { filterChatModelMap, resolveChatModelDefault } from "./chat-models"
+
+describe("VS Code chat model filtering", () => {
+	it("keeps legacy, text, and mixed text-output models", () => {
+		const models = new Map([
+			["legacy", {}],
+			[
+				"chat",
+				{
+					modalities: {
+						input: ["text"] as const,
+						output: ["text"] as const,
+					},
+				},
+			],
+			[
+				"mixed",
+				{
+					modalities: {
+						input: ["text", "image"] as const,
+						output: ["text", "image"] as const,
+					},
+				},
+			],
+		])
+
+		expect([...filterChatModelMap(models).keys()]).toEqual(["legacy", "chat", "mixed"])
+	})
+
+	it("removes dedicated transcription and media-generation models", () => {
+		const models = new Map([
+			[
+				"whisper",
+				{
+					modalities: {
+						input: ["audio"] as const,
+						output: ["text"] as const,
+					},
+				},
+			],
+			[
+				"tts",
+				{
+					modalities: {
+						input: ["text"] as const,
+						output: ["audio"] as const,
+					},
+				},
+			],
+		])
+
+		expect(filterChatModelMap(models).size).toBe(0)
+	})
+
+	it("falls back when the catalog default is not chat-compatible", () => {
+		const models = new Map([["chat", {}]])
+		expect(resolveChatModelDefault("whisper", models)).toBe("chat")
+		expect(resolveChatModelDefault("chat", models)).toBe("chat")
+		expect(resolveChatModelDefault("whisper", new Map())).toBeUndefined()
+	})
+})

--- a/apps/vscode/src/sdk/model-catalog/chat-models.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/chat-models.test.ts
@@ -30,6 +30,7 @@ describe("VS Code chat model filtering", () => {
 
 	it("removes dedicated transcription and media-generation models", () => {
 		const models = new Map([
+			["operation-only", { operation: "transcription" as const }],
 			[
 				"whisper",
 				{
@@ -53,10 +54,11 @@ describe("VS Code chat model filtering", () => {
 		expect(filterChatModelMap(models).size).toBe(0)
 	})
 
-	it("falls back when the catalog default is not chat-compatible", () => {
+	it("preserves only a declared chat-compatible catalog default", () => {
 		const models = new Map([["chat", {}]])
-		expect(resolveChatModelDefault("whisper", models)).toBe("chat")
+		expect(resolveChatModelDefault("whisper", models)).toBeUndefined()
 		expect(resolveChatModelDefault("chat", models)).toBe("chat")
 		expect(resolveChatModelDefault("whisper", new Map())).toBeUndefined()
+		expect(resolveChatModelDefault(undefined, models)).toBeUndefined()
 	})
 })

--- a/apps/vscode/src/sdk/model-catalog/chat-models.ts
+++ b/apps/vscode/src/sdk/model-catalog/chat-models.ts
@@ -1,16 +1,17 @@
-import { type ChatModelModalities, supportsChatModalities } from "@cline/shared"
+import { type ChatModelModalities, isChatCompatibleModel, type ModelOperation } from "@cline/shared"
 
 type ChatCatalogModel = {
+	readonly operation?: ModelOperation
 	readonly modalities?: ChatModelModalities
 }
 
 export function filterChatModelMap<T extends ChatCatalogModel>(models: ReadonlyMap<string, T>): Map<string, T> {
-	return new Map([...models].filter(([, model]) => supportsChatModalities(model.modalities)))
+	return new Map([...models].filter(([, model]) => isChatCompatibleModel(model)))
 }
 
 export function resolveChatModelDefault(
 	defaultModelId: string | undefined,
 	models: ReadonlyMap<string, unknown>,
 ): string | undefined {
-	return defaultModelId && models.has(defaultModelId) ? defaultModelId : models.keys().next().value
+	return defaultModelId && models.has(defaultModelId) ? defaultModelId : undefined
 }

--- a/apps/vscode/src/sdk/model-catalog/chat-models.ts
+++ b/apps/vscode/src/sdk/model-catalog/chat-models.ts
@@ -1,0 +1,16 @@
+import { type ChatModelModalities, supportsChatModalities } from "@cline/shared"
+
+type ChatCatalogModel = {
+	readonly modalities?: ChatModelModalities
+}
+
+export function filterChatModelMap<T extends ChatCatalogModel>(models: ReadonlyMap<string, T>): Map<string, T> {
+	return new Map([...models].filter(([, model]) => supportsChatModalities(model.modalities)))
+}
+
+export function resolveChatModelDefault(
+	defaultModelId: string | undefined,
+	models: ReadonlyMap<string, unknown>,
+): string | undefined {
+	return defaultModelId && models.has(defaultModelId) ? defaultModelId : models.keys().next().value
+}

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
@@ -50,6 +50,17 @@ describe("adaptSdkModelInfo", () => {
 			expect(() => adaptSdkModelInfo({ id: "m", pricing: { input: Number.POSITIVE_INFINITY } })).toThrow(CatalogShapeError)
 		})
 
+		it("throws CatalogShapeError when modalities are malformed", () => {
+			expect(() => adaptSdkModelInfo({ id: "m", modalities: "audio" })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", modalities: { input: ["audio"] } })).toThrow(CatalogShapeError)
+			expect(() =>
+				adaptSdkModelInfo({
+					id: "m",
+					modalities: { input: ["audio"], output: ["unknown"] },
+				}),
+			).toThrow(CatalogShapeError)
+		})
+
 		it("CatalogShapeError exposes useful message and details", () => {
 			try {
 				adaptSdkModelInfo({ id: 5 })
@@ -153,6 +164,21 @@ describe("adaptSdkModelInfo", () => {
 			expect(model.outputPrice).toBe(0)
 			expect(model.cacheReadsPrice).toBeUndefined()
 			expect(model.cacheWritesPrice).toBeUndefined()
+		})
+	})
+
+	describe("modalities", () => {
+		it("preserves validated SDK modality metadata", () => {
+			expect(
+				adaptSdkModelInfo({
+					id: "whisper-large-v3",
+					modalities: { input: ["audio"], output: ["text"] },
+				}).modalities,
+			).toEqual({ input: ["audio"], output: ["text"] })
+		})
+
+		it("leaves absent modality metadata undefined", () => {
+			expect(adaptSdkModelInfo({ id: "legacy-chat-model" }).modalities).toBeUndefined()
 		})
 	})
 

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -58,6 +58,77 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("filters image-output models from the merged Cline catalog", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								"vendor/live-chat-model": {
+									name: "Live Chat Model",
+									tool_call: true,
+								},
+								"vendor/live-image-model": {
+									name: "Live Image Model",
+									tool_call: true,
+									modalities: {
+										input: ["text", "image"],
+										output: ["text", "image"],
+									},
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}),
+		);
+
+		const resolved = await resolveProviderConfig(
+			"cline",
+			{
+				loadLatestOnInit: true,
+				failOnError: false,
+				cacheTtlMs: 0,
+			},
+			{
+				providerId: "cline",
+				modelId: "vendor/live-chat-model",
+				knownModels: {
+					"vendor/custom-image-model": {
+						id: "vendor/custom-image-model",
+						name: "Custom Image Model",
+						modalities: {
+							input: ["text"],
+							output: ["image"],
+						},
+					},
+					"vendor/custom-image-operation-model": {
+						id: "vendor/custom-image-operation-model",
+						name: "Custom Image Operation Model",
+						operation: "image-generation",
+					},
+				},
+			},
+		);
+
+		expect(resolved?.knownModels?.["vendor/live-chat-model"]?.name).toBe(
+			"Live Chat Model",
+		);
+		expect(resolved?.knownModels?.["vendor/live-image-model"]).toBeUndefined();
+		expect(
+			resolved?.knownModels?.["vendor/custom-image-model"],
+		).toBeUndefined();
+		expect(
+			resolved?.knownModels?.["vendor/custom-image-operation-model"],
+		).toBeUndefined();
+	});
+
 	it("uses only live Cline recommended models for ClinePass when live models are found", async () => {
 		const fetchMock = vi.fn(async (url: string) => {
 			if (url === "https://models.test/api.json") {

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -205,14 +205,18 @@ async function mergeKnownModels(
 
 	if (providerId === "cline") {
 		// Cline recommendations can use Vercel-style ids while the broader
-		// catalog includes OpenRouter aliases for the same models.
-		return Llms.sortModelsByReleaseDate({
-			...Llms.preferCanonicalModelIds(
-				knownModelsWithoutUserOverrides,
-				Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
-			),
-			...userKnownModels,
-		});
+		// catalog includes OpenRouter aliases for the same models. Image-output
+		// models are temporarily unavailable through Cline's inference backend,
+		// so filter them only at the Cline catalog boundary.
+		return Llms.sortModelsByReleaseDate(
+			Llms.filterImageOutputModels({
+				...Llms.preferCanonicalModelIds(
+					knownModelsWithoutUserOverrides,
+					Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
+				),
+				...userKnownModels,
+			}),
+		);
 	}
 
 	return Llms.sortModelsByReleaseDate({

--- a/sdk/packages/llms/src/catalog/model-filters.ts
+++ b/sdk/packages/llms/src/catalog/model-filters.ts
@@ -1,0 +1,19 @@
+import type { ModelInfo } from "./types";
+
+/**
+ * Remove models that declare image output from a model catalog.
+ *
+ * This includes both dedicated image-generation models and language models
+ * that can return mixed text-and-image output.
+ */
+export function filterImageOutputModels(
+	models: Record<string, ModelInfo>,
+): Record<string, ModelInfo> {
+	return Object.fromEntries(
+		Object.entries(models).filter(
+			([, model]) =>
+				model.operation !== "image-generation" &&
+				model.modalities?.output.includes("image") !== true,
+		),
+	);
+}

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -1,14 +1,17 @@
 export { CLINE_DEFAULT_MODEL_ID } from "@cline/shared";
 export type {
+	GetModelsForProviderOptions,
 	ModelCollection,
 	ModelIdAliasRule,
 	ModelInfo,
 	ModelInfo as CatalogModelInfo,
 	ProviderCapability as CatalogProviderCapability,
 	ProviderInfo,
+	ProviderModelFilter,
 } from "./models";
 export {
 	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	filterImageOutputModels,
 	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -1,5 +1,6 @@
 export { CLINE_DEFAULT_MODEL_ID } from "@cline/shared";
 export type {
+	GetModelsForProviderOptions,
 	ModelCollection,
 	ModelIdAliasRule,
 	ModelInfo,
@@ -7,12 +8,14 @@ export type {
 	ProviderCapability as CatalogProviderCapability,
 	ProviderClient,
 	ProviderInfo,
+	ProviderModelFilter,
 	ProviderProtocol,
 } from "./models";
 export {
 	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 	fetchLiveProviderModels,
 	fetchModelsDevProviderModels,
+	filterImageOutputModels,
 	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -7,6 +7,7 @@ export {
 	fetchModelsDevProviderModels,
 	sortModelsByReleaseDate,
 } from "./catalog/catalog-live";
+export { filterImageOutputModels } from "./catalog/model-filters";
 export type { ModelIdAliasRule } from "./catalog/model-id-aliases";
 export {
 	isCanonicalModelIdForAliasRules,
@@ -21,6 +22,10 @@ export type {
 	ProviderInfo,
 	ProviderProtocol,
 } from "./catalog/types";
+export type {
+	GetModelsForProviderOptions,
+	ProviderModelFilter,
+} from "./providers/model-registry";
 export {
 	getAllProviders,
 	getModelsForProvider,

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -90,6 +90,24 @@ describe("cline builtin models", () => {
 			pricing: expect.objectContaining({ input: 0.1, output: 0.2 }),
 		});
 	});
+
+	it("excludes image-output models without changing upstream catalogs", async () => {
+		const modelId = "google/gemini-3-pro-image";
+		const [clineModels, openRouterModels, vercelModels] = await Promise.all([
+			getModelsForProvider("cline"),
+			getModelsForProvider("openrouter"),
+			getModelsForProvider("vercel-ai-gateway"),
+		]);
+
+		expect(clineModels[modelId]).toBeUndefined();
+		expect(
+			Object.values(clineModels).some(
+				(model) => model.modalities?.output.includes("image") === true,
+			),
+		).toBe(false);
+		expect(openRouterModels[modelId]?.modalities?.output).toContain("image");
+		expect(vercelModels[modelId]?.modalities?.output).toContain("image");
+	});
 });
 
 describe("baked anthropic catalog reasoning options", () => {

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -13,6 +13,7 @@ import {
 	type ProviderConfigField,
 } from "@cline/shared";
 import { getGeneratedModelsForProvider } from "../catalog/catalog.generated-access";
+import { filterImageOutputModels } from "../catalog/model-filters";
 import {
 	isCanonicalModelIdForAliasRules,
 	preferCanonicalModelIds,
@@ -487,13 +488,17 @@ function buildClineModels(): Record<string, ModelInfo> {
 				) || VERCEL_ONLY_CLINE_MODEL_IDS.includes(modelId),
 		),
 	);
-	return preferCanonicalModelIds(
+	const models = preferCanonicalModelIds(
 		{
 			...generatedModels("openrouter"),
 			...vercelAliasModels,
 		},
 		VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES,
 	);
+
+	// Cline's inference backend currently rejects image-output models. Keep
+	// those models in their native OpenRouter and Vercel catalogs.
+	return filterImageOutputModels(models);
 }
 
 function buildVertexModels(): Record<string, ModelInfo> {

--- a/sdk/packages/llms/src/providers/model-registry.test.ts
+++ b/sdk/packages/llms/src/providers/model-registry.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getModelsForProvider,
+	registerModel,
+	registerProvider,
+	resetRegistry,
+} from "./model-registry";
+
+const PROVIDER_ID = "model-filter-test";
+
+afterEach(() => {
+	resetRegistry();
+});
+
+describe("getModelsForProvider", () => {
+	it("filters the merged provider catalog through query options", async () => {
+		registerProvider({
+			provider: {
+				id: PROVIDER_ID,
+				name: "Model Filter Test",
+				defaultModelId: "legacy",
+				client: "custom",
+				source: "system",
+			},
+			models: {
+				legacy: { id: "legacy", name: "Legacy" },
+				chat: {
+					id: "chat",
+					name: "Chat",
+					operation: "language",
+					modalities: { input: ["text"], output: ["text"] },
+				},
+				mixed: {
+					id: "mixed",
+					name: "Mixed",
+					operation: "language",
+					modalities: {
+						input: ["text", "image"],
+						output: ["text", "image"],
+					},
+				},
+				image: {
+					id: "image",
+					name: "Image",
+					operation: "image-generation",
+					modalities: { input: ["text"], output: ["image"] },
+				},
+				transcription: {
+					id: "transcription",
+					name: "Transcription",
+					operation: "transcription",
+					modalities: { input: ["audio"], output: ["text"] },
+				},
+			},
+		});
+		registerModel(PROVIDER_ID, "speech", {
+			id: "speech",
+			name: "Speech",
+			operation: "speech-generation",
+			modalities: { input: ["text"], output: ["audio"] },
+		});
+
+		expect(Object.keys(await getModelsForProvider(PROVIDER_ID))).toEqual([
+			"legacy",
+			"chat",
+			"mixed",
+			"image",
+			"transcription",
+			"speech",
+		]);
+		expect(
+			Object.keys(await getModelsForProvider(PROVIDER_ID, { filter: "chat" })),
+		).toEqual(["legacy", "chat", "mixed"]);
+	});
+});

--- a/sdk/packages/llms/src/providers/model-registry.ts
+++ b/sdk/packages/llms/src/providers/model-registry.ts
@@ -1,4 +1,4 @@
-import { supportsChatModalities } from "@cline/shared";
+import { isChatCompatibleModel } from "@cline/shared";
 import type {
 	ModelCollection,
 	ModelInfo,
@@ -13,9 +13,7 @@ export interface GetModelsForProviderOptions {
 }
 
 const PROVIDER_MODEL_FILTERS = {
-	chat: (model: ModelInfo) =>
-		(model.operation === undefined || model.operation === "language") &&
-		supportsChatModalities(model.modalities),
+	chat: (model: ModelInfo) => isChatCompatibleModel(model),
 } satisfies Record<ProviderModelFilter, (model: ModelInfo) => boolean>;
 
 function buildInitialRegistry(): Map<string, ModelCollection> {

--- a/sdk/packages/llms/src/providers/model-registry.ts
+++ b/sdk/packages/llms/src/providers/model-registry.ts
@@ -1,9 +1,22 @@
+import { supportsChatModalities } from "@cline/shared";
 import type {
 	ModelCollection,
 	ModelInfo,
 	ProviderInfo,
 } from "../catalog/types";
 import { BUILTIN_PROVIDER_COLLECTION_LIST } from "./builtins";
+
+export type ProviderModelFilter = "chat";
+
+export interface GetModelsForProviderOptions {
+	filter?: ProviderModelFilter;
+}
+
+const PROVIDER_MODEL_FILTERS = {
+	chat: (model: ModelInfo) =>
+		(model.operation === undefined || model.operation === "language") &&
+		supportsChatModalities(model.modalities),
+} satisfies Record<ProviderModelFilter, (model: ModelInfo) => boolean>;
 
 function buildInitialRegistry(): Map<string, ModelCollection> {
 	const map = new Map<string, ModelCollection>();
@@ -61,14 +74,22 @@ export async function getProviderCollection(
 
 export async function getModelsForProvider(
 	providerId: string,
+	options: GetModelsForProviderOptions = {},
 ): Promise<Record<string, ModelInfo>> {
 	const collection = getProviderFromCache(providerId);
 	const builtInModels = collection?.models ?? {};
 	const customModels = CUSTOM_MODELS.get(providerId);
-	if (customModels) {
-		return { ...builtInModels, ...Object.fromEntries(customModels) };
+	const models = customModels
+		? { ...builtInModels, ...Object.fromEntries(customModels) }
+		: builtInModels;
+	if (!options.filter) {
+		return models;
 	}
-	return builtInModels;
+
+	const matches = PROVIDER_MODEL_FILTERS[options.filter];
+	return Object.fromEntries(
+		Object.entries(models).filter(([, model]) => matches(model)),
+	);
 }
 
 export async function getAllProviders(): Promise<ProviderInfo[]> {

--- a/sdk/packages/shared/src/index.browser.test.ts
+++ b/sdk/packages/shared/src/index.browser.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+	type ChatModelModalities,
+	supportsChatModalities,
+} from "./index.browser";
+
+describe("browser entry point", () => {
+	it("exports the chat-model modality API", () => {
+		const modalities: ChatModelModalities = {
+			input: ["text"],
+			output: ["text"],
+		};
+
+		expectTypeOf(modalities).toMatchTypeOf<ChatModelModalities>();
+		expect(supportsChatModalities(modalities)).toBe(true);
+	});
+});

--- a/sdk/packages/shared/src/index.browser.test.ts
+++ b/sdk/packages/shared/src/index.browser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import {
 	type ChatModelModalities,
+	isChatCompatibleModel,
 	supportsChatModalities,
 } from "./index.browser";
 
@@ -13,5 +14,6 @@ describe("browser entry point", () => {
 
 		expectTypeOf(modalities).toMatchTypeOf<ChatModelModalities>();
 		expect(supportsChatModalities(modalities)).toBe(true);
+		expect(isChatCompatibleModel({ operation: "transcription" })).toBe(false);
 	});
 });

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -186,6 +186,7 @@ export type {
 export {
 	ApiFormat,
 	ApiFormatSchema,
+	type ChatModelModalities,
 	type ModelCapability,
 	ModelCapabilitySchema,
 	type ModelInfo,
@@ -207,6 +208,7 @@ export {
 	modelHasCapability,
 	modelProducesImages,
 	modelSupportsToolCalling,
+	supportsChatModalities,
 	type ThinkingConfig,
 	ThinkingConfigSchema,
 	usesImageGenerationOperation,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -186,7 +186,9 @@ export type {
 export {
 	ApiFormat,
 	ApiFormatSchema,
+	type ChatCompatibleModelDescriptor,
 	type ChatModelModalities,
+	isChatCompatibleModel,
 	type ModelCapability,
 	ModelCapabilitySchema,
 	type ModelInfo,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -211,6 +211,7 @@ export type {
 export {
 	ApiFormat,
 	ApiFormatSchema,
+	type ChatModelModalities,
 	type ModelCapability,
 	ModelCapabilitySchema,
 	type ModelInfo,
@@ -232,6 +233,7 @@ export {
 	modelHasCapability,
 	modelProducesImages,
 	modelSupportsToolCalling,
+	supportsChatModalities,
 	type ThinkingConfig,
 	ThinkingConfigSchema,
 	usesImageGenerationOperation,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -211,7 +211,9 @@ export type {
 export {
 	ApiFormat,
 	ApiFormatSchema,
+	type ChatCompatibleModelDescriptor,
 	type ChatModelModalities,
+	isChatCompatibleModel,
 	type ModelCapability,
 	ModelCapabilitySchema,
 	type ModelInfo,

--- a/sdk/packages/shared/src/llms/model-info.test.ts
+++ b/sdk/packages/shared/src/llms/model-info.test.ts
@@ -3,7 +3,39 @@ import {
 	ModelInfoSchema,
 	modelHasCapability,
 	modelSupportsToolCalling,
+	supportsChatModalities,
 } from "./model-info";
+
+describe("supportsChatModalities", () => {
+	it("keeps models with absent legacy modality metadata", () => {
+		expect(supportsChatModalities(undefined)).toBe(true);
+		expect(supportsChatModalities({})).toBe(true);
+	});
+
+	it("keeps text chat and mixed-output models", () => {
+		expect(supportsChatModalities({ input: ["text"], output: ["text"] })).toBe(
+			true,
+		);
+		expect(
+			supportsChatModalities({
+				input: ["text", "image"],
+				output: ["text", "image"],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects dedicated transcription and media-generation models", () => {
+		expect(supportsChatModalities({ input: ["audio"], output: ["text"] })).toBe(
+			false,
+		);
+		expect(supportsChatModalities({ input: ["text"], output: ["audio"] })).toBe(
+			false,
+		);
+		expect(supportsChatModalities({ input: ["text"], output: ["image"] })).toBe(
+			false,
+		);
+	});
+});
 
 describe("ModelInfoSchema operations", () => {
 	it("preserves an explicit operation and its execution modes", () => {

--- a/sdk/packages/shared/src/llms/model-info.test.ts
+++ b/sdk/packages/shared/src/llms/model-info.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	isChatCompatibleModel,
 	ModelInfoSchema,
 	modelHasCapability,
 	modelSupportsToolCalling,
@@ -34,6 +35,37 @@ describe("supportsChatModalities", () => {
 		expect(supportsChatModalities({ input: ["text"], output: ["image"] })).toBe(
 			false,
 		);
+	});
+});
+
+describe("isChatCompatibleModel", () => {
+	it("keeps legacy and explicit language models", () => {
+		expect(isChatCompatibleModel({})).toBe(true);
+		expect(
+			isChatCompatibleModel({
+				operation: "language",
+				modalities: { input: ["text"], output: ["text"] },
+			}),
+		).toBe(true);
+	});
+
+	it("rejects non-language operations even without modality metadata", () => {
+		expect(isChatCompatibleModel({ operation: "transcription" })).toBe(false);
+		expect(isChatCompatibleModel({ operation: "speech-generation" })).toBe(
+			false,
+		);
+		expect(isChatCompatibleModel({ operation: "image-generation" })).toBe(
+			false,
+		);
+	});
+
+	it("rejects language models without text chat modalities", () => {
+		expect(
+			isChatCompatibleModel({
+				operation: "language",
+				modalities: { input: ["text"], output: ["image"] },
+			}),
+		).toBe(false);
 	});
 });
 

--- a/sdk/packages/shared/src/llms/model-info.ts
+++ b/sdk/packages/shared/src/llms/model-info.ts
@@ -88,6 +88,29 @@ export const ModelModalitiesSchema = z.object({
 
 export type ModelModalities = z.infer<typeof ModelModalitiesSchema>;
 
+export type ChatModelModalities = {
+	readonly input?: readonly ModelModality[];
+	readonly output?: readonly ModelModality[];
+};
+
+/**
+ * Returns whether a model can participate in a text chat turn.
+ *
+ * Missing modality metadata is treated as chat-compatible for backwards
+ * compatibility. When a catalog does provide modalities, the model must both
+ * accept text and produce text; dedicated transcription and media-generation
+ * endpoints therefore stay available in the shared catalog without leaking
+ * into chat model pickers.
+ */
+export function supportsChatModalities(
+	modalities: ChatModelModalities | undefined,
+): boolean {
+	return (
+		(modalities?.input === undefined || modalities.input.includes("text")) &&
+		(modalities?.output === undefined || modalities.output.includes("text"))
+	);
+}
+
 /**
  * Provider operation used to execute a model request.
  *
@@ -176,6 +199,7 @@ export function modelSupportsToolCalling(model: {
 }): boolean {
 	return modelHasCapability(model, "tools", { assumeWhenUnspecified: true });
 }
+
 export const ModelInfoSchema = z.object({
 	id: z.string(),
 	name: z.string().optional(),

--- a/sdk/packages/shared/src/llms/model-info.ts
+++ b/sdk/packages/shared/src/llms/model-info.ts
@@ -129,6 +129,26 @@ export const ModelOperationSchema = z.enum([
 
 export type ModelOperation = z.infer<typeof ModelOperationSchema>;
 
+export type ChatCompatibleModelDescriptor = {
+	readonly operation?: ModelOperation;
+	readonly modalities?: ChatModelModalities;
+};
+
+/**
+ * Returns whether a model uses the language operation and supports a text chat
+ * turn. Missing operation and modality metadata remain chat-compatible for
+ * backwards compatibility, while any explicitly non-language operation is
+ * excluded even when its modalities are absent.
+ */
+export function isChatCompatibleModel(
+	model: ChatCompatibleModelDescriptor,
+): boolean {
+	return (
+		(model.operation === undefined || model.operation === "language") &&
+		supportsChatModalities(model.modalities)
+	);
+}
+
 /**
  * Execution modes supported by a non-language model operation.
  *

--- a/sdk/packages/shared/src/rpc/runtime.ts
+++ b/sdk/packages/shared/src/rpc/runtime.ts
@@ -1,6 +1,10 @@
 import z from "zod";
 import type { HubToolExecutorName } from "../hub";
-import type { ModelModality, ModelOperationMode } from "../llms/model-info";
+import type {
+	ModelModality,
+	ModelOperation,
+	ModelOperationMode,
+} from "../llms/model-info";
 import type { ReasoningLevel } from "../llms/reasoning-options";
 import type {
 	RuntimeConfigExtensionKind,
@@ -146,7 +150,7 @@ export type EnterpriseStatusResponse = EnterpriseSyncResponse;
 export interface ProviderModel {
 	id: string;
 	name: string;
-	operation?: import("../llms/model-info").ModelOperation;
+	operation?: ModelOperation;
 	contextWindow?: number;
 	supportsAttachments?: boolean;
 	supportsVision?: boolean;


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to #13023

### Description

The shared LLM catalog intentionally contains chat, transcription, and media-generation models, but chat clients must not offer dedicated non-chat endpoints as selectable chat models.

This PR keeps the provider catalog complete and applies operation-aware filtering at each chat consumer:

- CLI onboarding, defaults, provider pickers, and ACP model/config lists expose models that accept text and produce text.
- VS Code preserves SDK modality metadata at its catalog boundary, filters model-picker responses, and falls back when a provider default is not chat-compatible.
- Desktop and Hub catalog/model refresh paths apply the same shared predicate and omit providers with no chat-compatible models.
- Models without modality metadata remain available for compatibility.
- Mixed text/image, text/audio, or text/video models remain available when they also produce text.
- Cline-hosted image-generation models are filtered until that provider supports their request shape; supported providers retain their image models outside chat pickers.
- Provider model queries accept explicit filter options instead of requiring clients to filter returned arrays ad hoc.

This is a clean replacement for #13062, rebuilt directly on current `main` without the old voice-input ancestry or the separate `generate_media` feature.

### Test Procedure

- `bun run build:sdk`
- Shared model-info and browser-export suites: 11 tests passed
- LLM provider registry and built-in provider suites: 23 tests passed
- Core provider-default suite: 18 tests passed
- CLI chat-model and onboarding suites: 12 tests passed
- Hub provider-catalog suite: 2 tests passed
- Desktop provider-catalog suite: 7 tests passed
- VS Code chat-model and shape-adapter suites: 31 tests passed
- `bun -F @cline/cli typecheck`
- `bun -F @cline/cline-hub typecheck`
- `bun -F @cline/code typecheck`
- Biome checks across changed root and VS Code files
- `git diff --check`

The VS Code provider-handler suite could not load because generated protobuf modules are absent in this local Apple Silicon checkout. The two directly affected VS Code model-catalog suites passed; CI regenerates protobuf artifacts on its supported runner.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes model eligibility without changing picker layout.

### Additional Notes

The configurable `generate_media` tool is intentionally submitted in a separate stacked PR.
