### PR TITLE
fix(llms): use Google language operation

### DIFF
--- a/sdk/packages/llms/src/providers/vendors/google.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/google.test.ts
@@ -27,7 +27,7 @@ describe("createGoogleProviderModule", () => {
 			context(),
 		);
 
-		provider.model("gemini-2.5-pro");
+		provider.operations.language("gemini-2.5-pro");
 
 		expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith(
 			expect.objectContaining({


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Updates the Google provider custom-base-URL test to invoke the current `ProviderFactoryResult` language operation. The test still called the removed `provider.model(...)` API after model-driven image generation moved language model construction to `provider.operations.language(...)`, causing the SDK test matrix to fail on both Ubuntu and Windows.

This is a test-only correction; the Google provider implementation is unchanged.

### Test Procedure

- Ran the focused Google provider test: 2 passed.
- Ran the complete `@cline/llms` test suite: 724 passed, 4 skipped.
- Ran the `@cline/llms` typecheck.
- Ran Biome on the changed test and `git diff --check`.

The affected assertion still verifies that the configured base URL reaches `createGoogleGenerativeAI` and that the requested Gemini model ID reaches the mocked language operation.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a test-only correction.

### Additional Notes

The stale call was introduced by a PR tested against an older base where `ProviderFactoryResult.model` still existed, then merged after the provider contract moved to operation-specific methods. The change intentionally updates the test call site instead of restoring the obsolete interface.
