### PR TITLE
fix(desktop): align usage table columns CLINE-2996

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/account-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/account-view.test.tsx
@@ -33,7 +33,7 @@ afterEach(async () => {
 });
 
 describe("AccountView usage table", () => {
-	it("opens the full usage dashboard from the table footer", async () => {
+	it("opens the full usage dashboard from the empty table footer", async () => {
 		invoke.mockImplementation(
 			async (_command: string, args?: Record<string, unknown>) => {
 				switch (args?.operation) {
@@ -51,16 +51,7 @@ describe("AccountView usage table", () => {
 					case "fetchUserOrganizations":
 						return [];
 					case "fetchUsageTransactions":
-						return [
-							{
-								id: "usage-1",
-								aiModelName: "claude-fable-latest",
-								aiInferenceProviderName: "openrouter",
-								totalTokens: 57_167,
-								creditsUsed: 110_000,
-								createdAt: "2026-08-17T15:54:00Z",
-							},
-						];
+						return [];
 					default:
 						return {};
 				}
@@ -82,6 +73,7 @@ describe("AccountView usage table", () => {
 
 		await vi.waitFor(() => {
 			expect(container.textContent).toContain("See More");
+			expect(container.textContent).toContain("No usage transactions yet.");
 		});
 		const seeMoreButton = Array.from(container.querySelectorAll("button")).find(
 			(button) => button.textContent?.includes("See More"),

--- a/apps/examples/desktop-app/webview/components/views/settings/account-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/account-view.test.tsx
@@ -5,10 +5,13 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AccountView } from "./account-view";
 
-const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+const { invoke, openExternalUrl } = vi.hoisted(() => ({
+	invoke: vi.fn(),
+	openExternalUrl: vi.fn(),
+}));
 vi.mock("@/lib/desktop-client", () => ({
 	desktopClient: { invoke },
-	openExternalUrl: vi.fn(),
+	openExternalUrl,
 }));
 
 let container: HTMLDivElement;
@@ -17,6 +20,7 @@ let root: Root;
 beforeEach(() => {
 	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 	invoke.mockReset();
+	openExternalUrl.mockReset();
 	container = document.createElement("div");
 	document.body.appendChild(container);
 	root = createRoot(container);
@@ -26,6 +30,68 @@ afterEach(async () => {
 	await act(async () => root.unmount());
 	container.remove();
 	vi.restoreAllMocks();
+});
+
+describe("AccountView usage table", () => {
+	it("opens the full usage dashboard from the table footer", async () => {
+		invoke.mockImplementation(
+			async (_command: string, args?: Record<string, unknown>) => {
+				switch (args?.operation) {
+					case "fetchMe":
+						return {
+							id: "user-1",
+							email: "beatrix@cline.bot",
+							displayName: "Beatrix",
+							createdAt: "2024-01-01T00:00:00Z",
+							updatedAt: "2024-01-01T00:00:00Z",
+							organizations: [],
+						};
+					case "fetchBalance":
+						return { balance: 5_000_000 };
+					case "fetchUserOrganizations":
+						return [];
+					case "fetchUsageTransactions":
+						return [
+							{
+								id: "usage-1",
+								aiModelName: "claude-fable-latest",
+								aiInferenceProviderName: "openrouter",
+								totalTokens: 57_167,
+								creditsUsed: 110_000,
+								createdAt: "2026-08-17T15:54:00Z",
+							},
+						];
+					default:
+						return {};
+				}
+			},
+		);
+
+		await act(async () => {
+			root.render(<AccountView />);
+		});
+		await vi.waitFor(() => {
+			expect(container.textContent).toContain("Beatrix");
+		});
+
+		const usageTab = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "usage",
+		);
+		expect(usageTab).toBeDefined();
+		await act(async () => usageTab?.click());
+
+		await vi.waitFor(() => {
+			expect(container.textContent).toContain("See More");
+		});
+		const seeMoreButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.includes("See More"),
+		);
+		await act(async () => seeMoreButton?.click());
+
+		expect(openExternalUrl).toHaveBeenCalledWith(
+			"https://app.cline.bot/dashboard/usage",
+		);
+	});
 });
 
 describe("AccountView signed-out state", () => {

--- a/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
@@ -741,21 +741,19 @@ export function AccountView() {
 						</p>
 						{usageLoading && renderLoading()}
 						{usageError && renderError(usageError, loadUsage)}
-						{!usageLoading &&
-							!usageError &&
-							usageLoaded &&
-							(usageTransactions.length === 0 ? (
-								<p className="py-8 text-center text-sm text-muted-foreground">
-									No usage transactions yet.
-								</p>
-							) : (
-								<div className="rounded-lg border border-border overflow-hidden">
-									<div className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
-										<span>Model</span>
-										<span className="text-right">Tokens</span>
-										<span className="text-right">Credits</span>
-										<span className="text-right">Time</span>
-									</div>
+						{!usageLoading && !usageError && usageLoaded && (
+							<div className="overflow-hidden rounded-lg border border-border">
+								<div className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
+									<span>Model</span>
+									<span className="text-right">Tokens</span>
+									<span className="text-right">Credits</span>
+									<span className="text-right">Time</span>
+								</div>
+								{usageTransactions.length === 0 ? (
+									<p className="px-4 py-8 text-center text-sm text-muted-foreground">
+										No usage transactions yet.
+									</p>
+								) : (
 									<div className="divide-y divide-border">
 										{usageTransactions.map((tx) => (
 											<div
@@ -783,18 +781,19 @@ export function AccountView() {
 											</div>
 										))}
 									</div>
-									<div className="flex justify-center border-t border-border px-4 py-3">
-										<button
-											type="button"
-											onClick={() => void openExternalUrl(USAGE_DASHBOARD_URL)}
-											className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
-										>
-											See More
-											<ExternalLink className="h-3.5 w-3.5" />
-										</button>
-									</div>
+								)}
+								<div className="flex justify-center border-t border-border px-4 py-3">
+									<button
+										type="button"
+										onClick={() => void openExternalUrl(USAGE_DASHBOARD_URL)}
+										className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+									>
+										See More
+										<ExternalLink className="h-3.5 w-3.5" />
+									</button>
 								</div>
-							))}
+							</div>
+						)}
 					</div>
 				)}
 

--- a/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
@@ -32,6 +32,7 @@ import { invalidateProviderCatalogCache } from "@/lib/provider-model-catalog";
 import { cn } from "@/lib/utils";
 
 const DASHBOARD_URL = "https://app.cline.bot/dashboard";
+const USAGE_DASHBOARD_URL = "https://app.cline.bot/dashboard/usage";
 const USER_CREDITS_URL =
 	"https://app.cline.bot/dashboard/account?tab=credits&redirect=true";
 const ORGANIZATION_CREDITS_URL =
@@ -749,7 +750,7 @@ export function AccountView() {
 								</p>
 							) : (
 								<div className="rounded-lg border border-border overflow-hidden">
-									<div className="grid grid-cols-[1fr_auto_auto_auto] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
+									<div className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
 										<span>Model</span>
 										<span className="text-right">Tokens</span>
 										<span className="text-right">Credits</span>
@@ -759,7 +760,7 @@ export function AccountView() {
 										{usageTransactions.map((tx) => (
 											<div
 												key={tx.id}
-												className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
+												className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
 											>
 												<div className="min-w-0">
 													<p className="font-medium text-foreground truncate">
@@ -781,6 +782,16 @@ export function AccountView() {
 												</div>
 											</div>
 										))}
+									</div>
+									<div className="flex justify-center border-t border-border px-4 py-3">
+										<button
+											type="button"
+											onClick={() => void openExternalUrl(USAGE_DASHBOARD_URL)}
+											className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+										>
+											See More
+											<ExternalLink className="h-3.5 w-3.5" />
+										</button>
 									</div>
 								</div>
 							))}


### PR DESCRIPTION
### Related Issue

**Issue:**  https://linear.app/cline-bot/issue/CLINE-2996

### Description

Aligns the Usage table headers with their row values by giving the header and transaction rows a shared column template. Adds a table footer with a See More action that opens the full Cline usage dashboard in the user's default browser.

### Test Procedure

1. Open Account settings and select the Usage tab.
2. Verify the Model, Tokens, Credits, and Time headers align with their values across rows with different content lengths.
3. Click See More and verify `https://app.cline.bot/dashboard/usage` opens externally.
4. Run the focused account-view Vitest suite and the desktop app TypeScript typecheck.

Automated verification completed:
- `bunx vitest run webview/components/views/settings/account-view.test.tsx --config vitest.config.ts` (4 tests passed)
- `bun run typecheck`
- Biome check on both changed files

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The updated view uses the existing usage table styling with aligned fixed-width numeric columns and a centered See More footer action.

<img width="732" height="811" alt="image" src="https://github.com/user-attachments/assets/de62bd0e-44ce-498b-9010-e1cc3ee85eba" />


### Additional Notes

No related issue was provided; this is a small UI fix with a scoped follow-up action.
