### PR TITLE
feat(desktop): show beta channel identity in the app

### DIFF
--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -917,7 +917,13 @@ fn setup_tray_icon(app: &tauri::App) -> tauri::Result<()> {
     let menu = MenuBuilder::new(app)
         .text(
             TRAY_OPEN_MENU_ID,
-            format!("Cline Code v{}", app.package_info().version),
+            // package_info().name is the configured productName, so beta
+            // builds ("Cline Code Beta") identify themselves in the tray too.
+            format!(
+                "{} v{}",
+                app.package_info().name,
+                app.package_info().version
+            ),
         )
         .item(&status)
         .separator()
@@ -943,7 +949,7 @@ fn setup_tray_icon(app: &tauri::App) -> tauri::Result<()> {
     let tray = TrayIconBuilder::with_id(TRAY_ICON_ID)
         .icon(icon)
         .menu(&menu)
-        .tooltip("Cline Code");
+        .tooltip(app.package_info().name.as_str());
     #[cfg(target_os = "macos")]
     let tray = tray.icon_as_template(true);
 

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -48,6 +48,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	ContextMenu,
@@ -84,6 +85,11 @@ import type {
 	UseSessionHistoryResult,
 } from "@/hooks/use-session-history";
 import { formatCostUsd, formatTokenCount } from "@/hooks/use-session-history";
+import {
+	BETA_PRODUCT_NAME,
+	isBetaVersion,
+	productNameForVersion,
+} from "@/lib/app-channel";
 import { desktopClient } from "@/lib/desktop-client";
 import {
 	ALL_SESSION_SOURCES,
@@ -658,7 +664,9 @@ export function AgentSidebar({
 								className="w-64 p-3"
 								side="bottom"
 							>
-								<p className="text-sm font-medium">Cline Code</p>
+								<p className="text-sm font-medium">
+									{productNameForVersion(appVersion)}
+								</p>
 								<p className="mt-0.5 text-xs text-muted-foreground">
 									{appVersion ? `Version ${appVersion}` : "Version unavailable"}
 								</p>
@@ -685,6 +693,15 @@ export function AgentSidebar({
 								</div>
 							</HoverCardContent>
 						</HoverCard>
+						{!isCollapsed && isBetaVersion(appVersion) ? (
+							<Badge
+								className="ml-0.5 px-1.5 py-0 text-[10px] uppercase tracking-wide"
+								title={`${BETA_PRODUCT_NAME} — beta builds install side by side with the stable app and update from the beta channel`}
+								variant="secondary"
+							>
+								Beta
+							</Badge>
+						) : null}
 						{!isCollapsed ? <AppUpdateIndicator /> : null}
 					</div>
 					{!isCollapsed ? (

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -1,8 +1,10 @@
 import { Minus, Plus, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import { isBetaVersion, productNameForVersion } from "@/lib/app-channel";
 import {
 	DEFAULT_APP_FONT_SIZE,
 	isAppFontSize,
@@ -586,8 +588,31 @@ function GeneralSettingsContent() {
 	const [webSearchLoading, setWebSearchLoading] = useState(true);
 	const [webSearchSaving, setWebSearchSaving] = useState(false);
 	const [webSearchError, setWebSearchError] = useState<string | null>(null);
+	const [appVersion, setAppVersion] = useState<string | null>(null);
 
 	useEffect(() => subscribeToAppFontSize(setFontSize), []);
+
+	useEffect(() => {
+		let cancelled = false;
+		void desktopClient
+			.invoke<{ appVersion?: unknown }>("get_process_context")
+			.then((context) => {
+				if (cancelled) {
+					return;
+				}
+				const version =
+					typeof context?.appVersion === "string"
+						? context.appVersion.trim()
+						: "";
+				setAppVersion(version || null);
+			})
+			.catch(() => {
+				// Leave the About row versionless if the sidecar is unreachable.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const loadGlobalSettings = useCallback(async () => {
 		setTelemetryLoading(true);
@@ -955,6 +980,26 @@ function GeneralSettingsContent() {
 						<RotateCcw className="size-3" />
 						Replay
 					</Button>
+				</div>
+				<div className="flex py-4 items-center justify-between gap-5 max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
+					<div className="flex flex-col gap-1">
+						<p className="text-base font-semibold text-foreground">About</p>
+						<p className="text-sm text-muted-foreground">
+							{productNameForVersion(appVersion)}
+							{appVersion ? ` v${appVersion}` : ""}
+							{isBetaVersion(appVersion)
+								? " — beta builds install side by side with the stable app and update from the beta channel."
+								: ""}
+						</p>
+					</div>
+					{isBetaVersion(appVersion) ? (
+						<Badge
+							className="shrink-0 uppercase tracking-wide"
+							variant="secondary"
+						>
+							Beta
+						</Badge>
+					) : null}
 				</div>
 			</section>
 		</PageFrame>

--- a/apps/examples/desktop-app/webview/lib/app-channel.test.ts
+++ b/apps/examples/desktop-app/webview/lib/app-channel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	BETA_PRODUCT_NAME,
+	isBetaVersion,
+	productNameForVersion,
+	STABLE_PRODUCT_NAME,
+} from "./app-channel";
+
+describe("app channel", () => {
+	it("detects beta builds from the prerelease version suffix", () => {
+		expect(isBetaVersion("0.0.14-beta.1")).toBe(true);
+		expect(isBetaVersion("1.2.3-beta.12")).toBe(true);
+		expect(isBetaVersion("0.0.13")).toBe(false);
+		expect(isBetaVersion("")).toBe(false);
+		expect(isBetaVersion(null)).toBe(false);
+		expect(isBetaVersion(undefined)).toBe(false);
+	});
+
+	it("maps the version to the shipped product name", () => {
+		expect(productNameForVersion("0.0.14-beta.1")).toBe(BETA_PRODUCT_NAME);
+		expect(productNameForVersion("0.0.13")).toBe(STABLE_PRODUCT_NAME);
+		expect(productNameForVersion(null)).toBe(STABLE_PRODUCT_NAME);
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/app-channel.ts
+++ b/apps/examples/desktop-app/webview/lib/app-channel.ts
@@ -1,0 +1,23 @@
+/**
+ * Release-channel detection for the desktop app.
+ *
+ * Beta builds are cut from the desktop-experimental branch with prerelease
+ * versions (e.g. 0.0.14-beta.1), so the version string is the single source
+ * of truth for the channel: it is baked into package.json/tauri.conf.json at
+ * build time and reported by the sidecar's get_process_context, which works
+ * in both the Tauri shell and web dev mode (where no Tauri API exists).
+ * See apps/examples/desktop-app/EXPERIMENTAL.md for the channel model.
+ */
+
+export const STABLE_PRODUCT_NAME = "Cline Code";
+export const BETA_PRODUCT_NAME = "Cline Code Beta";
+
+export function isBetaVersion(version: string | null | undefined): boolean {
+	return typeof version === "string" && version.includes("-beta");
+}
+
+export function productNameForVersion(
+	version: string | null | undefined,
+): string {
+	return isBetaVersion(version) ? BETA_PRODUCT_NAME : STABLE_PRODUCT_NAME;
+}

--- a/apps/examples/desktop-app/webview/lib/desktop-window-title.test.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-window-title.test.ts
@@ -46,6 +46,13 @@ describe("desktop window title", () => {
 		expect(buildDesktopWindowTitle("")).toBe(DEFAULT_DESKTOP_WINDOW_TITLE);
 	});
 
+	it("titles beta builds with the beta product name", async () => {
+		const { buildDesktopWindowTitle } = await importFresh();
+		expect(buildDesktopWindowTitle("0.0.14-beta.1")).toBe(
+			"Cline Code Beta v0.0.14-beta.1",
+		);
+	});
+
 	it("does nothing outside the Tauri shell", async () => {
 		const { syncDesktopWindowTitle } = await importFresh();
 		await syncDesktopWindowTitle();

--- a/apps/examples/desktop-app/webview/lib/desktop-window-title.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-window-title.ts
@@ -1,12 +1,13 @@
 import type { ProcessContext } from "@/hooks/chat-session/types";
+import { productNameForVersion, STABLE_PRODUCT_NAME } from "@/lib/app-channel";
 import { desktopClient, isTauriAvailable } from "@/lib/desktop-client";
 
-export const DEFAULT_DESKTOP_WINDOW_TITLE = "Cline Code";
+export const DEFAULT_DESKTOP_WINDOW_TITLE = STABLE_PRODUCT_NAME;
 
 export function buildDesktopWindowTitle(version: string | undefined): string {
 	const trimmed = version?.trim();
 	return trimmed
-		? `${DEFAULT_DESKTOP_WINDOW_TITLE} v${trimmed}`
+		? `${productNameForVersion(trimmed)} v${trimmed}`
 		: DEFAULT_DESKTOP_WINDOW_TITLE;
 }
 


### PR DESCRIPTION
### Related Issue

Follow-up to #13321 (desktop beta release channel). Independent of it code-wise — this can merge before or after; the beta UI only activates on builds whose version carries a `-beta` suffix, which only #13321's release flow produces.

### Description

Beta builds of the desktop app ("Cline Code Beta", cut from `desktop-experimental`) previously only identified themselves via the bundle name — nothing inside the app said "beta". This PR makes the channel visible everywhere a user actually looks:

- **Sidebar footer**: a small `BETA` pill next to the logo (with a tooltip explaining the side-by-side model), and the hover card title says "Cline Code Beta".
- **Settings → General**: a new **About** row — product name, version, and a channel note + badge on beta.
- **Window title**: the existing runtime retitle (`desktop-window-title.ts`) now builds "Cline Code Beta v0.0.14-beta.1" on beta.
- **Tray**: menu header and tooltip now use `app.package_info().name` (= the configured `productName`) instead of a hardcoded "Cline Code", so the tray says "Cline Code Beta v…" on beta builds. This was the one Rust change.

**How channel detection works** — deliberately boring: `webview/lib/app-channel.ts` exposes `isBetaVersion()` / `productNameForVersion()`, keyed purely off the `-beta` suffix in the version string. The version is baked into `package.json`/`tauri.conf.json` at build time on the release branch and reported by the sidecar's existing `get_process_context`, so detection works identically in the Tauri shell and browser/web-dev mode — no `@tauri-apps/api/app` calls, no new capabilities, no new commands, no env plumbing.

**A road deliberately not taken**: setting the beta window title via a `windows` array override in `tauri.beta.conf.json` looks natural but is a trap — Tauri's `--config` merge replaces arrays wholesale, and the experimental branch adds windows (e.g. `avatar-overlay`), which an overlay copied from main would silently delete from beta builds. The runtime retitle path already existed and dodges that entirely.

On stable builds every one of these renders exactly what it does today (verified: `productNameForVersion` returns "Cline Code" for suffix-free/null versions, and the pill/badge/channel-note are conditional on `isBetaVersion`).

### Test Procedure

- New `webview/lib/app-channel.test.ts` (version-suffix matrix incl. null/empty) and a beta case added to `desktop-window-title.test.ts` — all pass.
- Existing `agent-sidebar.test.tsx` (14) and `settings-view.test.tsx` suites pass unchanged, confirming stable rendering is unaffected.
- `bun -F @cline/code typecheck` clean (after rebuilding the stale `@cline/shared` dist in the sandbox — unrelated to this PR).
- Rust change is a two-callsite string swap on the already-used `package_info()`; the desktop bundle only compiles on macOS, so the tray strings get eyeballed on the next beta/stable build.
- Real-world check happens with the first `0.0.14-beta.1` build: pill + About row + window title + tray all say Beta.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Not included (discussed, deferred): a badged beta **dock icon**. That needs badged variants of `icon.icns` + the four `icons/dock/*.png` (the runtime icon switcher would otherwise wipe the badge) — separate PR once there's a badge design.
