### PR TITLE
feat(desktop): beta release channel from desktop-experimental branch

### DIFF
--- a/.cline/skills/publish-desktop/SKILL.md
+++ b/.cline/skills/publish-desktop/SKILL.md
@@ -1,27 +1,33 @@
 ---
 name: publish-desktop
-description: Use when preparing, tagging, and publishing a Cline Code desktop app (apps/examples/desktop-app) release. Guides changelog drafting, version bumps in package.json + tauri.conf.json, desktop-vX.Y.Z tags, and the desktop-publish GitHub workflow that builds, signs, notarizes, and updates the auto-update feed.
+description: Use when preparing, tagging, and publishing a Cline Code desktop app (apps/examples/desktop-app) release — stable (desktop-vX.Y.Z from main) or beta (desktop-vX.Y.Z-beta.N from desktop-experimental, shipped as the side-by-side "Cline Code Beta" app). Guides changelog drafting, version bumps in package.json + tauri.conf.json, tagging, and the desktop-publish GitHub workflow that builds, signs, notarizes, and updates the per-channel auto-update feed.
 ---
 
 # Desktop App Release
 
-Use this skill when the user asks to release the desktop app, publish Cline Code, bump the desktop version, create a `desktop-vX.Y.Z` tag, or trigger the desktop publish workflow.
+Use this skill when the user asks to release the desktop app, publish Cline Code, cut a desktop beta, bump the desktop version, create a `desktop-vX.Y.Z` (or `desktop-vX.Y.Z-beta.N`) tag, or trigger the desktop publish workflow.
 
 > Working directory: run every command below from the repository root.
 
-Desktop releases are macOS-only today (a single signed + notarized universal DMG that runs natively on both Apple Silicon and Intel) and are built entirely in GitHub Actions — there is no local publish path. Installed apps discover new releases automatically through the Tauri updater, so publishing a release is what ships the update to every existing user.
+Desktop releases are macOS-only today (a single signed + notarized universal DMG that runs natively on both Apple Silicon and Intel) and are built entirely in GitHub Actions — there is no local publish path. Installed apps discover new releases automatically through the Tauri updater, so publishing a release is what ships the update to every existing user **on that channel**.
 
 ## Release contract
 
+- Two channels, one workflow (`channel` input on `desktop-publish.yml`):
+  - **stable** — tag `desktop-vX.Y.Z` (no suffix; the workflow rejects prerelease suffixes on this channel), cut from `main`, feeds the rolling `desktop-latest` release, ships as "Cline Code".
+  - **beta** — tag `desktop-vX.Y.Z-beta.N`, cut from `desktop-experimental`, feeds the rolling `desktop-beta` release, ships as "Cline Code Beta" (separate bundle identifier `bot.cline.app.beta`; installs side by side with stable). Built with the extra `src-tauri/tauri.beta.conf.json` overlay. Process background: `apps/examples/desktop-app/EXPERIMENTAL.md`.
 - Version sources (must match each other and the tag): `apps/examples/desktop-app/package.json` and `apps/examples/desktop-app/src-tauri/tauri.conf.json`. (`src-tauri/Cargo.toml` has its own version but `tauri.conf.json` overrides it; no need to touch it.)
-- Release tag: `desktop-vX.Y.Z`, where `X.Y.Z` matches both version files.
-- Release prep includes approved release notes, the version bumps, and an `apps/examples/desktop-app/CHANGELOG.md` update.
-- Publish path: `.github/workflows/desktop-publish.yml` (workflow_dispatch, requires the tag to exist, point at the checked-out commit, and be reachable from `origin/main`).
-- The workflow creates the `desktop-vX.Y.Z` GitHub release (universal DMG + updater artifact + `latest.json`) and refreshes the rolling `desktop-latest` release, which is the static auto-update feed every installed app polls. Never delete the `desktop-latest` release or tag.
-- The changelog's top `## X.Y.Z` section is extracted verbatim into the GitHub release body, the Slack announcement, and the updater manifest notes.
+- Beta versions are prereleases of the **next** stable: stable `0.0.13` → betas `0.0.14-beta.1`, `-beta.2`, … Once a stable ≥ the beta base ships, the next beta bumps its base (`0.0.15-beta.1`).
+- Release prep includes approved release notes, the version bumps, and an `apps/examples/desktop-app/CHANGELOG.md` update — committed on `main` for stable, on `desktop-experimental` for beta.
+- Publish path: `.github/workflows/desktop-publish.yml` (workflow_dispatch, requires the tag to exist, point at the checked-out commit, and be reachable from the channel's branch — `origin/main` for stable, `origin/desktop-experimental` for beta).
+- **Both channels dispatch from `main`.** This is a security invariant, not a convenience: the run executes `main`'s workflow copy and only the checkout points at the tag, so the signing-secret gates (the `github.ref == main` check and the PublishDesktop environment's main-only deployment-branch policy) hold for beta too. Never add `desktop-experimental` to the PublishDesktop deployment-branch policy.
+- The workflow creates the tag's GitHub release (universal DMG + updater artifact + `latest.json`; marked prerelease for beta) and refreshes the channel's rolling feed release, which is the static auto-update feed every installed app on that channel polls. Never delete the `desktop-latest` or `desktop-beta` release or tag.
+- The changelog's `## <version>` section (exact-match, not "topmost") is extracted verbatim into the GitHub release body, the Slack announcement, and the updater manifest notes.
 - Always ask before pushing commits or tags.
 
 ## Workflow
+
+0. Ask which channel this release is for — **stable or beta** — if the user has not said. Everything below branches on it; never guess.
 
 1. Gather context.
 
@@ -35,10 +41,15 @@ node -p "require('./apps/examples/desktop-app/src-tauri/tauri.conf.json').versio
 
 If there is no `desktop-v*` tag yet, this is the first release; use the desktop app's first commit as the baseline and say the baseline is inferred.
 
+For a **beta** release, work on `desktop-experimental` (check out `origin/desktop-experimental`; merge `origin/main` into it first if it is behind — see EXPERIMENTAL.md for the conflict policy) and read the version files from that branch. The last-tag baseline is the newest `desktop-v*` tag of either channel that is an ancestor of the branch.
+
 2. Collect release commits.
 
 ```sh
+# stable (on main):
 git log <last-desktop-tag>..HEAD --oneline --no-merges -- apps/examples/desktop-app sdk/packages .github/workflows/desktop-publish.yml
+# beta (on desktop-experimental):
+git log <last-desktop-tag>..origin/desktop-experimental --oneline --no-merges -- apps/examples/desktop-app sdk/packages .github/workflows/desktop-publish.yml
 ```
 
 The sidecar bundles `@cline/core` and friends from the monorepo, so SDK changes ship inside the desktop app too. Fold user-visible SDK changes (providers, models, behavior fixes) into the notes; skip purely internal ones.
@@ -49,13 +60,15 @@ Flat bullet list, user-facing language. Present the draft and wait for approval 
 
 4. Decide the version bump.
 
-Ask whether this is patch, minor, major, or an explicit version. Do not guess if the user has not made it clear.
+Stable: ask whether this is patch, minor, major, or an explicit version. Do not guess if the user has not made it clear.
 
-5. Update release files.
+Beta: apply the versioning rule — base = next stable version, increment `N` (`0.0.14-beta.1` → `0.0.14-beta.2`; after stable `0.0.14` ships, next is `0.0.15-beta.1`). Confirm the computed version with the user.
+
+5. Update release files (on `main` for stable, on `desktop-experimental` for beta).
 
 - `apps/examples/desktop-app/package.json` → new version
 - `apps/examples/desktop-app/src-tauri/tauri.conf.json` → same version
-- Prepend `## X.Y.Z` (no date) to `apps/examples/desktop-app/CHANGELOG.md` with the approved notes.
+- Prepend `## X.Y.Z` (no date; `## X.Y.Z-beta.N` for beta) to `apps/examples/desktop-app/CHANGELOG.md` with the approved notes.
 
 6. Verify before committing.
 
@@ -77,16 +90,20 @@ Ask before pushing the release commit, then before creating and pushing the tag:
 
 ```sh
 git push origin HEAD
-git tag -a desktop-vX.Y.Z -m "Desktop vX.Y.Z"
+git tag -a desktop-vX.Y.Z -m "Desktop vX.Y.Z"       # beta: desktop-vX.Y.Z-beta.N / "Desktop vX.Y.Z-beta.N"
 git push origin refs/tags/desktop-vX.Y.Z
 ```
 
 8. Publish.
 
-The release commit must be on `main` and the tag pushed first.
+The release commit must be on the channel's branch (`main` for stable, `desktop-experimental` for beta) and the tag pushed first. Dispatch from `main` for **both** channels (see the release contract for why).
 
 ```sh
-gh workflow run desktop-publish.yml -f git_tag=desktop-vX.Y.Z -f confirm_publish=publish
+# stable:
+gh workflow run desktop-publish.yml --ref main -f git_tag=desktop-vX.Y.Z -f channel=stable -f confirm_publish=publish
+# beta:
+gh workflow run desktop-publish.yml --ref main -f git_tag=desktop-vX.Y.Z-beta.N -f channel=beta -f confirm_publish=publish
+
 gh run list --workflow=desktop-publish.yml --limit=1 --json url,status,conclusion,createdAt --jq '.[0]'
 ```
 
@@ -103,21 +120,24 @@ gh api repos/cline/cline/actions/runs/<run-id>/pending_deployments \
 
 Nothing after `validate` runs — and no signing key is readable — until then.
 
-The workflow builds one universal macOS bundle (`tauri build --target universal-apple-darwin` lipos the aarch64 + x86_64 Rust binaries; the Bun sidecar is lipo'd by `build-sidecar-bin.ts`), verifies every Mach-O in the bundle carries both slices, signs with the Developer ID certificate, notarizes with the App Store Connect API key, signs the updater artifact with the Tauri updater key, creates the GitHub release, refreshes `desktop-latest/latest.json`, and posts to Slack. Notarization typically adds 2–10 minutes.
+The workflow builds one universal macOS bundle (`tauri build --target universal-apple-darwin` lipos the aarch64 + x86_64 Rust binaries; the Bun sidecar is lipo'd by `build-sidecar-bin.ts`; beta adds the `tauri.beta.conf.json` overlay), verifies every Mach-O in the bundle carries both slices and that the compiled binary embeds exactly its own channel's feed URL, signs with the Developer ID certificate, notarizes with the App Store Connect API key, signs the updater artifact with the Tauri updater key, creates the GitHub release (prerelease for beta), refreshes the channel's feed (`desktop-latest/latest.json` or `desktop-beta/latest.json`), and posts to Slack. Notarization typically adds 2–10 minutes.
 
 If the workflow fails on missing credentials, see "Publish secrets (one-time setup)" below.
 
 9. Verify the update feed after the run succeeds.
 
 ```sh
-curl -sL https://github.com/cline/cline/releases/download/desktop-latest/latest.json | head -30
+curl -sL https://github.com/cline/cline/releases/download/desktop-latest/latest.json | head -30   # stable
+curl -sL https://github.com/cline/cline/releases/download/desktop-beta/latest.json | head -30    # beta
 ```
 
-The `version` field must be the new release and both `darwin-aarch64` and `darwin-x86_64` entries must point at the same new `desktop-vX.Y.Z` universal `.app.tar.gz` asset (each slice of the fat binary requests its own arch key at runtime, so both keys serve the one artifact). Installed apps — including older per-arch installs — pick the update up on next launch or within 2 hours.
+The `version` field must be the new release and both `darwin-aarch64` and `darwin-x86_64` entries must point at the same new universal `.app.tar.gz` asset under the release tag (each slice of the fat binary requests its own arch key at runtime, so both keys serve the one artifact). Installed apps on that channel — including older per-arch installs — pick the update up on next launch or within 2 hours.
+
+After a **beta** publish, also confirm the stable feed was not touched: `desktop-latest/latest.json` must still serve the previous stable version. (The workflow guards this fail-closed, but it is cheap to verify and catastrophic to miss — the updater comparator is a plain semver "newer than", so a beta manifest on `desktop-latest` would auto-update every stable install onto the beta.)
 
 10. Final response.
 
-Report: version, tag, changelog updated, commit hash, what was pushed, workflow URL, and the feed verification result.
+Report: channel, version, tag, changelog updated, commit hash, what was pushed, workflow URL, and the feed verification result.
 
 ## Publish secrets (one-time setup)
 

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -11,6 +11,14 @@ on:
         description: 'Type "publish" to confirm the desktop release.'
         required: true
         type: string
+      channel:
+        description: "Release channel"
+        required: true
+        type: choice
+        options:
+          - stable
+          - beta
+        default: stable
 
 permissions:
   contents: read
@@ -30,6 +38,9 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      channel: ${{ steps.version.outputs.channel }}
+      feed: ${{ steps.version.outputs.feed }}
+      product: ${{ steps.version.outputs.product }}
     steps:
       # Companion to the presence check in `build`, and the half that actually
       # establishes scope. This job declares no environment, so a signing secret
@@ -81,11 +92,41 @@ jobs:
         id: version
         env:
           TAG: ${{ github.event.inputs.git_tag }}
+          # inputs.* (not github.event.inputs.*) so the declared default
+          # applies when an API dispatch omits the channel input entirely.
+          CHANNEL: ${{ inputs.channel }}
         run: |
-          if ! printf "%s\n" "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-            echo "git_tag must look like desktop-vX.Y.Z, got: ${TAG}"
-            exit 1
-          fi
+          # Fail-closed channel mapping: every channel defines its tag shape,
+          # its ancestry source, its feed, and its product name, and an unknown
+          # channel dies here. The feed assignment is the load-bearing one —
+          # the updater comparator is a plain semver "newer than", so a beta
+          # manifest landing on desktop-latest would auto-update every stable
+          # install onto the beta. The stable regex rejects prerelease
+          # suffixes for the same reason.
+          case "$CHANNEL" in
+            stable)
+              if ! printf "%s\n" "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+$'; then
+                echo "stable git_tag must look like desktop-vX.Y.Z with no suffix, got: ${TAG}"
+                exit 1
+              fi
+              ANCESTOR_REF=main
+              FEED=desktop-latest
+              PRODUCT="Cline Code"
+              ;;
+            beta)
+              if ! printf "%s\n" "$TAG" | grep -Eq '^desktop-v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'; then
+                echo "beta git_tag must look like desktop-vX.Y.Z-beta.N, got: ${TAG}"
+                exit 1
+              fi
+              ANCESTOR_REF=desktop-experimental
+              FEED=desktop-beta
+              PRODUCT="Cline Code Beta"
+              ;;
+            *)
+              echo "unknown channel: ${CHANNEL}"
+              exit 1
+              ;;
+          esac
 
           VERSION="${TAG#desktop-v}"
           PACKAGE_VERSION=$(node -p "require('./apps/examples/desktop-app/package.json').version")
@@ -108,14 +149,17 @@ jobs:
             exit 1
           fi
 
-          git fetch origin +main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$HEAD_COMMIT" origin/main; then
-            echo "${TAG} is not reachable from origin/main"
+          git fetch origin "+${ANCESTOR_REF}:refs/remotes/origin/${ANCESTOR_REF}"
+          if ! git merge-base --is-ancestor "$HEAD_COMMIT" "origin/${ANCESTOR_REF}"; then
+            echo "${TAG} is not reachable from origin/${ANCESTOR_REF}"
             exit 1
           fi
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "feed=${FEED}" >> "$GITHUB_OUTPUT"
+          echo "product=${PRODUCT}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build macOS (universal)
@@ -126,6 +170,12 @@ jobs:
     # run. Defense in depth: this `if` is advisory because a dispatched branch
     # runs its own copy of this file; the enforced gate is the PublishDesktop
     # environment's deployment-branch policy, which must also allow only main.
+    #
+    # Beta releases do not weaken this: a beta publish is ALSO dispatched from
+    # main (so this gate, the branch policy, and the workflow file executed all
+    # stay main's) — only the checked-out tag points into desktop-experimental,
+    # which validate pins via the ancestry check. A workflow copy edited on
+    # desktop-experimental can therefore never reach the signing secrets.
     if: github.ref == 'refs/heads/main'
     environment: PublishDesktop
     runs-on: macos-latest
@@ -223,8 +273,13 @@ jobs:
 
       - name: Build, sign, and notarize desktop bundle
         working-directory: apps/examples/desktop-app
-        run: bunx tauri build --target universal-apple-darwin --config src-tauri/tauri.release.conf.json
+        # Tauri merges repeated --config flags in order, so the beta overlay
+        # (product name, bundle identifier, beta update feed) layers on top of
+        # the release overlay without duplicating it. $CONFIG_ARGS is
+        # deliberately unquoted: it must word-split into separate flags.
+        run: bunx tauri build --target universal-apple-darwin $CONFIG_ARGS
         env:
+          CONFIG_ARGS: ${{ needs.validate.outputs.channel == 'beta' && '--config src-tauri/tauri.release.conf.json --config src-tauri/tauri.beta.conf.json' || '--config src-tauri/tauri.release.conf.json' }}
           # Telemetry config for the sidecar binary. Tauri's beforeBuildCommand
           # (`bun run build` -> build:sidecar:bin) compiles the sidecar during
           # this step and inlines these values into the binary via `--define`
@@ -258,8 +313,10 @@ jobs:
       # sidecar would otherwise ship fine and only crash on the other arch.
       - name: Verify bundle is a universal binary
         working-directory: apps/examples/desktop-app
+        env:
+          PRODUCT: ${{ needs.validate.outputs.product }}
         run: |
-          APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/Cline Code.app"
+          APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/${PRODUCT}.app"
           if [ ! -d "$APP" ]; then
             echo "app bundle not found at $APP"
             exit 1
@@ -275,6 +332,57 @@ jobs:
                 ;;
             esac
           done
+
+      # Guardrail: the updater endpoint is compiled into the main binary as a
+      # string literal (tauri-build embeds the merged config via codegen), so
+      # assert the bundle carries this channel's feed URL and not the other
+      # channel's, before anything gets signed into a release. This catches a
+      # --config overlay that silently failed to apply: a beta bundle polling
+      # desktop-latest would pull its users onto stable builds, and a stable
+      # bundle polling desktop-beta would push betas to every stable install.
+      - name: Verify updater feed endpoint
+        working-directory: apps/examples/desktop-app
+        env:
+          CHANNEL: ${{ needs.validate.outputs.channel }}
+          PRODUCT: ${{ needs.validate.outputs.product }}
+        run: |
+          APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/${PRODUCT}.app"
+          case "$CHANNEL" in
+            stable)
+              WANT="releases/download/desktop-latest/latest.json"
+              FORBID="releases/download/desktop-beta/latest.json"
+              ;;
+            beta)
+              WANT="releases/download/desktop-beta/latest.json"
+              FORBID="releases/download/desktop-latest/latest.json"
+              ;;
+            *)
+              echo "unknown channel: ${CHANNEL}"
+              exit 1
+              ;;
+          esac
+
+          # Plain grep >/dev/null rather than grep -q: -q exits at the first
+          # match, SIGPIPEs strings, and would read as a failed pipeline under
+          # pipefail.
+          found=0
+          for bin in "$APP/Contents/MacOS/"*; do
+            if strings -a "$bin" | grep "$FORBID" >/dev/null; then
+              echo "$bin embeds the other channel's feed URL (${FORBID})"
+              exit 1
+            fi
+            if strings -a "$bin" | grep "$WANT" >/dev/null; then
+              found=1
+            fi
+          done
+
+          if [ "$found" -ne 1 ]; then
+            echo "No binary in ${APP}/Contents/MacOS embeds ${WANT}."
+            echo "The updater endpoint overlay did not apply; check the"
+            echo "--config flags on the build step and tauri.beta.conf.json."
+            exit 1
+          fi
+          echo "Updater endpoint verified: ${WANT}"
 
       # Guardrail: assert the telemetry config actually made it into the
       # compiled sidecar. Missing env on the build step (or a regression in
@@ -308,25 +416,29 @@ jobs:
         working-directory: apps/examples/desktop-app
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          PRODUCT: ${{ needs.validate.outputs.product }}
         run: |
           BUNDLE_DIR="src-tauri/target/universal-apple-darwin/release/bundle"
           OUT="dist/publish"
           mkdir -p "$OUT"
+
+          # "Cline Code" -> Cline-Code, "Cline Code Beta" -> Cline-Code-Beta
+          PREFIX="${PRODUCT// /-}"
 
           DMG=$(find "$BUNDLE_DIR/dmg" -name '*.dmg' -print -quit)
           if [ -z "$DMG" ]; then
             echo "no DMG produced under $BUNDLE_DIR/dmg"
             exit 1
           fi
-          cp "$DMG" "$OUT/Cline-Code_${VERSION}_universal.dmg"
+          cp "$DMG" "$OUT/${PREFIX}_${VERSION}_universal.dmg"
 
           TARBALL=$(find "$BUNDLE_DIR/macos" -name '*.app.tar.gz' -print -quit)
           if [ -z "$TARBALL" ] || [ ! -f "${TARBALL}.sig" ]; then
             echo "updater artifact or signature missing under $BUNDLE_DIR/macos"
             exit 1
           fi
-          cp "$TARBALL" "$OUT/Cline-Code_${VERSION}_universal.app.tar.gz"
-          cp "${TARBALL}.sig" "$OUT/Cline-Code_${VERSION}_universal.app.tar.gz.sig"
+          cp "$TARBALL" "$OUT/${PREFIX}_${VERSION}_universal.app.tar.gz"
+          cp "${TARBALL}.sig" "$OUT/${PREFIX}_${VERSION}_universal.app.tar.gz.sig"
 
           ls -lh "$OUT"
 
@@ -364,9 +476,18 @@ jobs:
 
       - name: Get Changelog Entry
         id: changelog
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          # Grab content between the first "## " header and the next one
-          CONTENT=$(awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' apps/examples/desktop-app/CHANGELOG.md)
+          # Grab content between this release's "## <version>" header and the
+          # next one. Exact match, not "first section": once main and
+          # desktop-experimental cross-merge, stable and beta sections
+          # interleave and the top section may belong to the other channel.
+          CONTENT=$(awk -v ver="$VERSION" '$0 == "## " ver {found=1; next} /^## [0-9]/ {if (found) exit} found {print}' apps/examples/desktop-app/CHANGELOG.md)
+          if [ -z "$CONTENT" ]; then
+            echo "No '## ${VERSION}' section found in apps/examples/desktop-app/CHANGELOG.md"
+            exit 1
+          fi
           echo "content<<EOF" >> $GITHUB_OUTPUT
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -390,8 +511,15 @@ jobs:
         id: prev_tag
         env:
           CURRENT_TAG: ${{ needs.validate.outputs.tag }}
+          CHANNEL: ${{ needs.validate.outputs.channel }}
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 --match 'desktop-v*' "$CURRENT_TAG^" 2>/dev/null || echo "")
+          # Stable compare links skip beta tags so they read stable -> stable;
+          # beta compares against whatever shipped last on either channel.
+          if [ "$CHANNEL" = "stable" ]; then
+            PREV_TAG=$(git describe --tags --abbrev=0 --match 'desktop-v*' --exclude 'desktop-v*-beta*' "$CURRENT_TAG^" 2>/dev/null || echo "")
+          else
+            PREV_TAG=$(git describe --tags --abbrev=0 --match 'desktop-v*' "$CURRENT_TAG^" 2>/dev/null || echo "")
+          fi
           echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -402,6 +530,7 @@ jobs:
           # The repo-wide "latest" release stays owned by CLI releases; the
           # desktop auto-update feed is the rolling desktop-latest release.
           make_latest: "false"
+          prerelease: ${{ needs.validate.outputs.channel == 'beta' }}
           files: dist/desktop/*
           body: |
             ${{ steps.changelog.outputs.content }}
@@ -410,27 +539,58 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update auto-update feed (desktop-latest)
+      - name: Update auto-update feed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ needs.validate.outputs.channel }}
+          FEED: ${{ needs.validate.outputs.feed }}
         run: |
-          if ! gh release view desktop-latest >/dev/null 2>&1; then
-            gh release create desktop-latest \
-              --title "Cline Code desktop (auto-update feed)" \
-              --notes "Rolling release backing the desktop app auto-updater. The latest.json asset points at the newest desktop-vX.Y.Z release. Do not delete." \
-              --latest=false \
-              --target "$(git rev-parse HEAD)"
+          # Belt and braces: recompute the feed from the channel and require it
+          # to agree with validate's output, so no single threading bug can
+          # point a publish at the other channel's feed. Stable installs poll
+          # desktop-latest and beta installs poll desktop-beta; crossing the
+          # streams either pushes betas to every stable user or strands beta
+          # users on stale builds.
+          case "$CHANNEL" in
+            stable) EXPECTED_FEED=desktop-latest ;;
+            beta) EXPECTED_FEED=desktop-beta ;;
+            *)
+              echo "unknown channel: ${CHANNEL}"
+              exit 1
+              ;;
+          esac
+          if [ "$FEED" != "$EXPECTED_FEED" ]; then
+            echo "feed mismatch: validate says '${FEED}' but channel '${CHANNEL}' expects '${EXPECTED_FEED}'"
+            exit 1
           fi
-          gh release upload desktop-latest dist/desktop/latest.json --clobber
+
+          if ! gh release view "$FEED" >/dev/null 2>&1; then
+            if [ "$CHANNEL" = "beta" ]; then
+              gh release create "$FEED" \
+                --title "Cline Code desktop beta (auto-update feed)" \
+                --notes "Rolling release backing the beta desktop app auto-updater. The latest.json asset points at the newest desktop-vX.Y.Z-beta.N release. Only beta installs poll this feed; stable installs use desktop-latest. Do not delete." \
+                --latest=false \
+                --prerelease \
+                --target "$(git rev-parse HEAD)"
+            else
+              gh release create "$FEED" \
+                --title "Cline Code desktop (auto-update feed)" \
+                --notes "Rolling release backing the desktop app auto-updater. The latest.json asset points at the newest desktop-vX.Y.Z release. Do not delete." \
+                --latest=false \
+                --target "$(git rev-parse HEAD)"
+            fi
+          fi
+          gh release upload "$FEED" dist/desktop/latest.json --clobber
 
       - name: Summary
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
+          FEED: ${{ needs.validate.outputs.feed }}
         run: |
           echo "Published Cline Code desktop v${VERSION}"
           echo "Release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
-          echo "Auto-update feed refreshed: https://github.com/${GITHUB_REPOSITORY}/releases/download/desktop-latest/latest.json"
+          echo "Auto-update feed refreshed: https://github.com/${GITHUB_REPOSITORY}/releases/download/${FEED}/latest.json"
 
       - name: Post release to Slack
         uses: slackapi/slack-github-action@v3.0.1
@@ -439,12 +599,12 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: "C0APVKGGZFC"
-            text: "Cline Code desktop v${{ needs.validate.outputs.version }}"
+            text: "Cline Code desktop v${{ needs.validate.outputs.version }}${{ needs.validate.outputs.channel == 'beta' && ' (beta)' || '' }}"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "Cline Code desktop v${{ needs.validate.outputs.version }}"
+                  text: "Cline Code desktop v${{ needs.validate.outputs.version }}${{ needs.validate.outputs.channel == 'beta' && ' (beta)' || '' }}"
               - type: "section"
                 text:
                   type: "mrkdwn"
@@ -452,4 +612,4 @@ jobs:
               - type: "context"
                 elements:
                   - type: "mrkdwn"
-                    text: "<https://github.com/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.tag }}|Download DMG> — installed apps auto-update on next launch${{ steps.prev_tag.outputs.prev_tag != '' && format(' | Full Changelog: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, needs.validate.outputs.tag) || '' }}"
+                    text: "<https://github.com/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.tag }}|Download DMG> — ${{ needs.validate.outputs.channel == 'beta' && 'beta channel: installs side by side with the stable app and only beta installs auto-update; stable users are unaffected' || 'installed apps auto-update on next launch' }}${{ steps.prev_tag.outputs.prev_tag != '' && format(' | Full Changelog: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, needs.validate.outputs.tag) || '' }}"

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -176,6 +176,19 @@ jobs:
     # stay main's) — only the checked-out tag points into desktop-experimental,
     # which validate pins via the ancestry check. A workflow copy edited on
     # desktop-experimental can therefore never reach the signing secrets.
+    #
+    # What dispatch-from-main does NOT protect: the checked-out tag's own
+    # build scripts (bun install hooks, build:sdk, Tauri's beforeBuildCommand,
+    # build.rs) run inside this job with the signing secrets in scope, for
+    # stable and beta alike. The control for that is this environment's
+    # required-reviewer approval — the approver is vouching for the code the
+    # tag points at, not just for "a release happening". Two consequences:
+    # desktop-experimental must keep main-grade merge controls (branch
+    # protection, maintainer-only pushes), and an approval should only follow
+    # a look at what the tag actually contains. Building betas without these
+    # secrets is not an option: unsigned bundles fail Gatekeeper and updater
+    # artifacts must be signed with the same key or beta installs cannot
+    # verify their updates.
     if: github.ref == 'refs/heads/main'
     environment: PublishDesktop
     runs-on: macos-latest

--- a/apps/examples/desktop-app/EXPERIMENTAL.md
+++ b/apps/examples/desktop-app/EXPERIMENTAL.md
@@ -113,6 +113,16 @@ exactly as they are for stable, and a workflow file edited on
 `desktop-experimental` can never reach the signing secrets. Do **not** add
 `desktop-experimental` to the PublishDesktop deployment-branch policy.
 
+One thing dispatch-from-main does *not* cover: the build job checks out the
+tag and runs its build scripts (dependency install hooks, `build:sdk`,
+Tauri's `beforeBuildCommand`, `build.rs`) with the signing secrets in scope
+— true for stable and beta alike. The control is the PublishDesktop
+required-reviewer approval: **approving a publish means vouching for the
+code the tag points at**, not just for the release happening. That is why
+`desktop-experimental` must keep main-grade merge controls (branch
+protection, maintainer-only pushes) — anyone who can land code there can get
+it executed alongside the signing keys once a publish of it is approved.
+
 ## Guardrails worth knowing about
 
 - The updater comparator is a plain semver "newer than". Feed separation is

--- a/apps/examples/desktop-app/EXPERIMENTAL.md
+++ b/apps/examples/desktop-app/EXPERIMENTAL.md
@@ -23,6 +23,13 @@ The beta is a **separate app**, not a mode of the stable app:
   `desktop-beta` release. The feed URL is compiled into the binary, so a beta
   install only ever receives beta builds and vice versa. **Never delete either
   rolling release.**
+- Yes, the names are asymmetric: `desktop-latest` *is* the stable feed. Do
+  not rename it to `desktop-stable` — the URL is baked into every stable
+  binary ever shipped and the updater has no fallback endpoint, so renaming
+  (or deleting) the release silently strands every existing install on a
+  dead feed forever. Renaming would mean maintaining both feeds for as long
+  as any pre-rename install exists, i.e. permanently. Same applies to
+  `desktop-beta` once the first beta ships.
 - Both apps share `~/.cline` (provider credentials, global settings, hub
   daemon — the hub is multi-client by design, same as running the CLI and the
   app together). A beta that requires a newer hub build can trigger the

--- a/apps/examples/desktop-app/EXPERIMENTAL.md
+++ b/apps/examples/desktop-app/EXPERIMENTAL.md
@@ -1,0 +1,119 @@
+# Desktop Experimental Branch & Beta Channel
+
+How experimental desktop features are developed on the `desktop-experimental`
+branch, shipped to users as **Cline Code Beta**, and graduated into `main`.
+The release mechanics (workflow internals, secrets) live in
+[`.github/workflows/desktop-publish.yml`](../../../.github/workflows/desktop-publish.yml)
+and the `publish-desktop` skill
+([`.cline/skills/publish-desktop/SKILL.md`](../../../.cline/skills/publish-desktop/SKILL.md));
+this doc is the process.
+
+## What the beta channel is
+
+The beta is a **separate app**, not a mode of the stable app:
+
+- Product name `Cline Code Beta`, bundle identifier `bot.cline.app.beta`
+  (stable is `Cline Code` / `bot.cline.app`) — set by
+  [`src-tauri/tauri.beta.conf.json`](./src-tauri/tauri.beta.conf.json), which
+  is layered over `tauri.release.conf.json` at build time.
+- Both apps install and run **side by side**, so people can compare beta
+  features against stable directly.
+- Each channel polls its own auto-update feed: stable installs poll the
+  rolling `desktop-latest` release, beta installs poll the rolling
+  `desktop-beta` release. The feed URL is compiled into the binary, so a beta
+  install only ever receives beta builds and vice versa. **Never delete either
+  rolling release.**
+- Both apps share `~/.cline` (provider credentials, global settings, hub
+  daemon — the hub is multi-client by design, same as running the CLI and the
+  app together). A beta that requires a newer hub build can trigger the
+  hub-update-required flow in the stable app or vice versa; that's expected
+  version skew, not a bug in itself.
+
+Users join the beta by downloading the beta DMG from its GitHub release
+(announced on Slack). There is no auto-downgrade: leaving the beta means
+deleting the beta app (stable was never touched). Beta users get the stable
+version of a graduated feature through the normal stable release of the
+stable app they still have installed.
+
+## Branch model
+
+`desktop-experimental` is a long-lived branch where experimental features
+bake before graduating to `main`.
+
+- **Feature PRs target `desktop-experimental`** and are merged there to
+  iterate. Keep the feature's original PR against `main` open **as a draft**
+  — it accumulates the follow-up work done on the experimental branch and
+  documents intent to graduate.
+- **Graduation** = a fresh (or the updated draft) PR against `main`
+  containing the feature plus everything learned on the experimental branch.
+  Treat it as a normal `main` PR: full review, tests, no experimental
+  scaffolding.
+- **Sync direction is one-way**: merge `main` into `desktop-experimental`
+  regularly — at minimum after every stable desktop release — so the branch
+  never drifts far. Never merge `desktop-experimental` into `main` wholesale.
+- **Merge-conflict policy** when syncing `main` in:
+  - `package.json` / `src-tauri/tauri.conf.json` versions: keep the branch's
+    beta version (see versioning rule below for when to bump its base).
+  - `CHANGELOG.md`: keep both sides' sections, newest version first — stable
+    and beta sections interleave by recency.
+  - Feature code: main wins for anything that graduated; resolve toward
+    main's reviewed form.
+
+## Versioning & tags
+
+- Beta versions are prereleases of the **next** stable version: stable
+  `0.0.13` → betas `0.0.14-beta.1`, `0.0.14-beta.2`, …
+- Tag format: `desktop-vX.Y.Z-beta.N`, tagged on a `desktop-experimental`
+  commit. Stable tags (`desktop-vX.Y.Z`, no suffix) stay on `main`; the
+  workflow enforces both shapes and each channel's branch ancestry.
+- When a stable release ships with a version ≥ the current beta base, bump
+  the base for the next beta (stable `0.0.14` out → next beta is
+  `0.0.15-beta.1`). A beta must never share its `X.Y.Z` base with an
+  already-shipped stable.
+- Semver keeps the channels ordered: `0.0.14-beta.N` sorts above stable
+  `0.0.13` and below the eventual `0.0.14`.
+
+## Cutting a beta release
+
+Manual, like stable — no nightly automation. Short form (the
+`publish-desktop` skill walks through it):
+
+1. On `desktop-experimental`: merge `main` in, bump both version files to the
+   new beta version, prepend a `## X.Y.Z-beta.N` section to `CHANGELOG.md`,
+   commit, push.
+2. Tag `desktop-vX.Y.Z-beta.N` on that commit and push the tag.
+3. Dispatch **from `main`** with the beta channel:
+
+   ```sh
+   gh workflow run desktop-publish.yml --ref main \
+     -f git_tag=desktop-vX.Y.Z-beta.N \
+     -f channel=beta \
+     -f confirm_publish=publish
+   ```
+
+4. Approve the `PublishDesktop` environment gate; the workflow builds, signs,
+   and notarizes the beta bundle, creates a **prerelease** GitHub release,
+   refreshes `desktop-beta/latest.json`, and posts to Slack — same
+   announcement path as stable, marked as beta.
+
+**Why dispatch from `main` when the code is on `desktop-experimental`?**
+Security invariant: the workflow run executes `main`'s copy of
+`desktop-publish.yml` and only the *checkout* points at the beta tag (the
+`validate` job pins the tag to `desktop-experimental` ancestry). The
+signing-secret gates — the `github.ref == main` check and the
+`PublishDesktop` environment's main-only deployment-branch policy — stay
+exactly as they are for stable, and a workflow file edited on
+`desktop-experimental` can never reach the signing secrets. Do **not** add
+`desktop-experimental` to the PublishDesktop deployment-branch policy.
+
+## Guardrails worth knowing about
+
+- The updater comparator is a plain semver "newer than". Feed separation is
+  the entire safety story: a beta manifest on `desktop-latest` would
+  auto-update every stable install onto the beta. The workflow guards this
+  three ways: the stable channel rejects prerelease tags, the feed target is
+  derived fail-closed from the channel (and cross-checked in the release
+  job), and the build asserts the compiled binary embeds exactly its own
+  channel's feed URL before anything is signed into a release.
+- `tauri.beta.conf.json` must exist on the tagged commit (the build checks
+  out the tag), so keep it present on both `main` and `desktop-experimental`.

--- a/apps/examples/desktop-app/README.md
+++ b/apps/examples/desktop-app/README.md
@@ -55,6 +55,12 @@ lost: the `desktop-latest` release/tag (its feed URL is baked into shipped
 apps) and the updater private key (`TAURI_SIGNING_PRIVATE_KEY` — without it,
 shipped apps can't verify new updates).
 
+There is also a beta channel ("Cline Code Beta", a separate app that installs
+side by side with stable) cut from the `desktop-experimental` branch and
+served by the rolling `desktop-beta` release — the same never-delete rule
+applies to it. The experimental-branch process and beta release flow live in
+[`EXPERIMENTAL.md`](./EXPERIMENTAL.md).
+
 ## Shareable Desktop Packages (manual fallback)
 
 Tauri desktop bundles are OS-specific, so build each package on the target OS:

--- a/apps/examples/desktop-app/src-tauri/tauri.beta.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.beta.conf.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://schema.tauri.app/config/2",
+	"productName": "Cline Code Beta",
+	"identifier": "bot.cline.app.beta",
+	"plugins": {
+		"updater": {
+			"endpoints": [
+				"https://github.com/cline/cline/releases/download/desktop-beta/latest.json"
+			]
+		}
+	}
+}


### PR DESCRIPTION
### Related Issue

Agreed with JC on Slack (cline-mac-app, Aug 17): experimental desktop features bake on a long-lived branch and ship to beta users, then graduate to `main` via a second PR.

### Description

This adds a **beta release channel** for the desktop app, built around the new `desktop-experimental` branch (seeded from `feat/experimental-desktop-pr-bundle`, which already carries the cloud-sessions work).

**The model**

- Feature PRs merge into `desktop-experimental` and iterate there; the feature's original PR against `main` stays open as a draft and graduates later as a normal reviewed PR. `main` is merged into `desktop-experimental` regularly (at minimum after every stable desktop release); the experimental branch never merges into `main` wholesale.
- Betas are tagged `desktop-vX.Y.Z-beta.N` on `desktop-experimental` (prereleases of the *next* stable: stable `0.0.13` → `0.0.14-beta.1`). Announced on GitHub + Slack like stable releases, cut manually — no nightly automation.
- The beta is a **separate app**, not a mode: `tauri.beta.conf.json` overrides `productName` → "Cline Code Beta" and `identifier` → `bot.cline.app.beta`, so beta and stable install side by side and people can compare them directly. That's also why there's no in-app channel toggle — the overlay approach needs zero Rust changes.
- Each channel has its own rolling auto-update feed: stable installs poll `desktop-latest`, beta installs poll the new `desktop-beta` release. The feed URL is compiled into the binary.

**How a beta publish works (the security-relevant part)**

`desktop-publish.yml` gains a `channel` input (`stable`|`beta`, default `stable`). The non-obvious trick: **beta publishes are still dispatched from `main`**. The workflow checks out `inputs.git_tag` while `github.ref` stays the dispatch branch, so the run executes `main`'s copy of the workflow file, the `github.ref == main` gate holds, and the PublishDesktop environment's main-only deployment-branch policy is untouched. Only the *checkout* points into `desktop-experimental`, pinned by a channel-aware ancestry check (`merge-base --is-ancestor` against `origin/desktop-experimental` for beta). A workflow file edited on `desktop-experimental` can never reach the signing secrets, and the environment's required-reviewer approval still gates every build. **Do not add `desktop-experimental` to the PublishDesktop deployment-branch policy** — dispatching from main *is* the security model.

**A pre-existing hole this closes**

The old tag regex already accepted prerelease suffixes (`^desktop-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`), so a `desktop-v0.0.14-beta.1` tag on main would have sailed through and clobbered its manifest onto `desktop-latest`. tauri-plugin-updater 2.10.1's default comparator is a plain semver `release.version > current_version` (verified in the crate source — there is no channel awareness), and `0.0.14-beta.1 > 0.0.13`, so every stable install would have auto-updated onto the beta. Feed separation is the entire safety story, guarded three ways now:

1. Fail-closed `case "$CHANNEL"` in `validate`: stable requires a suffix-free tag reachable from `origin/main` → `desktop-latest`; beta requires `-beta.N` reachable from `origin/desktop-experimental` → `desktop-beta`; anything else dies. Downstream jobs read only `validate`'s outputs.
2. The release job recomputes the feed from the channel and refuses on mismatch before touching any rolling release.
3. A new build step runs `strings` over every binary in the bundle and asserts it embeds exactly its own channel's feed URL and not the other's. This works because tauri-build embeds the merged config as Rust string literals via codegen (`str_lit`/`json_value_lit` in tauri-utils) — it catches a `--config` overlay that silently failed to merge *before* anything is signed into a release.

**Other workflow changes**

- Beta builds layer `--config src-tauri/tauri.release.conf.json --config src-tauri/tauri.beta.conf.json` — Tauri merges repeated `--config` flags in order (RFC-7386-style), so the beta overlay doesn't duplicate `createUpdaterArtifacts`.
- Changelog extraction is now exact-version (`## <version>`) instead of "topmost section", with a hard failure if the section is missing — once the branches cross-merge, stable and beta sections interleave in `CHANGELOG.md` and "topmost" becomes merge-order-dependent. Verified against an interleaved fixture.
- Hardcoded "Cline Code" bundle paths and `Cline-Code_*` artifact names are derived from the channel's product name (`Cline-Code-Beta_X.Y.Z-beta.N_universal.dmg` etc.). The `_universal` suffix convention is unchanged, so `generate-update-manifest.ts` needs no changes (its `_universal` fan-out to both darwin arch keys already handles the beta names — tests pass).
- Beta GitHub releases are marked `prerelease: true`; the `desktop-beta` rolling release is created `--prerelease --latest=false` on first use. Stable compare links exclude beta tags (`git describe --exclude 'desktop-v*-beta*'`) so they read stable→stable.
- Slack post (same channel) gets a "(beta)" suffix and a context line noting beta installs side by side and stable users are unaffected.
- `CHANNEL` is read via `inputs.channel` rather than `github.event.inputs.channel` so the declared default applies when an API dispatch omits the input (with `github.event.inputs` it would arrive empty and fail closed — safe, but it would break existing dispatch muscle memory).
- The endpoint check uses plain `grep >/dev/null` instead of `grep -q`: `-q` exits at first match and SIGPIPEs `strings`, which reads as a failed pipeline if anyone later adds `shell: bash` (which turns on pipefail).

**Deliberately not included**: a "converge beta users onto stable" step (refreshing `desktop-beta` with the stable manifest after a stable release). With separate bundle identities that would install a stable-identified bundle inside `Cline Code Beta.app` — a beta-named app that Launch Services thinks is the stable app. Beta users exit by installing/keeping stable normally; no auto-downgrade is ever offered (the `>` comparator makes downgrades impossible on any feed).

**Docs**: `apps/examples/desktop-app/EXPERIMENTAL.md` documents the branch process, versioning rule, side-by-side model, and merge-conflict policy; README links to it. The `publish-desktop` skill now asks stable-or-beta up front and branches every step (context gathering, version rule, dispatch command, feed verification — including "confirm `desktop-latest` was NOT touched" after a beta publish).

### Test Procedure

- YAML parses (`yaml` strict mode); `bun test apps/examples/desktop-app/scripts/generate-update-manifest.test.ts` → 5/5 pass.
- Exact-version changelog awk tested against the real CHANGELOG (0.0.13) and a synthetic interleaved beta/stable fixture, including the missing-version → hard-fail path.
- Verified in vendored crate sources: updater comparator semantics (`tauri-plugin-updater-2.10.1/src/updater.rs`) and config-as-string-literals embedding (`tauri-utils-2.9.1` `ToTokens for PluginConfig`) that the `strings` assertion depends on.
- `bun -F @cline/code typecheck` fails on main and this branch identically (stale sandbox node_modules missing new `@ai-sdk` deps) — unrelated; this PR touches no TypeScript.
- The real end-to-end test is the first beta run (`desktop-v0.0.14-beta.1`, prepped on `desktop-experimental` as a follow-up): watch for the new endpoint-verification step passing, `Cline-Code-Beta_*` artifact names, and the one open question — a prerelease string in `CFBundleShortVersionString` through notarization (expected fine for Developer ID; App Store's three-integer rule doesn't apply; fallback is a `bundle.macOS` version override in the beta overlay).
- Stable path regression: a stable dispatch takes the exact same code path as before apart from the tightened regex, the exact-version changelog match, and the endpoint assertion (which asserts what stable builds already embed).

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🏃 Workflow Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

`desktop-experimental` has been created from `feat/experimental-desktop-pr-bundle` + a clean `origin/main` merge. @jc — push your pending cloud-session patches there (or to your branch and we'll merge it in), and target future experimental PRs at it. Suggested repo settings: branch protection on `desktop-experimental` (no force-push/deletion); explicitly do NOT add it to the PublishDesktop environment's deployment-branch policy.
