### PR TITLE
fix(vscode): reuse terminals without stealing editor focus

### DIFF
--- a/apps/vscode/src/core/controller/task/deleteTasksWithIds.ts
+++ b/apps/vscode/src/core/controller/task/deleteTasksWithIds.ts
@@ -35,6 +35,7 @@ export async function deleteTasksWithIds(controller: Controller, request: String
 	for (const id of request.value) {
 		await deleteTaskWithId(controller, id)
 	}
+	controller.terminalManager?.disposeAll(false)
 
 	return Empty.create()
 }

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
@@ -6,14 +6,6 @@ import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 import { VscodeTerminalManager } from "./VscodeTerminalManager"
 import { TerminalInfo, TerminalRegistry } from "./VscodeTerminalRegistry"
 
-function createNeverEndingStream(): AsyncIterable<string> {
-	return {
-		async *[Symbol.asyncIterator]() {
-			await new Promise(() => {})
-		},
-	}
-}
-
 function createMarkerlessStream(): AsyncIterable<string> {
 	return {
 		async *[Symbol.asyncIterator]() {
@@ -47,201 +39,86 @@ describe("VscodeTerminalManager", () => {
 		sandbox.restore()
 	})
 
-	it("creates a fresh terminal after timing out an unconfirmed reused-terminal cwd change", async () => {
-		setVscodeHostProviderMock()
-		const targetCwd = "/tmp/cline-target"
-		const executeCommandStub = sandbox.stub().returns({
-			read: () => createNeverEndingStream(),
-		})
+	it("reuses a terminal without shell integration using its tracked cwd", async () => {
+		const cwd = "/tmp/cline-target"
+		const showStub = sandbox.stub()
 		const terminalInfo: TerminalInfo = {
 			id: 1,
 			busy: false,
 			lastCommand: "",
 			lastActive: Date.now(),
+			trackedCwd: cwd,
 			terminal: {
-				shellIntegration: {
-					cwd: vscode.Uri.file("/tmp/cline-original"),
-					executeCommand: executeCommandStub,
-				},
-				show: sandbox.stub(),
-			} as unknown as vscode.Terminal,
-		}
-		const getAllTerminalsStub = sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
-
-		let didResolve = false
-		const terminalPromise = manager.getOrCreateTerminal(targetCwd).then((terminal) => {
-			didResolve = true
-			return terminal
-		})
-
-		await sandbox.clock.tickAsync(4999)
-		assert.equal(didResolve, false)
-
-		await sandbox.clock.tickAsync(1)
-		const terminal = (await terminalPromise) as unknown as TerminalInfo
-
-		try {
-			assert.notEqual(terminal, terminalInfo)
-			assert.equal(terminalInfo.busy, false)
-			assert.equal(terminalInfo.pendingCwdChange, undefined)
-			assert.equal(terminalInfo.cwdResolved, undefined)
-			assert.equal(terminal.busy, true)
-			assert.equal(getAllTerminalsStub.called, true)
-			assert.equal(executeCommandStub.calledOnceWith(`cd "${targetCwd}"`), true)
-		} finally {
-			terminal.terminal.dispose()
-			TerminalRegistry.removeTerminal(terminal.id)
-		}
-	})
-
-	it("reuses a terminal after its cwd change is confirmed", async () => {
-		const targetCwd = "/tmp/cline-target"
-		let currentCwd = vscode.Uri.file("/tmp/cline-original")
-		const terminalInfo: TerminalInfo = {
-			id: 1,
-			busy: false,
-			lastCommand: "",
-			lastActive: Date.now(),
-			terminal: {
-				shellIntegration: {
-					get cwd() {
-						return currentCwd
-					},
-					executeCommand: () => ({
-						read: () => ({
-							async *[Symbol.asyncIterator]() {
-								currentCwd = vscode.Uri.file(targetCwd)
-							},
-						}),
-					}),
-				},
-				show: sandbox.stub(),
+				processId: Promise.resolve(1),
+				shellIntegration: undefined,
+				show: showStub,
 			} as unknown as vscode.Terminal,
 		}
 		sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
 
-		const terminalPromise = manager.getOrCreateTerminal(targetCwd)
-		await sandbox.clock.tickAsync(100)
-		const terminal = await terminalPromise
+		const terminal = await manager.getOrCreateTerminal(cwd)
 
 		assert.equal(terminal, terminalInfo)
 		assert.equal(terminalInfo.busy, true)
-		assert.equal(terminalInfo.pendingCwdChange, undefined)
-		assert.equal(terminalInfo.cwdResolved, undefined)
+		assert.equal(showStub.called, false)
 	})
 
-	it("releases a reused terminal reservation when showing it fails", async () => {
+	it("prefixes cross-directory commands without showing the terminal", async () => {
+		const originalCwd = "/tmp/cline-original"
+		const targetCwd = "/tmp/cline-target"
+		const executeCommandStub = sandbox.stub().throws(new Error("stop after capture"))
+		const showStub = sandbox.stub()
 		const terminalInfo: TerminalInfo = {
 			id: 1,
-			busy: false,
+			busy: true,
 			lastCommand: "",
 			lastActive: Date.now(),
+			trackedCwd: originalCwd,
 			terminal: {
-				shellIntegration: { cwd: vscode.Uri.file("/tmp/cline-original") },
-				show: sandbox.stub().throws(new Error("terminal closed")),
-			} as unknown as vscode.Terminal,
-		}
-		sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
-
-		await assert.rejects(manager.getOrCreateTerminal("/tmp/cline-target"), /terminal closed/)
-
-		assert.equal(terminalInfo.busy, false)
-		assert.equal(terminalInfo.pendingCwdChange, undefined)
-		assert.equal(terminalInfo.cwdResolved, undefined)
-	})
-
-	it("creates a fresh terminal when the reused-terminal cwd command cannot start", async () => {
-		setVscodeHostProviderMock()
-		const terminalInfo: TerminalInfo = {
-			id: 1,
-			busy: false,
-			lastCommand: "",
-			lastActive: Date.now(),
-			terminal: {
+				processId: Promise.resolve(1),
 				shellIntegration: {
-					cwd: vscode.Uri.file("/tmp/cline-original"),
-					executeCommand: () => {
-						throw new Error("cwd command failed")
-					},
+					cwd: vscode.Uri.file(originalCwd),
+					executeCommand: executeCommandStub,
 				},
-				show: sandbox.stub(),
+				show: showStub,
 			} as unknown as vscode.Terminal,
 		}
-		sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
 
-		const terminal = (await manager.getOrCreateTerminal("/tmp/cline-target")) as unknown as TerminalInfo
-		try {
-			assert.notEqual(terminal, terminalInfo)
-			assert.equal(terminal.busy, true)
-			assert.equal(terminalInfo.busy, false)
-			assert.equal(terminalInfo.pendingCwdChange, undefined)
-			assert.equal(terminalInfo.cwdResolved, undefined)
-			assert.equal(TerminalRegistry.getTerminal(terminalInfo.id), undefined)
-		} finally {
-			terminal.terminal.dispose()
-			TerminalRegistry.removeTerminal(terminal.id)
-		}
+		const process = manager.runCommand(
+			terminalInfo as unknown as Parameters<VscodeTerminalManager["runCommand"]>[0],
+			"echo hi",
+			targetCwd,
+		)
+		await assert.rejects(process)
+
+		assert.equal(executeCommandStub.calledOnceWith(`cd "${targetCwd}" && echo hi`), true)
+		assert.equal(showStub.called, false)
 	})
 
-	it("creates a fresh terminal when the reused-terminal cwd command stream fails", async () => {
-		setVscodeHostProviderMock()
-		const terminalInfo: TerminalInfo = {
-			id: 1,
-			busy: false,
-			lastCommand: "",
-			lastActive: Date.now(),
-			terminal: {
-				shellIntegration: {
-					cwd: vscode.Uri.file("/tmp/cline-original"),
-					executeCommand: () => ({ read: () => createFailingStream(new Error("cwd stream failed")) }),
-				},
-				show: sandbox.stub(),
-			} as unknown as vscode.Terminal,
-		}
-		sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
+	it("queues an idle evicted terminal for disposal", () => {
+		const terminalInfo = TerminalRegistry.createTerminal("/tmp/cline-evicted")
+		const disposeSpy = sandbox.spy(terminalInfo.terminal, "dispose")
 
-		const terminal = (await manager.getOrCreateTerminal("/tmp/cline-target")) as unknown as TerminalInfo
-		try {
-			assert.notEqual(terminal, terminalInfo)
-			assert.equal(terminal.busy, true)
-			assert.equal(terminalInfo.busy, false)
-			assert.equal(terminalInfo.pendingCwdChange, undefined)
-			assert.equal(terminalInfo.cwdResolved, undefined)
-			assert.equal(TerminalRegistry.getTerminal(terminalInfo.id), undefined)
-		} finally {
-			terminal.terminal.dispose()
-			TerminalRegistry.removeTerminal(terminal.id)
-		}
+		;(manager as unknown as { evictTerminal: (info: TerminalInfo) => void }).evictTerminal(terminalInfo)
+		TerminalRegistry.disposeTerminalsPendingCleanup()
+
+		assert.equal(disposeSpy.calledOnce, true)
 	})
 
-	it("releases a reused terminal reservation when it closes during cwd setup", async () => {
-		let exitStatus: vscode.TerminalExitStatus | undefined
-		const terminalInfo: TerminalInfo = {
-			id: 1,
-			busy: false,
-			lastCommand: "",
-			lastActive: Date.now(),
-			terminal: {
-				get exitStatus() {
-					return exitStatus
-				},
-				shellIntegration: {
-					cwd: vscode.Uri.file("/tmp/cline-original"),
-					executeCommand: () => ({ read: createNeverEndingStream }),
-				},
-				show: sandbox.stub(),
-			} as unknown as vscode.Terminal,
-		}
-		sandbox.stub(TerminalRegistry, "getAllTerminals").returns([terminalInfo])
+	it("disposes idle terminals while preserving busy terminals", () => {
+		const idleTerminal = TerminalRegistry.createTerminal("/tmp/cline-idle")
+		const busyTerminal = TerminalRegistry.createTerminal("/tmp/cline-busy")
+		busyTerminal.busy = true
+		const idleDisposeSpy = sandbox.spy(idleTerminal.terminal, "dispose")
+		const busyDisposeSpy = sandbox.spy(busyTerminal.terminal, "dispose")
 
-		const rejectedAcquisition = assert.rejects(manager.getOrCreateTerminal("/tmp/cline-target"), /exited while preparing/)
-		exitStatus = { code: undefined, reason: vscode.TerminalExitReason.Unknown }
-		await sandbox.clock.tickAsync(5000)
-		await rejectedAcquisition
+		manager.disposeAll()
 
-		assert.equal(terminalInfo.busy, false)
-		assert.equal(terminalInfo.pendingCwdChange, undefined)
-		assert.equal(terminalInfo.cwdResolved, undefined)
+		assert.equal(idleDisposeSpy.calledOnce, true)
+		assert.equal(busyDisposeSpy.called, false)
+		assert.equal(TerminalRegistry.getTerminal(busyTerminal.id), busyTerminal)
+		busyTerminal.terminal.dispose()
+		TerminalRegistry.removeTerminal(busyTerminal.id)
 	})
 
 	it("reserves different terminals for parallel acquisitions", async () => {
@@ -267,6 +144,7 @@ describe("VscodeTerminalManager", () => {
 			busy: true,
 			lastCommand: "",
 			lastActive: Date.now(),
+			trackedCwd: "",
 			terminal: {
 				shellIntegration: {
 					executeCommand: () => {

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
@@ -237,7 +237,7 @@ describe("VscodeTerminalManager", () => {
 		assert.equal(disposeSpy.calledOnce, true)
 	})
 
-	it("defers fallback terminal disposal until the next terminal acquisition", async () => {
+	it("preserves an unobserved fallback terminal across the next terminal acquisition", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal()
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => undefined)
@@ -264,7 +264,7 @@ describe("VscodeTerminalManager", () => {
 
 			nextManager = new VscodeTerminalManager()
 			nextTerminal = (await nextManager.getOrCreateTerminal("/tmp/cline-next-command")) as unknown as TerminalInfo
-			assert.equal(disposeSpy.calledOnce, true, "the next acquisition must reclaim the fallback terminal")
+			assert.equal(disposeSpy.called, false, "an unobserved command remains user-owned")
 		} finally {
 			nextManager?.disposeAll()
 			nextTerminal?.terminal.dispose()

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.test.ts
@@ -167,6 +167,7 @@ describe("VscodeTerminalManager", () => {
 	it("does not reuse a terminal after its command stream fails", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal("/tmp/cline-stream-error")
+		sandbox.stub(terminalInfo.terminal, "processId").get(() => Promise.resolve(1))
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => ({
 			cwd: vscode.Uri.file("/tmp/cline-stream-error"),
 			executeCommand: () => ({ read: () => createFailingStream(new Error("command stream failed")) }),
@@ -240,6 +241,7 @@ describe("VscodeTerminalManager", () => {
 	it("preserves an unobserved fallback terminal across the next terminal acquisition", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal()
+		sandbox.stub(terminalInfo.terminal, "processId").get(() => Promise.resolve(1))
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => undefined)
 		sandbox.stub(terminalInfo.terminal, "sendText")
 		const disposeSpy = sandbox.spy(terminalInfo.terminal, "dispose")
@@ -281,6 +283,7 @@ describe("VscodeTerminalManager", () => {
 	it("preserves a detached fallback terminal across the next terminal acquisition", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal()
+		sandbox.stub(terminalInfo.terminal, "processId").get(() => Promise.resolve(1))
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => undefined)
 		sandbox.stub(terminalInfo.terminal, "sendText")
 		const disposeSpy = sandbox.spy(terminalInfo.terminal, "dispose")
@@ -313,6 +316,7 @@ describe("VscodeTerminalManager", () => {
 	it("preserves a continued fallback terminal across the next terminal acquisition", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal()
+		sandbox.stub(terminalInfo.terminal, "processId").get(() => Promise.resolve(1))
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => undefined)
 		sandbox.stub(terminalInfo.terminal, "sendText")
 		const disposeSpy = sandbox.spy(terminalInfo.terminal, "dispose")
@@ -345,6 +349,7 @@ describe("VscodeTerminalManager", () => {
 	it("preserves a markerless shell-integration terminal across the next terminal acquisition", async () => {
 		setVscodeHostProviderMock()
 		const terminalInfo = TerminalRegistry.createTerminal()
+		sandbox.stub(terminalInfo.terminal, "processId").get(() => Promise.resolve(1))
 		sandbox.stub(terminalInfo.terminal, "shellIntegration").get(() => ({
 			executeCommand: () => ({ read: createMarkerlessStream }),
 		}))

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -3,7 +3,6 @@ import { getShell, getShellForProfile } from "@utils/shell"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
 import {
-	getUnobservedTerminalCommandDisposition,
 	type TerminalInfo as ITerminalInfo,
 	type TerminalProcessResultPromise as ITerminalProcessResultPromise,
 } from "@/integrations/terminal/types"
@@ -133,13 +132,8 @@ export class VscodeTerminalManager {
 		process.once("unobserved_command", (outcome) => {
 			Logger.log(`unobserved_command (${outcome.source}) received for terminal ${vscodeTerminalInfo.id}`)
 			this.evictTerminal(vscodeTerminalInfo)
-			// Markerless streams (for example, an SSH session) and commands Cline no
-			// longer owns remain open. Ordinary managed sendText fallbacks are
-			// reclaimed at the next acquisition, after this tool result can report
-			// that their completion is indeterminate.
-			if (getUnobservedTerminalCommandDisposition(outcome) === "disposeBeforeNextTerminalAcquisition") {
-				TerminalRegistry.queueTerminalForCleanup(vscodeTerminalInfo)
-			}
+			// Completion is unobservable and the command may still be running, so
+			// leave the terminal open for the user to manage.
 		})
 
 		const promise = new Promise<void>((resolve, reject) => {

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalManager.ts
@@ -11,11 +11,6 @@ import { Logger } from "@/shared/services/Logger"
 import { mergePromise, VscodeTerminalProcess } from "./VscodeTerminalProcess"
 import { TerminalInfo, TerminalRegistry } from "./VscodeTerminalRegistry"
 
-const CWD_COMMAND_TIMEOUT_MS = 5000
-const CWD_STATE_TIMEOUT_MS = 1000
-
-type CwdChangeResult = "observed" | "unobserved"
-
 /*
 TerminalManager:
 - Creates/reuses terminals
@@ -100,99 +95,6 @@ export class VscodeTerminalManager {
 			e.execution.read()
 		})
 		this.disposables.push(startDisposable)
-
-		// Add a listener for terminal state changes to detect CWD updates
-		try {
-			const stateChangeDisposable = vscode.window.onDidChangeTerminalState((terminal) => {
-				const terminalInfo = this.findTerminalInfoByTerminal(terminal)
-				if (terminalInfo && terminalInfo.pendingCwdChange && terminalInfo.cwdResolved) {
-					// Check if CWD has been updated to match the expected path
-					if (this.isCwdMatchingExpected(terminalInfo)) {
-						const resolver = terminalInfo.cwdResolved.resolve
-						// Keep the target until the acquisition's finally block so the
-						// caller can confirm the resolved state before handing off.
-						terminalInfo.cwdResolved = undefined
-						resolver()
-					}
-				}
-			})
-			this.disposables.push(stateChangeDisposable)
-		} catch (error) {
-			Logger.error("Error setting up onDidChangeTerminalState", error)
-		}
-	}
-
-	//Find a TerminalInfo by its VSCode Terminal instance
-	private findTerminalInfoByTerminal(terminal: vscode.Terminal): TerminalInfo | undefined {
-		const terminals = TerminalRegistry.getAllTerminals()
-		return terminals.find((t) => t.terminal === terminal)
-	}
-
-	//Check if a terminal's CWD matches its expected pending change
-	private isCwdMatchingExpected(terminalInfo: TerminalInfo): boolean {
-		if (!terminalInfo.pendingCwdChange) {
-			return false
-		}
-
-		const currentCwd = terminalInfo.terminal.shellIntegration?.cwd?.fsPath
-		const targetCwd = vscode.Uri.file(terminalInfo.pendingCwdChange).fsPath
-
-		if (!currentCwd) {
-			return false
-		}
-
-		return arePathsEqual(currentCwd, targetCwd)
-	}
-
-	private async drainCommandOutput(output: AsyncIterable<string>): Promise<void> {
-		for await (const _chunk of output) {
-			// Drain the stream so shell integration can report command completion.
-		}
-	}
-
-	// VS Code shell integration sometimes finishes the internal `cd` command without
-	// reporting completion through the execution stream. Timeout this setup step so
-	// the user's actual command is still sent instead of leaving the chat stuck.
-	private async runCwdChangeCommand(terminalInfo: TerminalInfo, cwd: string): Promise<CwdChangeResult> {
-		const command = `cd "${cwd}"`
-		const shellIntegration = terminalInfo.terminal.shellIntegration
-
-		if (!shellIntegration?.executeCommand) {
-			terminalInfo.terminal.sendText(command, true)
-			Logger.warn(
-				`[TerminalManager] Shell integration executeCommand is unavailable while changing terminal ${terminalInfo.id} cwd. Proceeding after ${CWD_COMMAND_TIMEOUT_MS}ms.`,
-			)
-			await new Promise((resolve) => setTimeout(resolve, CWD_COMMAND_TIMEOUT_MS))
-			return "unobserved"
-		}
-
-		let timeout: NodeJS.Timeout | undefined
-		let didTimeOut = false
-
-		try {
-			const execution = shellIntegration.executeCommand(command)
-			await Promise.race([
-				this.drainCommandOutput(execution.read()),
-				new Promise<void>((resolve) => {
-					timeout = setTimeout(() => {
-						didTimeOut = true
-						Logger.warn(
-							`[TerminalManager] Timed out waiting ${CWD_COMMAND_TIMEOUT_MS}ms for terminal ${terminalInfo.id} to run cd "${cwd}". Proceeding with requested command.`,
-						)
-						resolve()
-					}, CWD_COMMAND_TIMEOUT_MS)
-				}),
-			])
-		} catch (error) {
-			Logger.warn(`[TerminalManager] Failed to observe terminal ${terminalInfo.id} cwd command completion`, error)
-			throw error
-		} finally {
-			if (timeout) {
-				clearTimeout(timeout)
-			}
-		}
-
-		return didTimeOut ? "unobserved" : "observed"
 	}
 
 	private runTerminalProcess(process: VscodeTerminalProcess, terminal: vscode.Terminal, command: string): void {
@@ -202,19 +104,13 @@ export class VscodeTerminalManager {
 		})
 	}
 
-	runCommand(terminalInfo: ITerminalInfo, command: string): ITerminalProcessResultPromise {
+	runCommand(terminalInfo: ITerminalInfo, command: string, cwd?: string): ITerminalProcessResultPromise {
 		// Cast to VSCode-specific TerminalInfo for internal use
 		// Using unknown as intermediate cast due to structural differences between ITerminal and vscode.Terminal
 		const vscodeTerminalInfo = terminalInfo as unknown as TerminalInfo
 		Logger.log(`[TerminalManager] Running command on terminal ${vscodeTerminalInfo.id}: "${command}"`)
 		Logger.log(`[TerminalManager] Terminal ${vscodeTerminalInfo.id} busy state before: ${vscodeTerminalInfo.busy}`)
 
-		try {
-			vscodeTerminalInfo.terminal.show()
-		} catch (error) {
-			vscodeTerminalInfo.busy = false
-			throw error
-		}
 		vscodeTerminalInfo.busy = true
 		vscodeTerminalInfo.lastCommand = command
 		const process = new VscodeTerminalProcess()
@@ -223,6 +119,9 @@ export class VscodeTerminalManager {
 		process.once("completed", () => {
 			Logger.log(`[TerminalManager] Terminal ${vscodeTerminalInfo.id} completed, setting busy to false`)
 			vscodeTerminalInfo.busy = false
+			if (vscodeTerminalInfo.terminal.exitStatus !== undefined) {
+				this.evictTerminal(vscodeTerminalInfo)
+			}
 		})
 		process.once("error", () => {
 			// A stream/API failure does not prove the launched command stopped.
@@ -253,37 +152,56 @@ export class VscodeTerminalManager {
 			})
 		})
 
-		// if shell integration is already active, run the command immediately
-		if (vscodeTerminalInfo.terminal.shellIntegration) {
-			process.waitForShellIntegration = false
-			this.runTerminalProcess(process, vscodeTerminalInfo.terminal, command)
-		} else {
-			// docs recommend waiting 3s for shell integration to activate
-			Logger.log(
-				`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
-			)
-			pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
-				timeout: this.shellIntegrationTimeout,
-			})
-				.then(() => {
-					Logger.log(
-						`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
-					)
+		const startCommand = async (): Promise<void> => {
+			// Accessing processId starts the pty without revealing the terminal.
+			await vscodeTerminalInfo.terminal.processId
+
+			const terminalCwd = vscodeTerminalInfo.terminal.shellIntegration?.cwd?.fsPath ?? vscodeTerminalInfo.trackedCwd
+			const terminalCommand =
+				cwd && !arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd) ? `cd "${cwd}" && ${command}` : command
+			if (cwd) {
+				vscodeTerminalInfo.trackedCwd = cwd
+			}
+			vscodeTerminalInfo.lastCommand = terminalCommand
+
+			// if shell integration is already active, run the command immediately
+			if (vscodeTerminalInfo.terminal.shellIntegration) {
+				process.waitForShellIntegration = false
+				this.runTerminalProcess(process, vscodeTerminalInfo.terminal, terminalCommand)
+			} else {
+				// docs recommend waiting 3s for shell integration to activate
+				Logger.log(
+					`[TerminalManager Test] Waiting for shell integration for terminal ${vscodeTerminalInfo.id} with timeout ${this.shellIntegrationTimeout}ms`,
+				)
+				pWaitFor(() => vscodeTerminalInfo.terminal.shellIntegration !== undefined, {
+					timeout: this.shellIntegrationTimeout,
 				})
-				.catch((err) => {
-					Logger.warn(
-						`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
-					)
-				})
-				.finally(() => {
-					Logger.log(`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`)
-					const existingProcess = this.processes.get(vscodeTerminalInfo.id)
-					if (existingProcess && existingProcess.waitForShellIntegration) {
-						existingProcess.waitForShellIntegration = false
-						this.runTerminalProcess(existingProcess, vscodeTerminalInfo.terminal, command)
-					}
-				})
+					.then(() => {
+						Logger.log(
+							`[TerminalManager Test] Shell integration activated for terminal ${vscodeTerminalInfo.id} within timeout.`,
+						)
+					})
+					.catch((err) => {
+						Logger.warn(
+							`[TerminalManager Test] Shell integration timed out or failed for terminal ${vscodeTerminalInfo.id}: ${err.message}`,
+						)
+					})
+					.finally(() => {
+						Logger.log(
+							`[TerminalManager Test] Proceeding with command execution for terminal ${vscodeTerminalInfo.id}.`,
+						)
+						const existingProcess = this.processes.get(vscodeTerminalInfo.id)
+						if (existingProcess && existingProcess.waitForShellIntegration) {
+							existingProcess.waitForShellIntegration = false
+							this.runTerminalProcess(existingProcess, vscodeTerminalInfo.terminal, terminalCommand)
+						}
+					})
+			}
 		}
+		void startCommand().catch((error) => {
+			process.releaseActiveExecutionResources()
+			process.emit("error", error instanceof Error ? error : new Error(String(error)))
+		})
 
 		return mergePromise(process, promise)
 	}
@@ -343,13 +261,9 @@ export class VscodeTerminalManager {
 			if (VscodeTerminalManager.effectiveShellPath(t.shellPath) !== effectiveExpected) {
 				return false
 			}
-			const terminalCwd = t.terminal.shellIntegration?.cwd // one of cline's commands could have changed the cwd of the terminal
-			if (!terminalCwd) {
-				Logger.log(`[TerminalManager] Terminal ${t.id} has no cwd, skipping`)
-				return false
-			}
-			const matches = arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd.fsPath)
-			Logger.log(`[TerminalManager] Terminal ${t.id} cwd: ${terminalCwd.fsPath}, matches: ${matches}`)
+			const terminalCwd = t.terminal.shellIntegration?.cwd?.fsPath ?? t.trackedCwd
+			const matches = arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd)
+			Logger.log(`[TerminalManager] Terminal ${t.id} cwd: ${terminalCwd}, matches: ${matches}`)
 			return matches
 		})
 		if (matchingTerminal) {
@@ -369,72 +283,8 @@ export class VscodeTerminalManager {
 			)
 			if (availableTerminal) {
 				availableTerminal.busy = true
-				let didHandOffReservation = false
-				try {
-					// Set up promise and tracking for CWD change after reserving the
-					// terminal so parallel acquisitions cannot select it.
-					const cwdPromise = new Promise<void>((resolve, reject) => {
-						availableTerminal.pendingCwdChange = cwd
-						availableTerminal.cwdResolved = { resolve, reject }
-					})
-					// Showing the reused terminal gives VS Code a chance to initialize shell integration.
-					// runCommand() below waits up to shellIntegrationTimeout for executeCommand before falling back.
-					availableTerminal.terminal.show()
-
-					let cwdChangeResult: CwdChangeResult | undefined
-					try {
-						cwdChangeResult = await this.runCwdChangeCommand(availableTerminal, cwd)
-					} catch (error) {
-						// The user's command has not started. The failed setup command may
-						// still change this terminal later, so evict it and continue with a
-						// fresh terminal rooted at the requested cwd.
-						Logger.warn(
-							`[TerminalManager] Failed to prepare terminal ${availableTerminal.id} for "${cwd}"; creating a new terminal`,
-							error,
-						)
-						this.evictTerminal(availableTerminal)
-					}
-
-					// Add a small delay to ensure terminal is ready after cd
-					if (cwdChangeResult === "observed") {
-						await new Promise((resolve) => setTimeout(resolve, 100))
-					}
-
-					// Either resolve immediately if CWD already updated or wait for event/timeout
-					const isCwdConfirmed = this.isCwdMatchingExpected(availableTerminal)
-					if (isCwdConfirmed) {
-						if (availableTerminal.cwdResolved) {
-							availableTerminal.cwdResolved.resolve()
-						}
-					} else if (cwdChangeResult === "observed") {
-						await Promise.race([cwdPromise, new Promise((resolve) => setTimeout(resolve, CWD_STATE_TIMEOUT_MS))])
-					}
-
-					if (cwdChangeResult !== undefined && availableTerminal.terminal.exitStatus !== undefined) {
-						TerminalRegistry.removeTerminal(availableTerminal.id)
-						throw new Error("The terminal's shell process exited while preparing to run the command.")
-					}
-
-					if (cwdChangeResult !== undefined && this.isCwdMatchingExpected(availableTerminal)) {
-						this.terminalIds.add(availableTerminal.id)
-						didHandOffReservation = true
-						return availableTerminal as unknown as ITerminalInfo
-					}
-
-					// Never run a command in a terminal whose working directory could
-					// not be confirmed. The setup command may still take effect later,
-					// so evict this terminal and create a fresh one at the requested cwd.
-					Logger.warn(
-						`[TerminalManager] Could not confirm terminal ${availableTerminal.id} changed to "${cwd}"; creating a new terminal`,
-					)
-					this.evictTerminal(availableTerminal)
-				} finally {
-					availableTerminal.pendingCwdChange = undefined
-					availableTerminal.cwdResolved = undefined
-					if (!didHandOffReservation) {
-						availableTerminal.busy = false
-					}
-				}
+				this.terminalIds.add(availableTerminal.id)
+				return availableTerminal as unknown as ITerminalInfo
 			}
 		}
 
@@ -466,10 +316,12 @@ export class VscodeTerminalManager {
 		return process ? process.isHot : false
 	}
 
-	disposeAll() {
-		// for (const info of this.terminals) {
-		// 	//info.terminal.dispose() // dont want to dispose terminals when task is aborted
-		// }
+	/** Dispose idle terminals; clear manager state only during full teardown. */
+	disposeAll(disposeManager = true): void {
+		TerminalRegistry.disposeIdleTerminals()
+		if (!disposeManager) {
+			return
+		}
 		this.terminalIds.clear()
 		this.processes.clear()
 		this.disposables.forEach((disposable) => disposable.dispose())
@@ -494,8 +346,15 @@ export class VscodeTerminalManager {
 	}
 
 	private evictTerminal(terminalInfo: TerminalInfo): void {
+		const process = this.processes.get(terminalInfo.id)
+		const completionDetails = process?.getCompletionDetails?.()
+		const hasUnobservedCommand = completionDetails?.unobservedCommand !== undefined
 		this.terminalIds.delete(terminalInfo.id)
 		this.processes.delete(terminalInfo.id)
-		TerminalRegistry.removeTerminal(terminalInfo.id)
+		if (!terminalInfo.busy && !hasUnobservedCommand) {
+			TerminalRegistry.queueTerminalForCleanup(terminalInfo)
+		} else {
+			TerminalRegistry.removeTerminal(terminalInfo.id)
+		}
 	}
 }

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -227,6 +227,7 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 		// Stub the sendText method to verify it's called
 		const sendTextStub = sandbox.stub(terminal, "sendText")
+		const showStub = sandbox.stub(terminal, "show")
 
 		// Spy on the emit function to verify events
 		const emitSpy = sandbox.spy(process, "emit")
@@ -242,6 +243,7 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 		// Check that the correct methods were called and events emitted
 		sendTextStub.calledWith("test-command", true).should.be.true()
+		showStub.calledOnce.should.be.true()
 		;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
 		;(emitSpy as sinon.SinonSpy).calledWith("continue").should.be.true()
 
@@ -271,6 +273,7 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 			// Stub terminal.shellIntegration to return our mock
 			sandbox.stub(terminal, "shellIntegration").get(() => mockShellIntegration)
+			const showStub = sandbox.stub(terminal, "show")
 
 			// Spy on emit to verify behavior
 			const emitSpy = sandbox.spy(process, "emit")
@@ -282,6 +285,7 @@ describe("TerminalProcess (Integration Tests)", () => {
 
 			// Verify the executeCommand was called with the right command
 			mockExecuteCommand.calledWith("echo test").should.be.true()
+			showStub.called.should.be.false()
 
 			// Check that the events were emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -482,6 +482,8 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 		} else {
 			// no shell integration detected, we'll fallback to running the command and capturing the terminal's output after some time
 			telemetryService.captureTerminalOutputFailure(TerminalOutputFailureReason.NO_SHELL_INTEGRATION, "vscode")
+			// Clipboard capture operates on the active terminal, so reveal it only for this degraded fallback path.
+			terminal.show()
 			terminal.sendText(command, true)
 
 			// wait 3 seconds for the command to run

--- a/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
+++ b/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
@@ -7,12 +7,8 @@ export interface TerminalInfo {
 	lastCommand: string
 	id: number
 	shellPath?: string
+	trackedCwd: string
 	lastActive: number
-	pendingCwdChange?: string
-	cwdResolved?: {
-		resolve: () => void
-		reject: (error: Error) => void
-	}
 }
 
 // Although vscode.window.terminals provides a list of all open terminals, there's no way to know whether they're busy or not (exitStatus does not provide useful information for most commands). In order to prevent creating too many terminals, we need to keep track of terminals through the life of the extension, as well as session specific terminals for the life of a task (to get latest unretrieved output).
@@ -42,13 +38,14 @@ export class TerminalRegistry {
 		}
 
 		const terminal = vscode.window.createTerminal(terminalOptions)
-		TerminalRegistry.nextTerminalId++
+		const id = TerminalRegistry.nextTerminalId++
 		const newInfo: TerminalInfo = {
 			terminal,
 			busy: false,
 			lastCommand: "",
-			id: TerminalRegistry.nextTerminalId,
+			id,
 			shellPath,
+			trackedCwd: typeof cwd === "string" ? cwd : (cwd?.fsPath ?? ""),
 			lastActive: Date.now(),
 		}
 		TerminalRegistry.terminals.push(newInfo)
@@ -101,6 +98,19 @@ export class TerminalRegistry {
 			} catch (error) {
 				TerminalRegistry.terminalsPendingCleanup.set(id, terminalInfo)
 				Logger.warn(`[TerminalRegistry] Failed to dispose fallback terminal ${id}; cleanup will be retried`, error)
+			}
+		}
+	}
+
+	static disposeIdleTerminals(): void {
+		const idle = TerminalRegistry.terminals.filter((terminalInfo) => !terminalInfo.busy)
+		TerminalRegistry.terminals = TerminalRegistry.terminals.filter((terminalInfo) => terminalInfo.busy)
+		for (const terminalInfo of idle) {
+			try {
+				terminalInfo.terminal.dispose()
+			} catch (error) {
+				TerminalRegistry.terminals.push(terminalInfo)
+				Logger.warn(`[TerminalRegistry] Failed to dispose idle terminal ${terminalInfo.id}`, error)
 			}
 		}
 	}

--- a/apps/vscode/src/integrations/terminal/types.ts
+++ b/apps/vscode/src/integrations/terminal/types.ts
@@ -126,12 +126,10 @@ export interface TerminalInfo {
 	lastCommand: string
 	/** The shell path used by this terminal (e.g., /bin/bash, /bin/zsh) */
 	shellPath?: string
+	/** The last working directory requested for this terminal */
+	trackedCwd: string
 	/** Timestamp of last activity */
 	lastActive: number
-	/** Pending CWD change path (used for tracking directory changes) */
-	pendingCwdChange?: string
-	/** Promise resolver for CWD change completion */
-	cwdResolved?: { resolve: () => void; reject: (err: Error) => void }
 }
 
 /**

--- a/apps/vscode/src/integrations/terminal/types.ts
+++ b/apps/vscode/src/integrations/terminal/types.ts
@@ -25,11 +25,11 @@ export interface UnobservedTerminalCommand {
 
 export type UnobservedTerminalCommandDisposition = "disposeBeforeNextTerminalAcquisition" | "preserve"
 
-/** Derive cleanup and reporting policy from the same unobserved-command snapshot. */
+/** Unobserved commands may still be running, so never dispose their terminals automatically. */
 export function getUnobservedTerminalCommandDisposition(
-	command: UnobservedTerminalCommand,
+	_command: UnobservedTerminalCommand,
 ): UnobservedTerminalCommandDisposition {
-	return command.source === "sendText" && command.ownership === "managed" ? "disposeBeforeNextTerminalAcquisition" : "preserve"
+	return "preserve"
 }
 
 export interface TerminalCompletionDetails {

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -800,6 +800,7 @@ export class Controller {
 		this.mcpHub?.clearToolListChangeCallback()
 		await this.diffEdits.discardAllPreviews("controller dispose")
 		await this.clearTask()
+		this._terminalManager?.disposeAll()
 		await this.sessions.dispose("SdkController.dispose")
 		await this.taskHistory.dispose()
 		this.mcpHub?.dispose?.()
@@ -1338,6 +1339,8 @@ export class Controller {
 		// No active task — UI returns to idle (input enabled, no buttons/thinking).
 		this.turnStateTracker.set("idle")
 		await this.taskControl.clearTask()
+		// Keep the controller-lifetime manager alive; only reclaim terminals at task boundaries.
+		this._terminalManager?.disposeAll(false)
 		await this.postStateToWebview()
 	}
 

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -395,7 +395,7 @@ describe("executeForeground", () => {
 			expect(error).toBeInstanceOf(CommandExitError)
 			expect((error as InstanceType<typeof CommandExitError>).output).toContain("must not be assumed to have succeeded")
 			expect((error as InstanceType<typeof CommandExitError>).output).toContain(
-				"The terminal remains open for now, but starting another foreground command will attempt to close it",
+				"The terminal has been left open and will not be closed automatically",
 			)
 			expect((error as InstanceType<typeof CommandExitError>).output).toContain("partial output")
 		}

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -283,7 +283,7 @@ export async function executeForeground(
 		const terminalPromise = terminalManager.getOrCreateTerminal(cwd, terminalProfileId)
 		const startDetached = (terminalInfo: Awaited<typeof terminalPromise>, log: DetachedCommandLog): void => {
 			try {
-				const process = terminalManager.runCommand(terminalInfo, terminalCommand)
+				const process = terminalManager.runCommand(terminalInfo, terminalCommand, cwd)
 				log.attach(process)
 				void process.catch((error) => log.fail(error))
 				process.detach()
@@ -352,7 +352,7 @@ export async function executeForeground(
 		state.phase = "started"
 		const { terminalInfo } = firstOutcome
 
-		const process = terminalManager.runCommand(terminalInfo, terminalCommand)
+		const process = terminalManager.runCommand(terminalInfo, terminalCommand, cwd)
 		const outputLines: string[] = []
 		let droppedLines = 0
 


### PR DESCRIPTION
### Related Issue

Possibly  #1293 

### Description

This PR fixes terminal spawning and focus stealing in the VS Code extension.

Previously, `run_commands` could create a new terminal for each command, reveal the terminal panel, and take focus away from the editor. Terminal reuse also depended on shell integration being available, which caused reuse to fail in some environments.

This changes:

- Reuses terminals using tracked working directories, even without shell integration.
- Prefixes cross-directory commands with `cd "<cwd>" &&`.
- Starts terminal processes without revealing them in the normal path.
- Keeps terminal reveal limited to the clipboard-based path.
- Evicts unusable terminals and disposes idle terminals when tasks are cleared.
- Preserves busy terminals used by detached or still-running commands.
- Fixes terminal ID allocation and passes the requested working directory through `run_commands`.

### Test Procedure

- Built the SDK dependencies with `bun run build:sdk`.
- Ran `cd apps/vscode && bun run package`.
- Ran the VS Code unit tests with `cd apps/vscode && bun run test:unit`.
- Manually verified in the Extension Development Host that:
  - Multiple commands reuse the same terminal unless terminal is stuck on a command, in that case it spawns a new one.
  - The terminal panel does not open during normal execution and editor focus is preserved.
  - Commands in different directories run correctly.
  - Idle terminals are removed after clearing/starting a new task.
  - Busy detached terminals remain available while still running.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed the contributor guidelines