### PR TITLE
fix(vscode): point provider signup URLs at their API key pages

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -69,7 +69,7 @@ describe("providerSettingsRegistry", () => {
 				"https://support.huaweicloud.com/intl/zh-cn/usermanual-maas/maas_01_0001.html",
 			],
 			["huggingface", "Hugging Face", "https://huggingface.co/settings/tokens"],
-			["mistral", "Mistral", "https://console.mistral.ai/codestral"],
+			["mistral", "Mistral", "https://console.mistral.ai/api-keys"],
 			["nebius", "Nebius", "https://auth.tokenfactory.nebius.com/ui/login"],
 			["nousResearch", "NousResearch", undefined],
 			["poolside", "Poolside", undefined],

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -23,7 +23,7 @@ describe("providerSettingsRegistry", () => {
 			allowsCustomIds: false,
 			providerId: "deepseek",
 			providerName: "DeepSeek",
-			signupUrl: "https://www.deepseek.com/",
+			signupUrl: "https://platform.deepseek.com/api_keys",
 		})
 	})
 
@@ -61,7 +61,7 @@ describe("providerSettingsRegistry", () => {
 			["cerebras", "Cerebras", "https://cloud.cerebras.ai/"],
 			["chutes", "Chutes", "https://chutes.ai/app/api"],
 			["doubao", "Doubao", "https://console.volcengine.com/home"],
-			["fireworks", "Fireworks", "https://fireworks.ai/"],
+			["fireworks", "Fireworks", "https://app.fireworks.ai/settings/users/api-keys"],
 			["groq", "Groq", "https://console.groq.com/keys"],
 			[
 				"huawei-cloud-maas",
@@ -159,7 +159,7 @@ describe("providerSettingsRegistry", () => {
 			allowsCustomIds: false,
 			providerId: "deepseek",
 			providerName: "DeepSeek",
-			signupUrl: "https://www.deepseek.com/",
+			signupUrl: "https://platform.deepseek.com/api_keys",
 		})
 		expect(getFallbackGenericProviderSettings("gemini")).toEqual({
 			allowsCustomIds: false,

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -40,13 +40,13 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		signupUrl: "https://app.baseten.co/settings/api_keys",
 	},
 	deepseek: {
-		signupUrl: "https://www.deepseek.com/",
+		signupUrl: "https://platform.deepseek.com/api_keys",
 	},
 	doubao: {
 		signupUrl: "https://console.volcengine.com/home",
 	},
 	fireworks: {
-		signupUrl: "https://fireworks.ai/",
+		signupUrl: "https://app.fireworks.ai/settings/users/api-keys",
 	},
 	groq: {
 		signupUrl: "https://console.groq.com/keys",

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -76,7 +76,7 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		},
 	},
 	mistral: {
-		signupUrl: "https://console.mistral.ai/codestral",
+		signupUrl: "https://console.mistral.ai/api-keys",
 	},
 	nebius: {
 		signupUrl: "https://auth.tokenfactory.nebius.com/ui/login",


### PR DESCRIPTION
## Problem

The Mistral provider's "Get API Key" link points to `https://console.mistral.ai/codestral`, Mistral's Codestral console. Keys issued there are Codestral-scoped and fail with 401 "Invalid API Key" against `api.mistral.ai` — the endpoint the Mistral provider actually uses. Users following the in-app link end up with a key that can never work.

While fixing that, an audit against the desktop app's `provider-key-urls.ts` map turned up two more registry entries pointing at marketing homepages instead of key-creation pages (less severe — keys reached from there do work, it's just needless friction).

## Fix

In `providerSettingsRegistry.ts` (and the matching test expectations):

- `mistral`: `console.mistral.ai/codestral` → `console.mistral.ai/api-keys` (the general API keys console — keys there are valid for `api.mistral.ai`)
- `deepseek`: `www.deepseek.com` → `platform.deepseek.com/api_keys`
- `fireworks`: `fireworks.ai` → `app.fireworks.ai/settings/users/api-keys`

All three targets verified: the Fireworks URL serves "API Keys - Fireworks AI" (and a bogus sibling path 404s, so it's not an SPA catch-all), and both the DeepSeek and Fireworks URLs are the ones the vendors' own docs link to. The VS Code registry now agrees with `apps/examples/desktop-app/webview/lib/provider-key-urls.ts` on every overlapping provider.

Fixes https://github.com/cline/cline/issues/13288
Linear: [CLINE-2982](https://linear.app/cline-bot/issue/CLINE-2982/mistral-invalid-api-key)

## Testing

`bunx vitest run src/components/settings/providers/providerSettingsRegistry.test.ts` — 8/8 pass.