### PR TITLE
fix(desktop): make routine selectors clickable

### DIFF
--- a/apps/cline-hub/src/webview/src/components/ui/combobox.tsx
+++ b/apps/cline-hub/src/webview/src/components/ui/combobox.tsx
@@ -105,7 +105,7 @@ function ComboboxContent({
 				align={align}
 				alignOffset={alignOffset}
 				anchor={anchor}
-				className="isolate z-50"
+				className="pointer-events-auto isolate z-[60]"
 			>
 				<ComboboxPrimitive.Popup
 					data-slot="combobox-content"

--- a/apps/cline-hub/src/webview/src/components/views/settings/routine-view.tsx
+++ b/apps/cline-hub/src/webview/src/components/views/settings/routine-view.tsx
@@ -1154,9 +1154,7 @@ export function RoutineSchedulesContent() {
 			>
 				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
 					<DialogHeader>
-						<DialogTitle>
-							{editingSchedule ? "Edit Routine" : "Create Routine"}
-						</DialogTitle>
+						<DialogTitle>Schedule</DialogTitle>
 						<DialogDescription>
 							{editingSchedule
 								? "Update this scheduler routine."

--- a/apps/examples/desktop-app/webview/components/ui/combobox.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/combobox.tsx
@@ -107,7 +107,7 @@ function ComboboxContent({
 				align={align}
 				alignOffset={alignOffset}
 				anchor={anchor}
-				className="isolate z-50"
+				className="pointer-events-auto isolate z-[60]"
 				side={side}
 				sideOffset={sideOffset}
 			>

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -1524,9 +1524,7 @@ export function RoutineSchedulesContent({
 			>
 				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
 					<DialogHeader>
-						<DialogTitle>
-							{editingSchedule ? "Edit Routine" : "Create Routine"}
-						</DialogTitle>
+						<DialogTitle>Schedule</DialogTitle>
 						<DialogDescription>
 							{editingSchedule
 								? "Update this scheduler routine."


### PR DESCRIPTION
### Related Issue

**Issue:** https://linear.app/cline-bot/issue/CLINE-2997

### Description

Fixes routine dialog combobox options not responding to mouse clicks inside the modal. The Base UI combobox popup is portaled outside the Radix dialog content and inherited the modal's disabled pointer events, even though keyboard navigation continued to work.

The popup positioner now explicitly enables pointer events and renders above the dialog layer in both the desktop app and Cline Hub webviews. The dialog title is also simplified to "Schedule" for both create and edit flows.

### Test Procedure

- Ran `bun run typecheck` in `apps/examples/desktop-app`.
- Ran `bun run typecheck` in `apps/cline-hub`.
- Ran `git diff --check`.
- Verify manually by opening Settings > Routines, opening the Schedule dialog, expanding the Provider or Model combobox, and clicking an option.

<img width="624" height="528" alt="image" src="https://github.com/user-attachments/assets/e31540a3-e13f-4648-999e-b407f82680a1" />


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The change restores pointer interaction without changing the dropdown's appearance, aside from the requested dialog title.

### Additional Notes

The combobox behavior is fixed at the shared UI component layer for both routine-capable webviews, so provider and model selectors receive the same interaction behavior.
