### PR TITLE
fix(desktop): degrade ask_question gracefully when tool context has no session ID

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1243,8 +1243,13 @@ export async function handleCommand(
 	}
 	if (command === "poll_ask_questions") {
 		const sessionId = String(args?.sessionId ?? "").trim();
+		// Questions without an owning session (older hub daemons don't send a
+		// session ID in the tool context) surface in whichever session polls.
 		return Array.from(ctx.pendingQuestions.values())
-			.filter((question) => question.item.sessionId === sessionId)
+			.filter(
+				(question) =>
+					!question.item.sessionId || question.item.sessionId === sessionId,
+			)
 			.map((question) => question.item);
 	}
 	if (command === "respond_ask_question") {

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -460,10 +460,49 @@ describe("Code sidecar runtime capabilities", () => {
 		);
 	});
 
-	it("rejects askQuestion requests without an owning session", async () => {
+	it("falls back to the conversation ID when the tool context has no session ID", async () => {
 		const { createSidecarContext, initializeSessionManager } = await import(
 			"./context"
 		);
+		const { handleCommand } = await import("./commands");
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() });
+		await initializeSessionManager(ctx);
+
+		const capabilities = createCoreMock.mock.calls[0][0]
+			.capabilities as RuntimeCapabilities;
+		const answer = capabilities.toolExecutors?.askQuestion?.(
+			"Which branch?",
+			["Keep current", "Create new"],
+			{ agentId: "agent-1", conversationId: "conversation-1", iteration: 3 },
+		);
+
+		const event = readEvents(ctx).find(
+			(item) => item.event.name === "ask_question_requested",
+		);
+		expect(event?.event.payload).toMatchObject({
+			sessionId: "conversation-1",
+			question: "Which branch?",
+		});
+		const requestId = String(event?.event.payload.requestId ?? "");
+		expect(
+			await handleCommand(ctx, "poll_ask_questions", {
+				sessionId: "conversation-1",
+			}),
+		).toEqual([expect.objectContaining({ requestId })]);
+
+		await handleCommand(ctx, "respond_ask_question", {
+			requestId,
+			answer: "Keep current",
+		});
+		await expect(answer).resolves.toBe("Keep current");
+	});
+
+	it("surfaces unrouted askQuestion requests to every session poll", async () => {
+		const { createSidecarContext, initializeSessionManager } = await import(
+			"./context"
+		);
+		const { handleCommand } = await import("./commands");
 		const ctx = createSidecarContext("/workspace/project");
 		ctx.wsClients.add({ send: vi.fn() });
 		await initializeSessionManager(ctx);
@@ -476,14 +515,26 @@ describe("Code sidecar runtime capabilities", () => {
 			{ agentId: "agent-1", iteration: 3 },
 		);
 
-		await expect(answer).rejects.toThrow(
-			"ask_question requires an active session ID",
+		const event = readEvents(ctx).find(
+			(item) => item.event.name === "ask_question_requested",
 		);
+		expect(event?.event.payload).toMatchObject({
+			sessionId: "",
+			question: "Which branch?",
+		});
+		const requestId = String(event?.event.payload.requestId ?? "");
+		expect(requestId.length).toBeGreaterThan(0);
 		expect(
-			readEvents(ctx).some(
-				(message) => message.event.name === "ask_question_requested",
-			),
-		).toBe(false);
+			await handleCommand(ctx, "poll_ask_questions", {
+				sessionId: "any-session",
+			}),
+		).toEqual([expect.objectContaining({ requestId, sessionId: "" })]);
+
+		await handleCommand(ctx, "respond_ask_question", {
+			requestId,
+			answer: "Create new",
+		});
+		await expect(answer).resolves.toBe("Create new");
 	});
 
 	it("resolves approval through websocket state", async () => {

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -581,12 +581,13 @@ export function requestSidecarAskQuestion(
 	options: string[],
 	context: AgentToolContext,
 ): Promise<string> {
-	const sessionId = context.sessionId?.trim();
-	if (!sessionId) {
-		return Promise.reject(
-			new Error("ask_question requires an active session ID"),
-		);
-	}
+	// An older shared hub daemon (see watchManagedHubBuildMismatch) may not
+	// serialize sessionId into the tool context yet. Fall back to the
+	// conversation ID — mirroring the runtime's approval-context fallback —
+	// and otherwise degrade to an unrouted question (empty session ID) that
+	// renders in whichever session is active, rather than failing the tool.
+	const sessionId =
+		context.sessionId?.trim() || context.conversationId?.trim() || "";
 	const choices = options
 		.map((option) => option.trim())
 		.filter((option) => option.length > 0)

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -1199,6 +1199,26 @@ describe("useChatSession", () => {
 		});
 	});
 
+	it("renders unrouted questions (no session ID) in the active session", async () => {
+		const unroutedQuestion = {
+			requestId: "question-unrouted",
+			sessionId: "",
+			createdAt: "2026-08-11T00:00:00.000Z",
+			question: "Which branch should I use?",
+			options: ["Keep current", "Create new"],
+		};
+		const askQuestionHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "ask_question_requested",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(askQuestionHandler).toBeTypeOf("function");
+
+		await act(async () => {
+			askQuestionHandler?.(unroutedQuestion);
+		});
+
+		expect(current.pendingAskQuestions).toEqual([unroutedQuestion]);
+	});
+
 	it("resets to the remembered provider/model after viewing a historical session", async () => {
 		window.localStorage.setItem(
 			MODEL_SELECTION_STORAGE_KEY,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -989,8 +989,10 @@ export function useChatSession() {
 		return desktopClient.subscribe("ask_question_requested", (payload) => {
 			if (!payload || typeof payload !== "object") return;
 			const item = payload as AskQuestionRequestItem;
+			// Questions without an owning session (older hub daemons don't send
+			// a session ID in the tool context) render in the active session.
 			if (
-				item.sessionId !== activeSessionIdRef.current ||
+				(item.sessionId && item.sessionId !== activeSessionIdRef.current) ||
 				!item.requestId ||
 				!item.question ||
 				!Array.isArray(item.options)


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to #13166 (https://linear.app/cline-bot/issue/CLIENTS-65)

### Description

Stacked on #13166 (targets `bee/desktop-notifications`).

#13166 makes `requestSidecarAskQuestion` reject with "ask_question requires an active session ID" when the tool context has no `sessionId`. The `sessionId` only reaches the sidecar because the same PR adds it to `serializeToolContext` in the hub daemon. The desktop app connects to a shared hub daemon that another Cline installation can replace, and the codebase explicitly supports running through that skew (`watchManagedHubBuildMismatch` surfaces a restart prompt while the app keeps working). During that window an older hub never sends `sessionId`, so every `ask_question` call would fail with an error instead of showing the question UI, which is a regression from the pre-#13166 behavior where questions rendered without session routing.

This change degrades instead of rejecting:

- `sidecar/context.ts`: fall back from `context.sessionId` to `context.conversationId` (mirroring the fallback chain the agent runtime already uses for approval contexts), and otherwise proceed with an empty session ID rather than failing the tool call.
- `sidecar/commands.ts`: `poll_ask_questions` also returns unrouted questions (empty session ID) for any session poll, so they survive session switches.
- `webview/hooks/use-chat-session.ts`: the `ask_question_requested` subscription accepts unrouted questions into the active session, matching pre-#13166 behavior.

Native notifications for unrouted questions are intentionally skipped (there is no session to deep-link to); the question still renders in the app.

### Test Procedure

- Replaced the rejection test in `sidecar/context.test.ts` with two tests: fallback to `conversationId` (event payload, poll routing, and answer resolution), and a fully unrouted question surfacing in every session poll and resolving normally.
- Added a `use-chat-session.test.tsx` test that an unrouted question renders in the active session.
- `vitest run sidecar/context.test.ts webview/hooks/use-chat-session.test.tsx webview/lib/desktop-notifications.test.ts`: 61/61 passed.
- `bun run typecheck` (desktop app): clean. Biome format and lint clean on all changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)