### PR TITLE
feat(desktop): sync main and integrate Cloud environment selection

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -8,11 +8,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { selectCloudHandoffModel } from "@cline/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { materializeUserFiles } from "./attachments";
 import {
 	assertSessionDeleteAllowedDuringHandoff,
 	buildSessionConnectionUpdate,
+	combineCloudHandoffModels,
 	consumeWorkspaceMetadata,
 	handleChatSessionCommand,
 	hasProviderChanged,
@@ -30,6 +32,30 @@ import {
 	CloudSessionError,
 } from "./cloud-sessions";
 import type { SidecarContext } from "./types";
+
+describe("cloud handoff model catalog", () => {
+	it("retains a catalog model duplicated in Cline Pass for organization use", () => {
+		const models = combineCloudHandoffModels({
+			catalog: [{ id: "shared/model", name: "Shared", catalogId: "cline" }],
+			clinePass: [
+				{ id: "shared/model", name: "Shared Pass", catalogId: "cline-pass" },
+			],
+			clineCloud: [],
+		});
+
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "shared/model",
+				models,
+				isOrganizationSession: true,
+			}),
+		).toMatchObject({
+			modelId: "shared/model",
+			catalogId: "cline",
+			usedFallback: false,
+		});
+	});
+});
 
 describe("rewriteDesktopTeamPrompt", () => {
 	it("rewrites /team for the core runtime", () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -18,6 +18,7 @@ import {
 	hasProviderChanged,
 	mergeSessionConfig,
 	prewarmWorkspaceMetadata,
+	reconcilePendingCloudHandoff,
 	rewriteDesktopTeamPrompt,
 	shouldUpdateSessionConnection,
 	updateHandoffMetadataOrThrow,
@@ -1598,6 +1599,100 @@ describe("workspace metadata prewarming", () => {
 });
 
 describe("cloud handoff gates", () => {
+	const pendingFingerprint = {
+		repoUrl: "https://github.com/cline/cline.git",
+		branch: "main",
+		headSha: "old-head",
+		modelId: "anthropic/claude-sonnet-4.6",
+	};
+	const pendingMetadata = {
+		workspace: "preserved",
+		handoff: {
+			status: "pending" as const,
+			toCloudSessionId: "ses-old-target",
+			handedOffAt: "2026-08-18T00:00:00.000Z",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=ses-old-target",
+			fingerprint: pendingFingerprint,
+		},
+	};
+	const changedFingerprint = { ...pendingFingerprint, headSha: "new-head" };
+
+	it("preserves a mismatched pending handoff while its target exists", async () => {
+		const update = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{ handoffTargetExists: vi.fn(async () => true) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("still pending for a different");
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("clears a mismatched pending handoff only after the target is gone", async () => {
+		const update = vi.fn(async () => ({ updated: true }));
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{ handoffTargetExists: vi.fn(async () => false) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).resolves.toEqual({ metadata: { workspace: "preserved" } });
+		expect(update).toHaveBeenCalledWith("local-1", {
+			metadata: { workspace: "preserved" },
+		});
+	});
+
+	it("preserves pending lineage when target lookup is uncertain", async () => {
+		const update = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{
+					handoffTargetExists: vi.fn(async () => {
+						throw new Error("network unavailable");
+					}),
+				},
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("network unavailable");
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("keeps the source locked when clearing gone lineage is not persisted", async () => {
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update: vi.fn(async () => ({ updated: false })) } as never,
+				{ handoffTargetExists: vi.fn(async () => false) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("local pending handoff record could not be cleared");
+	});
+
 	it("fails when a required handoff metadata update is not persisted", async () => {
 		const update = vi.fn(async () => ({ updated: false }));
 		await expect(

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -19,6 +19,7 @@ import {
 	prewarmWorkspaceMetadata,
 	rewriteDesktopTeamPrompt,
 	shouldUpdateSessionConnection,
+	updateHandoffMetadataOrThrow,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
 } from "./chat-session";
 import type { SidecarContext } from "./types";
@@ -1377,6 +1378,18 @@ describe("workspace metadata prewarming", () => {
 });
 
 describe("cloud handoff gates", () => {
+	it("fails when a required handoff metadata update is not persisted", async () => {
+		const update = vi.fn(async () => ({ updated: false }));
+		await expect(
+			updateHandoffMetadataOrThrow(
+				{ update } as never,
+				"local-1",
+				{ handoff: { status: "pending" } },
+				"recovery record was not saved",
+			),
+		).rejects.toThrow("recovery record was not saved");
+	});
+
 	function createHandoffGateContext(options: {
 		busy?: boolean;
 		messages?: Array<{ role: "user" | "assistant"; content: string }>;

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -19,6 +19,7 @@ import {
 	hasProviderChanged,
 	mergeSessionConfig,
 	prewarmWorkspaceMetadata,
+	reconcilePendingCloudHandoff,
 	rewriteDesktopTeamPrompt,
 	shouldUpdateSessionConnection,
 	updateHandoffMetadataOrThrow,
@@ -1883,6 +1884,100 @@ describe("workspace metadata prewarming", () => {
 });
 
 describe("cloud handoff gates", () => {
+	const pendingFingerprint = {
+		repoUrl: "https://github.com/cline/cline.git",
+		branch: "main",
+		headSha: "old-head",
+		modelId: "anthropic/claude-sonnet-4.6",
+	};
+	const pendingMetadata = {
+		workspace: "preserved",
+		handoff: {
+			status: "pending" as const,
+			toCloudSessionId: "ses-old-target",
+			handedOffAt: "2026-08-18T00:00:00.000Z",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=ses-old-target",
+			fingerprint: pendingFingerprint,
+		},
+	};
+	const changedFingerprint = { ...pendingFingerprint, headSha: "new-head" };
+
+	it("preserves a mismatched pending handoff while its target exists", async () => {
+		const update = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{ handoffTargetExists: vi.fn(async () => true) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("still pending for a different");
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("clears a mismatched pending handoff only after the target is gone", async () => {
+		const update = vi.fn(async () => ({ updated: true }));
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{ handoffTargetExists: vi.fn(async () => false) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).resolves.toEqual({ metadata: { workspace: "preserved" } });
+		expect(update).toHaveBeenCalledWith("local-1", {
+			metadata: { workspace: "preserved" },
+		});
+	});
+
+	it("preserves pending lineage when target lookup is uncertain", async () => {
+		const update = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update } as never,
+				{
+					handoffTargetExists: vi.fn(async () => {
+						throw new Error("network unavailable");
+					}),
+				},
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("network unavailable");
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("keeps the source locked when clearing gone lineage is not persisted", async () => {
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update: vi.fn(async () => ({ updated: false })) } as never,
+				{ handoffTargetExists: vi.fn(async () => false) },
+				{
+					sourceSessionId: "local-1",
+					metadata: pendingMetadata,
+					pending: pendingMetadata.handoff,
+					fingerprint: changedFingerprint,
+					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+				},
+			),
+		).rejects.toThrow("local pending handoff record could not be cleared");
+	});
+
 	it("fails when a required handoff metadata update is not persisted", async () => {
 		const update = vi.fn(async () => ({ updated: false }));
 		await expect(

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -1617,6 +1617,26 @@ describe("cloud handoff gates", () => {
 	};
 	const changedFingerprint = { ...pendingFingerprint, headSha: "new-head" };
 
+	it("does not build a recovery URL for a fresh handoff", async () => {
+		const handoffTargetExists = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update: vi.fn() } as never,
+				{ handoffTargetExists },
+				{
+					sourceSessionId: "local-1",
+					metadata: { workspace: "preserved" },
+					fingerprint: changedFingerprint,
+					appBaseUrl: "not a valid URL",
+				},
+			),
+		).resolves.toEqual({
+			metadata: { workspace: "preserved" },
+			pending: undefined,
+		});
+		expect(handoffTargetExists).not.toHaveBeenCalled();
+	});
+
 	it("preserves a mismatched pending handoff while its target exists", async () => {
 		const update = vi.fn();
 		await expect(
@@ -1628,7 +1648,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("still pending for a different");
@@ -1646,7 +1666,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).resolves.toEqual({ metadata: { workspace: "preserved" } });
@@ -1670,7 +1690,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("network unavailable");
@@ -1687,7 +1707,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("local pending handoff record could not be cleared");

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -1015,6 +1015,35 @@ describe("first-send connection updates", () => {
 		}
 	});
 
+	it("preserves an idle fork status when Core reports its resident process as running", async () => {
+		const { ctx, sessionId } = createContext();
+		const existing = ctx.liveSessions.get(sessionId);
+		if (!existing) throw new Error("missing session");
+		existing.status = "idle";
+		existing.busy = false;
+		(ctx.sessionManager as unknown as { get: unknown }).get = vi.fn(
+			async () => ({
+				sessionId,
+				status: "running",
+				provider: "cline",
+				model: "anthropic/claude-sonnet-4.6",
+				cwd: "/workspace",
+				workspaceRoot: "/workspace",
+			}),
+		);
+
+		const result = (await handleChatSessionCommand(ctx, {
+			action: "attach",
+			sessionId,
+		})) as { status: string };
+
+		expect(result.status).toBe("idle");
+		expect(ctx.liveSessions.get(sessionId)).toMatchObject({
+			status: "idle",
+			busy: false,
+		});
+	});
+
 	it("updates a changed connection before sending", async () => {
 		const { ctx, send, sessionId, updateSessionConnection } = createContext({
 			config: { ...baseConfig, reasoningEffort: "low" },

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -8,11 +8,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { selectCloudHandoffModel } from "@cline/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { materializeUserFiles } from "./attachments";
 import {
 	assertSessionDeleteAllowedDuringHandoff,
 	buildSessionConnectionUpdate,
+	combineCloudHandoffModels,
 	consumeWorkspaceMetadata,
 	copySessionGeneratedArtifacts,
 	handleChatSessionCommand,
@@ -68,6 +70,30 @@ function localSessionManager(ctx: SidecarContext): Record<string, unknown> {
 		unknown
 	>;
 }
+
+describe("cloud handoff model catalog", () => {
+	it("retains a catalog model duplicated in Cline Pass for organization use", () => {
+		const models = combineCloudHandoffModels({
+			catalog: [{ id: "shared/model", name: "Shared", catalogId: "cline" }],
+			clinePass: [
+				{ id: "shared/model", name: "Shared Pass", catalogId: "cline-pass" },
+			],
+			clineCloud: [],
+		});
+
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "shared/model",
+				models,
+				isOrganizationSession: true,
+			}),
+		).toMatchObject({
+			modelId: "shared/model",
+			catalogId: "cline",
+			usedFallback: false,
+		});
+	});
+});
 
 describe("rewriteDesktopTeamPrompt", () => {
 	it("rewrites /team for the core runtime", () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -1902,6 +1902,26 @@ describe("cloud handoff gates", () => {
 	};
 	const changedFingerprint = { ...pendingFingerprint, headSha: "new-head" };
 
+	it("does not build a recovery URL for a fresh handoff", async () => {
+		const handoffTargetExists = vi.fn();
+		await expect(
+			reconcilePendingCloudHandoff(
+				{ update: vi.fn() } as never,
+				{ handoffTargetExists },
+				{
+					sourceSessionId: "local-1",
+					metadata: { workspace: "preserved" },
+					fingerprint: changedFingerprint,
+					appBaseUrl: "not a valid URL",
+				},
+			),
+		).resolves.toEqual({
+			metadata: { workspace: "preserved" },
+			pending: undefined,
+		});
+		expect(handoffTargetExists).not.toHaveBeenCalled();
+	});
+
 	it("preserves a mismatched pending handoff while its target exists", async () => {
 		const update = vi.fn();
 		await expect(
@@ -1913,7 +1933,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("still pending for a different");
@@ -1931,7 +1951,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).resolves.toEqual({ metadata: { workspace: "preserved" } });
@@ -1955,7 +1975,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("network unavailable");
@@ -1972,7 +1992,7 @@ describe("cloud handoff gates", () => {
 					metadata: pendingMetadata,
 					pending: pendingMetadata.handoff,
 					fingerprint: changedFingerprint,
-					dashboardUrl: pendingMetadata.handoff.dashboardUrl,
+					appBaseUrl: "https://app.cline.bot",
 				},
 			),
 		).rejects.toThrow("local pending handoff record could not be cleared");

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -20,6 +20,7 @@ import {
 	prewarmWorkspaceMetadata,
 	rewriteDesktopTeamPrompt,
 	shouldUpdateSessionConnection,
+	updateHandoffMetadataOrThrow,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
 } from "./chat-session";
 import type { SidecarContext } from "./types";
@@ -392,6 +393,120 @@ describe("session forks", () => {
 		}
 	});
 
+	it("keeps a persisted pending handoff read-only after restart", async () => {
+		const send = vi.fn();
+		const restore = vi.fn();
+		const sourceSessionId = "pending-handoff-source";
+		const pendingSession = {
+			sessionId: sourceSessionId,
+			status: "idle",
+			metadata: {
+				handoff: {
+					status: "pending",
+					toCloudSessionId: "cloud-pending",
+					handedOffAt: "2026-08-18T00:00:00.000Z",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+				},
+			},
+		};
+		const ctx = {
+			liveSessions: new Map([
+				[
+					sourceSessionId,
+					{
+						config: { cwd: "/workspace/project" },
+						messages: [{ role: "user", content: "continue" }],
+						promptsInQueue: [],
+						busy: false,
+						startedAt: Date.now(),
+						status: "idle",
+					},
+				],
+			]),
+			restoringWorkspacePaths: new Set(),
+			streamIndices: new Map(),
+			wsClients: new Set(),
+			...localRuntimeContext(
+				{
+					get: vi.fn(async () => pendingSession),
+					send,
+					restore,
+				},
+				{ sessionIds: [sourceSessionId], workspaceRoot: "/workspace/project" },
+			),
+		} as unknown as SidecarContext;
+		const recovery = "Cloud handoff is still pending";
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId: sourceSessionId,
+				prompt: "race",
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "fork",
+				sessionId: sourceSessionId,
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "reset",
+				sessionId: sourceSessionId,
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "restore_checkpoint",
+				sessionId: sourceSessionId,
+				checkpointRunCount: 1,
+				config: { cwd: "/workspace/project" },
+			}),
+		).rejects.toThrow(recovery);
+		expect(send).not.toHaveBeenCalled();
+		expect(restore).not.toHaveBeenCalled();
+	});
+
+	it("rejects checkpoint restore after the source completed a cloud handoff", async () => {
+		const restore = vi.fn();
+		const ctx = {
+			liveSessions: new Map(),
+			restoringWorkspacePaths: new Set(),
+			streamIndices: new Map(),
+			wsClients: new Set(),
+			...localRuntimeContext(
+				{
+					get: vi.fn(async () => ({
+						sessionId: "handed-off-source",
+						metadata: {
+							handoff: {
+								status: "complete",
+								toCloudSessionId: "cloud-target",
+								handedOffAt: "2026-08-18T00:00:00.000Z",
+							},
+						},
+					})),
+					restore,
+				},
+				{
+					sessionIds: ["handed-off-source"],
+					workspaceRoot: "/workspace/project",
+				},
+			),
+		} as unknown as SidecarContext;
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "restore_checkpoint",
+				sessionId: "handed-off-source",
+				checkpointRunCount: 1,
+				config: { cwd: "/workspace/project" },
+			}),
+		).rejects.toThrow("Fork locally before restoring a checkpoint");
+		expect(restore).not.toHaveBeenCalled();
+	});
+
 	it("restores the selected workspace checkpoint before forking for message editing", async () => {
 		const sourceSessionId = `source-fork-${Date.now()}`;
 		const sourceMessages = [
@@ -651,6 +766,13 @@ describe("session forks", () => {
 						model: "anthropic/claude-sonnet-4.6",
 						cwd: "/workspace/project",
 						workspaceRoot: "/workspace/project",
+						metadata: {
+							handoff: {
+								toCloudSessionId: "ses-cloud-copy",
+								handedOffAt: "2026-08-18T00:00:00.000Z",
+								status: "complete",
+							},
+						},
 					})),
 					readMessages,
 					restore,
@@ -673,7 +795,12 @@ describe("session forks", () => {
 
 		expect(restore).not.toHaveBeenCalled();
 		expect(start).toHaveBeenCalledWith(
-			expect.objectContaining({ initialMessages: sourceMessages }),
+			expect.objectContaining({
+				initialMessages: sourceMessages,
+				sessionMetadata: expect.not.objectContaining({
+					handoff: expect.anything(),
+				}),
+			}),
 		);
 	});
 
@@ -864,6 +991,7 @@ describe("first-send connection updates", () => {
 		const stop = vi.fn(async () => undefined);
 		const sessionId = "session-connection-test";
 		const start = vi.fn(async (_input?: unknown) => ({ sessionId }));
+		const get = vi.fn(async () => ({ sessionId, status: "idle" }));
 		const ctx = {
 			liveSessions: new Map([
 				[
@@ -884,6 +1012,7 @@ describe("first-send connection updates", () => {
 			wsClients: new Set(),
 			...localRuntimeContext(
 				{
+					get,
 					readMessages,
 					readSessionCompactionState,
 					send,
@@ -1178,6 +1307,35 @@ describe("first-send connection updates", () => {
 			}
 			rmSync(testSessionDataDir, { recursive: true, force: true });
 		}
+	});
+
+	it("preserves an idle fork status when Core reports its resident process as running", async () => {
+		const { ctx, sessionId } = createContext();
+		const existing = ctx.liveSessions.get(sessionId);
+		if (!existing) throw new Error("missing session");
+		existing.status = "idle";
+		existing.busy = false;
+		(localSessionManager(ctx) as unknown as { get: unknown }).get = vi.fn(
+			async () => ({
+				sessionId,
+				status: "running",
+				provider: "cline",
+				model: "anthropic/claude-sonnet-4.6",
+				cwd: "/workspace",
+				workspaceRoot: "/workspace",
+			}),
+		);
+
+		const result = (await handleChatSessionCommand(ctx, {
+			action: "attach",
+			sessionId,
+		})) as { status: string };
+
+		expect(result.status).toBe("idle");
+		expect(ctx.liveSessions.get(sessionId)).toMatchObject({
+			status: "idle",
+			busy: false,
+		});
 	});
 
 	it("updates a changed connection before sending", async () => {
@@ -1630,6 +1788,115 @@ describe("workspace metadata prewarming", () => {
 			),
 		).resolves.toBe("current metadata");
 		expect(load).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("cloud handoff gates", () => {
+	it("fails when a required handoff metadata update is not persisted", async () => {
+		const update = vi.fn(async () => ({ updated: false }));
+		await expect(
+			updateHandoffMetadataOrThrow(
+				{ update } as never,
+				"local-1",
+				{ handoff: { status: "pending" } },
+				"recovery record was not saved",
+			),
+		).rejects.toThrow("recovery record was not saved");
+	});
+
+	function createHandoffGateContext(options: {
+		busy?: boolean;
+		messages?: Array<{ role: "user" | "assistant"; content: string }>;
+		metadata?: Record<string, unknown>;
+	}) {
+		const sessionId = "local-handoff-source";
+		const send = vi.fn();
+		const messages = options.messages ?? [
+			{ role: "user" as const, content: "continue this work" },
+		];
+		const ctx = {
+			workspaceRoot: "/workspace/project",
+			liveSessions: new Map([
+				[
+					sessionId,
+					{
+						config: {
+							cwd: "/workspace/project",
+							provider: "cline",
+							model: "anthropic/claude-sonnet-4.6",
+						},
+						messages,
+						promptsInQueue: [],
+						busy: options.busy ?? false,
+						startedAt: Date.now(),
+						status: options.busy ? "running" : "idle",
+					},
+				],
+			]),
+			restoringWorkspacePaths: new Set(),
+			streamIndices: new Map(),
+			wsClients: new Set(),
+			...localRuntimeContext(
+				{
+					get: vi.fn(async () => ({
+						sessionId,
+						status: options.busy ? "running" : "completed",
+						cwd: "/workspace/project",
+						model: "anthropic/claude-sonnet-4.6",
+						metadata: options.metadata,
+					})),
+					readLiveMessages: vi.fn(async () => messages),
+					send,
+					pendingPrompts: { list: vi.fn(async () => []) },
+				},
+				{ sessionIds: [sessionId], workspaceRoot: "/workspace/project" },
+			),
+		} as unknown as SidecarContext;
+		return { ctx, send, sessionId };
+	}
+
+	it("rejects a busy source before provisioning", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({ busy: true });
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.toThrow("Stop the current run");
+		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
+	it("rejects an empty source before provisioning", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({ messages: [] });
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.toThrow("Start a conversation");
+		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
+	it("rejects normal sends after ownership moved to cloud", async () => {
+		const { ctx, send, sessionId } = createHandoffGateContext({
+			metadata: {
+				handoff: {
+					toCloudSessionId: "ses-cloud-target",
+					handedOffAt: "2026-08-18T00:00:00.000Z",
+					status: "complete",
+					dashboardUrl:
+						"https://app.cline.bot/agents?sessionId=ses-cloud-target",
+				},
+			},
+		});
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "keep editing locally",
+			}),
+		).rejects.toThrow("Fork locally");
+		expect(send).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -21,10 +21,15 @@ import {
 	prewarmWorkspaceMetadata,
 	reconcilePendingCloudHandoff,
 	rewriteDesktopTeamPrompt,
+	shouldCleanupFailedHandoffVerification,
 	shouldUpdateSessionConnection,
 	updateHandoffMetadataOrThrow,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
 } from "./chat-session";
+import {
+	CloudHandoffSeedUnsupportedError,
+	CloudSessionError,
+} from "./cloud-sessions";
 import type { SidecarContext } from "./types";
 
 function localRuntimeContext(
@@ -1884,6 +1889,19 @@ describe("workspace metadata prewarming", () => {
 });
 
 describe("cloud handoff gates", () => {
+	it("cleans up an old runtime that ignored the seeded transcript", () => {
+		expect(
+			shouldCleanupFailedHandoffVerification(
+				new CloudHandoffSeedUnsupportedError(),
+			),
+		).toBe(true);
+		expect(
+			shouldCleanupFailedHandoffVerification(
+				new CloudSessionError("request_failed", "temporary read failure"),
+			),
+		).toBe(false);
+	});
+
 	const pendingFingerprint = {
 		repoUrl: "https://github.com/cline/cline.git",
 		branch: "main",

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { materializeUserFiles } from "./attachments";
 import {
+	assertSessionDeleteAllowedDuringHandoff,
 	buildSessionConnectionUpdate,
 	consumeWorkspaceMetadata,
 	handleChatSessionCommand,
@@ -231,6 +232,89 @@ describe("pathless session starts", () => {
 });
 
 describe("session forks", () => {
+	it("blocks the delete command while a persisted cloud handoff is pending", async () => {
+		const remove = vi.fn();
+		const ctx = {
+			liveSessions: new Map(),
+			sessionManager: {
+				get: vi.fn(async () => ({
+					sessionId: "pending-handoff-source",
+					metadata: {
+						handoff: {
+							status: "pending",
+							toCloudSessionId: "cloud-pending",
+							handedOffAt: "2026-08-18T00:00:00.000Z",
+							dashboardUrl:
+								"https://app.cline.bot/agents?sessionId=cloud-pending",
+						},
+					},
+				})),
+				delete: remove,
+			},
+		} as unknown as SidecarContext;
+		const { handleCommand } = await import("./commands");
+
+		await expect(
+			handleCommand(ctx, "delete_chat_session", {
+				sessionId: "pending-handoff-source",
+			}),
+		).rejects.toThrow("Cloud handoff is still pending");
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("blocks deletion while the handoff request is starting", async () => {
+		let releaseGet: ((value: undefined) => void) | undefined;
+		const ctx = {
+			liveSessions: new Map(),
+			sessionManager: {
+				get: vi.fn(
+					async () =>
+						await new Promise<undefined>((resolve) => {
+							releaseGet = resolve;
+						}),
+				),
+			},
+		} as unknown as SidecarContext;
+		const handoff = handleChatSessionCommand(ctx, {
+			action: "handoff",
+			sessionId: "starting-handoff-source",
+			fingerprint: {
+				repoUrl: "https://github.com/cline/cline.git",
+				branch: "main",
+				headSha: "abc123",
+				modelId: "anthropic/claude-sonnet-4.6",
+			},
+		});
+
+		await expect(
+			assertSessionDeleteAllowedDuringHandoff(ctx, "starting-handoff-source"),
+		).rejects.toThrow("Wait for the cloud handoff to finish before deleting");
+		releaseGet?.(undefined);
+		await expect(handoff).rejects.toThrow("was not found");
+	});
+
+	it("allows deletion after a cloud handoff has completed", async () => {
+		const ctx = {
+			liveSessions: new Map(),
+			sessionManager: {
+				get: vi.fn(async () => ({
+					sessionId: "completed-handoff-source",
+					metadata: {
+						handoff: {
+							status: "complete",
+							toCloudSessionId: "cloud-complete",
+							handedOffAt: "2026-08-18T00:00:00.000Z",
+						},
+					},
+				})),
+			},
+		} as unknown as SidecarContext;
+
+		await expect(
+			assertSessionDeleteAllowedDuringHandoff(ctx, "completed-handoff-source"),
+		).resolves.toBeUndefined();
+	});
+
 	it("keeps a persisted pending handoff read-only after restart", async () => {
 		const send = vi.fn();
 		const restore = vi.fn();

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -231,6 +231,111 @@ describe("pathless session starts", () => {
 });
 
 describe("session forks", () => {
+	it("keeps a persisted pending handoff read-only after restart", async () => {
+		const send = vi.fn();
+		const restore = vi.fn();
+		const sourceSessionId = "pending-handoff-source";
+		const pendingSession = {
+			sessionId: sourceSessionId,
+			status: "idle",
+			metadata: {
+				handoff: {
+					status: "pending",
+					toCloudSessionId: "cloud-pending",
+					handedOffAt: "2026-08-18T00:00:00.000Z",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+				},
+			},
+		};
+		const ctx = {
+			liveSessions: new Map([
+				[
+					sourceSessionId,
+					{
+						config: { cwd: "/workspace/project" },
+						messages: [{ role: "user", content: "continue" }],
+						promptsInQueue: [],
+						busy: false,
+						startedAt: Date.now(),
+						status: "idle",
+					},
+				],
+			]),
+			restoringWorkspacePaths: new Set(),
+			sessionManager: {
+				get: vi.fn(async () => pendingSession),
+				send,
+				restore,
+			},
+			streamIndices: new Map(),
+			wsClients: new Set(),
+		} as unknown as SidecarContext;
+		const recovery = "Cloud handoff is still pending";
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId: sourceSessionId,
+				prompt: "race",
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "fork",
+				sessionId: sourceSessionId,
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "reset",
+				sessionId: sourceSessionId,
+			}),
+		).rejects.toThrow(recovery);
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "restore_checkpoint",
+				sessionId: sourceSessionId,
+				checkpointRunCount: 1,
+				config: { cwd: "/workspace/project" },
+			}),
+		).rejects.toThrow(recovery);
+		expect(send).not.toHaveBeenCalled();
+		expect(restore).not.toHaveBeenCalled();
+	});
+
+	it("rejects checkpoint restore after the source completed a cloud handoff", async () => {
+		const restore = vi.fn();
+		const ctx = {
+			liveSessions: new Map(),
+			restoringWorkspacePaths: new Set(),
+			sessionManager: {
+				get: vi.fn(async () => ({
+					sessionId: "handed-off-source",
+					metadata: {
+						handoff: {
+							status: "complete",
+							toCloudSessionId: "cloud-target",
+							handedOffAt: "2026-08-18T00:00:00.000Z",
+						},
+					},
+				})),
+				restore,
+			},
+			streamIndices: new Map(),
+			wsClients: new Set(),
+		} as unknown as SidecarContext;
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "restore_checkpoint",
+				sessionId: "handed-off-source",
+				checkpointRunCount: 1,
+				config: { cwd: "/workspace/project" },
+			}),
+		).rejects.toThrow("Fork locally before restoring a checkpoint");
+		expect(restore).not.toHaveBeenCalled();
+	});
+
 	it("restores the selected workspace checkpoint before forking for message editing", async () => {
 		const sourceSessionId = `source-fork-${Date.now()}`;
 		const sourceMessages = [
@@ -700,6 +805,7 @@ describe("first-send connection updates", () => {
 		const stop = vi.fn(async () => undefined);
 		const sessionId = "session-connection-test";
 		const start = vi.fn(async (_input?: unknown) => ({ sessionId }));
+		const get = vi.fn(async () => ({ sessionId, status: "idle" }));
 		const ctx = {
 			liveSessions: new Map([
 				[
@@ -719,6 +825,7 @@ describe("first-send connection updates", () => {
 			streamIndices: new Map(),
 			wsClients: new Set(),
 			sessionManager: {
+				get,
 				readMessages,
 				readSessionCompactionState,
 				send,

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -1957,6 +1957,47 @@ describe("cloud handoff gates", () => {
 		expect(ctx.cloudSessionManager).toBeFalsy();
 	});
 
+	it("checks handoff readiness in the source session environment", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({ busy: false });
+		const sourceBinding = ctx.runtimeBindings.get("local");
+		if (!sourceBinding) throw new Error("missing local runtime binding");
+		const sourceGet = vi.fn(
+			async () =>
+				({
+					sessionId,
+					status: "running",
+					cwd: "/workspace/project",
+				}) as never,
+		);
+		ctx.runtimeBindings.set("ssh-source", {
+			...sourceBinding,
+			environmentId: "ssh-source",
+			kind: "ssh",
+			sessionManager: {
+				...sourceBinding.sessionManager,
+				get: sourceGet,
+			} as unknown as typeof sourceBinding.sessionManager,
+		});
+		ctx.runtimeBindings.set("local", {
+			...sourceBinding,
+			sessionManager: {
+				...sourceBinding.sessionManager,
+				get: vi.fn(async () => undefined),
+			} as unknown as typeof sourceBinding.sessionManager,
+		});
+		ctx.sessionEnvironmentIds.set(sessionId, "ssh-source");
+		ctx.activeEnvironmentId = "local";
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.toThrow("Stop the current run");
+		expect(sourceGet).toHaveBeenCalledWith(sessionId);
+		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
 	it("rejects an empty source before provisioning", async () => {
 		const { ctx, sessionId } = createHandoffGateContext({ messages: [] });
 		await expect(

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { materializeUserFiles } from "./attachments";
 import {
+	assertSessionDeleteAllowedDuringHandoff,
 	buildSessionConnectionUpdate,
 	consumeWorkspaceMetadata,
 	copySessionGeneratedArtifacts,
@@ -391,6 +392,96 @@ describe("session forks", () => {
 			}
 			rmSync(sessionsDir, { recursive: true, force: true });
 		}
+	});
+
+	it("blocks the delete command while a persisted cloud handoff is pending", async () => {
+		const sessionId = "pending-handoff-source";
+		const remove = vi.fn();
+		const manager = {
+			get: vi.fn(async () => ({
+				sessionId,
+				metadata: {
+					handoff: {
+						status: "pending",
+						toCloudSessionId: "cloud-pending",
+						handedOffAt: "2026-08-18T00:00:00.000Z",
+						dashboardUrl:
+							"https://app.cline.bot/agents?sessionId=cloud-pending",
+					},
+				},
+			})),
+			delete: remove,
+		};
+		const ctx = {
+			liveSessions: new Map(),
+			cloudSessionManager: null,
+			...localRuntimeContext(manager, { sessionIds: [sessionId] }),
+		} as unknown as SidecarContext;
+		const { handleCommand } = await import("./commands");
+
+		await expect(
+			handleCommand(ctx, "delete_chat_session", {
+				sessionId,
+			}),
+		).rejects.toThrow("Cloud handoff is still pending");
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("blocks deletion while the handoff request is starting", async () => {
+		const sessionId = "starting-handoff-source";
+		let releaseGet: ((value: undefined) => void) | undefined;
+		const manager = {
+			get: vi.fn(
+				async () =>
+					await new Promise<undefined>((resolve) => {
+						releaseGet = resolve;
+					}),
+			),
+		};
+		const ctx = {
+			liveSessions: new Map(),
+			...localRuntimeContext(manager, { sessionIds: [sessionId] }),
+		} as unknown as SidecarContext;
+		const handoff = handleChatSessionCommand(ctx, {
+			action: "handoff",
+			sessionId,
+			fingerprint: {
+				repoUrl: "https://github.com/cline/cline.git",
+				branch: "main",
+				headSha: "abc123",
+				modelId: "anthropic/claude-sonnet-4.6",
+			},
+		});
+
+		await expect(
+			assertSessionDeleteAllowedDuringHandoff(ctx, sessionId),
+		).rejects.toThrow("Wait for the cloud handoff to finish before deleting");
+		releaseGet?.(undefined);
+		await expect(handoff).rejects.toThrow("was not found");
+	});
+
+	it("allows deletion after a cloud handoff has completed", async () => {
+		const sessionId = "completed-handoff-source";
+		const manager = {
+			get: vi.fn(async () => ({
+				sessionId,
+				metadata: {
+					handoff: {
+						status: "complete",
+						toCloudSessionId: "cloud-complete",
+						handedOffAt: "2026-08-18T00:00:00.000Z",
+					},
+				},
+			})),
+		};
+		const ctx = {
+			liveSessions: new Map(),
+			...localRuntimeContext(manager, { sessionIds: [sessionId] }),
+		} as unknown as SidecarContext;
+
+		await expect(
+			assertSessionDeleteAllowedDuringHandoff(ctx, sessionId),
+		).resolves.toBeUndefined();
 	});
 
 	it("keeps a persisted pending handoff read-only after restart", async () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -2056,6 +2056,7 @@ describe("cloud handoff gates", () => {
 
 	function createHandoffGateContext(options: {
 		busy?: boolean;
+		persistedStatus?: string;
 		messages?: Array<{ role: "user" | "assistant"; content: string }>;
 		metadata?: Record<string, unknown>;
 	}) {
@@ -2090,7 +2091,9 @@ describe("cloud handoff gates", () => {
 				{
 					get: vi.fn(async () => ({
 						sessionId,
-						status: options.busy ? "running" : "completed",
+						status:
+							options.persistedStatus ??
+							(options.busy ? "running" : "completed"),
 						cwd: "/workspace/project",
 						model: "anthropic/claude-sonnet-4.6",
 						metadata: options.metadata,
@@ -2114,6 +2117,20 @@ describe("cloud handoff gates", () => {
 			}),
 		).rejects.toThrow("Stop the current run");
 		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
+	it("trusts an authoritative idle live session over a legacy running record", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({
+			busy: false,
+			persistedStatus: "running",
+		});
+
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.not.toThrow("Stop the current run");
 	});
 
 	it("rejects remote SSH handoff before running Git preflight locally", async () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -482,6 +482,13 @@ describe("session forks", () => {
 					model: "anthropic/claude-sonnet-4.6",
 					cwd: "/workspace/project",
 					workspaceRoot: "/workspace/project",
+					metadata: {
+						handoff: {
+							toCloudSessionId: "ses-cloud-copy",
+							handedOffAt: "2026-08-18T00:00:00.000Z",
+							status: "complete",
+						},
+					},
 				})),
 				readMessages,
 				restore,
@@ -502,7 +509,12 @@ describe("session forks", () => {
 
 		expect(restore).not.toHaveBeenCalled();
 		expect(start).toHaveBeenCalledWith(
-			expect.objectContaining({ initialMessages: sourceMessages }),
+			expect.objectContaining({
+				initialMessages: sourceMessages,
+				sessionMetadata: expect.not.objectContaining({
+					handoff: expect.anything(),
+				}),
+			}),
 		);
 	});
 
@@ -1361,6 +1373,100 @@ describe("workspace metadata prewarming", () => {
 			),
 		).resolves.toBe("current metadata");
 		expect(load).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("cloud handoff gates", () => {
+	function createHandoffGateContext(options: {
+		busy?: boolean;
+		messages?: Array<{ role: "user" | "assistant"; content: string }>;
+		metadata?: Record<string, unknown>;
+	}) {
+		const sessionId = "local-handoff-source";
+		const send = vi.fn();
+		const messages = options.messages ?? [
+			{ role: "user" as const, content: "continue this work" },
+		];
+		const ctx = {
+			workspaceRoot: "/workspace/project",
+			liveSessions: new Map([
+				[
+					sessionId,
+					{
+						config: {
+							cwd: "/workspace/project",
+							provider: "cline",
+							model: "anthropic/claude-sonnet-4.6",
+						},
+						messages,
+						promptsInQueue: [],
+						busy: options.busy ?? false,
+						startedAt: Date.now(),
+						status: options.busy ? "running" : "idle",
+					},
+				],
+			]),
+			restoringWorkspacePaths: new Set(),
+			streamIndices: new Map(),
+			wsClients: new Set(),
+			sessionManager: {
+				get: vi.fn(async () => ({
+					sessionId,
+					status: options.busy ? "running" : "completed",
+					cwd: "/workspace/project",
+					model: "anthropic/claude-sonnet-4.6",
+					metadata: options.metadata,
+				})),
+				readLiveMessages: vi.fn(async () => messages),
+				send,
+				pendingPrompts: { list: vi.fn(async () => []) },
+			},
+		} as unknown as SidecarContext;
+		return { ctx, send, sessionId };
+	}
+
+	it("rejects a busy source before provisioning", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({ busy: true });
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.toThrow("Stop the current run");
+		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
+	it("rejects an empty source before provisioning", async () => {
+		const { ctx, sessionId } = createHandoffGateContext({ messages: [] });
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "prepare_handoff",
+				sessionId,
+			}),
+		).rejects.toThrow("Start a conversation");
+		expect(ctx.cloudSessionManager).toBeFalsy();
+	});
+
+	it("rejects normal sends after ownership moved to cloud", async () => {
+		const { ctx, send, sessionId } = createHandoffGateContext({
+			metadata: {
+				handoff: {
+					toCloudSessionId: "ses-cloud-target",
+					handedOffAt: "2026-08-18T00:00:00.000Z",
+					status: "complete",
+					dashboardUrl:
+						"https://app.cline.bot/agents?sessionId=ses-cloud-target",
+				},
+			},
+		});
+		await expect(
+			handleChatSessionCommand(ctx, {
+				action: "send",
+				sessionId,
+				prompt: "keep editing locally",
+			}),
+		).rejects.toThrow("Fork locally");
+		expect(send).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -2090,7 +2090,7 @@ describe("cloud handoff gates", () => {
 		expect(ctx.cloudSessionManager).toBeFalsy();
 	});
 
-	it("checks handoff readiness in the source session environment", async () => {
+	it("rejects remote SSH handoff before running Git preflight locally", async () => {
 		const { ctx, sessionId } = createHandoffGateContext({ busy: false });
 		const sourceBinding = ctx.runtimeBindings.get("local");
 		if (!sourceBinding) throw new Error("missing local runtime binding");
@@ -2126,8 +2126,8 @@ describe("cloud handoff gates", () => {
 				action: "prepare_handoff",
 				sessionId,
 			}),
-		).rejects.toThrow("Stop the current run");
-		expect(sourceGet).toHaveBeenCalledWith(sessionId);
+		).rejects.toThrow("SSH workspace is not supported");
+		expect(sourceGet).not.toHaveBeenCalled();
 		expect(ctx.cloudSessionManager).toBeFalsy();
 	});
 

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -20,10 +20,15 @@ import {
 	prewarmWorkspaceMetadata,
 	reconcilePendingCloudHandoff,
 	rewriteDesktopTeamPrompt,
+	shouldCleanupFailedHandoffVerification,
 	shouldUpdateSessionConnection,
 	updateHandoffMetadataOrThrow,
 	WORKSPACE_METADATA_PREWARM_TTL_MS,
 } from "./chat-session";
+import {
+	CloudHandoffSeedUnsupportedError,
+	CloudSessionError,
+} from "./cloud-sessions";
 import type { SidecarContext } from "./types";
 
 describe("rewriteDesktopTeamPrompt", () => {
@@ -1599,6 +1604,19 @@ describe("workspace metadata prewarming", () => {
 });
 
 describe("cloud handoff gates", () => {
+	it("cleans up an old runtime that ignored the seeded transcript", () => {
+		expect(
+			shouldCleanupFailedHandoffVerification(
+				new CloudHandoffSeedUnsupportedError(),
+			),
+		).toBe(true);
+		expect(
+			shouldCleanupFailedHandoffVerification(
+				new CloudSessionError("request_failed", "temporary read failure"),
+			),
+		).toBe(false);
+	});
+
 	const pendingFingerprint = {
 		repoUrl: "https://github.com/cline/cline.git",
 		branch: "main",

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1624,15 +1624,13 @@ export async function handleChatSessionCommand(
 						"File attachments are not supported in cloud sessions",
 					);
 				}
-				const live = ctx.liveSessions.get(sessionId);
-				const delivery = request.delivery ?? (live?.busy ? "queue" : undefined);
 				const modelId = String(
 					request.config?.model ?? request.config?.modelId ?? "",
 				).trim();
 				return await cloud.send(
 					sessionId,
 					prompt,
-					delivery,
+					request.delivery,
 					modelId || undefined,
 					request.attachments?.userImages,
 				);

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1978,7 +1978,7 @@ async function prepareCloudHandoff(
 ): Promise<PreparedCloudHandoff> {
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
-	const manager = getSessionManager(ctx);
+	const manager = getSessionManager(ctx, sessionId, request.config);
 	await assertHandoffIdle(ctx, manager, sessionId);
 	if ((await manager.readLiveMessages(sessionId)).length === 0) {
 		throw new Error("Start a conversation before handing it off to cloud.");
@@ -2073,7 +2073,7 @@ async function handleHandoffOnce(
 			"The repository, branch, commit, or cloud model changed after handoff started. Review the handoff details and try again.",
 		);
 	}
-	const manager = getSessionManager(ctx);
+	const manager = getSessionManager(ctx, sourceSessionId, request.config);
 	const cloud = getCloudSessionManager(ctx);
 	const environment = getClineEnvironmentConfig();
 	const emitProgress = (

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -14,6 +14,7 @@ import {
 	type ClineCore,
 	type ClineCoreStartConfig,
 	type CloudHandoffFingerprint,
+	type CloudHandoffMetadata,
 	type CloudHandoffModel,
 	CloudHandoffTranscriptMismatchError,
 	clearCloudHandoffMetadata,
@@ -52,7 +53,11 @@ import {
 	materializeUserFiles,
 	trackQueuedAttachments,
 } from "./attachments";
-import { CloudSessionError, getCloudSessionManager } from "./cloud-sessions";
+import {
+	CloudSessionError,
+	type CloudSessionManager,
+	getCloudSessionManager,
+} from "./cloud-sessions";
 import {
 	emitChunk,
 	findSessionRuntimeBinding,
@@ -1972,6 +1977,38 @@ export async function updateHandoffMetadataOrThrow(
 	if (!result.updated) throw new Error(failureMessage);
 }
 
+export async function reconcilePendingCloudHandoff(
+	manager: Pick<ClineCore, "update">,
+	cloud: Pick<CloudSessionManager, "handoffTargetExists">,
+	input: {
+		sourceSessionId: string;
+		metadata: JsonRecord;
+		pending?: CloudHandoffMetadata;
+		fingerprint: CloudHandoffFingerprint;
+		dashboardUrl: string;
+	},
+): Promise<{ metadata: JsonRecord; pending?: CloudHandoffMetadata }> {
+	if (
+		input.pending?.status !== "pending" ||
+		cloudHandoffFingerprintsEqual(input.pending.fingerprint, input.fingerprint)
+	) {
+		return { metadata: input.metadata, pending: input.pending };
+	}
+	if (await cloud.handoffTargetExists(input.pending.toCloudSessionId)) {
+		throw new Error(
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${input.dashboardUrl}`,
+		);
+	}
+	const metadata = clearCloudHandoffMetadata(input.metadata);
+	await updateHandoffMetadataOrThrow(
+		manager,
+		input.sourceSessionId,
+		metadata,
+		"The previous cloud workspace is gone, but its local pending handoff record could not be cleared.",
+	);
+	return { metadata };
+}
+
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -2104,24 +2141,25 @@ async function handleHandoffOnce(
 	};
 
 	const persistedBefore = await manager.get(sourceSessionId);
-	const metadataBefore =
+	let metadataBefore =
 		(persistedBefore?.metadata as JsonRecord | null | undefined) ??
-		readSessionMetadata(sourceSessionId);
-	const pending = readCloudHandoffMetadata(metadataBefore);
-	if (
-		pending?.status === "pending" &&
-		!cloudHandoffFingerprintsEqual(pending.fingerprint, prepared.fingerprint)
-	) {
-		const dashboardUrl =
-			pending.dashboardUrl ??
+		readSessionMetadata(sourceSessionId) ??
+		{};
+	let pending = readCloudHandoffMetadata(metadataBefore);
+	const reconciled = await reconcilePendingCloudHandoff(manager, cloud, {
+		sourceSessionId,
+		metadata: metadataBefore,
+		pending,
+		fingerprint: prepared.fingerprint,
+		dashboardUrl:
+			pending?.dashboardUrl ??
 			buildCloudHandoffDashboardUrl(
 				environment.appBaseUrl,
-				pending.toCloudSessionId,
-			);
-		throw new Error(
-			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
-		);
-	}
+				pending?.toCloudSessionId ?? "",
+			),
+	});
+	metadataBefore = reconciled.metadata;
+	pending = reconciled.pending;
 
 	let outerSessionId = pending?.toCloudSessionId ?? "";
 	let innerSessionId = pending?.innerSessionId ?? "";

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1859,15 +1859,13 @@ export async function handleChatSessionCommand(
 						"File attachments are not supported in cloud sessions",
 					);
 				}
-				const live = ctx.liveSessions.get(sessionId);
-				const delivery = request.delivery ?? (live?.busy ? "queue" : undefined);
 				const modelId = String(
 					request.config?.model ?? request.config?.modelId ?? "",
 				).trim();
 				return await cloud.send(
 					sessionId,
 					prompt,
-					delivery,
+					request.delivery,
 					modelId || undefined,
 					request.attachments?.userImages,
 				);

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1893,6 +1893,16 @@ function readCloudHandoffModels(
 		: [];
 }
 
+export function combineCloudHandoffModels(input: {
+	catalog: CloudHandoffModel[];
+	clinePass: CloudHandoffModel[];
+	clineCloud: CloudHandoffModel[];
+}): CloudHandoffModel[] {
+	// Recommended entries stay first for personal selection, but retain catalog
+	// duplicates so organization filtering cannot remove the model entirely.
+	return [...input.clinePass, ...input.clineCloud, ...input.catalog];
+}
+
 async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
 	const { apiBaseUrl } = getClineEnvironmentConfig();
 	const baseUrl = apiBaseUrl.trim().replace(/\/+$/, "");
@@ -1933,12 +1943,11 @@ async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
 			: recommendedEnvelope;
 	const pass = readCloudHandoffModels(recommended?.clinePass, "cline-pass");
 	const cloud = readCloudHandoffModels(recommended?.clineCloud, "cline-cloud");
-	const prioritizedIds = new Set([...pass, ...cloud].map((model) => model.id));
-	return [
-		...catalog.filter((model) => !prioritizedIds.has(model.id)),
-		...pass,
-		...cloud,
-	];
+	return combineCloudHandoffModels({
+		catalog,
+		clinePass: pass,
+		clineCloud: cloud,
+	});
 }
 
 async function assertHandoffIdle(
@@ -2028,6 +2037,7 @@ export function shouldCleanupFailedHandoffVerification(
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
+	options: { pinnedModelId?: string } = {},
 ): Promise<PreparedCloudHandoff> {
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
@@ -2067,11 +2077,16 @@ async function prepareCloudHandoff(
 	const localModelId = String(
 		config.model ?? config.modelId ?? persisted?.model ?? "",
 	).trim();
-	const selection = selectCloudHandoffModel({
-		localModelId,
-		models: await loadCloudHandoffModels(),
-		isOrganizationSession: Boolean(organizationId),
-	});
+	const selection = options.pinnedModelId
+		? {
+				modelId: options.pinnedModelId,
+				usedFallback: options.pinnedModelId !== localModelId,
+			}
+		: selectCloudHandoffModel({
+				localModelId,
+				models: await loadCloudHandoffModels(),
+				isOrganizationSession: Boolean(organizationId),
+			});
 	const fingerprint = createCloudHandoffFingerprint({
 		repoUrl: git.repoUrl,
 		branch: git.branch,
@@ -2128,7 +2143,9 @@ async function handleHandoffOnce(
 		throw new Error("Add a command to send the attached images after handoff.");
 	}
 	const expectedFingerprint = readRequestedHandoffFingerprint(request);
-	const prepared = await prepareCloudHandoff(ctx, request);
+	const prepared = await prepareCloudHandoff(ctx, request, {
+		pinnedModelId: expectedFingerprint.modelId,
+	});
 	if (
 		!cloudHandoffFingerprintsEqual(expectedFingerprint, prepared.fingerprint)
 	) {
@@ -2289,9 +2306,7 @@ async function handleHandoffOnce(
 			repoUrl: prepared.repoUrl,
 			branch: prepared.branch,
 			modelId: prepared.modelId,
-			...(prepared.fingerprint.organizationId
-				? { organizationId: prepared.fingerprint.organizationId }
-				: {}),
+			organizationId: prepared.fingerprint.organizationId ?? null,
 			...(typeof request.config?.autoApproveTools === "boolean"
 				? { autoApproveTools: request.config.autoApproveTools }
 				: {}),

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1659,6 +1659,16 @@ function readCloudHandoffModels(
 		: [];
 }
 
+export function combineCloudHandoffModels(input: {
+	catalog: CloudHandoffModel[];
+	clinePass: CloudHandoffModel[];
+	clineCloud: CloudHandoffModel[];
+}): CloudHandoffModel[] {
+	// Recommended entries stay first for personal selection, but retain catalog
+	// duplicates so organization filtering cannot remove the model entirely.
+	return [...input.clinePass, ...input.clineCloud, ...input.catalog];
+}
+
 async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
 	const { apiBaseUrl } = getClineEnvironmentConfig();
 	const baseUrl = apiBaseUrl.trim().replace(/\/+$/, "");
@@ -1699,12 +1709,11 @@ async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
 			: recommendedEnvelope;
 	const pass = readCloudHandoffModels(recommended?.clinePass, "cline-pass");
 	const cloud = readCloudHandoffModels(recommended?.clineCloud, "cline-cloud");
-	const prioritizedIds = new Set([...pass, ...cloud].map((model) => model.id));
-	return [
-		...catalog.filter((model) => !prioritizedIds.has(model.id)),
-		...pass,
-		...cloud,
-	];
+	return combineCloudHandoffModels({
+		catalog,
+		clinePass: pass,
+		clineCloud: cloud,
+	});
 }
 
 async function assertHandoffIdle(
@@ -1794,6 +1803,7 @@ export function shouldCleanupFailedHandoffVerification(
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
+	options: { pinnedModelId?: string } = {},
 ): Promise<PreparedCloudHandoff> {
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
@@ -1823,11 +1833,16 @@ async function prepareCloudHandoff(
 	const localModelId = String(
 		config.model ?? config.modelId ?? persisted?.model ?? "",
 	).trim();
-	const selection = selectCloudHandoffModel({
-		localModelId,
-		models: await loadCloudHandoffModels(),
-		isOrganizationSession: Boolean(organizationId),
-	});
+	const selection = options.pinnedModelId
+		? {
+				modelId: options.pinnedModelId,
+				usedFallback: options.pinnedModelId !== localModelId,
+			}
+		: selectCloudHandoffModel({
+				localModelId,
+				models: await loadCloudHandoffModels(),
+				isOrganizationSession: Boolean(organizationId),
+			});
 	const fingerprint = createCloudHandoffFingerprint({
 		repoUrl: git.repoUrl,
 		branch: git.branch,
@@ -1884,7 +1899,9 @@ async function handleHandoffOnce(
 		throw new Error("Add a command to send the attached images after handoff.");
 	}
 	const expectedFingerprint = readRequestedHandoffFingerprint(request);
-	const prepared = await prepareCloudHandoff(ctx, request);
+	const prepared = await prepareCloudHandoff(ctx, request, {
+		pinnedModelId: expectedFingerprint.modelId,
+	});
 	if (
 		!cloudHandoffFingerprintsEqual(expectedFingerprint, prepared.fingerprint)
 	) {
@@ -2045,9 +2062,7 @@ async function handleHandoffOnce(
 			repoUrl: prepared.repoUrl,
 			branch: prepared.branch,
 			modelId: prepared.modelId,
-			...(prepared.fingerprint.organizationId
-				? { organizationId: prepared.fingerprint.organizationId }
-				: {}),
+			organizationId: prepared.fingerprint.organizationId ?? null,
 			...(typeof request.config?.autoApproveTools === "boolean"
 				? { autoApproveTools: request.config.autoApproveTools }
 				: {}),

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -8,35 +8,51 @@ import {
 import { basename, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
+	buildCloudHandoffDashboardUrl,
 	buildConnectionUpdate,
 	buildWorkspaceMetadata,
 	type ClineCore,
 	type ClineCoreStartConfig,
+	type CloudHandoffFingerprint,
+	type CloudHandoffModel,
+	CloudHandoffTranscriptMismatchError,
+	clearCloudHandoffMetadata,
+	cloudHandoffFingerprintsEqual,
+	cloudHandoffTranscriptsEqual,
+	createCloudHandoffFingerprint,
 	createSessionCompactionState,
 	createUserInstructionConfigService,
 	getCoreBuiltinToolCatalog,
+	mergeCloudHandoffMetadata,
 	ProviderSettingsManager,
+	preflightCloudHandoffGit,
 	projectSessionCompactionState,
+	RuntimeOAuthTokenManager,
+	readCloudHandoffMetadata,
 	readGlobalSettings,
 	resolveProviderApiKeyFromSettings,
-	RuntimeOAuthTokenManager,
 	type SessionCompactionState,
 	type SessionPendingPrompt,
 	type SessionRecord,
 	SessionSource,
+	selectCloudHandoffModel,
 	splitCoreSessionConfig,
 	toProviderConfig,
 	trimMessagesBeforeUserRun,
 } from "@cline/core";
 import type { MessageWithMetadata } from "@cline/llms";
-import { buildClineSystemPrompt, formatUserCommandBlock } from "@cline/shared";
+import {
+	buildClineSystemPrompt,
+	formatUserCommandBlock,
+	getClineEnvironmentConfig,
+} from "@cline/shared";
 import {
 	deleteMaterializedAttachments,
 	discardAllTrackedAttachments,
 	materializeUserFiles,
 	trackQueuedAttachments,
 } from "./attachments";
-import { getCloudSessionManager } from "./cloud-sessions";
+import { CloudSessionError, getCloudSessionManager } from "./cloud-sessions";
 import {
 	emitChunk,
 	findSessionRuntimeBinding,
@@ -116,7 +132,7 @@ function workspacePathKey(
  * token: the slash menu hides same-named user commands, so expansion must
  * not hijack them either.
  */
-const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "team"]);
+const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "handoff", "team"]);
 
 /**
  * Expand a leading `/skill` or `/workflow` token into its configured
@@ -870,6 +886,9 @@ async function handleAttach(
 			? (session.metadata as JsonRecord)
 			: undefined;
 	const existing = ctx.liveSessions.get(sessionId);
+	// A live sidecar session has already seen run.started/run.completed and is
+	// more authoritative than Core's persisted `running` process status.
+	const attachedStatus = existing?.status ?? session.status;
 	await binding.hubClient.command("session.attach", { sessionId }, sessionId);
 	const baseAttachedConfig: JsonRecord = {
 		...(existing?.config ?? {}),
@@ -899,7 +918,7 @@ async function handleAttach(
 			environmentId: binding.environmentId,
 			messages: existing?.messages ?? [],
 			promptsInQueue: existing?.promptsInQueue ?? [],
-			status: session.status,
+			status: attachedStatus,
 			prompt:
 				session.prompt ||
 				(typeof metadata?.prompt === "string" ? metadata.prompt : undefined) ||
@@ -921,7 +940,7 @@ async function handleAttach(
 	return {
 		sessionId,
 		environmentId: binding.environmentId,
-		status: session.status,
+		status: attachedStatus,
 		provider: session.provider,
 		model: session.model,
 		cwd: session.cwd,
@@ -1065,6 +1084,11 @@ async function handleSend(
 	if (!prompt && !hasAttachments) {
 		throw new Error("prompt or attachment is required");
 	}
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error(
+			"Cloud handoff is in progress. Wait for it to finish before sending another prompt.",
+		);
+	}
 	const session = ctx.liveSessions.get(sessionId);
 	const binding = getSessionRuntimeBinding(
 		ctx,
@@ -1072,6 +1096,23 @@ async function handleSend(
 		readEnvironmentId(request.config),
 	);
 	const manager = binding.sessionManager;
+	const persistedSession =
+		typeof manager.get === "function"
+			? await manager.get(sessionId)
+			: undefined;
+	const handoff = readCloudHandoffMetadata(
+		persistedSession?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (handoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+		);
+	}
+	if (handoff?.status === "complete") {
+		throw new Error(
+			`This session continued in Cline Cloud: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}. Fork locally to continue here.`,
+		);
+	}
 	const lockedWorkspaceKey = workspacePathKey(
 		session?.config ?? request.config,
 	);
@@ -1334,6 +1375,9 @@ async function handleFork(
 ): Promise<unknown> {
 	const sourceSessionId = request.sessionId?.trim();
 	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (handoffRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error("Wait for the cloud handoff to finish before forking.");
+	}
 	const forkBeforeRunCount = request.forkBeforeRunCount;
 	if (
 		forkBeforeRunCount !== undefined &&
@@ -1351,6 +1395,14 @@ async function handleFork(
 		throw new Error(WORKSPACE_RESTORE_BUSY_ERROR);
 	}
 	const sourceSession = await manager.get(sourceSessionId);
+	const sourceHandoff = readCloudHandoffMetadata(
+		sourceSession?.metadata ?? readSessionMetadata(sourceSessionId),
+	);
+	if (sourceHandoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${sourceHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, sourceHandoff.toCloudSessionId)}`,
+		);
+	}
 	if (
 		forkBeforeRunCount !== undefined &&
 		(sourceSession?.status === "running" || sourceSession?.status === "pending")
@@ -1461,7 +1513,7 @@ async function handleForkUnlocked(
 			? sourceMessages
 			: trimMessagesBeforeUserRun(sourceMessages, forkBeforeRunCount);
 	const forkMetadata: JsonRecord = {
-		...(sourceMetadata ?? {}),
+		...clearCloudHandoffMetadata(sourceMetadata),
 		fork: {
 			forkedFromSessionId: sourceSessionId,
 			forkedAt: new Date().toISOString(),
@@ -1558,6 +1610,19 @@ async function handleReset(
 ): Promise<unknown> {
 	const sessionId = request.sessionId?.trim();
 	if (sessionId) {
+		if (handoffRequests.get(ctx)?.has(sessionId)) {
+			throw new Error("Wait for the cloud handoff to finish before resetting.");
+		}
+		const manager = getSessionManager(ctx, sessionId, request.config);
+		const persisted = await manager.get(sessionId);
+		const pendingHandoff = readCloudHandoffMetadata(
+			persisted?.metadata ?? readSessionMetadata(sessionId),
+		);
+		if (pendingHandoff?.status === "pending") {
+			throw new Error(
+				`Cloud handoff is still pending. Retry /handoff or continue here: ${pendingHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, pendingHandoff.toCloudSessionId)}`,
+			);
+		}
 		const session = ctx.liveSessions.get(sessionId);
 		if (
 			session?.busy ||
@@ -1565,7 +1630,7 @@ async function handleReset(
 			session?.status === "running" ||
 			session?.status === "stopping"
 		) {
-			await getSessionManager(ctx, sessionId, request.config).stop(sessionId);
+			await manager.stop(sessionId);
 		}
 		discardAllTrackedAttachments(sessionId, session);
 		ctx.liveSessions.delete(sessionId);
@@ -1581,6 +1646,11 @@ async function handleRestoreCheckpoint(
 ): Promise<unknown> {
 	const sourceSessionId = request.sessionId?.trim();
 	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (handoffRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error(
+			"Wait for the cloud handoff to finish before restoring a checkpoint.",
+		);
+	}
 	const runCount = request.checkpointRunCount;
 	if (
 		typeof runCount !== "number" ||
@@ -1603,6 +1673,20 @@ async function handleRestoreCheckpoint(
 		readEnvironmentId(requestedConfig),
 	);
 	const manager = binding.sessionManager;
+	const persisted = await manager.get(sourceSessionId);
+	const completedHandoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sourceSessionId),
+	);
+	if (completedHandoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${completedHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, completedHandoff.toCloudSessionId)}`,
+		);
+	}
+	if (completedHandoff?.status === "complete") {
+		throw new Error(
+			"This session continued in Cline Cloud. Fork locally before restoring a checkpoint.",
+		);
+	}
 	const config =
 		binding.kind === "ssh"
 			? await withRemoteProviderCredentials(requestedConfig)
@@ -1764,6 +1848,587 @@ async function handleRemovePendingPrompt(
 	};
 }
 
+type PreparedCloudHandoff = {
+	fingerprint: CloudHandoffFingerprint;
+	repoUrl: string;
+	branch: string;
+	headSha: string;
+	modelId: string;
+	modelFallback?: { from: string; to: string };
+};
+
+function readCloudHandoffModel(
+	value: unknown,
+	catalogId: CloudHandoffModel["catalogId"],
+): CloudHandoffModel | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const record = value as Record<string, unknown>;
+	const id = typeof record.id === "string" ? record.id.trim() : "";
+	if (!id) return undefined;
+	const displayName =
+		typeof record.display_name === "string"
+			? record.display_name.trim()
+			: typeof record.displayName === "string"
+				? record.displayName.trim()
+				: "";
+	const name = typeof record.name === "string" ? record.name.trim() : "";
+	return { id, name: displayName || name || id, catalogId };
+}
+
+function readCloudHandoffModels(
+	value: unknown,
+	catalogId: CloudHandoffModel["catalogId"],
+): CloudHandoffModel[] {
+	return Array.isArray(value)
+		? value.flatMap((entry) => {
+				const model = readCloudHandoffModel(entry, catalogId);
+				return model ? [model] : [];
+			})
+		: [];
+}
+
+async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
+	const { apiBaseUrl } = getClineEnvironmentConfig();
+	const baseUrl = apiBaseUrl.trim().replace(/\/+$/, "");
+	const load = async (path: string): Promise<unknown> => {
+		const response = await fetch(`${baseUrl}${path}`, {
+			headers: { Accept: "application/json" },
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+		return await response.json();
+	};
+	let catalogPayload: unknown;
+	try {
+		catalogPayload = await load("/api/v1/ai/cline/models");
+	} catch (error) {
+		throw new Error("Could not load the cloud model catalog.", {
+			cause: error,
+		});
+	}
+	const recommendedPayload = await load(
+		"/api/v1/ai/cline/recommended-models",
+	).catch(() => undefined);
+	const catalogRecord =
+		catalogPayload && typeof catalogPayload === "object"
+			? (catalogPayload as Record<string, unknown>)
+			: undefined;
+	const catalog = readCloudHandoffModels(
+		Array.isArray(catalogPayload) ? catalogPayload : catalogRecord?.data,
+		"cline",
+	);
+	const recommendedEnvelope =
+		recommendedPayload && typeof recommendedPayload === "object"
+			? (recommendedPayload as Record<string, unknown>)
+			: undefined;
+	const recommended =
+		recommendedEnvelope?.data && typeof recommendedEnvelope.data === "object"
+			? (recommendedEnvelope.data as Record<string, unknown>)
+			: recommendedEnvelope;
+	const pass = readCloudHandoffModels(recommended?.clinePass, "cline-pass");
+	const cloud = readCloudHandoffModels(recommended?.clineCloud, "cline-cloud");
+	const prioritizedIds = new Set([...pass, ...cloud].map((model) => model.id));
+	return [
+		...catalog.filter((model) => !prioritizedIds.has(model.id)),
+		...pass,
+		...cloud,
+	];
+}
+
+async function assertHandoffIdle(
+	ctx: SidecarContext,
+	manager: ClineCore,
+	sessionId: string,
+): Promise<void> {
+	const live = ctx.liveSessions.get(sessionId);
+	const persisted = await manager.get(sessionId);
+	if (!live && !persisted) {
+		throw new Error(`Session ${sessionId} was not found.`);
+	}
+	if (
+		live?.busy ||
+		live?.transitioningProvider ||
+		live?.status === "starting" ||
+		live?.status === "running" ||
+		live?.status === "stopping" ||
+		persisted?.status === "running" ||
+		persisted?.status === "pending"
+	) {
+		throw new Error("Stop the current run before handing off to cloud.");
+	}
+	const queued = await manager.pendingPrompts.list({ sessionId });
+	if (queued.length > 0 || (live?.promptsInQueue.length ?? 0) > 0) {
+		throw new Error("Remove queued prompts before handing off to cloud.");
+	}
+}
+
+export async function updateHandoffMetadataOrThrow(
+	manager: Pick<ClineCore, "update">,
+	sessionId: string,
+	metadata: Record<string, unknown>,
+	failureMessage: string,
+): Promise<void> {
+	const result = await manager.update(sessionId, { metadata });
+	if (!result.updated) throw new Error(failureMessage);
+}
+
+async function prepareCloudHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<PreparedCloudHandoff> {
+	const sessionId = request.sessionId?.trim();
+	if (!sessionId) throw new Error("sessionId is required");
+	const manager = getSessionManager(ctx);
+	await assertHandoffIdle(ctx, manager, sessionId);
+	if ((await manager.readLiveMessages(sessionId)).length === 0) {
+		throw new Error("Start a conversation before handing it off to cloud.");
+	}
+	const persisted = await manager.get(sessionId);
+	const existingHandoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (existingHandoff?.status === "complete") {
+		throw new Error(
+			`This session already continued in Cline Cloud: ${existingHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, existingHandoff.toCloudSessionId)}`,
+		);
+	}
+	const config = {
+		...(ctx.liveSessions.get(sessionId)?.config ?? {}),
+		...(request.config ?? {}),
+	};
+	const cwd = readWorkspacePath(config) ?? readWorkspacePath(persisted);
+	if (!cwd) throw new Error("Cloud handoff requires a workspace path.");
+	const git = await preflightCloudHandoffGit({ cwd });
+	const cloud = getCloudSessionManager(ctx);
+	const { organizationId } = await cloud.prepareHandoffRepository(git.repoUrl);
+	const localModelId = String(
+		config.model ?? config.modelId ?? persisted?.model ?? "",
+	).trim();
+	const selection = selectCloudHandoffModel({
+		localModelId,
+		models: await loadCloudHandoffModels(),
+		isOrganizationSession: Boolean(organizationId),
+	});
+	const fingerprint = createCloudHandoffFingerprint({
+		repoUrl: git.repoUrl,
+		branch: git.branch,
+		headSha: git.headSha,
+		modelId: selection.modelId,
+		...(organizationId ? { organizationId } : {}),
+	});
+	return {
+		fingerprint,
+		repoUrl: git.repoUrl,
+		branch: git.branch,
+		headSha: git.headSha,
+		modelId: selection.modelId,
+		...(selection.usedFallback && localModelId
+			? { modelFallback: { from: localModelId, to: selection.modelId } }
+			: {}),
+	};
+}
+
+function readRequestedHandoffFingerprint(
+	request: ChatSessionCommandRequest,
+): CloudHandoffFingerprint {
+	const value = request.fingerprint;
+	if (!value) throw new Error("Run handoff preflight again before continuing.");
+	return createCloudHandoffFingerprint({
+		repoUrl: String(value.repoUrl ?? ""),
+		branch: String(value.branch ?? ""),
+		headSha: String(value.headSha ?? ""),
+		modelId: String(value.modelId ?? ""),
+		...(typeof value.organizationId === "string"
+			? { organizationId: value.organizationId }
+			: {}),
+	});
+}
+
+async function handlePrepareHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<PreparedCloudHandoff> {
+	return await prepareCloudHandoff(ctx, request);
+}
+
+async function handleHandoffOnce(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<unknown> {
+	const sourceSessionId = request.sessionId?.trim();
+	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (request.attachments?.userFiles?.length) {
+		throw new Error("Only image attachments can be sent with a cloud handoff.");
+	}
+	const nextCommand = request.nextCommand?.trim() ?? "";
+	if (!nextCommand && request.attachments?.userImages?.length) {
+		throw new Error("Add a command to send the attached images after handoff.");
+	}
+	const expectedFingerprint = readRequestedHandoffFingerprint(request);
+	const prepared = await prepareCloudHandoff(ctx, request);
+	if (
+		!cloudHandoffFingerprintsEqual(expectedFingerprint, prepared.fingerprint)
+	) {
+		throw new Error(
+			"The repository, branch, commit, or cloud model changed after handoff started. Review the handoff details and try again.",
+		);
+	}
+	const manager = getSessionManager(ctx);
+	const cloud = getCloudSessionManager(ctx);
+	const environment = getClineEnvironmentConfig();
+	const emitProgress = (
+		phase:
+			| "creating"
+			| "provisioning"
+			| "connecting"
+			| "seeding"
+			| "verifying"
+			| "complete",
+		message: string,
+		outerSessionId?: string,
+	) => {
+		sendEvent(ctx, "cloud_handoff_progress", {
+			sourceSessionId,
+			phase,
+			message,
+			...(outerSessionId
+				? {
+						sessionId: outerSessionId,
+						dashboardUrl: buildCloudHandoffDashboardUrl(
+							environment.appBaseUrl,
+							outerSessionId,
+						),
+					}
+				: {}),
+		});
+	};
+
+	const persistedBefore = await manager.get(sourceSessionId);
+	const metadataBefore =
+		(persistedBefore?.metadata as JsonRecord | null | undefined) ??
+		readSessionMetadata(sourceSessionId);
+	const pending = readCloudHandoffMetadata(metadataBefore);
+	if (
+		pending?.status === "pending" &&
+		!cloudHandoffFingerprintsEqual(pending.fingerprint, prepared.fingerprint)
+	) {
+		const dashboardUrl =
+			pending.dashboardUrl ??
+			buildCloudHandoffDashboardUrl(
+				environment.appBaseUrl,
+				pending.toCloudSessionId,
+			);
+		throw new Error(
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
+		);
+	}
+
+	let outerSessionId = pending?.toCloudSessionId ?? "";
+	let innerSessionId = pending?.innerSessionId ?? "";
+	let seededMessages: MessageWithMetadata[] | undefined;
+	const readSeedMessages = async (): Promise<MessageWithMetadata[]> => {
+		await assertHandoffIdle(ctx, manager, sourceSessionId);
+		emitProgress(
+			"connecting",
+			"Connecting securely to the cloud workspace…",
+			outerSessionId || undefined,
+		);
+		const messages = await manager.readLiveMessages(sourceSessionId);
+		if (messages.length === 0) {
+			throw new Error("Start a conversation before handing it off to cloud.");
+		}
+		seededMessages = messages;
+		return messages;
+	};
+	const clearPendingTarget = async (sessionId: string): Promise<void> => {
+		try {
+			await cloud.delete(sessionId);
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				// An authoritative gone response means there is no target left to adopt.
+			} else {
+				// Preserve the pending lineage and recovery URL on transient cleanup
+				// failures. Clearing them here would let the next retry create a
+				// duplicate sandbox with no way to recover the first one.
+				throw new Error(
+					"Could not clean up the previous cloud handoff; retry after deleting it from Cline Cloud.",
+					{ cause: error },
+				);
+			}
+		}
+		const current = await manager.get(sourceSessionId);
+		await updateHandoffMetadataOrThrow(
+			manager,
+			sourceSessionId,
+			clearCloudHandoffMetadata(
+				(current?.metadata as JsonRecord | null | undefined) ?? metadataBefore,
+			),
+			"The cloud target was removed, but its local pending handoff record could not be cleared.",
+		);
+	};
+
+	if (outerSessionId) {
+		if (!pending) {
+			throw new Error("The pending cloud handoff metadata is incomplete.");
+		}
+		const pendingHandoff = pending;
+		const dashboardUrl = buildCloudHandoffDashboardUrl(
+			environment.appBaseUrl,
+			outerSessionId,
+		);
+		emitProgress(
+			"provisioning",
+			"Resuming the existing cloud handoff…",
+			outerSessionId,
+		);
+		try {
+			await cloud.waitUntilReady(outerSessionId);
+			const seed = await readSeedMessages();
+			const resumed = await cloud.seedHandoff(outerSessionId, {
+				sourceSessionId,
+				messages: seed,
+				onSeeding: () =>
+					emitProgress(
+						"seeding",
+						"Copying the local conversation to cloud…",
+						outerSessionId,
+					),
+			});
+			innerSessionId = resumed.innerSessionId;
+			if (!pendingHandoff.dashboardUrl) {
+				await updateHandoffMetadataOrThrow(
+					manager,
+					sourceSessionId,
+					mergeCloudHandoffMetadata(metadataBefore, {
+						...pendingHandoff,
+						dashboardUrl,
+						innerSessionId,
+					}),
+					"The resumed cloud handoff could not update its local recovery record.",
+				);
+			}
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				await clearPendingTarget(outerSessionId);
+				outerSessionId = "";
+				innerSessionId = "";
+				seededMessages = undefined;
+			} else {
+				throw error;
+			}
+		}
+	}
+	if (!outerSessionId) {
+		emitProgress("creating", "Creating the cloud workspace…");
+		const created = await cloud.create({
+			repoUrl: prepared.repoUrl,
+			branch: prepared.branch,
+			modelId: prepared.modelId,
+			...(prepared.fingerprint.organizationId
+				? { organizationId: prepared.fingerprint.organizationId }
+				: {}),
+			...(typeof request.config?.autoApproveTools === "boolean"
+				? { autoApproveTools: request.config.autoApproveTools }
+				: {}),
+			...(typeof request.config?.thinking === "boolean"
+				? { thinking: request.config.thinking }
+				: {}),
+			...(readReasoningEffort(request.config?.reasoningEffort)
+				? {
+						reasoningEffort: readReasoningEffort(
+							request.config?.reasoningEffort,
+						),
+					}
+				: {}),
+			handoff: {
+				sourceSessionId,
+				resolveMessages: readSeedMessages,
+				onOuterSessionCreated: async (createdSessionId) => {
+					outerSessionId = createdSessionId;
+					const dashboardUrl = buildCloudHandoffDashboardUrl(
+						environment.appBaseUrl,
+						createdSessionId,
+					);
+					const current = await manager.get(sourceSessionId);
+					await updateHandoffMetadataOrThrow(
+						manager,
+						sourceSessionId,
+						mergeCloudHandoffMetadata(
+							(current?.metadata as JsonRecord | null | undefined) ??
+								metadataBefore,
+							{
+								toCloudSessionId: createdSessionId,
+								handedOffAt: new Date().toISOString(),
+								status: "pending",
+								dashboardUrl,
+								fingerprint: prepared.fingerprint,
+							},
+						),
+						`Cloud workspace ${createdSessionId} was created, but its recovery link could not be saved locally.`,
+					);
+					emitProgress(
+						"provisioning",
+						"Preparing the cloud workspace…",
+						createdSessionId,
+					);
+				},
+				onSeeding: () =>
+					emitProgress(
+						"seeding",
+						"Copying the local conversation to cloud…",
+						outerSessionId,
+					),
+			},
+		});
+		outerSessionId = String(created.sessionId ?? "").trim();
+		innerSessionId = String(created.innerSessionId ?? "").trim();
+	}
+
+	if (!outerSessionId || !innerSessionId || !seededMessages) {
+		throw new Error("Cloud handoff did not initialize a conversation.");
+	}
+	emitProgress(
+		"verifying",
+		"Verifying the transferred conversation…",
+		outerSessionId,
+	);
+	try {
+		await cloud.verifyHandoffTranscript(outerSessionId, seededMessages);
+	} catch (error) {
+		if (!(error instanceof CloudHandoffTranscriptMismatchError)) {
+			throw error;
+		}
+		try {
+			await clearPendingTarget(outerSessionId);
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"Cloud transcript verification failed and the incomplete cloud handoff could not be cleaned up.",
+			);
+		}
+		throw error;
+	}
+	await assertHandoffIdle(ctx, manager, sourceSessionId);
+	const finalLocalMessages = await manager.readLiveMessages(sourceSessionId);
+	if (!cloudHandoffTranscriptsEqual(finalLocalMessages, seededMessages)) {
+		const error = new Error(
+			"The local conversation changed during handoff. Nothing was closed; try again when the session is idle.",
+		);
+		try {
+			await clearPendingTarget(outerSessionId);
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"The local conversation changed during handoff and the incomplete cloud handoff could not be cleaned up.",
+			);
+		}
+		throw error;
+	}
+	const dashboardUrl = buildCloudHandoffDashboardUrl(
+		environment.appBaseUrl,
+		outerSessionId,
+	);
+	const latest = await manager.get(sourceSessionId);
+	const latestMetadata =
+		(latest?.metadata as JsonRecord | null | undefined) ?? metadataBefore;
+	const handedOffAt =
+		readCloudHandoffMetadata(latestMetadata)?.handedOffAt ??
+		new Date().toISOString();
+	await updateHandoffMetadataOrThrow(
+		manager,
+		sourceSessionId,
+		mergeCloudHandoffMetadata(latestMetadata, {
+			toCloudSessionId: outerSessionId,
+			handedOffAt,
+			status: "complete",
+			innerSessionId,
+			dashboardUrl,
+			fingerprint: prepared.fingerprint,
+		}),
+		"The cloud transcript was verified, but the local handoff marker could not be saved. The local session remains open.",
+	);
+
+	let warning: string | undefined;
+	if (nextCommand) {
+		try {
+			await cloud.send(
+				outerSessionId,
+				nextCommand,
+				"queue",
+				prepared.modelId,
+				request.attachments?.userImages,
+			);
+		} catch (error) {
+			warning = `The handoff completed, but the follow-up command was not queued: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	}
+	const destination = isCloudAgentsEnabled() ? "in_app" : "external";
+	emitProgress("complete", "Ready in Cline Cloud.", outerSessionId);
+	return {
+		sessionId: outerSessionId,
+		outerSessionId,
+		innerSessionId,
+		dashboardUrl,
+		destination,
+		...(warning ? { warning } : {}),
+	};
+}
+
+type HandoffRequestIdentity = {
+	fingerprint: JsonRecord | null;
+	nextCommand: string;
+	userImages: string[];
+	userFiles: Array<{ name: string; content: string }>;
+};
+
+const handoffRequests = new WeakMap<
+	SidecarContext,
+	Map<string, { identity: HandoffRequestIdentity; promise: Promise<unknown> }>
+>();
+
+async function handleHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<unknown> {
+	const sourceSessionId = request.sessionId?.trim();
+	if (!sourceSessionId) throw new Error("sessionId is required");
+	let requests = handoffRequests.get(ctx);
+	if (!requests) {
+		requests = new Map();
+		handoffRequests.set(ctx, requests);
+	}
+	const identity: HandoffRequestIdentity = {
+		fingerprint: request.fingerprint ?? null,
+		nextCommand: request.nextCommand?.trim() ?? "",
+		userImages: [...(request.attachments?.userImages ?? [])],
+		userFiles: (request.attachments?.userFiles ?? []).map((file) => ({
+			...file,
+		})),
+	};
+	const existing = requests.get(sourceSessionId);
+	if (existing) {
+		if (!isDeepStrictEqual(existing.identity, identity)) {
+			throw new Error(
+				"A different cloud handoff is already in progress for this session.",
+			);
+		}
+		return await existing.promise;
+	}
+	const running = handleHandoffOnce(ctx, request).finally(() => {
+		if (requests?.get(sourceSessionId)?.promise === running) {
+			requests.delete(sourceSessionId);
+		}
+	});
+	requests.set(sourceSessionId, { identity, promise: running });
+	return await running;
+}
+
 // ---------------------------------------------------------------------------
 // Action dispatch
 // ---------------------------------------------------------------------------
@@ -1775,6 +2440,8 @@ const ACTION_HANDLERS: Record<
 	start: handleStart,
 	attach: handleAttach,
 	send: handleSend,
+	prepare_handoff: handlePrepareHandoff,
+	handoff: handleHandoff,
 	stop: handleStop,
 	abort: handleAbort,
 	fork: handleFork,

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2158,6 +2158,30 @@ const handoffRequests = new WeakMap<
 	Map<string, { identity: HandoffRequestIdentity; promise: Promise<unknown> }>
 >();
 
+/**
+ * Deleting a source session while its cloud handoff is in flight can remove
+ * the only durable recovery record for an already-created sandbox. Keep this
+ * check in the sidecar as well as the UI so alternate clients cannot bypass it.
+ */
+export async function assertSessionDeleteAllowedDuringHandoff(
+	ctx: SidecarContext,
+	sessionId: string,
+): Promise<void> {
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error("Wait for the cloud handoff to finish before deleting.");
+	}
+	const manager = getSessionManager(ctx);
+	const persisted = await manager.get(sessionId);
+	const handoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (handoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+		);
+	}
+}
+
 async function handleHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2316,15 +2316,13 @@ export async function handleChatSessionCommand(
 						"File attachments are not supported in cloud sessions",
 					);
 				}
-				const live = ctx.liveSessions.get(sessionId);
-				const delivery = request.delivery ?? (live?.busy ? "queue" : undefined);
 				const modelId = String(
 					request.config?.model ?? request.config?.modelId ?? "",
 				).trim();
 				return await cloud.send(
 					sessionId,
 					prompt,
-					delivery,
+					request.delivery,
 					modelId || undefined,
 					request.attachments?.userImages,
 				);

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -8,6 +8,7 @@ import {
 	type ClineCore,
 	type ClineCoreStartConfig,
 	type CloudHandoffFingerprint,
+	type CloudHandoffMetadata,
 	type CloudHandoffModel,
 	CloudHandoffTranscriptMismatchError,
 	clearCloudHandoffMetadata,
@@ -42,7 +43,11 @@ import {
 	materializeUserFiles,
 	trackQueuedAttachments,
 } from "./attachments";
-import { CloudSessionError, getCloudSessionManager } from "./cloud-sessions";
+import {
+	CloudSessionError,
+	type CloudSessionManager,
+	getCloudSessionManager,
+} from "./cloud-sessions";
 import { emitChunk, nowMs, sendEvent } from "./context";
 import { isCloudAgentsEnabled } from "./feature-flags";
 import { readSessionManifest, sharedSessionDataDir } from "./paths";
@@ -1738,6 +1743,38 @@ export async function updateHandoffMetadataOrThrow(
 	if (!result.updated) throw new Error(failureMessage);
 }
 
+export async function reconcilePendingCloudHandoff(
+	manager: Pick<ClineCore, "update">,
+	cloud: Pick<CloudSessionManager, "handoffTargetExists">,
+	input: {
+		sourceSessionId: string;
+		metadata: JsonRecord;
+		pending?: CloudHandoffMetadata;
+		fingerprint: CloudHandoffFingerprint;
+		dashboardUrl: string;
+	},
+): Promise<{ metadata: JsonRecord; pending?: CloudHandoffMetadata }> {
+	if (
+		input.pending?.status !== "pending" ||
+		cloudHandoffFingerprintsEqual(input.pending.fingerprint, input.fingerprint)
+	) {
+		return { metadata: input.metadata, pending: input.pending };
+	}
+	if (await cloud.handoffTargetExists(input.pending.toCloudSessionId)) {
+		throw new Error(
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${input.dashboardUrl}`,
+		);
+	}
+	const metadata = clearCloudHandoffMetadata(input.metadata);
+	await updateHandoffMetadataOrThrow(
+		manager,
+		input.sourceSessionId,
+		metadata,
+		"The previous cloud workspace is gone, but its local pending handoff record could not be cleared.",
+	);
+	return { metadata };
+}
+
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -1870,24 +1907,25 @@ async function handleHandoffOnce(
 	};
 
 	const persistedBefore = await manager.get(sourceSessionId);
-	const metadataBefore =
+	let metadataBefore =
 		(persistedBefore?.metadata as JsonRecord | null | undefined) ??
-		readSessionMetadata(sourceSessionId);
-	const pending = readCloudHandoffMetadata(metadataBefore);
-	if (
-		pending?.status === "pending" &&
-		!cloudHandoffFingerprintsEqual(pending.fingerprint, prepared.fingerprint)
-	) {
-		const dashboardUrl =
-			pending.dashboardUrl ??
+		readSessionMetadata(sourceSessionId) ??
+		{};
+	let pending = readCloudHandoffMetadata(metadataBefore);
+	const reconciled = await reconcilePendingCloudHandoff(manager, cloud, {
+		sourceSessionId,
+		metadata: metadataBefore,
+		pending,
+		fingerprint: prepared.fingerprint,
+		dashboardUrl:
+			pending?.dashboardUrl ??
 			buildCloudHandoffDashboardUrl(
 				environment.appBaseUrl,
-				pending.toCloudSessionId,
-			);
-		throw new Error(
-			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
-		);
-	}
+				pending?.toCloudSessionId ?? "",
+			),
+	});
+	metadataBefore = reconciled.metadata;
+	pending = reconciled.pending;
 
 	let outerSessionId = pending?.toCloudSessionId ?? "";
 	let innerSessionId = pending?.innerSessionId ?? "";

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2031,7 +2031,17 @@ async function prepareCloudHandoff(
 ): Promise<PreparedCloudHandoff> {
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
-	const manager = getSessionManager(ctx, sessionId, request.config);
+	const binding = getSessionRuntimeBinding(
+		ctx,
+		sessionId,
+		readEnvironmentId(request.config),
+	);
+	if (binding.kind === "ssh") {
+		throw new Error(
+			"Cloud handoff from an SSH workspace is not supported yet. Open the repository locally before using /handoff.",
+		);
+	}
+	const manager = binding.sessionManager;
 	await assertHandoffIdle(ctx, manager, sessionId);
 	if ((await manager.readLiveMessages(sessionId)).length === 0) {
 		throw new Error("Start a conversation before handing it off to cloud.");

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -924,12 +924,17 @@ async function handleSend(
 		typeof manager.get === "function"
 			? await manager.get(sessionId)
 			: undefined;
-	const completedHandoff = readCloudHandoffMetadata(
+	const handoff = readCloudHandoffMetadata(
 		persistedSession?.metadata ?? readSessionMetadata(sessionId),
 	);
-	if (completedHandoff?.status === "complete") {
+	if (handoff?.status === "pending") {
 		throw new Error(
-			`This session continued in Cline Cloud: ${completedHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, completedHandoff.toCloudSessionId)}. Fork locally to continue here.`,
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+		);
+	}
+	if (handoff?.status === "complete") {
+		throw new Error(
+			`This session continued in Cline Cloud: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}. Fork locally to continue here.`,
 		);
 	}
 	const session = ctx.liveSessions.get(sessionId);
@@ -1195,6 +1200,14 @@ async function handleFork(
 		throw new Error(WORKSPACE_RESTORE_BUSY_ERROR);
 	}
 	const sourceSession = await manager.get(sourceSessionId);
+	const sourceHandoff = readCloudHandoffMetadata(
+		sourceSession?.metadata ?? readSessionMetadata(sourceSessionId),
+	);
+	if (sourceHandoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${sourceHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, sourceHandoff.toCloudSessionId)}`,
+		);
+	}
 	if (
 		forkBeforeRunCount !== undefined &&
 		(sourceSession?.status === "running" || sourceSession?.status === "pending")
@@ -1386,6 +1399,16 @@ async function handleReset(
 		if (handoffRequests.get(ctx)?.has(sessionId)) {
 			throw new Error("Wait for the cloud handoff to finish before resetting.");
 		}
+		const manager = getSessionManager(ctx);
+		const persisted = await manager.get(sessionId);
+		const pendingHandoff = readCloudHandoffMetadata(
+			persisted?.metadata ?? readSessionMetadata(sessionId),
+		);
+		if (pendingHandoff?.status === "pending") {
+			throw new Error(
+				`Cloud handoff is still pending. Retry /handoff or continue here: ${pendingHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, pendingHandoff.toCloudSessionId)}`,
+			);
+		}
 		const session = ctx.liveSessions.get(sessionId);
 		if (
 			session?.busy ||
@@ -1393,7 +1416,7 @@ async function handleReset(
 			session?.status === "running" ||
 			session?.status === "stopping"
 		) {
-			await getSessionManager(ctx).stop(sessionId);
+			await manager.stop(sessionId);
 		}
 		discardAllTrackedAttachments(sessionId, session);
 		ctx.liveSessions.delete(sessionId);
@@ -1420,6 +1443,21 @@ async function handleRestoreCheckpoint(
 		runCount < 1
 	)
 		throw new Error("checkpointRunCount must be a positive integer");
+	const manager = getSessionManager(ctx);
+	const persisted = await manager.get(sourceSessionId);
+	const completedHandoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sourceSessionId),
+	);
+	if (completedHandoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${completedHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, completedHandoff.toCloudSessionId)}`,
+		);
+	}
+	if (completedHandoff?.status === "complete") {
+		throw new Error(
+			"This session continued in Cline Cloud. Fork locally before restoring a checkpoint.",
+		);
+	}
 	const config = request.config;
 	if (!config) throw new Error("config is required to restore a checkpoint");
 	const cwd =
@@ -1427,7 +1465,6 @@ async function handleRestoreCheckpoint(
 		(typeof config.workspaceRoot === "string" && config.workspaceRoot.trim()) ||
 		"";
 	if (!cwd) throw new Error("config.cwd or config.workspaceRoot is required");
-	const manager = getSessionManager(ctx);
 	return withWorkspaceRestoreLock(ctx, cwd, async () => {
 		const restored = await manager.restore({
 			sessionId: sourceSessionId,
@@ -1799,7 +1836,7 @@ async function handleHandoffOnce(
 		!cloudHandoffFingerprintsEqual(expectedFingerprint, prepared.fingerprint)
 	) {
 		throw new Error(
-			"The repository, branch, commit, or cloud model changed after confirmation. Review the handoff details and try again.",
+			"The repository, branch, commit, or cloud model changed after handoff started. Review the handoff details and try again.",
 		);
 	}
 	const manager = getSessionManager(ctx);

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -54,6 +54,7 @@ import {
 	trackQueuedAttachments,
 } from "./attachments";
 import {
+	CloudHandoffSeedUnsupportedError,
 	CloudSessionError,
 	type CloudSessionManager,
 	getCloudSessionManager,
@@ -2015,6 +2016,15 @@ export async function reconcilePendingCloudHandoff(
 	return { metadata };
 }
 
+export function shouldCleanupFailedHandoffVerification(
+	error: unknown,
+): boolean {
+	return (
+		error instanceof CloudHandoffTranscriptMismatchError ||
+		error instanceof CloudHandoffSeedUnsupportedError
+	);
+}
+
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -2340,7 +2350,7 @@ async function handleHandoffOnce(
 	try {
 		await cloud.verifyHandoffTranscript(outerSessionId, seededMessages);
 	} catch (error) {
-		if (!(error instanceof CloudHandoffTranscriptMismatchError)) {
+		if (!shouldCleanupFailedHandoffVerification(error)) {
 			throw error;
 		}
 		try {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -43,6 +43,7 @@ import {
 } from "@cline/core";
 import type { MessageWithMetadata } from "@cline/llms";
 import {
+	type AgentMode,
 	buildClineSystemPrompt,
 	formatUserCommandBlock,
 	getClineEnvironmentConfig,
@@ -1960,21 +1961,28 @@ async function assertHandoffIdle(
 	if (!live && !persisted) {
 		throw new Error(`Session ${sessionId} was not found.`);
 	}
-	if (
+	const liveIsBusy =
 		live?.busy ||
 		live?.transitioningProvider ||
 		live?.status === "starting" ||
 		live?.status === "running" ||
-		live?.status === "stopping" ||
-		persisted?.status === "running" ||
-		persisted?.status === "pending"
-	) {
+		live?.status === "stopping";
+	const persistedIsBusy =
+		!live &&
+		(persisted?.status === "running" || persisted?.status === "pending");
+	if (liveIsBusy || persistedIsBusy) {
 		throw new Error("Stop the current run before handing off to cloud.");
 	}
 	const queued = await manager.pendingPrompts.list({ sessionId });
 	if (queued.length > 0 || (live?.promptsInQueue.length ?? 0) > 0) {
 		throw new Error("Remove queued prompts before handing off to cloud.");
 	}
+}
+
+function readCloudHandoffMode(value: unknown): AgentMode {
+	return value === "plan" || value === "yolo" || value === "zen"
+		? value
+		: "act";
 }
 
 export async function updateHandoffMetadataOrThrow(
@@ -2077,22 +2085,35 @@ async function prepareCloudHandoff(
 	const localModelId = String(
 		config.model ?? config.modelId ?? persisted?.model ?? "",
 	).trim();
-	const selection = options.pinnedModelId
-		? {
-				modelId: options.pinnedModelId,
-				usedFallback: options.pinnedModelId !== localModelId,
-			}
-		: selectCloudHandoffModel({
-				localModelId,
-				models: await loadCloudHandoffModels(),
-				isOrganizationSession: Boolean(organizationId),
-			});
+	const models = await loadCloudHandoffModels();
+	let selection = selectCloudHandoffModel({
+		localModelId: options.pinnedModelId ?? localModelId,
+		models,
+		isOrganizationSession: Boolean(organizationId),
+	});
+	if (options.pinnedModelId) {
+		if (selection.modelId !== options.pinnedModelId) {
+			throw new Error(
+				`Cloud model ${options.pinnedModelId} is no longer available for this account. Run /handoff again to select an available model.`,
+			);
+		}
+		selection = {
+			modelId: options.pinnedModelId,
+			usedFallback: options.pinnedModelId !== localModelId,
+			catalogId: selection.catalogId,
+		};
+	}
+	const mode = readCloudHandoffMode(config.mode);
 	const fingerprint = createCloudHandoffFingerprint({
 		repoUrl: git.repoUrl,
 		branch: git.branch,
 		headSha: git.headSha,
 		modelId: selection.modelId,
 		...(organizationId ? { organizationId } : {}),
+		...(git.workspaceRelativePath
+			? { workspaceRelativePath: git.workspaceRelativePath }
+			: {}),
+		...(mode !== "act" ? { mode } : {}),
 	});
 	return {
 		fingerprint,
@@ -2118,6 +2139,12 @@ function readRequestedHandoffFingerprint(
 		modelId: String(value.modelId ?? ""),
 		...(typeof value.organizationId === "string"
 			? { organizationId: value.organizationId }
+			: {}),
+		...(typeof value.workspaceRelativePath === "string"
+			? { workspaceRelativePath: value.workspaceRelativePath }
+			: {}),
+		...(value.mode === "plan" || value.mode === "yolo" || value.mode === "zen"
+			? { mode: value.mode }
 			: {}),
 	});
 }
@@ -2266,6 +2293,8 @@ async function handleHandoffOnce(
 			const resumed = await cloud.seedHandoff(outerSessionId, {
 				sourceSessionId,
 				messages: seed,
+				workspaceRelativePath: prepared.fingerprint.workspaceRelativePath,
+				mode: prepared.fingerprint.mode ?? "act",
 				onSeeding: () =>
 					emitProgress(
 						"seeding",
@@ -2275,14 +2304,19 @@ async function handleHandoffOnce(
 			});
 			innerSessionId = resumed.innerSessionId;
 			if (!pendingHandoff.dashboardUrl) {
+				const current = await manager.get(sourceSessionId);
 				await updateHandoffMetadataOrThrow(
 					manager,
 					sourceSessionId,
-					mergeCloudHandoffMetadata(metadataBefore, {
-						...pendingHandoff,
-						dashboardUrl,
-						innerSessionId,
-					}),
+					mergeCloudHandoffMetadata(
+						(current?.metadata as JsonRecord | null | undefined) ??
+							metadataBefore,
+						{
+							...pendingHandoff,
+							dashboardUrl,
+							innerSessionId,
+						},
+					),
 					"The resumed cloud handoff could not update its local recovery record.",
 				);
 			}
@@ -2306,6 +2340,8 @@ async function handleHandoffOnce(
 			repoUrl: prepared.repoUrl,
 			branch: prepared.branch,
 			modelId: prepared.modelId,
+			mode: prepared.fingerprint.mode ?? "act",
+			workspaceRelativePath: prepared.fingerprint.workspaceRelativePath,
 			organizationId: prepared.fingerprint.organizationId ?? null,
 			...(typeof request.config?.autoApproveTools === "boolean"
 				? { autoApproveTools: request.config.autoApproveTools }

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -734,6 +734,10 @@ async function handleAttach(
 			? (session.metadata as JsonRecord)
 			: undefined;
 	const existing = ctx.liveSessions.get(sessionId);
+	// A live sidecar session has already seen run.started/run.completed and is
+	// more authoritative than Core's persisted `running` process status.
+	// Capture it before session.attach can emit a resident-process snapshot.
+	const attachedStatus = existing?.status ?? session.status;
 	if (ctx.hubClient) {
 		await ctx.hubClient.command("session.attach", { sessionId }, sessionId);
 	}
@@ -759,7 +763,7 @@ async function handleAttach(
 		createLiveSession(attachedConfig, {
 			messages: existing?.messages ?? [],
 			promptsInQueue: existing?.promptsInQueue ?? [],
-			status: session.status,
+			status: attachedStatus,
 			prompt:
 				session.prompt ||
 				(typeof metadata?.prompt === "string" ? metadata.prompt : undefined) ||
@@ -779,7 +783,7 @@ async function handleAttach(
 
 	return {
 		sessionId,
-		status: session.status,
+		status: attachedStatus,
 		provider: session.provider,
 		model: session.model,
 		cwd: session.cwd,

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1985,7 +1985,7 @@ export async function reconcilePendingCloudHandoff(
 		metadata: JsonRecord;
 		pending?: CloudHandoffMetadata;
 		fingerprint: CloudHandoffFingerprint;
-		dashboardUrl: string;
+		appBaseUrl: string;
 	},
 ): Promise<{ metadata: JsonRecord; pending?: CloudHandoffMetadata }> {
 	if (
@@ -1995,8 +1995,14 @@ export async function reconcilePendingCloudHandoff(
 		return { metadata: input.metadata, pending: input.pending };
 	}
 	if (await cloud.handoffTargetExists(input.pending.toCloudSessionId)) {
+		const dashboardUrl =
+			input.pending.dashboardUrl ??
+			buildCloudHandoffDashboardUrl(
+				input.appBaseUrl,
+				input.pending.toCloudSessionId,
+			);
 		throw new Error(
-			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${input.dashboardUrl}`,
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
 		);
 	}
 	const metadata = clearCloudHandoffMetadata(input.metadata);
@@ -2151,12 +2157,7 @@ async function handleHandoffOnce(
 		metadata: metadataBefore,
 		pending,
 		fingerprint: prepared.fingerprint,
-		dashboardUrl:
-			pending?.dashboardUrl ??
-			buildCloudHandoffDashboardUrl(
-				environment.appBaseUrl,
-				pending?.toCloudSessionId ?? "",
-			),
+		appBaseUrl: environment.appBaseUrl,
 	});
 	metadataBefore = reconciled.metadata;
 	pending = reconciled.pending;

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -44,6 +44,7 @@ import {
 	trackQueuedAttachments,
 } from "./attachments";
 import {
+	CloudHandoffSeedUnsupportedError,
 	CloudSessionError,
 	type CloudSessionManager,
 	getCloudSessionManager,
@@ -1781,6 +1782,15 @@ export async function reconcilePendingCloudHandoff(
 	return { metadata };
 }
 
+export function shouldCleanupFailedHandoffVerification(
+	error: unknown,
+): boolean {
+	return (
+		error instanceof CloudHandoffTranscriptMismatchError ||
+		error instanceof CloudHandoffSeedUnsupportedError
+	);
+}
+
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -2106,7 +2116,7 @@ async function handleHandoffOnce(
 	try {
 		await cloud.verifyHandoffTranscript(outerSessionId, seededMessages);
 	} catch (error) {
-		if (!(error instanceof CloudHandoffTranscriptMismatchError)) {
+		if (!shouldCleanupFailedHandoffVerification(error)) {
 			throw error;
 		}
 		try {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1751,7 +1751,7 @@ export async function reconcilePendingCloudHandoff(
 		metadata: JsonRecord;
 		pending?: CloudHandoffMetadata;
 		fingerprint: CloudHandoffFingerprint;
-		dashboardUrl: string;
+		appBaseUrl: string;
 	},
 ): Promise<{ metadata: JsonRecord; pending?: CloudHandoffMetadata }> {
 	if (
@@ -1761,8 +1761,14 @@ export async function reconcilePendingCloudHandoff(
 		return { metadata: input.metadata, pending: input.pending };
 	}
 	if (await cloud.handoffTargetExists(input.pending.toCloudSessionId)) {
+		const dashboardUrl =
+			input.pending.dashboardUrl ??
+			buildCloudHandoffDashboardUrl(
+				input.appBaseUrl,
+				input.pending.toCloudSessionId,
+			);
 		throw new Error(
-			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${input.dashboardUrl}`,
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
 		);
 	}
 	const metadata = clearCloudHandoffMetadata(input.metadata);
@@ -1917,12 +1923,7 @@ async function handleHandoffOnce(
 		metadata: metadataBefore,
 		pending,
 		fingerprint: prepared.fingerprint,
-		dashboardUrl:
-			pending?.dashboardUrl ??
-			buildCloudHandoffDashboardUrl(
-				environment.appBaseUrl,
-				pending?.toCloudSessionId ?? "",
-			),
+		appBaseUrl: environment.appBaseUrl,
 	});
 	metadataBefore = reconciled.metadata;
 	pending = reconciled.pending;

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -1379,6 +1379,9 @@ async function handleReset(
 ): Promise<unknown> {
 	const sessionId = request.sessionId?.trim();
 	if (sessionId) {
+		if (handoffRequests.get(ctx)?.has(sessionId)) {
+			throw new Error("Wait for the cloud handoff to finish before resetting.");
+		}
 		const session = ctx.liveSessions.get(sessionId);
 		if (
 			session?.busy ||
@@ -1401,6 +1404,11 @@ async function handleRestoreCheckpoint(
 ): Promise<unknown> {
 	const sourceSessionId = request.sessionId?.trim();
 	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (handoffRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error(
+			"Wait for the cloud handoff to finish before restoring a checkpoint.",
+		);
+	}
 	const runCount = request.checkpointRunCount;
 	if (
 		typeof runCount !== "number" ||
@@ -1679,6 +1687,16 @@ async function assertHandoffIdle(
 	}
 }
 
+export async function updateHandoffMetadataOrThrow(
+	manager: Pick<ClineCore, "update">,
+	sessionId: string,
+	metadata: Record<string, unknown>,
+	failureMessage: string,
+): Promise<void> {
+	const result = await manager.update(sessionId, { metadata });
+	if (!result.updated) throw new Error(failureMessage);
+}
+
 async function prepareCloudHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
@@ -1814,27 +1832,20 @@ async function handleHandoffOnce(
 	const metadataBefore =
 		(persistedBefore?.metadata as JsonRecord | null | undefined) ??
 		readSessionMetadata(sourceSessionId);
-	let pending = readCloudHandoffMetadata(metadataBefore);
+	const pending = readCloudHandoffMetadata(metadataBefore);
 	if (
 		pending?.status === "pending" &&
 		!cloudHandoffFingerprintsEqual(pending.fingerprint, prepared.fingerprint)
 	) {
-		await cloud.delete(pending.toCloudSessionId).catch((error) => {
-			if (
-				error instanceof CloudSessionError &&
-				(error.code === "session_not_found" || error.code === "session_expired")
-			) {
-				return;
-			}
-			throw new Error(
-				"The previous cloud handoff no longer matches this workspace and could not be cleaned up. Delete it from Cline Cloud before retrying.",
-				{ cause: error },
+		const dashboardUrl =
+			pending.dashboardUrl ??
+			buildCloudHandoffDashboardUrl(
+				environment.appBaseUrl,
+				pending.toCloudSessionId,
 			);
-		});
-		await manager.update(sourceSessionId, {
-			metadata: clearCloudHandoffMetadata(metadataBefore),
-		});
-		pending = undefined;
+		throw new Error(
+			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
+		);
 	}
 
 	let outerSessionId = pending?.toCloudSessionId ?? "";
@@ -1874,11 +1885,14 @@ async function handleHandoffOnce(
 			}
 		}
 		const current = await manager.get(sourceSessionId);
-		await manager.update(sourceSessionId, {
-			metadata: clearCloudHandoffMetadata(
+		await updateHandoffMetadataOrThrow(
+			manager,
+			sourceSessionId,
+			clearCloudHandoffMetadata(
 				(current?.metadata as JsonRecord | null | undefined) ?? metadataBefore,
 			),
-		});
+			"The cloud target was removed, but its local pending handoff record could not be cleared.",
+		);
 	};
 
 	if (outerSessionId) {
@@ -1896,6 +1910,7 @@ async function handleHandoffOnce(
 			outerSessionId,
 		);
 		try {
+			await cloud.waitUntilReady(outerSessionId);
 			const seed = await readSeedMessages();
 			const resumed = await cloud.seedHandoff(outerSessionId, {
 				sourceSessionId,
@@ -1909,13 +1924,16 @@ async function handleHandoffOnce(
 			});
 			innerSessionId = resumed.innerSessionId;
 			if (!pendingHandoff.dashboardUrl) {
-				await manager.update(sourceSessionId, {
-					metadata: mergeCloudHandoffMetadata(metadataBefore, {
+				await updateHandoffMetadataOrThrow(
+					manager,
+					sourceSessionId,
+					mergeCloudHandoffMetadata(metadataBefore, {
 						...pendingHandoff,
 						dashboardUrl,
 						innerSessionId,
 					}),
-				});
+					"The resumed cloud handoff could not update its local recovery record.",
+				);
 			}
 		} catch (error) {
 			if (
@@ -1963,8 +1981,10 @@ async function handleHandoffOnce(
 						createdSessionId,
 					);
 					const current = await manager.get(sourceSessionId);
-					await manager.update(sourceSessionId, {
-						metadata: mergeCloudHandoffMetadata(
+					await updateHandoffMetadataOrThrow(
+						manager,
+						sourceSessionId,
+						mergeCloudHandoffMetadata(
 							(current?.metadata as JsonRecord | null | undefined) ??
 								metadataBefore,
 							{
@@ -1975,7 +1995,8 @@ async function handleHandoffOnce(
 								fingerprint: prepared.fingerprint,
 							},
 						),
-					});
+						`Cloud workspace ${createdSessionId} was created, but its recovery link could not be saved locally.`,
+					);
 					emitProgress(
 						"provisioning",
 						"Preparing the cloud workspace…",
@@ -2018,15 +2039,12 @@ async function handleHandoffOnce(
 		}
 		throw error;
 	}
-	try {
-		await assertHandoffIdle(ctx, manager, sourceSessionId);
-		const finalLocalMessages = await manager.readLiveMessages(sourceSessionId);
-		if (!cloudHandoffTranscriptsEqual(finalLocalMessages, seededMessages)) {
-			throw new Error(
-				"The local conversation changed during handoff. Nothing was closed; try again when the session is idle.",
-			);
-		}
-	} catch (error) {
+	await assertHandoffIdle(ctx, manager, sourceSessionId);
+	const finalLocalMessages = await manager.readLiveMessages(sourceSessionId);
+	if (!cloudHandoffTranscriptsEqual(finalLocalMessages, seededMessages)) {
+		const error = new Error(
+			"The local conversation changed during handoff. Nothing was closed; try again when the session is idle.",
+		);
 		try {
 			await clearPendingTarget(outerSessionId);
 		} catch (cleanupError) {
@@ -2047,8 +2065,10 @@ async function handleHandoffOnce(
 	const handedOffAt =
 		readCloudHandoffMetadata(latestMetadata)?.handedOffAt ??
 		new Date().toISOString();
-	await manager.update(sourceSessionId, {
-		metadata: mergeCloudHandoffMetadata(latestMetadata, {
+	await updateHandoffMetadataOrThrow(
+		manager,
+		sourceSessionId,
+		mergeCloudHandoffMetadata(latestMetadata, {
 			toCloudSessionId: outerSessionId,
 			handedOffAt,
 			status: "complete",
@@ -2056,7 +2076,8 @@ async function handleHandoffOnce(
 			dashboardUrl,
 			fingerprint: prepared.fingerprint,
 		}),
-	});
+		"The cloud transcript was verified, but the local handoff marker could not be saved. The local session remains open.",
+	);
 
 	let warning: string | undefined;
 	if (nextCommand) {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2,31 +2,47 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
+	buildCloudHandoffDashboardUrl,
 	buildConnectionUpdate,
 	buildWorkspaceMetadata,
 	type ClineCore,
 	type ClineCoreStartConfig,
+	type CloudHandoffFingerprint,
+	type CloudHandoffModel,
+	CloudHandoffTranscriptMismatchError,
+	clearCloudHandoffMetadata,
+	cloudHandoffFingerprintsEqual,
+	cloudHandoffTranscriptsEqual,
+	createCloudHandoffFingerprint,
 	createSessionCompactionState,
 	createUserInstructionConfigService,
 	getCoreBuiltinToolCatalog,
+	mergeCloudHandoffMetadata,
+	preflightCloudHandoffGit,
 	projectSessionCompactionState,
+	readCloudHandoffMetadata,
 	readGlobalSettings,
 	type SessionCompactionState,
 	type SessionPendingPrompt,
 	type SessionRecord,
 	SessionSource,
+	selectCloudHandoffModel,
 	splitCoreSessionConfig,
 	trimMessagesBeforeUserRun,
 } from "@cline/core";
 import type { MessageWithMetadata } from "@cline/llms";
-import { buildClineSystemPrompt, formatUserCommandBlock } from "@cline/shared";
+import {
+	buildClineSystemPrompt,
+	formatUserCommandBlock,
+	getClineEnvironmentConfig,
+} from "@cline/shared";
 import {
 	deleteMaterializedAttachments,
 	discardAllTrackedAttachments,
 	materializeUserFiles,
 	trackQueuedAttachments,
 } from "./attachments";
-import { getCloudSessionManager } from "./cloud-sessions";
+import { CloudSessionError, getCloudSessionManager } from "./cloud-sessions";
 import { emitChunk, nowMs, sendEvent } from "./context";
 import { isCloudAgentsEnabled } from "./feature-flags";
 import { readSessionManifest, sharedSessionDataDir } from "./paths";
@@ -99,7 +115,7 @@ function workspacePathKey(
  * token: the slash menu hides same-named user commands, so expansion must
  * not hijack them either.
  */
-const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "team"]);
+const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "handoff", "team"]);
 
 /**
  * Expand a leading `/skill` or `/workflow` token into its configured
@@ -894,7 +910,24 @@ async function handleSend(
 	if (!prompt && !hasAttachments) {
 		throw new Error("prompt or attachment is required");
 	}
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error(
+			"Cloud handoff is in progress. Wait for it to finish before sending another prompt.",
+		);
+	}
 	const manager = getSessionManager(ctx);
+	const persistedSession =
+		typeof manager.get === "function"
+			? await manager.get(sessionId)
+			: undefined;
+	const completedHandoff = readCloudHandoffMetadata(
+		persistedSession?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (completedHandoff?.status === "complete") {
+		throw new Error(
+			`This session continued in Cline Cloud: ${completedHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, completedHandoff.toCloudSessionId)}. Fork locally to continue here.`,
+		);
+	}
 	const session = ctx.liveSessions.get(sessionId);
 	const lockedWorkspaceKey = workspacePathKey(
 		session?.config ?? request.config,
@@ -1138,6 +1171,9 @@ async function handleFork(
 ): Promise<unknown> {
 	const sourceSessionId = request.sessionId?.trim();
 	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (handoffRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error("Wait for the cloud handoff to finish before forking.");
+	}
 	const forkBeforeRunCount = request.forkBeforeRunCount;
 	if (
 		forkBeforeRunCount !== undefined &&
@@ -1252,7 +1288,7 @@ async function handleForkUnlocked(
 			? sourceMessages
 			: trimMessagesBeforeUserRun(sourceMessages, forkBeforeRunCount);
 	const forkMetadata: JsonRecord = {
-		...(sourceMetadata ?? {}),
+		...clearCloudHandoffMetadata(sourceMetadata),
 		fork: {
 			forkedFromSessionId: sourceSessionId,
 			forkedAt: new Date().toISOString(),
@@ -1529,6 +1565,574 @@ async function handleRemovePendingPrompt(
 	};
 }
 
+type PreparedCloudHandoff = {
+	fingerprint: CloudHandoffFingerprint;
+	repoUrl: string;
+	branch: string;
+	headSha: string;
+	modelId: string;
+	modelFallback?: { from: string; to: string };
+};
+
+function readCloudHandoffModel(
+	value: unknown,
+	catalogId: CloudHandoffModel["catalogId"],
+): CloudHandoffModel | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const record = value as Record<string, unknown>;
+	const id = typeof record.id === "string" ? record.id.trim() : "";
+	if (!id) return undefined;
+	const displayName =
+		typeof record.display_name === "string"
+			? record.display_name.trim()
+			: typeof record.displayName === "string"
+				? record.displayName.trim()
+				: "";
+	const name = typeof record.name === "string" ? record.name.trim() : "";
+	return { id, name: displayName || name || id, catalogId };
+}
+
+function readCloudHandoffModels(
+	value: unknown,
+	catalogId: CloudHandoffModel["catalogId"],
+): CloudHandoffModel[] {
+	return Array.isArray(value)
+		? value.flatMap((entry) => {
+				const model = readCloudHandoffModel(entry, catalogId);
+				return model ? [model] : [];
+			})
+		: [];
+}
+
+async function loadCloudHandoffModels(): Promise<CloudHandoffModel[]> {
+	const { apiBaseUrl } = getClineEnvironmentConfig();
+	const baseUrl = apiBaseUrl.trim().replace(/\/+$/, "");
+	const load = async (path: string): Promise<unknown> => {
+		const response = await fetch(`${baseUrl}${path}`, {
+			headers: { Accept: "application/json" },
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+		return await response.json();
+	};
+	let catalogPayload: unknown;
+	try {
+		catalogPayload = await load("/api/v1/ai/cline/models");
+	} catch (error) {
+		throw new Error("Could not load the cloud model catalog.", {
+			cause: error,
+		});
+	}
+	const recommendedPayload = await load(
+		"/api/v1/ai/cline/recommended-models",
+	).catch(() => undefined);
+	const catalogRecord =
+		catalogPayload && typeof catalogPayload === "object"
+			? (catalogPayload as Record<string, unknown>)
+			: undefined;
+	const catalog = readCloudHandoffModels(
+		Array.isArray(catalogPayload) ? catalogPayload : catalogRecord?.data,
+		"cline",
+	);
+	const recommendedEnvelope =
+		recommendedPayload && typeof recommendedPayload === "object"
+			? (recommendedPayload as Record<string, unknown>)
+			: undefined;
+	const recommended =
+		recommendedEnvelope?.data && typeof recommendedEnvelope.data === "object"
+			? (recommendedEnvelope.data as Record<string, unknown>)
+			: recommendedEnvelope;
+	const pass = readCloudHandoffModels(recommended?.clinePass, "cline-pass");
+	const cloud = readCloudHandoffModels(recommended?.clineCloud, "cline-cloud");
+	const prioritizedIds = new Set([...pass, ...cloud].map((model) => model.id));
+	return [
+		...catalog.filter((model) => !prioritizedIds.has(model.id)),
+		...pass,
+		...cloud,
+	];
+}
+
+async function assertHandoffIdle(
+	ctx: SidecarContext,
+	manager: ClineCore,
+	sessionId: string,
+): Promise<void> {
+	const live = ctx.liveSessions.get(sessionId);
+	const persisted = await manager.get(sessionId);
+	if (!live && !persisted) {
+		throw new Error(`Session ${sessionId} was not found.`);
+	}
+	if (
+		live?.busy ||
+		live?.transitioningProvider ||
+		live?.status === "starting" ||
+		live?.status === "running" ||
+		live?.status === "stopping" ||
+		persisted?.status === "running" ||
+		persisted?.status === "pending"
+	) {
+		throw new Error("Stop the current run before handing off to cloud.");
+	}
+	const queued = await manager.pendingPrompts.list({ sessionId });
+	if (queued.length > 0 || (live?.promptsInQueue.length ?? 0) > 0) {
+		throw new Error("Remove queued prompts before handing off to cloud.");
+	}
+}
+
+async function prepareCloudHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<PreparedCloudHandoff> {
+	const sessionId = request.sessionId?.trim();
+	if (!sessionId) throw new Error("sessionId is required");
+	const manager = getSessionManager(ctx);
+	await assertHandoffIdle(ctx, manager, sessionId);
+	if ((await manager.readLiveMessages(sessionId)).length === 0) {
+		throw new Error("Start a conversation before handing it off to cloud.");
+	}
+	const persisted = await manager.get(sessionId);
+	const existingHandoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (existingHandoff?.status === "complete") {
+		throw new Error(
+			`This session already continued in Cline Cloud: ${existingHandoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, existingHandoff.toCloudSessionId)}`,
+		);
+	}
+	const config = {
+		...(ctx.liveSessions.get(sessionId)?.config ?? {}),
+		...(request.config ?? {}),
+	};
+	const cwd = readWorkspacePath(config) ?? readWorkspacePath(persisted);
+	if (!cwd) throw new Error("Cloud handoff requires a workspace path.");
+	const git = await preflightCloudHandoffGit({ cwd });
+	const cloud = getCloudSessionManager(ctx);
+	const { organizationId } = await cloud.prepareHandoffRepository(git.repoUrl);
+	const localModelId = String(
+		config.model ?? config.modelId ?? persisted?.model ?? "",
+	).trim();
+	const selection = selectCloudHandoffModel({
+		localModelId,
+		models: await loadCloudHandoffModels(),
+		isOrganizationSession: Boolean(organizationId),
+	});
+	const fingerprint = createCloudHandoffFingerprint({
+		repoUrl: git.repoUrl,
+		branch: git.branch,
+		headSha: git.headSha,
+		modelId: selection.modelId,
+		...(organizationId ? { organizationId } : {}),
+	});
+	return {
+		fingerprint,
+		repoUrl: git.repoUrl,
+		branch: git.branch,
+		headSha: git.headSha,
+		modelId: selection.modelId,
+		...(selection.usedFallback && localModelId
+			? { modelFallback: { from: localModelId, to: selection.modelId } }
+			: {}),
+	};
+}
+
+function readRequestedHandoffFingerprint(
+	request: ChatSessionCommandRequest,
+): CloudHandoffFingerprint {
+	const value = request.fingerprint;
+	if (!value) throw new Error("Run handoff preflight again before continuing.");
+	return createCloudHandoffFingerprint({
+		repoUrl: String(value.repoUrl ?? ""),
+		branch: String(value.branch ?? ""),
+		headSha: String(value.headSha ?? ""),
+		modelId: String(value.modelId ?? ""),
+		...(typeof value.organizationId === "string"
+			? { organizationId: value.organizationId }
+			: {}),
+	});
+}
+
+async function handlePrepareHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<PreparedCloudHandoff> {
+	return await prepareCloudHandoff(ctx, request);
+}
+
+async function handleHandoffOnce(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<unknown> {
+	const sourceSessionId = request.sessionId?.trim();
+	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (request.attachments?.userFiles?.length) {
+		throw new Error("Only image attachments can be sent with a cloud handoff.");
+	}
+	const nextCommand = request.nextCommand?.trim() ?? "";
+	if (!nextCommand && request.attachments?.userImages?.length) {
+		throw new Error("Add a command to send the attached images after handoff.");
+	}
+	const expectedFingerprint = readRequestedHandoffFingerprint(request);
+	const prepared = await prepareCloudHandoff(ctx, request);
+	if (
+		!cloudHandoffFingerprintsEqual(expectedFingerprint, prepared.fingerprint)
+	) {
+		throw new Error(
+			"The repository, branch, commit, or cloud model changed after confirmation. Review the handoff details and try again.",
+		);
+	}
+	const manager = getSessionManager(ctx);
+	const cloud = getCloudSessionManager(ctx);
+	const environment = getClineEnvironmentConfig();
+	const emitProgress = (
+		phase:
+			| "creating"
+			| "provisioning"
+			| "connecting"
+			| "seeding"
+			| "verifying"
+			| "complete",
+		message: string,
+		outerSessionId?: string,
+	) => {
+		sendEvent(ctx, "cloud_handoff_progress", {
+			sourceSessionId,
+			phase,
+			message,
+			...(outerSessionId
+				? {
+						sessionId: outerSessionId,
+						dashboardUrl: buildCloudHandoffDashboardUrl(
+							environment.appBaseUrl,
+							outerSessionId,
+						),
+					}
+				: {}),
+		});
+	};
+
+	const persistedBefore = await manager.get(sourceSessionId);
+	const metadataBefore =
+		(persistedBefore?.metadata as JsonRecord | null | undefined) ??
+		readSessionMetadata(sourceSessionId);
+	let pending = readCloudHandoffMetadata(metadataBefore);
+	if (
+		pending?.status === "pending" &&
+		!cloudHandoffFingerprintsEqual(pending.fingerprint, prepared.fingerprint)
+	) {
+		await cloud.delete(pending.toCloudSessionId).catch((error) => {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				return;
+			}
+			throw new Error(
+				"The previous cloud handoff no longer matches this workspace and could not be cleaned up. Delete it from Cline Cloud before retrying.",
+				{ cause: error },
+			);
+		});
+		await manager.update(sourceSessionId, {
+			metadata: clearCloudHandoffMetadata(metadataBefore),
+		});
+		pending = undefined;
+	}
+
+	let outerSessionId = pending?.toCloudSessionId ?? "";
+	let innerSessionId = pending?.innerSessionId ?? "";
+	let seededMessages: MessageWithMetadata[] | undefined;
+	const readSeedMessages = async (): Promise<MessageWithMetadata[]> => {
+		await assertHandoffIdle(ctx, manager, sourceSessionId);
+		emitProgress(
+			"connecting",
+			"Connecting securely to the cloud workspace…",
+			outerSessionId || undefined,
+		);
+		const messages = await manager.readLiveMessages(sourceSessionId);
+		if (messages.length === 0) {
+			throw new Error("Start a conversation before handing it off to cloud.");
+		}
+		seededMessages = messages;
+		return messages;
+	};
+	const clearPendingTarget = async (sessionId: string): Promise<void> => {
+		try {
+			await cloud.delete(sessionId);
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				// An authoritative gone response means there is no target left to adopt.
+			} else {
+				// Preserve the pending lineage and recovery URL on transient cleanup
+				// failures. Clearing them here would let the next retry create a
+				// duplicate sandbox with no way to recover the first one.
+				throw new Error(
+					"Could not clean up the previous cloud handoff; retry after deleting it from Cline Cloud.",
+					{ cause: error },
+				);
+			}
+		}
+		const current = await manager.get(sourceSessionId);
+		await manager.update(sourceSessionId, {
+			metadata: clearCloudHandoffMetadata(
+				(current?.metadata as JsonRecord | null | undefined) ?? metadataBefore,
+			),
+		});
+	};
+
+	if (outerSessionId) {
+		if (!pending) {
+			throw new Error("The pending cloud handoff metadata is incomplete.");
+		}
+		const pendingHandoff = pending;
+		const dashboardUrl = buildCloudHandoffDashboardUrl(
+			environment.appBaseUrl,
+			outerSessionId,
+		);
+		emitProgress(
+			"provisioning",
+			"Resuming the existing cloud handoff…",
+			outerSessionId,
+		);
+		try {
+			const seed = await readSeedMessages();
+			const resumed = await cloud.seedHandoff(outerSessionId, {
+				sourceSessionId,
+				messages: seed,
+				onSeeding: () =>
+					emitProgress(
+						"seeding",
+						"Copying the local conversation to cloud…",
+						outerSessionId,
+					),
+			});
+			innerSessionId = resumed.innerSessionId;
+			if (!pendingHandoff.dashboardUrl) {
+				await manager.update(sourceSessionId, {
+					metadata: mergeCloudHandoffMetadata(metadataBefore, {
+						...pendingHandoff,
+						dashboardUrl,
+						innerSessionId,
+					}),
+				});
+			}
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				await clearPendingTarget(outerSessionId);
+				outerSessionId = "";
+				innerSessionId = "";
+				seededMessages = undefined;
+			} else {
+				throw error;
+			}
+		}
+	}
+	if (!outerSessionId) {
+		emitProgress("creating", "Creating the cloud workspace…");
+		const created = await cloud.create({
+			repoUrl: prepared.repoUrl,
+			branch: prepared.branch,
+			modelId: prepared.modelId,
+			...(prepared.fingerprint.organizationId
+				? { organizationId: prepared.fingerprint.organizationId }
+				: {}),
+			...(typeof request.config?.autoApproveTools === "boolean"
+				? { autoApproveTools: request.config.autoApproveTools }
+				: {}),
+			...(typeof request.config?.thinking === "boolean"
+				? { thinking: request.config.thinking }
+				: {}),
+			...(readReasoningEffort(request.config?.reasoningEffort)
+				? {
+						reasoningEffort: readReasoningEffort(
+							request.config?.reasoningEffort,
+						),
+					}
+				: {}),
+			handoff: {
+				sourceSessionId,
+				resolveMessages: readSeedMessages,
+				onOuterSessionCreated: async (createdSessionId) => {
+					outerSessionId = createdSessionId;
+					const dashboardUrl = buildCloudHandoffDashboardUrl(
+						environment.appBaseUrl,
+						createdSessionId,
+					);
+					const current = await manager.get(sourceSessionId);
+					await manager.update(sourceSessionId, {
+						metadata: mergeCloudHandoffMetadata(
+							(current?.metadata as JsonRecord | null | undefined) ??
+								metadataBefore,
+							{
+								toCloudSessionId: createdSessionId,
+								handedOffAt: new Date().toISOString(),
+								status: "pending",
+								dashboardUrl,
+								fingerprint: prepared.fingerprint,
+							},
+						),
+					});
+					emitProgress(
+						"provisioning",
+						"Preparing the cloud workspace…",
+						createdSessionId,
+					);
+				},
+				onSeeding: () =>
+					emitProgress(
+						"seeding",
+						"Copying the local conversation to cloud…",
+						outerSessionId,
+					),
+			},
+		});
+		outerSessionId = String(created.sessionId ?? "").trim();
+		innerSessionId = String(created.innerSessionId ?? "").trim();
+	}
+
+	if (!outerSessionId || !innerSessionId || !seededMessages) {
+		throw new Error("Cloud handoff did not initialize a conversation.");
+	}
+	emitProgress(
+		"verifying",
+		"Verifying the transferred conversation…",
+		outerSessionId,
+	);
+	try {
+		await cloud.verifyHandoffTranscript(outerSessionId, seededMessages);
+	} catch (error) {
+		if (!(error instanceof CloudHandoffTranscriptMismatchError)) {
+			throw error;
+		}
+		try {
+			await clearPendingTarget(outerSessionId);
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"Cloud transcript verification failed and the incomplete cloud handoff could not be cleaned up.",
+			);
+		}
+		throw error;
+	}
+	try {
+		await assertHandoffIdle(ctx, manager, sourceSessionId);
+		const finalLocalMessages = await manager.readLiveMessages(sourceSessionId);
+		if (!cloudHandoffTranscriptsEqual(finalLocalMessages, seededMessages)) {
+			throw new Error(
+				"The local conversation changed during handoff. Nothing was closed; try again when the session is idle.",
+			);
+		}
+	} catch (error) {
+		try {
+			await clearPendingTarget(outerSessionId);
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"The local conversation changed during handoff and the incomplete cloud handoff could not be cleaned up.",
+			);
+		}
+		throw error;
+	}
+	const dashboardUrl = buildCloudHandoffDashboardUrl(
+		environment.appBaseUrl,
+		outerSessionId,
+	);
+	const latest = await manager.get(sourceSessionId);
+	const latestMetadata =
+		(latest?.metadata as JsonRecord | null | undefined) ?? metadataBefore;
+	const handedOffAt =
+		readCloudHandoffMetadata(latestMetadata)?.handedOffAt ??
+		new Date().toISOString();
+	await manager.update(sourceSessionId, {
+		metadata: mergeCloudHandoffMetadata(latestMetadata, {
+			toCloudSessionId: outerSessionId,
+			handedOffAt,
+			status: "complete",
+			innerSessionId,
+			dashboardUrl,
+			fingerprint: prepared.fingerprint,
+		}),
+	});
+
+	let warning: string | undefined;
+	if (nextCommand) {
+		try {
+			await cloud.send(
+				outerSessionId,
+				nextCommand,
+				"queue",
+				prepared.modelId,
+				request.attachments?.userImages,
+			);
+		} catch (error) {
+			warning = `The handoff completed, but the follow-up command was not queued: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	}
+	const destination = isCloudAgentsEnabled() ? "in_app" : "external";
+	emitProgress("complete", "Ready in Cline Cloud.", outerSessionId);
+	return {
+		sessionId: outerSessionId,
+		outerSessionId,
+		innerSessionId,
+		dashboardUrl,
+		destination,
+		...(warning ? { warning } : {}),
+	};
+}
+
+type HandoffRequestIdentity = {
+	fingerprint: JsonRecord | null;
+	nextCommand: string;
+	userImages: string[];
+	userFiles: Array<{ name: string; content: string }>;
+};
+
+const handoffRequests = new WeakMap<
+	SidecarContext,
+	Map<string, { identity: HandoffRequestIdentity; promise: Promise<unknown> }>
+>();
+
+async function handleHandoff(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<unknown> {
+	const sourceSessionId = request.sessionId?.trim();
+	if (!sourceSessionId) throw new Error("sessionId is required");
+	let requests = handoffRequests.get(ctx);
+	if (!requests) {
+		requests = new Map();
+		handoffRequests.set(ctx, requests);
+	}
+	const identity: HandoffRequestIdentity = {
+		fingerprint: request.fingerprint ?? null,
+		nextCommand: request.nextCommand?.trim() ?? "",
+		userImages: [...(request.attachments?.userImages ?? [])],
+		userFiles: (request.attachments?.userFiles ?? []).map((file) => ({
+			...file,
+		})),
+	};
+	const existing = requests.get(sourceSessionId);
+	if (existing) {
+		if (!isDeepStrictEqual(existing.identity, identity)) {
+			throw new Error(
+				"A different cloud handoff is already in progress for this session.",
+			);
+		}
+		return await existing.promise;
+	}
+	const running = handleHandoffOnce(ctx, request).finally(() => {
+		if (requests?.get(sourceSessionId)?.promise === running) {
+			requests.delete(sourceSessionId);
+		}
+	});
+	requests.set(sourceSessionId, { identity, promise: running });
+	return await running;
+}
+
 // ---------------------------------------------------------------------------
 // Action dispatch
 // ---------------------------------------------------------------------------
@@ -1540,6 +2144,8 @@ const ACTION_HANDLERS: Record<
 	start: handleStart,
 	attach: handleAttach,
 	send: handleSend,
+	prepare_handoff: handlePrepareHandoff,
+	handoff: handleHandoff,
 	stop: handleStop,
 	abort: handleAbort,
 	fork: handleFork,

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2392,6 +2392,34 @@ const handoffRequests = new WeakMap<
 	Map<string, { identity: HandoffRequestIdentity; promise: Promise<unknown> }>
 >();
 
+/**
+ * Deleting a source session while its cloud handoff is in flight can remove
+ * the only durable recovery record for an already-created sandbox. Keep this
+ * check in the sidecar as well as the UI so alternate clients cannot bypass it.
+ */
+export async function assertSessionDeleteAllowedDuringHandoff(
+	ctx: SidecarContext,
+	sessionId: string,
+	sessionManager?: ClineCore,
+): Promise<void> {
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error("Wait for the cloud handoff to finish before deleting.");
+	}
+	const manager =
+		sessionManager ??
+		(await findSessionRuntimeBinding(ctx, sessionId))?.sessionManager ??
+		getSessionManager(ctx, sessionId);
+	const persisted = await manager.get(sessionId);
+	const handoff = readCloudHandoffMetadata(
+		persisted?.metadata ?? readSessionMetadata(sessionId),
+	);
+	if (handoff?.status === "pending") {
+		throw new Error(
+			`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+		);
+	}
+}
+
 async function handleHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -3,6 +3,7 @@ import type { HubEventEnvelope, MessageWithMetadata } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
 import {
+	CloudHandoffSeedUnsupportedError,
 	CloudSessionApi,
 	CloudSessionError,
 	CloudSessionManager,
@@ -269,6 +270,54 @@ class FakeHubClient {
 }
 
 describe("CloudSessionApi", () => {
+	it("never adopts a list-recovered session for a handoff without request identity", async () => {
+		const now = new Date().toISOString();
+		const onOuterSessionCreated = vi.fn();
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) =>
+				init?.method === "POST"
+					? jsonResponse({ success: false, error: "gateway timeout" }, 500)
+					: jsonResponse({
+							success: true,
+							data: [
+								{
+									id: "ses-unproven",
+									status: "ready",
+									sandboxUrl: "https://pod.example",
+									repoContext: {
+										repoUrl: "https://github.com/cline/test",
+									},
+									metadata: { modelId: "model" },
+									createdAt: now,
+									updatedAt: now,
+								},
+							],
+						}),
+		});
+
+		const error = await api
+			.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated,
+				},
+			})
+			.catch((caught) => caught);
+
+		expect(error).toMatchObject({
+			code: "request_failed",
+			connectUrl: "https://app.example/agents",
+		});
+		expect(String(error)).toContain("cannot prove it created it");
+		expect(onOuterSessionCreated).not.toHaveBeenCalled();
+	});
+
 	it("reports the outer id before returning and keeps handoff hooks off the wire", async () => {
 		let postedBody: Record<string, unknown> | undefined;
 		const order: string[] = [];
@@ -2245,9 +2294,11 @@ describe("CloudSessionManager", () => {
 			},
 		});
 
-		await expect(
-			manager.verifyHandoffTranscript("ses-handoff", expected),
-		).rejects.toThrow("must use @cline/core 0.0.72 or newer");
+		const error = await manager
+			.verifyHandoffTranscript("ses-handoff", expected)
+			.catch((caught) => caught);
+		expect(error).toBeInstanceOf(CloudHandoffSeedUnsupportedError);
+		expect(String(error)).toContain("must use @cline/core 0.0.72 or newer");
 	});
 
 	it("reuses only one inner session owned by the same handoff source", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -2167,6 +2167,75 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
+	it("retries only the transient GitHub installation-token failure", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		const create = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new CloudSessionError(
+					"request_failed",
+					"couldn't authenticate with GitHub; try reconnecting the integration",
+					undefined,
+					502,
+				),
+			)
+			.mockRejectedValueOnce(
+				new CloudSessionError(
+					"request_failed",
+					"couldn't authenticate with GitHub; try reconnecting the integration",
+					undefined,
+					502,
+				),
+			)
+			.mockResolvedValue({ sessionId: "ses-retried", sandboxUrl: "pod" });
+		const sleep = vi.fn(async () => undefined);
+		const manager = new CloudSessionManager(ctx, {
+			api: { create } as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+			sleep,
+		});
+
+		await expect(
+			manager.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+			}),
+		).resolves.toMatchObject({ sessionId: "ses-retried" });
+		expect(create).toHaveBeenCalledTimes(3);
+		expect(sleep.mock.calls).toEqual([[500], [1000]]);
+	});
+
+	it("does not retry an arbitrary 502 that could have provisioned", async () => {
+		const { ctx } = createContext();
+		const create = vi.fn(async () => {
+			throw new CloudSessionError(
+				"request_failed",
+				"upstream request failed",
+				undefined,
+				502,
+			);
+		});
+		const sleep = vi.fn(async () => undefined);
+		const manager = new CloudSessionManager(ctx, {
+			api: { create } as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			sleep,
+		});
+
+		await expect(
+			manager.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+			}),
+		).rejects.toThrow("upstream request failed");
+		expect(create).toHaveBeenCalledOnce();
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
 	it("persists the outer handoff before seeding rich initial messages", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient(false);
@@ -2205,6 +2274,8 @@ describe("CloudSessionManager", () => {
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 			branch: "main",
+			mode: "plan",
+			workspaceRelativePath: "apps/examples/desktop-app",
 			handoff: {
 				sourceSessionId: "local-1",
 				onOuterSessionCreated: async () => {
@@ -2227,7 +2298,15 @@ describe("CloudSessionManager", () => {
 			(entry) => entry.command === "session.create",
 		);
 		expect(innerCreate?.payload).toMatchObject({
+			workspaceRoot: "/workspace",
+			cwd: "/workspace/apps/examples/desktop-app",
 			initialMessages,
+			sessionConfig: {
+				workspaceRoot: "/workspace",
+				cwd: "/workspace/apps/examples/desktop-app",
+				mode: "plan",
+			},
+			runtimeOptions: { mode: "plan" },
 			metadata: {
 				handoff: {
 					from: "local",
@@ -3546,7 +3625,12 @@ describe("CloudSessionManager", () => {
 		const { ctx } = createContext();
 		let sessions = [REMOTE_SESSION];
 		const manager = new CloudSessionManager(ctx, {
-			api: { list: async () => sessions } as unknown as CloudSessionApi,
+			api: {
+				list: async () => sessions,
+				status: async () => {
+					throw new CloudSessionError("session_not_found", "gone");
+				},
+			} as unknown as CloudSessionApi,
 			apiBaseUrl: "https://api.example",
 			getAuthToken: async () => "workos:fresh",
 		});
@@ -3559,6 +3643,30 @@ describe("CloudSessionManager", () => {
 				session_id: "ses-outer",
 			}),
 		).resolves.toBeNull();
+	});
+
+	it("opens a cached session from another scope after id revalidation", async () => {
+		const { ctx } = createContext();
+		let sessions = [REMOTE_SESSION];
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => sessions,
+				status: async () => ({ status: "ready" }),
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+		});
+		await manager.list();
+		ctx.cloudSessionManager = manager;
+		sessions = [];
+
+		await expect(
+			handleCommand(ctx, "get_discovered_session", {
+				session_id: "ses-outer",
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({ sessionId: "ses-outer", status: "ready" }),
+		);
 	});
 
 	it("uses only the active organization for billing and session listing", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -72,6 +72,7 @@ class FakeHubClient {
 	invalidMessagesSnapshot = false;
 	malformedQueueReply = false;
 	listedModel?: string;
+	sessionStatus?: string;
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -179,6 +180,12 @@ class FakeHubClient {
 				payload: this.invalidMessagesSnapshot
 					? { messages: "invalid" }
 					: { messages: this.messages },
+			};
+		}
+		if (command === "session.get" && this.sessionStatus) {
+			return {
+				ok: true,
+				payload: { session: { status: this.sessionStatus } },
 			};
 		}
 		return { ok: true, payload: {} };
@@ -2081,6 +2088,28 @@ describe("CloudSessionManager", () => {
 		await expect(
 			manager.send("ses-outer", "Do this once"),
 		).resolves.toMatchObject({ ok: true, recoveredAfterDisconnect: true });
+	});
+
+	it("queues an implicit send when a cold session is already running", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionStatus = "running";
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+
+		await expect(
+			manager.send("ses-outer", "Run this next"),
+		).resolves.toMatchObject({ ok: true, queued: true });
+		expect(
+			hub.commands.find((entry) => entry.command === "session.send_input"),
+		).toMatchObject({
+			payload: { prompt: "Run this next", delivery: "queue" },
+		});
 	});
 
 	it("does not confirm a lost duplicate prompt against an earlier delivery", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -1,4 +1,4 @@
-import { HubTransportError } from "@cline/core";
+import { cloudHandoffTranscriptsEqual, HubTransportError } from "@cline/core";
 import type { HubEventEnvelope } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
@@ -25,6 +25,37 @@ const REMOTE_SESSION: CloudSessionRecord = {
 	createdAt: "2026-08-05T10:00:00.000Z",
 	updatedAt: "2026-08-05T10:01:00.000Z",
 };
+
+describe("cloud handoff transcript comparison", () => {
+	it("compares roles and rich image content exactly", () => {
+		const expected = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "inspect this" },
+					{ type: "image", source: { type: "base64", data: "abc" } },
+				],
+				metadata: { localOnly: true },
+			},
+		];
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{ ...expected[0], metadata: { cloudOnly: true } },
+			]),
+		).toBe(true);
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{
+					...expected[0],
+					content: [
+						{ type: "text", text: "inspect this" },
+						{ type: "image", source: { type: "base64", data: "xyz" } },
+					],
+				},
+			]),
+		).toBe(false);
+	});
+});
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -190,6 +221,122 @@ class FakeHubClient {
 }
 
 describe("CloudSessionApi", () => {
+	it("reports the outer id before returning and keeps handoff hooks off the wire", async () => {
+		let postedBody: Record<string, unknown> | undefined;
+		const order: string[] = [];
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				postedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-handoff",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		const created = await api.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => [],
+				onOuterSessionCreated: async (sessionId) => {
+					order.push(`pending:${sessionId}`);
+				},
+			},
+		});
+		order.push("returned");
+
+		expect(order).toEqual(["pending:ses-handoff", "returned"]);
+		expect(created.sessionId).toBe("ses-handoff");
+		expect(postedBody).toEqual({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+		});
+	});
+
+	it("deletes a new outer session when its local recovery record cannot be saved", async () => {
+		const methods: string[] = [];
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				methods.push(init?.method ?? "GET");
+				if (init?.method === "DELETE") {
+					return new Response(undefined, { status: 204 });
+				}
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-unrecorded",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		await expect(
+			api.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated: async () => {
+						throw new Error("metadata write failed");
+					},
+				},
+			}),
+		).rejects.toThrow("metadata write failed");
+		expect(methods).toEqual(["POST", "DELETE"]);
+	});
+
+	it("surfaces the recovery URL when an unrecorded outer session cannot be cleaned up", async () => {
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				if (init?.method === "DELETE") {
+					return jsonResponse({ error: "cleanup unavailable" }, 503);
+				}
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-needs-recovery",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		await expect(
+			api.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated: async () => {
+						throw new Error("metadata write failed");
+					},
+				},
+			}),
+		).rejects.toThrow(
+			"Cloud session ses-needs-recovery: https://app.example/agents?sessionId=ses-needs-recovery",
+		);
+	});
+
 	it("resolves a fresh bearer token for every REST request", async () => {
 		const tokens = ["workos:first", "workos:second"];
 		const authorizations: string[] = [];
@@ -1888,6 +2035,81 @@ describe("CloudSessionManager", () => {
 			command: "session.attach",
 			sessionId: "inner-created",
 		});
+	});
+
+	it("persists the outer handoff before seeding rich initial messages", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		const order: string[] = [];
+		const initialMessages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "continue with this image" },
+					{
+						type: "image" as const,
+						data: "abc",
+						mediaType: "image/png",
+					},
+				],
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async (input: {
+					handoff?: {
+						onOuterSessionCreated(id: string): Promise<void>;
+					};
+				}) => {
+					await input.handoff?.onOuterSessionCreated("ses-handoff");
+					order.push("provisioned");
+					return { sessionId: "ses-handoff", sandboxUrl: "pod" };
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		const created = await manager.create({
+			modelId: "anthropic/claude-sonnet-5",
+			repoUrl: "https://github.com/cline/test",
+			branch: "main",
+			handoff: {
+				sourceSessionId: "local-1",
+				onOuterSessionCreated: async () => {
+					order.push("pending");
+				},
+				resolveMessages: async () => {
+					order.push("read-live");
+					return initialMessages;
+				},
+				onSeeding: () => order.push("seeding"),
+			},
+		});
+
+		expect(order).toEqual(["pending", "provisioned", "read-live", "seeding"]);
+		expect(created).toMatchObject({
+			sessionId: "ses-handoff",
+			innerSessionId: "inner-created",
+		});
+		const innerCreate = hub.commands.find(
+			(entry) => entry.command === "session.create",
+		);
+		expect(innerCreate?.payload).toMatchObject({
+			initialMessages,
+			metadata: {
+				handoff: {
+					from: "local",
+					sourceSessionId: "local-1",
+					outerSessionId: "ses-handoff",
+				},
+			},
+		});
+		expect(
+			(innerCreate?.payload?.sessionConfig as { systemPrompt?: string })
+				.systemPrompt,
+		).toContain("fresh clone");
 	});
 
 	it("updates the cloud model before sending and skips redundant updates", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -104,6 +104,7 @@ class FakeHubClient {
 	malformedQueueReply = false;
 	listedModel?: string;
 	sessionRows?: Array<Record<string, unknown>>;
+	sessionStatus?: string;
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -213,6 +214,12 @@ class FakeHubClient {
 				payload: this.invalidMessagesSnapshot
 					? { messages: "invalid" }
 					: { messages: this.messages },
+			};
+		}
+		if (command === "session.get" && this.sessionStatus) {
+			return {
+				ok: true,
+				payload: { session: { status: this.sessionStatus } },
 			};
 		}
 		return { ok: true, payload: {} };
@@ -2507,6 +2514,28 @@ describe("CloudSessionManager", () => {
 		await expect(
 			manager.send("ses-outer", "Do this once"),
 		).resolves.toMatchObject({ ok: true, recoveredAfterDisconnect: true });
+	});
+
+	it("queues an implicit send when a cold session is already running", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionStatus = "running";
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+
+		await expect(
+			manager.send("ses-outer", "Run this next"),
+		).resolves.toMatchObject({ ok: true, queued: true });
+		expect(
+			hub.commands.find((entry) => entry.command === "session.send_input"),
+		).toMatchObject({
+			payload: { prompt: "Run this next", delivery: "queue" },
+		});
 	});
 
 	it("does not confirm a lost duplicate prompt against an earlier delivery", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -3376,6 +3376,38 @@ describe("CloudSessionManager", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
+	it("opens a known cloud session without re-fetching account scope", async () => {
+		const { ctx } = createContext();
+		let listCalls = 0;
+		let failListing = false;
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => {
+					listCalls += 1;
+					if (failListing) throw new Error("environment lookup failed");
+					return [REMOTE_SESSION];
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+		});
+		await manager.list();
+		ctx.cloudSessionManager = manager;
+		failListing = true;
+
+		await expect(
+			handleCommand(ctx, "get_discovered_session", {
+				session_id: "ses-outer",
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({
+				sessionId: "ses-outer",
+				origin: "cloud",
+			}),
+		);
+		expect(listCalls).toBe(1);
+	});
+
 	it("uses only the active organization for billing and session listing", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient(false);

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -103,6 +103,7 @@ class FakeHubClient {
 	invalidMessagesSnapshot = false;
 	malformedQueueReply = false;
 	listedModel?: string;
+	sessionRows?: Array<Record<string, unknown>>;
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -155,17 +156,19 @@ class FakeHubClient {
 			return {
 				ok: true,
 				payload: {
-					sessions: this.hasExistingInner
-						? [
-								{
-									sessionId: "inner-1",
-									updatedAt: 20,
-									...(this.listedModel
-										? { metadata: { model: this.listedModel } }
-										: {}),
-								},
-							]
-						: [],
+					sessions:
+						this.sessionRows ??
+						(this.hasExistingInner
+							? [
+									{
+										sessionId: "inner-1",
+										updatedAt: 20,
+										...(this.listedModel
+											? { metadata: { model: this.listedModel } }
+											: {}),
+									},
+								]
+							: []),
 				},
 			};
 		}
@@ -2198,6 +2201,80 @@ describe("CloudSessionManager", () => {
 		await expect(
 			manager.verifyHandoffTranscript("ses-handoff", expected),
 		).rejects.toThrow("must use @cline/core 0.0.72 or newer");
+	});
+
+	it("reuses only one inner session owned by the same handoff source", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: {
+					handoff: { sourceSessionId: "local-1" },
+				},
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		const seeded = await manager.seedHandoff("ses-outer", {
+			sourceSessionId: "local-1",
+			messages: [{ role: "user", content: "continue" }],
+		});
+
+		expect(seeded.innerSessionId).toBe("inner-handoff");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
+	});
+
+	it.each([
+		{
+			name: "an unrelated inner session",
+			rows: [
+				{
+					sessionId: "inner-unrelated",
+					metadata: { handoff: { sourceSessionId: "another-local" } },
+				},
+			],
+		},
+		{
+			name: "multiple inner sessions",
+			rows: [
+				{
+					sessionId: "inner-handoff",
+					metadata: { handoff: { sourceSessionId: "local-1" } },
+				},
+				{
+					sessionId: "inner-other",
+					metadata: { handoff: { sourceSessionId: "local-1" } },
+				},
+			],
+		},
+	])("refuses handoff adoption with $name", async ({ rows }) => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = rows;
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		await expect(
+			manager.seedHandoff("ses-outer", {
+				sourceSessionId: "local-1",
+				messages: [{ role: "user", content: "continue" }],
+			}),
+		).rejects.toThrow("already contains another conversation");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
 	});
 
 	it("updates the cloud model before sending and skips redundant updates", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -1,4 +1,8 @@
-import { cloudHandoffTranscriptsEqual, HubTransportError } from "@cline/core";
+import {
+	cloudHandoffTranscriptsEqual,
+	HubCommandError,
+	HubTransportError,
+} from "@cline/core";
 import type { HubEventEnvelope } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
@@ -2741,6 +2745,45 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
+	it("confirms a queued prompt after an ambiguous command timeout", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+		hub.commandHook = (command) => {
+			if (command !== "session.send_input") return;
+			hub.commandHook = undefined;
+			hub.prompts.push({
+				id: "q-timeout",
+				prompt: "Queued before the timeout",
+				delivery: "queue",
+				attachmentCount: 0,
+			});
+			throw new HubCommandError(
+				"session.send_input",
+				"hub_command_timeout",
+				"timed out",
+			);
+		};
+
+		await expect(
+			manager.send("ses-outer", "Queued before the timeout", "queue"),
+		).resolves.toMatchObject({
+			ok: true,
+			queued: true,
+			recoveredAfterDisconnect: true,
+		});
+		expect(
+			hub.commands.filter((entry) => entry.command === "session.send_input"),
+		).toHaveLength(1);
+	});
+
 	it("disposes the Hub connection before deleting the outer session", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient();
@@ -3465,7 +3508,7 @@ describe("CloudSessionManager", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
-	it("opens a known cloud session without re-fetching account scope", async () => {
+	it("falls back to a cached cloud session when fresh discovery fails", async () => {
 		const { ctx } = createContext();
 		let listCalls = 0;
 		let failListing = false;
@@ -3494,7 +3537,26 @@ describe("CloudSessionManager", () => {
 				origin: "cloud",
 			}),
 		);
-		expect(listCalls).toBe(1);
+		expect(listCalls).toBe(2);
+	});
+
+	it("does not reopen a cached cloud session removed on another device", async () => {
+		const { ctx } = createContext();
+		let sessions = [REMOTE_SESSION];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => sessions } as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+		});
+		await manager.list();
+		ctx.cloudSessionManager = manager;
+		sessions = [];
+
+		await expect(
+			handleCommand(ctx, "get_discovered_session", {
+				session_id: "ses-outer",
+			}),
+		).resolves.toBeNull();
 	});
 
 	it("uses only the active organization for billing and session listing", async () => {
@@ -3549,6 +3611,32 @@ describe("CloudSessionManager", () => {
 			repoUrl: "https://github.com/cline/test",
 		});
 		expect(createInput).toMatchObject({ organizationId: "org-cline-bot" });
+	});
+
+	it("keeps an explicitly personal handoff out of the active organization", async () => {
+		const { ctx } = createContext();
+		let createInput: Record<string, unknown> | undefined;
+		const scopeLookup = vi.fn(async () => "org-cline-bot");
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async (input: Record<string, unknown>) => {
+					createInput = input;
+					return { sessionId: "ses-personal", sandboxUrl: "pod" };
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			getActiveOrganizationId: scopeLookup,
+		});
+
+		await manager.create({
+			modelId: "anthropic/claude-sonnet-5",
+			repoUrl: "https://github.com/cline/test",
+			organizationId: null,
+		});
+
+		expect(scopeLookup).not.toHaveBeenCalled();
+		expect(createInput?.organizationId).toBeUndefined();
 	});
 
 	it("refreshes the active organization before creating a session", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -706,6 +706,27 @@ describe("CloudSessionApi", () => {
 		expect(error.code).toBe("authentication_required");
 	});
 
+	it("turns a generic forbidden response into actionable account guidance", async () => {
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:test",
+			fetch: async () =>
+				jsonResponse({ success: false, error: "forbidden" }, 403),
+		});
+
+		const error = await api
+			.create({ modelId: "model", repoUrl: "https://github.com/cline/test" })
+			.catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(CloudSessionError);
+		expect(error.code).toBe("request_failed");
+		expect(error.status).toBe(403);
+		expect(error.message).toContain(
+			"Switch to Personal or another organization in Settings → Account",
+		);
+	});
+
 	it("lists connected GitHub repositories and their branches", async () => {
 		const requestedPaths: string[] = [];
 		const api = new CloudSessionApi({

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -72,6 +72,7 @@ class FakeHubClient {
 	invalidMessagesSnapshot = false;
 	malformedQueueReply = false;
 	listedModel?: string;
+	sessionStatus?: string;
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -179,6 +180,12 @@ class FakeHubClient {
 				payload: this.invalidMessagesSnapshot
 					? { messages: "invalid" }
 					: { messages: this.messages },
+			};
+		}
+		if (command === "session.get" && this.sessionStatus) {
+			return {
+				ok: true,
+				payload: { session: { status: this.sessionStatus } },
 			};
 		}
 		return { ok: true, payload: {} };
@@ -2083,6 +2090,28 @@ describe("CloudSessionManager", () => {
 		await expect(
 			manager.send("ses-outer", "Do this once"),
 		).resolves.toMatchObject({ ok: true, recoveredAfterDisconnect: true });
+	});
+
+	it("queues an implicit send when a cold session is already running", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionStatus = "running";
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+
+		await expect(
+			manager.send("ses-outer", "Run this next"),
+		).resolves.toMatchObject({ ok: true, queued: true });
+		expect(
+			hub.commands.find((entry) => entry.command === "session.send_input"),
+		).toMatchObject({
+			payload: { prompt: "Run this next", delivery: "queue" },
+		});
 	});
 
 	it("does not confirm a lost duplicate prompt against an earlier delivery", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -1,4 +1,8 @@
-import { cloudHandoffTranscriptsEqual, HubTransportError } from "@cline/core";
+import {
+	cloudHandoffTranscriptsEqual,
+	HubCommandError,
+	HubTransportError,
+} from "@cline/core";
 import type { HubEventEnvelope, MessageWithMetadata } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
@@ -2743,6 +2747,45 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
+	it("confirms a queued prompt after an ambiguous command timeout", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+		hub.commandHook = (command) => {
+			if (command !== "session.send_input") return;
+			hub.commandHook = undefined;
+			hub.prompts.push({
+				id: "q-timeout",
+				prompt: "Queued before the timeout",
+				delivery: "queue",
+				attachmentCount: 0,
+			});
+			throw new HubCommandError(
+				"session.send_input",
+				"hub_command_timeout",
+				"timed out",
+			);
+		};
+
+		await expect(
+			manager.send("ses-outer", "Queued before the timeout", "queue"),
+		).resolves.toMatchObject({
+			ok: true,
+			queued: true,
+			recoveredAfterDisconnect: true,
+		});
+		expect(
+			hub.commands.filter((entry) => entry.command === "session.send_input"),
+		).toHaveLength(1);
+	});
+
 	it("disposes the Hub connection before deleting the outer session", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient();
@@ -3467,7 +3510,7 @@ describe("CloudSessionManager", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
-	it("opens a known cloud session without re-fetching account scope", async () => {
+	it("falls back to a cached cloud session when fresh discovery fails", async () => {
 		const { ctx } = createContext();
 		let listCalls = 0;
 		let failListing = false;
@@ -3496,7 +3539,26 @@ describe("CloudSessionManager", () => {
 				origin: "cloud",
 			}),
 		);
-		expect(listCalls).toBe(1);
+		expect(listCalls).toBe(2);
+	});
+
+	it("does not reopen a cached cloud session removed on another device", async () => {
+		const { ctx } = createContext();
+		let sessions = [REMOTE_SESSION];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => sessions } as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+		});
+		await manager.list();
+		ctx.cloudSessionManager = manager;
+		sessions = [];
+
+		await expect(
+			handleCommand(ctx, "get_discovered_session", {
+				session_id: "ses-outer",
+			}),
+		).resolves.toBeNull();
 	});
 
 	it("uses only the active organization for billing and session listing", async () => {
@@ -3551,6 +3613,32 @@ describe("CloudSessionManager", () => {
 			repoUrl: "https://github.com/cline/test",
 		});
 		expect(createInput).toMatchObject({ organizationId: "org-cline-bot" });
+	});
+
+	it("keeps an explicitly personal handoff out of the active organization", async () => {
+		const { ctx } = createContext();
+		let createInput: Record<string, unknown> | undefined;
+		const scopeLookup = vi.fn(async () => "org-cline-bot");
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async (input: Record<string, unknown>) => {
+					createInput = input;
+					return { sessionId: "ses-personal", sandboxUrl: "pod" };
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			getActiveOrganizationId: scopeLookup,
+		});
+
+		await manager.create({
+			modelId: "anthropic/claude-sonnet-5",
+			repoUrl: "https://github.com/cline/test",
+			organizationId: null,
+		});
+
+		expect(scopeLookup).not.toHaveBeenCalled();
+		expect(createInput?.organizationId).toBeUndefined();
 	});
 
 	it("refreshes the active organization before creating a session", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -1,4 +1,4 @@
-import { HubTransportError } from "@cline/core";
+import { cloudHandoffTranscriptsEqual, HubTransportError } from "@cline/core";
 import type { HubEventEnvelope, MessageWithMetadata } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
@@ -25,6 +25,37 @@ const REMOTE_SESSION: CloudSessionRecord = {
 	createdAt: "2026-08-05T10:00:00.000Z",
 	updatedAt: "2026-08-05T10:01:00.000Z",
 };
+
+describe("cloud handoff transcript comparison", () => {
+	it("compares roles and rich image content exactly", () => {
+		const expected = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "inspect this" },
+					{ type: "image", source: { type: "base64", data: "abc" } },
+				],
+				metadata: { localOnly: true },
+			},
+		];
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{ ...expected[0], metadata: { cloudOnly: true } },
+			]),
+		).toBe(true);
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{
+					...expected[0],
+					content: [
+						{ type: "text", text: "inspect this" },
+						{ type: "image", source: { type: "base64", data: "xyz" } },
+					],
+				},
+			]),
+		).toBe(false);
+	});
+});
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -73,6 +104,7 @@ class FakeHubClient {
 	malformedQueueReply = false;
 	listedModel?: string;
 	sessionStatus?: string;
+	sessionRows?: Array<Record<string, unknown>>;
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -125,17 +157,19 @@ class FakeHubClient {
 			return {
 				ok: true,
 				payload: {
-					sessions: this.hasExistingInner
-						? [
-								{
-									sessionId: "inner-1",
-									updatedAt: 20,
-									...(this.listedModel
-										? { metadata: { model: this.listedModel } }
-										: {}),
-								},
-							]
-						: [],
+					sessions:
+						this.sessionRows ??
+						(this.hasExistingInner
+							? [
+									{
+										sessionId: "inner-1",
+										updatedAt: 20,
+										...(this.listedModel
+											? { metadata: { model: this.listedModel } }
+											: {}),
+									},
+								]
+							: []),
 				},
 			};
 		}
@@ -197,6 +231,122 @@ class FakeHubClient {
 }
 
 describe("CloudSessionApi", () => {
+	it("reports the outer id before returning and keeps handoff hooks off the wire", async () => {
+		let postedBody: Record<string, unknown> | undefined;
+		const order: string[] = [];
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				postedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-handoff",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		const created = await api.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => [],
+				onOuterSessionCreated: async (sessionId) => {
+					order.push(`pending:${sessionId}`);
+				},
+			},
+		});
+		order.push("returned");
+
+		expect(order).toEqual(["pending:ses-handoff", "returned"]);
+		expect(created.sessionId).toBe("ses-handoff");
+		expect(postedBody).toEqual({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+		});
+	});
+
+	it("deletes a new outer session when its local recovery record cannot be saved", async () => {
+		const methods: string[] = [];
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				methods.push(init?.method ?? "GET");
+				if (init?.method === "DELETE") {
+					return new Response(undefined, { status: 204 });
+				}
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-unrecorded",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		await expect(
+			api.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated: async () => {
+						throw new Error("metadata write failed");
+					},
+				},
+			}),
+		).rejects.toThrow("metadata write failed");
+		expect(methods).toEqual(["POST", "DELETE"]);
+	});
+
+	it("surfaces the recovery URL when an unrecorded outer session cannot be cleaned up", async () => {
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) => {
+				if (init?.method === "DELETE") {
+					return jsonResponse({ error: "cleanup unavailable" }, 503);
+				}
+				return jsonResponse({
+					success: true,
+					data: {
+						sessionId: "ses-needs-recovery",
+						sandboxUrl: "https://pod.example",
+						status: "ready",
+					},
+				});
+			},
+		});
+
+		await expect(
+			api.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated: async () => {
+						throw new Error("metadata write failed");
+					},
+				},
+			}),
+		).rejects.toThrow(
+			"Cloud session ses-needs-recovery: https://app.example/agents?sessionId=ses-needs-recovery",
+		);
+	});
+
 	it("resolves a fresh bearer token for every REST request", async () => {
 		const tokens = ["workos:first", "workos:second"];
 		const authorizations: string[] = [];
@@ -566,6 +716,27 @@ describe("CloudSessionApi", () => {
 		expect(error.code).toBe("authentication_required");
 	});
 
+	it("turns a generic forbidden response into actionable account guidance", async () => {
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:test",
+			fetch: async () =>
+				jsonResponse({ success: false, error: "forbidden" }, 403),
+		});
+
+		const error = await api
+			.create({ modelId: "model", repoUrl: "https://github.com/cline/test" })
+			.catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(CloudSessionError);
+		expect(error.code).toBe("request_failed");
+		expect(error.status).toBe(403);
+		expect(error.message).toContain(
+			"Switch to Personal or another organization in Settings → Account",
+		);
+	});
+
 	it("lists connected GitHub repositories and their branches", async () => {
 		const requestedPaths: string[] = [];
 		const api = new CloudSessionApi({
@@ -717,7 +888,7 @@ describe("CloudSessionApi", () => {
 		]);
 	});
 
-	it("recovers distinct sessions for overlapping identical create requests", async () => {
+	it("refuses ambiguous recovery for overlapping identical create requests", async () => {
 		const now = new Date().toISOString();
 		const record = (id: string, createdAt: string) => ({
 			id,
@@ -748,17 +919,23 @@ describe("CloudSessionApi", () => {
 			repoUrl: "https://github.com/cline/test",
 		};
 
-		// Two identical CONCURRENT requests fail over to list-based recovery;
-		// each must claim a different record or one sandbox is orphaned.
-		const [first, second] = await Promise.all([
+		// The API exposes no request id that can map either failed POST to one of
+		// these rows. Newest-wins can steal another conversation's sandbox.
+		const results = await Promise.allSettled([
 			api.create(input),
 			api.create(input),
 		]);
 
-		expect([first.sessionId, second.sessionId].sort()).toEqual([
-			"ses-newer",
-			"ses-older",
+		expect(results.map((result) => result.status)).toEqual([
+			"rejected",
+			"rejected",
 		]);
+		for (const result of results) {
+			if (result.status === "rejected") {
+				expect(result.reason).toMatchObject({ code: "request_failed" });
+				expect(String(result.reason)).toContain("ambiguous result");
+			}
+		}
 	});
 
 	it("recovery never steals a session whose successful POST is still completing", async () => {
@@ -1897,6 +2074,255 @@ describe("CloudSessionManager", () => {
 			command: "session.attach",
 			sessionId: "inner-created",
 		});
+	});
+
+	it("persists the outer handoff before seeding rich initial messages", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		const order: string[] = [];
+		const initialMessages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "continue with this image" },
+					{
+						type: "image" as const,
+						data: "abc",
+						mediaType: "image/png",
+					},
+				],
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async (input: {
+					handoff?: {
+						onOuterSessionCreated(id: string): Promise<void>;
+					};
+				}) => {
+					await input.handoff?.onOuterSessionCreated("ses-handoff");
+					order.push("provisioned");
+					return { sessionId: "ses-handoff", sandboxUrl: "pod" };
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		const created = await manager.create({
+			modelId: "anthropic/claude-sonnet-5",
+			repoUrl: "https://github.com/cline/test",
+			branch: "main",
+			handoff: {
+				sourceSessionId: "local-1",
+				onOuterSessionCreated: async () => {
+					order.push("pending");
+				},
+				resolveMessages: async () => {
+					order.push("read-live");
+					return initialMessages;
+				},
+				onSeeding: () => order.push("seeding"),
+			},
+		});
+
+		expect(order).toEqual(["pending", "provisioned", "read-live", "seeding"]);
+		expect(created).toMatchObject({
+			sessionId: "ses-handoff",
+			innerSessionId: "inner-created",
+		});
+		const innerCreate = hub.commands.find(
+			(entry) => entry.command === "session.create",
+		);
+		expect(innerCreate?.payload).toMatchObject({
+			initialMessages,
+			metadata: {
+				handoff: {
+					from: "local",
+					sourceSessionId: "local-1",
+					outerSessionId: "ses-handoff",
+				},
+			},
+		});
+		expect(
+			(innerCreate?.payload?.sessionConfig as { systemPrompt?: string })
+				.systemPrompt,
+		).toContain("fresh clone");
+	});
+
+	it("verifies handoff seeding from the live Hub without archive fallback", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		const expected = [{ role: "user" as const, content: "continue" }];
+		const history = vi.fn(async () => expected);
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
+				history,
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => expected,
+				onOuterSessionCreated: async () => undefined,
+			},
+		});
+		hub.commandHook = (command) => {
+			if (command === "session.messages") throw new Error("live read failed");
+		};
+
+		await expect(
+			manager.verifyHandoffTranscript("ses-handoff", expected),
+		).rejects.toThrow("live read failed");
+		expect(history).not.toHaveBeenCalled();
+	});
+
+	it("identifies a runtime that ignored seeded initialMessages", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		hub.messages = [];
+		const expected = [{ role: "user" as const, content: "continue" }];
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => expected,
+				onOuterSessionCreated: async () => undefined,
+			},
+		});
+
+		await expect(
+			manager.verifyHandoffTranscript("ses-handoff", expected),
+		).rejects.toThrow("must use @cline/core 0.0.72 or newer");
+	});
+
+	it("reuses only one inner session owned by the same handoff source", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: {
+					handoff: { sourceSessionId: "local-1" },
+				},
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		const seeded = await manager.seedHandoff("ses-outer", {
+			sourceSessionId: "local-1",
+			messages: [{ role: "user", content: "continue" }],
+		});
+
+		expect(seeded.innerSessionId).toBe("inner-handoff");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
+	});
+
+	it.each([
+		{
+			name: "an unrelated inner session",
+			rows: [
+				{
+					sessionId: "inner-unrelated",
+					metadata: { handoff: { sourceSessionId: "another-local" } },
+				},
+			],
+		},
+		{
+			name: "multiple inner sessions",
+			rows: [
+				{
+					sessionId: "inner-handoff",
+					metadata: { handoff: { sourceSessionId: "local-1" } },
+				},
+				{
+					sessionId: "inner-other",
+					metadata: { handoff: { sourceSessionId: "local-1" } },
+				},
+			],
+		},
+	])("refuses handoff adoption with $name", async ({ rows }) => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = rows;
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		await expect(
+			manager.seedHandoff("ses-outer", {
+				sourceSessionId: "local-1",
+				messages: [{ role: "user", content: "continue" }],
+			}),
+		).rejects.toThrow("already contains another conversation");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
+	});
+
+	it("revalidates all inner sessions before reusing a cached handoff connection", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: { handoff: { sourceSessionId: "local-1" } },
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: { handoff: { sourceSessionId: "local-1" } },
+			},
+			{
+				sessionId: "inner-sibling",
+				metadata: { handoff: { sourceSessionId: "another-local" } },
+			},
+		];
+
+		await expect(
+			manager.seedHandoff("ses-outer", {
+				sourceSessionId: "local-1",
+				messages: [{ role: "user", content: "continue" }],
+			}),
+		).rejects.toThrow("already contains another conversation");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
 	});
 
 	it("updates the cloud model before sending and skips redundant updates", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -2277,6 +2277,45 @@ describe("CloudSessionManager", () => {
 		).toBe(false);
 	});
 
+	it("revalidates all inner sessions before reusing a cached handoff connection", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: { handoff: { sourceSessionId: "local-1" } },
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+		hub.sessionRows = [
+			{
+				sessionId: "inner-handoff",
+				metadata: { handoff: { sourceSessionId: "local-1" } },
+			},
+			{
+				sessionId: "inner-sibling",
+				metadata: { handoff: { sourceSessionId: "another-local" } },
+			},
+		];
+
+		await expect(
+			manager.seedHandoff("ses-outer", {
+				sourceSessionId: "local-1",
+				messages: [{ role: "user", content: "continue" }],
+			}),
+		).rejects.toThrow("already contains another conversation");
+		expect(
+			hub.commands.some((entry) => entry.command === "session.create"),
+		).toBe(false);
+	});
+
 	it("updates the cloud model before sending and skips redundant updates", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient();

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -3378,6 +3378,38 @@ describe("CloudSessionManager", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	});
 
+	it("opens a known cloud session without re-fetching account scope", async () => {
+		const { ctx } = createContext();
+		let listCalls = 0;
+		let failListing = false;
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => {
+					listCalls += 1;
+					if (failListing) throw new Error("environment lookup failed");
+					return [REMOTE_SESSION];
+				},
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+		});
+		await manager.list();
+		ctx.cloudSessionManager = manager;
+		failListing = true;
+
+		await expect(
+			handleCommand(ctx, "get_discovered_session", {
+				session_id: "ses-outer",
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({
+				sessionId: "ses-outer",
+				origin: "cloud",
+			}),
+		);
+		expect(listCalls).toBe(1);
+	});
+
 	it("uses only the active organization for billing and session listing", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient(false);

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -878,7 +878,7 @@ describe("CloudSessionApi", () => {
 		]);
 	});
 
-	it("recovers distinct sessions for overlapping identical create requests", async () => {
+	it("refuses ambiguous recovery for overlapping identical create requests", async () => {
 		const now = new Date().toISOString();
 		const record = (id: string, createdAt: string) => ({
 			id,
@@ -909,17 +909,23 @@ describe("CloudSessionApi", () => {
 			repoUrl: "https://github.com/cline/test",
 		};
 
-		// Two identical CONCURRENT requests fail over to list-based recovery;
-		// each must claim a different record or one sandbox is orphaned.
-		const [first, second] = await Promise.all([
+		// The API exposes no request id that can map either failed POST to one of
+		// these rows. Newest-wins can steal another conversation's sandbox.
+		const results = await Promise.allSettled([
 			api.create(input),
 			api.create(input),
 		]);
 
-		expect([first.sessionId, second.sessionId].sort()).toEqual([
-			"ses-newer",
-			"ses-older",
+		expect(results.map((result) => result.status)).toEqual([
+			"rejected",
+			"rejected",
 		]);
+		for (const result of results) {
+			if (result.status === "rejected") {
+				expect(result.reason).toMatchObject({ code: "request_failed" });
+				expect(String(result.reason)).toContain("ambiguous result");
+			}
+		}
 	});
 
 	it("recovery never steals a session whose successful POST is still completing", async () => {
@@ -2131,6 +2137,67 @@ describe("CloudSessionManager", () => {
 			(innerCreate?.payload?.sessionConfig as { systemPrompt?: string })
 				.systemPrompt,
 		).toContain("fresh clone");
+	});
+
+	it("verifies handoff seeding from the live Hub without archive fallback", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		const expected = [{ role: "user" as const, content: "continue" }];
+		const history = vi.fn(async () => expected);
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
+				history,
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => expected,
+				onOuterSessionCreated: async () => undefined,
+			},
+		});
+		hub.commandHook = (command) => {
+			if (command === "session.messages") throw new Error("live read failed");
+		};
+
+		await expect(
+			manager.verifyHandoffTranscript("ses-handoff", expected),
+		).rejects.toThrow("live read failed");
+		expect(history).not.toHaveBeenCalled();
+	});
+
+	it("identifies a runtime that ignored seeded initialMessages", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient(false);
+		hub.messages = [];
+		const expected = [{ role: "user" as const, content: "continue" }];
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.create({
+			modelId: "model",
+			repoUrl: "https://github.com/cline/test",
+			handoff: {
+				sourceSessionId: "local-1",
+				resolveMessages: async () => expected,
+				onOuterSessionCreated: async () => undefined,
+			},
+		});
+
+		await expect(
+			manager.verifyHandoffTranscript("ses-handoff", expected),
+		).rejects.toThrow("must use @cline/core 0.0.72 or newer");
 	});
 
 	it("updates the cloud model before sending and skips redundant updates", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -3,6 +3,7 @@ import type { HubEventEnvelope } from "@cline/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
 import {
+	CloudHandoffSeedUnsupportedError,
 	CloudSessionApi,
 	CloudSessionError,
 	CloudSessionManager,
@@ -269,6 +270,54 @@ class FakeHubClient {
 }
 
 describe("CloudSessionApi", () => {
+	it("never adopts a list-recovered session for a handoff without request identity", async () => {
+		const now = new Date().toISOString();
+		const onOuterSessionCreated = vi.fn();
+		const api = new CloudSessionApi({
+			apiBaseUrl: "https://api.example",
+			appBaseUrl: "https://app.example",
+			getAuthToken: async () => "workos:fresh",
+			fetch: async (_input, init) =>
+				init?.method === "POST"
+					? jsonResponse({ success: false, error: "gateway timeout" }, 500)
+					: jsonResponse({
+							success: true,
+							data: [
+								{
+									id: "ses-unproven",
+									status: "ready",
+									sandboxUrl: "https://pod.example",
+									repoContext: {
+										repoUrl: "https://github.com/cline/test",
+									},
+									metadata: { modelId: "model" },
+									createdAt: now,
+									updatedAt: now,
+								},
+							],
+						}),
+		});
+
+		const error = await api
+			.create({
+				modelId: "model",
+				repoUrl: "https://github.com/cline/test",
+				handoff: {
+					sourceSessionId: "local-1",
+					resolveMessages: async () => [],
+					onOuterSessionCreated,
+				},
+			})
+			.catch((caught) => caught);
+
+		expect(error).toMatchObject({
+			code: "request_failed",
+			connectUrl: "https://app.example/agents",
+		});
+		expect(String(error)).toContain("cannot prove it created it");
+		expect(onOuterSessionCreated).not.toHaveBeenCalled();
+	});
+
 	it("reports the outer id before returning and keeps handoff hooks off the wire", async () => {
 		let postedBody: Record<string, unknown> | undefined;
 		const order: string[] = [];
@@ -2243,9 +2292,11 @@ describe("CloudSessionManager", () => {
 			},
 		});
 
-		await expect(
-			manager.verifyHandoffTranscript("ses-handoff", expected),
-		).rejects.toThrow("must use @cline/core 0.0.72 or newer");
+		const error = await manager
+			.verifyHandoffTranscript("ses-handoff", expected)
+			.catch((caught) => caught);
+		expect(error).toBeInstanceOf(CloudHandoffSeedUnsupportedError);
+		expect(String(error)).toContain("must use @cline/core 0.0.72 or newer");
 	});
 
 	it("reuses only one inner session owned by the same handoff source", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -94,6 +94,44 @@ function createContext(): {
 	return { ctx, events };
 }
 
+describe("cloud handoff target existence", () => {
+	function createManager(status: () => Promise<unknown>): CloudSessionManager {
+		const { ctx } = createContext();
+		return new CloudSessionManager(ctx, {
+			api: { status } as never,
+			getAuthToken: async () => "token",
+			apiBaseUrl: "https://api.example.com",
+		});
+	}
+
+	it("reports an existing target without waiting for provisioning", async () => {
+		await expect(
+			createManager(async () => ({
+				status: "provisioning",
+			})).handoffTargetExists("ses-existing"),
+		).resolves.toBe(true);
+	});
+
+	it.each([
+		"session_not_found",
+		"session_expired",
+	] as const)("treats %s as authoritative absence", async (code) => {
+		await expect(
+			createManager(async () => {
+				throw new CloudSessionError(code, "gone");
+			}).handoffTargetExists("ses-gone"),
+		).resolves.toBe(false);
+	});
+
+	it("does not treat transient lookup failures as absence", async () => {
+		await expect(
+			createManager(async () => {
+				throw new CloudSessionError("request_failed", "unavailable");
+			}).handoffTargetExists("ses-unknown"),
+		).rejects.toMatchObject({ code: "request_failed" });
+	});
+});
+
 class FakeHubClient {
 	events?: (event: HubEventEnvelope) => void;
 	disposed = false;

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1745,7 +1745,7 @@ export class CloudSessionManager {
 	async send(
 		outerSessionId: string,
 		prompt: string,
-		delivery?: "queue" | "steer",
+		requestedDelivery?: "queue" | "steer",
 		modelId?: string,
 		userImages?: string[],
 	): Promise<{
@@ -1776,6 +1776,7 @@ export class CloudSessionManager {
 			await this.rehydrateAfterTransportDrop(outerSessionId, connection);
 		}
 		const live = this.ctx.liveSessions.get(outerSessionId);
+		const delivery = requestedDelivery ?? (live?.busy ? "queue" : undefined);
 		const promptOccurrencesBeforeSend = countPromptOccurrences(
 			live?.messages ?? [],
 			live?.promptsInQueue ?? [],

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -807,6 +807,7 @@ type CloudConnection = {
 	remote: CloudSessionRecord;
 	client: CloudHubClient;
 	innerSessionId?: string;
+	handoffSourceSessionId?: string;
 	rehydrationPromise?: Promise<CloudRehydrationSnapshot>;
 	rehydrationRerunRequested?: boolean;
 	bufferingEvents?: boolean;
@@ -979,6 +980,20 @@ function sessionRowModelId(record: JsonRecord | undefined): string {
 			? (record.metadata as JsonRecord)
 			: undefined;
 	return String(metadata?.model ?? record?.model ?? "").trim();
+}
+
+function sessionRowHandoffSourceSessionId(
+	record: JsonRecord | undefined,
+): string {
+	const metadata =
+		record?.metadata && typeof record.metadata === "object"
+			? (record.metadata as JsonRecord)
+			: undefined;
+	const handoff =
+		metadata?.handoff && typeof metadata.handoff === "object"
+			? (metadata.handoff as JsonRecord)
+			: undefined;
+	return String(handoff?.sourceSessionId ?? "").trim();
 }
 
 function parseApprovalInput(value: unknown): unknown {
@@ -2371,6 +2386,16 @@ export class CloudSessionManager {
 		}
 		const existing = this.connections.get(outerSessionId);
 		if (existing) {
+			if (
+				options.handoffSeed &&
+				existing.innerSessionId &&
+				existing.handoffSourceSessionId !== options.handoffSeed.sourceSessionId
+			) {
+				throw new CloudSessionError(
+					"request_failed",
+					"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+				);
+			}
 			if (options.createInner && !existing.innerSessionId) {
 				await this.createInnerSession(existing, options.handoffSeed);
 			}
@@ -2379,6 +2404,17 @@ export class CloudSessionManager {
 		const pending = this.connectionPromises.get(outerSessionId);
 		if (pending) {
 			const connection = await pending;
+			if (
+				options.handoffSeed &&
+				connection.innerSessionId &&
+				connection.handoffSourceSessionId !==
+					options.handoffSeed.sourceSessionId
+			) {
+				throw new CloudSessionError(
+					"request_failed",
+					"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+				);
+			}
 			if (options.createInner && !connection.innerSessionId) {
 				await this.createInnerSession(connection, options.handoffSeed);
 			}
@@ -2458,12 +2494,31 @@ export class CloudSessionManager {
 					throw new Error("Cloud session manager was disposed");
 				}
 				const listed = await client.command("session.list", { limit: 100 });
-				const newest = readSessionRows(listed.payload).sort(
-					(left, right) => updatedAt(right) - updatedAt(left),
-				)[0];
+				const rows = readSessionRows(listed.payload);
+				let newest: JsonRecord | undefined;
+				if (options.handoffSeed && rows.length > 0) {
+					const [only] = rows;
+					if (
+						rows.length !== 1 ||
+						sessionRowHandoffSourceSessionId(only) !==
+							options.handoffSeed.sourceSessionId
+					) {
+						throw new CloudSessionError(
+							"request_failed",
+							"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+						);
+					}
+					newest = only;
+				} else {
+					newest = rows.sort(
+						(left, right) => updatedAt(right) - updatedAt(left),
+					)[0];
+				}
 				const innerSessionId = String(newest?.sessionId ?? "").trim();
 				if (innerSessionId) {
 					connection.innerSessionId = innerSessionId;
+					connection.handoffSourceSessionId =
+						sessionRowHandoffSourceSessionId(newest) || undefined;
 					const modelId = sessionRowModelId(newest);
 					if (modelId) this.applyModel(connection, modelId);
 					await this.ensureAttached(connection);
@@ -2588,6 +2643,7 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub did not return an inner session id");
 		}
 		connection.innerSessionId = innerSessionId;
+		connection.handoffSourceSessionId = handoffSeed?.sourceSessionId;
 		// Seeded content is authoritative only after a strict session.messages
 		// read-back verifies that the pod persisted initialMessages.
 		connection.transcriptKnown = !handoffSeed;

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -6,6 +6,7 @@ import {
 	ClineAccountService,
 	CloudHandoffTranscriptMismatchError,
 	cloudHandoffTranscriptsEqual,
+	isHubCommandTimeoutError,
 	isHubReconnectableTransportError,
 	NodeHubClient,
 	ProviderSettingsManager,
@@ -81,8 +82,8 @@ export type CreateCloudSessionInput = {
 	autoApproveTools?: boolean;
 	thinking?: boolean;
 	reasoningEffort?: "low" | "medium" | "high" | "xhigh";
-	/** Omit for a personal session; otherwise scopes billing to this org. */
-	organizationId?: string;
+	/** Null selects personal scope; omit to use the currently active scope. */
+	organizationId?: string | null;
 	/** Desktop handoff-only hooks; never serialized into the provisioning API body. */
 	handoff?: {
 		sourceSessionId: string;
@@ -572,9 +573,10 @@ export class CloudSessionApi {
 					(await this.options.getAuthToken().catch(() => undefined))?.trim() ||
 					creationAuthToken;
 				const candidates = (
-					await this.listWithToken(input.organizationId, recoveryToken).catch(
-						() => [],
-					)
+					await this.listWithToken(
+						input.organizationId ?? undefined,
+						recoveryToken,
+					).catch(() => [])
 				)
 					.filter(
 						(session) =>
@@ -1492,7 +1494,9 @@ export class CloudSessionManager {
 
 	async create(input: CreateCloudSessionInput): Promise<JsonRecord> {
 		const key = [
-			input.organizationId?.trim() ?? "",
+			input.organizationId === null
+				? "personal"
+				: (input.organizationId?.trim() ?? "active"),
 			input.repoUrl,
 			input.branch?.trim() ?? "",
 			input.modelId,
@@ -1639,8 +1643,9 @@ export class CloudSessionManager {
 		input: CreateCloudSessionInput,
 	): Promise<JsonRecord> {
 		const organizationId =
-			input.organizationId ??
-			(await this.resolveActiveOrganizationId({ fresh: true }));
+			input.organizationId === undefined
+				? await this.resolveActiveOrganizationId({ fresh: true })
+				: (input.organizationId ?? undefined);
 		const created = await this.options.api.create({
 			...input,
 			organizationId,
@@ -1874,7 +1879,10 @@ export class CloudSessionManager {
 				result: reply.payload?.result,
 			};
 		} catch (error) {
-			if (isHubReconnectableTransportError(error)) {
+			if (
+				isHubReconnectableTransportError(error) ||
+				isHubCommandTimeoutError(error, "session.send_input")
+			) {
 				let snapshot: CloudRehydrationSnapshot;
 				try {
 					snapshot = await this.rehydrateAfterTransportDrop(

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -138,6 +138,15 @@ export class CloudSessionError extends Error {
 	}
 }
 
+export class CloudHandoffSeedUnsupportedError extends Error {
+	constructor() {
+		super(
+			"The cloud session was created, but its transcript was not persisted. This cloud runtime cannot durably seed handoff transcripts and must use @cline/core 0.0.72 or newer. Updating the cloud runtime or pod is required; retrying /handoff against this same pod will not help.",
+		);
+		this.name = "CloudHandoffSeedUnsupportedError";
+	}
+}
+
 type ApiResponse<T> = {
 	success?: boolean;
 	data?: T;
@@ -585,6 +594,16 @@ export class CloudSessionApi {
 					([peerSequence]) => !awaited.has(peerSequence),
 				);
 				await Promise.allSettled(latePeers.map(([, settled]) => settled));
+				const unclaimedCandidates = candidates.filter(
+					(candidate) => !this.claimedSessionIds.has(candidate.id),
+				);
+				if (input.handoff && unclaimedCandidates.length > 0) {
+					throw new CloudSessionError(
+						"request_failed",
+						"Cloud session creation had an ambiguous result. Check Cline Cloud for the new workspace before retrying; it was not adopted because this client cannot prove it created it.",
+						new URL("/agents", this.appBaseUrl).toString(),
+					);
+				}
 				const recovered = this.claimOnlyUnclaimed(candidates);
 				if (recovered) {
 					await this.persistHandoffOuterSession(
@@ -1533,9 +1552,7 @@ export class CloudSessionManager {
 			throw new Error("Cloud runtime returned no transcript after seeding.");
 		}
 		if (expected.length > 0 && actual.length === 0) {
-			throw new Error(
-				"The cloud session was created, but its transcript was not persisted. This cloud runtime cannot durably seed handoff transcripts and must use @cline/core 0.0.72 or newer. Updating the cloud runtime or pod is required; retrying /handoff against this same pod will not help.",
-			);
+			throw new CloudHandoffSeedUnsupportedError();
 		}
 		if (!cloudHandoffTranscriptsEqual(expected, actual)) {
 			throw new CloudHandoffTranscriptMismatchError(

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import {
+	buildCloudHandoffDashboardUrl,
+	buildCloudHandoffSystemPrompt,
+	CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
 	ClineAccountService,
+	CloudHandoffTranscriptMismatchError,
+	cloudHandoffTranscriptsEqual,
 	isHubReconnectableTransportError,
 	NodeHubClient,
 	ProviderSettingsManager,
@@ -41,12 +46,6 @@ const REQUEST_TIMEOUT_MS = 15_000;
 const CLOUD_ERROR_PREFIX = "CLOUD_SESSION_ERROR:";
 const MAX_BUFFERED_SYNC_EVENTS = 2_000;
 const MAX_SEEN_EVENT_IDS = 2_000;
-const GITHUB_AUTH_SYSTEM_PROMPT =
-	"IMPORTANT: GitHub API authentication is handled automatically by the infrastructure. " +
-	"A secrets-proxy sidecar injects the necessary authentication credentials into all GitHub API requests. " +
-	"You do NOT need to set up, configure, or manage any authentication tokens, API keys, or credentials for GitHub API calls. " +
-	"Simply make your GitHub API calls normally — authentication will be injected transparently.";
-
 type FetchLike = (
 	input: string | URL | Request,
 	init?: RequestInit,
@@ -83,6 +82,19 @@ export type CreateCloudSessionInput = {
 	reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 	/** Omit for a personal session; otherwise scopes billing to this org. */
 	organizationId?: string;
+	/** Desktop handoff-only hooks; never serialized into the provisioning API body. */
+	handoff?: {
+		sourceSessionId: string;
+		resolveMessages: () => Promise<MessageWithMetadata[]>;
+		onOuterSessionCreated: (sessionId: string) => Promise<void>;
+		onSeeding?: () => void;
+	};
+};
+
+type CloudHandoffSeed = {
+	sourceSessionId: string;
+	messages: MessageWithMetadata[];
+	onSeeding?: () => void;
 };
 
 // The repository/branch wire contract is owned by the webview lib so the two
@@ -495,6 +507,11 @@ export class CloudSessionApi {
 			this.claimedSessionIds.add(sessionId);
 			createdSessionId = sessionId;
 			settlePost();
+			await this.persistHandoffOuterSession(
+				input,
+				sessionId,
+				creationAuthToken,
+			);
 			if (created.status === "provisioning" || !created.sandboxUrl?.trim()) {
 				await this.waitUntilReady(sessionId, controller.signal);
 			}
@@ -561,6 +578,11 @@ export class CloudSessionApi {
 				await Promise.allSettled(latePeers.map(([, settled]) => settled));
 				const recovered = this.claimFirstUnclaimed(candidates);
 				if (recovered) {
+					await this.persistHandoffOuterSession(
+						input,
+						recovered.id,
+						creationAuthToken,
+					);
 					if (
 						recovered.status === "provisioning" ||
 						!recovered.sandboxUrl?.trim()
@@ -658,6 +680,41 @@ export class CloudSessionApi {
 			return candidate;
 		}
 		return undefined;
+	}
+
+	private async persistHandoffOuterSession(
+		input: CreateCloudSessionInput,
+		sessionId: string,
+		authToken: string,
+	): Promise<void> {
+		const persist = input.handoff?.onOuterSessionCreated;
+		if (!persist) return;
+		try {
+			await persist(sessionId);
+		} catch (persistenceError) {
+			try {
+				await this.delete(sessionId, authToken);
+			} catch (cleanupError) {
+				if (
+					!(
+						cleanupError instanceof CloudSessionError &&
+						(cleanupError.code === "session_not_found" ||
+							cleanupError.code === "session_expired")
+					)
+				) {
+					const dashboardUrl = buildCloudHandoffDashboardUrl(
+						this.appBaseUrl,
+						sessionId,
+					);
+					throw new AggregateError(
+						[persistenceError, cleanupError],
+						`The cloud session was created, but its local recovery record could not be saved or cleaned up. Cloud session ${sessionId}: ${dashboardUrl}`,
+					);
+				}
+			}
+			this.claimedSessionIds.delete(sessionId);
+			throw persistenceError;
+		}
 	}
 
 	async delete(sessionId: string, authToken?: string): Promise<void> {
@@ -1236,6 +1293,39 @@ export class CloudSessionManager {
 		);
 	}
 
+	/** Validates account auth and GitHub access before provisioning a handoff. */
+	async prepareHandoffRepository(repoUrl: string): Promise<{
+		organizationId?: string;
+	}> {
+		const organizationId = await this.resolveActiveOrganizationId();
+		const listed = await this.options.api.listRepositories(organizationId);
+		if (!listed.connected) {
+			throw new CloudSessionError(
+				"github_not_connected",
+				"Connect GitHub before handing this session off to cloud.",
+				listed.connectUrl,
+			);
+		}
+		const normalize = (value: string) =>
+			value
+				.trim()
+				.replace(/\.git$/i, "")
+				.replace(/\/+$/, "")
+				.toLowerCase();
+		if (
+			!listed.repositories.some(
+				(repository) => normalize(repository.url) === normalize(repoUrl),
+			)
+		) {
+			throw new CloudSessionError(
+				"github_not_connected",
+				`The GitHub integration cannot access ${cloudRepositoryLabel(repoUrl, repoUrl)}. Grant repository access before handing off.`,
+				listed.connectUrl,
+			);
+		}
+		return organizationId ? { organizationId } : {};
+	}
+
 	async listBranches(
 		repositoryId: number,
 		options: CloudBranchListOptions = {},
@@ -1332,6 +1422,7 @@ export class CloudSessionManager {
 			String(input.thinking ?? ""),
 			input.reasoningEffort ?? "",
 			String(input.autoApproveTools ?? ""),
+			input.handoff?.sourceSessionId ?? "",
 		].join("\u0000");
 		const existing = this.createRequests.get(key);
 		if (existing) return await existing;
@@ -1342,6 +1433,34 @@ export class CloudSessionManager {
 		});
 		this.createRequests.set(key, creating);
 		return await creating;
+	}
+
+	/** Seeds an already-provisioned outer session when retrying a pending handoff. */
+	async seedHandoff(
+		outerSessionId: string,
+		seed: CloudHandoffSeed,
+	): Promise<{ innerSessionId: string }> {
+		const connection = await this.ensureConnection(outerSessionId, {
+			createInner: true,
+			handoffSeed: seed,
+		});
+		if (!connection.innerSessionId) {
+			throw new Error("Cloud Hub did not return an inner session id");
+		}
+		return { innerSessionId: connection.innerSessionId };
+	}
+
+	async verifyHandoffTranscript(
+		outerSessionId: string,
+		expected: readonly MessageWithMetadata[],
+	): Promise<void> {
+		const actual = await this.readMessages(outerSessionId);
+		if (!cloudHandoffTranscriptsEqual(expected, actual)) {
+			throw new CloudHandoffTranscriptMismatchError(
+				expected.length,
+				actual.length,
+			);
+		}
 	}
 
 	private async createOnce(
@@ -1467,10 +1586,22 @@ export class CloudSessionManager {
 			live.config.reasoningEffort = input.reasoningEffort;
 		}
 		this.ctx.liveSessions.set(record.id, live);
-		// Provisioning succeeded; a transient Hub connect must not report create failure.
+		const handoffSeed = input.handoff
+			? {
+					sourceSessionId: input.handoff.sourceSessionId,
+					messages: await input.handoff.resolveMessages(),
+					onSeeding: input.handoff.onSeeding,
+				}
+			: undefined;
+		// A handoff must seed durably before it can report success. Ordinary cloud
+		// creation keeps its existing best-effort initial-connect behavior.
 		try {
-			await this.ensureConnection(record.id, { createInner: true });
+			await this.ensureConnection(record.id, {
+				createInner: true,
+				handoffSeed,
+			});
 		} catch (error) {
+			if (handoffSeed) throw error;
 			this.ctx.logger?.log(
 				"Cloud session provisioned but initial connect failed; will connect on demand",
 				{ sessionId: record.id, error },
@@ -1497,6 +1628,9 @@ export class CloudSessionManager {
 			cwd: CLOUD_WORKSPACE_ROOT,
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			...(live.prompt ? { prompt: live.prompt } : {}),
+			...(this.connections.get(record.id)?.innerSessionId
+				? { innerSessionId: this.connections.get(record.id)?.innerSessionId }
+				: {}),
 		};
 	}
 
@@ -2181,7 +2315,7 @@ export class CloudSessionManager {
 
 	private async ensureConnection(
 		outerSessionId: string,
-		options: { createInner?: boolean } = {},
+		options: { createInner?: boolean; handoffSeed?: CloudHandoffSeed } = {},
 	): Promise<CloudConnection> {
 		if (this.disposed) {
 			throw new Error("Cloud session manager was disposed");
@@ -2195,7 +2329,7 @@ export class CloudSessionManager {
 		const existing = this.connections.get(outerSessionId);
 		if (existing) {
 			if (options.createInner && !existing.innerSessionId) {
-				await this.createInnerSession(existing);
+				await this.createInnerSession(existing, options.handoffSeed);
 			}
 			return existing;
 		}
@@ -2203,7 +2337,7 @@ export class CloudSessionManager {
 		if (pending) {
 			const connection = await pending;
 			if (options.createInner && !connection.innerSessionId) {
-				await this.createInnerSession(connection);
+				await this.createInnerSession(connection, options.handoffSeed);
 			}
 			return connection;
 		}
@@ -2296,7 +2430,7 @@ export class CloudSessionManager {
 				}
 				this.connections.set(outerSessionId, connection);
 				if (options.createInner && !connection.innerSessionId) {
-					await this.createInnerSession(connection);
+					await this.createInnerSession(connection, options.handoffSeed);
 				}
 				return connection;
 			} catch (error) {
@@ -2322,14 +2456,20 @@ export class CloudSessionManager {
 		return await connecting;
 	}
 
-	private async createInnerSession(connection: CloudConnection): Promise<void> {
+	private async createInnerSession(
+		connection: CloudConnection,
+		handoffSeed?: CloudHandoffSeed,
+	): Promise<void> {
 		if (connection.innerSessionId) {
 			return;
 		}
 		if (connection.innerSessionCreation) {
 			return await connection.innerSessionCreation;
 		}
-		const creation = this.createInnerSessionOnce(connection).finally(() => {
+		const creation = this.createInnerSessionOnce(
+			connection,
+			handoffSeed,
+		).finally(() => {
 			connection.innerSessionCreation = undefined;
 		});
 		connection.innerSessionCreation = creation;
@@ -2338,21 +2478,32 @@ export class CloudSessionManager {
 
 	private async createInnerSessionOnce(
 		connection: CloudConnection,
+		handoffSeed?: CloudHandoffSeed,
 	): Promise<void> {
 		const modelId = connection.remote.metadata.modelId?.trim();
 		if (!modelId) {
 			throw new Error("Cloud session is missing its model id");
 		}
 		const live = this.ctx.liveSessions.get(connection.remote.id);
+		handoffSeed?.onSeeding?.();
 		const reply = await connection.client.command("session.create", {
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			cwd: CLOUD_WORKSPACE_ROOT,
+			...(handoffSeed ? { initialMessages: handoffSeed.messages } : {}),
 			sessionConfig: {
 				providerId: "cline",
 				modelId,
 				workspaceRoot: CLOUD_WORKSPACE_ROOT,
 				cwd: CLOUD_WORKSPACE_ROOT,
-				systemPrompt: GITHUB_AUTH_SYSTEM_PROMPT,
+				systemPrompt: handoffSeed
+					? buildCloudHandoffSystemPrompt({
+							repoUrl:
+								connection.remote.repoContext.repoUrl ?? "the repository",
+							branch:
+								connection.remote.repoContext.branch ?? "the selected branch",
+							workspaceRoot: CLOUD_WORKSPACE_ROOT,
+						})
+					: CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
 				mode: "act",
 				enableTools: true,
 				...(typeof live?.config.thinking === "boolean"
@@ -2367,6 +2518,15 @@ export class CloudSessionManager {
 				provider: "cline",
 				model: modelId,
 				interactive: true,
+				...(handoffSeed
+					? {
+							handoff: {
+								from: "local",
+								sourceSessionId: handoffSeed.sourceSessionId,
+								outerSessionId: connection.remote.id,
+							},
+						}
+					: {}),
 			},
 			runtimeOptions: { mode: "act" },
 			modelSelection: { provider: "cline", model: modelId },

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -202,6 +202,14 @@ function cloudErrorForResponse(
 				`${trimTrailingSlash(appBaseUrl)}/dashboard/integrations`,
 		);
 	}
+	if (status === 403 && message.trim().toLowerCase() === "forbidden") {
+		return new CloudSessionError(
+			"request_failed",
+			"Your active account or organization cannot create cloud sessions. Switch to Personal or another organization in Settings → Account, then try again.",
+			undefined,
+			status,
+		);
+	}
 	return new CloudSessionError("request_failed", message, undefined, status);
 }
 

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1318,6 +1318,27 @@ export class CloudSessionManager {
 		return scoped;
 	}
 
+	/**
+	 * Checks whether an exact handoff target still exists without waiting for
+	 * provisioning. Only an authoritative gone response is treated as absent;
+	 * auth, network, and server failures remain errors so callers preserve the
+	 * local recovery record.
+	 */
+	async handoffTargetExists(sessionId: string): Promise<boolean> {
+		try {
+			await this.options.api.status(sessionId);
+			return true;
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
 	private async resolveActiveOrganizationId(options?: {
 		fresh?: boolean;
 	}): Promise<string | undefined> {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1556,7 +1556,7 @@ export class CloudSessionManager {
 	async send(
 		outerSessionId: string,
 		prompt: string,
-		delivery?: "queue" | "steer",
+		requestedDelivery?: "queue" | "steer",
 		modelId?: string,
 		userImages?: string[],
 	): Promise<{
@@ -1587,6 +1587,7 @@ export class CloudSessionManager {
 			await this.rehydrateAfterTransportDrop(outerSessionId, connection);
 		}
 		const live = this.ctx.liveSessions.get(outerSessionId);
+		const delivery = requestedDelivery ?? (live?.busy ? "queue" : undefined);
 		const promptOccurrencesBeforeSend = countPromptOccurrences(
 			live?.messages ?? [],
 			live?.promptsInQueue ?? [],

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { posix } from "node:path";
 import {
 	buildCloudHandoffDashboardUrl,
 	buildCloudHandoffSystemPrompt,
@@ -12,6 +13,7 @@ import {
 	ProviderSettingsManager,
 } from "@cline/core";
 import {
+	type AgentMode,
 	getClineEnvironmentConfig,
 	type HubEventEnvelope,
 	type MessageWithMetadata,
@@ -82,6 +84,10 @@ export type CreateCloudSessionInput = {
 	autoApproveTools?: boolean;
 	thinking?: boolean;
 	reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+	/** Handoff-only source mode; ordinary cloud creation defaults to Act. */
+	mode?: AgentMode;
+	/** Handoff-only source cwd relative to the repository root. */
+	workspaceRelativePath?: string;
 	/** Null selects personal scope; omit to use the currently active scope. */
 	organizationId?: string | null;
 	/** Desktop handoff-only hooks; never serialized into the provisioning API body. */
@@ -96,8 +102,16 @@ export type CreateCloudSessionInput = {
 type CloudHandoffSeed = {
 	sourceSessionId: string;
 	messages: MessageWithMetadata[];
+	mode?: AgentMode;
+	workspaceRelativePath?: string;
 	onSeeding?: () => void;
 };
+
+function cloudWorkspaceCwd(workspaceRelativePath?: string): string {
+	return workspaceRelativePath
+		? posix.join(CLOUD_WORKSPACE_ROOT, workspaceRelativePath)
+		: CLOUD_WORKSPACE_ROOT;
+}
 
 // The repository/branch wire contract is owned by the webview lib so the two
 // sides of the desktop client cannot silently drift; re-exported here for
@@ -127,16 +141,26 @@ type CloudErrorCode =
 export class CloudSessionError extends Error {
 	constructor(
 		readonly code: CloudErrorCode,
-		message: string,
+		readonly detail: string,
 		readonly connectUrl?: string,
 		/** HTTP status of the failed request, when one was received. */
 		readonly status?: number,
 	) {
 		super(
-			`${CLOUD_ERROR_PREFIX}${JSON.stringify({ code, message, connectUrl })}`,
+			`${CLOUD_ERROR_PREFIX}${JSON.stringify({ code, message: detail, connectUrl })}`,
 		);
 		this.name = "CloudSessionError";
 	}
+}
+
+function isTransientGitHubTokenVendFailure(error: unknown): boolean {
+	if (!(error instanceof CloudSessionError) || error.status !== 502)
+		return false;
+	const detail = error.detail.toLowerCase();
+	return (
+		detail.includes("couldn't authenticate with github") &&
+		detail.includes("reconnecting the integration")
+	);
 }
 
 export class CloudHandoffSeedUnsupportedError extends Error {
@@ -869,6 +893,8 @@ type CloudSessionManagerOptions = {
 	createHubClient?: (
 		options: ConstructorParameters<typeof NodeHubClient>[0],
 	) => CloudHubClient;
+	/** Test seam for the narrow GitHub token-vending retry. */
+	sleep?: (ms: number) => Promise<void>;
 };
 
 /** Recognizes server ids even before the in-memory cloud registry is warm. */
@@ -1279,6 +1305,31 @@ export class CloudSessionManager {
 		return record ? cloudSessionToDiscoveryRecord(record) : undefined;
 	}
 
+	/** Revalidates a cached row by id when the active-scope list does not include it. */
+	async getCrossScopeDiscoveryRecord(
+		sessionId: string,
+	): Promise<JsonRecord | undefined> {
+		const cached = this.getCachedDiscoveryRecord(sessionId);
+		if (!cached || typeof this.options.api.status !== "function") {
+			return undefined;
+		}
+		try {
+			const status = await this.options.api.status(sessionId);
+			const value = status.status?.trim();
+			return value ? { ...cached, status: value } : cached;
+		} catch (error) {
+			if (
+				error instanceof CloudSessionError &&
+				(error.code === "session_not_found" || error.code === "session_expired")
+			) {
+				this.knownSessions.delete(sessionId);
+				return undefined;
+			}
+			// A scope/auth/network failure cannot prove the cached session is gone.
+			return cached;
+		}
+	}
+
 	getProvisioningOutcome(
 		placeholderId: string,
 	): CloudProvisioningOutcome | null {
@@ -1503,6 +1554,8 @@ export class CloudSessionManager {
 			String(input.thinking ?? ""),
 			input.reasoningEffort ?? "",
 			String(input.autoApproveTools ?? ""),
+			input.mode ?? "act",
+			input.workspaceRelativePath ?? "",
 			input.handoff?.sourceSessionId ?? "",
 		].join("\u0000");
 		const existing = this.createRequests.get(key);
@@ -1585,7 +1638,7 @@ export class CloudSessionManager {
 			model: input.modelId,
 			repoUrl: input.repoUrl,
 			branch: input.branch ?? "",
-			cwd: CLOUD_WORKSPACE_ROOT,
+			cwd: cloudWorkspaceCwd(input.workspaceRelativePath),
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			...(input.initialPrompt?.trim()
 				? { prompt: input.initialPrompt.trim() }
@@ -1646,10 +1699,25 @@ export class CloudSessionManager {
 			input.organizationId === undefined
 				? await this.resolveActiveOrganizationId({ fresh: true })
 				: (input.organizationId ?? undefined);
-		const created = await this.options.api.create({
-			...input,
-			organizationId,
-		});
+		let created: Awaited<ReturnType<CloudSessionApi["create"]>> | undefined;
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			try {
+				created = await this.options.api.create({
+					...input,
+					organizationId,
+				});
+				break;
+			} catch (error) {
+				if (!isTransientGitHubTokenVendFailure(error) || attempt === 2) {
+					throw error;
+				}
+				await (
+					this.options.sleep ??
+					((ms: number) =>
+						new Promise<void>((resolve) => setTimeout(resolve, ms)))
+				)(500 * (attempt + 1));
+			}
+		}
 		if (!created?.sessionId?.trim()) {
 			throw new CloudSessionError(
 				"request_failed",
@@ -1695,6 +1763,8 @@ export class CloudSessionManager {
 			? {
 					sourceSessionId: input.handoff.sourceSessionId,
 					messages: await input.handoff.resolveMessages(),
+					mode: input.mode ?? "act",
+					workspaceRelativePath: input.workspaceRelativePath,
 					onSeeding: input.handoff.onSeeding,
 				}
 			: undefined;
@@ -1730,7 +1800,7 @@ export class CloudSessionManager {
 			model: input.modelId,
 			repoUrl: input.repoUrl,
 			branch: input.branch ?? "",
-			cwd: CLOUD_WORKSPACE_ROOT,
+			cwd: cloudWorkspaceCwd(input.workspaceRelativePath),
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			...(live.prompt ? { prompt: live.prompt } : {}),
 			...(this.connections.get(record.id)?.innerSessionId
@@ -2646,26 +2716,28 @@ export class CloudSessionManager {
 			throw new Error("Cloud session is missing its model id");
 		}
 		const live = this.ctx.liveSessions.get(connection.remote.id);
+		const cwd = cloudWorkspaceCwd(handoffSeed?.workspaceRelativePath);
+		const mode = handoffSeed?.mode ?? "act";
 		handoffSeed?.onSeeding?.();
 		const reply = await connection.client.command("session.create", {
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
-			cwd: CLOUD_WORKSPACE_ROOT,
+			cwd,
 			...(handoffSeed ? { initialMessages: handoffSeed.messages } : {}),
 			sessionConfig: {
 				providerId: "cline",
 				modelId,
 				workspaceRoot: CLOUD_WORKSPACE_ROOT,
-				cwd: CLOUD_WORKSPACE_ROOT,
+				cwd,
 				systemPrompt: handoffSeed
-					? buildCloudHandoffSystemPrompt({
+					? `${buildCloudHandoffSystemPrompt({
 							repoUrl:
 								connection.remote.repoContext.repoUrl ?? "the repository",
 							branch:
 								connection.remote.repoContext.branch ?? "the selected branch",
 							workspaceRoot: CLOUD_WORKSPACE_ROOT,
-						})
+						})}${cwd === CLOUD_WORKSPACE_ROOT ? "" : `\n\nContinue from the original repository subdirectory at ${cwd}.`}`
 					: CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
-				mode: "act",
+				mode,
 				enableTools: true,
 				...(typeof live?.config.thinking === "boolean"
 					? { thinking: live.config.thinking }
@@ -2689,7 +2761,7 @@ export class CloudSessionManager {
 						}
 					: {}),
 			},
-			runtimeOptions: { mode: "act" },
+			runtimeOptions: { mode },
 			modelSelection: { provider: "cline", model: modelId },
 			toolPolicies: {
 				"*": { autoApprove: live?.config.autoApproveTools !== false },

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -807,7 +807,6 @@ type CloudConnection = {
 	remote: CloudSessionRecord;
 	client: CloudHubClient;
 	innerSessionId?: string;
-	handoffSourceSessionId?: string;
 	rehydrationPromise?: Promise<CloudRehydrationSnapshot>;
 	rehydrationRerunRequested?: boolean;
 	bufferingEvents?: boolean;
@@ -2386,14 +2385,10 @@ export class CloudSessionManager {
 		}
 		const existing = this.connections.get(outerSessionId);
 		if (existing) {
-			if (
-				options.handoffSeed &&
-				existing.innerSessionId &&
-				existing.handoffSourceSessionId !== options.handoffSeed.sourceSessionId
-			) {
-				throw new CloudSessionError(
-					"request_failed",
-					"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+			if (options.handoffSeed && existing.innerSessionId) {
+				await this.assertHandoffConnectionReusable(
+					existing,
+					options.handoffSeed,
 				);
 			}
 			if (options.createInner && !existing.innerSessionId) {
@@ -2404,15 +2399,10 @@ export class CloudSessionManager {
 		const pending = this.connectionPromises.get(outerSessionId);
 		if (pending) {
 			const connection = await pending;
-			if (
-				options.handoffSeed &&
-				connection.innerSessionId &&
-				connection.handoffSourceSessionId !==
-					options.handoffSeed.sourceSessionId
-			) {
-				throw new CloudSessionError(
-					"request_failed",
-					"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+			if (options.handoffSeed && connection.innerSessionId) {
+				await this.assertHandoffConnectionReusable(
+					connection,
+					options.handoffSeed,
 				);
 			}
 			if (options.createInner && !connection.innerSessionId) {
@@ -2517,8 +2507,6 @@ export class CloudSessionManager {
 				const innerSessionId = String(newest?.sessionId ?? "").trim();
 				if (innerSessionId) {
 					connection.innerSessionId = innerSessionId;
-					connection.handoffSourceSessionId =
-						sessionRowHandoffSourceSessionId(newest) || undefined;
 					const modelId = sessionRowModelId(newest);
 					if (modelId) this.applyModel(connection, modelId);
 					await this.ensureAttached(connection);
@@ -2552,6 +2540,27 @@ export class CloudSessionManager {
 		});
 		this.connectionPromises.set(outerSessionId, connecting);
 		return await connecting;
+	}
+
+	private async assertHandoffConnectionReusable(
+		connection: CloudConnection,
+		handoffSeed: CloudHandoffSeed,
+	): Promise<void> {
+		const listed = await connection.client.command("session.list", {
+			limit: 100,
+		});
+		const rows = readSessionRows(listed.payload);
+		const [only] = rows;
+		if (
+			rows.length !== 1 ||
+			String(only?.sessionId ?? "").trim() !== connection.innerSessionId ||
+			sessionRowHandoffSourceSessionId(only) !== handoffSeed.sourceSessionId
+		) {
+			throw new CloudSessionError(
+				"request_failed",
+				"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+			);
+		}
 	}
 
 	private async createInnerSession(
@@ -2643,7 +2652,6 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub did not return an inner session id");
 		}
 		connection.innerSessionId = innerSessionId;
-		connection.handoffSourceSessionId = handoffSeed?.sourceSessionId;
 		// Seeded content is authoritative only after a strict session.messages
 		// read-back verifies that the pod persisted initialMessages.
 		connection.transcriptKnown = !handoffSeed;

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import {
+	buildCloudHandoffDashboardUrl,
+	buildCloudHandoffSystemPrompt,
+	CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
 	ClineAccountService,
+	CloudHandoffTranscriptMismatchError,
+	cloudHandoffTranscriptsEqual,
 	isHubReconnectableTransportError,
 	NodeHubClient,
 	ProviderSettingsManager,
@@ -36,17 +41,12 @@ import type {
 const CLOUD_WORKSPACE_ROOT = "/workspace";
 const CREATE_TIMEOUT_MS = 610_000;
 const PROVISIONING_POLL_MS = 3_000;
+const QUEUE_COMMAND_TIMEOUT_MS = 30_000;
 // Bound hot-path REST calls so a dead network cannot hang the sidebar.
 const REQUEST_TIMEOUT_MS = 15_000;
 const CLOUD_ERROR_PREFIX = "CLOUD_SESSION_ERROR:";
 const MAX_BUFFERED_SYNC_EVENTS = 2_000;
 const MAX_SEEN_EVENT_IDS = 2_000;
-const GITHUB_AUTH_SYSTEM_PROMPT =
-	"IMPORTANT: GitHub API authentication is handled automatically by the infrastructure. " +
-	"A secrets-proxy sidecar injects the necessary authentication credentials into all GitHub API requests. " +
-	"You do NOT need to set up, configure, or manage any authentication tokens, API keys, or credentials for GitHub API calls. " +
-	"Simply make your GitHub API calls normally — authentication will be injected transparently.";
-
 type FetchLike = (
 	input: string | URL | Request,
 	init?: RequestInit,
@@ -83,6 +83,19 @@ export type CreateCloudSessionInput = {
 	reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 	/** Omit for a personal session; otherwise scopes billing to this org. */
 	organizationId?: string;
+	/** Desktop handoff-only hooks; never serialized into the provisioning API body. */
+	handoff?: {
+		sourceSessionId: string;
+		resolveMessages: () => Promise<MessageWithMetadata[]>;
+		onOuterSessionCreated: (sessionId: string) => Promise<void>;
+		onSeeding?: () => void;
+	};
+};
+
+type CloudHandoffSeed = {
+	sourceSessionId: string;
+	messages: MessageWithMetadata[];
+	onSeeding?: () => void;
 };
 
 // The repository/branch wire contract is owned by the webview lib so the two
@@ -188,6 +201,14 @@ function cloudErrorForResponse(
 			message,
 			githubConnectUrl ??
 				`${trimTrailingSlash(appBaseUrl)}/dashboard/integrations`,
+		);
+	}
+	if (status === 403 && message.trim().toLowerCase() === "forbidden") {
+		return new CloudSessionError(
+			"request_failed",
+			"Your active account or organization cannot create cloud sessions. Switch to Personal or another organization in Settings → Account, then try again.",
+			undefined,
+			status,
 		);
 	}
 	return new CloudSessionError("request_failed", message, undefined, status);
@@ -495,6 +516,11 @@ export class CloudSessionApi {
 			this.claimedSessionIds.add(sessionId);
 			createdSessionId = sessionId;
 			settlePost();
+			await this.persistHandoffOuterSession(
+				input,
+				sessionId,
+				creationAuthToken,
+			);
 			if (created.status === "provisioning" || !created.sandboxUrl?.trim()) {
 				await this.waitUntilReady(sessionId, controller.signal);
 			}
@@ -559,8 +585,13 @@ export class CloudSessionApi {
 					([peerSequence]) => !awaited.has(peerSequence),
 				);
 				await Promise.allSettled(latePeers.map(([, settled]) => settled));
-				const recovered = this.claimFirstUnclaimed(candidates);
+				const recovered = this.claimOnlyUnclaimed(candidates);
 				if (recovered) {
+					await this.persistHandoffOuterSession(
+						input,
+						recovered.id,
+						creationAuthToken,
+					);
 					if (
 						recovered.status === "provisioning" ||
 						!recovered.sandboxUrl?.trim()
@@ -597,9 +628,9 @@ export class CloudSessionApi {
 		}
 	}
 
-	private async waitUntilReady(
+	async waitUntilReady(
 		sessionId: string,
-		signal: AbortSignal,
+		signal: AbortSignal = AbortSignal.timeout(CREATE_TIMEOUT_MS),
 	): Promise<void> {
 		while (!signal.aborted) {
 			let result:
@@ -649,15 +680,56 @@ export class CloudSessionApi {
 	 * that atomicity (per event-loop continuation) is what guarantees two
 	 * concurrent recoveries can never adopt the same session record.
 	 */
-	private claimFirstUnclaimed(
+	private claimOnlyUnclaimed(
 		candidates: CloudSessionRecord[],
 	): CloudSessionRecord | undefined {
-		for (const candidate of candidates) {
-			if (this.claimedSessionIds.has(candidate.id)) continue;
-			this.claimedSessionIds.add(candidate.id);
-			return candidate;
+		const unclaimed = candidates.filter(
+			(candidate) => !this.claimedSessionIds.has(candidate.id),
+		);
+		if (unclaimed.length > 1) {
+			throw new CloudSessionError(
+				"request_failed",
+				"Cloud session creation had an ambiguous result. Check your cloud session list before trying again.",
+			);
 		}
-		return undefined;
+		const candidate = unclaimed[0];
+		if (candidate) this.claimedSessionIds.add(candidate.id);
+		return candidate;
+	}
+
+	private async persistHandoffOuterSession(
+		input: CreateCloudSessionInput,
+		sessionId: string,
+		authToken: string,
+	): Promise<void> {
+		const persist = input.handoff?.onOuterSessionCreated;
+		if (!persist) return;
+		try {
+			await persist(sessionId);
+		} catch (persistenceError) {
+			try {
+				await this.delete(sessionId, authToken);
+			} catch (cleanupError) {
+				if (
+					!(
+						cleanupError instanceof CloudSessionError &&
+						(cleanupError.code === "session_not_found" ||
+							cleanupError.code === "session_expired")
+					)
+				) {
+					const dashboardUrl = buildCloudHandoffDashboardUrl(
+						this.appBaseUrl,
+						sessionId,
+					);
+					throw new AggregateError(
+						[persistenceError, cleanupError],
+						`The cloud session was created, but its local recovery record could not be saved or cleaned up. Cloud session ${sessionId}: ${dashboardUrl}`,
+					);
+				}
+			}
+			this.claimedSessionIds.delete(sessionId);
+			throw persistenceError;
+		}
 	}
 
 	async delete(sessionId: string, authToken?: string): Promise<void> {
@@ -761,6 +833,7 @@ type CloudSessionManagerOptions = {
 		| "delete"
 		| "list"
 		| "status"
+		| "waitUntilReady"
 		| "history"
 		| "updateTitle"
 		| "listRepositories"
@@ -906,6 +979,20 @@ function sessionRowModelId(record: JsonRecord | undefined): string {
 			? (record.metadata as JsonRecord)
 			: undefined;
 	return String(metadata?.model ?? record?.model ?? "").trim();
+}
+
+function sessionRowHandoffSourceSessionId(
+	record: JsonRecord | undefined,
+): string {
+	const metadata =
+		record?.metadata && typeof record.metadata === "object"
+			? (record.metadata as JsonRecord)
+			: undefined;
+	const handoff =
+		metadata?.handoff && typeof metadata.handoff === "object"
+			? (metadata.handoff as JsonRecord)
+			: undefined;
+	return String(handoff?.sourceSessionId ?? "").trim();
 }
 
 function parseApprovalInput(value: unknown): unknown {
@@ -1236,6 +1323,39 @@ export class CloudSessionManager {
 		);
 	}
 
+	/** Validates account auth and GitHub access before provisioning a handoff. */
+	async prepareHandoffRepository(repoUrl: string): Promise<{
+		organizationId?: string;
+	}> {
+		const organizationId = await this.resolveActiveOrganizationId();
+		const listed = await this.options.api.listRepositories(organizationId);
+		if (!listed.connected) {
+			throw new CloudSessionError(
+				"github_not_connected",
+				"Connect GitHub before handing this session off to cloud.",
+				listed.connectUrl,
+			);
+		}
+		const normalize = (value: string) =>
+			value
+				.trim()
+				.replace(/\.git$/i, "")
+				.replace(/\/+$/, "")
+				.toLowerCase();
+		if (
+			!listed.repositories.some(
+				(repository) => normalize(repository.url) === normalize(repoUrl),
+			)
+		) {
+			throw new CloudSessionError(
+				"github_not_connected",
+				`The GitHub integration cannot access ${cloudRepositoryLabel(repoUrl, repoUrl)}. Grant repository access before handing off.`,
+				listed.connectUrl,
+			);
+		}
+		return organizationId ? { organizationId } : {};
+	}
+
 	async listBranches(
 		repositoryId: number,
 		options: CloudBranchListOptions = {},
@@ -1332,6 +1452,7 @@ export class CloudSessionManager {
 			String(input.thinking ?? ""),
 			input.reasoningEffort ?? "",
 			String(input.autoApproveTools ?? ""),
+			input.handoff?.sourceSessionId ?? "",
 		].join("\u0000");
 		const existing = this.createRequests.get(key);
 		if (existing) return await existing;
@@ -1342,6 +1463,59 @@ export class CloudSessionManager {
 		});
 		this.createRequests.set(key, creating);
 		return await creating;
+	}
+
+	/** Waits for an adopted pending handoff target before opening its Hub proxy. */
+	async waitUntilReady(outerSessionId: string): Promise<void> {
+		await this.options.api.waitUntilReady(outerSessionId);
+		await this.refreshKnownSession(outerSessionId);
+	}
+
+	/** Seeds an already-provisioned outer session when retrying a pending handoff. */
+	async seedHandoff(
+		outerSessionId: string,
+		seed: CloudHandoffSeed,
+	): Promise<{ innerSessionId: string }> {
+		const connection = await this.ensureConnection(outerSessionId, {
+			createInner: true,
+			handoffSeed: seed,
+		});
+		if (!connection.innerSessionId) {
+			throw new Error("Cloud Hub did not return an inner session id");
+		}
+		return { innerSessionId: connection.innerSessionId };
+	}
+
+	async verifyHandoffTranscript(
+		outerSessionId: string,
+		expected: readonly MessageWithMetadata[],
+	): Promise<void> {
+		const connection = await this.ensureConnection(outerSessionId);
+		const innerSessionId = connection.innerSessionId;
+		if (!innerSessionId) {
+			throw new Error("Cloud Hub did not return an inner session id");
+		}
+		const reply = await connection.client.command(
+			"session.messages",
+			{ sessionId: innerSessionId },
+			innerSessionId,
+		);
+		const actual = reply.payload?.messages;
+		if (!Array.isArray(actual)) {
+			throw new Error("Cloud runtime returned no transcript after seeding.");
+		}
+		if (expected.length > 0 && actual.length === 0) {
+			throw new Error(
+				"The cloud session was created, but its transcript was not persisted. This cloud runtime cannot durably seed handoff transcripts and must use @cline/core 0.0.72 or newer. Updating the cloud runtime or pod is required; retrying /handoff against this same pod will not help.",
+			);
+		}
+		if (!cloudHandoffTranscriptsEqual(expected, actual)) {
+			throw new CloudHandoffTranscriptMismatchError(
+				expected.length,
+				actual.length,
+			);
+		}
+		connection.transcriptKnown = true;
 	}
 
 	private async createOnce(
@@ -1467,10 +1641,22 @@ export class CloudSessionManager {
 			live.config.reasoningEffort = input.reasoningEffort;
 		}
 		this.ctx.liveSessions.set(record.id, live);
-		// Provisioning succeeded; a transient Hub connect must not report create failure.
+		const handoffSeed = input.handoff
+			? {
+					sourceSessionId: input.handoff.sourceSessionId,
+					messages: await input.handoff.resolveMessages(),
+					onSeeding: input.handoff.onSeeding,
+				}
+			: undefined;
+		// A handoff must seed durably before it can report success. Ordinary cloud
+		// creation keeps its existing best-effort initial-connect behavior.
 		try {
-			await this.ensureConnection(record.id, { createInner: true });
+			await this.ensureConnection(record.id, {
+				createInner: true,
+				handoffSeed,
+			});
 		} catch (error) {
+			if (handoffSeed) throw error;
 			this.ctx.logger?.log(
 				"Cloud session provisioned but initial connect failed; will connect on demand",
 				{ sessionId: record.id, error },
@@ -1497,6 +1683,9 @@ export class CloudSessionManager {
 			cwd: CLOUD_WORKSPACE_ROOT,
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			...(live.prompt ? { prompt: live.prompt } : {}),
+			...(this.connections.get(record.id)?.innerSessionId
+				? { innerSessionId: this.connections.get(record.id)?.innerSessionId }
+				: {}),
 		};
 	}
 
@@ -1622,7 +1811,9 @@ export class CloudSessionManager {
 					...(userImages?.length ? { attachments: { userImages } } : {}),
 				},
 				innerSessionId,
-				{ timeoutMs: null },
+				delivery === "queue"
+					? { timeoutMs: QUEUE_COMMAND_TIMEOUT_MS }
+					: { timeoutMs: null },
 			);
 			// Advance the baseline so an older identical prompt cannot confirm this send.
 			if (live && delivery !== "queue") {
@@ -2182,7 +2373,7 @@ export class CloudSessionManager {
 
 	private async ensureConnection(
 		outerSessionId: string,
-		options: { createInner?: boolean } = {},
+		options: { createInner?: boolean; handoffSeed?: CloudHandoffSeed } = {},
 	): Promise<CloudConnection> {
 		if (this.disposed) {
 			throw new Error("Cloud session manager was disposed");
@@ -2195,16 +2386,28 @@ export class CloudSessionManager {
 		}
 		const existing = this.connections.get(outerSessionId);
 		if (existing) {
+			if (options.handoffSeed && existing.innerSessionId) {
+				await this.assertHandoffConnectionReusable(
+					existing,
+					options.handoffSeed,
+				);
+			}
 			if (options.createInner && !existing.innerSessionId) {
-				await this.createInnerSession(existing);
+				await this.createInnerSession(existing, options.handoffSeed);
 			}
 			return existing;
 		}
 		const pending = this.connectionPromises.get(outerSessionId);
 		if (pending) {
 			const connection = await pending;
+			if (options.handoffSeed && connection.innerSessionId) {
+				await this.assertHandoffConnectionReusable(
+					connection,
+					options.handoffSeed,
+				);
+			}
 			if (options.createInner && !connection.innerSessionId) {
-				await this.createInnerSession(connection);
+				await this.createInnerSession(connection, options.handoffSeed);
 			}
 			return connection;
 		}
@@ -2282,9 +2485,26 @@ export class CloudSessionManager {
 					throw new Error("Cloud session manager was disposed");
 				}
 				const listed = await client.command("session.list", { limit: 100 });
-				const newest = readSessionRows(listed.payload).sort(
-					(left, right) => updatedAt(right) - updatedAt(left),
-				)[0];
+				const rows = readSessionRows(listed.payload);
+				let newest: JsonRecord | undefined;
+				if (options.handoffSeed && rows.length > 0) {
+					const [only] = rows;
+					if (
+						rows.length !== 1 ||
+						sessionRowHandoffSourceSessionId(only) !==
+							options.handoffSeed.sourceSessionId
+					) {
+						throw new CloudSessionError(
+							"request_failed",
+							"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+						);
+					}
+					newest = only;
+				} else {
+					newest = rows.sort(
+						(left, right) => updatedAt(right) - updatedAt(left),
+					)[0];
+				}
 				const innerSessionId = String(newest?.sessionId ?? "").trim();
 				if (innerSessionId) {
 					connection.innerSessionId = innerSessionId;
@@ -2297,7 +2517,7 @@ export class CloudSessionManager {
 				}
 				this.connections.set(outerSessionId, connection);
 				if (options.createInner && !connection.innerSessionId) {
-					await this.createInnerSession(connection);
+					await this.createInnerSession(connection, options.handoffSeed);
 				}
 				return connection;
 			} catch (error) {
@@ -2323,14 +2543,41 @@ export class CloudSessionManager {
 		return await connecting;
 	}
 
-	private async createInnerSession(connection: CloudConnection): Promise<void> {
+	private async assertHandoffConnectionReusable(
+		connection: CloudConnection,
+		handoffSeed: CloudHandoffSeed,
+	): Promise<void> {
+		const listed = await connection.client.command("session.list", {
+			limit: 100,
+		});
+		const rows = readSessionRows(listed.payload);
+		const [only] = rows;
+		if (
+			rows.length !== 1 ||
+			String(only?.sessionId ?? "").trim() !== connection.innerSessionId ||
+			sessionRowHandoffSourceSessionId(only) !== handoffSeed.sourceSessionId
+		) {
+			throw new CloudSessionError(
+				"request_failed",
+				"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+			);
+		}
+	}
+
+	private async createInnerSession(
+		connection: CloudConnection,
+		handoffSeed?: CloudHandoffSeed,
+	): Promise<void> {
 		if (connection.innerSessionId) {
 			return;
 		}
 		if (connection.innerSessionCreation) {
 			return await connection.innerSessionCreation;
 		}
-		const creation = this.createInnerSessionOnce(connection).finally(() => {
+		const creation = this.createInnerSessionOnce(
+			connection,
+			handoffSeed,
+		).finally(() => {
 			connection.innerSessionCreation = undefined;
 		});
 		connection.innerSessionCreation = creation;
@@ -2339,21 +2586,32 @@ export class CloudSessionManager {
 
 	private async createInnerSessionOnce(
 		connection: CloudConnection,
+		handoffSeed?: CloudHandoffSeed,
 	): Promise<void> {
 		const modelId = connection.remote.metadata.modelId?.trim();
 		if (!modelId) {
 			throw new Error("Cloud session is missing its model id");
 		}
 		const live = this.ctx.liveSessions.get(connection.remote.id);
+		handoffSeed?.onSeeding?.();
 		const reply = await connection.client.command("session.create", {
 			workspaceRoot: CLOUD_WORKSPACE_ROOT,
 			cwd: CLOUD_WORKSPACE_ROOT,
+			...(handoffSeed ? { initialMessages: handoffSeed.messages } : {}),
 			sessionConfig: {
 				providerId: "cline",
 				modelId,
 				workspaceRoot: CLOUD_WORKSPACE_ROOT,
 				cwd: CLOUD_WORKSPACE_ROOT,
-				systemPrompt: GITHUB_AUTH_SYSTEM_PROMPT,
+				systemPrompt: handoffSeed
+					? buildCloudHandoffSystemPrompt({
+							repoUrl:
+								connection.remote.repoContext.repoUrl ?? "the repository",
+							branch:
+								connection.remote.repoContext.branch ?? "the selected branch",
+							workspaceRoot: CLOUD_WORKSPACE_ROOT,
+						})
+					: CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
 				mode: "act",
 				enableTools: true,
 				...(typeof live?.config.thinking === "boolean"
@@ -2368,6 +2626,15 @@ export class CloudSessionManager {
 				provider: "cline",
 				model: modelId,
 				interactive: true,
+				...(handoffSeed
+					? {
+							handoff: {
+								from: "local",
+								sourceSessionId: handoffSeed.sourceSessionId,
+								outerSessionId: connection.remote.id,
+							},
+						}
+					: {}),
 			},
 			runtimeOptions: { mode: "act" },
 			modelSelection: { provider: "cline", model: modelId },
@@ -2386,8 +2653,9 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub did not return an inner session id");
 		}
 		connection.innerSessionId = innerSessionId;
-		// A newly-created inner session has an authoritative empty transcript.
-		connection.transcriptKnown = true;
+		// Seeded content is authoritative only after a strict session.messages
+		// read-back verifies that the pod persisted initialMessages.
+		connection.transcriptKnown = !handoffSeed;
 	}
 
 	private handleEvent(

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -41,6 +41,7 @@ import type {
 const CLOUD_WORKSPACE_ROOT = "/workspace";
 const CREATE_TIMEOUT_MS = 610_000;
 const PROVISIONING_POLL_MS = 3_000;
+const QUEUE_COMMAND_TIMEOUT_MS = 30_000;
 // Bound hot-path REST calls so a dead network cannot hang the sidebar.
 const REQUEST_TIMEOUT_MS = 15_000;
 const CLOUD_ERROR_PREFIX = "CLOUD_SESSION_ERROR:";
@@ -584,7 +585,7 @@ export class CloudSessionApi {
 					([peerSequence]) => !awaited.has(peerSequence),
 				);
 				await Promise.allSettled(latePeers.map(([, settled]) => settled));
-				const recovered = this.claimFirstUnclaimed(candidates);
+				const recovered = this.claimOnlyUnclaimed(candidates);
 				if (recovered) {
 					await this.persistHandoffOuterSession(
 						input,
@@ -627,9 +628,9 @@ export class CloudSessionApi {
 		}
 	}
 
-	private async waitUntilReady(
+	async waitUntilReady(
 		sessionId: string,
-		signal: AbortSignal,
+		signal: AbortSignal = AbortSignal.timeout(CREATE_TIMEOUT_MS),
 	): Promise<void> {
 		while (!signal.aborted) {
 			let result:
@@ -679,15 +680,21 @@ export class CloudSessionApi {
 	 * that atomicity (per event-loop continuation) is what guarantees two
 	 * concurrent recoveries can never adopt the same session record.
 	 */
-	private claimFirstUnclaimed(
+	private claimOnlyUnclaimed(
 		candidates: CloudSessionRecord[],
 	): CloudSessionRecord | undefined {
-		for (const candidate of candidates) {
-			if (this.claimedSessionIds.has(candidate.id)) continue;
-			this.claimedSessionIds.add(candidate.id);
-			return candidate;
+		const unclaimed = candidates.filter(
+			(candidate) => !this.claimedSessionIds.has(candidate.id),
+		);
+		if (unclaimed.length > 1) {
+			throw new CloudSessionError(
+				"request_failed",
+				"Cloud session creation had an ambiguous result. Check your cloud session list before trying again.",
+			);
 		}
-		return undefined;
+		const candidate = unclaimed[0];
+		if (candidate) this.claimedSessionIds.add(candidate.id);
+		return candidate;
 	}
 
 	private async persistHandoffOuterSession(
@@ -826,6 +833,7 @@ type CloudSessionManagerOptions = {
 		| "delete"
 		| "list"
 		| "status"
+		| "waitUntilReady"
 		| "history"
 		| "updateTitle"
 		| "listRepositories"
@@ -1443,6 +1451,12 @@ export class CloudSessionManager {
 		return await creating;
 	}
 
+	/** Waits for an adopted pending handoff target before opening its Hub proxy. */
+	async waitUntilReady(outerSessionId: string): Promise<void> {
+		await this.options.api.waitUntilReady(outerSessionId);
+		await this.refreshKnownSession(outerSessionId);
+	}
+
 	/** Seeds an already-provisioned outer session when retrying a pending handoff. */
 	async seedHandoff(
 		outerSessionId: string,
@@ -1462,13 +1476,32 @@ export class CloudSessionManager {
 		outerSessionId: string,
 		expected: readonly MessageWithMetadata[],
 	): Promise<void> {
-		const actual = await this.readMessages(outerSessionId);
+		const connection = await this.ensureConnection(outerSessionId);
+		const innerSessionId = connection.innerSessionId;
+		if (!innerSessionId) {
+			throw new Error("Cloud Hub did not return an inner session id");
+		}
+		const reply = await connection.client.command(
+			"session.messages",
+			{ sessionId: innerSessionId },
+			innerSessionId,
+		);
+		const actual = reply.payload?.messages;
+		if (!Array.isArray(actual)) {
+			throw new Error("Cloud runtime returned no transcript after seeding.");
+		}
+		if (expected.length > 0 && actual.length === 0) {
+			throw new Error(
+				"The cloud session was created, but its transcript was not persisted. This cloud runtime cannot durably seed handoff transcripts and must use @cline/core 0.0.72 or newer. Updating the cloud runtime or pod is required; retrying /handoff against this same pod will not help.",
+			);
+		}
 		if (!cloudHandoffTranscriptsEqual(expected, actual)) {
 			throw new CloudHandoffTranscriptMismatchError(
 				expected.length,
 				actual.length,
 			);
 		}
+		connection.transcriptKnown = true;
 	}
 
 	private async createOnce(
@@ -1763,7 +1796,9 @@ export class CloudSessionManager {
 					...(userImages?.length ? { attachments: { userImages } } : {}),
 				},
 				innerSessionId,
-				{ timeoutMs: null },
+				delivery === "queue"
+					? { timeoutMs: QUEUE_COMMAND_TIMEOUT_MS }
+					: { timeoutMs: null },
 			);
 			// Advance the baseline so an older identical prompt cannot confirm this send.
 			if (live && delivery !== "queue") {
@@ -2553,8 +2588,9 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub did not return an inner session id");
 		}
 		connection.innerSessionId = innerSessionId;
-		// A newly-created inner session has an authoritative empty transcript.
-		connection.transcriptKnown = true;
+		// Seeded content is authoritative only after a strict session.messages
+		// read-back verifies that the pod persisted initialMessages.
+		connection.transcriptKnown = !handoffSeed;
 	}
 
 	private handleEvent(

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -1251,6 +1251,13 @@ export class CloudSessionManager {
 		);
 	}
 
+	/** Returns a session this process already created or discovered without
+	 * making account/environment availability a prerequisite for opening it. */
+	getCachedDiscoveryRecord(sessionId: string): JsonRecord | undefined {
+		const record = this.knownSessions.get(sessionId);
+		return record ? cloudSessionToDiscoveryRecord(record) : undefined;
+	}
+
 	getProvisioningOutcome(
 		placeholderId: string,
 	): CloudProvisioningOutcome | null {

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1290,9 +1290,11 @@ export async function handleCommand(
 		const cloud = getCloudSessionManager(ctx);
 		if (cloud.isCloudSession(sessionId)) {
 			return (
+				cloud.getCachedDiscoveryRecord(sessionId) ??
 				(await cloud.listForDiscovery()).find(
 					(session) => session.sessionId === sessionId,
-				) ?? null
+				) ??
+				null
 			);
 		}
 		return (await getSessionFromSidecarManager(ctx, sessionId)) ?? null;

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1914,9 +1914,11 @@ export async function handleCommand(
 		const cloud = getCloudSessionManager(ctx);
 		if (!requestedEnvironmentId(args) && cloud.isCloudSession(sessionId)) {
 			return (
+				cloud.getCachedDiscoveryRecord(sessionId) ??
 				(await cloud.listForDiscovery()).find(
 					(session) => session.sessionId === sessionId,
-				) ?? null
+				) ??
+				null
 			);
 		}
 		return (

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1999,11 +1999,19 @@ export async function handleCommand(
 			await cloud.delete(sessionId);
 			return true;
 		}
+		const { assertSessionDeleteAllowedDuringHandoff } = await import(
+			"./chat-session"
+		);
+		const binding = await getCommandSessionBinding(ctx, sessionId, args);
+		await assertSessionDeleteAllowedDuringHandoff(
+			ctx,
+			sessionId,
+			binding?.sessionManager,
+		);
 		ctx.logger?.log("Deleting desktop chat session", { command, sessionId });
 		const store = new SqliteSessionStore();
 		const row = store.get(sessionId);
 		const manifest = readSessionManifest(sessionId);
-		const binding = await getCommandSessionBinding(ctx, sessionId, args);
 		let deleted = false;
 		let deleteError: Error | null = null;
 		try {

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1360,6 +1360,10 @@ export async function handleCommand(
 			await cloud.delete(sessionId);
 			return true;
 		}
+		const { assertSessionDeleteAllowedDuringHandoff } = await import(
+			"./chat-session"
+		);
+		await assertSessionDeleteAllowedDuringHandoff(ctx, sessionId);
 		ctx.logger?.log("Deleting desktop chat session", { command, sessionId });
 		const store = new SqliteSessionStore();
 		const row = store.get(sessionId);

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1289,13 +1289,17 @@ export async function handleCommand(
 		if (!sessionId) throw new Error("session id is required");
 		const cloud = getCloudSessionManager(ctx);
 		if (cloud.isCloudSession(sessionId)) {
-			return (
-				cloud.getCachedDiscoveryRecord(sessionId) ??
-				(await cloud.listForDiscovery()).find(
-					(session) => session.sessionId === sessionId,
-				) ??
-				null
-			);
+			try {
+				return (
+					(await cloud.listForDiscovery()).find(
+						(session) => session.sessionId === sessionId,
+					) ?? null
+				);
+			} catch {
+				// Preserve offline access, but never let a successful fresh list be
+				// shadowed forever by a session deleted on another device.
+				return cloud.getCachedDiscoveryRecord(sessionId) ?? null;
+			}
 		}
 		return (await getSessionFromSidecarManager(ctx, sessionId)) ?? null;
 	}

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1913,13 +1913,17 @@ export async function handleCommand(
 		if (!sessionId) throw new Error("session id is required");
 		const cloud = getCloudSessionManager(ctx);
 		if (!requestedEnvironmentId(args) && cloud.isCloudSession(sessionId)) {
-			return (
-				cloud.getCachedDiscoveryRecord(sessionId) ??
-				(await cloud.listForDiscovery()).find(
-					(session) => session.sessionId === sessionId,
-				) ??
-				null
-			);
+			try {
+				return (
+					(await cloud.listForDiscovery()).find(
+						(session) => session.sessionId === sessionId,
+					) ?? null
+				);
+			} catch {
+				// Preserve offline access, but never let a successful fresh list be
+				// shadowed forever by a session deleted on another device.
+				return cloud.getCachedDiscoveryRecord(sessionId) ?? null;
+			}
 		}
 		return (
 			(await getSessionFromSidecarManager(

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1914,10 +1914,13 @@ export async function handleCommand(
 		const cloud = getCloudSessionManager(ctx);
 		if (!requestedEnvironmentId(args) && cloud.isCloudSession(sessionId)) {
 			try {
+				const listed = (await cloud.listForDiscovery()).find(
+					(session) => session.sessionId === sessionId,
+				);
 				return (
-					(await cloud.listForDiscovery()).find(
-						(session) => session.sessionId === sessionId,
-					) ?? null
+					listed ??
+					(await cloud.getCrossScopeDiscoveryRecord(sessionId)) ??
+					null
 				);
 			} catch {
 				// Preserve offline access, but never let a successful fresh list be

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -422,6 +422,43 @@ describe("Code sidecar runtime capabilities", () => {
 		expect(readEvents(ctx)).toEqual([]);
 	});
 
+	it("does not treat a resident Hub process as an active turn after attach", async () => {
+		const { createSidecarContext, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.liveSessions.set("forked-session", {
+			config: {},
+			messages: [],
+			promptsInQueue: [],
+			busy: false,
+			startedAt: Date.now(),
+			status: "idle",
+			attachedViaHub: true,
+		});
+
+		handleHubLiveEvent(ctx, {
+			event: "session.updated",
+			sessionId: "forked-session",
+			payload: { session: { status: "running" } },
+		});
+
+		expect(ctx.liveSessions.get("forked-session")).toMatchObject({
+			status: "idle",
+			busy: false,
+		});
+
+		handleHubLiveEvent(ctx, {
+			event: "run.started",
+			sessionId: "forked-session",
+		});
+
+		expect(ctx.liveSessions.get("forked-session")).toMatchObject({
+			status: "running",
+			busy: true,
+		});
+	});
+
 	it("resolves askQuestion through the websocket request/response protocol", async () => {
 		const { createSidecarContext, initializeSessionManager } = await import(
 			"./context"

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -380,6 +380,43 @@ describe("Code sidecar runtime capabilities", () => {
 		expect(readEvents(ctx)).toEqual([]);
 	});
 
+	it("does not treat a resident Hub process as an active turn after attach", async () => {
+		const { createSidecarContext, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.liveSessions.set("forked-session", {
+			config: {},
+			messages: [],
+			promptsInQueue: [],
+			busy: false,
+			startedAt: Date.now(),
+			status: "idle",
+			attachedViaHub: true,
+		});
+
+		handleHubLiveEvent(ctx, {
+			event: "session.updated",
+			sessionId: "forked-session",
+			payload: { session: { status: "running" } },
+		});
+
+		expect(ctx.liveSessions.get("forked-session")).toMatchObject({
+			status: "idle",
+			busy: false,
+		});
+
+		handleHubLiveEvent(ctx, {
+			event: "run.started",
+			sessionId: "forked-session",
+		});
+
+		expect(ctx.liveSessions.get("forked-session")).toMatchObject({
+			status: "running",
+			busy: true,
+		});
+	});
+
 	it("resolves askQuestion through the websocket request/response protocol", async () => {
 		const { createSidecarContext, initializeSessionManager } = await import(
 			"./context"

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -872,7 +872,15 @@ export function handleHubLiveEvent(
 			);
 			return;
 		}
-		case "run.started":
+		case "run.started": {
+			const statusChanged = session.status !== "running";
+			session.status = "running";
+			session.busy = true;
+			if (statusChanged) {
+				sendEvent(ctx, "chat_session_status", { sessionId, status: "running" });
+			}
+			return;
+		}
 		case "session.attached":
 		case "session.updated": {
 			const payloadSession =
@@ -884,13 +892,23 @@ export function handleHubLiveEvent(
 			const runtimeStatus =
 				typeof payloadSession?.status === "string"
 					? payloadSession.status
-					: event.event === "run.started"
-						? "running"
-						: session.status;
+					: session.status;
 			// Hub "pending" means the run is blocked on approval or otherwise
 			// still active. Desktop has no pending status, so expose it as running
 			// and keep later prompts on the queue path.
 			const status = runtimeStatus === "pending" ? "running" : runtimeStatus;
+			// Core's persisted `running` status also means the interactive runtime
+			// process is resident; it does not prove a model turn is active. Only
+			// run.started may move an already-idle attached session to running.
+			// This is especially important for an idle fork created from handoff
+			// history, which otherwise renders "Thinking" forever after attach.
+			if (
+				runtimeStatus === "running" &&
+				session.status !== "running" &&
+				session.config.executionTarget !== "cloud"
+			) {
+				return;
+			}
 			// Pods emit periodic session.updated snapshots; re-broadcasting an
 			// unchanged status marks the session unread in the sidebar every time.
 			const statusChanged = session.status !== status;

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -827,7 +827,15 @@ export function handleHubLiveEvent(
 			});
 			return;
 		}
-		case "run.started":
+		case "run.started": {
+			const statusChanged = session.status !== "running";
+			session.status = "running";
+			session.busy = true;
+			if (statusChanged) {
+				sendEvent(ctx, "chat_session_status", { sessionId, status: "running" });
+			}
+			return;
+		}
 		case "session.attached":
 		case "session.updated": {
 			const payloadSession =
@@ -839,13 +847,23 @@ export function handleHubLiveEvent(
 			const runtimeStatus =
 				typeof payloadSession?.status === "string"
 					? payloadSession.status
-					: event.event === "run.started"
-						? "running"
-						: session.status;
+					: session.status;
 			// Hub "pending" means the run is blocked on approval or otherwise
 			// still active. Desktop has no pending status, so expose it as running
 			// and keep later prompts on the queue path.
 			const status = runtimeStatus === "pending" ? "running" : runtimeStatus;
+			// Core's persisted `running` status also means the interactive runtime
+			// process is resident; it does not prove a model turn is active. Only
+			// run.started may move an already-idle attached session to running.
+			// This is especially important for an idle fork created from handoff
+			// history, which otherwise renders "Thinking" forever after attach.
+			if (
+				runtimeStatus === "running" &&
+				session.status !== "running" &&
+				session.config.executionTarget !== "cloud"
+			) {
+				return;
+			}
 			// Pods emit periodic session.updated snapshots; re-broadcasting an
 			// unchanged status marks the session unread in the sidebar every time.
 			const statusChanged = session.status !== status;

--- a/apps/examples/desktop-app/sidecar/remote-environment-commands.test.ts
+++ b/apps/examples/desktop-app/sidecar/remote-environment-commands.test.ts
@@ -745,6 +745,7 @@ describe("remote environment command routing", () => {
 		const update = vi.fn(async () => ({ updated: true }));
 		const deleteSession = vi.fn(async () => true);
 		const sessionManager = {
+			get: vi.fn(async () => ({ sessionId: "remote-session", metadata: {} })),
 			readMessages,
 			update,
 			delete: deleteSession,

--- a/apps/examples/desktop-app/sidecar/restore-checkpoint.test.ts
+++ b/apps/examples/desktop-app/sidecar/restore-checkpoint.test.ts
@@ -41,6 +41,21 @@ describe("restore_checkpoint", () => {
 		// makes the read after a restore prefer the file over the live session.
 		persistSessionMessages(sessionId, fullMessages);
 
+		const sessionManager = {
+			get: vi.fn(async () => ({
+				sessionId,
+				status: "idle",
+				cwd: "/tmp/project",
+				workspaceRoot: "/tmp/project",
+			})),
+			// A restore that reuses the source id is what the hub does today.
+			restore: vi.fn(async () => ({
+				sessionId,
+				messages: restoredMessages,
+				checkpoint: { ref: "first", createdAt: 1, runCount: 1 },
+			})),
+			pendingPrompts: { list: vi.fn(async () => []) },
+		};
 		const ctx = {
 			liveSessions: new Map([
 				[
@@ -60,21 +75,23 @@ describe("restore_checkpoint", () => {
 			pendingQuestions: new Map(),
 			streamIndices: new Map(),
 			wsClients: new Set(),
-			sessionManager: {
-				get: vi.fn(async () => ({
-					sessionId,
-					status: "idle",
-					cwd: "/tmp/project",
-					workspaceRoot: "/tmp/project",
-				})),
-				// A restore that reuses the source id is what the hub does today.
-				restore: vi.fn(async () => ({
-					sessionId,
-					messages: restoredMessages,
-					checkpoint: { ref: "first", createdAt: 1, runCount: 1 },
-				})),
-				pendingPrompts: { list: vi.fn(async () => []) },
-			},
+			runtimeBindings: new Map([
+				[
+					"local",
+					{
+						environmentId: "local",
+						kind: "local",
+						workspaceRoot: "/tmp/project",
+						sessionManager,
+						hubClient: { command: vi.fn(async () => undefined) },
+						unsubscribeSessionEvents: () => {},
+					},
+				],
+			]),
+			sessionEnvironmentIds: new Map([[sessionId, "local"]]),
+			activeEnvironmentId: "local",
+			remoteEnvironments: null,
+			localWorkspaceRoot: "/tmp/project",
 		} as unknown as SidecarContext;
 
 		await handleChatSessionCommand(ctx, {

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -21,6 +21,8 @@ export type ChatSessionCommandRequest = {
 		| "start"
 		| "attach"
 		| "send"
+		| "prepare_handoff"
+		| "handoff"
 		| "stop"
 		| "abort"
 		| "fork"
@@ -38,6 +40,10 @@ export type ChatSessionCommandRequest = {
 	delivery?: "queue" | "steer";
 	config?: JsonRecord;
 	attachments?: ChatTurnAttachments;
+	/** Opaque preflight result returned by prepare_handoff and revalidated by handoff. */
+	fingerprint?: JsonRecord;
+	/** Optional first prompt to queue after ownership moves to the cloud session. */
+	nextCommand?: string;
 };
 
 export type PromptInQueue = {

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -27,6 +27,8 @@ export type ChatSessionCommandRequest = {
 		| "start"
 		| "attach"
 		| "send"
+		| "prepare_handoff"
+		| "handoff"
 		| "stop"
 		| "abort"
 		| "fork"
@@ -45,6 +47,10 @@ export type ChatSessionCommandRequest = {
 	source?: "desktop" | "realtime";
 	config?: JsonRecord;
 	attachments?: ChatTurnAttachments;
+	/** Opaque preflight result returned by prepare_handoff and revalidated by handoff. */
+	fingerprint?: JsonRecord;
+	/** Optional first prompt to queue after ownership moves to the cloud session. */
+	nextCommand?: string;
 };
 
 export type PromptInQueue = {

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -33,8 +33,14 @@ import {
 	SidebarRail,
 	SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { ToastAction } from "@/components/ui/toast";
 import { ChatInputBar } from "@/components/views/chat/chat-input-bar";
 import { ChatMessages } from "@/components/views/chat/chat-messages";
+import {
+	CloudHandoffProgress,
+	CloudHandoffReceipt,
+	CloudHandoffRecoveryNotice,
+} from "@/components/views/chat/cloud-handoff";
 import { EnvironmentSelector } from "@/components/views/chat/environment-selector";
 import { RemoteDirectoryPicker } from "@/components/views/chat/remote-directory-picker";
 import { WelcomeScreen } from "@/components/views/chat/welcome-chat";
@@ -43,6 +49,7 @@ import type { OnboardingStep } from "@/components/views/onboarding/onboarding-vi
 import type { SettingsSection } from "@/components/views/settings/sections";
 import { AccountProvider, useAccount } from "@/contexts/account-context";
 import { WorkspaceProvider } from "@/contexts/workspace-context";
+import { serializeAttachments } from "@/hooks/chat-session/attachments";
 import type { ProcessContext } from "@/hooks/chat-session/types";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
@@ -54,10 +61,28 @@ import { applyAppZoomAction, syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
 import {
+	formatHandoffModelFallback,
+	HANDOFF_PROGRESS_LABELS,
+	type HandoffPreflight,
+	type HandoffProgressPhase,
+	type HandoffResult,
+	parseHandoffCommand,
+	readHandoffReceipt,
+	readPendingHandoffRecovery,
+	shouldOpenHandoffInApp,
+	validateHandoffAttachments,
+} from "@/lib/cloud-handoff";
+import {
+	type CloudHandoffUiAction,
+	type CloudHandoffUiState,
+	cloudHandoffUiReducer,
+} from "@/lib/cloud-handoff-ui-state";
+import {
 	cloudRepositoryLabel,
 	isCloudProvisioningSessionId,
 } from "@/lib/cloud-repositories";
 import {
+	humanizeCloudHandoffError,
 	humanizeCloudSessionError,
 	parseCloudSessionError,
 } from "@/lib/cloud-session-error";
@@ -67,7 +92,7 @@ import {
 	type DesktopAppView,
 	desktopAppReducer,
 } from "@/lib/desktop-app-state";
-import { desktopClient } from "@/lib/desktop-client";
+import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import {
 	subscribeToDesktopMenuActions,
 	watchDesktopTrayStatus,
@@ -173,6 +198,10 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
+// The sidecar caps provisioning at 610s and all subsequent Hub commands have
+// finite deadlines. Keep the UI above that bound without waiting forever for
+// a lost transport response.
+const HANDOFF_INVOKE_TIMEOUT_MS = 15 * 60_000;
 
 /** Shared provisioning status for the originating thread and placeholder. */
 function useCloudProvisioningPhase(repoUrl?: string): string {
@@ -237,6 +266,37 @@ export default function Home() {
 				"General",
 				LOCAL_WORKSPACE_ENVIRONMENT_ID,
 			),
+	);
+	const [handoffUiState, dispatchHandoffUi] = useReducer(
+		cloudHandoffUiReducer,
+		{},
+	);
+	useEffect(
+		() =>
+			desktopClient.subscribe("cloud_handoff_progress", (payload) => {
+				if (!payload || typeof payload !== "object") return;
+				const progress = payload as {
+					sourceSessionId?: string;
+					phase?: HandoffProgressPhase;
+					message?: string;
+					dashboardUrl?: string;
+				};
+				if (
+					!progress.sourceSessionId?.trim() ||
+					!progress.phase ||
+					!(progress.phase in HANDOFF_PROGRESS_LABELS)
+				) {
+					return;
+				}
+				dispatchHandoffUi({
+					type: "progress",
+					sourceSessionId: progress.sourceSessionId,
+					phase: progress.phase,
+					message: progress.message,
+					dashboardUrl: progress.dashboardUrl,
+				});
+			}),
+		[],
 	);
 	// Starts false on both server and first client render (hydration-safe);
 	// the effect below reads the persisted state right after mount.
@@ -640,6 +700,8 @@ export default function Home() {
 			?.sessionId ?? null;
 	const activeThread =
 		threads.find((thread) => thread.id === activeThreadId) ?? threads[0];
+	const activeLocationRef = useRef({ activeThreadId, view });
+	activeLocationRef.current = { activeThreadId, view };
 	const handleHome = useCallback(() => {
 		if (activeThread?.historySession || activeThread?.hasStarted) {
 			handleNewThread();
@@ -812,21 +874,6 @@ export default function Home() {
 		)?.title;
 		return { sessionId: parentSessionId, title };
 	}, [activeThread?.historySession?.parentSessionId, sessionHistory.threads]);
-	const renderedChatThreads = useMemo(() => {
-		const realtimeThreadId = realtimeVoiceOpen
-			? pinnedRealtimeBridge?.threadId
-			: undefined;
-		return threads.filter(
-			(thread) =>
-				thread.id === activeThread?.id || thread.id === realtimeThreadId,
-		);
-	}, [
-		activeThread?.id,
-		pinnedRealtimeBridge?.threadId,
-		realtimeVoiceOpen,
-		threads,
-	]);
-
 	return (
 		<AccountProvider>
 			<SidebarProvider>
@@ -895,6 +942,8 @@ export default function Home() {
 									environmentProfiles={remoteEnvironmentProfiles}
 									environmentProfilesLoading={remoteEnvironmentProfilesLoading}
 									historySession={activeThread.historySession}
+									handoffUiState={handoffUiState}
+									onHandoffUiAction={dispatchHandoffUi}
 									liveHistoryStatus={
 										// Live entry wins; otherwise trust the clicked snapshot
 										// (the list can lag by a refresh). Resolution is handled
@@ -913,6 +962,11 @@ export default function Home() {
 									onUpdateSessionMetadata={handleUpdateSessionMetadata}
 									threadId={activeThread.id}
 									onAddSshHost={handleAddSshHost}
+									isThreadActive={() =>
+										activeLocationRef.current.activeThreadId ===
+											activeThread.id &&
+										activeLocationRef.current.view === "chat"
+									}
 									onDeleteSession={handleDeleteSession}
 									onNewThread={handleNewThread}
 									onOpenSession={handleOpenSession}
@@ -1009,6 +1063,9 @@ function ChatThreadPane({
 	onOpenVoiceOutputSettings,
 	onRealtimeBridgeChange,
 	onThreadStarted,
+	isThreadActive,
+	handoffUiState,
+	onHandoffUiAction,
 }: {
 	threadId: string;
 	activeEnvironmentId: string;
@@ -1049,6 +1106,9 @@ function ChatThreadPane({
 	onOpenVoiceOutputSettings?: () => void;
 	onRealtimeBridgeChange?: (bridge: RealtimeChatBridge) => void;
 	onThreadStarted?: (threadId: string) => void;
+	isThreadActive?: () => boolean;
+	handoffUiState: CloudHandoffUiState;
+	onHandoffUiAction: (action: CloudHandoffUiAction) => void;
 }) {
 	const {
 		sessionId,
@@ -1108,6 +1168,47 @@ function ChatThreadPane({
 	const [gitBranch, setGitBranch] = useState<string | null>(null);
 	// Re-evaluate the account-targeted flag after sign-in changes.
 	const [cloudAgentsEnabled, setCloudAgentsEnabled] = useState(false);
+	const handoffStartingRef = useRef(false);
+	const sourceSessionId = sessionId ?? historySession?.sessionId;
+	const handoffUi = sourceSessionId
+		? handoffUiState[sourceSessionId]
+		: undefined;
+	const handoffProgress = handoffUi?.status === "progress" ? handoffUi : null;
+	const pendingHandoffRecovery = readPendingHandoffRecovery(
+		historySession?.metadata,
+	);
+	const dismissedHandoffRecoveryUrl =
+		handoffUi?.status === "recovery_dismissed" ? handoffUi.dashboardUrl : null;
+	const handoffRecoveryUrl =
+		(handoffUi?.status === "recovery" ? handoffUi.dashboardUrl : null) ??
+		(pendingHandoffRecovery?.dashboardUrl !== dismissedHandoffRecoveryUrl
+			? pendingHandoffRecovery?.dashboardUrl
+			: null) ??
+		null;
+	const handoffRetry =
+		(handoffUi?.status === "recovery" || handoffUi?.status === "failed") &&
+		(handoffUi.retryDraft || handoffUi.retryAttachments?.length)
+			? {
+					draft: handoffUi.retryDraft,
+					attachments: handoffUi.retryAttachments,
+				}
+			: null;
+	const handoffReceipt =
+		(handoffUi?.status === "complete" ? handoffUi.receipt : null) ??
+		readHandoffReceipt(historySession?.metadata);
+	const handoffExternalPresentation =
+		handoffUi?.status === "complete" && handoffUi.externalPresentation;
+	useEffect(() => {
+		if (!sourceSessionId || !handoffRetry) return;
+		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
+		if (handoffRetry.attachments?.length) {
+			setPendingAttachments([...handoffRetry.attachments]);
+		}
+		onHandoffUiAction({
+			type: "retry_restored",
+			sourceSessionId,
+		});
+	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 	const { user: accountUser } = useAccount();
 	const accountUserId = accountUser?.id ?? null;
 	useEffect(() => {
@@ -1677,9 +1778,261 @@ function ChatThreadPane({
 		threadId,
 	]);
 
+	const runHandoff = useCallback(
+		async (
+			preflight: HandoffPreflight,
+			nextCommand: string,
+			sourceAttachments: File[],
+			sourceSessionId: string,
+		) => {
+			onHandoffUiAction({
+				type: "progress",
+				sourceSessionId,
+				phase: "creating",
+			});
+			try {
+				const attachments = await serializeAttachments(sourceAttachments);
+				const result = await desktopClient.invoke<HandoffResult>(
+					"chat_session_command",
+					{
+						request: {
+							action: "handoff",
+							sessionId: sourceSessionId,
+							config,
+							fingerprint: preflight.fingerprint,
+							nextCommand: nextCommand || undefined,
+							attachments:
+								attachments.userImages.length > 0 ? attachments : undefined,
+						},
+					},
+					{ timeoutMs: HANDOFF_INVOKE_TIMEOUT_MS },
+				);
+				const targetSessionId = (
+					result.outerSessionId ||
+					result.sessionId ||
+					""
+				).trim();
+				const dashboardUrl = result.dashboardUrl?.trim();
+				if (!targetSessionId || !dashboardUrl) {
+					throw new Error("Cloud handoff did not return a cloud session.");
+				}
+				const receipt = { targetSessionId, dashboardUrl };
+				const destination =
+					result.destination ?? (cloudAgentsEnabled ? "in_app" : "external");
+				onHandoffUiAction({
+					type: "complete",
+					sourceSessionId,
+					receipt,
+					externalPresentation: destination === "external",
+				});
+				if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
+					const opened = await onOpenSessionById?.(targetSessionId, {
+						silent: true,
+					}).catch(() => false);
+					if (!opened) {
+						onHandoffUiAction({ type: "external", sourceSessionId });
+						await openExternalUrl(dashboardUrl).catch(() => undefined);
+						toast({
+							title: "Opened handoff in your browser",
+							description:
+								"The cloud session could not be attached inside Cline Code.",
+						});
+					}
+				} else if (destination === "external") {
+					await openExternalUrl(dashboardUrl).catch(() =>
+						toast({
+							title: "Cloud handoff complete",
+							description: "Use the recovery link to open the cloud session.",
+						}),
+					);
+				} else {
+					toast({
+						title: "Cloud handoff complete",
+						description: "The cloud session is ready in your session list.",
+					});
+				}
+				if (result.warning) {
+					toast({
+						title: "Handoff completed with a warning",
+						description: result.warning,
+					});
+				}
+			} catch (error) {
+				onHandoffUiAction({
+					type: "failed",
+					sourceSessionId,
+					exposeRecovery: true,
+					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
+					retryAttachments: sourceAttachments,
+				});
+				const rawError = error instanceof Error ? error.message : String(error);
+				const cloudError = parseCloudSessionError(rawError);
+				const connectUrl = cloudError?.connectUrl;
+				toast({
+					title: "Handoff failed",
+					description: humanizeCloudHandoffError(
+						cloudError?.message ?? rawError,
+					),
+					variant: "destructive",
+					action: connectUrl ? (
+						<ToastAction
+							altText="Connect GitHub"
+							onClick={() => void openExternalUrl(connectUrl)}
+						>
+							Connect GitHub
+						</ToastAction>
+					) : undefined,
+				});
+			}
+		},
+		[
+			cloudAgentsEnabled,
+			config,
+			isThreadActive,
+			onOpenSessionById,
+			onHandoffUiAction,
+		],
+	);
+
+	const prepareHandoff = useCallback(
+		async (nextCommand: string) => {
+			const sourceSessionId = sessionId ?? historySession?.sessionId;
+			if (isCloudSession) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Already in Cline Cloud",
+					description: "Handoff is available from local sessions.",
+				});
+				return;
+			}
+			if (!sourceSessionId) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Start the local session first",
+					description: "Send at least one message before handing off to cloud.",
+				});
+				return;
+			}
+			if (
+				status === "starting" ||
+				status === "running" ||
+				status === "stopping" ||
+				promptsInQueue.length > 0
+			) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Wait for the current turn",
+					description:
+						"Handoff can start once the local agent is idle and its prompt queue is empty.",
+				});
+				return;
+			}
+			const attachmentError = validateHandoffAttachments(
+				pendingAttachments,
+				nextCommand,
+			);
+			if (attachmentError) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Handoff is not ready",
+					description: attachmentError,
+					variant: "destructive",
+				});
+				return;
+			}
+
+			if (handoffStartingRef.current) {
+				toast({
+					title: "Handoff is already starting",
+					description: "Wait for the current handoff request to finish.",
+				});
+				return;
+			}
+			handoffStartingRef.current = true;
+			const sourceAttachments = [...pendingAttachments];
+			onHandoffUiAction({
+				type: "start",
+				sourceSessionId,
+			});
+			setPendingAttachments([]);
+			try {
+				const preflight = await desktopClient.invoke<HandoffPreflight>(
+					"chat_session_command",
+					{
+						request: {
+							action: "prepare_handoff",
+							sessionId: sourceSessionId,
+							config,
+						},
+					},
+				);
+				const fallbackMessage = formatHandoffModelFallback(
+					preflight.modelFallback,
+				);
+				if (fallbackMessage) {
+					toast({
+						title: "Using a cloud-compatible model",
+						description: fallbackMessage,
+					});
+				}
+				await runHandoff(
+					preflight,
+					nextCommand,
+					sourceAttachments,
+					sourceSessionId,
+				);
+			} catch (error) {
+				onHandoffUiAction({
+					type: "failed",
+					sourceSessionId,
+					exposeRecovery: true,
+					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
+					retryAttachments: sourceAttachments,
+				});
+				const rawError = error instanceof Error ? error.message : String(error);
+				const cloudError = parseCloudSessionError(rawError);
+				const connectUrl = cloudError?.connectUrl;
+				toast({
+					title: "Handoff is not ready",
+					description: humanizeCloudHandoffError(
+						cloudError?.message ?? rawError,
+					),
+					variant: "destructive",
+					action: connectUrl ? (
+						<ToastAction
+							altText="Connect GitHub"
+							onClick={() => void openExternalUrl(connectUrl)}
+						>
+							Connect GitHub
+						</ToastAction>
+					) : undefined,
+				});
+			} finally {
+				handoffStartingRef.current = false;
+			}
+		},
+		[
+			config,
+			historySession?.sessionId,
+			isCloudSession,
+			pendingAttachments,
+			promptsInQueue.length,
+			runHandoff,
+			sessionId,
+			setPromptInput,
+			status,
+			onHandoffUiAction,
+		],
+	);
+
 	const handleSend = useCallback(
 		async (prompt: string) => {
 			const trimmed = prompt.trim();
+			const handoff = parseHandoffCommand(trimmed);
+			if (handoff) {
+				await prepareHandoff(handoff.nextCommand);
+				return;
+			}
 			if (!trimmed && pendingAttachments.length === 0) {
 				return;
 			}
@@ -1700,6 +2053,7 @@ function ChatThreadPane({
 			isCloudSession,
 			onThreadStarted,
 			pendingAttachments,
+			prepareHandoff,
 			sendPrompt,
 			sessionId,
 			setPromptInput,
@@ -2113,6 +2467,56 @@ function ChatThreadPane({
 		(prompt: string) => void handleSend(prompt),
 		[handleSend],
 	);
+	const handleOpenHandoffCloud = useCallback(async () => {
+		const receipt = handoffReceipt;
+		if (!receipt) {
+			return;
+		}
+		if (cloudAgentsEnabled) {
+			const opened = await onOpenSessionById?.(receipt.targetSessionId, {
+				silent: true,
+			}).catch(() => false);
+			if (opened) {
+				return;
+			}
+			if (sourceSessionId) {
+				onHandoffUiAction({ type: "external", sourceSessionId });
+			}
+		}
+		await openExternalUrl(receipt.dashboardUrl).catch(() =>
+			toast({
+				title: "Unable to open the browser",
+				description: "Copy the recovery link and open it manually.",
+				variant: "destructive",
+			}),
+		);
+	}, [
+		cloudAgentsEnabled,
+		handoffReceipt,
+		onHandoffUiAction,
+		onOpenSessionById,
+		sourceSessionId,
+	]);
+	const handleOpenHandoffProgressLink = useCallback(() => {
+		const dashboardUrl = handoffProgress?.dashboardUrl ?? handoffRecoveryUrl;
+		if (dashboardUrl) {
+			void openExternalUrl(dashboardUrl).catch(() =>
+				toast({
+					title: "Unable to open the browser",
+					description: "Copy the link shown above and open it manually.",
+					variant: "destructive",
+				}),
+			);
+		}
+	}, [handoffProgress?.dashboardUrl, handoffRecoveryUrl]);
+	const handleDismissHandoffRecovery = useCallback(() => {
+		if (!sourceSessionId || !handoffRecoveryUrl) return;
+		onHandoffUiAction({
+			type: "dismiss_recovery",
+			sourceSessionId,
+			dashboardUrl: handoffRecoveryUrl,
+		});
+	}, [handoffRecoveryUrl, onHandoffUiAction, sourceSessionId]);
 
 	const firstUserMessage = messages.find(
 		(message) => message.role === "user",
@@ -2149,9 +2553,6 @@ function ChatThreadPane({
 		: null;
 	const displayedStatus = hideDeletedSessionUi ? "idle" : status;
 	const displayedSessionId = hideDeletedSessionUi ? null : sessionId;
-	const isAwaitingInitialHydration = Boolean(
-		historySession && hydratedSessionRef.current !== historySession.sessionId,
-	);
 	const displayedIsSwitching = hideDeletedSessionUi
 		? false
 		: isHydratingSession;
@@ -2300,7 +2701,7 @@ function ChatThreadPane({
 		);
 	}
 
-	const composer = (
+	const chatComposer = (
 		<ChatInputBar
 			attachments={attachmentList}
 			onAbort={handleAbort}
@@ -2335,6 +2736,34 @@ function ChatThreadPane({
 			thinking={config.thinking}
 			variant={isWelcomeState ? "welcome" : "conversation"}
 		/>
+	);
+	const composer = handoffReceipt ? (
+		<CloudHandoffReceipt
+			onForkLocally={() => void handleForkSession()}
+			onOpenCloud={() => void handleOpenHandoffCloud()}
+			receipt={handoffReceipt}
+			showRecoveryUrl={handoffExternalPresentation || !cloudAgentsEnabled}
+		/>
+	) : handoffProgress ? (
+		<CloudHandoffProgress
+			dashboardUrl={
+				cloudAgentsEnabled ? undefined : handoffProgress.dashboardUrl
+			}
+			message={handoffProgress.message}
+			onOpenCloud={handleOpenHandoffProgressLink}
+			phase={handoffProgress.phase}
+		/>
+	) : handoffRecoveryUrl ? (
+		<div className="w-full">
+			<CloudHandoffRecoveryNotice
+				dashboardUrl={handoffRecoveryUrl}
+				onDismiss={handleDismissHandoffRecovery}
+				onOpenCloud={handleOpenHandoffProgressLink}
+			/>
+			{chatComposer}
+		</div>
+	) : (
+		chatComposer
 	);
 
 	return (
@@ -2452,7 +2881,9 @@ function ChatThreadPane({
 								messages={displayedMessages}
 								onEditMessage={isCloudSession ? undefined : handleEditMessage}
 								onRestoreCheckpoint={
-									isCloudSession ? undefined : handleRestoreCheckpoint
+									isCloudSession || handoffReceipt
+										? undefined
+										: handleRestoreCheckpoint
 								}
 								onForkSession={isCloudSession ? undefined : handleForkSession}
 								onOpenVoiceOutputSettings={onOpenVoiceOutputSettings}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -41,6 +41,7 @@ import { AccountProvider, useAccount } from "@/contexts/account-context";
 import { WorkspaceProvider } from "@/contexts/workspace-context";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
+import { useProvisioningOutcome } from "@/hooks/use-provisioning-outcome";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
@@ -154,12 +155,6 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
-const PROVISIONING_OUTCOME_POLL_MS = 1_500;
-
-type CloudProvisioningOutcome =
-	| { status: "provisioning" }
-	| { status: "ready"; sessionId: string }
-	| { status: "failed"; message: string };
 
 /** Shared provisioning status for the originating thread and placeholder. */
 function useCloudProvisioningPhase(repoUrl?: string): string {
@@ -719,16 +714,26 @@ function ChatThreadPane({
 	useEffect(() => {
 		void accountUserId;
 		let cancelled = false;
-		desktopClient
-			.invoke("get_feature_flags", {})
-			.then((flags) => {
-				if (!cancelled) {
-					setCloudAgentsEnabled(
-						Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
-					);
-				}
-			})
-			.catch(() => undefined);
+		let retryTimer: number | undefined;
+		let attempts = 0;
+		const fetchFlags = () => {
+			desktopClient
+				.invoke("get_feature_flags", {})
+				.then((flags) => {
+					if (!cancelled) {
+						setCloudAgentsEnabled(
+							Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
+						);
+					}
+				})
+				.catch(() => {
+					attempts += 1;
+					if (!cancelled && attempts < 10) {
+						retryTimer = window.setTimeout(fetchFlags, 2_000);
+					}
+				});
+		};
+		fetchFlags();
 		// The Settings → General cloud toggle broadcasts immediately so the
 		// composer reflects the change without a restart or account switch.
 		const unsubscribe = desktopClient.subscribe(
@@ -744,6 +749,7 @@ function ChatThreadPane({
 		return () => {
 			cancelled = true;
 			unsubscribe();
+			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
 		};
 	}, [accountUserId]);
 	const [providerCredentials, setProviderCredentials] = useState<
@@ -796,53 +802,31 @@ function ChatThreadPane({
 	const [provisioningError, setProvisioningError] = useState<string | null>(
 		null,
 	);
+	const provisioningPlaceholderId =
+		historySession?.sessionId &&
+		isCloudProvisioningSessionId(historySession.sessionId)
+			? historySession.sessionId
+			: undefined;
 	useEffect(() => {
-		const placeholderId = historySession?.sessionId;
-		if (!placeholderId || !isCloudProvisioningSessionId(placeholderId)) return;
-		let cancelled = false;
-		let retryTimer: number | undefined;
+		void provisioningPlaceholderId;
 		setProvisioningError(null);
-
-		async function checkOutcome() {
-			try {
-				const outcome =
-					await desktopClient.invoke<CloudProvisioningOutcome | null>(
-						"get_cloud_provisioning_outcome",
-						{ placeholderId },
-					);
-				if (cancelled) return;
-				if (outcome?.status === "ready") {
-					const opened = await onOpenSessionById?.(outcome.sessionId, {
-						silent: true,
-					});
-					if (opened && !cancelled) {
-						onDeleteSession?.(placeholderId, threadId);
-						return;
-					}
-				} else if (outcome?.status === "failed") {
-					setProvisioningError(
-						humanizeCloudSessionError(outcome.message) ||
-							"The cloud session could not be started.",
-					);
-					return;
-				}
-			} catch {
-				// Retry after a transport interruption.
-			}
-			if (!cancelled) {
-				retryTimer = window.setTimeout(
-					checkOutcome,
-					PROVISIONING_OUTCOME_POLL_MS,
-				);
-			}
+	}, [provisioningPlaceholderId]);
+	const handleProvisioningReady = useCallback(
+		async (sessionId: string) =>
+			Boolean(await onOpenSessionById?.(sessionId, { silent: true })),
+		[onOpenSessionById],
+	);
+	const handleProvisioningResolved = useCallback(() => {
+		if (provisioningPlaceholderId) {
+			onDeleteSession?.(provisioningPlaceholderId, threadId);
 		}
-
-		void checkOutcome();
-		return () => {
-			cancelled = true;
-			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-		};
-	}, [historySession?.sessionId, onDeleteSession, onOpenSessionById, threadId]);
+	}, [onDeleteSession, provisioningPlaceholderId, threadId]);
+	useProvisioningOutcome({
+		placeholderId: provisioningPlaceholderId,
+		onOpenReady: handleProvisioningReady,
+		onResolved: handleProvisioningResolved,
+		onError: setProvisioningError,
+	});
 	// The placeholder id covers list-refresh lag before live status arrives.
 	const isProvisioningCloudSession =
 		!provisioningError &&

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -786,11 +786,7 @@ function ChatThreadPane({
 	const [gitBranch, setGitBranch] = useState<string | null>(null);
 	// Re-evaluate the account-targeted flag after sign-in changes.
 	const [cloudAgentsEnabled, setCloudAgentsEnabled] = useState(false);
-	const [handoffConfirmOpen, setHandoffConfirmOpen] = useState(false);
-	const [handoffPreflight, setHandoffPreflight] =
-		useState<HandoffPreflight | null>(null);
-	const [handoffNextCommand, setHandoffNextCommand] = useState("");
-	const handoffConfirmingRef = useRef(false);
+	const handoffStartingRef = useRef(false);
 	const sourceSessionId = sessionId ?? historySession?.sessionId;
 	const handoffUi = sourceSessionId
 		? handoffUiState[sourceSessionId]
@@ -1371,11 +1367,125 @@ function ChatThreadPane({
 		threadId,
 	]);
 
-	const restoreHandoffDraft = useCallback(() => {
-		setPromptInput(
-			handoffNextCommand ? `/handoff ${handoffNextCommand}` : "/handoff",
-		);
-	}, [handoffNextCommand, setPromptInput]);
+	const runHandoff = useCallback(
+		async (
+			preflight: HandoffPreflight,
+			nextCommand: string,
+			sourceAttachments: File[],
+			sourceSessionId: string,
+		) => {
+			onHandoffUiAction({
+				type: "progress",
+				sourceSessionId,
+				phase: "creating",
+			});
+			setPendingAttachments([]);
+			try {
+				const attachments = await serializeAttachments(sourceAttachments);
+				const result = await desktopClient.invoke<HandoffResult>(
+					"chat_session_command",
+					{
+						request: {
+							action: "handoff",
+							sessionId: sourceSessionId,
+							config,
+							fingerprint: preflight.fingerprint,
+							nextCommand: nextCommand || undefined,
+							attachments:
+								attachments.userImages.length > 0 ? attachments : undefined,
+						},
+					},
+					{ timeoutMs: HANDOFF_INVOKE_TIMEOUT_MS },
+				);
+				const targetSessionId = (
+					result.outerSessionId ||
+					result.sessionId ||
+					""
+				).trim();
+				const dashboardUrl = result.dashboardUrl?.trim();
+				if (!targetSessionId || !dashboardUrl) {
+					throw new Error("Cloud handoff did not return a cloud session.");
+				}
+				const receipt = { targetSessionId, dashboardUrl };
+				const destination =
+					result.destination ?? (cloudAgentsEnabled ? "in_app" : "external");
+				onHandoffUiAction({
+					type: "complete",
+					sourceSessionId,
+					receipt,
+					externalPresentation: destination === "external",
+				});
+				if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
+					const opened = await onOpenSessionById?.(targetSessionId, {
+						silent: true,
+					}).catch(() => false);
+					if (!opened) {
+						onHandoffUiAction({ type: "external", sourceSessionId });
+						await openExternalUrl(dashboardUrl).catch(() => undefined);
+						toast({
+							title: "Opened handoff in your browser",
+							description:
+								"The cloud session could not be attached inside Cline Code.",
+						});
+					}
+				} else if (destination === "external") {
+					await openExternalUrl(dashboardUrl).catch(() =>
+						toast({
+							title: "Cloud handoff complete",
+							description: "Use the recovery link to open the cloud session.",
+						}),
+					);
+				} else {
+					toast({
+						title: "Cloud handoff complete",
+						description: "The cloud session is ready in your session list.",
+					});
+				}
+				if (result.warning) {
+					toast({
+						title: "Handoff completed with a warning",
+						description: result.warning,
+					});
+				}
+			} catch (error) {
+				onHandoffUiAction({
+					type: "failed",
+					sourceSessionId,
+					exposeRecovery: !cloudAgentsEnabled,
+					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
+					retryAttachments: sourceAttachments,
+				});
+				const cloudError = parseCloudSessionError(
+					error instanceof Error ? error.message : String(error),
+				);
+				const connectUrl = cloudError?.connectUrl;
+				toast({
+					title: "Handoff failed",
+					description:
+						cloudError?.message ??
+						humanizeCloudSessionError(
+							error instanceof Error ? error.message : String(error),
+						),
+					variant: "destructive",
+					action: connectUrl ? (
+						<ToastAction
+							altText="Connect GitHub"
+							onClick={() => void openExternalUrl(connectUrl)}
+						>
+							Connect GitHub
+						</ToastAction>
+					) : undefined,
+				});
+			}
+		},
+		[
+			cloudAgentsEnabled,
+			config,
+			isThreadActive,
+			onOpenSessionById,
+			onHandoffUiAction,
+		],
+	);
 
 	const prepareHandoff = useCallback(
 		async (nextCommand: string) => {
@@ -1424,7 +1534,15 @@ function ChatThreadPane({
 				return;
 			}
 
-			setHandoffNextCommand(nextCommand);
+			if (handoffStartingRef.current) {
+				toast({
+					title: "Handoff is already starting",
+					description: "Wait for the current handoff request to finish.",
+				});
+				return;
+			}
+			handoffStartingRef.current = true;
+			const sourceAttachments = [...pendingAttachments];
 			try {
 				const preflight = await desktopClient.invoke<HandoffPreflight>(
 					"chat_session_command",
@@ -1436,8 +1554,12 @@ function ChatThreadPane({
 						},
 					},
 				);
-				setHandoffPreflight(preflight);
-				setHandoffConfirmOpen(true);
+				await runHandoff(
+					preflight,
+					nextCommand,
+					sourceAttachments,
+					sourceSessionId,
+				);
 			} catch (error) {
 				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
 				const cloudError = parseCloudSessionError(
@@ -1461,6 +1583,8 @@ function ChatThreadPane({
 						</ToastAction>
 					) : undefined,
 				});
+			} finally {
+				handoffStartingRef.current = false;
 			}
 		},
 		[
@@ -1469,140 +1593,12 @@ function ChatThreadPane({
 			isCloudSession,
 			pendingAttachments,
 			promptsInQueue.length,
+			runHandoff,
 			sessionId,
 			setPromptInput,
 			status,
 		],
 	);
-
-	const runHandoff = useCallback(async () => {
-		const preflight = handoffPreflight;
-		const sourceSessionId = sessionId ?? historySession?.sessionId;
-		if (!preflight || !sourceSessionId) {
-			return;
-		}
-		const sourceAttachments = [...pendingAttachments];
-		handoffConfirmingRef.current = true;
-		setHandoffConfirmOpen(false);
-		onHandoffUiAction({
-			type: "progress",
-			sourceSessionId,
-			phase: "creating",
-		});
-		setPendingAttachments([]);
-		try {
-			const attachments = await serializeAttachments(sourceAttachments);
-			const result = await desktopClient.invoke<HandoffResult>(
-				"chat_session_command",
-				{
-					request: {
-						action: "handoff",
-						sessionId: sourceSessionId,
-						config,
-						fingerprint: preflight.fingerprint,
-						nextCommand: handoffNextCommand || undefined,
-						attachments:
-							attachments.userImages.length > 0 ? attachments : undefined,
-					},
-				},
-				{ timeoutMs: HANDOFF_INVOKE_TIMEOUT_MS },
-			);
-			const targetSessionId = (
-				result.outerSessionId ||
-				result.sessionId ||
-				""
-			).trim();
-			const dashboardUrl = result.dashboardUrl?.trim();
-			if (!targetSessionId || !dashboardUrl) {
-				throw new Error("Cloud handoff did not return a cloud session.");
-			}
-			const receipt = { targetSessionId, dashboardUrl };
-			const destination =
-				result.destination ?? (cloudAgentsEnabled ? "in_app" : "external");
-			onHandoffUiAction({
-				type: "complete",
-				sourceSessionId,
-				receipt,
-				externalPresentation: destination === "external",
-			});
-			if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
-				const opened = await onOpenSessionById?.(targetSessionId, {
-					silent: true,
-				}).catch(() => false);
-				if (!opened) {
-					onHandoffUiAction({ type: "external", sourceSessionId });
-					await openExternalUrl(dashboardUrl).catch(() => undefined);
-					toast({
-						title: "Opened handoff in your browser",
-						description:
-							"The cloud session could not be attached inside Cline Code.",
-					});
-				}
-			} else if (destination === "external") {
-				await openExternalUrl(dashboardUrl).catch(() =>
-					toast({
-						title: "Cloud handoff complete",
-						description: "Use the recovery link to open the cloud session.",
-					}),
-				);
-			} else {
-				toast({
-					title: "Cloud handoff complete",
-					description: "The cloud session is ready in your session list.",
-				});
-			}
-			if (result.warning) {
-				toast({
-					title: "Handoff completed with a warning",
-					description: result.warning,
-				});
-			}
-		} catch (error) {
-			onHandoffUiAction({
-				type: "failed",
-				sourceSessionId,
-				exposeRecovery: !cloudAgentsEnabled,
-				retryDraft: handoffNextCommand
-					? `/handoff ${handoffNextCommand}`
-					: "/handoff",
-				retryAttachments: sourceAttachments,
-			});
-			const cloudError = parseCloudSessionError(
-				error instanceof Error ? error.message : String(error),
-			);
-			const connectUrl = cloudError?.connectUrl;
-			toast({
-				title: "Handoff failed",
-				description:
-					cloudError?.message ??
-					humanizeCloudSessionError(
-						error instanceof Error ? error.message : String(error),
-					),
-				variant: "destructive",
-				action: connectUrl ? (
-					<ToastAction
-						altText="Connect GitHub"
-						onClick={() => void openExternalUrl(connectUrl)}
-					>
-						Connect GitHub
-					</ToastAction>
-				) : undefined,
-			});
-		} finally {
-			handoffConfirmingRef.current = false;
-		}
-	}, [
-		cloudAgentsEnabled,
-		config,
-		handoffNextCommand,
-		handoffPreflight,
-		historySession?.sessionId,
-		isThreadActive,
-		onOpenSessionById,
-		onHandoffUiAction,
-		pendingAttachments,
-		sessionId,
-	]);
 
 	const handleSend = useCallback(
 		async (prompt: string) => {
@@ -2472,73 +2468,6 @@ function ChatThreadPane({
 							onClick={() => void handleDeleteSession()}
 						>
 							{deletingSession ? "Deleting..." : "Delete"}
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
-			<AlertDialog
-				open={handoffConfirmOpen}
-				onOpenChange={(open) => {
-					setHandoffConfirmOpen(open);
-					if (!open && !handoffConfirmingRef.current) {
-						restoreHandoffDraft();
-					}
-				}}
-			>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Continue in Cline Cloud?</AlertDialogTitle>
-						<AlertDialogDescription>
-							The conversation will be copied to a fresh cloud workspace. Your
-							local session stays available as read-only history.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					{handoffPreflight ? (
-						<div className="grid gap-2 rounded-md border bg-muted/30 p-3 text-sm">
-							<div className="grid grid-cols-[5rem_1fr] gap-2">
-								<span className="text-muted-foreground">Repository</span>
-								<span className="min-w-0 truncate font-medium">
-									{cloudRepositoryLabel(
-										handoffPreflight.repoUrl,
-										handoffPreflight.repoUrl,
-									)}
-								</span>
-								<span className="text-muted-foreground">Branch</span>
-								<span className="min-w-0 truncate font-medium">
-									{handoffPreflight.branch}
-								</span>
-								<span className="text-muted-foreground">Model</span>
-								<span className="min-w-0 truncate font-medium">
-									{handoffPreflight.modelId}
-									{handoffPreflight.modelFallback
-										? ` (fallback from ${handoffPreflight.modelFallback.from})`
-										: ""}
-								</span>
-								{handoffNextCommand ? (
-									<>
-										<span className="text-muted-foreground">Continue</span>
-										<span className="line-clamp-2 font-medium">
-											{handoffNextCommand}
-										</span>
-									</>
-								) : null}
-								{pendingAttachments.length > 0 ? (
-									<>
-										<span className="text-muted-foreground">Images</span>
-										<span className="font-medium">
-											{pendingAttachments.length}
-										</span>
-									</>
-								) : null}
-							</div>
-						</div>
-					) : null}
-					<AlertDialogFooter>
-						<AlertDialogCancel onClick={restoreHandoffDraft}>
-							Cancel
-						</AlertDialogCancel>
-						<AlertDialogAction onClick={() => void runHandoff()}>
-							Continue in Cloud
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -46,6 +46,7 @@ import { WorkspaceProvider } from "@/contexts/workspace-context";
 import type { ProcessContext } from "@/hooks/chat-session/types";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
+import { useProvisioningOutcome } from "@/hooks/use-provisioning-outcome";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
@@ -172,12 +173,6 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
-const PROVISIONING_OUTCOME_POLL_MS = 1_500;
-
-type CloudProvisioningOutcome =
-	| { status: "provisioning" }
-	| { status: "ready"; sessionId: string }
-	| { status: "failed"; message: string };
 
 /** Shared provisioning status for the originating thread and placeholder. */
 function useCloudProvisioningPhase(repoUrl?: string): string {
@@ -1118,16 +1113,26 @@ function ChatThreadPane({
 	useEffect(() => {
 		void accountUserId;
 		let cancelled = false;
-		desktopClient
-			.invoke("get_feature_flags", {})
-			.then((flags) => {
-				if (!cancelled) {
-					setCloudAgentsEnabled(
-						Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
-					);
-				}
-			})
-			.catch(() => undefined);
+		let retryTimer: number | undefined;
+		let attempts = 0;
+		const fetchFlags = () => {
+			desktopClient
+				.invoke("get_feature_flags", {})
+				.then((flags) => {
+					if (!cancelled) {
+						setCloudAgentsEnabled(
+							Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
+						);
+					}
+				})
+				.catch(() => {
+					attempts += 1;
+					if (!cancelled && attempts < 10) {
+						retryTimer = window.setTimeout(fetchFlags, 2_000);
+					}
+				});
+		};
+		fetchFlags();
 		// The Settings → General cloud toggle broadcasts immediately so the
 		// composer reflects the change without a restart or account switch.
 		const unsubscribe = desktopClient.subscribe(
@@ -1143,6 +1148,7 @@ function ChatThreadPane({
 		return () => {
 			cancelled = true;
 			unsubscribe();
+			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
 		};
 	}, [accountUserId]);
 	const [providerCredentials, setProviderCredentials] = useState<
@@ -1195,55 +1201,33 @@ function ChatThreadPane({
 	const [provisioningError, setProvisioningError] = useState<string | null>(
 		null,
 	);
+	const provisioningPlaceholderId =
+		historySession?.sessionId &&
+		isCloudProvisioningSessionId(historySession.sessionId)
+			? historySession.sessionId
+			: undefined;
 	useEffect(() => {
-		const placeholderId = historySession?.sessionId;
-		if (!placeholderId || !isCloudProvisioningSessionId(placeholderId)) return;
-		let cancelled = false;
-		let retryTimer: number | undefined;
+		void provisioningPlaceholderId;
 		setProvisioningError(null);
-
-		async function checkOutcome() {
-			try {
-				const outcome =
-					await desktopClient.invoke<CloudProvisioningOutcome | null>(
-						"get_cloud_provisioning_outcome",
-						{ placeholderId },
-					);
-				if (cancelled) return;
-				if (outcome?.status === "ready") {
-					const opened = await onOpenSessionById?.(
-						outcome.sessionId,
-						undefined,
-						{ silent: true },
-					);
-					if (opened && !cancelled) {
-						onDeleteSession?.(placeholderId, threadId);
-						return;
-					}
-				} else if (outcome?.status === "failed") {
-					setProvisioningError(
-						humanizeCloudSessionError(outcome.message) ||
-							"The cloud session could not be started.",
-					);
-					return;
-				}
-			} catch {
-				// Retry after a transport interruption.
-			}
-			if (!cancelled) {
-				retryTimer = window.setTimeout(
-					checkOutcome,
-					PROVISIONING_OUTCOME_POLL_MS,
-				);
-			}
+	}, [provisioningPlaceholderId]);
+	const handleProvisioningReady = useCallback(
+		async (sessionId: string) =>
+			Boolean(
+				await onOpenSessionById?.(sessionId, undefined, { silent: true }),
+			),
+		[onOpenSessionById],
+	);
+	const handleProvisioningResolved = useCallback(() => {
+		if (provisioningPlaceholderId) {
+			onDeleteSession?.(provisioningPlaceholderId, threadId);
 		}
-
-		void checkOutcome();
-		return () => {
-			cancelled = true;
-			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-		};
-	}, [historySession?.sessionId, onDeleteSession, onOpenSessionById, threadId]);
+	}, [onDeleteSession, provisioningPlaceholderId, threadId]);
+	useProvisioningOutcome({
+		placeholderId: provisioningPlaceholderId,
+		onOpenReady: handleProvisioningReady,
+		onResolved: handleProvisioningResolved,
+		onError: setProvisioningError,
+	});
 	// The placeholder id covers list-refresh lag before live status arrives.
 	const isProvisioningCloudSession =
 		!provisioningError &&

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -2494,9 +2494,12 @@ function ChatThreadPane({
 					environmentSelector={
 						<EnvironmentSelector
 							activeEnvironmentId={activeEnvironmentId}
+							cloudEnabled={cloudAgentsEnabled}
+							executionTarget={isCloudSession ? "cloud" : "local"}
 							loading={environmentProfilesLoading}
 							onAddSshHost={onAddSshHost}
 							onSelectEnvironment={onSelectEnvironment}
+							onSelectExecutionTarget={handleExecutionTargetChange}
 							profiles={environmentProfiles}
 						/>
 					}
@@ -2517,7 +2520,6 @@ function ChatThreadPane({
 					executionTarget={isCloudSession ? "cloud" : "local"}
 					repoUrl={config.repoUrl ?? ""}
 					cloudBranch={config.branch ?? ""}
-					onExecutionTargetChange={handleExecutionTargetChange}
 					onRepoUrlChange={handleCloudRepoUrlChange}
 					onCloudBranchChange={handleCloudBranchChange}
 					cloudAgentsEnabled={cloudAgentsEnabled}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -814,17 +814,6 @@ function ChatThreadPane({
 		readHandoffReceipt(historySession?.metadata);
 	const handoffExternalPresentation =
 		handoffUi?.status === "complete" && handoffUi.externalPresentation;
-	useEffect(() => {
-		if (!sourceSessionId || !handoffRetry) return;
-		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
-		if (handoffRetry.attachments?.length) {
-			setPendingAttachments([...handoffRetry.attachments]);
-		}
-		onHandoffUiAction({
-			type: "retry_restored",
-			sourceSessionId,
-		});
-	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 	const { user: accountUser } = useAccount();
 	const accountUserId = accountUser?.id ?? null;
 	useEffect(() => {
@@ -1362,6 +1351,21 @@ function ChatThreadPane({
 		setPromptInput,
 		threadId,
 	]);
+
+	// Hydrate first, then restore a failed handoff's draft and attachments. If
+	// this ran above the hydration effect, hydration would immediately wipe the
+	// only retained retry payload after navigation back to the source session.
+	useEffect(() => {
+		if (!sourceSessionId || !handoffRetry) return;
+		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
+		if (handoffRetry.attachments?.length) {
+			setPendingAttachments([...handoffRetry.attachments]);
+		}
+		onHandoffUiAction({
+			type: "retry_restored",
+			sourceSessionId,
+		});
+	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 
 	const runHandoff = useCallback(
 		async (

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -31,6 +31,7 @@ import {
 	SidebarRail,
 	SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { ToastAction } from "@/components/ui/toast";
 import { ChatInputBar } from "@/components/views/chat/chat-input-bar";
 import { ChatMessages } from "@/components/views/chat/chat-messages";
 import {
@@ -176,6 +177,10 @@ type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
 const PROVISIONING_OUTCOME_POLL_MS = 1_500;
+// The sidecar caps provisioning at 610s and all subsequent Hub commands have
+// finite deadlines. Keep the UI above that bound without waiting forever for
+// a lost transport response.
+const HANDOFF_INVOKE_TIMEOUT_MS = 15 * 60_000;
 
 type CloudProvisioningOutcome =
 	| { status: "provisioning" }
@@ -1435,12 +1440,26 @@ function ChatThreadPane({
 				setHandoffConfirmOpen(true);
 			} catch (error) {
 				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				const cloudError = parseCloudSessionError(
+					error instanceof Error ? error.message : String(error),
+				);
+				const connectUrl = cloudError?.connectUrl;
 				toast({
 					title: "Handoff is not ready",
-					description: humanizeCloudSessionError(
-						error instanceof Error ? error.message : String(error),
-					),
+					description:
+						cloudError?.message ??
+						humanizeCloudSessionError(
+							error instanceof Error ? error.message : String(error),
+						),
 					variant: "destructive",
+					action: connectUrl ? (
+						<ToastAction
+							altText="Connect GitHub"
+							onClick={() => void openExternalUrl(connectUrl)}
+						>
+							Connect GitHub
+						</ToastAction>
+					) : undefined,
 				});
 			}
 		},
@@ -1486,7 +1505,7 @@ function ChatThreadPane({
 							attachments.userImages.length > 0 ? attachments : undefined,
 					},
 				},
-				{ timeoutMs: null },
+				{ timeoutMs: HANDOFF_INVOKE_TIMEOUT_MS },
 			);
 			const targetSessionId = (
 				result.outerSessionId ||
@@ -1548,12 +1567,26 @@ function ChatThreadPane({
 					: "/handoff",
 				retryAttachments: sourceAttachments,
 			});
+			const cloudError = parseCloudSessionError(
+				error instanceof Error ? error.message : String(error),
+			);
+			const connectUrl = cloudError?.connectUrl;
 			toast({
 				title: "Handoff failed",
-				description: humanizeCloudSessionError(
-					error instanceof Error ? error.message : String(error),
-				),
+				description:
+					cloudError?.message ??
+					humanizeCloudSessionError(
+						error instanceof Error ? error.message : String(error),
+					),
 				variant: "destructive",
+				action: connectUrl ? (
+					<ToastAction
+						altText="Connect GitHub"
+						onClick={() => void openExternalUrl(connectUrl)}
+					>
+						Connect GitHub
+					</ToastAction>
+				) : undefined,
 			});
 		} finally {
 			handoffConfirmingRef.current = false;

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1198,17 +1198,6 @@ function ChatThreadPane({
 		readHandoffReceipt(historySession?.metadata);
 	const handoffExternalPresentation =
 		handoffUi?.status === "complete" && handoffUi.externalPresentation;
-	useEffect(() => {
-		if (!sourceSessionId || !handoffRetry) return;
-		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
-		if (handoffRetry.attachments?.length) {
-			setPendingAttachments([...handoffRetry.attachments]);
-		}
-		onHandoffUiAction({
-			type: "retry_restored",
-			sourceSessionId,
-		});
-	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 	const { user: accountUser } = useAccount();
 	const accountUserId = accountUser?.id ?? null;
 	useEffect(() => {
@@ -1777,6 +1766,21 @@ function ChatThreadPane({
 		setPromptInput,
 		threadId,
 	]);
+
+	// Hydrate first, then restore a failed handoff's draft and attachments. If
+	// this ran above the hydration effect, hydration would immediately wipe the
+	// only retained retry payload after navigation back to the source session.
+	useEffect(() => {
+		if (!sourceSessionId || !handoffRetry) return;
+		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
+		if (handoffRetry.attachments?.length) {
+			setPendingAttachments([...handoffRetry.attachments]);
+		}
+		onHandoffUiAction({
+			type: "retry_restored",
+			sourceSessionId,
+		});
+	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 
 	const runHandoff = useCallback(
 		async (

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -798,9 +798,13 @@ function ChatThreadPane({
 	const pendingHandoffRecovery = readPendingHandoffRecovery(
 		historySession?.metadata,
 	);
+	const dismissedHandoffRecoveryUrl =
+		handoffUi?.status === "recovery_dismissed" ? handoffUi.dashboardUrl : null;
 	const handoffRecoveryUrl =
 		(handoffUi?.status === "recovery" ? handoffUi.dashboardUrl : null) ??
-		pendingHandoffRecovery?.dashboardUrl ??
+		(pendingHandoffRecovery?.dashboardUrl !== dismissedHandoffRecoveryUrl
+			? pendingHandoffRecovery?.dashboardUrl
+			: null) ??
 		null;
 	const handoffRetry =
 		(handoffUi?.status === "recovery" || handoffUi?.status === "failed") &&
@@ -2068,6 +2072,14 @@ function ChatThreadPane({
 			);
 		}
 	}, [handoffProgress?.dashboardUrl, handoffRecoveryUrl]);
+	const handleDismissHandoffRecovery = useCallback(() => {
+		if (!sourceSessionId || !handoffRecoveryUrl) return;
+		onHandoffUiAction({
+			type: "dismiss_recovery",
+			sourceSessionId,
+			dashboardUrl: handoffRecoveryUrl,
+		});
+	}, [handoffRecoveryUrl, onHandoffUiAction, sourceSessionId]);
 
 	const firstUserMessage = messages.find(
 		(message) => message.role === "user",
@@ -2305,6 +2317,7 @@ function ChatThreadPane({
 		<div className="w-full">
 			<CloudHandoffRecoveryNotice
 				dashboardUrl={handoffRecoveryUrl}
+				onDismiss={handleDismissHandoffRecovery}
 				onOpenCloud={handleOpenHandoffProgressLink}
 			/>
 			{chatComposer}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -48,6 +48,7 @@ import { WorkspaceProvider } from "@/contexts/workspace-context";
 import { serializeAttachments } from "@/hooks/chat-session/attachments";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
+import { useProvisioningOutcome } from "@/hooks/use-provisioning-outcome";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
@@ -179,16 +180,10 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
-const PROVISIONING_OUTCOME_POLL_MS = 1_500;
 // create() can spend one 610s window on the original POST and another on
 // timeout recovery. Leave room for auth, Hub attach, seeding, and verification
 // without waiting forever for a lost transport response.
 const HANDOFF_INVOKE_TIMEOUT_MS = 25 * 60_000;
-
-type CloudProvisioningOutcome =
-	| { status: "provisioning" }
-	| { status: "ready"; sessionId: string }
-	| { status: "failed"; message: string };
 
 /** Shared provisioning status for the originating thread and placeholder. */
 function useCloudProvisioningPhase(repoUrl?: string): string {
@@ -835,16 +830,26 @@ function ChatThreadPane({
 	useEffect(() => {
 		void accountUserId;
 		let cancelled = false;
-		desktopClient
-			.invoke("get_feature_flags", {})
-			.then((flags) => {
-				if (!cancelled) {
-					setCloudAgentsEnabled(
-						Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
-					);
-				}
-			})
-			.catch(() => undefined);
+		let retryTimer: number | undefined;
+		let attempts = 0;
+		const fetchFlags = () => {
+			desktopClient
+				.invoke("get_feature_flags", {})
+				.then((flags) => {
+					if (!cancelled) {
+						setCloudAgentsEnabled(
+							Boolean((flags as { cloudAgents?: boolean })?.cloudAgents),
+						);
+					}
+				})
+				.catch(() => {
+					attempts += 1;
+					if (!cancelled && attempts < 10) {
+						retryTimer = window.setTimeout(fetchFlags, 2_000);
+					}
+				});
+		};
+		fetchFlags();
 		// The Settings → General cloud toggle broadcasts immediately so the
 		// composer reflects the change without a restart or account switch.
 		const unsubscribe = desktopClient.subscribe(
@@ -860,6 +865,7 @@ function ChatThreadPane({
 		return () => {
 			cancelled = true;
 			unsubscribe();
+			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
 		};
 	}, [accountUserId]);
 	const [providerCredentials, setProviderCredentials] = useState<
@@ -912,53 +918,31 @@ function ChatThreadPane({
 	const [provisioningError, setProvisioningError] = useState<string | null>(
 		null,
 	);
+	const provisioningPlaceholderId =
+		historySession?.sessionId &&
+		isCloudProvisioningSessionId(historySession.sessionId)
+			? historySession.sessionId
+			: undefined;
 	useEffect(() => {
-		const placeholderId = historySession?.sessionId;
-		if (!placeholderId || !isCloudProvisioningSessionId(placeholderId)) return;
-		let cancelled = false;
-		let retryTimer: number | undefined;
+		void provisioningPlaceholderId;
 		setProvisioningError(null);
-
-		async function checkOutcome() {
-			try {
-				const outcome =
-					await desktopClient.invoke<CloudProvisioningOutcome | null>(
-						"get_cloud_provisioning_outcome",
-						{ placeholderId },
-					);
-				if (cancelled) return;
-				if (outcome?.status === "ready") {
-					const opened = await onOpenSessionById?.(outcome.sessionId, {
-						silent: true,
-					});
-					if (opened && !cancelled) {
-						onDeleteSession?.(placeholderId, threadId);
-						return;
-					}
-				} else if (outcome?.status === "failed") {
-					setProvisioningError(
-						humanizeCloudSessionError(outcome.message) ||
-							"The cloud session could not be started.",
-					);
-					return;
-				}
-			} catch {
-				// Retry after a transport interruption.
-			}
-			if (!cancelled) {
-				retryTimer = window.setTimeout(
-					checkOutcome,
-					PROVISIONING_OUTCOME_POLL_MS,
-				);
-			}
+	}, [provisioningPlaceholderId]);
+	const handleProvisioningReady = useCallback(
+		async (sessionId: string) =>
+			Boolean(await onOpenSessionById?.(sessionId, { silent: true })),
+		[onOpenSessionById],
+	);
+	const handleProvisioningResolved = useCallback(() => {
+		if (provisioningPlaceholderId) {
+			onDeleteSession?.(provisioningPlaceholderId, threadId);
 		}
-
-		void checkOutcome();
-		return () => {
-			cancelled = true;
-			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-		};
-	}, [historySession?.sessionId, onDeleteSession, onOpenSessionById, threadId]);
+	}, [onDeleteSession, provisioningPlaceholderId, threadId]);
+	useProvisioningOutcome({
+		placeholderId: provisioningPlaceholderId,
+		onOpenReady: handleProvisioningReady,
+		onResolved: handleProvisioningResolved,
+		onError: setProvisioningError,
+	});
 	// The placeholder id covers list-refresh lag before live status arrives.
 	const isProvisioningCloudSession =
 		!provisioningError &&

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -55,6 +55,7 @@ import { applyAppZoomAction, syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
 import {
+	formatHandoffModelFallback,
 	HANDOFF_PROGRESS_LABELS,
 	type HandoffPreflight,
 	type HandoffProgressPhase,
@@ -75,6 +76,7 @@ import {
 	isCloudProvisioningSessionId,
 } from "@/lib/cloud-repositories";
 import {
+	humanizeCloudHandoffError,
 	humanizeCloudSessionError,
 	parseCloudSessionError,
 } from "@/lib/cloud-session-error";
@@ -1460,17 +1462,14 @@ function ChatThreadPane({
 					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
 					retryAttachments: sourceAttachments,
 				});
-				const cloudError = parseCloudSessionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				const rawError = error instanceof Error ? error.message : String(error);
+				const cloudError = parseCloudSessionError(rawError);
 				const connectUrl = cloudError?.connectUrl;
 				toast({
 					title: "Handoff failed",
-					description:
-						cloudError?.message ??
-						humanizeCloudSessionError(
-							error instanceof Error ? error.message : String(error),
-						),
+					description: humanizeCloudHandoffError(
+						cloudError?.message ?? rawError,
+					),
 					variant: "destructive",
 					action: connectUrl ? (
 						<ToastAction
@@ -1564,6 +1563,15 @@ function ChatThreadPane({
 						},
 					},
 				);
+				const fallbackMessage = formatHandoffModelFallback(
+					preflight.modelFallback,
+				);
+				if (fallbackMessage) {
+					toast({
+						title: "Using a cloud-compatible model",
+						description: fallbackMessage,
+					});
+				}
 				await runHandoff(
 					preflight,
 					nextCommand,
@@ -1578,17 +1586,14 @@ function ChatThreadPane({
 					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
 					retryAttachments: sourceAttachments,
 				});
-				const cloudError = parseCloudSessionError(
-					error instanceof Error ? error.message : String(error),
-				);
+				const rawError = error instanceof Error ? error.message : String(error);
+				const cloudError = parseCloudSessionError(rawError);
 				const connectUrl = cloudError?.connectUrl;
 				toast({
 					title: "Handoff is not ready",
-					description:
-						cloudError?.message ??
-						humanizeCloudSessionError(
-							error instanceof Error ? error.message : String(error),
-						),
+					description: humanizeCloudHandoffError(
+						cloudError?.message ?? rawError,
+					),
 					variant: "destructive",
 					action: connectUrl ? (
 						<ToastAction

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -198,10 +198,10 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
-// The sidecar caps provisioning at 610s and all subsequent Hub commands have
-// finite deadlines. Keep the UI above that bound without waiting forever for
-// a lost transport response.
-const HANDOFF_INVOKE_TIMEOUT_MS = 15 * 60_000;
+// create() can spend one 610s window on the original POST and another on
+// timeout recovery. Leave room for auth, Hub attach, seeding, and verification
+// without waiting forever for a lost transport response.
+const HANDOFF_INVOKE_TIMEOUT_MS = 25 * 60_000;
 
 /** Shared provisioning status for the originating thread and placeholder. */
 function useCloudProvisioningPhase(repoUrl?: string): string {
@@ -2202,13 +2202,16 @@ function ChatThreadPane({
 	const activeSessionToDelete = hideDeletedSessionUi
 		? null
 		: (sessionId ?? visibleHistorySession?.sessionId ?? null);
+	const handoffDeleteLocked = Boolean(
+		handoffProgress || pendingHandoffRecovery,
+	);
 
 	const requestDeleteSession = useCallback(() => {
-		if (!activeSessionToDelete || deletingSession) {
+		if (!activeSessionToDelete || deletingSession || handoffDeleteLocked) {
 			return;
 		}
 		setDeleteConfirmOpen(true);
-	}, [activeSessionToDelete, deletingSession]);
+	}, [activeSessionToDelete, deletingSession, handoffDeleteLocked]);
 
 	const handleDeleteSession = useCallback(async () => {
 		if (!activeSessionToDelete || deletingSession) {
@@ -2807,7 +2810,9 @@ function ChatThreadPane({
 							canEditTitle={
 								Boolean(activeSessionForTitle) && !isProvisioningCloudSession
 							}
-							canDeleteSession={Boolean(activeSessionToDelete)}
+							canDeleteSession={
+								Boolean(activeSessionToDelete) && !handoffDeleteLocked
+							}
 							deletingSession={deletingSession}
 							diff={isCloudSession ? undefined : headerDiff}
 							onDeleteSession={requestDeleteSession}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -61,6 +61,7 @@ import {
 	type HandoffResult,
 	parseHandoffCommand,
 	readHandoffReceipt,
+	readPendingHandoffRecovery,
 	shouldOpenHandoffInApp,
 	validateHandoffAttachments,
 } from "@/lib/cloud-handoff";
@@ -792,8 +793,13 @@ function ChatThreadPane({
 		? handoffUiState[sourceSessionId]
 		: undefined;
 	const handoffProgress = handoffUi?.status === "progress" ? handoffUi : null;
+	const pendingHandoffRecovery = readPendingHandoffRecovery(
+		historySession?.metadata,
+	);
 	const handoffRecoveryUrl =
-		handoffUi?.status === "recovery" ? handoffUi.dashboardUrl : null;
+		(handoffUi?.status === "recovery" ? handoffUi.dashboardUrl : null) ??
+		pendingHandoffRecovery?.dashboardUrl ??
+		null;
 	const handoffRetry =
 		(handoffUi?.status === "recovery" || handoffUi?.status === "failed") &&
 		(handoffUi.retryDraft || handoffUi.retryAttachments?.length)
@@ -1379,7 +1385,6 @@ function ChatThreadPane({
 				sourceSessionId,
 				phase: "creating",
 			});
-			setPendingAttachments([]);
 			try {
 				const attachments = await serializeAttachments(sourceAttachments);
 				const result = await desktopClient.invoke<HandoffResult>(
@@ -1451,7 +1456,7 @@ function ChatThreadPane({
 				onHandoffUiAction({
 					type: "failed",
 					sourceSessionId,
-					exposeRecovery: !cloudAgentsEnabled,
+					exposeRecovery: true,
 					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
 					retryAttachments: sourceAttachments,
 				});
@@ -1543,6 +1548,11 @@ function ChatThreadPane({
 			}
 			handoffStartingRef.current = true;
 			const sourceAttachments = [...pendingAttachments];
+			onHandoffUiAction({
+				type: "start",
+				sourceSessionId,
+			});
+			setPendingAttachments([]);
 			try {
 				const preflight = await desktopClient.invoke<HandoffPreflight>(
 					"chat_session_command",
@@ -1561,7 +1571,13 @@ function ChatThreadPane({
 					sourceSessionId,
 				);
 			} catch (error) {
-				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				onHandoffUiAction({
+					type: "failed",
+					sourceSessionId,
+					exposeRecovery: true,
+					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
+					retryAttachments: sourceAttachments,
+				});
 				const cloudError = parseCloudSessionError(
 					error instanceof Error ? error.message : String(error),
 				);
@@ -1597,6 +1613,7 @@ function ChatThreadPane({
 			sessionId,
 			setPromptInput,
 			status,
+			onHandoffUiAction,
 		],
 	);
 
@@ -2279,7 +2296,7 @@ function ChatThreadPane({
 			onOpenCloud={handleOpenHandoffProgressLink}
 			phase={handoffProgress.phase}
 		/>
-	) : handoffRecoveryUrl && !cloudAgentsEnabled ? (
+	) : handoffRecoveryUrl ? (
 		<div className="w-full">
 			<CloudHandoffRecoveryNotice
 				dashboardUrl={handoffRecoveryUrl}
@@ -2395,7 +2412,9 @@ function ChatThreadPane({
 								messages={displayedMessages}
 								onEditMessage={isCloudSession ? undefined : handleEditMessage}
 								onRestoreCheckpoint={
-									isCloudSession ? undefined : handleRestoreCheckpoint
+									isCloudSession || handoffReceipt
+										? undefined
+										: handleRestoreCheckpoint
 								}
 								onForkSession={isCloudSession ? undefined : handleForkSession}
 								startingLabel={

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -180,10 +180,10 @@ type AppLocation = DesktopAppLocation<SettingsSection>;
 
 const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
 const PROVISIONING_OUTCOME_POLL_MS = 1_500;
-// The sidecar caps provisioning at 610s and all subsequent Hub commands have
-// finite deadlines. Keep the UI above that bound without waiting forever for
-// a lost transport response.
-const HANDOFF_INVOKE_TIMEOUT_MS = 15 * 60_000;
+// create() can spend one 610s window on the original POST and another on
+// timeout recovery. Leave room for auth, Hub attach, seeding, and verification
+// without waiting forever for a lost transport response.
+const HANDOFF_INVOKE_TIMEOUT_MS = 25 * 60_000;
 
 type CloudProvisioningOutcome =
 	| { status: "provisioning" }
@@ -1767,13 +1767,16 @@ function ChatThreadPane({
 	const activeSessionToDelete = hideDeletedSessionUi
 		? null
 		: (sessionId ?? visibleHistorySession?.sessionId ?? null);
+	const handoffDeleteLocked = Boolean(
+		handoffProgress || pendingHandoffRecovery,
+	);
 
 	const requestDeleteSession = useCallback(() => {
-		if (!activeSessionToDelete || deletingSession) {
+		if (!activeSessionToDelete || deletingSession || handoffDeleteLocked) {
 			return;
 		}
 		setDeleteConfirmOpen(true);
-	}, [activeSessionToDelete, deletingSession]);
+	}, [activeSessionToDelete, deletingSession, handoffDeleteLocked]);
 
 	const handleDeleteSession = useCallback(async () => {
 		if (!activeSessionToDelete || deletingSession) {
@@ -2367,7 +2370,9 @@ function ChatThreadPane({
 							canEditTitle={
 								Boolean(activeSessionForTitle) && !isProvisioningCloudSession
 							}
-							canDeleteSession={Boolean(activeSessionToDelete)}
+							canDeleteSession={
+								Boolean(activeSessionToDelete) && !handoffDeleteLocked
+							}
 							deletingSession={deletingSession}
 							diff={isCloudSession ? undefined : headerDiff}
 							onDeleteSession={requestDeleteSession}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -33,12 +33,18 @@ import {
 } from "@/components/ui/sidebar";
 import { ChatInputBar } from "@/components/views/chat/chat-input-bar";
 import { ChatMessages } from "@/components/views/chat/chat-messages";
+import {
+	CloudHandoffProgress,
+	CloudHandoffReceipt,
+	CloudHandoffRecoveryNotice,
+} from "@/components/views/chat/cloud-handoff";
 import { WelcomeScreen } from "@/components/views/chat/welcome-chat";
 import { WelcomeSetupNotice } from "@/components/views/chat/welcome-setup-notice";
 import type { OnboardingStep } from "@/components/views/onboarding/onboarding-view";
 import type { SettingsSection } from "@/components/views/settings/sections";
 import { AccountProvider, useAccount } from "@/contexts/account-context";
 import { WorkspaceProvider } from "@/contexts/workspace-context";
+import { serializeAttachments } from "@/hooks/chat-session/attachments";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
 import { useSessionAgents } from "@/hooks/use-session-agents";
@@ -47,6 +53,21 @@ import { toast } from "@/hooks/use-toast";
 import { applyAppZoomAction, syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
+import {
+	HANDOFF_PROGRESS_LABELS,
+	type HandoffPreflight,
+	type HandoffProgressPhase,
+	type HandoffResult,
+	parseHandoffCommand,
+	readHandoffReceipt,
+	shouldOpenHandoffInApp,
+	validateHandoffAttachments,
+} from "@/lib/cloud-handoff";
+import {
+	type CloudHandoffUiAction,
+	type CloudHandoffUiState,
+	cloudHandoffUiReducer,
+} from "@/lib/cloud-handoff-ui-state";
 import {
 	cloudRepositoryLabel,
 	isCloudProvisioningSessionId,
@@ -61,7 +82,7 @@ import {
 	type DesktopAppView,
 	desktopAppReducer,
 } from "@/lib/desktop-app-state";
-import { desktopClient } from "@/lib/desktop-client";
+import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import {
 	subscribeToDesktopMenuActions,
 	watchDesktopTrayStatus,
@@ -220,6 +241,37 @@ export default function Home() {
 		initialThreadId,
 		(threadId) => createDesktopAppState(threadId, "General"),
 	);
+	const [handoffUiState, dispatchHandoffUi] = useReducer(
+		cloudHandoffUiReducer,
+		{},
+	);
+	useEffect(
+		() =>
+			desktopClient.subscribe("cloud_handoff_progress", (payload) => {
+				if (!payload || typeof payload !== "object") return;
+				const progress = payload as {
+					sourceSessionId?: string;
+					phase?: HandoffProgressPhase;
+					message?: string;
+					dashboardUrl?: string;
+				};
+				if (
+					!progress.sourceSessionId?.trim() ||
+					!progress.phase ||
+					!(progress.phase in HANDOFF_PROGRESS_LABELS)
+				) {
+					return;
+				}
+				dispatchHandoffUi({
+					type: "progress",
+					sourceSessionId: progress.sourceSessionId,
+					phase: progress.phase,
+					message: progress.message,
+					dashboardUrl: progress.dashboardUrl,
+				});
+			}),
+		[],
+	);
 	// Starts false on both server and first client render (hydration-safe);
 	// the effect below reads the persisted state right after mount.
 	const [showOnboarding, setShowOnboarding] = useState(false);
@@ -341,6 +393,8 @@ export default function Home() {
 			?.sessionId ?? null;
 	const activeThread =
 		threads.find((thread) => thread.id === activeThreadId) ?? threads[0];
+	const activeLocationRef = useRef({ activeThreadId, view });
+	activeLocationRef.current = { activeThreadId, view };
 	const handleHome = useCallback(() => {
 		if (activeThread?.historySession || activeThread?.hasStarted) {
 			handleNewThread();
@@ -546,6 +600,8 @@ export default function Home() {
 								<ChatThreadPane
 									key={activeThread.id}
 									historySession={activeThread.historySession}
+									handoffUiState={handoffUiState}
+									onHandoffUiAction={dispatchHandoffUi}
 									liveHistoryStatus={
 										// Live entry wins; otherwise trust the clicked snapshot
 										// (the list can lag by a refresh). Resolution is handled
@@ -563,6 +619,11 @@ export default function Home() {
 									}
 									onUpdateSessionMetadata={handleUpdateSessionMetadata}
 									threadId={activeThread.id}
+									isThreadActive={() =>
+										activeLocationRef.current.activeThreadId ===
+											activeThread.id &&
+										activeLocationRef.current.view === "chat"
+									}
 									onDeleteSession={handleDeleteSession}
 									onNewThread={handleNewThread}
 									onOpenSession={handleOpenSession}
@@ -628,6 +689,9 @@ function ChatThreadPane({
 	parentSession,
 	onOpenVoiceInputSettings,
 	onThreadStarted,
+	isThreadActive,
+	handoffUiState,
+	onHandoffUiAction,
 }: {
 	threadId: string;
 	historySession?: SessionHistoryItem;
@@ -655,6 +719,9 @@ function ChatThreadPane({
 	parentSession?: { sessionId: string; title?: string };
 	onOpenVoiceInputSettings?: () => void;
 	onThreadStarted?: (threadId: string) => void;
+	isThreadActive?: () => boolean;
+	handoffUiState: CloudHandoffUiState;
+	onHandoffUiAction: (action: CloudHandoffUiAction) => void;
 }) {
 	const {
 		sessionId,
@@ -714,6 +781,42 @@ function ChatThreadPane({
 	const [gitBranch, setGitBranch] = useState<string | null>(null);
 	// Re-evaluate the account-targeted flag after sign-in changes.
 	const [cloudAgentsEnabled, setCloudAgentsEnabled] = useState(false);
+	const [handoffConfirmOpen, setHandoffConfirmOpen] = useState(false);
+	const [handoffPreflight, setHandoffPreflight] =
+		useState<HandoffPreflight | null>(null);
+	const [handoffNextCommand, setHandoffNextCommand] = useState("");
+	const handoffConfirmingRef = useRef(false);
+	const sourceSessionId = sessionId ?? historySession?.sessionId;
+	const handoffUi = sourceSessionId
+		? handoffUiState[sourceSessionId]
+		: undefined;
+	const handoffProgress = handoffUi?.status === "progress" ? handoffUi : null;
+	const handoffRecoveryUrl =
+		handoffUi?.status === "recovery" ? handoffUi.dashboardUrl : null;
+	const handoffRetry =
+		(handoffUi?.status === "recovery" || handoffUi?.status === "failed") &&
+		(handoffUi.retryDraft || handoffUi.retryAttachments?.length)
+			? {
+					draft: handoffUi.retryDraft,
+					attachments: handoffUi.retryAttachments,
+				}
+			: null;
+	const handoffReceipt =
+		(handoffUi?.status === "complete" ? handoffUi.receipt : null) ??
+		readHandoffReceipt(historySession?.metadata);
+	const handoffExternalPresentation =
+		handoffUi?.status === "complete" && handoffUi.externalPresentation;
+	useEffect(() => {
+		if (!sourceSessionId || !handoffRetry) return;
+		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
+		if (handoffRetry.attachments?.length) {
+			setPendingAttachments([...handoffRetry.attachments]);
+		}
+		onHandoffUiAction({
+			type: "retry_restored",
+			sourceSessionId,
+		});
+	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
 	const { user: accountUser } = useAccount();
 	const accountUserId = accountUser?.id ?? null;
 	useEffect(() => {
@@ -1263,9 +1366,215 @@ function ChatThreadPane({
 		threadId,
 	]);
 
+	const restoreHandoffDraft = useCallback(() => {
+		setPromptInput(
+			handoffNextCommand ? `/handoff ${handoffNextCommand}` : "/handoff",
+		);
+	}, [handoffNextCommand, setPromptInput]);
+
+	const prepareHandoff = useCallback(
+		async (nextCommand: string) => {
+			const sourceSessionId = sessionId ?? historySession?.sessionId;
+			if (isCloudSession) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Already in Cline Cloud",
+					description: "Handoff is available from local sessions.",
+				});
+				return;
+			}
+			if (!sourceSessionId) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Start the local session first",
+					description: "Send at least one message before handing off to cloud.",
+				});
+				return;
+			}
+			if (
+				status === "starting" ||
+				status === "running" ||
+				status === "stopping" ||
+				promptsInQueue.length > 0
+			) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Wait for the current turn",
+					description:
+						"Handoff can start once the local agent is idle and its prompt queue is empty.",
+				});
+				return;
+			}
+			const attachmentError = validateHandoffAttachments(
+				pendingAttachments,
+				nextCommand,
+			);
+			if (attachmentError) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Handoff is not ready",
+					description: attachmentError,
+					variant: "destructive",
+				});
+				return;
+			}
+
+			setHandoffNextCommand(nextCommand);
+			try {
+				const preflight = await desktopClient.invoke<HandoffPreflight>(
+					"chat_session_command",
+					{
+						request: {
+							action: "prepare_handoff",
+							sessionId: sourceSessionId,
+							config,
+						},
+					},
+				);
+				setHandoffPreflight(preflight);
+				setHandoffConfirmOpen(true);
+			} catch (error) {
+				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
+				toast({
+					title: "Handoff is not ready",
+					description: error instanceof Error ? error.message : String(error),
+					variant: "destructive",
+				});
+			}
+		},
+		[
+			config,
+			historySession?.sessionId,
+			isCloudSession,
+			pendingAttachments,
+			promptsInQueue.length,
+			sessionId,
+			setPromptInput,
+			status,
+		],
+	);
+
+	const runHandoff = useCallback(async () => {
+		const preflight = handoffPreflight;
+		const sourceSessionId = sessionId ?? historySession?.sessionId;
+		if (!preflight || !sourceSessionId) {
+			return;
+		}
+		const sourceAttachments = [...pendingAttachments];
+		handoffConfirmingRef.current = true;
+		setHandoffConfirmOpen(false);
+		onHandoffUiAction({
+			type: "progress",
+			sourceSessionId,
+			phase: "creating",
+		});
+		setPendingAttachments([]);
+		try {
+			const attachments = await serializeAttachments(sourceAttachments);
+			const result = await desktopClient.invoke<HandoffResult>(
+				"chat_session_command",
+				{
+					request: {
+						action: "handoff",
+						sessionId: sourceSessionId,
+						config,
+						fingerprint: preflight.fingerprint,
+						nextCommand: handoffNextCommand || undefined,
+						attachments:
+							attachments.userImages.length > 0 ? attachments : undefined,
+					},
+				},
+				{ timeoutMs: null },
+			);
+			const targetSessionId = (
+				result.outerSessionId ||
+				result.sessionId ||
+				""
+			).trim();
+			const dashboardUrl = result.dashboardUrl?.trim();
+			if (!targetSessionId || !dashboardUrl) {
+				throw new Error("Cloud handoff did not return a cloud session.");
+			}
+			const receipt = { targetSessionId, dashboardUrl };
+			const destination =
+				result.destination ?? (cloudAgentsEnabled ? "in_app" : "external");
+			onHandoffUiAction({
+				type: "complete",
+				sourceSessionId,
+				receipt,
+				externalPresentation: destination === "external",
+			});
+			if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
+				const opened = await onOpenSessionById?.(targetSessionId, {
+					silent: true,
+				}).catch(() => false);
+				if (!opened) {
+					onHandoffUiAction({ type: "external", sourceSessionId });
+					await openExternalUrl(dashboardUrl).catch(() => undefined);
+					toast({
+						title: "Opened handoff in your browser",
+						description:
+							"The cloud session could not be attached inside Cline Code.",
+					});
+				}
+			} else if (destination === "external") {
+				await openExternalUrl(dashboardUrl).catch(() =>
+					toast({
+						title: "Cloud handoff complete",
+						description: "Use the recovery link to open the cloud session.",
+					}),
+				);
+			} else {
+				toast({
+					title: "Cloud handoff complete",
+					description: "The cloud session is ready in your session list.",
+				});
+			}
+			if (result.warning) {
+				toast({
+					title: "Handoff completed with a warning",
+					description: result.warning,
+				});
+			}
+		} catch (error) {
+			onHandoffUiAction({
+				type: "failed",
+				sourceSessionId,
+				exposeRecovery: !cloudAgentsEnabled,
+				retryDraft: handoffNextCommand
+					? `/handoff ${handoffNextCommand}`
+					: "/handoff",
+				retryAttachments: sourceAttachments,
+			});
+			toast({
+				title: "Handoff failed",
+				description: error instanceof Error ? error.message : String(error),
+				variant: "destructive",
+			});
+		} finally {
+			handoffConfirmingRef.current = false;
+		}
+	}, [
+		cloudAgentsEnabled,
+		config,
+		handoffNextCommand,
+		handoffPreflight,
+		historySession?.sessionId,
+		isThreadActive,
+		onOpenSessionById,
+		onHandoffUiAction,
+		pendingAttachments,
+		sessionId,
+	]);
+
 	const handleSend = useCallback(
 		async (prompt: string) => {
 			const trimmed = prompt.trim();
+			const handoff = parseHandoffCommand(trimmed);
+			if (handoff) {
+				await prepareHandoff(handoff.nextCommand);
+				return;
+			}
 			if (!trimmed && pendingAttachments.length === 0) {
 				return;
 			}
@@ -1286,6 +1595,7 @@ function ChatThreadPane({
 			isCloudSession,
 			onThreadStarted,
 			pendingAttachments,
+			prepareHandoff,
 			sendPrompt,
 			sessionId,
 			setPromptInput,
@@ -1661,6 +1971,48 @@ function ChatThreadPane({
 		(prompt: string) => void handleSend(prompt),
 		[handleSend],
 	);
+	const handleOpenHandoffCloud = useCallback(async () => {
+		const receipt = handoffReceipt;
+		if (!receipt) {
+			return;
+		}
+		if (cloudAgentsEnabled) {
+			const opened = await onOpenSessionById?.(receipt.targetSessionId, {
+				silent: true,
+			}).catch(() => false);
+			if (opened) {
+				return;
+			}
+			if (sourceSessionId) {
+				onHandoffUiAction({ type: "external", sourceSessionId });
+			}
+		}
+		await openExternalUrl(receipt.dashboardUrl).catch(() =>
+			toast({
+				title: "Unable to open the browser",
+				description: "Copy the recovery link and open it manually.",
+				variant: "destructive",
+			}),
+		);
+	}, [
+		cloudAgentsEnabled,
+		handoffReceipt,
+		onHandoffUiAction,
+		onOpenSessionById,
+		sourceSessionId,
+	]);
+	const handleOpenHandoffProgressLink = useCallback(() => {
+		const dashboardUrl = handoffProgress?.dashboardUrl ?? handoffRecoveryUrl;
+		if (dashboardUrl) {
+			void openExternalUrl(dashboardUrl).catch(() =>
+				toast({
+					title: "Unable to open the browser",
+					description: "Copy the link shown above and open it manually.",
+					variant: "destructive",
+				}),
+			);
+		}
+	}, [handoffProgress?.dashboardUrl, handoffRecoveryUrl]);
 
 	const firstUserMessage = messages.find(
 		(message) => message.role === "user",
@@ -1842,7 +2194,7 @@ function ChatThreadPane({
 		);
 	}
 
-	const composer = (
+	const chatComposer = (
 		<ChatInputBar
 			attachments={attachmentList}
 			onAbort={handleAbort}
@@ -1877,6 +2229,33 @@ function ChatThreadPane({
 			thinking={config.thinking}
 			variant={isWelcomeState ? "welcome" : "conversation"}
 		/>
+	);
+	const composer = handoffReceipt ? (
+		<CloudHandoffReceipt
+			onForkLocally={() => void handleForkSession()}
+			onOpenCloud={() => void handleOpenHandoffCloud()}
+			receipt={handoffReceipt}
+			showRecoveryUrl={handoffExternalPresentation || !cloudAgentsEnabled}
+		/>
+	) : handoffProgress ? (
+		<CloudHandoffProgress
+			dashboardUrl={
+				cloudAgentsEnabled ? undefined : handoffProgress.dashboardUrl
+			}
+			message={handoffProgress.message}
+			onOpenCloud={handleOpenHandoffProgressLink}
+			phase={handoffProgress.phase}
+		/>
+	) : handoffRecoveryUrl && !cloudAgentsEnabled ? (
+		<div className="w-full">
+			<CloudHandoffRecoveryNotice
+				dashboardUrl={handoffRecoveryUrl}
+				onOpenCloud={handleOpenHandoffProgressLink}
+			/>
+			{chatComposer}
+		</div>
+	) : (
+		chatComposer
 	);
 
 	return (
@@ -2056,6 +2435,73 @@ function ChatThreadPane({
 							onClick={() => void handleDeleteSession()}
 						>
 							{deletingSession ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+			<AlertDialog
+				open={handoffConfirmOpen}
+				onOpenChange={(open) => {
+					setHandoffConfirmOpen(open);
+					if (!open && !handoffConfirmingRef.current) {
+						restoreHandoffDraft();
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Continue in Cline Cloud?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The conversation will be copied to a fresh cloud workspace. Your
+							local session stays available as read-only history.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					{handoffPreflight ? (
+						<div className="grid gap-2 rounded-md border bg-muted/30 p-3 text-sm">
+							<div className="grid grid-cols-[5rem_1fr] gap-2">
+								<span className="text-muted-foreground">Repository</span>
+								<span className="min-w-0 truncate font-medium">
+									{cloudRepositoryLabel(
+										handoffPreflight.repoUrl,
+										handoffPreflight.repoUrl,
+									)}
+								</span>
+								<span className="text-muted-foreground">Branch</span>
+								<span className="min-w-0 truncate font-medium">
+									{handoffPreflight.branch}
+								</span>
+								<span className="text-muted-foreground">Model</span>
+								<span className="min-w-0 truncate font-medium">
+									{handoffPreflight.modelId}
+									{handoffPreflight.modelFallback
+										? ` (fallback from ${handoffPreflight.modelFallback.from})`
+										: ""}
+								</span>
+								{handoffNextCommand ? (
+									<>
+										<span className="text-muted-foreground">Continue</span>
+										<span className="line-clamp-2 font-medium">
+											{handoffNextCommand}
+										</span>
+									</>
+								) : null}
+								{pendingAttachments.length > 0 ? (
+									<>
+										<span className="text-muted-foreground">Images</span>
+										<span className="font-medium">
+											{pendingAttachments.length}
+										</span>
+									</>
+								) : null}
+							</div>
+						</div>
+					) : null}
+					<AlertDialogFooter>
+						<AlertDialogCancel onClick={restoreHandoffDraft}>
+							Cancel
+						</AlertDialogCancel>
+						<AlertDialogAction onClick={() => void runHandoff()}>
+							Continue in Cloud
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1437,7 +1437,9 @@ function ChatThreadPane({
 				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
 				toast({
 					title: "Handoff is not ready",
-					description: error instanceof Error ? error.message : String(error),
+					description: humanizeCloudSessionError(
+						error instanceof Error ? error.message : String(error),
+					),
 					variant: "destructive",
 				});
 			}
@@ -1548,7 +1550,9 @@ function ChatThreadPane({
 			});
 			toast({
 				title: "Handoff failed",
-				description: error instanceof Error ? error.message : String(error),
+				description: humanizeCloudSessionError(
+					error instanceof Error ? error.message : String(error),
+				),
 				variant: "destructive",
 			});
 		} finally {

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1826,9 +1826,9 @@ function ChatThreadPane({
 					externalPresentation: destination === "external",
 				});
 				if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
-					const opened = await onOpenSessionById?.(targetSessionId, {
-						silent: true,
-					}).catch(() => false);
+					const opened = await Promise.resolve(
+						onOpenSessionById?.(targetSessionId, undefined, { silent: true }),
+					).catch(() => false);
 					if (!opened) {
 						onHandoffUiAction({ type: "external", sourceSessionId });
 						await openExternalUrl(dashboardUrl).catch(() => undefined);
@@ -2476,9 +2476,11 @@ function ChatThreadPane({
 			return;
 		}
 		if (cloudAgentsEnabled) {
-			const opened = await onOpenSessionById?.(receipt.targetSessionId, {
-				silent: true,
-			}).catch(() => false);
+			const opened = await Promise.resolve(
+				onOpenSessionById?.(receipt.targetSessionId, undefined, {
+					silent: true,
+				}),
+			).catch(() => false);
 			if (opened) {
 				return;
 			}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -10,6 +10,7 @@ import {
 	parseModelSelectionStorage,
 } from "@/lib/model-selection";
 import {
+	BUILTIN_SLASH_COMMANDS,
 	buildUserInstructionSlashCommands,
 	ChatInputBar,
 } from "./chat-input-bar";
@@ -203,6 +204,10 @@ async function renderVoiceComposer({
 
 describe("ChatInputBar", () => {
 	it("builds slash commands from both workflows and skills", () => {
+		expect(BUILTIN_SLASH_COMMANDS).toContainEqual({
+			name: "handoff",
+			description: "Continue this local session in Cline Cloud",
+		});
 		expect(
 			buildUserInstructionSlashCommands({
 				runtimeCommands: [
@@ -218,6 +223,7 @@ describe("ChatInputBar", () => {
 						kind: "skill",
 					},
 					{ id: "skill:fork", name: "fork", kind: "skill" },
+					{ id: "workflow:handoff", name: "handoff", kind: "workflow" },
 				],
 			}),
 		).toEqual([

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -10,6 +10,7 @@ import {
 	parseModelSelectionStorage,
 } from "@/lib/model-selection";
 import {
+	BUILTIN_SLASH_COMMANDS,
 	buildUserInstructionSlashCommands,
 	buildWorkspaceFileSearchKey,
 	ChatInputBar,
@@ -223,6 +224,10 @@ describe("ChatInputBar", () => {
 	});
 
 	it("builds slash commands from both workflows and skills", () => {
+		expect(BUILTIN_SLASH_COMMANDS).toContainEqual({
+			name: "handoff",
+			description: "Continue this local session in Cline Cloud",
+		});
 		expect(
 			buildUserInstructionSlashCommands({
 				runtimeCommands: [
@@ -238,6 +243,7 @@ describe("ChatInputBar", () => {
 						kind: "skill",
 					},
 					{ id: "skill:fork", name: "fork", kind: "skill" },
+					{ id: "workflow:handoff", name: "handoff", kind: "workflow" },
 				],
 			}),
 		).toEqual([

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -7,10 +7,7 @@ import {
 import { AgentPromptQueue, SearchCombobox } from "@cline/ui";
 import {
 	ArrowRight,
-	ArrowUp,
-	Brain,
 	CircleStop,
-	Cloud,
 	Cpu,
 	Paperclip,
 	Signal,
@@ -36,7 +33,6 @@ import {
 	SelectContent,
 	SelectItem,
 	SelectTrigger,
-	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { useWorkspace } from "@/contexts/workspace-context";
@@ -96,7 +92,11 @@ type UserInstructionConfigResponse = {
 	runtimeCommands?: UserInstructionCommand[];
 };
 
-const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
+export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
+	{
+		name: "handoff",
+		description: "Continue this local session in Cline Cloud",
+	},
 	{
 		name: "fork",
 		description: "Create a copy of the current session into a new session",
@@ -378,7 +378,6 @@ function ChatInputBarImpl({
 	provider,
 	model,
 	modelContextWindow,
-	mode,
 	thinking,
 	reasoningEffort,
 	gitBranch,
@@ -390,7 +389,6 @@ function ChatInputBarImpl({
 	onPromptInputChange,
 	onProviderChange,
 	onModelChange,
-	onModeToggle,
 	onReasoningChange,
 	onListGitBranches,
 	onSwitchGitBranch,

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -89,7 +89,11 @@ type UserInstructionConfigResponse = {
 	runtimeCommands?: UserInstructionCommand[];
 };
 
-const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
+export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
+	{
+		name: "handoff",
+		description: "Continue this local session in Cline Cloud",
+	},
 	{
 		name: "fork",
 		description: "Create a copy of the current session into a new session",

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
@@ -94,17 +94,33 @@ describe("CloudHandoffReceipt", () => {
 describe("CloudHandoffRecoveryNotice", () => {
 	it("retains a non-spinning link after handoff progress stops", () => {
 		const onOpenCloud = vi.fn();
+		const onDismiss = vi.fn();
 		const view = render(
 			<CloudHandoffRecoveryNotice
 				dashboardUrl="https://app.cline.bot/agents?sessionId=orphan-1"
+				onDismiss={onDismiss}
 				onOpenCloud={onOpenCloud}
 			/>,
 		);
-		expect(view.textContent).toContain("Cloud handoff was interrupted");
-		expect(view.textContent).toContain("retry /handoff");
+		expect(view.textContent).toContain("Handoff interrupted");
+		expect(view.textContent).toContain(
+			"A cloud session was created and may still be available",
+		);
 		expect(view.textContent).toContain("sessionId=orphan-1");
 		expect(view.querySelector(".animate-spin")).toBeNull();
-		act(() => view.querySelector("button")?.click());
+		act(() =>
+			Array.from(view.querySelectorAll("button"))
+				.find((button) => button.textContent?.includes("Open Cloud"))
+				?.click(),
+		);
 		expect(onOpenCloud).toHaveBeenCalledOnce();
+		act(() =>
+			view
+				.querySelector<HTMLButtonElement>(
+					'[aria-label="Dismiss handoff recovery"]',
+				)
+				?.click(),
+		);
+		expect(onDismiss).toHaveBeenCalledOnce();
 	});
 });

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	CloudHandoffProgress,
+	CloudHandoffReceipt,
+	CloudHandoffRecoveryNotice,
+} from "./cloud-handoff";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+	container?.remove();
+	container = null;
+});
+
+function render(node: React.ReactNode) {
+	container = document.createElement("div");
+	document.body.append(container);
+	const root = createRoot(container);
+	act(() => root.render(node));
+	return container;
+}
+
+describe("CloudHandoffProgress", () => {
+	it("shows a truthful phase and an optional early external link", () => {
+		const onOpenCloud = vi.fn();
+		const view = render(
+			<CloudHandoffProgress
+				dashboardUrl="https://staging-app.cline.bot/agents?sessionId=cloud-1"
+				onOpenCloud={onOpenCloud}
+				phase="seeding"
+			/>,
+		);
+		expect(view.textContent).toContain("Transferring the conversation");
+		expect(view.textContent).toContain("available to watch");
+		expect(view.textContent).not.toContain("ready to open");
+		const button = Array.from(view.querySelectorAll("button")).find((item) =>
+			item.textContent?.includes("Open Cloud"),
+		);
+		act(() => button?.click());
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+	});
+});
+
+describe("CloudHandoffReceipt", () => {
+	it("explains the local copy and offers cloud and local-fork actions", () => {
+		const onOpenCloud = vi.fn();
+		const onForkLocally = vi.fn();
+		const view = render(
+			<CloudHandoffReceipt
+				onForkLocally={onForkLocally}
+				onOpenCloud={onOpenCloud}
+				receipt={{
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				}}
+				showRecoveryUrl
+			/>,
+		);
+		expect(view.textContent).toContain("read-only history");
+		expect(view.textContent).toContain("sessionId=cloud-1");
+		const buttons = Array.from(view.querySelectorAll("button"));
+		act(() =>
+			buttons.find((item) => item.textContent?.includes("Open Cloud"))?.click(),
+		);
+		act(() =>
+			buttons
+				.find((item) => item.textContent?.includes("Fork Locally"))
+				?.click(),
+		);
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+		expect(onForkLocally).toHaveBeenCalledOnce();
+	});
+
+	it("keeps the dashboard URL out of the in-app receipt", () => {
+		const view = render(
+			<CloudHandoffReceipt
+				onForkLocally={() => undefined}
+				onOpenCloud={() => undefined}
+				receipt={{
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				}}
+			/>,
+		);
+		expect(view.textContent).not.toContain("sessionId=cloud-1");
+		expect(view.textContent).not.toContain("Copy recovery link");
+	});
+});
+
+describe("CloudHandoffRecoveryNotice", () => {
+	it("retains a non-spinning link after handoff progress stops", () => {
+		const onOpenCloud = vi.fn();
+		const view = render(
+			<CloudHandoffRecoveryNotice
+				dashboardUrl="https://app.cline.bot/agents?sessionId=orphan-1"
+				onOpenCloud={onOpenCloud}
+			/>,
+		);
+		expect(view.textContent).toContain("may still be available");
+		expect(view.textContent).toContain("sessionId=orphan-1");
+		expect(view.querySelector(".animate-spin")).toBeNull();
+		act(() => view.querySelector("button")?.click());
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	CloudHandoffProgress,
+	CloudHandoffReceipt,
+	CloudHandoffRecoveryNotice,
+} from "./cloud-handoff";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+	container?.remove();
+	container = null;
+});
+
+function render(node: React.ReactNode) {
+	container = document.createElement("div");
+	document.body.append(container);
+	const root = createRoot(container);
+	act(() => root.render(node));
+	return container;
+}
+
+describe("CloudHandoffProgress", () => {
+	it("shows a truthful phase and an optional early external link", () => {
+		const onOpenCloud = vi.fn();
+		const view = render(
+			<CloudHandoffProgress
+				dashboardUrl="https://staging-app.cline.bot/agents?sessionId=cloud-1"
+				onOpenCloud={onOpenCloud}
+				phase="seeding"
+			/>,
+		);
+		expect(view.textContent).toContain("Transferring the conversation");
+		expect(view.textContent).toContain("available to watch");
+		expect(view.textContent).not.toContain("ready to open");
+		const button = Array.from(view.querySelectorAll("button")).find((item) =>
+			item.textContent?.includes("Open Cloud"),
+		);
+		act(() => button?.click());
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+	});
+});
+
+describe("CloudHandoffReceipt", () => {
+	it("explains the local copy and offers cloud and local-fork actions", () => {
+		const onOpenCloud = vi.fn();
+		const onForkLocally = vi.fn();
+		const view = render(
+			<CloudHandoffReceipt
+				onForkLocally={onForkLocally}
+				onOpenCloud={onOpenCloud}
+				receipt={{
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				}}
+				showRecoveryUrl
+			/>,
+		);
+		expect(view.textContent).toContain("read-only history");
+		expect(view.textContent).toContain("sessionId=cloud-1");
+		const buttons = Array.from(view.querySelectorAll("button"));
+		act(() =>
+			buttons.find((item) => item.textContent?.includes("Open Cloud"))?.click(),
+		);
+		act(() =>
+			buttons
+				.find((item) => item.textContent?.includes("Fork Locally"))
+				?.click(),
+		);
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+		expect(onForkLocally).toHaveBeenCalledOnce();
+	});
+
+	it("keeps the dashboard URL out of the in-app receipt", () => {
+		const view = render(
+			<CloudHandoffReceipt
+				onForkLocally={() => undefined}
+				onOpenCloud={() => undefined}
+				receipt={{
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				}}
+			/>,
+		);
+		expect(view.textContent).not.toContain("sessionId=cloud-1");
+		expect(view.textContent).not.toContain("Copy recovery link");
+	});
+});
+
+describe("CloudHandoffRecoveryNotice", () => {
+	it("retains a non-spinning link after handoff progress stops", () => {
+		const onOpenCloud = vi.fn();
+		const onDismiss = vi.fn();
+		const view = render(
+			<CloudHandoffRecoveryNotice
+				dashboardUrl="https://app.cline.bot/agents?sessionId=orphan-1"
+				onDismiss={onDismiss}
+				onOpenCloud={onOpenCloud}
+			/>,
+		);
+		expect(view.textContent).toContain("Handoff interrupted");
+		expect(view.textContent).toContain(
+			"A cloud session was created and may still be available",
+		);
+		expect(view.textContent).toContain("sessionId=orphan-1");
+		expect(view.querySelector(".animate-spin")).toBeNull();
+		act(() =>
+			Array.from(view.querySelectorAll("button"))
+				.find((button) => button.textContent?.includes("Open Cloud"))
+				?.click(),
+		);
+		expect(onOpenCloud).toHaveBeenCalledOnce();
+		act(() =>
+			view
+				.querySelector<HTMLButtonElement>(
+					'[aria-label="Dismiss handoff recovery"]',
+				)
+				?.click(),
+		);
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
@@ -100,7 +100,8 @@ describe("CloudHandoffRecoveryNotice", () => {
 				onOpenCloud={onOpenCloud}
 			/>,
 		);
-		expect(view.textContent).toContain("may still be available");
+		expect(view.textContent).toContain("Cloud handoff was interrupted");
+		expect(view.textContent).toContain("retry /handoff");
 		expect(view.textContent).toContain("sessionId=orphan-1");
 		expect(view.querySelector(".animate-spin")).toBeNull();
 		act(() => view.querySelector("button")?.click());

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
@@ -70,7 +70,10 @@ export function CloudHandoffRecoveryNotice({
 			className="mx-auto mb-2 flex w-full max-w-xl items-start justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs"
 		>
 			<div className="min-w-0">
-				<p className="font-medium">The cloud session may still be available.</p>
+				<p className="font-medium">Cloud handoff was interrupted.</p>
+				<p className="mt-1 text-muted-foreground">
+					Open the cloud session or retry /handoff.
+				</p>
 				<p className="mt-1 break-all text-muted-foreground">{dashboardUrl}</p>
 			</div>
 			<Button

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Cloud, Copy, ExternalLink, GitFork, Loader2, X } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import type {
+	HandoffProgressPhase,
+	HandoffReceipt as HandoffReceiptValue,
+} from "@/lib/cloud-handoff";
+import { HANDOFF_PROGRESS_LABELS } from "@/lib/cloud-handoff";
+
+export function CloudHandoffProgress({
+	phase,
+	message,
+	dashboardUrl,
+	onOpenCloud,
+}: {
+	phase: HandoffProgressPhase;
+	message?: string;
+	dashboardUrl?: string;
+	onOpenCloud: () => void;
+}) {
+	return (
+		<output
+			aria-live="polite"
+			className="mx-auto flex w-full max-w-xl flex-col gap-3 rounded-lg border bg-card p-5 shadow-sm"
+		>
+			<div className="flex items-center gap-3">
+				<Loader2 className="size-4 animate-spin text-primary" />
+				<div>
+					<p className="text-sm font-medium">
+						{message?.trim() || HANDOFF_PROGRESS_LABELS[phase]}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						You can use the rest of Cline Code while this finishes.
+					</p>
+				</div>
+			</div>
+			{dashboardUrl ? (
+				<div className="rounded-md border bg-muted/30 p-3 text-xs">
+					<p className="font-medium">
+						Your cloud session is available to watch while verification
+						finishes.
+					</p>
+					<p className="mt-1 break-all text-muted-foreground">{dashboardUrl}</p>
+					<Button
+						className="mt-2 h-7 gap-1.5 px-2 text-xs"
+						onClick={onOpenCloud}
+						size="sm"
+						variant="outline"
+					>
+						<ExternalLink className="size-3.5" />
+						Open Cloud
+					</Button>
+				</div>
+			) : null}
+		</output>
+	);
+}
+
+export function CloudHandoffRecoveryNotice({
+	dashboardUrl,
+	onOpenCloud,
+	onDismiss,
+}: {
+	dashboardUrl: string;
+	onOpenCloud: () => void;
+	onDismiss: () => void;
+}) {
+	return (
+		<Alert className="mx-auto mb-2 w-full max-w-xl pr-10">
+			<Cloud />
+			<AlertTitle>Handoff interrupted</AlertTitle>
+			<AlertDescription>
+				<p>A cloud session was created and may still be available.</p>
+				<div className="mt-2 flex w-full items-start justify-between gap-3">
+					<p className="min-w-0 break-all text-xs">{dashboardUrl}</p>
+					<Button
+						className="h-7 shrink-0 gap-1.5 px-2 text-xs"
+						onClick={onOpenCloud}
+						size="sm"
+						variant="outline"
+					>
+						<ExternalLink className="size-3.5" />
+						Open Cloud
+					</Button>
+				</div>
+			</AlertDescription>
+			<Button
+				aria-label="Dismiss handoff recovery"
+				className="absolute right-2 top-2 size-7 text-muted-foreground"
+				onClick={onDismiss}
+				size="icon"
+				variant="ghost"
+			>
+				<X className="size-4" />
+			</Button>
+		</Alert>
+	);
+}
+
+export function CloudHandoffReceipt({
+	receipt,
+	onOpenCloud,
+	onForkLocally,
+	showRecoveryUrl = false,
+}: {
+	receipt: HandoffReceiptValue;
+	onOpenCloud: () => void;
+	onForkLocally: () => void;
+	showRecoveryUrl?: boolean;
+}) {
+	return (
+		<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-10 text-center">
+			<div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+				<Cloud className="size-5" />
+			</div>
+			<div>
+				<h2 className="text-base font-semibold">Continued in Cline Cloud</h2>
+				<p className="mt-1 text-sm text-muted-foreground">
+					This local session is preserved as read-only history.
+				</p>
+			</div>
+			<div className="flex flex-wrap justify-center gap-2">
+				<Button className="gap-1.5" onClick={onOpenCloud} size="sm">
+					<ExternalLink className="size-3.5" />
+					Open Cloud
+				</Button>
+				<Button
+					className="gap-1.5"
+					onClick={onForkLocally}
+					size="sm"
+					variant="outline"
+				>
+					<GitFork className="size-3.5" />
+					Fork Locally
+				</Button>
+			</div>
+			{showRecoveryUrl ? (
+				<button
+					className="max-w-full break-all text-xs text-primary underline-offset-4 hover:underline"
+					onClick={onOpenCloud}
+					type="button"
+				>
+					{receipt.dashboardUrl}
+				</button>
+			) : null}
+			{showRecoveryUrl ? (
+				<button
+					className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+					onClick={() =>
+						void navigator.clipboard?.writeText(receipt.dashboardUrl)
+					}
+					type="button"
+				>
+					<Copy className="size-3" />
+					Copy recovery link
+				</button>
+			) : null}
+		</div>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Cloud, Copy, ExternalLink, GitFork, Loader2 } from "lucide-react";
+import { Cloud, Copy, ExternalLink, GitFork, Loader2, X } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import type {
 	HandoffProgressPhase,
@@ -60,32 +61,41 @@ export function CloudHandoffProgress({
 export function CloudHandoffRecoveryNotice({
 	dashboardUrl,
 	onOpenCloud,
+	onDismiss,
 }: {
 	dashboardUrl: string;
 	onOpenCloud: () => void;
+	onDismiss: () => void;
 }) {
 	return (
-		<div
-			aria-live="polite"
-			className="mx-auto mb-2 flex w-full max-w-xl items-start justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs"
-		>
-			<div className="min-w-0">
-				<p className="font-medium">Cloud handoff was interrupted.</p>
-				<p className="mt-1 text-muted-foreground">
-					Open the cloud session or retry /handoff.
-				</p>
-				<p className="mt-1 break-all text-muted-foreground">{dashboardUrl}</p>
-			</div>
+		<Alert className="mx-auto mb-2 w-full max-w-xl pr-10">
+			<Cloud />
+			<AlertTitle>Handoff interrupted</AlertTitle>
+			<AlertDescription>
+				<p>A cloud session was created and may still be available.</p>
+				<div className="mt-2 flex w-full items-start justify-between gap-3">
+					<p className="min-w-0 break-all text-xs">{dashboardUrl}</p>
+					<Button
+						className="h-7 shrink-0 gap-1.5 px-2 text-xs"
+						onClick={onOpenCloud}
+						size="sm"
+						variant="outline"
+					>
+						<ExternalLink className="size-3.5" />
+						Open Cloud
+					</Button>
+				</div>
+			</AlertDescription>
 			<Button
-				className="h-7 shrink-0 gap-1.5 px-2 text-xs"
-				onClick={onOpenCloud}
-				size="sm"
-				variant="outline"
+				aria-label="Dismiss handoff recovery"
+				className="absolute right-2 top-2 size-7 text-muted-foreground"
+				onClick={onDismiss}
+				size="icon"
+				variant="ghost"
 			>
-				<ExternalLink className="size-3.5" />
-				Open
+				<X className="size-4" />
 			</Button>
-		</div>
+		</Alert>
 	);
 }
 

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Cloud, Copy, ExternalLink, GitFork, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type {
+	HandoffProgressPhase,
+	HandoffReceipt as HandoffReceiptValue,
+} from "@/lib/cloud-handoff";
+import { HANDOFF_PROGRESS_LABELS } from "@/lib/cloud-handoff";
+
+export function CloudHandoffProgress({
+	phase,
+	message,
+	dashboardUrl,
+	onOpenCloud,
+}: {
+	phase: HandoffProgressPhase;
+	message?: string;
+	dashboardUrl?: string;
+	onOpenCloud: () => void;
+}) {
+	return (
+		<output
+			aria-live="polite"
+			className="mx-auto flex w-full max-w-xl flex-col gap-3 rounded-lg border bg-card p-5 shadow-sm"
+		>
+			<div className="flex items-center gap-3">
+				<Loader2 className="size-4 animate-spin text-primary" />
+				<div>
+					<p className="text-sm font-medium">
+						{message?.trim() || HANDOFF_PROGRESS_LABELS[phase]}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						You can use the rest of Cline Code while this finishes.
+					</p>
+				</div>
+			</div>
+			{dashboardUrl ? (
+				<div className="rounded-md border bg-muted/30 p-3 text-xs">
+					<p className="font-medium">
+						Your cloud session is available to watch while verification
+						finishes.
+					</p>
+					<p className="mt-1 break-all text-muted-foreground">{dashboardUrl}</p>
+					<Button
+						className="mt-2 h-7 gap-1.5 px-2 text-xs"
+						onClick={onOpenCloud}
+						size="sm"
+						variant="outline"
+					>
+						<ExternalLink className="size-3.5" />
+						Open Cloud
+					</Button>
+				</div>
+			) : null}
+		</output>
+	);
+}
+
+export function CloudHandoffRecoveryNotice({
+	dashboardUrl,
+	onOpenCloud,
+}: {
+	dashboardUrl: string;
+	onOpenCloud: () => void;
+}) {
+	return (
+		<div
+			aria-live="polite"
+			className="mx-auto mb-2 flex w-full max-w-xl items-start justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs"
+		>
+			<div className="min-w-0">
+				<p className="font-medium">The cloud session may still be available.</p>
+				<p className="mt-1 break-all text-muted-foreground">{dashboardUrl}</p>
+			</div>
+			<Button
+				className="h-7 shrink-0 gap-1.5 px-2 text-xs"
+				onClick={onOpenCloud}
+				size="sm"
+				variant="outline"
+			>
+				<ExternalLink className="size-3.5" />
+				Open
+			</Button>
+		</div>
+	);
+}
+
+export function CloudHandoffReceipt({
+	receipt,
+	onOpenCloud,
+	onForkLocally,
+	showRecoveryUrl = false,
+}: {
+	receipt: HandoffReceiptValue;
+	onOpenCloud: () => void;
+	onForkLocally: () => void;
+	showRecoveryUrl?: boolean;
+}) {
+	return (
+		<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-10 text-center">
+			<div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+				<Cloud className="size-5" />
+			</div>
+			<div>
+				<h2 className="text-base font-semibold">Continued in Cline Cloud</h2>
+				<p className="mt-1 text-sm text-muted-foreground">
+					This local session is preserved as read-only history.
+				</p>
+			</div>
+			<div className="flex flex-wrap justify-center gap-2">
+				<Button className="gap-1.5" onClick={onOpenCloud} size="sm">
+					<ExternalLink className="size-3.5" />
+					Open Cloud
+				</Button>
+				<Button
+					className="gap-1.5"
+					onClick={onForkLocally}
+					size="sm"
+					variant="outline"
+				>
+					<GitFork className="size-3.5" />
+					Fork Locally
+				</Button>
+			</div>
+			{showRecoveryUrl ? (
+				<button
+					className="max-w-full break-all text-xs text-primary underline-offset-4 hover:underline"
+					onClick={onOpenCloud}
+					type="button"
+				>
+					{receipt.dashboardUrl}
+				</button>
+			) : null}
+			{showRecoveryUrl ? (
+				<button
+					className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+					onClick={() =>
+						void navigator.clipboard?.writeText(receipt.dashboardUrl)
+					}
+					type="button"
+				>
+					<Copy className="size-3" />
+					Copy recovery link
+				</button>
+			) : null}
+		</div>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/chat/environment-selector.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/environment-selector.test.tsx
@@ -176,6 +176,53 @@ describe("EnvironmentSelector", () => {
 		expect(onAddSshHost).toHaveBeenCalledTimes(1);
 	});
 
+	it("selects Cloud when enabled and returns through the same menu", async () => {
+		const onSelectEnvironment = vi.fn(async () => undefined);
+		const onSelectExecutionTarget = vi.fn(async () => undefined);
+		await act(async () => {
+			root.render(
+				<EnvironmentSelector
+					activeEnvironmentId="local"
+					cloudEnabled
+					onAddSshHost={vi.fn()}
+					onSelectEnvironment={onSelectEnvironment}
+					onSelectExecutionTarget={onSelectExecutionTarget}
+					profiles={profiles}
+				/>,
+			);
+		});
+
+		await pointerDown(trigger());
+		const cloudItem = menuItemContaining("Cloud");
+		expect(cloudItem.textContent).not.toContain("Coming soon");
+		expect(cloudItem.getAttribute("data-disabled")).toBeNull();
+		await click(cloudItem);
+		expect(onSelectExecutionTarget).toHaveBeenCalledWith("cloud");
+
+		await act(async () => {
+			root.render(
+				<EnvironmentSelector
+					activeEnvironmentId="local"
+					cloudEnabled
+					executionTarget="cloud"
+					onAddSshHost={vi.fn()}
+					onSelectEnvironment={onSelectEnvironment}
+					onSelectExecutionTarget={onSelectExecutionTarget}
+					profiles={profiles}
+				/>,
+			);
+		});
+
+		expect(trigger().getAttribute("aria-label")).toBe("Environment: Cloud");
+		await pointerDown(trigger());
+		expect(menuItemContaining("Cloud").getAttribute("aria-current")).toBe(
+			"true",
+		);
+		await click(menuItemContaining("Local"));
+		expect(onSelectExecutionTarget).toHaveBeenLastCalledWith("local");
+		expect(onSelectEnvironment).not.toHaveBeenCalled();
+	});
+
 	it("reopens the menu after a rejected environment switch", async () => {
 		const onSelectEnvironment = vi
 			.fn()

--- a/apps/examples/desktop-app/webview/components/views/chat/environment-selector.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/environment-selector.tsx
@@ -35,10 +35,13 @@ export type EnvironmentSelectorModel = {
 
 export type EnvironmentSelectorProps = {
 	activeEnvironmentId: string;
+	cloudEnabled?: boolean;
+	executionTarget?: "local" | "cloud";
 	profiles: RemoteEnvironmentProfile[];
 	loading?: boolean;
 	switchingEnvironmentId?: string | null;
 	onSelectEnvironment: (environmentId: string) => void | Promise<void>;
+	onSelectExecutionTarget?: (target: "local" | "cloud") => void | Promise<void>;
 	onAddSshHost: () => void;
 };
 
@@ -83,10 +86,13 @@ export function buildEnvironmentSelectorModel(
 
 export function EnvironmentSelector({
 	activeEnvironmentId,
+	cloudEnabled = false,
+	executionTarget = "local",
 	profiles,
 	loading = false,
 	switchingEnvironmentId,
 	onSelectEnvironment,
+	onSelectExecutionTarget = () => undefined,
 	onAddSshHost,
 }: EnvironmentSelectorProps) {
 	const model = useMemo(
@@ -99,17 +105,42 @@ export function EnvironmentSelector({
 	const [open, setOpen] = useState(false);
 	const pendingEnvironmentId = switchingEnvironmentId ?? internalSwitchingId;
 	const busy = loading || pendingEnvironmentId !== null;
-	const ActiveIcon = model.activeKind === "remote" ? Server : Laptop;
+	const cloudSelected = executionTarget === "cloud";
+	const activeLabel = cloudSelected ? "Cloud" : model.activeLabel;
+	const ActiveIcon = cloudSelected
+		? Cloud
+		: model.activeKind === "remote"
+			? Server
+			: Laptop;
 
 	const selectEnvironment = async (environmentId: string) => {
-		if (busy || environmentId === activeEnvironmentId) return;
+		if (
+			busy ||
+			(executionTarget === "local" && environmentId === activeEnvironmentId)
+		) {
+			return;
+		}
 		setInternalSwitchingId(environmentId);
 		try {
-			await onSelectEnvironment(environmentId);
+			if (executionTarget === "cloud") {
+				await onSelectExecutionTarget("local");
+			}
+			if (environmentId !== activeEnvironmentId) {
+				await onSelectEnvironment(environmentId);
+			}
 		} catch {
 			// The parent owns connection errors and their user-facing presentation;
 			// reopen so the failed choice does not strand the user at a closed menu.
 			setOpen(true);
+		} finally {
+			setInternalSwitchingId(null);
+		}
+	};
+	const selectCloud = async () => {
+		if (!cloudEnabled || busy || cloudSelected) return;
+		setInternalSwitchingId("cloud");
+		try {
+			await onSelectExecutionTarget("cloud");
 		} finally {
 			setInternalSwitchingId(null);
 		}
@@ -124,7 +155,7 @@ export function EnvironmentSelector({
 				</span>
 			);
 		}
-		if (option.status) {
+		if (!cloudSelected && option.status) {
 			return (
 				<span className="ml-auto text-xs text-muted-foreground">
 					{option.status}
@@ -138,11 +169,11 @@ export function EnvironmentSelector({
 		<DropdownMenu onOpenChange={setOpen} open={open}>
 			<DropdownMenuTrigger asChild>
 				<Button
-					aria-label={`Environment: ${model.activeLabel}`}
+					aria-label={`Environment: ${activeLabel}`}
 					className="size-9 shrink-0 rounded-md border border-border/70 bg-background/80 p-0 text-foreground shadow-none transition-colors hover:bg-accent hover:text-foreground"
 					disabled={busy}
 					id="environment-selector-btn"
-					title={`Environment: ${model.activeLabel}`}
+					title={`Environment: ${activeLabel}`}
 					variant="ghost"
 				>
 					{busy ? (
@@ -154,14 +185,18 @@ export function EnvironmentSelector({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start" className="w-72" side="bottom">
 				<DropdownMenuItem
-					aria-current={model.local.selected ? "true" : undefined}
+					aria-current={
+						!cloudSelected && model.local.selected ? "true" : undefined
+					}
 					disabled={busy}
 					onSelect={() => void selectEnvironment(model.local.id)}
 				>
 					<Laptop />
 					<span>Local</span>
 					{optionStatus(model.local)}
-					{model.local.selected ? <Check className="ml-1" /> : null}
+					{!cloudSelected && model.local.selected ? (
+						<Check className="ml-1" />
+					) : null}
 				</DropdownMenuItem>
 
 				<DropdownMenuSeparator />
@@ -171,7 +206,9 @@ export function EnvironmentSelector({
 				{model.remotes.length > 0 ? (
 					model.remotes.map((option) => (
 						<DropdownMenuItem
-							aria-current={option.selected ? "true" : undefined}
+							aria-current={
+								!cloudSelected && option.selected ? "true" : undefined
+							}
 							disabled={busy}
 							key={option.id}
 							onSelect={() => void selectEnvironment(option.id)}
@@ -186,7 +223,9 @@ export function EnvironmentSelector({
 								) : null}
 							</span>
 							{optionStatus(option)}
-							{option.selected ? <Check className="ml-1" /> : null}
+							{!cloudSelected && option.selected ? (
+								<Check className="ml-1" />
+							) : null}
 						</DropdownMenuItem>
 					))
 				) : (
@@ -200,12 +239,20 @@ export function EnvironmentSelector({
 				<DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
 					Cloud
 				</DropdownMenuLabel>
-				<DropdownMenuItem disabled>
+				<DropdownMenuItem
+					aria-current={cloudSelected ? "true" : undefined}
+					disabled={!cloudEnabled || busy}
+					onSelect={() => void selectCloud()}
+				>
 					<Cloud />
 					<span>Cloud</span>
-					<span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-						Coming soon
-					</span>
+					{!cloudEnabled ? (
+						<span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+							Coming soon
+						</span>
+					) : cloudSelected ? (
+						<Check className="ml-auto" />
+					) : null}
 				</DropdownMenuItem>
 
 				<DropdownMenuSeparator />

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-chat.tsx
@@ -54,7 +54,6 @@ export function WelcomeScreen({
 	executionTarget = "local",
 	repoUrl = "",
 	cloudBranch = "",
-	onExecutionTargetChange = () => undefined,
 	onRepoUrlChange = () => undefined,
 	onCloudBranchChange = () => undefined,
 	cloudAgentsEnabled = false,
@@ -72,7 +71,6 @@ export function WelcomeScreen({
 	executionTarget?: "local" | "cloud";
 	repoUrl?: string;
 	cloudBranch?: string;
-	onExecutionTargetChange?: (target: "local" | "cloud") => void;
 	onRepoUrlChange?: (repoUrl: string) => void;
 	onCloudBranchChange?: (branch: string) => void;
 	cloudAgentsEnabled?: boolean;
@@ -314,7 +312,6 @@ export function WelcomeScreen({
 									onOpenExternalUrl={openExternalUrl}
 									onPickWorkspaceDirectory={pickWorkspaceDirectory}
 									onRefreshWorkspaces={refreshWorkspaces}
-									onExecutionTargetChange={onExecutionTargetChange}
 									onRepoUrlChange={onRepoUrlChange}
 									onSignIn={signIn}
 									onSelectChat={selectChat}

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.test.tsx
@@ -59,7 +59,6 @@ function renderControls(
 		onCloudBranchChange: vi.fn(),
 		signedIn: true,
 		signingIn: false,
-		onExecutionTargetChange: vi.fn(),
 		onRepoUrlChange: vi.fn(),
 		onListCloudRepositories: vi.fn(async () => ({
 			connected: true,
@@ -99,22 +98,6 @@ function renderControls(
 }
 
 describe("WelcomeWorkspaceControls cloud mode", () => {
-	it("selects Cloud from the same workspace control row", async () => {
-		const props = renderControls();
-		await click(button("Cloud"));
-		expect(props.onExecutionTargetChange).toHaveBeenCalledWith("cloud");
-	});
-
-	it("hides the Local/Cloud selector when the feature flag is off", () => {
-		renderControls({ cloudEnabled: false });
-		const buttons = [...container.querySelectorAll("button")].map(
-			(candidate) => candidate.textContent ?? "",
-		);
-		expect(buttons.some((text) => text.includes("Cloud"))).toBe(false);
-		// Local workspace controls still render.
-		expect(buttons.some((text) => text.includes("cline"))).toBe(true);
-	});
-
 	it("requires sign in before choosing a cloud repository", async () => {
 		const props = renderControls({
 			executionTarget: "cloud",

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.tsx
@@ -3,12 +3,10 @@
 import { isChatWorkspacePath } from "@cline/shared/browser";
 import {
 	Check,
-	Cloud,
 	FilePlus2,
 	Folder,
 	GitBranch,
 	Github,
-	HardDrive,
 	LoaderCircle,
 	LogIn,
 	Plus,
@@ -64,41 +62,6 @@ const TRIGGER_CLASS =
 	"inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-background/80 px-3 py-1.5 text-sm font-medium text-foreground hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 const PANEL_CLASS =
 	"absolute left-0 top-full z-50 mt-2 w-72 rounded-lg border border-border bg-popover shadow-xl";
-
-function ExecutionTargetPicker({
-	executionTarget,
-	onChange,
-}: {
-	executionTarget: "local" | "cloud";
-	onChange: (target: "local" | "cloud") => void;
-}) {
-	return (
-		<fieldset className="inline-flex shrink-0 items-center rounded-md border border-border/70 bg-background/80 p-0.5">
-			<legend className="sr-only">Execution location</legend>
-			{(["local", "cloud"] as const).map((target) => {
-				const active = executionTarget === target;
-				const Icon = target === "local" ? HardDrive : Cloud;
-				return (
-					<button
-						aria-pressed={active}
-						className={cn(
-							"inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
-							active
-								? "bg-accent text-foreground shadow-xs"
-								: "text-muted-foreground hover:text-foreground",
-						)}
-						key={target}
-						onClick={() => onChange(target)}
-						type="button"
-					>
-						<Icon className="size-3" />
-						{target === "local" ? "Local" : "Cloud"}
-					</button>
-				);
-			})}
-		</fieldset>
-	);
-}
 
 function CloudRepositoryPicker({
 	open,
@@ -906,7 +869,6 @@ export function WelcomeWorkspaceControls({
 	cloudBranch,
 	signedIn,
 	signingIn,
-	onExecutionTargetChange,
 	onCloudBranchChange,
 	onListCloudRepositories,
 	onListCloudBranches,
@@ -941,7 +903,6 @@ export function WelcomeWorkspaceControls({
 	onOpenExternalUrl: (url: string) => Promise<void>;
 	signedIn: boolean;
 	signingIn: boolean;
-	onExecutionTargetChange: (target: "local" | "cloud") => void;
 	onRepoUrlChange: (repoUrl: string) => void;
 	onSignIn: () => void | Promise<void>;
 	workspaceRoot: string;
@@ -996,15 +957,6 @@ export function WelcomeWorkspaceControls({
 			className="flex min-w-0 flex-wrap items-center gap-2"
 			ref={containerRef}
 		>
-			{cloudEnabled ? (
-				<ExecutionTargetPicker
-					executionTarget={executionTarget}
-					onChange={(target) => {
-						setOpenMenu(null);
-						onExecutionTargetChange(target);
-					}}
-				/>
-			) : null}
 			{cloudEnabled && executionTarget === "cloud" ? (
 				cloudControlsHidden ? null : signedIn ? (
 					<>

--- a/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type CloudProvisioningOutcome,
+	PROVISIONING_OPEN_GIVE_UP_ATTEMPTS,
+	PROVISIONING_OUTCOME_POLL_MS,
+	PROVISIONING_UNKNOWN_GIVE_UP_POLLS,
+	useProvisioningOutcome,
+} from "./use-provisioning-outcome";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock("@/lib/desktop-client", () => ({
+	desktopClient: { invoke: invokeMock },
+}));
+
+type HarnessProps = {
+	placeholderId?: string;
+	onOpenReady: (sessionId: string) => Promise<boolean>;
+	onResolved: () => void;
+	onError: (message: string) => void;
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness(props: HarnessProps) {
+	useProvisioningOutcome(props);
+	return null;
+}
+
+async function renderHarness(props: HarnessProps) {
+	await act(async () => {
+		root.render(<Harness {...props} />);
+		await Promise.resolve();
+	});
+}
+
+async function advancePoll() {
+	await act(async () => {
+		vi.advanceTimersByTime(PROVISIONING_OUTCOME_POLL_MS);
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+}
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	vi.useFakeTimers();
+	invokeMock.mockReset();
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("useProvisioningOutcome", () => {
+	it("opens the ready session and resolves its placeholder", async () => {
+		invokeMock.mockResolvedValue({
+			status: "ready",
+			sessionId: "ses-real",
+		} satisfies CloudProvisioningOutcome);
+		const onOpenReady = vi.fn(async () => true);
+		const onResolved = vi.fn();
+
+		await renderHarness({
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady,
+			onResolved,
+			onError: vi.fn(),
+		});
+
+		expect(onOpenReady).toHaveBeenCalledWith("ses-real");
+		expect(onResolved).toHaveBeenCalledOnce();
+		invokeMock.mockClear();
+		await advancePoll();
+		expect(invokeMock).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a failed outcome and stops polling", async () => {
+		invokeMock.mockResolvedValue({
+			status: "failed",
+			message: "Insufficient balance",
+		} satisfies CloudProvisioningOutcome);
+		const onError = vi.fn();
+
+		await renderHarness({
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady: vi.fn(async () => true),
+			onResolved: vi.fn(),
+			onError,
+		});
+
+		expect(onError).toHaveBeenCalledWith(
+			expect.stringContaining("Insufficient balance"),
+		);
+		invokeMock.mockClear();
+		await advancePoll();
+		expect(invokeMock).not.toHaveBeenCalled();
+	});
+
+	it("bounds unknown outcomes without resetting on callback changes", async () => {
+		invokeMock.mockResolvedValue(null);
+		const firstError = vi.fn();
+		const latestError = vi.fn();
+		const base = {
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady: vi.fn(async () => true),
+			onResolved: vi.fn(),
+		};
+
+		await renderHarness({ ...base, onError: firstError });
+		for (let i = 1; i < PROVISIONING_UNKNOWN_GIVE_UP_POLLS - 1; i += 1) {
+			await advancePoll();
+		}
+		await renderHarness({
+			...base,
+			onOpenReady: vi.fn(async () => true),
+			onResolved: vi.fn(),
+			onError: latestError,
+		});
+		await advancePoll();
+
+		expect(firstError).not.toHaveBeenCalled();
+		expect(latestError).toHaveBeenCalledWith(
+			expect.stringContaining("provisioning state was lost"),
+		);
+	});
+
+	it("stops when a ready session repeatedly cannot be opened", async () => {
+		invokeMock.mockResolvedValue({
+			status: "ready",
+			sessionId: "ses-gone",
+		} satisfies CloudProvisioningOutcome);
+		const onOpenReady = vi.fn(async () => false);
+		const onError = vi.fn();
+
+		await renderHarness({
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady,
+			onResolved: vi.fn(),
+			onError,
+		});
+		for (let i = 1; i < PROVISIONING_OPEN_GIVE_UP_ATTEMPTS; i += 1) {
+			await advancePoll();
+		}
+
+		expect(onOpenReady).toHaveBeenCalledTimes(
+			PROVISIONING_OPEN_GIVE_UP_ATTEMPTS,
+		);
+		expect(onError).toHaveBeenCalledWith(
+			expect.stringContaining("could not be opened automatically"),
+		);
+	});
+
+	it("recovers after a temporary transport interruption", async () => {
+		invokeMock
+			.mockRejectedValueOnce(new Error("transport closed"))
+			.mockResolvedValueOnce({
+				status: "ready",
+				sessionId: "ses-real",
+			} satisfies CloudProvisioningOutcome);
+		const onResolved = vi.fn();
+
+		await renderHarness({
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady: vi.fn(async () => true),
+			onResolved,
+			onError: vi.fn(),
+		});
+		await advancePoll();
+
+		expect(onResolved).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from "react";
+import { humanizeCloudSessionError } from "@/lib/cloud-session-error";
+import { desktopClient } from "@/lib/desktop-client";
+
+export type CloudProvisioningOutcome =
+	| { status: "provisioning" }
+	| { status: "ready"; sessionId: string }
+	| { status: "failed"; message: string };
+
+export const PROVISIONING_OUTCOME_POLL_MS = 1_500;
+export const PROVISIONING_UNKNOWN_GIVE_UP_POLLS = 8;
+export const PROVISIONING_OPEN_GIVE_UP_ATTEMPTS = 5;
+
+export function useProvisioningOutcome(options: {
+	placeholderId: string | undefined;
+	onOpenReady: (sessionId: string) => Promise<boolean>;
+	onResolved: () => void;
+	onError: (message: string) => void;
+}): void {
+	const callbacksRef = useRef(options);
+	callbacksRef.current = options;
+
+	useEffect(() => {
+		if (!options.placeholderId) return;
+		const placeholderId = options.placeholderId;
+		let cancelled = false;
+		let retryTimer: number | undefined;
+		let unknownPolls = 0;
+		let failedOpens = 0;
+
+		async function checkOutcome() {
+			try {
+				const outcome =
+					await desktopClient.invoke<CloudProvisioningOutcome | null>(
+						"get_cloud_provisioning_outcome",
+						{ placeholderId },
+					);
+				if (cancelled) return;
+				if (outcome?.status === "ready") {
+					const opened = await callbacksRef.current.onOpenReady(
+						outcome.sessionId,
+					);
+					if (cancelled) return;
+					if (opened) {
+						callbacksRef.current.onResolved();
+						return;
+					}
+					failedOpens += 1;
+					if (failedOpens >= PROVISIONING_OPEN_GIVE_UP_ATTEMPTS) {
+						callbacksRef.current.onError(
+							"The cloud session was created but could not be opened automatically. Open it from the sidebar.",
+						);
+						return;
+					}
+				} else if (outcome?.status === "failed") {
+					callbacksRef.current.onError(
+						humanizeCloudSessionError(outcome.message) ||
+							"The cloud session could not be started.",
+					);
+					return;
+				} else if (outcome === null) {
+					unknownPolls += 1;
+					if (unknownPolls >= PROVISIONING_UNKNOWN_GIVE_UP_POLLS) {
+						callbacksRef.current.onError(
+							"This session's provisioning state was lost. Check the sidebar for the session, or start a new one.",
+						);
+						return;
+					}
+				} else {
+					unknownPolls = 0;
+				}
+			} catch {
+				// Keep polling through a temporary sidecar interruption.
+			}
+			if (!cancelled) {
+				retryTimer = window.setTimeout(
+					checkOutcome,
+					PROVISIONING_OUTCOME_POLL_MS,
+				);
+			}
+		}
+
+		void checkOutcome();
+		return () => {
+			cancelled = true;
+			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+		};
+	}, [options.placeholderId]);
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -110,4 +110,35 @@ describe("cloudHandoffUiReducer", () => {
 			phase: "checking",
 		});
 	});
+
+	it("dismisses recovery for this app run without accepting late progress", () => {
+		const recovery = {
+			"local-1": {
+				status: "recovery" as const,
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		};
+		const dismissed = cloudHandoffUiReducer(recovery, {
+			type: "dismiss_recovery",
+			sourceSessionId: "local-1",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(dismissed["local-1"]).toEqual({
+			status: "recovery_dismissed",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(
+			cloudHandoffUiReducer(dismissed, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(dismissed);
+		expect(
+			cloudHandoffUiReducer(dismissed, {
+				type: "start",
+				sourceSessionId: "local-1",
+			})["local-1"],
+		).toEqual({ status: "progress", phase: "checking" });
+	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { cloudHandoffUiReducer } from "./cloud-handoff-ui-state";
+
+describe("cloudHandoffUiReducer", () => {
+	it("keeps a source locked across pane remounts and preserves its latest phase", () => {
+		const creating = cloudHandoffUiReducer(
+			{},
+			{
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "creating",
+			},
+		);
+		const provisioning = cloudHandoffUiReducer(creating, {
+			type: "progress",
+			sourceSessionId: "local-1",
+			phase: "provisioning",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(provisioning["local-1"]).toMatchObject({
+			status: "progress",
+			phase: "provisioning",
+		});
+	});
+
+	it("turns failed external progress into recovery without exposing in-app URLs", () => {
+		const progress = cloudHandoffUiReducer(
+			{},
+			{
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "verifying",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		);
+		const recovery = cloudHandoffUiReducer(progress, {
+			type: "failed",
+			sourceSessionId: "local-1",
+			exposeRecovery: true,
+			retryDraft: "/handoff continue",
+		});
+		expect(recovery["local-1"]).toEqual({
+			status: "recovery",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			retryDraft: "/handoff continue",
+			retryAttachments: undefined,
+		});
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "retry_restored",
+				sourceSessionId: "local-1",
+			})["local-1"],
+		).toEqual({
+			status: "recovery",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(
+			cloudHandoffUiReducer(progress, {
+				type: "failed",
+				sourceSessionId: "local-1",
+				exposeRecovery: false,
+			})["local-1"],
+		).toEqual({
+			status: "failed",
+			retryDraft: undefined,
+			retryAttachments: undefined,
+		});
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -85,4 +85,29 @@ describe("cloudHandoffUiReducer", () => {
 			}),
 		).toBe(failed);
 	});
+
+	it("lets an explicit retry replace recovery while ignoring late old progress", () => {
+		const recovery = {
+			"local-1": {
+				status: "recovery" as const,
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		};
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(recovery);
+
+		const retry = cloudHandoffUiReducer(recovery, {
+			type: "start",
+			sourceSessionId: "local-1",
+		});
+		expect(retry["local-1"]).toEqual({
+			status: "progress",
+			phase: "checking",
+		});
+	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -84,6 +84,18 @@ describe("cloudHandoffUiReducer", () => {
 				phase: "complete",
 			}),
 		).toBe(failed);
+		const restored = cloudHandoffUiReducer(failed, {
+			type: "retry_restored",
+			sourceSessionId: "local-1",
+		});
+		expect(restored["local-1"]).toEqual({ status: "retry_restored" });
+		expect(
+			cloudHandoffUiReducer(restored, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(restored);
 	});
 
 	it("lets an explicit retry replace recovery while ignoring late old progress", () => {

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { cloudHandoffUiReducer } from "./cloud-handoff-ui-state";
+
+describe("cloudHandoffUiReducer", () => {
+	it("keeps a source locked across pane remounts and preserves its latest phase", () => {
+		const creating = cloudHandoffUiReducer(
+			{},
+			{
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "creating",
+			},
+		);
+		const provisioning = cloudHandoffUiReducer(creating, {
+			type: "progress",
+			sourceSessionId: "local-1",
+			phase: "provisioning",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(provisioning["local-1"]).toMatchObject({
+			status: "progress",
+			phase: "provisioning",
+		});
+	});
+
+	it("turns failed external progress into recovery without exposing in-app URLs", () => {
+		const progress = cloudHandoffUiReducer(
+			{},
+			{
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "verifying",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		);
+		const recovery = cloudHandoffUiReducer(progress, {
+			type: "failed",
+			sourceSessionId: "local-1",
+			exposeRecovery: true,
+			retryDraft: "/handoff continue",
+		});
+		expect(recovery["local-1"]).toEqual({
+			status: "recovery",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			retryDraft: "/handoff continue",
+			retryAttachments: undefined,
+		});
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "retry_restored",
+				sourceSessionId: "local-1",
+			})["local-1"],
+		).toEqual({
+			status: "recovery",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(
+			cloudHandoffUiReducer(progress, {
+				type: "failed",
+				sourceSessionId: "local-1",
+				exposeRecovery: false,
+			})["local-1"],
+		).toEqual({
+			status: "failed",
+			retryDraft: undefined,
+			retryAttachments: undefined,
+		});
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(recovery);
+		const failed = cloudHandoffUiReducer(progress, {
+			type: "failed",
+			sourceSessionId: "local-1",
+			exposeRecovery: false,
+		});
+		expect(
+			cloudHandoffUiReducer(failed, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(failed);
+	});
+
+	it("lets an explicit retry replace recovery while ignoring late old progress", () => {
+		const recovery = {
+			"local-1": {
+				status: "recovery" as const,
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		};
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(recovery);
+
+		const retry = cloudHandoffUiReducer(recovery, {
+			type: "start",
+			sourceSessionId: "local-1",
+		});
+		expect(retry["local-1"]).toEqual({
+			status: "progress",
+			phase: "checking",
+		});
+	});
+
+	it("dismisses recovery for this app run without accepting late progress", () => {
+		const recovery = {
+			"local-1": {
+				status: "recovery" as const,
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		};
+		const dismissed = cloudHandoffUiReducer(recovery, {
+			type: "dismiss_recovery",
+			sourceSessionId: "local-1",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(dismissed["local-1"]).toEqual({
+			status: "recovery_dismissed",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(
+			cloudHandoffUiReducer(dismissed, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(dismissed);
+		expect(
+			cloudHandoffUiReducer(dismissed, {
+				type: "start",
+				sourceSessionId: "local-1",
+			})["local-1"],
+		).toEqual({ status: "progress", phase: "checking" });
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -65,5 +65,24 @@ describe("cloudHandoffUiReducer", () => {
 			retryDraft: undefined,
 			retryAttachments: undefined,
 		});
+		expect(
+			cloudHandoffUiReducer(recovery, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(recovery);
+		const failed = cloudHandoffUiReducer(progress, {
+			type: "failed",
+			sourceSessionId: "local-1",
+			exposeRecovery: false,
+		});
+		expect(
+			cloudHandoffUiReducer(failed, {
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+			}),
+		).toBe(failed);
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -53,7 +53,13 @@ export function cloudHandoffUiReducer(
 	const current = state[action.sourceSessionId];
 	switch (action.type) {
 		case "progress":
-			if (current?.status === "complete") return state;
+			if (
+				current?.status === "complete" ||
+				current?.status === "failed" ||
+				current?.status === "recovery"
+			) {
+				return state;
+			}
 			return {
 				...state,
 				[action.sourceSessionId]: {

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -15,6 +15,7 @@ export type CloudHandoffUiEntry =
 	  }
 	| { status: "recovery_dismissed"; dashboardUrl: string }
 	| { status: "failed"; retryDraft?: string; retryAttachments?: File[] }
+	| { status: "retry_restored" }
 	| {
 			status: "complete";
 			receipt: HandoffReceipt;
@@ -75,7 +76,8 @@ export function cloudHandoffUiReducer(
 				current?.status === "complete" ||
 				current?.status === "failed" ||
 				current?.status === "recovery" ||
-				current?.status === "recovery_dismissed"
+				current?.status === "recovery_dismissed" ||
+				current?.status === "retry_restored"
 			) {
 				return state;
 			}
@@ -142,8 +144,10 @@ export function cloudHandoffUiReducer(
 			};
 		case "retry_restored":
 			if (current?.status === "failed") {
-				const { [action.sourceSessionId]: _removed, ...rest } = state;
-				return rest;
+				return {
+					...state,
+					[action.sourceSessionId]: { status: "retry_restored" },
+				};
 			}
 			if (current?.status === "recovery") {
 				return {

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -1,0 +1,126 @@
+import type { HandoffProgressPhase, HandoffReceipt } from "@/lib/cloud-handoff";
+
+export type CloudHandoffUiEntry =
+	| {
+			status: "progress";
+			phase: HandoffProgressPhase;
+			message?: string;
+			dashboardUrl?: string;
+	  }
+	| {
+			status: "recovery";
+			dashboardUrl: string;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
+	| { status: "failed"; retryDraft?: string; retryAttachments?: File[] }
+	| {
+			status: "complete";
+			receipt: HandoffReceipt;
+			externalPresentation: boolean;
+	  };
+
+export type CloudHandoffUiState = Record<string, CloudHandoffUiEntry>;
+
+export type CloudHandoffUiAction =
+	| {
+			type: "progress";
+			sourceSessionId: string;
+			phase: HandoffProgressPhase;
+			message?: string;
+			dashboardUrl?: string;
+	  }
+	| {
+			type: "failed";
+			sourceSessionId: string;
+			exposeRecovery: boolean;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
+	| {
+			type: "complete";
+			sourceSessionId: string;
+			receipt: HandoffReceipt;
+			externalPresentation: boolean;
+	  }
+	| { type: "external"; sourceSessionId: string }
+	| { type: "retry_restored"; sourceSessionId: string };
+
+export function cloudHandoffUiReducer(
+	state: CloudHandoffUiState,
+	action: CloudHandoffUiAction,
+): CloudHandoffUiState {
+	const current = state[action.sourceSessionId];
+	switch (action.type) {
+		case "progress":
+			if (current?.status === "complete") return state;
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "progress",
+					phase: action.phase,
+					message: action.message,
+					dashboardUrl:
+						action.dashboardUrl ||
+						(current?.status === "progress" ? current.dashboardUrl : undefined),
+				},
+			};
+		case "failed": {
+			const dashboardUrl =
+				current?.status === "progress" ? current.dashboardUrl : undefined;
+			if (action.exposeRecovery && dashboardUrl) {
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						status: "recovery",
+						dashboardUrl,
+						retryDraft: action.retryDraft,
+						retryAttachments: action.retryAttachments,
+					},
+				};
+			}
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "failed",
+					retryDraft: action.retryDraft,
+					retryAttachments: action.retryAttachments,
+				},
+			};
+		}
+		case "complete":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "complete",
+					receipt: action.receipt,
+					externalPresentation: action.externalPresentation,
+				},
+			};
+		case "external":
+			return current?.status === "complete"
+				? {
+						...state,
+						[action.sourceSessionId]: {
+							...current,
+							externalPresentation: true,
+						},
+					}
+				: state;
+		case "retry_restored":
+			if (current?.status === "failed") {
+				const { [action.sourceSessionId]: _removed, ...rest } = state;
+				return rest;
+			}
+			if (current?.status === "recovery") {
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						status: "recovery",
+						dashboardUrl: current.dashboardUrl,
+					},
+				};
+			}
+			return state;
+	}
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -24,6 +24,10 @@ export type CloudHandoffUiState = Record<string, CloudHandoffUiEntry>;
 
 export type CloudHandoffUiAction =
 	| {
+			type: "start";
+			sourceSessionId: string;
+	  }
+	| {
 			type: "progress";
 			sourceSessionId: string;
 			phase: HandoffProgressPhase;
@@ -52,6 +56,14 @@ export function cloudHandoffUiReducer(
 ): CloudHandoffUiState {
 	const current = state[action.sourceSessionId];
 	switch (action.type) {
+		case "start":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "progress",
+					phase: "checking",
+				},
+			};
 		case "progress":
 			if (
 				current?.status === "complete" ||

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -1,0 +1,159 @@
+import type { HandoffProgressPhase, HandoffReceipt } from "@/lib/cloud-handoff";
+
+export type CloudHandoffUiEntry =
+	| {
+			status: "progress";
+			phase: HandoffProgressPhase;
+			message?: string;
+			dashboardUrl?: string;
+	  }
+	| {
+			status: "recovery";
+			dashboardUrl: string;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
+	| { status: "recovery_dismissed"; dashboardUrl: string }
+	| { status: "failed"; retryDraft?: string; retryAttachments?: File[] }
+	| {
+			status: "complete";
+			receipt: HandoffReceipt;
+			externalPresentation: boolean;
+	  };
+
+export type CloudHandoffUiState = Record<string, CloudHandoffUiEntry>;
+
+export type CloudHandoffUiAction =
+	| {
+			type: "start";
+			sourceSessionId: string;
+	  }
+	| {
+			type: "progress";
+			sourceSessionId: string;
+			phase: HandoffProgressPhase;
+			message?: string;
+			dashboardUrl?: string;
+	  }
+	| {
+			type: "failed";
+			sourceSessionId: string;
+			exposeRecovery: boolean;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
+	| {
+			type: "complete";
+			sourceSessionId: string;
+			receipt: HandoffReceipt;
+			externalPresentation: boolean;
+	  }
+	| { type: "external"; sourceSessionId: string }
+	| {
+			type: "dismiss_recovery";
+			sourceSessionId: string;
+			dashboardUrl: string;
+	  }
+	| { type: "retry_restored"; sourceSessionId: string };
+
+export function cloudHandoffUiReducer(
+	state: CloudHandoffUiState,
+	action: CloudHandoffUiAction,
+): CloudHandoffUiState {
+	const current = state[action.sourceSessionId];
+	switch (action.type) {
+		case "start":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "progress",
+					phase: "checking",
+				},
+			};
+		case "progress":
+			if (
+				current?.status === "complete" ||
+				current?.status === "failed" ||
+				current?.status === "recovery" ||
+				current?.status === "recovery_dismissed"
+			) {
+				return state;
+			}
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "progress",
+					phase: action.phase,
+					message: action.message,
+					dashboardUrl:
+						action.dashboardUrl ||
+						(current?.status === "progress" ? current.dashboardUrl : undefined),
+				},
+			};
+		case "failed": {
+			const dashboardUrl =
+				current?.status === "progress" ? current.dashboardUrl : undefined;
+			if (action.exposeRecovery && dashboardUrl) {
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						status: "recovery",
+						dashboardUrl,
+						retryDraft: action.retryDraft,
+						retryAttachments: action.retryAttachments,
+					},
+				};
+			}
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "failed",
+					retryDraft: action.retryDraft,
+					retryAttachments: action.retryAttachments,
+				},
+			};
+		}
+		case "complete":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "complete",
+					receipt: action.receipt,
+					externalPresentation: action.externalPresentation,
+				},
+			};
+		case "external":
+			return current?.status === "complete"
+				? {
+						...state,
+						[action.sourceSessionId]: {
+							...current,
+							externalPresentation: true,
+						},
+					}
+				: state;
+		case "dismiss_recovery":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "recovery_dismissed",
+					dashboardUrl: action.dashboardUrl,
+				},
+			};
+		case "retry_restored":
+			if (current?.status === "failed") {
+				const { [action.sourceSessionId]: _removed, ...rest } = state;
+				return rest;
+			}
+			if (current?.status === "recovery") {
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						status: "recovery",
+						dashboardUrl: current.dashboardUrl,
+					},
+				};
+			}
+			return state;
+	}
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -13,6 +13,7 @@ export type CloudHandoffUiEntry =
 			retryDraft?: string;
 			retryAttachments?: File[];
 	  }
+	| { status: "recovery_dismissed"; dashboardUrl: string }
 	| { status: "failed"; retryDraft?: string; retryAttachments?: File[] }
 	| {
 			status: "complete";
@@ -48,6 +49,11 @@ export type CloudHandoffUiAction =
 			externalPresentation: boolean;
 	  }
 	| { type: "external"; sourceSessionId: string }
+	| {
+			type: "dismiss_recovery";
+			sourceSessionId: string;
+			dashboardUrl: string;
+	  }
 	| { type: "retry_restored"; sourceSessionId: string };
 
 export function cloudHandoffUiReducer(
@@ -68,7 +74,8 @@ export function cloudHandoffUiReducer(
 			if (
 				current?.status === "complete" ||
 				current?.status === "failed" ||
-				current?.status === "recovery"
+				current?.status === "recovery" ||
+				current?.status === "recovery_dismissed"
 			) {
 				return state;
 			}
@@ -125,6 +132,14 @@ export function cloudHandoffUiReducer(
 						},
 					}
 				: state;
+		case "dismiss_recovery":
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "recovery_dismissed",
+					dashboardUrl: action.dashboardUrl,
+				},
+			};
 		case "retry_restored":
 			if (current?.status === "failed") {
 				const { [action.sourceSessionId]: _removed, ...rest } = state;

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseHandoffCommand,
+	readHandoffReceipt,
+	shouldOpenHandoffInApp,
+	validateHandoffAttachments,
+} from "./cloud-handoff";
+
+describe("cloud handoff helpers", () => {
+	it("parses the bare command and preserves an optional next command", () => {
+		expect(parseHandoffCommand("/handoff")).toEqual({ nextCommand: "" });
+		expect(parseHandoffCommand(" /HANDOFF   continue the tests ")).toEqual({
+			nextCommand: "continue the tests",
+		});
+		expect(parseHandoffCommand("/handoffish")).toBeNull();
+		expect(parseHandoffCommand("please /handoff")).toBeNull();
+	});
+
+	it("accepts images only when a cloud command will consume them", () => {
+		const image = new File(["image"], "screen.png", { type: "image/png" });
+		const text = new File(["text"], "notes.txt", { type: "text/plain" });
+		expect(validateHandoffAttachments([image], "inspect this")).toBeNull();
+		expect(validateHandoffAttachments([image], "")).toContain("Add a command");
+		expect(validateHandoffAttachments([text], "inspect this")).toContain(
+			"notes.txt",
+		);
+	});
+
+	it("reads completed handoff metadata into a receipt", () => {
+		expect(
+			readHandoffReceipt({
+				handoff: {
+					status: "complete",
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				},
+			}),
+		).toEqual({
+			targetSessionId: "cloud-1",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(readHandoffReceipt({ handoff: { status: "pending" } })).toBeNull();
+	});
+
+	it("only focuses an in-app target while its source is still active", () => {
+		expect(shouldOpenHandoffInApp("in_app", true)).toBe(true);
+		expect(shouldOpenHandoffInApp("in_app", false)).toBe(false);
+		expect(shouldOpenHandoffInApp("external", true)).toBe(false);
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	parseHandoffCommand,
 	readHandoffReceipt,
+	readPendingHandoffRecovery,
 	shouldOpenHandoffInApp,
 	validateHandoffAttachments,
 } from "./cloud-handoff";
@@ -40,6 +41,30 @@ describe("cloud handoff helpers", () => {
 			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
 		});
 		expect(readHandoffReceipt({ handoff: { status: "pending" } })).toBeNull();
+	});
+
+	it("reads pending handoff metadata into restart recovery", () => {
+		expect(
+			readPendingHandoffRecovery({
+				handoff: {
+					status: "pending",
+					toCloudSessionId: "cloud-pending",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+				},
+			}),
+		).toEqual({
+			targetSessionId: "cloud-pending",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+		});
+		expect(
+			readPendingHandoffRecovery({
+				handoff: {
+					status: "complete",
+					toCloudSessionId: "cloud-complete",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-complete",
+				},
+			}),
+		).toBeNull();
 	});
 
 	it("only focuses an in-app target while its source is still active", () => {

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatHandoffModelFallback,
+	parseHandoffCommand,
+	readHandoffReceipt,
+	readPendingHandoffRecovery,
+	shouldOpenHandoffInApp,
+	validateHandoffAttachments,
+} from "./cloud-handoff";
+
+describe("cloud handoff helpers", () => {
+	it("discloses a cloud model fallback", () => {
+		expect(
+			formatHandoffModelFallback({
+				from: "local/model",
+				to: "cloud/model",
+			}),
+		).toBe(
+			"local/model isn’t available in Cline Cloud. Continuing with cloud/model.",
+		);
+		expect(formatHandoffModelFallback()).toBeNull();
+	});
+
+	it("parses the bare command and preserves an optional next command", () => {
+		expect(parseHandoffCommand("/handoff")).toEqual({ nextCommand: "" });
+		expect(parseHandoffCommand(" /HANDOFF   continue the tests ")).toEqual({
+			nextCommand: "continue the tests",
+		});
+		expect(parseHandoffCommand("/handoffish")).toBeNull();
+		expect(parseHandoffCommand("please /handoff")).toBeNull();
+	});
+
+	it("accepts images only when a cloud command will consume them", () => {
+		const image = new File(["image"], "screen.png", { type: "image/png" });
+		const text = new File(["text"], "notes.txt", { type: "text/plain" });
+		expect(validateHandoffAttachments([image], "inspect this")).toBeNull();
+		expect(validateHandoffAttachments([image], "")).toContain("Add a command");
+		expect(validateHandoffAttachments([text], "inspect this")).toContain(
+			"notes.txt",
+		);
+	});
+
+	it("reads completed handoff metadata into a receipt", () => {
+		expect(
+			readHandoffReceipt({
+				handoff: {
+					status: "complete",
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				},
+			}),
+		).toEqual({
+			targetSessionId: "cloud-1",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+		expect(readHandoffReceipt({ handoff: { status: "pending" } })).toBeNull();
+	});
+
+	it("reads pending handoff metadata into restart recovery", () => {
+		expect(
+			readPendingHandoffRecovery({
+				handoff: {
+					status: "pending",
+					toCloudSessionId: "cloud-pending",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+				},
+			}),
+		).toEqual({
+			targetSessionId: "cloud-pending",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-pending",
+		});
+		expect(
+			readPendingHandoffRecovery({
+				handoff: {
+					status: "complete",
+					toCloudSessionId: "cloud-complete",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-complete",
+				},
+			}),
+		).toBeNull();
+	});
+
+	it("only focuses an in-app target while its source is still active", () => {
+		expect(shouldOpenHandoffInApp("in_app", true)).toBe(true);
+		expect(shouldOpenHandoffInApp("in_app", false)).toBe(false);
+		expect(shouldOpenHandoffInApp("external", true)).toBe(false);
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	formatHandoffModelFallback,
 	parseHandoffCommand,
 	readHandoffReceipt,
 	readPendingHandoffRecovery,
@@ -8,6 +9,18 @@ import {
 } from "./cloud-handoff";
 
 describe("cloud handoff helpers", () => {
+	it("discloses a cloud model fallback", () => {
+		expect(
+			formatHandoffModelFallback({
+				from: "local/model",
+				to: "cloud/model",
+			}),
+		).toBe(
+			"local/model isn’t available in Cline Cloud. Continuing with cloud/model.",
+		);
+		expect(formatHandoffModelFallback()).toBeNull();
+	});
+
 	it("parses the bare command and preserves an optional next command", () => {
 		expect(parseHandoffCommand("/handoff")).toEqual({ nextCommand: "" });
 		expect(parseHandoffCommand(" /HANDOFF   continue the tests ")).toEqual({

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
@@ -93,6 +93,24 @@ export function readHandoffReceipt(
 		: null;
 }
 
+export function readPendingHandoffRecovery(
+	metadata?: SessionMetadata,
+): HandoffReceipt | null {
+	const raw = metadata?.handoff;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return null;
+	}
+	const handoff = raw as Record<string, unknown>;
+	if (handoff.status !== "pending") {
+		return null;
+	}
+	const targetSessionId = stringField(handoff.toCloudSessionId);
+	const dashboardUrl = stringField(handoff.dashboardUrl);
+	return targetSessionId && dashboardUrl
+		? { targetSessionId, dashboardUrl }
+		: null;
+}
+
 export function shouldOpenHandoffInApp(
 	destination: HandoffResult["destination"],
 	isSourceStillActive: boolean,

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
@@ -1,0 +1,126 @@
+import type {
+	CloudHandoffFingerprint,
+	CloudHandoffProgressPhase,
+	CloudHandoffResult,
+} from "@cline/core";
+import type { SessionMetadata } from "@/lib/session-history";
+
+export type ParsedHandoffCommand = {
+	nextCommand: string;
+};
+
+export type HandoffPreflight = {
+	fingerprint: CloudHandoffFingerprint;
+	repoUrl: string;
+	branch: string;
+	headSha?: string;
+	modelId: string;
+	modelFallback?: { from: string; to: string };
+};
+
+export type HandoffResult = CloudHandoffResult & {
+	/** Backward-compatible alias used by early desktop spikes. */
+	sessionId?: string;
+};
+
+export type HandoffReceipt = {
+	targetSessionId: string;
+	dashboardUrl: string;
+};
+
+export type HandoffProgressPhase = CloudHandoffProgressPhase;
+
+export const HANDOFF_PROGRESS_LABELS: Record<HandoffProgressPhase, string> = {
+	checking: "Checking the local session...",
+	creating: "Creating the cloud session...",
+	provisioning: "Preparing the cloud workspace...",
+	connecting: "Connecting to the cloud agent...",
+	seeding: "Transferring the conversation...",
+	verifying: "Verifying the handoff...",
+	starting: "Starting the cloud task...",
+	complete: "Cloud handoff complete.",
+};
+
+export function formatHandoffModelFallback(
+	fallback?: HandoffPreflight["modelFallback"],
+): string | null {
+	if (!fallback?.from.trim() || !fallback.to.trim()) return null;
+	return `${fallback.from} isn’t available in Cline Cloud. Continuing with ${fallback.to}.`;
+}
+
+/** Returns null for ordinary prompts and slash-command lookalikes. */
+export function parseHandoffCommand(
+	input: string,
+): ParsedHandoffCommand | null {
+	const match = input.trim().match(/^\/handoff(?:\s+([\s\S]*))?$/i);
+	if (!match) {
+		return null;
+	}
+	return { nextCommand: (match[1] ?? "").trim() };
+}
+
+export function validateHandoffAttachments(
+	files: readonly File[],
+	nextCommand: string,
+): string | null {
+	const nonImage = files.find((file) => !file.type.startsWith("image/"));
+	if (nonImage) {
+		return `Cloud handoff only supports image attachments. Remove ${nonImage.name} and try again.`;
+	}
+	if (files.length > 0 && !nextCommand.trim()) {
+		return "Add a command after /handoff to send the attached images in cloud.";
+	}
+	return null;
+}
+
+function stringField(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+export function readHandoffReceipt(
+	metadata?: SessionMetadata,
+): HandoffReceipt | null {
+	const raw = metadata?.handoff;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return null;
+	}
+	const handoff = raw as Record<string, unknown>;
+	if (handoff.status !== "complete") {
+		return null;
+	}
+	const targetSessionId =
+		stringField(handoff.toCloudSessionId) ||
+		stringField(handoff.targetSessionId) ||
+		stringField(handoff.cloudSessionId) ||
+		stringField(handoff.sessionId);
+	const dashboardUrl =
+		stringField(handoff.dashboardUrl) || stringField(handoff.url);
+	return targetSessionId && dashboardUrl
+		? { targetSessionId, dashboardUrl }
+		: null;
+}
+
+export function readPendingHandoffRecovery(
+	metadata?: SessionMetadata,
+): HandoffReceipt | null {
+	const raw = metadata?.handoff;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return null;
+	}
+	const handoff = raw as Record<string, unknown>;
+	if (handoff.status !== "pending") {
+		return null;
+	}
+	const targetSessionId = stringField(handoff.toCloudSessionId);
+	const dashboardUrl = stringField(handoff.dashboardUrl);
+	return targetSessionId && dashboardUrl
+		? { targetSessionId, dashboardUrl }
+		: null;
+}
+
+export function shouldOpenHandoffInApp(
+	destination: HandoffResult["destination"],
+	isSourceStillActive: boolean,
+): boolean {
+	return destination === "in_app" && isSourceStillActive;
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
@@ -41,6 +41,13 @@ export const HANDOFF_PROGRESS_LABELS: Record<HandoffProgressPhase, string> = {
 	complete: "Cloud handoff complete.",
 };
 
+export function formatHandoffModelFallback(
+	fallback?: HandoffPreflight["modelFallback"],
+): string | null {
+	if (!fallback?.from.trim() || !fallback.to.trim()) return null;
+	return `${fallback.from} isn’t available in Cline Cloud. Continuing with ${fallback.to}.`;
+}
+
 /** Returns null for ordinary prompts and slash-command lookalikes. */
 export function parseHandoffCommand(
 	input: string,

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
@@ -1,0 +1,101 @@
+import type {
+	CloudHandoffFingerprint,
+	CloudHandoffProgressPhase,
+	CloudHandoffResult,
+} from "@cline/core";
+import type { SessionMetadata } from "@/lib/session-history";
+
+export type ParsedHandoffCommand = {
+	nextCommand: string;
+};
+
+export type HandoffPreflight = {
+	fingerprint: CloudHandoffFingerprint;
+	repoUrl: string;
+	branch: string;
+	headSha?: string;
+	modelId: string;
+	modelFallback?: { from: string; to: string };
+};
+
+export type HandoffResult = CloudHandoffResult & {
+	/** Backward-compatible alias used by early desktop spikes. */
+	sessionId?: string;
+};
+
+export type HandoffReceipt = {
+	targetSessionId: string;
+	dashboardUrl: string;
+};
+
+export type HandoffProgressPhase = CloudHandoffProgressPhase;
+
+export const HANDOFF_PROGRESS_LABELS: Record<HandoffProgressPhase, string> = {
+	checking: "Checking the local session...",
+	creating: "Creating the cloud session...",
+	provisioning: "Preparing the cloud workspace...",
+	connecting: "Connecting to the cloud agent...",
+	seeding: "Transferring the conversation...",
+	verifying: "Verifying the handoff...",
+	starting: "Starting the cloud task...",
+	complete: "Cloud handoff complete.",
+};
+
+/** Returns null for ordinary prompts and slash-command lookalikes. */
+export function parseHandoffCommand(
+	input: string,
+): ParsedHandoffCommand | null {
+	const match = input.trim().match(/^\/handoff(?:\s+([\s\S]*))?$/i);
+	if (!match) {
+		return null;
+	}
+	return { nextCommand: (match[1] ?? "").trim() };
+}
+
+export function validateHandoffAttachments(
+	files: readonly File[],
+	nextCommand: string,
+): string | null {
+	const nonImage = files.find((file) => !file.type.startsWith("image/"));
+	if (nonImage) {
+		return `Cloud handoff only supports image attachments. Remove ${nonImage.name} and try again.`;
+	}
+	if (files.length > 0 && !nextCommand.trim()) {
+		return "Add a command after /handoff to send the attached images in cloud.";
+	}
+	return null;
+}
+
+function stringField(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+export function readHandoffReceipt(
+	metadata?: SessionMetadata,
+): HandoffReceipt | null {
+	const raw = metadata?.handoff;
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return null;
+	}
+	const handoff = raw as Record<string, unknown>;
+	if (handoff.status !== "complete") {
+		return null;
+	}
+	const targetSessionId =
+		stringField(handoff.toCloudSessionId) ||
+		stringField(handoff.targetSessionId) ||
+		stringField(handoff.cloudSessionId) ||
+		stringField(handoff.sessionId);
+	const dashboardUrl =
+		stringField(handoff.dashboardUrl) || stringField(handoff.url);
+	return targetSessionId && dashboardUrl
+		? { targetSessionId, dashboardUrl }
+		: null;
+}
+
+export function shouldOpenHandoffInApp(
+	destination: HandoffResult["destination"],
+	isSourceStillActive: boolean,
+): boolean {
+	return destination === "in_app" && isSourceStillActive;
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	humanizeCloudHandoffError,
 	humanizeCloudSessionError,
 	parseCloudSessionError,
 } from "./cloud-session-error";
@@ -58,5 +59,21 @@ describe("parseCloudSessionError", () => {
 				'CLOUD_SESSION_ERROR:{"code":"request_failed","message":"Switch to Personal and try again."}',
 			),
 		).toBe("Switch to Personal and try again.");
+	});
+
+	it("reassures handoff users when Cline Cloud is unreachable", () => {
+		for (const message of [
+			"fetch failed",
+			"Failed to fetch",
+			"network request failed",
+			"Load failed",
+		]) {
+			expect(humanizeCloudHandoffError(message)).toBe(
+				"Couldn’t reach Cline Cloud. Your local conversation is still available.",
+			);
+		}
+		expect(humanizeCloudHandoffError("Cloud session expired")).toBe(
+			"Cloud session expired",
+		);
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseCloudSessionError } from "./cloud-session-error";
+import {
+	humanizeCloudSessionError,
+	parseCloudSessionError,
+} from "./cloud-session-error";
 
 describe("parseCloudSessionError", () => {
 	it("parses environment-aware GitHub connection guidance", () => {
@@ -47,5 +50,13 @@ describe("parseCloudSessionError", () => {
 	it("ignores ordinary and malformed errors", () => {
 		expect(parseCloudSessionError("fetch failed")).toBeNull();
 		expect(parseCloudSessionError("CLOUD_SESSION_ERROR:not-json")).toBeNull();
+	});
+
+	it("shows the cloud message without exposing the transport envelope", () => {
+		expect(
+			humanizeCloudSessionError(
+				'CLOUD_SESSION_ERROR:{"code":"request_failed","message":"Switch to Personal and try again."}',
+			),
+		).toBe("Switch to Personal and try again.");
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseCloudSessionError } from "./cloud-session-error";
+import {
+	humanizeCloudHandoffError,
+	humanizeCloudSessionError,
+	parseCloudSessionError,
+} from "./cloud-session-error";
 
 describe("parseCloudSessionError", () => {
 	it("parses environment-aware GitHub connection guidance", () => {
@@ -47,5 +51,29 @@ describe("parseCloudSessionError", () => {
 	it("ignores ordinary and malformed errors", () => {
 		expect(parseCloudSessionError("fetch failed")).toBeNull();
 		expect(parseCloudSessionError("CLOUD_SESSION_ERROR:not-json")).toBeNull();
+	});
+
+	it("shows the cloud message without exposing the transport envelope", () => {
+		expect(
+			humanizeCloudSessionError(
+				'CLOUD_SESSION_ERROR:{"code":"request_failed","message":"Switch to Personal and try again."}',
+			),
+		).toBe("Switch to Personal and try again.");
+	});
+
+	it("reassures handoff users when Cline Cloud is unreachable", () => {
+		for (const message of [
+			"fetch failed",
+			"Failed to fetch",
+			"network request failed",
+			"Load failed",
+		]) {
+			expect(humanizeCloudHandoffError(message)).toBe(
+				"Couldn’t reach Cline Cloud. Your local conversation is still available.",
+			);
+		}
+		expect(humanizeCloudHandoffError("Cloud session expired")).toBe(
+			"Cloud session expired",
+		);
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.test.ts
@@ -61,6 +61,16 @@ describe("parseCloudSessionError", () => {
 		).toBe("Switch to Personal and try again.");
 	});
 
+	it("replaces malformed environment mismatch details with actionable copy", () => {
+		expect(
+			humanizeCloudSessionError(
+				"The session belongs to environment undefined, not [object Object].",
+			),
+		).toBe(
+			"Cline Code couldn’t identify this cloud session’s environment. Open it from its dashboard link or retry where it was created.",
+		);
+	});
+
 	it("reassures handoff users when Cline Cloud is unreachable", () => {
 		for (const message of [
 			"fetch failed",

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
@@ -71,3 +71,18 @@ export function parseCloudSessionError(
 export function humanizeCloudSessionError(value: string): string {
 	return parseCloudSessionError(value)?.message ?? value;
 }
+
+/** Adds handoff-specific reassurance for transport failures. */
+export function humanizeCloudHandoffError(value: string): string {
+	const message = humanizeCloudSessionError(value).trim();
+	const normalized = message.toLowerCase();
+	if (
+		normalized === "fetch failed" ||
+		normalized === "failed to fetch" ||
+		normalized === "network request failed" ||
+		normalized === "load failed"
+	) {
+		return "Couldn’t reach Cline Cloud. Your local conversation is still available.";
+	}
+	return message;
+}

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
@@ -69,7 +69,14 @@ export function parseCloudSessionError(
 
 /** Strips the machine-readable cloud error envelope for display. */
 export function humanizeCloudSessionError(value: string): string {
-	return parseCloudSessionError(value)?.message ?? value;
+	const message = parseCloudSessionError(value)?.message ?? value;
+	if (
+		/session belongs to environment/i.test(message) &&
+		(/\bundefined\b/i.test(message) || message.includes("[object Object]"))
+	) {
+		return "Cline Code couldn’t identify this cloud session’s environment. Open it from its dashboard link or retry where it was created.";
+	}
+	return message;
 }
 
 /** Adds handoff-specific reassurance for transport failures. */

--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogHandlers.test.ts
@@ -279,6 +279,80 @@ describe("provider model catalog handlers", () => {
 		expect(stateManager.flushPendingState).toHaveBeenCalledTimes(1)
 	})
 
+	it("commitModelSelection carries cached dynamic model metadata into the host store", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("litellm")
+		const store = makeStore({ providerId, apiKey: "litellm-key" })
+		const catalog = makeCatalog()
+		const modelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+		vi.mocked(catalog.peekModels).mockReturnValue({
+			ok: true,
+			providerId,
+			configFingerprint: computeConfigFingerprint(providerId, { providerId, apiKey: "litellm-key" }),
+			models: new Map([["openai/grok-4.6", modelInfo]]),
+			defaultModelId: "openai/grok-4.6",
+			source: "sdk-dynamic",
+			fetchedAt: 99,
+		})
+		const controller = makeController(store, catalog)
+
+		await commitModelSelection(controller, {
+			providerId: "litellm",
+			mode: "act",
+			modelId: "openai/grok-4.6",
+		})
+
+		expect(catalog.peekModels).toHaveBeenCalledWith(providerId)
+		expect(store.commitSelection).toHaveBeenCalledWith(
+			providerId,
+			"act",
+			{
+				providerId,
+				modelId: "openai/grok-4.6",
+				overrides: undefined,
+			},
+			modelInfo,
+		)
+	})
+
+	it("commitModelSelection does not substitute a different cached model when the selected ID has no metadata", async () => {
+		const { commitModelSelection } = await import("../commitModelSelection")
+		const providerId = parseProviderId("litellm")
+		const store = makeStore({ providerId, apiKey: "litellm-key" })
+		const catalog = makeCatalog()
+		vi.mocked(catalog.peekModels).mockReturnValue({
+			ok: true,
+			providerId,
+			configFingerprint: computeConfigFingerprint(providerId, { providerId, apiKey: "litellm-key" }),
+			models: new Map([
+				["openai/other-model", { name: "Other model", maxInputTokens: 200_000, supportsPromptCache: false }],
+			]),
+			defaultModelId: "openai/other-model",
+			source: "sdk-dynamic",
+			fetchedAt: 99,
+		})
+		const controller = makeController(store, catalog)
+
+		await commitModelSelection(controller, {
+			providerId: "litellm",
+			mode: "act",
+			modelId: "custom/no-metadata",
+		})
+
+		expect(catalog.peekModels).toHaveBeenCalledWith(providerId)
+		expect(store.commitSelection).toHaveBeenCalledWith(providerId, "act", {
+			providerId,
+			modelId: "custom/no-metadata",
+			overrides: undefined,
+		})
+	})
+
 	// The settings UI sources provider ids from the SDK catalog, whose OpenAI
 	// Compatible built-in is spelled `openai-compatible`. Committing under that
 	// spelling must land on the legacy `openai` state keys

--- a/apps/vscode/src/core/controller/models/commitModelSelection.ts
+++ b/apps/vscode/src/core/controller/models/commitModelSelection.ts
@@ -20,7 +20,13 @@ export async function commitModelSelection(
 	const previousApiConfiguration = hasProviderCatalogStateController(controller)
 		? controller.stateManager.getApiConfiguration?.()
 		: undefined
-	controller.getProviderConfigStore().commitSelection(providerId, mode, selection)
+	const cachedModels = controller.getProviderCatalog().peekModels(providerId)
+	const baseModelInfoHint = cachedModels?.ok ? cachedModels.models.get(selection.modelId) : undefined
+	if (baseModelInfoHint) {
+		controller.getProviderConfigStore().commitSelection(providerId, mode, selection, baseModelInfoHint)
+	} else {
+		controller.getProviderConfigStore().commitSelection(providerId, mode, selection)
+	}
 
 	if (hasProviderCatalogStateController(controller)) {
 		controller.stateManager.setGlobalStateBatch({

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -550,6 +550,8 @@ export class Controller {
 			isClineManagedProviderActive: () => this.isClineManagedProviderActive(),
 			emitClineAuthError: () => this.emitClineAuthErrorWithTelemetry(),
 			resetMessageTranslator: () => this.resetMessageTranslatorAndFence(),
+			recordOptimisticPendingPrompt: (prompt, images, files) =>
+				this.messageTranslatorState.recordOptimisticPendingPrompt(prompt, images, files),
 			postStateToWebview: () => this.postStateToWebview(),
 			onResumeFailed: () => {
 				this.turnStateTracker.set("error")

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -550,8 +550,8 @@ export class Controller {
 			isClineManagedProviderActive: () => this.isClineManagedProviderActive(),
 			emitClineAuthError: () => this.emitClineAuthErrorWithTelemetry(),
 			resetMessageTranslator: () => this.resetMessageTranslatorAndFence(),
-			recordOptimisticPendingPrompt: (prompt, images, files) =>
-				this.messageTranslatorState.recordOptimisticPendingPrompt(prompt, images, files),
+			recordSyntheticPendingPrompt: (prompt, images, files) =>
+				this.messageTranslatorState.recordSyntheticPendingPrompt(prompt, images, files),
 			postStateToWebview: () => this.postStateToWebview(),
 			onResumeFailed: () => {
 				this.turnStateTracker.set("error")

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -713,6 +713,80 @@ describe("buildSessionConfig", () => {
 		expect(knownModel.family).toBe(expectedModel.family)
 	})
 
+	it("injects cached LiteLLM max input tokens when the dynamic model is absent from the SDK registry", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: "openai/grok-4.6",
+			liteLlmApiKey: "litellm-key",
+			actModeLiteLlmModelInfo: {
+				name: "xai/grok-4.6",
+				contextWindow: 500_000,
+				maxInputTokens: 500_000,
+				maxTokens: 64_000,
+				supportsPromptCache: false,
+			},
+		} as any)
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["openai/grok-4.6"]
+
+		expect(config.providerId).toBe("litellm")
+		expect(knownModel).toMatchObject({
+			id: "openai/grok-4.6",
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+		})
+		expect(config.knownModels?.["openai/grok-4.6"]).toEqual(knownModel)
+		getModelsSpy.mockRestore()
+	})
+
+	it("keeps an explicit max-input override ahead of cached LiteLLM metadata", async () => {
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: modelId,
+			liteLlmApiKey: "litellm-key",
+			actModeLiteLlmModelInfo: {
+				name: "xai/grok-4.6",
+				contextWindow: 500_000,
+				maxInputTokens: 500_000,
+				supportsPromptCache: false,
+			},
+		} as any)
+		createProviderConfigStore().commitSelection(providerId, "act", {
+			providerId,
+			modelId,
+			overrides: { maxInputTokens: 300_000 },
+		})
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels[modelId]
+
+		expect(knownModel.contextWindow).toBe(500_000)
+		expect(knownModel.maxInputTokens).toBe(300_000)
+		getModelsSpy.mockRestore()
+	})
+
+	it("does not inject fabricated max input metadata for an unknown LiteLLM model", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "litellm",
+			actModeLiteLlmModelId: "custom/no-metadata",
+			liteLlmApiKey: "litellm-key",
+		} as any)
+		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockResolvedValueOnce({})
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.knownModels).toBeUndefined()
+		expect(config.providerConfig).not.toHaveProperty("knownModels")
+		getModelsSpy.mockRestore()
+	})
+
 	it("keeps session creation non-fatal when known-model lookup fails", async () => {
 		const lookupError = new Error("registry unavailable")
 		const getModelsSpy = vi.spyOn(LlmsModels, "getModelsForProvider").mockRejectedValueOnce(lookupError)

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -271,7 +271,8 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 
 	const maxTokens = positiveFiniteNumber(modelInfo.maxTokens)
 	const contextWindow = positiveFiniteNumber(modelInfo.contextWindow)
-	const maxInputTokens = positiveFiniteNumber(selection.overrides?.maxInputTokens)
+	const maxInputTokens =
+		positiveFiniteNumber(selection.overrides?.maxInputTokens) ?? positiveFiniteNumber(modelInfo.maxInputTokens)
 	const temperature = nonNegativeFiniteNumber(modelInfo.temperature)
 	const inputPrice = nonNegativeFiniteNumber(modelInfo.inputPrice)
 	const outputPrice = nonNegativeFiniteNumber(modelInfo.outputPrice)

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -228,6 +228,57 @@ describe("translateSessionEvent — pending prompts", () => {
 			}),
 		])
 	})
+
+	it("does not echo a synthetic resumption prompt that was auto-queued behind a settling abort", () => {
+		// A bare Resume that races the abort settling is auto-queued by the
+		// runtime; when it drains, the submitted-prompt echo must not leak the
+		// synthetic [TASK RESUMPTION] text as a visible user bubble (it is
+		// hidden from every other transcript surface, and a visible bubble
+		// would shift edit/regenerate ordinal mapping).
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "pending-1",
+				prompt: "[TASK RESUMPTION] Please continue where you left off.",
+				delivery: "queue",
+				attachmentCount: 0,
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+
+		expect(result.messages).toEqual([])
+	})
+
+	it("still renders attachments carried by a synthetic resumption prompt, without the synthetic text", () => {
+		// Attachment-only follow-ups ride on the synthetic prompt; the user's
+		// images/files are real content and must stay visible (matching
+		// isSyntheticSdkUserMessage, which counts such messages as visible).
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "pending-1",
+				prompt: '<user_input mode="act">[TASK RESUMPTION] Please continue where you left off.</user_input>',
+				delivery: "queue",
+				attachmentCount: 1,
+				userImages: ["image.png"],
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+
+		expect(result.messages).toEqual([
+			expect.objectContaining({
+				say: "user_feedback",
+				text: "",
+				images: ["image.png"],
+			}),
+		])
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -12,6 +12,7 @@ import {
 	sdkMessagesToClineMessages,
 	translateSessionEvent,
 } from "./message-translator"
+import { TASK_RESUMPTION_PROMPT } from "./sdk-user-message-mapping"
 
 // ---------------------------------------------------------------------------
 // MessageTranslatorState
@@ -174,27 +175,89 @@ describe("translateSessionEvent — chunk events", () => {
 // ---------------------------------------------------------------------------
 
 describe("translateSessionEvent — pending prompts", () => {
-	it("does not echo an idle follow-up again when an abort race queued it", () => {
+	it("binds generated resume suppression to the new queue id, not identical content", () => {
 		const state = new MessageTranslatorState()
-		state.recordOptimisticPendingPrompt("please just finish", ["image.png"], ["notes.txt"])
-		const event: CoreSessionEvent = {
+		const prompt = TASK_RESUMPTION_PROMPT
+		state.recordSyntheticPendingPrompt(prompt)
+		translateSessionEvent(
+			{
+				type: "pending_prompts",
+				payload: {
+					sessionId: "session-1",
+					prompts: [
+						{ id: "older-user", prompt, delivery: "queue", attachmentCount: 0 },
+						{ id: "generated-resume", prompt, delivery: "queue", attachmentCount: 0 },
+					],
+				},
+			},
+			state,
+		)
+		const olderEvent: CoreSessionEvent = {
 			type: "pending_prompt_submitted",
 			payload: {
 				sessionId: "session-1",
-				id: "pending-1",
-				prompt: "please just finish",
+				id: "older-user",
+				prompt,
 				delivery: "queue",
-				attachmentCount: 2,
-				userImages: ["image.png"],
-				userFiles: ["notes.txt"],
+				attachmentCount: 0,
 			},
 		}
-
-		expect(translateSessionEvent(event, state).messages).toEqual([])
-		expect(translateSessionEvent(event, state).messages).toEqual([
+		expect(translateSessionEvent(olderEvent, state).messages).toEqual([
 			expect.objectContaining({
 				say: "user_feedback",
-				text: "please just finish",
+				text: prompt,
+			}),
+		])
+		expect(
+			translateSessionEvent(
+				{
+					...olderEvent,
+					payload: { ...olderEvent.payload, id: "generated-resume" },
+				},
+				state,
+			).messages,
+		).toEqual([])
+	})
+
+	it("renders an id-bound generated resume when the user edits its text", () => {
+		const state = new MessageTranslatorState()
+		state.recordSyntheticPendingPrompt(TASK_RESUMPTION_PROMPT)
+		translateSessionEvent(
+			{
+				type: "pending_prompts",
+				payload: {
+					sessionId: "session-1",
+					prompts: [
+						{
+							id: "generated-resume",
+							prompt: TASK_RESUMPTION_PROMPT,
+							delivery: "queue",
+							attachmentCount: 0,
+						},
+					],
+				},
+			},
+			state,
+		)
+
+		const result = translateSessionEvent(
+			{
+				type: "pending_prompt_submitted",
+				payload: {
+					sessionId: "session-1",
+					id: "generated-resume",
+					prompt: "finish the edited task",
+					delivery: "queue",
+					attachmentCount: 0,
+				},
+			},
+			state,
+		)
+
+		expect(result.messages).toEqual([
+			expect.objectContaining({
+				say: "user_feedback",
+				text: "finish the edited task",
 			}),
 		])
 	})
@@ -254,12 +317,7 @@ describe("translateSessionEvent — pending prompts", () => {
 		])
 	})
 
-	it("does not echo a synthetic resumption prompt that was auto-queued behind a settling abort", () => {
-		// A bare Resume that races the abort settling is auto-queued by the
-		// runtime; when it drains, the submitted-prompt echo must not leak the
-		// synthetic [TASK RESUMPTION] text as a visible user bubble (it is
-		// hidden from every other transcript surface, and a visible bubble
-		// would shift edit/regenerate ordinal mapping).
+	it("renders user-authored text even when it resembles a synthetic prompt", () => {
 		const state = new MessageTranslatorState()
 		const event: CoreSessionEvent = {
 			type: "pending_prompt_submitted",
@@ -274,20 +332,45 @@ describe("translateSessionEvent — pending prompts", () => {
 
 		const result = translateSessionEvent(event, state)
 
-		expect(result.messages).toEqual([])
+		expect(result.messages).toEqual([
+			expect.objectContaining({
+				say: "user_feedback",
+				text: "[TASK RESUMPTION] Please continue where you left off.",
+			}),
+		])
 	})
 
-	it("still renders attachments carried by a synthetic resumption prompt, without the synthetic text", () => {
+	it("hides id-bound generated resume text while retaining its attachments", () => {
 		// Attachment-only follow-ups ride on the synthetic prompt; the user's
 		// images/files are real content and must stay visible (matching
 		// isSyntheticSdkUserMessage, which counts such messages as visible).
 		const state = new MessageTranslatorState()
+		const prompt = `<user_input mode="act">${TASK_RESUMPTION_PROMPT}</user_input>`
+		state.recordSyntheticPendingPrompt(prompt, ["image.png"])
+		translateSessionEvent(
+			{
+				type: "pending_prompts",
+				payload: {
+					sessionId: "session-1",
+					prompts: [
+						{
+							id: "pending-1",
+							prompt,
+							delivery: "queue",
+							attachmentCount: 1,
+							userImages: ["image.png"],
+						},
+					],
+				},
+			},
+			state,
+		)
 		const event: CoreSessionEvent = {
 			type: "pending_prompt_submitted",
 			payload: {
 				sessionId: "session-1",
 				id: "pending-1",
-				prompt: '<user_input mode="act">[TASK RESUMPTION] Please continue where you left off.</user_input>',
+				prompt,
 				delivery: "queue",
 				attachmentCount: 1,
 				userImages: ["image.png"],

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -175,7 +175,11 @@ describe("translateSessionEvent — chunk events", () => {
 // ---------------------------------------------------------------------------
 
 describe("translateSessionEvent — pending prompts", () => {
-	it("binds generated resume suppression to the new queue id, not identical content", () => {
+	it("hides every marker-carrying queued prompt, including duplicates", () => {
+		// Only Cline generates <cline_internal_prompt> content, so no
+		// marker-carrying submission may ever surface as a user bubble — even
+		// one whose queue id was never bound (e.g. a duplicate generated
+		// resume, or a binding lost to state.reset()).
 		const state = new MessageTranslatorState()
 		const prompt = TASK_RESUMPTION_PROMPT
 		state.recordSyntheticPendingPrompt(prompt)
@@ -185,7 +189,7 @@ describe("translateSessionEvent — pending prompts", () => {
 				payload: {
 					sessionId: "session-1",
 					prompts: [
-						{ id: "older-user", prompt, delivery: "queue", attachmentCount: 0 },
+						{ id: "older-resume", prompt, delivery: "queue", attachmentCount: 0 },
 						{ id: "generated-resume", prompt, delivery: "queue", attachmentCount: 0 },
 					],
 				},
@@ -196,18 +200,13 @@ describe("translateSessionEvent — pending prompts", () => {
 			type: "pending_prompt_submitted",
 			payload: {
 				sessionId: "session-1",
-				id: "older-user",
+				id: "older-resume",
 				prompt,
 				delivery: "queue",
 				attachmentCount: 0,
 			},
 		}
-		expect(translateSessionEvent(olderEvent, state).messages).toEqual([
-			expect.objectContaining({
-				say: "user_feedback",
-				text: prompt,
-			}),
-		])
+		expect(translateSessionEvent(olderEvent, state).messages).toEqual([])
 		expect(
 			translateSessionEvent(
 				{
@@ -317,27 +316,63 @@ describe("translateSessionEvent — pending prompts", () => {
 		])
 	})
 
-	it("renders user-authored text even when it resembles a synthetic prompt", () => {
+	it("hides a generated resume even when reset() wiped the id binding", () => {
+		// The settling run's `ended` always precedes the queue drain and calls
+		// state.reset(), which clears the synthetic-prompt id binding. The
+		// stateless marker check must still hide the generated resume or the
+		// raw <cline_internal_prompt> text leaks as a user bubble.
 		const state = new MessageTranslatorState()
-		const event: CoreSessionEvent = {
-			type: "pending_prompt_submitted",
-			payload: {
-				sessionId: "session-1",
-				id: "pending-1",
-				prompt: "[TASK RESUMPTION] Please continue where you left off.",
-				delivery: "queue",
-				attachmentCount: 0,
+		state.recordSyntheticPendingPrompt(TASK_RESUMPTION_PROMPT)
+		translateSessionEvent(
+			{
+				type: "pending_prompts",
+				payload: {
+					sessionId: "session-1",
+					prompts: [{ id: "generated-resume", prompt: TASK_RESUMPTION_PROMPT, delivery: "queue", attachmentCount: 0 }],
+				},
 			},
-		}
+			state,
+		)
+		state.reset()
 
-		const result = translateSessionEvent(event, state)
+		const result = translateSessionEvent(
+			{
+				type: "pending_prompt_submitted",
+				payload: {
+					sessionId: "session-1",
+					id: "generated-resume",
+					prompt: TASK_RESUMPTION_PROMPT,
+					delivery: "queue",
+					attachmentCount: 0,
+				},
+			},
+			state,
+		)
 
-		expect(result.messages).toEqual([
-			expect.objectContaining({
-				say: "user_feedback",
-				text: "[TASK RESUMPTION] Please continue where you left off.",
-			}),
-		])
+		expect(result.messages).toEqual([])
+	})
+
+	it("hides pre-marker legacy synthetic prompt shapes without an id binding", () => {
+		// Old sessions and the legacy task path still produce the
+		// [TASK RESUMPTION] prefix; hiding it here keeps the live transcript
+		// consistent with history projection (isSyntheticSdkUserMessage), which
+		// skips these shapes when computing edit/regenerate ordinals.
+		const state = new MessageTranslatorState()
+		const result = translateSessionEvent(
+			{
+				type: "pending_prompt_submitted",
+				payload: {
+					sessionId: "session-1",
+					id: "pending-1",
+					prompt: "[TASK RESUMPTION] Please continue where you left off.",
+					delivery: "queue",
+					attachmentCount: 0,
+				},
+			},
+			state,
+		)
+
+		expect(result.messages).toEqual([])
 	})
 
 	it("hides id-bound generated resume text while retaining its attachments", () => {

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -174,6 +174,31 @@ describe("translateSessionEvent — chunk events", () => {
 // ---------------------------------------------------------------------------
 
 describe("translateSessionEvent — pending prompts", () => {
+	it("does not echo an idle follow-up again when an abort race queued it", () => {
+		const state = new MessageTranslatorState()
+		state.recordOptimisticPendingPrompt("please just finish", ["image.png"], ["notes.txt"])
+		const event: CoreSessionEvent = {
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "pending-1",
+				prompt: "please just finish",
+				delivery: "queue",
+				attachmentCount: 2,
+				userImages: ["image.png"],
+				userFiles: ["notes.txt"],
+			},
+		}
+
+		expect(translateSessionEvent(event, state).messages).toEqual([])
+		expect(translateSessionEvent(event, state).messages).toEqual([
+			expect.objectContaining({
+				say: "user_feedback",
+				text: "please just finish",
+			}),
+		])
+	})
+
 	it("renders a submitted queued prompt as user feedback", () => {
 		const state = new MessageTranslatorState()
 		const event: CoreSessionEvent = {

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -49,7 +49,7 @@ import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage } from "../services/error/ClineError"
 import { MessageIdMinter } from "./message-id-minter"
 import { describeMissingCredentialError } from "./provider-credential-error"
-import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
+import { isSyntheticSdkUserMessage, isSyntheticUserPrompt } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
@@ -2109,10 +2109,19 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 
 		case "pending_prompt_submitted": {
 			const { prompt, userImages, userFiles } = event.payload
+			// Synthetic prompts (task resumption, plan -> act auto-continue) are
+			// hidden from every other transcript surface, and this echo must
+			// hide them too: a send that races a settling abort is auto-queued
+			// by the runtime, so a bare Resume can arrive here carrying the
+			// synthetic resumption prompt. Echoing it would leak model-facing
+			// text as a user bubble and shift the visible-user-message ordinals
+			// that edit/regenerate mapping relies on. Attachments the user
+			// supplied alongside a synthetic prompt still render (matching
+			// isSyntheticSdkUserMessage, which counts those as visible).
 			// Display boundary: formatDisplayUserInput strips runtime-generated
 			// notice elements (e.g. mode_notice) that normalizeUserInput must
 			// preserve, since the latter also sanitizes model-bound prompts.
-			const displayPrompt = formatDisplayUserInput(prompt)
+			const displayPrompt = isSyntheticUserPrompt(prompt) ? "" : formatDisplayUserInput(prompt)
 			const hasPrompt = displayPrompt.trim().length > 0
 			const hasImages = (userImages?.length ?? 0) > 0
 			const hasFiles = (userFiles?.length ?? 0) > 0

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -26,7 +26,7 @@
 // - SDK "agent_event" usage → ClineMessage say="api_req_started" with ClineApiReqInfo JSON
 // - SDK "ended" event → finalizes the session
 
-import type { CoreSessionEvent } from "@cline/core"
+import type { CoreSessionEvent, SessionPendingPrompt } from "@cline/core"
 import { PATCH_MARKERS, projectSessionMessagesForDisplay } from "@cline/core"
 import type { MessageWithMetadata as SdkMessage } from "@cline/llms"
 import { type AgentEvent, formatDisplayUserInput } from "@cline/shared"
@@ -49,7 +49,7 @@ import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage } from "../services/error/ClineError"
 import { MessageIdMinter } from "./message-id-minter"
 import { describeMissingCredentialError } from "./provider-credential-error"
-import { isSyntheticSdkUserMessage, isSyntheticUserPrompt } from "./sdk-user-message-mapping"
+import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
@@ -130,12 +130,8 @@ export class MessageTranslatorState {
 	private streamingToolInput: unknown | undefined
 	/** Stored tool name from content_start — used at content_end for consistency */
 	private streamingToolName: string | undefined
-	/**
-	 * A user message already rendered by the idle follow-up path. If an abort
-	 * race makes that same send enter Core's queue, suppress the later
-	 * pending_prompt_submitted echo exactly once.
-	 */
-	private optimisticPendingPromptKey: string | undefined
+	/** Cline-generated resume text waiting to be associated with Core's queue id. */
+	private syntheticPendingPrompt: { key: string; displayPrompt: string; id?: string } | undefined
 	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
 	private approvedToolMessageTsByCallId = new Map<string, number>()
 	/**
@@ -174,17 +170,32 @@ export class MessageTranslatorState {
 		return this.getActiveModelId?.()
 	}
 
-	recordOptimisticPendingPrompt(prompt: string, userImages?: string[], userFiles?: string[]): void {
-		this.optimisticPendingPromptKey = this.pendingPromptKey(prompt, userImages, userFiles)
+	recordSyntheticPendingPrompt(prompt: string, userImages?: string[], userFiles?: string[]): void {
+		this.syntheticPendingPrompt = {
+			key: this.pendingPromptKey(prompt, userImages, userFiles),
+			displayPrompt: formatDisplayUserInput(prompt),
+		}
 	}
 
-	consumeOptimisticPendingPrompt(prompt: string, userImages?: string[], userFiles?: string[]): boolean {
-		const key = this.pendingPromptKey(prompt, userImages, userFiles)
-		if (key !== this.optimisticPendingPromptKey) {
-			return false
+	observePendingPrompts(prompts: readonly SessionPendingPrompt[]): void {
+		if (!this.syntheticPendingPrompt || this.syntheticPendingPrompt.id) return
+		const match = [...prompts]
+			.reverse()
+			.find(
+				(prompt) =>
+					this.pendingPromptKey(prompt.prompt, prompt.userImages, prompt.userFiles) ===
+					this.syntheticPendingPrompt?.key,
+			)
+		if (match) {
+			this.syntheticPendingPrompt.id = match.id
 		}
-		this.optimisticPendingPromptKey = undefined
-		return true
+	}
+
+	consumeSyntheticPendingPrompt(id: string, prompt: string): boolean {
+		if (this.syntheticPendingPrompt?.id !== id) return false
+		const suppress = this.syntheticPendingPrompt.displayPrompt === formatDisplayUserInput(prompt)
+		this.syntheticPendingPrompt = undefined
+		return suppress
 	}
 
 	private pendingPromptKey(prompt: string, userImages?: string[], userFiles?: string[]): string {
@@ -529,7 +540,7 @@ export class MessageTranslatorState {
 		this.streamingToolTs = undefined
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
-		this.optimisticPendingPromptKey = undefined
+		this.syntheticPendingPrompt = undefined
 		this.clearApprovedToolMessageTs()
 		this.deniedToolApprovalsByCallId.clear()
 		this.clearSpawnAgents()
@@ -2131,24 +2142,21 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			break
 		}
 
+		case "pending_prompts": {
+			state.observePendingPrompts(event.payload.prompts)
+			break
+		}
+
 		case "pending_prompt_submitted": {
-			const { prompt, userImages, userFiles } = event.payload
-			if (state.consumeOptimisticPendingPrompt(prompt, userImages, userFiles)) {
-				break
-			}
-			// Synthetic prompts (task resumption, plan -> act auto-continue) are
-			// hidden from every other transcript surface, and this echo must
-			// hide them too: a send that races a settling abort is auto-queued
-			// by the runtime, so a bare Resume can arrive here carrying the
-			// synthetic resumption prompt. Echoing it would leak model-facing
-			// text as a user bubble and shift the visible-user-message ordinals
-			// that edit/regenerate mapping relies on. Attachments the user
-			// supplied alongside a synthetic prompt still render (matching
-			// isSyntheticSdkUserMessage, which counts those as visible).
+			const { id, prompt, userImages, userFiles } = event.payload
+			// Hide only the exact queue id associated with a Cline-generated bare
+			// Resume. Content inspection is insufficient: users may type the same
+			// text, and multiple identical queued prompts remain distinct turns.
+			// Attachments carried by the generated resume still render.
 			// Display boundary: formatDisplayUserInput strips runtime-generated
 			// notice elements (e.g. mode_notice) that normalizeUserInput must
 			// preserve, since the latter also sanitizes model-bound prompts.
-			const displayPrompt = isSyntheticUserPrompt(prompt) ? "" : formatDisplayUserInput(prompt)
+			const displayPrompt = state.consumeSyntheticPendingPrompt(id, prompt) ? "" : formatDisplayUserInput(prompt)
 			const hasPrompt = displayPrompt.trim().length > 0
 			const hasImages = (userImages?.length ?? 0) > 0
 			const hasFiles = (userFiles?.length ?? 0) > 0
@@ -2166,8 +2174,7 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			break
 		}
 
-		case "team_progress":
-		case "pending_prompts": {
+		case "team_progress": {
 			// These are handled by the team/subagent system, not translated
 			// to ClineMessages at this layer
 			break

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -49,7 +49,7 @@ import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage } from "../services/error/ClineError"
 import { MessageIdMinter } from "./message-id-minter"
 import { describeMissingCredentialError } from "./provider-credential-error"
-import { isSyntheticSdkUserMessage } from "./sdk-user-message-mapping"
+import { isSyntheticSdkUserMessage, isSyntheticUserPrompt } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
 // ---------------------------------------------------------------------------
@@ -2149,14 +2149,18 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 
 		case "pending_prompt_submitted": {
 			const { id, prompt, userImages, userFiles } = event.payload
-			// Hide only the exact queue id associated with a Cline-generated bare
-			// Resume. Content inspection is insufficient: users may type the same
-			// text, and multiple identical queued prompts remain distinct turns.
+			// Hide the queue id associated with a Cline-generated bare Resume.
+			// The id binding can be wiped before this event arrives: state.reset()
+			// runs on the settling run's `ended` (which always precedes the queue
+			// drain) and on `iteration_start`. isSyntheticUserPrompt is the
+			// stateless fallback — safe now that synthetic prompts carry the
+			// <cline_internal_prompt> marker user text cannot accidentally match.
 			// Attachments carried by the generated resume still render.
 			// Display boundary: formatDisplayUserInput strips runtime-generated
 			// notice elements (e.g. mode_notice) that normalizeUserInput must
 			// preserve, since the latter also sanitizes model-bound prompts.
-			const displayPrompt = state.consumeSyntheticPendingPrompt(id, prompt) ? "" : formatDisplayUserInput(prompt)
+			const suppress = state.consumeSyntheticPendingPrompt(id, prompt) || isSyntheticUserPrompt(prompt)
+			const displayPrompt = suppress ? "" : formatDisplayUserInput(prompt)
 			const hasPrompt = displayPrompt.trim().length > 0
 			const hasImages = (userImages?.length ?? 0) > 0
 			const hasFiles = (userFiles?.length ?? 0) > 0

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -130,6 +130,12 @@ export class MessageTranslatorState {
 	private streamingToolInput: unknown | undefined
 	/** Stored tool name from content_start — used at content_end for consistency */
 	private streamingToolName: string | undefined
+	/**
+	 * A user message already rendered by the idle follow-up path. If an abort
+	 * race makes that same send enter Core's queue, suppress the later
+	 * pending_prompt_submitted echo exactly once.
+	 */
+	private optimisticPendingPromptKey: string | undefined
 	/** Approved tool-call ids mapped to the approval row that should be updated in place. */
 	private approvedToolMessageTsByCallId = new Map<string, number>()
 	/**
@@ -166,6 +172,23 @@ export class MessageTranslatorState {
 	/** Model backing the active turn, if the host can supply it. */
 	activeModelId(): string | undefined {
 		return this.getActiveModelId?.()
+	}
+
+	recordOptimisticPendingPrompt(prompt: string, userImages?: string[], userFiles?: string[]): void {
+		this.optimisticPendingPromptKey = this.pendingPromptKey(prompt, userImages, userFiles)
+	}
+
+	consumeOptimisticPendingPrompt(prompt: string, userImages?: string[], userFiles?: string[]): boolean {
+		const key = this.pendingPromptKey(prompt, userImages, userFiles)
+		if (key !== this.optimisticPendingPromptKey) {
+			return false
+		}
+		this.optimisticPendingPromptKey = undefined
+		return true
+	}
+
+	private pendingPromptKey(prompt: string, userImages?: string[], userFiles?: string[]): string {
+		return JSON.stringify([formatDisplayUserInput(prompt), userImages ?? [], userFiles ?? []])
 	}
 
 	/**
@@ -506,6 +529,7 @@ export class MessageTranslatorState {
 		this.streamingToolTs = undefined
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
+		this.optimisticPendingPromptKey = undefined
 		this.clearApprovedToolMessageTs()
 		this.deniedToolApprovalsByCallId.clear()
 		this.clearSpawnAgents()
@@ -2109,6 +2133,9 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 
 		case "pending_prompt_submitted": {
 			const { prompt, userImages, userFiles } = event.payload
+			if (state.consumeOptimisticPendingPrompt(prompt, userImages, userFiles)) {
+				break
+			}
 			// Synthetic prompts (task resumption, plan -> act auto-continue) are
 			// hidden from every other transcript surface, and this echo must
 			// hide them too: a send that races a settling abort is auto-queued

--- a/apps/vscode/src/sdk/model-catalog/contracts.ts
+++ b/apps/vscode/src/sdk/model-catalog/contracts.ts
@@ -201,9 +201,9 @@ export interface ResolvedModelSelection extends ModelSelection {
 	/**
 	 * Where the base `modelInfo` came from, before overrides were applied:
 	 *
-	 *  - "catalog"  — SDK catalog metadata (generated snapshot or registry).
+	 *  - "catalog"  — SDK catalog metadata (generated snapshot, registry, or live host cache).
 	 *  - "state"    — the mode-specific `*ModeModelInfo` snapshot persisted by
-	 *    the picker at selection time. Authoritative for dynamic-list providers
+	 *    the host at selection time. Authoritative for dynamic-list providers
 	 *    (openrouter, litellm, requesty, …) whose models are not in the static
 	 *    catalog.
 	 *  - "fallback" — provider-safe defaults fabricated because nothing better
@@ -404,10 +404,15 @@ export interface ProviderConfigStore extends ProviderConfigReader {
 	 * Supplying overrides replaces that model's stored override entry; omitting
 	 * them leaves the existing entry unchanged.
 	 *
+	 * `baseModelInfoHint` is the exact host-resolved catalog metadata selected
+	 * by the user. It is authoritative for that commit, including when a
+	 * private/dynamic provider reuses an id from the static SDK registry. It is
+	 * not user-authored and must never be persisted as an override.
+	 *
 	 * I2: refresh handlers do not have access to this method by type, since
 	 * `ProviderCatalog` holds only a `ProviderConfigReader`.
 	 */
-	commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection): void
+	commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection, baseModelInfoHint?: ModelInfo): void
 }
 
 /**

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
@@ -20,6 +20,9 @@ describe("adaptSdkModelInfo", () => {
 
 		it("throws CatalogShapeError when optional scalar fields are malformed", () => {
 			expect(() => adaptSdkModelInfo({ id: "m", contextWindow: "big" })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: "huge" })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: Number.NaN })).toThrow(CatalogShapeError)
+			expect(() => adaptSdkModelInfo({ id: "m", maxInputTokens: Number.POSITIVE_INFINITY })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", maxTokens: "huge" })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", name: 1 })).toThrow(CatalogShapeError)
 			expect(() => adaptSdkModelInfo({ id: "m", description: 1 })).toThrow(CatalogShapeError)
@@ -172,10 +175,34 @@ describe("adaptSdkModelInfo", () => {
 			expect(model.description).toBeUndefined()
 		})
 
-		it("treats null contextWindow/maxTokens as missing (live LiteLLM /model/info reports unknown limits as null)", () => {
-			const model = adaptSdkModelInfo({ id: "claude-opus-5", contextWindow: null, maxTokens: null })
+		it("treats null token limits as missing (live LiteLLM /model/info reports unknown limits as null)", () => {
+			const model = adaptSdkModelInfo({
+				id: "claude-opus-5",
+				contextWindow: null,
+				maxInputTokens: null,
+				maxTokens: null,
+			})
 			expect(model.contextWindow).toBe(openAiModelInfoSafeDefaults.contextWindow)
+			expect(model.maxInputTokens).toBeUndefined()
 			expect(model.maxTokens).toBe(openAiModelInfoSafeDefaults.maxTokens)
+		})
+
+		it("uses a reported input limit when LiteLLM omits the context window", () => {
+			const model = adaptSdkModelInfo({ id: "openai/grok-4.6", maxInputTokens: 500_000 })
+
+			expect(model.contextWindow).toBe(500_000)
+			expect(model.maxInputTokens).toBe(500_000)
+		})
+
+		it("keeps distinct context and input limits when both are reported", () => {
+			const model = adaptSdkModelInfo({
+				id: "openai/grok-4.6",
+				contextWindow: 600_000,
+				maxInputTokens: 500_000,
+			})
+
+			expect(model.contextWindow).toBe(600_000)
+			expect(model.maxInputTokens).toBe(500_000)
 		})
 
 		it("falls back to id when name is omitted and passes through description", () => {
@@ -199,6 +226,7 @@ describe("adaptSdkModelInfo", () => {
 			id: "deepseek-v4-flash",
 			name: "DeepSeek V4 Flash",
 			contextWindow: 200_000,
+			maxInputTokens: 180_000,
 			maxTokens: 8192,
 			capabilities: ["tools", "reasoning", "structured_output", "temperature", "prompt-cache", "images"],
 			pricing: { input: 0.5, output: 1.5, cacheRead: 0.05, cacheWrite: 0.1 },
@@ -210,6 +238,7 @@ describe("adaptSdkModelInfo", () => {
 		expect(model).toMatchObject({
 			name: "DeepSeek V4 Flash",
 			contextWindow: 200_000,
+			maxInputTokens: 180_000,
 			maxTokens: 8192,
 			supportsImages: true,
 			supportsPromptCache: true,
@@ -229,6 +258,7 @@ describe("adaptSdkModelInfo", () => {
 			id: "m",
 			name: "M",
 			contextWindow: 32_000,
+			maxInputTokens: 30_000,
 			maxTokens: 4096,
 			capabilities: ["tools", "reasoning"],
 			pricing: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
@@ -11,6 +11,7 @@
  *   id: string,                  // only consistently-required field
  *   name?: string,
  *   contextWindow?: number,
+ *   maxInputTokens?: number,
  *   maxTokens?: number,
  *   capabilities?: string[],     // e.g. ["tools", "reasoning", "prompt-cache", "images"]
  *   modalities?: { input: string[], output: string[] },
@@ -28,7 +29,8 @@
  * | extension ModelInfo field | source | default if missing |
  * | --- | --- | --- |
  * | name | `sdk.name ?? sdk.id` | n/a (id is required) |
- * | contextWindow | `sdk.contextWindow` if finite number (null = missing) | safe default: 128_000 |
+ * | contextWindow | `sdk.contextWindow`, or positive `sdk.maxInputTokens` for legacy display compatibility | safe default: 128_000 |
+ * | maxInputTokens | `sdk.maxInputTokens` if finite number (null = missing) | omitted (undefined) |
  * | maxTokens | `sdk.maxTokens` if finite number (null = missing) | safe default: -1 |
  * | supportsImages | capabilities includes `images` or `vision` | safe default: true when capabilities absent |
  * | supportsPromptCache | capabilities includes `prompt-cache` | safe default: false when capabilities absent |
@@ -226,6 +228,13 @@ export function adaptSdkModelInfo(input: unknown): ModelInfo {
 		})
 	}
 
+	const rawMaxInputTokens = input.maxInputTokens
+	if (rawMaxInputTokens !== undefined && rawMaxInputTokens !== null && !isFiniteNumber(rawMaxInputTokens)) {
+		throw new CatalogShapeError("SDK model-info `maxInputTokens` must be a finite number when present.", {
+			details: { receivedType: typeof rawMaxInputTokens },
+		})
+	}
+
 	const rawMaxTokens = input.maxTokens
 	if (rawMaxTokens !== undefined && rawMaxTokens !== null && !isFiniteNumber(rawMaxTokens)) {
 		throw new CatalogShapeError("SDK model-info `maxTokens` must be a finite number when present.", {
@@ -249,15 +258,29 @@ export function adaptSdkModelInfo(input: unknown): ModelInfo {
 		})
 	}
 
+	const maxInputTokens = isFiniteNumber(rawMaxInputTokens) ? rawMaxInputTokens : undefined
+	// Legacy extension consumers display and budget exclusively from
+	// `contextWindow`. When a provider reports only a positive prompt limit,
+	// use it as a conservative compatibility proxy while still preserving the
+	// authoritative `maxInputTokens` field independently for the SDK runtime.
+	const contextWindow = isFiniteNumber(rawContextWindow)
+		? rawContextWindow
+		: maxInputTokens !== undefined && maxInputTokens > 0
+			? maxInputTokens
+			: openAiModelInfoSafeDefaults.contextWindow
+
 	const result: ModelInfo = {
 		name: rawName ?? id,
-		contextWindow: isFiniteNumber(rawContextWindow) ? rawContextWindow : openAiModelInfoSafeDefaults.contextWindow,
+		contextWindow,
 		maxTokens: isFiniteNumber(rawMaxTokens) ? rawMaxTokens : openAiModelInfoSafeDefaults.maxTokens,
 		supportsPromptCache: capabilities
 			? capabilities.includes(PROMPT_CACHE_CAPABILITY)
 			: openAiModelInfoSafeDefaults.supportsPromptCache,
 		inputPrice: pricing?.input ?? openAiModelInfoSafeDefaults.inputPrice,
 		outputPrice: pricing?.output ?? openAiModelInfoSafeDefaults.outputPrice,
+	}
+	if (maxInputTokens !== undefined) {
+		result.maxInputTokens = maxInputTokens
 	}
 
 	if (capabilities) {

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -91,6 +91,7 @@ vi.mock("../provider-migration", () => ({
 }))
 
 vi.mock("@cline/core", () => ({
+	isPrivateModelCatalogProvider: (providerId: string) => ["baseten", "hicap", "litellm", "poolside"].includes(providerId),
 	syncStoredProviderRegistration: vi.fn(),
 	readModelsFileSync: vi.fn(() => mocks.getModelsFile()),
 	resolveModelsRegistryPath: vi.fn(() => "/tmp/models.json"),
@@ -219,6 +220,143 @@ describe("createProviderConfigStore", () => {
 			apiFormat: "openai-responses",
 			capabilities: ["prompt-cache"],
 		})
+	})
+
+	it("persists host catalog metadata for a dynamic LiteLLM model without turning it into an override", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		const liveModelInfo: ModelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+			supportsReasoning: true,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			providerId,
+			modelId,
+			overrides: undefined,
+			modelInfoSource: "state",
+			baseModelInfo: liveModelInfo,
+			modelInfo: liveModelInfo,
+		})
+		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
+	})
+
+	it.each([
+		["litellm", "actModeLiteLlmModelInfo"],
+		["baseten", "actModeBasetenModelInfo"],
+		["hicap", "actModeHicapModelInfo"],
+	] as const)("keeps a persisted %s private-catalog snapshot authoritative after reload", async (provider, modelInfoKey) => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId(provider)
+		const modelId = "shared-private-model"
+		const staticModelInfo: ModelInfo = {
+			name: "SDK fallback model",
+			contextWindow: 128_000,
+			maxInputTokens: 128_000,
+			maxTokens: 16_384,
+			supportsPromptCache: true,
+		}
+		const liveModelInfo: ModelInfo = {
+			name: "Private endpoint deployment",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+		mocks.setGeneratedModels(provider, { [modelId]: staticModelInfo })
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration()[modelInfoKey]).toEqual(liveModelInfo)
+
+		// A window reload clears the in-process catalog and selection envelope;
+		// the durable provider snapshot must still beat the same-id static entry.
+		vi.resetModules()
+		const { createProviderConfigStore: createReloadedStore } = await import("./store")
+		expect(createReloadedStore().readSelection(providerId, "act")).toMatchObject({
+			modelInfoSource: "state",
+			baseModelInfo: liveModelInfo,
+			modelInfo: liveModelInfo,
+		})
+	})
+
+	it("lets a public catalog update supersede an older persisted snapshot after reload", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openrouter")
+		const modelId = "shared-public-model"
+		const refreshedModelInfo: ModelInfo = {
+			name: "Refreshed public catalog model",
+			contextWindow: 256_000,
+			maxTokens: 32_000,
+			supportsPromptCache: true,
+		}
+		const selectedModelInfo: ModelInfo = {
+			name: "Catalog model at selection time",
+			contextWindow: 128_000,
+			maxTokens: 16_000,
+			supportsPromptCache: false,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId }, selectedModelInfo)
+		mocks.setGeneratedModels("openrouter", { [modelId]: refreshedModelInfo })
+
+		vi.resetModules()
+		const { createProviderConfigStore: createReloadedStore } = await import("./store")
+		expect(createReloadedStore().readSelection(providerId, "act")).toMatchObject({
+			modelInfoSource: "catalog",
+			baseModelInfo: refreshedModelInfo,
+			modelInfo: refreshedModelInfo,
+		})
+	})
+
+	it("keeps a LiteLLM max-input override ahead of cached catalog metadata without baking it into the base", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "openai/grok-4.6"
+		const liveModelInfo: ModelInfo = {
+			name: "xai/grok-4.6",
+			contextWindow: 500_000,
+			maxInputTokens: 500_000,
+			maxTokens: 64_000,
+			supportsPromptCache: false,
+		}
+
+		store.commitSelection(providerId, "act", { providerId, modelId, overrides: { maxInputTokens: 300_000 } }, liveModelInfo)
+
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toEqual(liveModelInfo)
+		expect(store.readSelection(providerId, "act")).toMatchObject({
+			baseModelInfo: liveModelInfo,
+			overrides: { maxInputTokens: 300_000 },
+			modelInfo: { maxInputTokens: 300_000 },
+		})
+	})
+
+	it("does not fabricate maxInputTokens or a metadata snapshot when a dynamic model has no catalog metadata", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("litellm")
+		const modelId = "custom/no-metadata"
+
+		store.commitSelection(providerId, "act", { providerId, modelId })
+
+		expect(mocks.getApiConfiguration()).toMatchObject({ actModeLiteLlmModelId: modelId })
+		expect(mocks.getApiConfiguration().actModeLiteLlmModelInfo).toBeUndefined()
+		const resolved = store.readSelection(providerId, "act")
+		expect(resolved?.modelInfoSource).toBe("fallback")
+		expect(resolved?.modelInfo.maxInputTokens).toBeUndefined()
+		expect(mocks.getModelsFile().providers.litellm?.models?.[modelId]).toBeUndefined()
 	})
 
 	it("round-trips generic provider selections using the in-process modelInfo envelope", async () => {

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -1,4 +1,5 @@
 import {
+	isPrivateModelCatalogProvider,
 	readModelsFileSync,
 	resolveModelsRegistryPath,
 	type StoredModelEntry,
@@ -352,8 +353,7 @@ function applyModelOverrides(modelInfo: ModelInfo, overrides: ModelSelectionOver
 	if (overrides.name !== undefined) next.name = overrides.name
 	if (overrides.maxTokens !== undefined) next.maxTokens = overrides.maxTokens
 	if (overrides.contextWindow !== undefined) next.contextWindow = overrides.contextWindow
-	if (overrides.maxInputTokens !== undefined)
-		(next as ModelInfo & { maxInputTokens?: number }).maxInputTokens = overrides.maxInputTokens
+	if (overrides.maxInputTokens !== undefined) next.maxInputTokens = overrides.maxInputTokens
 	if (overrides.inputPrice !== undefined) next.inputPrice = overrides.inputPrice
 	if (overrides.outputPrice !== undefined) next.outputPrice = overrides.outputPrice
 	if (overrides.cacheReadsPrice !== undefined) next.cacheReadsPrice = overrides.cacheReadsPrice
@@ -413,22 +413,57 @@ function readBaseModelInfoForProvider(providerId: ProviderId, modelId: string): 
 	return undefined
 }
 
-function resolveSelection(selection: ModelSelection, stateModelInfoHint?: ModelInfo): ResolvedModelSelection {
+interface BaseModelInfoHint {
+	modelInfo: ModelInfo
+	source: "catalog" | "state"
+}
+
+interface BaseModelInfoCandidate {
+	modelInfo: ModelInfo
+	source: "catalog" | "state" | "fallback"
+}
+
+function resolveSelection(selection: ModelSelection, baseModelInfoHint?: BaseModelInfoHint): ResolvedModelSelection {
 	const overrides = normalizeModelSelectionOverrides(
 		selection.overrides ?? readModelOverrides(selection.providerId, selection.modelId),
 	)
-	// Base resolution order: SDK catalog, then the picker's persisted state
-	// snapshot (the only accurate data for dynamic-list models the static
-	// catalog does not know), then provider-safe fallback defaults.
+	// A host catalog hint is the exact live entry the user selected, so it must
+	// win even when a private/dynamic provider reuses an id from the static SDK
+	// catalog. Persisted state is weaker by default; the private-catalog
+	// exception is applied below.
 	const catalogModelInfo = readBaseModelInfoForProvider(selection.providerId, selection.modelId)
-	const baseModelInfo = catalogModelInfo ?? stateModelInfoHint ?? fallbackModelInfo(selection.modelId)
-	const modelInfoSource = catalogModelInfo ? "catalog" : stateModelInfoHint ? "state" : "fallback"
+	const liveCatalogHint = baseModelInfoHint?.source === "catalog" ? baseModelInfoHint.modelInfo : undefined
+	const stateModelInfoHint = baseModelInfoHint?.source === "state" ? baseModelInfoHint.modelInfo : undefined
+	const liveCatalogCandidate: BaseModelInfoCandidate | undefined = liveCatalogHint
+		? { modelInfo: liveCatalogHint, source: "catalog" }
+		: undefined
+	const staticCatalogCandidate: BaseModelInfoCandidate | undefined = catalogModelInfo
+		? { modelInfo: catalogModelInfo, source: "catalog" }
+		: undefined
+	const stateCandidate: BaseModelInfoCandidate | undefined = stateModelInfoHint
+		? { modelInfo: stateModelInfoHint, source: "state" }
+		: undefined
+
+	// Private catalogs belong to the customer's configured endpoint. Their
+	// persisted snapshot therefore remains authoritative after the live cache
+	// is gone, including when that endpoint reuses an id from the static SDK
+	// catalog. Public providers retain static-catalog-over-snapshot semantics so
+	// SDK catalog updates can refresh an existing selection.
+	const authoritativeStateCandidate = isPrivateModelCatalogProvider(providerKey(selection.providerId))
+		? stateCandidate
+		: undefined
+	const base =
+		liveCatalogCandidate ??
+		authoritativeStateCandidate ??
+		staticCatalogCandidate ??
+		stateCandidate ??
+		({ modelInfo: fallbackModelInfo(selection.modelId), source: "fallback" } satisfies BaseModelInfoCandidate)
 	return {
 		...selection,
 		overrides,
-		modelInfoSource,
-		baseModelInfo,
-		modelInfo: sanitizeResolvedModelInfo(applyModelOverrides(baseModelInfo, overrides)),
+		modelInfoSource: base.source,
+		baseModelInfo: base.modelInfo,
+		modelInfo: sanitizeResolvedModelInfo(applyModelOverrides(base.modelInfo, overrides)),
 	}
 }
 
@@ -680,17 +715,15 @@ function writeSelectionToProviderSettings(providerId: ProviderId, selection: Mod
 	saveProviderSettings(providerId, next)
 }
 
-type LegacyModelInfo = ModelInfo & { maxInputTokens?: number }
 type MutableModelSelectionOverrides = { -readonly [Key in keyof ModelSelectionOverrides]: ModelSelectionOverrides[Key] }
 
-function legacyModelInfoToOverrides(modelInfo: LegacyModelInfo, fallback: ModelInfo): ModelSelectionOverrides | undefined {
-	const fallbackInfo = fallback as LegacyModelInfo
+function legacyModelInfoToOverrides(modelInfo: ModelInfo, fallback: ModelInfo): ModelSelectionOverrides | undefined {
 	const overrides: MutableModelSelectionOverrides = {}
 	if (modelInfo.name !== undefined && modelInfo.name !== fallback.name) overrides.name = modelInfo.name
 	if (modelInfo.maxTokens !== undefined && modelInfo.maxTokens !== fallback.maxTokens) overrides.maxTokens = modelInfo.maxTokens
 	if (modelInfo.contextWindow !== undefined && modelInfo.contextWindow !== fallback.contextWindow)
 		overrides.contextWindow = modelInfo.contextWindow
-	if (modelInfo.maxInputTokens !== undefined && modelInfo.maxInputTokens !== fallbackInfo.maxInputTokens)
+	if (modelInfo.maxInputTokens !== undefined && modelInfo.maxInputTokens !== fallback.maxInputTokens)
 		overrides.maxInputTokens = modelInfo.maxInputTokens
 
 	const supportsVision = modelInfo.supportsImages ?? fallback.supportsImages
@@ -740,7 +773,7 @@ function migrateLegacyModelOverridesIfNeeded(providerId: ProviderId, modelId: st
 	if (readBaseModelInfoForProvider(providerId, modelId) !== undefined) {
 		return
 	}
-	const overrides = legacyModelInfoToOverrides(modelInfo as LegacyModelInfo, fallbackModelInfo(modelId))
+	const overrides = legacyModelInfoToOverrides(modelInfo, fallbackModelInfo(modelId))
 	if (overrides) {
 		try {
 			writeModelOverrides(providerId, modelId, overrides)
@@ -757,10 +790,11 @@ function migrateLegacyModelOverridesIfNeeded(providerId: ProviderId, modelId: st
 }
 
 /**
- * The picker writes the live model metadata to the mode-specific
- * `*ModeModelInfo` state key before committing. When the state still refers to
- * the model being resolved, that snapshot is the best available base for
- * dynamic-list models the static catalog does not know.
+ * The host persists live model metadata to the mode-specific `*ModeModelInfo`
+ * state key when a selection is committed. When the state still refers to the
+ * model being resolved, that snapshot is the best available base for
+ * dynamic-list models the static catalog does not know. Pre-existing snapshots
+ * from older picker flows remain valid inputs here.
  *
  * openai-compatible is excluded: its legacy state snapshot is user-authored
  * metadata that {@link migrateLegacyModelOverridesIfNeeded} converts into
@@ -822,7 +856,11 @@ function readSelectionFromState(providerId: ProviderId, mode: Mode): ResolvedMod
 		if (isModelInfo(modelInfo)) {
 			migrateLegacyModelOverridesIfNeeded(providerId, modelId, modelInfo)
 		}
-		return resolveSelection({ providerId, modelId }, readStateModelInfoHint(providerId, mode, modelId))
+		const stateModelInfoHint = readStateModelInfoHint(providerId, mode, modelId)
+		return resolveSelection(
+			{ providerId, modelId },
+			stateModelInfoHint ? { modelInfo: stateModelInfoHint, source: "state" } : undefined,
+		)
 	}
 
 	const providerSettingsSelection = readSelectionFromProviderSettings(providerId)
@@ -881,16 +919,23 @@ export function createProviderConfigStore(): ProviderConfigStore {
 			return config
 		},
 
-		commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection): void {
+		commitSelection(providerId: ProviderId, mode: Mode, selection: ModelSelection, baseModelInfoHint?: ModelInfo): void {
 			writeSelectionToProviderSettings(providerId, selection)
 			if (selection.overrides !== undefined) {
 				writeModelOverrides(providerId, selection.modelId, selection.overrides)
 			}
-			// Read the picker-written state snapshot before writeSelectionToState
-			// replaces it, so dynamic-list models keep their live metadata instead
-			// of being re-resolved to fallback defaults.
+			// Prefer metadata resolved by the host catalog for this commit. Fall
+			// back to an existing state snapshot for legacy callers, then persist
+			// the genuine base so dynamic-list models survive future reads.
 			const stateModelInfoHint = readStateModelInfoHint(providerId, mode, selection.modelId)
-			const resolvedSelection = resolveSelection({ providerId, modelId: selection.modelId }, stateModelInfoHint)
+			const resolvedSelection = resolveSelection(
+				{ providerId, modelId: selection.modelId },
+				baseModelInfoHint
+					? { modelInfo: baseModelInfoHint, source: "catalog" }
+					: stateModelInfoHint
+						? { modelInfo: stateModelInfoHint, source: "state" }
+						: undefined,
+			)
 			writeSelectionToState(providerId, mode, resolvedSelection)
 			emit({ kind: "selection", providerId, mode, selection: resolvedSelection })
 		},

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -67,7 +67,6 @@ describe("SdkFollowupCoordinator", () => {
 			"resolved: hello @file",
 			["image.png"],
 			["a.ts"],
-			undefined,
 		)
 	})
 
@@ -166,7 +165,6 @@ describe("SdkFollowupCoordinator", () => {
 			"resolved: next request",
 			undefined,
 			undefined,
-			undefined,
 		)
 	})
 
@@ -228,7 +226,6 @@ describe("SdkFollowupCoordinator", () => {
 			rebuiltSession.sdkHost,
 			"session-123",
 			"resolved: after rebuild",
-			undefined,
 			undefined,
 			undefined,
 		)
@@ -424,6 +421,100 @@ describe("SdkFollowupCoordinator", () => {
 				],
 			}),
 		)
+	})
+
+	it("continues the surviving idle session on a bare resume instead of rebuilding", async () => {
+		// Stop -> Resume: cancelling a turn keeps the session alive, so a bare
+		// Resume must continue that session in place (like the CLI does after
+		// an abort) rather than tearing it down and rebuilding from history.
+		const activeSession = makeActiveSession({ isRunning: false })
+		const task = makeTask("session-123")
+		const { coordinator, options } = makeCoordinator({ activeSession, task })
+
+		await coordinator.askResponse(undefined)
+
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(options.loadInitialMessages).not.toHaveBeenCalled()
+		expect(options.sessions.setRunning).toHaveBeenCalledWith(true)
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledOnce()
+		const [sdkHost, sessionId, sentPrompt] = options.sessions.fireAndForgetSend.mock.calls[0]
+		expect(sdkHost).toBe(activeSession.sdkHost)
+		expect(sessionId).toBe("session-123")
+		expect(sentPrompt).toContain("[TASK RESUMPTION]")
+		// A bare resumption prompt is synthetic and must not render a user bubble.
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
+	})
+
+	it("continues the surviving idle session for a typed follow-up instead of rebuilding", async () => {
+		const activeSession = makeActiveSession({ isRunning: false })
+		const task = makeTask("session-123")
+		const { coordinator, options } = makeCoordinator({ activeSession, task })
+
+		await coordinator.askResponse("keep going", ["image.png"], undefined)
+
+		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
+		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+			[
+				expect.objectContaining({
+					say: "user_feedback",
+					text: "keep going",
+					images: ["image.png"],
+				}),
+			],
+			{ type: "status", payload: { sessionId: "session-123", status: "running" } },
+		)
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			activeSession.sdkHost,
+			"session-123",
+			"resolved: keep going",
+			["image.png"],
+			undefined,
+		)
+	})
+
+	it("rebuilds from history when the idle session does not match the displayed task", async () => {
+		const activeSession = makeActiveSession({ isRunning: false })
+		const task = makeTask("task-1")
+		const { coordinator, options } = makeCoordinator({ activeSession, task })
+
+		await coordinator.askResponse("continue")
+
+		expect(options.sessions.startNewSession).toHaveBeenCalledOnce()
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+			expect.anything(),
+			"resumed-session",
+			"resolved: continue",
+			undefined,
+			undefined,
+		)
+	})
+
+	it("does not resubmit the original task text when a bare resume must rebuild the session", async () => {
+		// No live session (task opened from history / extension reload): the
+		// rebuild path reconstructs the session from persisted messages. The
+		// resumption prompt must stay neutral; re-sending historyItem.task as
+		// "new instructions" made the model redo completed commands (#12975).
+		const task = makeTask("task-1")
+		const historyItem = {
+			id: "task-1",
+			ts: 1,
+			task: "Run the five terminal commands",
+			tokensIn: 0,
+			tokensOut: 0,
+			totalCost: 0,
+			cwdOnTaskInitialization: "/task-cwd",
+		}
+		const { coordinator, options } = makeCoordinator({ task, historyItem })
+
+		await coordinator.askResponse(undefined)
+
+		expect(options.sessions.startNewSession).toHaveBeenCalledOnce()
+		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledOnce()
+		const sentPrompt = options.sessions.fireAndForgetSend.mock.calls[0][2] as string
+		expect(sentPrompt).toBe("resolved: [TASK RESUMPTION] Please continue where you left off.")
+		expect(sentPrompt).not.toContain("Run the five terminal commands")
+		// A bare resumption prompt is synthetic and must not render a user bubble.
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 	})
 
 	it("echoes attachments on an attachment-only resume", async () => {

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -61,6 +61,7 @@ describe("SdkFollowupCoordinator", () => {
 		)
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 		expect(options.resolveContextMentions).toHaveBeenCalledWith("hello @file")
+		expect(options.recordOptimisticPendingPrompt).toHaveBeenCalledWith("resolved: hello @file", ["image.png"], ["a.ts"])
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			activeSession.sdkHost,
 			"session-123",
@@ -633,6 +634,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		isClineManagedProviderActive: vi.fn(() => false),
 		emitClineAuthError: vi.fn(),
 		resetMessageTranslator: vi.fn(),
+		recordOptimisticPendingPrompt: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 		waitForPendingRebuilds: input.waitForPendingRebuilds ?? vi.fn().mockResolvedValue(undefined),
 		runExclusive: input.runExclusive ?? vi.fn(async (operation: () => Promise<unknown>) => operation()),
@@ -670,6 +672,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		isClineManagedProviderActive: ReturnType<typeof vi.fn>
 		emitClineAuthError: ReturnType<typeof vi.fn>
 		resetMessageTranslator: ReturnType<typeof vi.fn>
+		recordOptimisticPendingPrompt: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
 		runExclusive: ReturnType<typeof vi.fn>
 		onResumeFailed: ReturnType<typeof vi.fn>

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
 import { SdkFollowupCoordinator, type SdkFollowupCoordinatorOptions } from "./sdk-followup-coordinator"
+import { TASK_RESUMPTION_PROMPT } from "./sdk-user-message-mapping"
 
 vi.mock("@/shared/services/Logger", () => ({
 	Logger: {
@@ -47,27 +48,17 @@ describe("SdkFollowupCoordinator", () => {
 		await coordinator.askResponse("hello @file", ["image.png"], ["a.ts"])
 
 		expect(options.sessions.setRunning).toHaveBeenCalledWith(true)
-		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[
-				expect.objectContaining({
-					type: "say",
-					say: "user_feedback",
-					text: "hello @file",
-					images: ["image.png"],
-					files: ["a.ts"],
-				}),
-			],
-			{ type: "status", payload: { sessionId: "session-123", status: "running" } },
-		)
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 		expect(options.resolveContextMentions).toHaveBeenCalledWith("hello @file")
-		expect(options.recordOptimisticPendingPrompt).toHaveBeenCalledWith("resolved: hello @file", ["image.png"], ["a.ts"])
+		expect(options.recordSyntheticPendingPrompt).not.toHaveBeenCalled()
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			activeSession.sdkHost,
 			"session-123",
 			"resolved: hello @file",
 			["image.png"],
 			["a.ts"],
+			"queue",
 		)
 	})
 
@@ -149,16 +140,7 @@ describe("SdkFollowupCoordinator", () => {
 
 		await coordinator.askResponse("next request", undefined, undefined, "messageResponse", "completed")
 
-		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[
-				expect.objectContaining({
-					type: "say",
-					say: "user_feedback",
-					text: "next request",
-				}),
-			],
-			{ type: "status", payload: { sessionId: "session-123", status: "running" } },
-		)
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 		expect(options.resetMessageTranslator).toHaveBeenCalledOnce()
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			activeSession.sdkHost,
@@ -166,6 +148,7 @@ describe("SdkFollowupCoordinator", () => {
 			"resolved: next request",
 			undefined,
 			undefined,
+			"queue",
 		)
 	})
 
@@ -229,6 +212,7 @@ describe("SdkFollowupCoordinator", () => {
 			"resolved: after rebuild",
 			undefined,
 			undefined,
+			"queue",
 		)
 	})
 
@@ -441,7 +425,9 @@ describe("SdkFollowupCoordinator", () => {
 		const [sdkHost, sessionId, sentPrompt] = options.sessions.fireAndForgetSend.mock.calls[0]
 		expect(sdkHost).toBe(activeSession.sdkHost)
 		expect(sessionId).toBe("session-123")
-		expect(sentPrompt).toContain("[TASK RESUMPTION]")
+		expect(sentPrompt).toBe(`resolved: ${TASK_RESUMPTION_PROMPT}`)
+		expect(options.recordSyntheticPendingPrompt).toHaveBeenCalledWith(sentPrompt, undefined, undefined)
+		expect(options.sessions.fireAndForgetSend.mock.calls[0][5]).toBe("queue")
 		// A bare resumption prompt is synthetic and must not render a user bubble.
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 	})
@@ -454,22 +440,14 @@ describe("SdkFollowupCoordinator", () => {
 		await coordinator.askResponse("keep going", ["image.png"], undefined)
 
 		expect(options.sessions.startNewSession).not.toHaveBeenCalled()
-		expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
-			[
-				expect.objectContaining({
-					say: "user_feedback",
-					text: "keep going",
-					images: ["image.png"],
-				}),
-			],
-			{ type: "status", payload: { sessionId: "session-123", status: "running" } },
-		)
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			activeSession.sdkHost,
 			"session-123",
 			"resolved: keep going",
 			["image.png"],
 			undefined,
+			"queue",
 		)
 	})
 
@@ -512,7 +490,7 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.sessions.startNewSession).toHaveBeenCalledOnce()
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledOnce()
 		const sentPrompt = options.sessions.fireAndForgetSend.mock.calls[0][2] as string
-		expect(sentPrompt).toBe("resolved: [TASK RESUMPTION] Please continue where you left off.")
+		expect(sentPrompt).toBe(`resolved: ${TASK_RESUMPTION_PROMPT}`)
 		expect(sentPrompt).not.toContain("Run the five terminal commands")
 		// A bare resumption prompt is synthetic and must not render a user bubble.
 		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
@@ -548,7 +526,7 @@ describe("SdkFollowupCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			expect.anything(),
 			"resumed-session",
-			expect.stringContaining("[TASK RESUMPTION]"),
+			expect.stringContaining("cline_internal_prompt"),
 			["data:image/png;base64,abc"],
 			[],
 		)
@@ -634,7 +612,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		isClineManagedProviderActive: vi.fn(() => false),
 		emitClineAuthError: vi.fn(),
 		resetMessageTranslator: vi.fn(),
-		recordOptimisticPendingPrompt: vi.fn(),
+		recordSyntheticPendingPrompt: vi.fn(),
 		postStateToWebview: vi.fn().mockResolvedValue(undefined),
 		waitForPendingRebuilds: input.waitForPendingRebuilds ?? vi.fn().mockResolvedValue(undefined),
 		runExclusive: input.runExclusive ?? vi.fn(async (operation: () => Promise<unknown>) => operation()),
@@ -672,7 +650,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		isClineManagedProviderActive: ReturnType<typeof vi.fn>
 		emitClineAuthError: ReturnType<typeof vi.fn>
 		resetMessageTranslator: ReturnType<typeof vi.fn>
-		recordOptimisticPendingPrompt: ReturnType<typeof vi.fn>
+		recordSyntheticPendingPrompt: ReturnType<typeof vi.fn>
 		postStateToWebview: ReturnType<typeof vi.fn>
 		runExclusive: ReturnType<typeof vi.fn>
 		onResumeFailed: ReturnType<typeof vi.fn>

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -17,6 +17,15 @@ import type { VscodeSessionHost } from "./vscode-session-host"
 type StartInput = Parameters<VscodeSessionHost["start"]>[0]
 type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
 
+/**
+ * Sent when the user resumes a task without typing anything: a turn cannot
+ * start without a prompt, so the Resume button needs a synthetic one. Never
+ * include the original task text here — the model treats it as new
+ * instructions and redoes already-completed work (#12975). Hidden from the
+ * transcript by isSyntheticUserPrompt via the [TASK RESUMPTION] prefix.
+ */
+const TASK_RESUMPTION_PROMPT = "[TASK RESUMPTION] Please continue where you left off."
+
 export interface SdkFollowupCoordinatorOptions {
 	stateManager: StateManager
 	interactions: SdkInteractionCoordinator
@@ -74,7 +83,7 @@ export class SdkFollowupCoordinator {
 		const task = this.options.getTask()
 		const submittedDuringActiveTurn = turnPhaseAtSubmit === "streaming" || turnPhaseAtSubmit === "awaiting_approval"
 		if (activeSession && (activeSession.isRunning || submittedDuringActiveTurn)) {
-			await this.sendToActiveSession(activeSession, true, prompt, images, files)
+			await this.queueToActiveSession(activeSession, prompt, images, files)
 			return
 		}
 
@@ -96,7 +105,17 @@ export class SdkFollowupCoordinator {
 
 			const currentSession = this.options.sessions.getActiveSession()
 			if (currentSession && (currentSession.isRunning || submittedDuringActiveTurn)) {
-				await this.sendToActiveSession(currentSession, true, prompt, images, files)
+				await this.queueToActiveSession(currentSession, prompt, images, files)
+				return
+			}
+
+			// Stopping a turn keeps the session alive, so a matching idle
+			// session is continued in place — mirroring the CLI, which reuses
+			// the live session after an abort. Rebuilding from task history is
+			// reserved for tasks without a live session (opened from history,
+			// extension host reload).
+			if (currentSession && (!task || currentSession.sessionId === task.taskId)) {
+				await this.continueIdleSession(currentSession, prompt, images, files)
 				return
 			}
 
@@ -106,43 +125,52 @@ export class SdkFollowupCoordinator {
 				return
 			}
 
-			if (!currentSession) {
-				Logger.error("[SdkController] askResponse: No active session")
-				await this.abandonFollowUp("askResponse: No active session to receive the follow-up")
-				return
-			}
-
-			await this.sendToActiveSession(currentSession, false, prompt, images, files)
+			Logger.error("[SdkController] askResponse: No active session")
+			await this.abandonFollowUp("askResponse: No active session to receive the follow-up")
 		})
 	}
 
-	private async sendToActiveSession(
+	/** Queue a follow-up onto a session whose turn is still running. */
+	private async queueToActiveSession(
 		activeSession: NonNullable<ReturnType<SdkSessionLifecycle["getActiveSession"]>>,
-		shouldQueue: boolean,
 		prompt?: string,
 		images?: string[],
 		files?: string[],
 	): Promise<void> {
 		const { sdkHost, sessionId } = activeSession
-		if (shouldQueue) {
-			Logger.log(`[SdkController] Session is running - queuing follow-up message for session: ${sessionId}`)
-		}
+		Logger.log(`[SdkController] Session is running - queuing follow-up message for session: ${sessionId}`)
 
 		this.options.sessions.setRunning(true)
-		if (!shouldQueue) {
-			this.emitUserFeedback(sessionId, prompt, images, files)
-			this.options.resetMessageTranslator()
-		}
-
 		const resolvedPrompt = prompt ? await this.options.resolveContextMentions(prompt) : ""
-		this.options.sessions.fireAndForgetSend(
-			sdkHost,
-			sessionId,
-			resolvedPrompt,
-			images,
-			files,
-			shouldQueue ? "queue" : undefined,
-		)
+		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files, "queue")
+	}
+
+	/**
+	 * Continue a live idle session in place instead of tearing it down and
+	 * rebuilding it from task history. A bare resume (no user content) sends
+	 * the synthetic resumption prompt without echoing a user bubble;
+	 * user-provided content is echoed and sent as-is. If the session's abort
+	 * is still settling, the runtime auto-queues the send and drains it once
+	 * the abort completes.
+	 */
+	private async continueIdleSession(
+		activeSession: NonNullable<ReturnType<SdkSessionLifecycle["getActiveSession"]>>,
+		prompt?: string,
+		images?: string[],
+		files?: string[],
+	): Promise<void> {
+		const { sdkHost, sessionId } = activeSession
+		Logger.log(`[SdkController] Continuing idle session for follow-up: ${sessionId}`)
+
+		this.options.sessions.setRunning(true)
+		if (prompt?.trim() || images?.length || files?.length) {
+			this.emitUserFeedback(sessionId, prompt, images, files)
+		}
+		this.options.resetMessageTranslator()
+
+		const effectivePrompt = prompt?.trim() || TASK_RESUMPTION_PROMPT
+		const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
+		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files)
 	}
 
 	private async tryResumeSessionFromTask(task: TaskProxy, prompt?: string, images?: string[], files?: string[]): Promise<void> {
@@ -224,11 +252,7 @@ export class SdkFollowupCoordinator {
 				}
 			}
 
-			const effectivePrompt =
-				prompt?.trim() ||
-				(historyItem
-					? `[TASK RESUMPTION] This task was interrupted. It may or may not be complete, so please reassess the task context. The conversation history has been preserved. New instructions from the user: ${historyItem.task}`
-					: "[TASK RESUMPTION] Please continue where you left off.")
+			const effectivePrompt = prompt?.trim() || TASK_RESUMPTION_PROMPT
 			const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
 			if (this.options.getTask()?.taskId !== taskId) {
 				await this.endStartedResume(sdkHost, startResult.sessionId)

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -10,6 +10,7 @@ import type { SdkSessionConfigBuilder } from "./sdk-session-config-builder"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import type { SdkTaskHistory } from "./sdk-task-history"
 import { prepareTaskResumeStartInput } from "./sdk-task-resume"
+import { TASK_RESUMPTION_PROMPT } from "./sdk-user-message-mapping"
 import type { SdkSessionHost } from "./session-host"
 import type { TaskProxy } from "./task-proxy"
 import type { VscodeSessionHost } from "./vscode-session-host"
@@ -22,9 +23,9 @@ type SessionConfig = Awaited<ReturnType<SdkSessionConfigBuilder["build"]>>
  * start without a prompt, so the Resume button needs a synthetic one. Never
  * include the original task text here — the model treats it as new
  * instructions and redoes already-completed work (#12975). Hidden from the
- * transcript by isSyntheticUserPrompt via the [TASK RESUMPTION] prefix.
+ * transcript by an internal prompt marker that user-authored text cannot
+ * accidentally match.
  */
-const TASK_RESUMPTION_PROMPT = "[TASK RESUMPTION] Please continue where you left off."
 
 export interface SdkFollowupCoordinatorOptions {
 	stateManager: StateManager
@@ -42,7 +43,7 @@ export interface SdkFollowupCoordinatorOptions {
 	isClineManagedProviderActive: () => boolean
 	emitClineAuthError: () => void
 	resetMessageTranslator: () => void
-	recordOptimisticPendingPrompt?: (prompt: string, images?: string[], files?: string[]) => void
+	recordSyntheticPendingPrompt?: (prompt: string, images?: string[], files?: string[]) => void
 	postStateToWebview: () => Promise<void>
 	/** Resolves once no session rebuild is in flight. */
 	waitForPendingRebuilds: () => Promise<void>
@@ -150,9 +151,9 @@ export class SdkFollowupCoordinator {
 	 * Continue a live idle session in place instead of tearing it down and
 	 * rebuilding it from task history. A bare resume (no user content) sends
 	 * the synthetic resumption prompt without echoing a user bubble;
-	 * user-provided content is echoed and sent as-is. If the session's abort
-	 * is still settling, the runtime auto-queues the send and drains it once
-	 * the abort completes.
+	 * user-provided content is emitted by Core's submitted-prompt event. Always
+	 * queue through Core so an abort-settling race and a truly idle session use
+	 * the same single, id-addressable transcript path.
 	 */
 	private async continueIdleSession(
 		activeSession: NonNullable<ReturnType<SdkSessionLifecycle["getActiveSession"]>>,
@@ -164,17 +165,15 @@ export class SdkFollowupCoordinator {
 		Logger.log(`[SdkController] Continuing idle session for follow-up: ${sessionId}`)
 
 		this.options.sessions.setRunning(true)
-		if (prompt?.trim() || images?.length || files?.length) {
-			this.emitUserFeedback(sessionId, prompt, images, files)
-		}
 		this.options.resetMessageTranslator()
 
+		const hasUserPrompt = Boolean(prompt?.trim())
 		const effectivePrompt = prompt?.trim() || TASK_RESUMPTION_PROMPT
 		const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
-		if (prompt?.trim() || images?.length || files?.length) {
-			this.options.recordOptimisticPendingPrompt?.(resolvedPrompt, images, files)
+		if (!hasUserPrompt) {
+			this.options.recordSyntheticPendingPrompt?.(resolvedPrompt, images, files)
 		}
-		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files)
+		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files, "queue")
 	}
 
 	private async tryResumeSessionFromTask(task: TaskProxy, prompt?: string, images?: string[], files?: string[]): Promise<void> {

--- a/apps/vscode/src/sdk/sdk-followup-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-followup-coordinator.ts
@@ -42,6 +42,7 @@ export interface SdkFollowupCoordinatorOptions {
 	isClineManagedProviderActive: () => boolean
 	emitClineAuthError: () => void
 	resetMessageTranslator: () => void
+	recordOptimisticPendingPrompt?: (prompt: string, images?: string[], files?: string[]) => void
 	postStateToWebview: () => Promise<void>
 	/** Resolves once no session rebuild is in flight. */
 	waitForPendingRebuilds: () => Promise<void>
@@ -170,6 +171,9 @@ export class SdkFollowupCoordinator {
 
 		const effectivePrompt = prompt?.trim() || TASK_RESUMPTION_PROMPT
 		const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
+		if (prompt?.trim() || images?.length || files?.length) {
+			this.options.recordOptimisticPendingPrompt?.(resolvedPrompt, images, files)
+		}
 		this.options.sessions.fireAndForgetSend(sdkHost, sessionId, resolvedPrompt, images, files)
 	}
 

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
@@ -2,6 +2,7 @@ import type { ClineMessage } from "@shared/ExtensionMessage"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { StateManager } from "@/core/storage/StateManager"
 import { SdkModeCoordinator, type SdkModeCoordinatorOptions } from "./sdk-mode-coordinator"
+import { ACT_MODE_CONTINUATION_PROMPT } from "./sdk-user-message-mapping"
 
 vi.mock("@/shared/services/Logger", () => ({
 	Logger: {
@@ -151,7 +152,7 @@ describe("SdkModeCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			expect.anything(),
 			"new-session",
-			"The user approved switching to act mode. Continue with the approved plan now.",
+			ACT_MODE_CONTINUATION_PROMPT,
 			undefined,
 			undefined,
 		)
@@ -186,7 +187,7 @@ describe("SdkModeCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			expect.anything(),
 			"new-session",
-			"The user approved switching to act mode. Continue with the approved plan now.",
+			ACT_MODE_CONTINUATION_PROMPT,
 			undefined,
 			undefined,
 		)
@@ -211,7 +212,7 @@ describe("SdkModeCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			expect.anything(),
 			"new-session",
-			"The user approved switching to act mode. Continue with the approved plan now.",
+			ACT_MODE_CONTINUATION_PROMPT,
 			undefined,
 			undefined,
 		)
@@ -309,7 +310,7 @@ describe("SdkModeCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
 			expect.anything(),
 			"new-session",
-			"The user approved switching to act mode. Continue with the approved plan now.",
+			ACT_MODE_CONTINUATION_PROMPT,
 			["data:image/png;base64,abc"],
 			undefined,
 		)

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -8,6 +8,7 @@ import { deleteLegacyTask, readApiConversationHistory, readTaskHistory, readUiMe
 import { sdkMessagesToClineMessages } from "./message-translator"
 import type { SdkSessionLifecycle } from "./sdk-session-lifecycle"
 import { SdkTaskHistory, sessionHistoryRecordToHistoryItem } from "./sdk-task-history"
+import { ACT_MODE_CONTINUATION_PROMPT, TASK_RESUMPTION_PROMPT } from "./sdk-user-message-mapping"
 import type { VscodeSessionHost } from "./vscode-session-host"
 
 vi.mock("@/core/storage/disk", () => ({
@@ -268,8 +269,7 @@ describe("SdkTaskHistory", () => {
 			{ role: "assistant", content: [{ type: "text", text: "Here is the plan." }] },
 			{
 				role: "user",
-				content:
-					'<user_input mode="act"><mode_notice>The user switched from plan mode to act mode before sending this message.</mode_notice>The user approved switching to act mode. Continue with the approved plan now.</user_input>',
+				content: `<user_input mode="act"><mode_notice>The user switched from plan mode to act mode before sending this message.</mode_notice>${ACT_MODE_CONTINUATION_PROMPT}</user_input>`,
 			},
 			{ role: "assistant", content: [{ type: "text", text: "Implemented." }] },
 		] as never)
@@ -283,14 +283,14 @@ describe("SdkTaskHistory", () => {
 		expect(result).toContainEqual(expect.objectContaining({ type: "say", say: "completion_result", text: "Implemented." }))
 	})
 
-	it("hides [TASK RESUMPTION] prompts when rehydrating from history", async () => {
+	it("hides internally marked task resumption prompts when rehydrating from history", async () => {
 		const { history, readMessages } = makeHistory([makeSessionRecord("task-1")])
 		readMessages.mockResolvedValueOnce([
 			{ role: "user", content: '<user_input mode="act">build the feature</user_input>' },
 			{ role: "assistant", content: [{ type: "text", text: "Partway done." }] },
 			{
 				role: "user",
-				content: '<user_input mode="act">[TASK RESUMPTION] Please continue where you left off.</user_input>',
+				content: `<user_input mode="act">${TASK_RESUMPTION_PROMPT}</user_input>`,
 			},
 			{ role: "assistant", content: [{ type: "text", text: "Finished." }] },
 		] as never)
@@ -298,7 +298,7 @@ describe("SdkTaskHistory", () => {
 		const result = await history.getClineMessages("task-1")
 
 		expect(result.filter((m) => m.say === "user_feedback")).toHaveLength(0)
-		expect(result.map((m) => m.text).join("\n")).not.toContain("[TASK RESUMPTION]")
+		expect(result.map((m) => m.text).join("\n")).not.toContain("cline_internal_prompt")
 		expect(result).toContainEqual(expect.objectContaining({ type: "say", say: "completion_result", text: "Finished." }))
 	})
 

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
@@ -23,11 +23,25 @@ describe("isSyntheticUserPrompt", () => {
 		expect(isSyntheticUserPrompt(wrapped(TASK_RESUMPTION_PROMPT, "plan"))).toBe(true)
 	})
 
-	it("does not flag ordinary or synthetic-looking user messages", () => {
+	it("does not flag ordinary user messages", () => {
 		expect(isSyntheticUserPrompt("make a plan for the auth refactor")).toBe(false)
 		expect(isSyntheticUserPrompt(wrapped("go ahead and implement step 1"))).toBe(false)
-		expect(isSyntheticUserPrompt("[TASK RESUMPTION] Please continue where you left off.")).toBe(false)
-		expect(isSyntheticUserPrompt("The user approved switching to act mode. Continue with the approved plan now.")).toBe(false)
+		expect(isSyntheticUserPrompt("[task resumption] lowercase lookalike")).toBe(false)
+	})
+
+	it("keeps flagging the pre-marker synthetic prompt shapes", () => {
+		// Sessions persisted before the <cline_internal_prompt> marker carry
+		// these exact shapes (and the legacy task path still generates the
+		// [TASK RESUMPTION] prefix). They must stay hidden on reopen or every
+		// later edit/regenerate ordinal in those transcripts shifts by one.
+		expect(isSyntheticUserPrompt("[TASK RESUMPTION] Please continue where you left off.")).toBe(true)
+		expect(isSyntheticUserPrompt(wrapped("[TASK RESUMPTION] Please continue where you left off."))).toBe(true)
+		expect(isSyntheticUserPrompt("The user approved switching to act mode. Continue with the approved plan now.")).toBe(true)
+		expect(
+			isSyntheticUserPrompt(
+				wrapped("The user approved switching to act mode. Continue with the approved plan now.", "plan"),
+			),
+		).toBe(true)
 	})
 
 	it("flags synthetic prompts that carry a mode-switch notice", () => {

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.test.ts
@@ -5,6 +5,7 @@ import {
 	findSdkUserMessageIndexByOrdinal,
 	getSdkCheckpointRunCountForMessageIndex,
 	isSyntheticUserPrompt,
+	TASK_RESUMPTION_PROMPT,
 } from "./sdk-user-message-mapping"
 
 // Persisted prompts are wrapped by formatModePrompt before they reach SDK
@@ -12,19 +13,21 @@ import {
 const wrapped = (text: string, mode = "act") => `<user_input mode="${mode}">${text}</user_input>`
 
 describe("isSyntheticUserPrompt", () => {
-	it("flags task resumption and act-mode continuation prompts", () => {
-		expect(isSyntheticUserPrompt("[TASK RESUMPTION] Please continue where you left off.")).toBe(true)
+	it("flags internally marked task resumption and act-mode continuation prompts", () => {
+		expect(isSyntheticUserPrompt(TASK_RESUMPTION_PROMPT)).toBe(true)
 		expect(isSyntheticUserPrompt(ACT_MODE_CONTINUATION_PROMPT)).toBe(true)
 	})
 
 	it("flags the wrapped persisted shape of synthetic prompts", () => {
 		expect(isSyntheticUserPrompt(wrapped(ACT_MODE_CONTINUATION_PROMPT))).toBe(true)
-		expect(isSyntheticUserPrompt(wrapped("[TASK RESUMPTION] Please continue where you left off.", "plan"))).toBe(true)
+		expect(isSyntheticUserPrompt(wrapped(TASK_RESUMPTION_PROMPT, "plan"))).toBe(true)
 	})
 
-	it("does not flag ordinary user messages, wrapped or raw", () => {
+	it("does not flag ordinary or synthetic-looking user messages", () => {
 		expect(isSyntheticUserPrompt("make a plan for the auth refactor")).toBe(false)
 		expect(isSyntheticUserPrompt(wrapped("go ahead and implement step 1"))).toBe(false)
+		expect(isSyntheticUserPrompt("[TASK RESUMPTION] Please continue where you left off.")).toBe(false)
+		expect(isSyntheticUserPrompt("The user approved switching to act mode. Continue with the approved plan now.")).toBe(false)
 	})
 
 	it("flags synthetic prompts that carry a mode-switch notice", () => {
@@ -71,7 +74,7 @@ describe("findSdkUserMessageIndexByOrdinal", () => {
 		const messages = [
 			user(wrapped("original task")),
 			assistant("partial work"),
-			user(wrapped("[TASK RESUMPTION] Please continue where you left off.")),
+			user(wrapped(TASK_RESUMPTION_PROMPT)),
 			assistant("resumed work"),
 			user(wrapped("looks good, keep going")),
 		]

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.ts
@@ -14,6 +14,18 @@ export const TASK_RESUMPTION_PROMPT =
 export const ACT_MODE_CONTINUATION_PROMPT =
 	'<cline_internal_prompt kind="act_mode_continuation">The user approved switching to act mode. Continue with the approved plan now.</cline_internal_prompt>'
 
+/**
+ * The synthetic prompt shapes used before the <cline_internal_prompt> marker
+ * existed. Sessions persisted with them (and legacy-path resumptions, see
+ * core/prompts/responses.ts) must keep hiding them on reopen, or previously
+ * hidden prompts surface as user bubbles and shift every later
+ * edit/regenerate ordinal. Trade-off: a user message deliberately starting
+ * with "[TASK RESUMPTION]" is hidden too — accepted, matching the behavior
+ * these transcripts were recorded under.
+ */
+const LEGACY_TASK_RESUMPTION_PREFIX = "[TASK RESUMPTION]"
+const LEGACY_ACT_MODE_CONTINUATION_PROMPT = "The user approved switching to act mode. Continue with the approved plan now."
+
 export type SdkUserMessage = {
 	role?: unknown
 	content?: unknown
@@ -61,7 +73,11 @@ export function isSyntheticUserPrompt(text: string): boolean {
 	// the synthetic prompt would start counting as a visible user message and
 	// shift every later edit/regenerate ordinal by one.
 	const normalized = stripModeNotices(normalizeUserInput(text))
-	return normalized.startsWith(SYNTHETIC_PROMPT_PREFIX)
+	return (
+		normalized.startsWith(SYNTHETIC_PROMPT_PREFIX) ||
+		normalized.startsWith(LEGACY_TASK_RESUMPTION_PREFIX) ||
+		normalized === LEGACY_ACT_MODE_CONTINUATION_PROMPT
+	)
 }
 
 function hasAttachmentBlocks(message: SdkUserMessage): boolean {

--- a/apps/vscode/src/sdk/sdk-user-message-mapping.ts
+++ b/apps/vscode/src/sdk/sdk-user-message-mapping.ts
@@ -6,7 +6,13 @@ import { normalizeUserInput, stripModeNotices } from "@cline/shared"
  * coordinator so display-layer consumers (message-translator, ordinal
  * mapping) don't pull the coordinator's heavy import graph into their tests.
  */
-export const ACT_MODE_CONTINUATION_PROMPT = "The user approved switching to act mode. Continue with the approved plan now."
+const SYNTHETIC_PROMPT_PREFIX = '<cline_internal_prompt kind="'
+
+export const TASK_RESUMPTION_PROMPT =
+	'<cline_internal_prompt kind="task_resumption">Please continue where you left off.</cline_internal_prompt>'
+
+export const ACT_MODE_CONTINUATION_PROMPT =
+	'<cline_internal_prompt kind="act_mode_continuation">The user approved switching to act mode. Continue with the approved plan now.</cline_internal_prompt>'
 
 export type SdkUserMessage = {
 	role?: unknown
@@ -55,7 +61,7 @@ export function isSyntheticUserPrompt(text: string): boolean {
 	// the synthetic prompt would start counting as a visible user message and
 	// shift every later edit/regenerate ordinal by one.
 	const normalized = stripModeNotices(normalizeUserInput(text))
-	return normalized.startsWith("[TASK RESUMPTION]") || normalized === ACT_MODE_CONTINUATION_PROMPT
+	return normalized.startsWith(SYNTHETIC_PROMPT_PREFIX)
 }
 
 function hasAttachmentBlocks(message: SdkUserMessage): boolean {

--- a/apps/vscode/src/sdk/vscode-lm/register-vscode-lm.test.ts
+++ b/apps/vscode/src/sdk/vscode-lm/register-vscode-lm.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const registerHandler = vi.fn()
 const registerProvider = vi.fn()
-vi.mock("@cline/llms", () => ({ registerHandler, registerProvider }))
+vi.mock("@cline/llms", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cline/llms")>()),
+	registerHandler,
+	registerProvider,
+}))
 vi.mock("@/shared/services/Logger", () => ({ Logger: { debug: vi.fn() } }))
 
 // `vscode.lm` presence is the gate. Use a mutable mock so each test controls it.

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -72,6 +72,8 @@ export interface ModelInfo {
 	name?: string
 	maxTokens?: number
 	contextWindow?: number
+	/** Prompt/input token budget reported by the provider. Kept separate from the total context window. */
+	maxInputTokens?: number
 	supportsImages?: boolean
 	supportsPromptCache: boolean // this value is hardcoded for now
 	supportsReasoning?: boolean // Whether the model supports reasoning/thinking mode

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -53,6 +53,7 @@ export function resolveModelsRegistryPath(): string {
 
 export function ensureCustomProvidersLoadedSync(): void {}
 
+export { isPrivateModelCatalogProvider } from "../../../../sdk/packages/core/src/services/llms/provider-defaults"
 // Real implementation re-exported from the sdk source (same pattern as the
 // apply-patch executors below) so store writes are reflected in the live
 // @cline/llms registry exactly as in production. Tests that touch it must

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -23,7 +23,7 @@ describe("providerSettingsRegistry", () => {
 			allowsCustomIds: false,
 			providerId: "deepseek",
 			providerName: "DeepSeek",
-			signupUrl: "https://www.deepseek.com/",
+			signupUrl: "https://platform.deepseek.com/api_keys",
 		})
 	})
 
@@ -61,7 +61,7 @@ describe("providerSettingsRegistry", () => {
 			["cerebras", "Cerebras", "https://cloud.cerebras.ai/"],
 			["chutes", "Chutes", "https://chutes.ai/app/api"],
 			["doubao", "Doubao", "https://console.volcengine.com/home"],
-			["fireworks", "Fireworks", "https://fireworks.ai/"],
+			["fireworks", "Fireworks", "https://app.fireworks.ai/settings/users/api-keys"],
 			["groq", "Groq", "https://console.groq.com/keys"],
 			[
 				"huawei-cloud-maas",
@@ -69,7 +69,7 @@ describe("providerSettingsRegistry", () => {
 				"https://support.huaweicloud.com/intl/zh-cn/usermanual-maas/maas_01_0001.html",
 			],
 			["huggingface", "Hugging Face", "https://huggingface.co/settings/tokens"],
-			["mistral", "Mistral", "https://console.mistral.ai/codestral"],
+			["mistral", "Mistral", "https://console.mistral.ai/api-keys"],
 			["nebius", "Nebius", "https://auth.tokenfactory.nebius.com/ui/login"],
 			["nousResearch", "NousResearch", undefined],
 			["poolside", "Poolside", undefined],
@@ -159,7 +159,7 @@ describe("providerSettingsRegistry", () => {
 			allowsCustomIds: false,
 			providerId: "deepseek",
 			providerName: "DeepSeek",
-			signupUrl: "https://www.deepseek.com/",
+			signupUrl: "https://platform.deepseek.com/api_keys",
 		})
 		expect(getFallbackGenericProviderSettings("gemini")).toEqual({
 			allowsCustomIds: false,

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -40,13 +40,13 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		signupUrl: "https://app.baseten.co/settings/api_keys",
 	},
 	deepseek: {
-		signupUrl: "https://www.deepseek.com/",
+		signupUrl: "https://platform.deepseek.com/api_keys",
 	},
 	doubao: {
 		signupUrl: "https://console.volcengine.com/home",
 	},
 	fireworks: {
-		signupUrl: "https://fireworks.ai/",
+		signupUrl: "https://app.fireworks.ai/settings/users/api-keys",
 	},
 	groq: {
 		signupUrl: "https://console.groq.com/keys",
@@ -76,7 +76,7 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 		},
 	},
 	mistral: {
-		signupUrl: "https://console.mistral.ai/codestral",
+		signupUrl: "https://console.mistral.ai/api-keys",
 	},
 	nebius: {
 		signupUrl: "https://auth.tokenfactory.nebius.com/ui/login",

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -951,6 +951,7 @@ export {
 	DEFAULT_MODELS_CATALOG_URL,
 	getLiveModelsCatalog,
 	getProviderConfig,
+	isPrivateModelCatalogProvider,
 	OPENAI_COMPATIBLE_PROVIDERS,
 	resolveProviderConfig,
 } from "./services/llms/provider-defaults";

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -971,6 +971,7 @@ export {
 	DEFAULT_MODELS_CATALOG_URL,
 	getLiveModelsCatalog,
 	getProviderConfig,
+	isPrivateModelCatalogProvider,
 	OPENAI_COMPATIBLE_PROVIDERS,
 	resolveProviderConfig,
 } from "./services/llms/provider-defaults";

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -505,6 +505,7 @@ export {
 	type DesktopToolApprovalOptions,
 	requestDesktopToolApproval,
 } from "./runtime/tools/tool-approval";
+export * from "./services/cloud-handoff";
 export { listActiveConnectors } from "./services/connectors/active-connectors";
 export {
 	disableConnectorAutostart,

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -109,7 +109,7 @@ describe("preflightCloudHandoffGit", () => {
 		const error = await preflightCloudHandoffGit({
 			cwd: "/repo",
 			git: fakeGit({
-					"remote get-url origin": "git@gitlab.com:cline/cline.git\n",
+				"remote get-url origin": "git@gitlab.com:cline/cline.git\n",
 			}),
 		}).catch((caught) => caught);
 

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -105,6 +105,30 @@ describe("preflightCloudHandoffGit", () => {
 		expect(error.message).toContain("Push the current commit");
 	});
 
+	it("distinguishes a missing remote ref from an authentication failure", async () => {
+		const missing = Object.assign(new Error("missing"), { code: 2 });
+		const missingError = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"ls-remote --exit-code origin refs/heads/feature/handoff": missing,
+			}),
+		}).catch((caught) => caught);
+		expect(missingError.code).toBe("remote_branch_missing");
+
+		const auth = Object.assign(new Error("auth"), {
+			code: 128,
+			stderr: "fatal: could not read Username",
+		});
+		const authError = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"ls-remote --exit-code origin refs/heads/feature/handoff": auth,
+			}),
+		}).catch((caught) => caught);
+		expect(authError.code).toBe("git_command_failed");
+		expect(authError.message).toContain("GitHub authentication");
+	});
+
 	it("refuses non-GitHub upstreams", async () => {
 		const error = await preflightCloudHandoffGit({
 			cwd: "/repo",

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -16,7 +16,7 @@ function fakeGit(overrides: Record<string, string | Error> = {}): GitCommand {
 		"config --get branch.feature/handoff.remote": "origin\n",
 		"config --get branch.feature/handoff.merge": "refs/heads/feature/handoff\n",
 		"rev-parse HEAD": `${HEAD}\n`,
-		"config --get remote.origin.url": "git@github.com:cline/cline.git\n",
+		"remote get-url origin": "git@github.com:cline/cline.git\n",
 		"ls-remote --exit-code origin refs/heads/feature/handoff": `${HEAD}\trefs/heads/feature/handoff\n`,
 		...overrides,
 	};
@@ -109,7 +109,7 @@ describe("preflightCloudHandoffGit", () => {
 		const error = await preflightCloudHandoffGit({
 			cwd: "/repo",
 			git: fakeGit({
-				"config --get remote.origin.url": "git@gitlab.com:cline/cline.git\n",
+					"remote get-url origin": "git@gitlab.com:cline/cline.git\n",
 			}),
 		}).catch((caught) => caught);
 

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	CloudHandoffGitPreflightError,
+	type GitCommand,
+	normalizeGitHubRemoteUrl,
+	preflightCloudHandoffGit,
+} from "./git-preflight";
+
+const HEAD = "a".repeat(40);
+
+function fakeGit(overrides: Record<string, string | Error> = {}): GitCommand {
+	const outputs: Record<string, string | Error> = {
+		"rev-parse --is-inside-work-tree": "true\n",
+		"status --porcelain=v1 --untracked-files=all": "",
+		"symbolic-ref --quiet --short HEAD": "feature/handoff\n",
+		"config --get branch.feature/handoff.remote": "origin\n",
+		"config --get branch.feature/handoff.merge": "refs/heads/feature/handoff\n",
+		"rev-parse HEAD": `${HEAD}\n`,
+		"config --get remote.origin.url": "git@github.com:cline/cline.git\n",
+		"ls-remote --exit-code origin refs/heads/feature/handoff": `${HEAD}\trefs/heads/feature/handoff\n`,
+		...overrides,
+	};
+	return vi.fn(async (args) => {
+		const result = outputs[args.join(" ")];
+		if (result instanceof Error) throw result;
+		if (result === undefined) throw new Error(`Unexpected git args: ${args}`);
+		return { stdout: result };
+	});
+}
+
+describe("normalizeGitHubRemoteUrl", () => {
+	it.each([
+		["git@github.com:cline/cline.git", "https://github.com/cline/cline"],
+		["https://github.com/cline/cline.git", "https://github.com/cline/cline"],
+		["ssh://git@github.com/cline/cline.git", "https://github.com/cline/cline"],
+		["git://github.com/cline/cline", "https://github.com/cline/cline"],
+	])("normalizes %s", (remote, expected) => {
+		expect(normalizeGitHubRemoteUrl(remote)).toBe(expected);
+	});
+
+	it("rejects non-GitHub and nested paths", () => {
+		expect(
+			normalizeGitHubRemoteUrl("git@gitlab.com:cline/cline.git"),
+		).toBeNull();
+		expect(normalizeGitHubRemoteUrl("https://github.com/a/b/c.git")).toBeNull();
+	});
+});
+
+describe("preflightCloudHandoffGit", () => {
+	it("returns the exact pushed upstream context", async () => {
+		await expect(
+			preflightCloudHandoffGit({ cwd: "/repo", git: fakeGit() }),
+		).resolves.toEqual({
+			repoUrl: "https://github.com/cline/cline",
+			branch: "feature/handoff",
+			remoteName: "origin",
+			headSha: HEAD,
+		});
+	});
+
+	it("refuses tracked or untracked worktree changes with a compact summary", async () => {
+		const dirty = Array.from(
+			{ length: 8 },
+			(_, index) => ` M changed-${index + 1}.ts`,
+		).join("\n");
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"status --porcelain=v1 --untracked-files=all": dirty,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(CloudHandoffGitPreflightError);
+		expect(error.code).toBe("dirty_worktree");
+		expect(error.message).toContain("Uncommitted files are not transferred");
+		expect(error.message).toContain("changed-5.ts");
+		expect(error.message).not.toContain("changed-6.ts");
+		expect(error.message).toContain("...and 3 more");
+	});
+
+	it("classifies detached HEAD errors", async () => {
+		const detached = Object.assign(new Error("not a symbolic ref"), {
+			stderr: "fatal: ref HEAD is not a symbolic ref",
+		});
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"symbolic-ref --quiet --short HEAD": detached,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("detached_head");
+	});
+
+	it("refuses when local HEAD differs from the remote branch", async () => {
+		const remoteHead = "b".repeat(40);
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"ls-remote --exit-code origin refs/heads/feature/handoff": `${remoteHead}\trefs/heads/feature/handoff\n`,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("unpushed_commits");
+		expect(error.message).toContain("Push the current commit");
+	});
+
+	it("refuses non-GitHub upstreams", async () => {
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"config --get remote.origin.url": "git@gitlab.com:cline/cline.git\n",
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("unsupported_remote");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	CloudHandoffGitPreflightError,
+	type GitCommand,
+	normalizeGitHubRemoteUrl,
+	preflightCloudHandoffGit,
+} from "./git-preflight";
+
+const HEAD = "a".repeat(40);
+
+function fakeGit(overrides: Record<string, string | Error> = {}): GitCommand {
+	const outputs: Record<string, string | Error> = {
+		"rev-parse --is-inside-work-tree": "true\n",
+		"status --porcelain=v1 --untracked-files=all": "",
+		"symbolic-ref --quiet --short HEAD": "feature/handoff\n",
+		"config --get branch.feature/handoff.remote": "origin\n",
+		"config --get branch.feature/handoff.merge": "refs/heads/feature/handoff\n",
+		"rev-parse HEAD": `${HEAD}\n`,
+		"remote get-url origin": "git@github.com:cline/cline.git\n",
+		"ls-remote --exit-code origin refs/heads/feature/handoff": `${HEAD}\trefs/heads/feature/handoff\n`,
+		...overrides,
+	};
+	return vi.fn(async (args) => {
+		const result = outputs[args.join(" ")];
+		if (result instanceof Error) throw result;
+		if (result === undefined) throw new Error(`Unexpected git args: ${args}`);
+		return { stdout: result };
+	});
+}
+
+describe("normalizeGitHubRemoteUrl", () => {
+	it.each([
+		["git@github.com:cline/cline.git", "https://github.com/cline/cline"],
+		["https://github.com/cline/cline.git", "https://github.com/cline/cline"],
+		["ssh://git@github.com/cline/cline.git", "https://github.com/cline/cline"],
+		["git://github.com/cline/cline", "https://github.com/cline/cline"],
+	])("normalizes %s", (remote, expected) => {
+		expect(normalizeGitHubRemoteUrl(remote)).toBe(expected);
+	});
+
+	it("rejects non-GitHub and nested paths", () => {
+		expect(
+			normalizeGitHubRemoteUrl("git@gitlab.com:cline/cline.git"),
+		).toBeNull();
+		expect(normalizeGitHubRemoteUrl("https://github.com/a/b/c.git")).toBeNull();
+	});
+});
+
+describe("preflightCloudHandoffGit", () => {
+	it("returns the exact pushed upstream context", async () => {
+		await expect(
+			preflightCloudHandoffGit({ cwd: "/repo", git: fakeGit() }),
+		).resolves.toEqual({
+			repoUrl: "https://github.com/cline/cline",
+			branch: "feature/handoff",
+			remoteName: "origin",
+			headSha: HEAD,
+		});
+	});
+
+	it("refuses tracked or untracked worktree changes with a compact summary", async () => {
+		const dirty = Array.from(
+			{ length: 8 },
+			(_, index) => ` M changed-${index + 1}.ts`,
+		).join("\n");
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"status --porcelain=v1 --untracked-files=all": dirty,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(CloudHandoffGitPreflightError);
+		expect(error.code).toBe("dirty_worktree");
+		expect(error.message).toContain("Uncommitted files are not transferred");
+		expect(error.message).toContain("changed-5.ts");
+		expect(error.message).not.toContain("changed-6.ts");
+		expect(error.message).toContain("...and 3 more");
+	});
+
+	it("classifies detached HEAD errors", async () => {
+		const detached = Object.assign(new Error("not a symbolic ref"), {
+			stderr: "fatal: ref HEAD is not a symbolic ref",
+		});
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"symbolic-ref --quiet --short HEAD": detached,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("detached_head");
+	});
+
+	it("refuses when local HEAD differs from the remote branch", async () => {
+		const remoteHead = "b".repeat(40);
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"ls-remote --exit-code origin refs/heads/feature/handoff": `${remoteHead}\trefs/heads/feature/handoff\n`,
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("unpushed_commits");
+		expect(error.message).toContain("Push the current commit");
+	});
+
+	it("refuses non-GitHub upstreams", async () => {
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({
+				"remote get-url origin": "git@gitlab.com:cline/cline.git\n",
+			}),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("unsupported_remote");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -11,6 +11,7 @@ const HEAD = "a".repeat(40);
 function fakeGit(overrides: Record<string, string | Error> = {}): GitCommand {
 	const outputs: Record<string, string | Error> = {
 		"rev-parse --is-inside-work-tree": "true\n",
+		"rev-parse --show-prefix": "",
 		"status --porcelain=v1 --untracked-files=all": "",
 		"symbolic-ref --quiet --short HEAD": "feature/handoff\n",
 		"config --get branch.feature/handoff.remote": "origin\n",
@@ -58,6 +59,17 @@ describe("preflightCloudHandoffGit", () => {
 		});
 	});
 
+	it("preserves a workspace path relative to the repository root", async () => {
+		await expect(
+			preflightCloudHandoffGit({
+				cwd: "/repo/apps/desktop",
+				git: fakeGit({ "rev-parse --show-prefix": "apps/desktop/\n" }),
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({ workspaceRelativePath: "apps/desktop" }),
+		);
+	});
+
 	it("refuses tracked or untracked worktree changes with a compact summary", async () => {
 		const dirty = Array.from(
 			{ length: 8 },
@@ -80,6 +92,7 @@ describe("preflightCloudHandoffGit", () => {
 
 	it("classifies detached HEAD errors", async () => {
 		const detached = Object.assign(new Error("not a symbolic ref"), {
+			code: 1,
 			stderr: "fatal: ref HEAD is not a symbolic ref",
 		});
 		const error = await preflightCloudHandoffGit({
@@ -90,6 +103,20 @@ describe("preflightCloudHandoffGit", () => {
 		}).catch((caught) => caught);
 
 		expect(error.code).toBe("detached_head");
+	});
+
+	it("does not misclassify branch inspection failures as detached HEAD", async () => {
+		const failed = Object.assign(new Error("git unavailable"), {
+			code: 128,
+			stderr: "fatal: unable to read repository",
+		});
+		const error = await preflightCloudHandoffGit({
+			cwd: "/repo",
+			git: fakeGit({ "symbolic-ref --quiet --short HEAD": failed }),
+		}).catch((caught) => caught);
+
+		expect(error.code).toBe("git_command_failed");
+		expect(error.message).toContain("Could not inspect");
 	});
 
 	it("refuses when local HEAD differs from the remote branch", async () => {

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -92,6 +92,12 @@ function commandErrorMessage(error: unknown): string {
 	return typeof stderr === "string" ? stderr.trim() : "";
 }
 
+function commandExitCode(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "number" ? code : undefined;
+}
+
 async function runRequired(
 	git: GitCommand,
 	cwd: string,
@@ -238,14 +244,26 @@ export async function preflightCloudHandoffGit(input: {
 		);
 	}
 
-	const remoteOutput = await runRequired(
-		git,
-		cwd,
-		["ls-remote", "--exit-code", remoteName, mergeRef],
-		"remote_branch_missing",
-		`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
-		input.signal,
-	);
+	let remoteOutput: string;
+	try {
+		remoteOutput = (
+			await git(["ls-remote", "--exit-code", remoteName, mergeRef], {
+				cwd,
+				signal: input.signal,
+			})
+		).stdout.trim();
+	} catch (error) {
+		const missing = commandExitCode(error) === 2;
+		const detail = commandErrorMessage(error);
+		const message = missing
+			? `Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`
+			: "Could not verify the remote branch. Check your network and GitHub authentication, then try again.";
+		throw new CloudHandoffGitPreflightError(
+			missing ? "remote_branch_missing" : "git_command_failed",
+			detail ? `${message} (${detail})` : message,
+			{ cause: error },
+		);
+	}
 	const remoteSha = parseRemoteHead(remoteOutput, upstreamBranch);
 	if (!remoteSha) {
 		throw new CloudHandoffGitPreflightError(

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -1,0 +1,269 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitCommand = (
+	args: readonly string[],
+	options: { cwd: string; signal?: AbortSignal },
+) => Promise<{ stdout: string; stderr?: string }>;
+
+export type CloudHandoffGitContext = {
+	repoUrl: string;
+	branch: string;
+	remoteName: string;
+	headSha: string;
+};
+
+export type CloudHandoffGitPreflightErrorCode =
+	| "not_git_repository"
+	| "dirty_worktree"
+	| "detached_head"
+	| "missing_upstream"
+	| "unsupported_remote"
+	| "remote_branch_missing"
+	| "unpushed_commits"
+	| "git_command_failed";
+
+export class CloudHandoffGitPreflightError extends Error {
+	constructor(
+		readonly code: CloudHandoffGitPreflightErrorCode,
+		message: string,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "CloudHandoffGitPreflightError";
+	}
+}
+
+function defaultGitCommand(
+	args: readonly string[],
+	options: { cwd: string; signal?: AbortSignal },
+): Promise<{ stdout: string; stderr: string }> {
+	return execFileAsync("git", args, {
+		cwd: options.cwd,
+		encoding: "utf8",
+		windowsHide: true,
+		signal: options.signal,
+		timeout: 15_000,
+		maxBuffer: 10 * 1024 * 1024,
+		env: {
+			...process.env,
+			GIT_TERMINAL_PROMPT: "0",
+			GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND || "ssh -o BatchMode=yes",
+		},
+	});
+}
+
+function trimGitSuffix(pathname: string): string {
+	return pathname
+		.replace(/^\/+/, "")
+		.replace(/\/+$/, "")
+		.replace(/\.git$/i, "");
+}
+
+/** Converts supported GitHub clone URLs to the URL expected by cloud sessions. */
+export function normalizeGitHubRemoteUrl(remoteUrl: string): string | null {
+	const value = remoteUrl.trim();
+	if (!value) return null;
+
+	const scpMatch = value.match(/^(?:[^@/\s]+@)?github\.com:([^\s]+)$/i);
+	if (scpMatch?.[1]) {
+		const path = trimGitSuffix(scpMatch[1]);
+		return path.split("/").length === 2 ? `https://github.com/${path}` : null;
+	}
+
+	try {
+		const url = new URL(value);
+		if (url.hostname.toLowerCase() !== "github.com") return null;
+		if (!new Set(["https:", "http:", "ssh:", "git:"]).has(url.protocol)) {
+			return null;
+		}
+		const path = trimGitSuffix(url.pathname);
+		return path.split("/").length === 2 ? `https://github.com/${path}` : null;
+	} catch {
+		return null;
+	}
+}
+
+function commandErrorMessage(error: unknown): string {
+	if (!error || typeof error !== "object") return "";
+	const stderr = (error as { stderr?: unknown }).stderr;
+	return typeof stderr === "string" ? stderr.trim() : "";
+}
+
+async function runRequired(
+	git: GitCommand,
+	cwd: string,
+	args: readonly string[],
+	code: CloudHandoffGitPreflightErrorCode,
+	message: string,
+	signal?: AbortSignal,
+): Promise<string> {
+	try {
+		return (await git(args, { cwd, signal })).stdout.trim();
+	} catch (error) {
+		const detail = commandErrorMessage(error);
+		throw new CloudHandoffGitPreflightError(
+			code,
+			detail ? `${message} (${detail})` : message,
+			{ cause: error },
+		);
+	}
+}
+
+function parseRemoteHead(stdout: string, branch: string): string | null {
+	const expectedRef = `refs/heads/${branch}`;
+	for (const line of stdout.split("\n")) {
+		const [sha, ref] = line.trim().split(/\s+/, 2);
+		if (ref === expectedRef && /^[0-9a-f]{40,64}$/i.test(sha ?? "")) {
+			return sha ?? null;
+		}
+	}
+	return null;
+}
+
+/**
+ * Refuses handoff unless a fresh GitHub clone of the upstream branch will be
+ * byte-for-byte anchored at the current local commit.
+ */
+export async function preflightCloudHandoffGit(input: {
+	cwd: string;
+	git?: GitCommand;
+	signal?: AbortSignal;
+}): Promise<CloudHandoffGitContext> {
+	const git = input.git ?? defaultGitCommand;
+	const cwd = input.cwd;
+
+	const insideWorktree = await runRequired(
+		git,
+		cwd,
+		["rev-parse", "--is-inside-work-tree"],
+		"not_git_repository",
+		"Cloud handoff requires a Git repository.",
+		input.signal,
+	);
+	if (insideWorktree !== "true") {
+		throw new CloudHandoffGitPreflightError(
+			"not_git_repository",
+			"Cloud handoff requires a Git working tree.",
+		);
+	}
+
+	const dirty = await runRequired(
+		git,
+		cwd,
+		["status", "--porcelain=v1", "--untracked-files=all"],
+		"git_command_failed",
+		"Could not inspect the Git worktree.",
+		input.signal,
+	);
+	if (dirty) {
+		const lines = dirty.split("\n").filter(Boolean);
+		const summary = lines.slice(0, 5).join("\n");
+		const remainder =
+			lines.length > 5 ? `\n...and ${lines.length - 5} more` : "";
+		throw new CloudHandoffGitPreflightError(
+			"dirty_worktree",
+			`Commit and push local changes before handing off to cloud. Uncommitted files are not transferred.\n\n${summary}${remainder}`,
+		);
+	}
+
+	const branch = await runRequired(
+		git,
+		cwd,
+		["symbolic-ref", "--quiet", "--short", "HEAD"],
+		"detached_head",
+		"Cloud handoff requires a checked-out branch; detached HEAD is not supported.",
+		input.signal,
+	);
+	if (!branch) {
+		throw new CloudHandoffGitPreflightError(
+			"detached_head",
+			"Cloud handoff requires a checked-out branch; detached HEAD is not supported.",
+		);
+	}
+
+	const [remoteName, mergeRef, headSha] = await Promise.all([
+		runRequired(
+			git,
+			cwd,
+			["config", "--get", `branch.${branch}.remote`],
+			"missing_upstream",
+			`Branch ${branch} has no upstream. Push it with -u before handing off.`,
+			input.signal,
+		),
+		runRequired(
+			git,
+			cwd,
+			["config", "--get", `branch.${branch}.merge`],
+			"missing_upstream",
+			`Branch ${branch} has no upstream. Push it with -u before handing off.`,
+			input.signal,
+		),
+		runRequired(
+			git,
+			cwd,
+			["rev-parse", "HEAD"],
+			"git_command_failed",
+			"Could not resolve the current commit.",
+			input.signal,
+		),
+	]);
+	if (
+		!remoteName ||
+		remoteName === "." ||
+		!mergeRef.startsWith("refs/heads/")
+	) {
+		throw new CloudHandoffGitPreflightError(
+			"missing_upstream",
+			`Branch ${branch} has no remote branch upstream. Push it with -u before handing off.`,
+		);
+	}
+
+	const upstreamBranch = mergeRef.slice("refs/heads/".length);
+	const rawRemoteUrl = await runRequired(
+		git,
+		cwd,
+		["remote", "get-url", remoteName],
+		"missing_upstream",
+		`Could not resolve the ${remoteName} remote.`,
+		input.signal,
+	);
+	const repoUrl = normalizeGitHubRemoteUrl(rawRemoteUrl);
+	if (!repoUrl) {
+		throw new CloudHandoffGitPreflightError(
+			"unsupported_remote",
+			"Cloud handoff currently requires a github.com upstream remote.",
+		);
+	}
+
+	const remoteOutput = await runRequired(
+		git,
+		cwd,
+		["ls-remote", "--exit-code", remoteName, mergeRef],
+		"remote_branch_missing",
+		`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
+		input.signal,
+	);
+	const remoteSha = parseRemoteHead(remoteOutput, upstreamBranch);
+	if (!remoteSha) {
+		throw new CloudHandoffGitPreflightError(
+			"remote_branch_missing",
+			`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
+		);
+	}
+	if (remoteSha.toLowerCase() !== headSha.toLowerCase()) {
+		throw new CloudHandoffGitPreflightError(
+			"unpushed_commits",
+			`Local HEAD does not match ${remoteName}/${upstreamBranch}. Push the current commit before handing off.`,
+		);
+	}
+
+	return {
+		repoUrl,
+		branch: upstreamBranch,
+		remoteName,
+		headSha,
+	};
+}

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -1,0 +1,269 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitCommand = (
+	args: readonly string[],
+	options: { cwd: string; signal?: AbortSignal },
+) => Promise<{ stdout: string; stderr?: string }>;
+
+export type CloudHandoffGitContext = {
+	repoUrl: string;
+	branch: string;
+	remoteName: string;
+	headSha: string;
+};
+
+export type CloudHandoffGitPreflightErrorCode =
+	| "not_git_repository"
+	| "dirty_worktree"
+	| "detached_head"
+	| "missing_upstream"
+	| "unsupported_remote"
+	| "remote_branch_missing"
+	| "unpushed_commits"
+	| "git_command_failed";
+
+export class CloudHandoffGitPreflightError extends Error {
+	constructor(
+		readonly code: CloudHandoffGitPreflightErrorCode,
+		message: string,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "CloudHandoffGitPreflightError";
+	}
+}
+
+function defaultGitCommand(
+	args: readonly string[],
+	options: { cwd: string; signal?: AbortSignal },
+): Promise<{ stdout: string; stderr: string }> {
+	return execFileAsync("git", args, {
+		cwd: options.cwd,
+		encoding: "utf8",
+		windowsHide: true,
+		signal: options.signal,
+		timeout: 15_000,
+		maxBuffer: 10 * 1024 * 1024,
+		env: {
+			...process.env,
+			GIT_TERMINAL_PROMPT: "0",
+			GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND || "ssh -o BatchMode=yes",
+		},
+	});
+}
+
+function trimGitSuffix(pathname: string): string {
+	return pathname
+		.replace(/^\/+/, "")
+		.replace(/\/+$/, "")
+		.replace(/\.git$/i, "");
+}
+
+/** Converts supported GitHub clone URLs to the URL expected by cloud sessions. */
+export function normalizeGitHubRemoteUrl(remoteUrl: string): string | null {
+	const value = remoteUrl.trim();
+	if (!value) return null;
+
+	const scpMatch = value.match(/^(?:[^@/\s]+@)?github\.com:([^\s]+)$/i);
+	if (scpMatch?.[1]) {
+		const path = trimGitSuffix(scpMatch[1]);
+		return path.split("/").length === 2 ? `https://github.com/${path}` : null;
+	}
+
+	try {
+		const url = new URL(value);
+		if (url.hostname.toLowerCase() !== "github.com") return null;
+		if (!new Set(["https:", "http:", "ssh:", "git:"]).has(url.protocol)) {
+			return null;
+		}
+		const path = trimGitSuffix(url.pathname);
+		return path.split("/").length === 2 ? `https://github.com/${path}` : null;
+	} catch {
+		return null;
+	}
+}
+
+function commandErrorMessage(error: unknown): string {
+	if (!error || typeof error !== "object") return "";
+	const stderr = (error as { stderr?: unknown }).stderr;
+	return typeof stderr === "string" ? stderr.trim() : "";
+}
+
+async function runRequired(
+	git: GitCommand,
+	cwd: string,
+	args: readonly string[],
+	code: CloudHandoffGitPreflightErrorCode,
+	message: string,
+	signal?: AbortSignal,
+): Promise<string> {
+	try {
+		return (await git(args, { cwd, signal })).stdout.trim();
+	} catch (error) {
+		const detail = commandErrorMessage(error);
+		throw new CloudHandoffGitPreflightError(
+			code,
+			detail ? `${message} (${detail})` : message,
+			{ cause: error },
+		);
+	}
+}
+
+function parseRemoteHead(stdout: string, branch: string): string | null {
+	const expectedRef = `refs/heads/${branch}`;
+	for (const line of stdout.split("\n")) {
+		const [sha, ref] = line.trim().split(/\s+/, 2);
+		if (ref === expectedRef && /^[0-9a-f]{40,64}$/i.test(sha ?? "")) {
+			return sha ?? null;
+		}
+	}
+	return null;
+}
+
+/**
+ * Refuses handoff unless a fresh GitHub clone of the upstream branch will be
+ * byte-for-byte anchored at the current local commit.
+ */
+export async function preflightCloudHandoffGit(input: {
+	cwd: string;
+	git?: GitCommand;
+	signal?: AbortSignal;
+}): Promise<CloudHandoffGitContext> {
+	const git = input.git ?? defaultGitCommand;
+	const cwd = input.cwd;
+
+	const insideWorktree = await runRequired(
+		git,
+		cwd,
+		["rev-parse", "--is-inside-work-tree"],
+		"not_git_repository",
+		"Cloud handoff requires a Git repository.",
+		input.signal,
+	);
+	if (insideWorktree !== "true") {
+		throw new CloudHandoffGitPreflightError(
+			"not_git_repository",
+			"Cloud handoff requires a Git working tree.",
+		);
+	}
+
+	const dirty = await runRequired(
+		git,
+		cwd,
+		["status", "--porcelain=v1", "--untracked-files=all"],
+		"git_command_failed",
+		"Could not inspect the Git worktree.",
+		input.signal,
+	);
+	if (dirty) {
+		const lines = dirty.split("\n").filter(Boolean);
+		const summary = lines.slice(0, 5).join("\n");
+		const remainder =
+			lines.length > 5 ? `\n...and ${lines.length - 5} more` : "";
+		throw new CloudHandoffGitPreflightError(
+			"dirty_worktree",
+			`Commit and push local changes before handing off to cloud. Uncommitted files are not transferred.\n\n${summary}${remainder}`,
+		);
+	}
+
+	const branch = await runRequired(
+		git,
+		cwd,
+		["symbolic-ref", "--quiet", "--short", "HEAD"],
+		"detached_head",
+		"Cloud handoff requires a checked-out branch; detached HEAD is not supported.",
+		input.signal,
+	);
+	if (!branch) {
+		throw new CloudHandoffGitPreflightError(
+			"detached_head",
+			"Cloud handoff requires a checked-out branch; detached HEAD is not supported.",
+		);
+	}
+
+	const [remoteName, mergeRef, headSha] = await Promise.all([
+		runRequired(
+			git,
+			cwd,
+			["config", "--get", `branch.${branch}.remote`],
+			"missing_upstream",
+			`Branch ${branch} has no upstream. Push it with -u before handing off.`,
+			input.signal,
+		),
+		runRequired(
+			git,
+			cwd,
+			["config", "--get", `branch.${branch}.merge`],
+			"missing_upstream",
+			`Branch ${branch} has no upstream. Push it with -u before handing off.`,
+			input.signal,
+		),
+		runRequired(
+			git,
+			cwd,
+			["rev-parse", "HEAD"],
+			"git_command_failed",
+			"Could not resolve the current commit.",
+			input.signal,
+		),
+	]);
+	if (
+		!remoteName ||
+		remoteName === "." ||
+		!mergeRef.startsWith("refs/heads/")
+	) {
+		throw new CloudHandoffGitPreflightError(
+			"missing_upstream",
+			`Branch ${branch} has no remote branch upstream. Push it with -u before handing off.`,
+		);
+	}
+
+	const upstreamBranch = mergeRef.slice("refs/heads/".length);
+	const rawRemoteUrl = await runRequired(
+		git,
+		cwd,
+		["config", "--get", `remote.${remoteName}.url`],
+		"missing_upstream",
+		`Could not resolve the ${remoteName} remote.`,
+		input.signal,
+	);
+	const repoUrl = normalizeGitHubRemoteUrl(rawRemoteUrl);
+	if (!repoUrl) {
+		throw new CloudHandoffGitPreflightError(
+			"unsupported_remote",
+			"Cloud handoff currently requires a github.com upstream remote.",
+		);
+	}
+
+	const remoteOutput = await runRequired(
+		git,
+		cwd,
+		["ls-remote", "--exit-code", remoteName, mergeRef],
+		"remote_branch_missing",
+		`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
+		input.signal,
+	);
+	const remoteSha = parseRemoteHead(remoteOutput, upstreamBranch);
+	if (!remoteSha) {
+		throw new CloudHandoffGitPreflightError(
+			"remote_branch_missing",
+			`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
+		);
+	}
+	if (remoteSha.toLowerCase() !== headSha.toLowerCase()) {
+		throw new CloudHandoffGitPreflightError(
+			"unpushed_commits",
+			`Local HEAD does not match ${remoteName}/${upstreamBranch}. Push the current commit before handing off.`,
+		);
+	}
+
+	return {
+		repoUrl,
+		branch: upstreamBranch,
+		remoteName,
+		headSha,
+	};
+}

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -13,6 +13,7 @@ export type CloudHandoffGitContext = {
 	branch: string;
 	remoteName: string;
 	headSha: string;
+	workspaceRelativePath?: string;
 };
 
 export type CloudHandoffGitPreflightErrorCode =
@@ -129,6 +130,22 @@ function parseRemoteHead(stdout: string, branch: string): string | null {
 	return null;
 }
 
+function normalizeWorkspaceRelativePath(value: string): string | undefined {
+	const normalized = value.trim().replace(/\/+$/, "");
+	if (!normalized) return undefined;
+	const parts = normalized.split("/");
+	if (
+		normalized.startsWith("/") ||
+		parts.some((part) => !part || part === "." || part === "..")
+	) {
+		throw new CloudHandoffGitPreflightError(
+			"git_command_failed",
+			"Could not resolve the workspace path relative to the Git repository.",
+		);
+	}
+	return normalized;
+}
+
 /**
  * Refuses handoff unless a fresh GitHub clone of the upstream branch will be
  * byte-for-byte anchored at the current local commit.
@@ -155,6 +172,16 @@ export async function preflightCloudHandoffGit(input: {
 			"Cloud handoff requires a Git working tree.",
 		);
 	}
+	const workspaceRelativePath = normalizeWorkspaceRelativePath(
+		await runRequired(
+			git,
+			cwd,
+			["rev-parse", "--show-prefix"],
+			"git_command_failed",
+			"Could not resolve the workspace path relative to the Git repository.",
+			input.signal,
+		),
+	);
 
 	const dirty = await runRequired(
 		git,
@@ -175,14 +202,26 @@ export async function preflightCloudHandoffGit(input: {
 		);
 	}
 
-	const branch = await runRequired(
-		git,
-		cwd,
-		["symbolic-ref", "--quiet", "--short", "HEAD"],
-		"detached_head",
-		"Cloud handoff requires a checked-out branch; detached HEAD is not supported.",
-		input.signal,
-	);
+	let branch: string;
+	try {
+		branch = (
+			await git(["symbolic-ref", "--quiet", "--short", "HEAD"], {
+				cwd,
+				signal: input.signal,
+			})
+		).stdout.trim();
+	} catch (error) {
+		const detached = commandExitCode(error) === 1;
+		const detail = commandErrorMessage(error);
+		const message = detached
+			? "Cloud handoff requires a checked-out branch; detached HEAD is not supported."
+			: "Could not inspect the current Git branch.";
+		throw new CloudHandoffGitPreflightError(
+			detached ? "detached_head" : "git_command_failed",
+			detail ? `${message} (${detail})` : message,
+			{ cause: error },
+		);
+	}
 	if (!branch) {
 		throw new CloudHandoffGitPreflightError(
 			"detached_head",
@@ -233,7 +272,7 @@ export async function preflightCloudHandoffGit(input: {
 		cwd,
 		["remote", "get-url", remoteName],
 		"missing_upstream",
-		`Could not resolve the ${remoteName} remote.`,
+		"Could not resolve the upstream remote.",
 		input.signal,
 	);
 	const repoUrl = normalizeGitHubRemoteUrl(rawRemoteUrl);
@@ -254,13 +293,12 @@ export async function preflightCloudHandoffGit(input: {
 		).stdout.trim();
 	} catch (error) {
 		const missing = commandExitCode(error) === 2;
-		const detail = commandErrorMessage(error);
 		const message = missing
-			? `Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`
+			? `The upstream branch ${upstreamBranch} was not found. Push it before handing off.`
 			: "Could not verify the remote branch. Check your network and GitHub authentication, then try again.";
 		throw new CloudHandoffGitPreflightError(
 			missing ? "remote_branch_missing" : "git_command_failed",
-			detail ? `${message} (${detail})` : message,
+			message,
 			{ cause: error },
 		);
 	}
@@ -268,13 +306,13 @@ export async function preflightCloudHandoffGit(input: {
 	if (!remoteSha) {
 		throw new CloudHandoffGitPreflightError(
 			"remote_branch_missing",
-			`Remote branch ${remoteName}/${upstreamBranch} was not found. Push it before handing off.`,
+			`The upstream branch ${upstreamBranch} was not found. Push it before handing off.`,
 		);
 	}
 	if (remoteSha.toLowerCase() !== headSha.toLowerCase()) {
 		throw new CloudHandoffGitPreflightError(
 			"unpushed_commits",
-			`Local HEAD does not match ${remoteName}/${upstreamBranch}. Push the current commit before handing off.`,
+			`Local HEAD does not match the upstream branch ${upstreamBranch}. Push the current commit before handing off.`,
 		);
 	}
 
@@ -283,5 +321,6 @@ export async function preflightCloudHandoffGit(input: {
 		branch: upstreamBranch,
 		remoteName,
 		headSha,
+		...(workspaceRelativePath ? { workspaceRelativePath } : {}),
 	};
 }

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -225,7 +225,7 @@ export async function preflightCloudHandoffGit(input: {
 	const rawRemoteUrl = await runRequired(
 		git,
 		cwd,
-		["config", "--get", `remote.${remoteName}.url`],
+		["remote", "get-url", remoteName],
 		"missing_upstream",
 		`Could not resolve the ${remoteName} remote.`,
 		input.signal,

--- a/sdk/packages/core/src/services/cloud-handoff/index.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/index.ts
@@ -1,0 +1,6 @@
+export * from "./git-preflight";
+export * from "./metadata";
+export * from "./model-selection";
+export * from "./session-prompt";
+export * from "./transcript";
+export * from "./types";

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCloudHandoffDashboardUrl,
+	clearCloudHandoffMetadata,
+	cloudHandoffFingerprintsEqual,
+	createCloudHandoffFingerprint,
+	mergeCloudHandoffMetadata,
+	readCloudHandoffMetadata,
+} from "./metadata";
+
+describe("cloud handoff metadata", () => {
+	const fingerprint = createCloudHandoffFingerprint({
+		repoUrl: " https://github.com/cline/cline ",
+		branch: " main ",
+		headSha: "A".repeat(40),
+		modelId: " cloud/model ",
+	});
+
+	it("merges, reads, and clears handoff metadata without losing siblings", () => {
+		const merged = mergeCloudHandoffMetadata(
+			{ title: "Local work", nested: { keep: true } },
+			{
+				toCloudSessionId: "ses-1",
+				handedOffAt: "2026-08-18T12:00:00.000Z",
+				status: "complete",
+				innerSessionId: "inner-1",
+				dashboardUrl: "https://staging-app.cline.bot/agents?sessionId=ses-1",
+				fingerprint,
+			},
+		);
+
+		expect(readCloudHandoffMetadata(merged)).toEqual({
+			toCloudSessionId: "ses-1",
+			handedOffAt: "2026-08-18T12:00:00.000Z",
+			status: "complete",
+			innerSessionId: "inner-1",
+			dashboardUrl: "https://staging-app.cline.bot/agents?sessionId=ses-1",
+			fingerprint,
+		});
+		expect(clearCloudHandoffMetadata(merged)).toEqual({
+			title: "Local work",
+			nested: { keep: true },
+		});
+	});
+
+	it("rejects malformed envelopes and drops malformed optional fingerprints", () => {
+		expect(readCloudHandoffMetadata({ handoff: { status: "complete" } })).toBe(
+			undefined,
+		);
+		expect(
+			readCloudHandoffMetadata({
+				handoff: {
+					toCloudSessionId: "ses-1",
+					handedOffAt: "now",
+					status: "pending",
+					fingerprint: { repoUrl: "missing the rest" },
+				},
+			}),
+		).toEqual({
+			toCloudSessionId: "ses-1",
+			handedOffAt: "now",
+			status: "pending",
+		});
+	});
+
+	it("compares fingerprints case-insensitively only for the Git SHA", () => {
+		expect(
+			cloudHandoffFingerprintsEqual(fingerprint, {
+				...fingerprint,
+				headSha: fingerprint.headSha.toLowerCase(),
+			}),
+		).toBe(true);
+		expect(
+			cloudHandoffFingerprintsEqual(fingerprint, {
+				...fingerprint,
+				branch: "other",
+			}),
+		).toBe(false);
+		expect(cloudHandoffFingerprintsEqual(undefined, undefined)).toBe(false);
+	});
+
+	it("builds an environment-specific dashboard URL", () => {
+		expect(
+			buildCloudHandoffDashboardUrl(
+				"https://staging-app.cline.bot/base",
+				"ses-1",
+			),
+		).toBe("https://staging-app.cline.bot/agents?sessionId=ses-1");
+	});
+
+	it("rejects empty required fingerprint and session id fields", () => {
+		expect(() =>
+			createCloudHandoffFingerprint({
+				repoUrl: "",
+				branch: "main",
+				headSha: "a".repeat(40),
+				modelId: "model",
+			}),
+		).toThrow("cannot be empty");
+		expect(() =>
+			buildCloudHandoffDashboardUrl("https://app.cline.bot", " "),
+		).toThrow("cannot be empty");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
@@ -14,6 +14,8 @@ describe("cloud handoff metadata", () => {
 		branch: " main ",
 		headSha: "A".repeat(40),
 		modelId: " cloud/model ",
+		workspaceRelativePath: " apps/desktop ",
+		mode: "plan",
 	});
 
 	it("merges, reads, and clears handoff metadata without losing siblings", () => {
@@ -74,6 +76,18 @@ describe("cloud handoff metadata", () => {
 			cloudHandoffFingerprintsEqual(fingerprint, {
 				...fingerprint,
 				branch: "other",
+			}),
+		).toBe(false);
+		expect(
+			cloudHandoffFingerprintsEqual(fingerprint, {
+				...fingerprint,
+				workspaceRelativePath: "apps/cli",
+			}),
+		).toBe(false);
+		expect(
+			cloudHandoffFingerprintsEqual(fingerprint, {
+				...fingerprint,
+				mode: "yolo",
 			}),
 		).toBe(false);
 		expect(cloudHandoffFingerprintsEqual(undefined, undefined)).toBe(false);

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.ts
@@ -1,0 +1,134 @@
+import type { CloudHandoffFingerprint, CloudHandoffMetadata } from "./types";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function readRequiredString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed || undefined;
+}
+
+export function createCloudHandoffFingerprint(input: {
+	repoUrl: string;
+	branch: string;
+	headSha: string;
+	modelId: string;
+	organizationId?: string;
+}): CloudHandoffFingerprint {
+	const repoUrl = readRequiredString(input.repoUrl);
+	const branch = readRequiredString(input.branch);
+	const headSha = readRequiredString(input.headSha);
+	const modelId = readRequiredString(input.modelId);
+	if (!repoUrl || !branch || !headSha || !modelId) {
+		throw new Error("Cloud handoff fingerprint fields cannot be empty.");
+	}
+	const organizationId = readRequiredString(input.organizationId);
+	return {
+		repoUrl,
+		branch,
+		headSha,
+		modelId,
+		...(organizationId ? { organizationId } : {}),
+	};
+}
+
+export function cloudHandoffFingerprintsEqual(
+	left: CloudHandoffFingerprint | undefined,
+	right: CloudHandoffFingerprint | undefined,
+): boolean {
+	return (
+		left !== undefined &&
+		right !== undefined &&
+		left.repoUrl === right.repoUrl &&
+		left.branch === right.branch &&
+		left.headSha.toLowerCase() === right.headSha.toLowerCase() &&
+		left.modelId === right.modelId &&
+		left.organizationId === right.organizationId
+	);
+}
+
+function readCloudHandoffFingerprint(
+	value: unknown,
+): CloudHandoffFingerprint | undefined {
+	const fingerprint = asRecord(value);
+	if (
+		!fingerprint ||
+		typeof fingerprint.repoUrl !== "string" ||
+		typeof fingerprint.branch !== "string" ||
+		typeof fingerprint.headSha !== "string" ||
+		typeof fingerprint.modelId !== "string"
+	) {
+		return undefined;
+	}
+	try {
+		return createCloudHandoffFingerprint({
+			repoUrl: fingerprint.repoUrl,
+			branch: fingerprint.branch,
+			headSha: fingerprint.headSha,
+			modelId: fingerprint.modelId,
+			...(typeof fingerprint.organizationId === "string"
+				? { organizationId: fingerprint.organizationId }
+				: {}),
+		});
+	} catch {
+		return undefined;
+	}
+}
+
+export function readCloudHandoffMetadata(
+	metadata: unknown,
+): CloudHandoffMetadata | undefined {
+	const value = asRecord(asRecord(metadata)?.handoff);
+	if (!value) return undefined;
+	const toCloudSessionId = readRequiredString(value.toCloudSessionId);
+	const handedOffAt = readRequiredString(value.handedOffAt);
+	const status = value.status;
+	if (
+		!toCloudSessionId ||
+		!handedOffAt ||
+		(status !== "pending" && status !== "complete")
+	) {
+		return undefined;
+	}
+
+	const innerSessionId = readRequiredString(value.innerSessionId);
+	const dashboardUrl = readRequiredString(value.dashboardUrl);
+	const fingerprint = readCloudHandoffFingerprint(value.fingerprint);
+	return {
+		toCloudSessionId,
+		handedOffAt,
+		status,
+		...(innerSessionId ? { innerSessionId } : {}),
+		...(dashboardUrl ? { dashboardUrl } : {}),
+		...(fingerprint ? { fingerprint } : {}),
+	};
+}
+
+export function mergeCloudHandoffMetadata(
+	metadata: Record<string, unknown> | null | undefined,
+	handoff: CloudHandoffMetadata,
+): Record<string, unknown> {
+	return { ...(metadata ?? {}), handoff };
+}
+
+export function clearCloudHandoffMetadata(
+	metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+	const { handoff: _handoff, ...rest } = metadata ?? {};
+	return rest;
+}
+
+export function buildCloudHandoffDashboardUrl(
+	appBaseUrl: string,
+	outerSessionId: string,
+): string {
+	const sessionId = outerSessionId.trim();
+	if (!sessionId) throw new Error("Cloud session id cannot be empty.");
+	const url = new URL("/agents", appBaseUrl);
+	url.searchParams.set("sessionId", sessionId);
+	return url.toString();
+}

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.ts
@@ -18,6 +18,8 @@ export function createCloudHandoffFingerprint(input: {
 	headSha: string;
 	modelId: string;
 	organizationId?: string;
+	workspaceRelativePath?: string;
+	mode?: "plan" | "yolo" | "zen";
 }): CloudHandoffFingerprint {
 	const repoUrl = readRequiredString(input.repoUrl);
 	const branch = readRequiredString(input.branch);
@@ -27,12 +29,16 @@ export function createCloudHandoffFingerprint(input: {
 		throw new Error("Cloud handoff fingerprint fields cannot be empty.");
 	}
 	const organizationId = readRequiredString(input.organizationId);
+	const workspaceRelativePath = readRequiredString(input.workspaceRelativePath);
+	const mode = input.mode;
 	return {
 		repoUrl,
 		branch,
 		headSha,
 		modelId,
 		...(organizationId ? { organizationId } : {}),
+		...(workspaceRelativePath ? { workspaceRelativePath } : {}),
+		...(mode ? { mode } : {}),
 	};
 }
 
@@ -47,7 +53,9 @@ export function cloudHandoffFingerprintsEqual(
 		left.branch === right.branch &&
 		left.headSha.toLowerCase() === right.headSha.toLowerCase() &&
 		left.modelId === right.modelId &&
-		left.organizationId === right.organizationId
+		left.organizationId === right.organizationId &&
+		left.workspaceRelativePath === right.workspaceRelativePath &&
+		left.mode === right.mode
 	);
 }
 
@@ -72,6 +80,14 @@ function readCloudHandoffFingerprint(
 			modelId: fingerprint.modelId,
 			...(typeof fingerprint.organizationId === "string"
 				? { organizationId: fingerprint.organizationId }
+				: {}),
+			...(typeof fingerprint.workspaceRelativePath === "string"
+				? { workspaceRelativePath: fingerprint.workspaceRelativePath }
+				: {}),
+			...(fingerprint.mode === "plan" ||
+			fingerprint.mode === "yolo" ||
+			fingerprint.mode === "zen"
+				? { mode: fingerprint.mode }
 				: {}),
 		});
 	} catch {

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
@@ -13,9 +13,10 @@ const MODELS: CloudHandoffModel[] = [
 describe("selectCloudHandoffModel", () => {
 	it("keeps an available local model", () => {
 		expect(
-			selectCloudHandoffModel({
-				localModelId: "paid/model",
-				models: MODELS,
+				selectCloudHandoffModel({
+					localModelId: "paid/model",
+					models: MODELS,
+					isOrganizationSession: false,
 			}),
 		).toEqual({
 			modelId: "paid/model",
@@ -26,9 +27,10 @@ describe("selectCloudHandoffModel", () => {
 
 	it("falls back to Cline Cloud before the base catalog", () => {
 		expect(
-			selectCloudHandoffModel({
-				localModelId: "local-only/model",
-				models: MODELS,
+				selectCloudHandoffModel({
+					localModelId: "local-only/model",
+					models: MODELS,
+					isOrganizationSession: false,
 			}),
 		).toEqual({
 			modelId: "cloud/model",

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+	type CloudHandoffModel,
+	selectCloudHandoffModel,
+} from "./model-selection";
+
+const MODELS: CloudHandoffModel[] = [
+	{ id: "paid/model", name: "Paid Model", catalogId: "cline" },
+	{ id: "pass/model", name: "Pass Model", catalogId: "cline-pass" },
+	{ id: "cloud/model", name: "Cloud Model", catalogId: "cline-cloud" },
+];
+
+describe("selectCloudHandoffModel", () => {
+	it("keeps an available local model", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "paid/model",
+				models: MODELS,
+				isOrganizationSession: false,
+			}),
+		).toEqual({
+			modelId: "paid/model",
+			catalogId: "cline",
+			usedFallback: false,
+		});
+	});
+
+	it("falls back to Cline Cloud before the base catalog", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "local-only/model",
+				models: MODELS,
+				isOrganizationSession: false,
+			}),
+		).toEqual({
+			modelId: "cloud/model",
+			catalogId: "cline-cloud",
+			usedFallback: true,
+		});
+	});
+
+	it("excludes Cline Pass for organization sessions", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "pass/model",
+				models: MODELS,
+				isOrganizationSession: true,
+			}),
+		).toEqual({
+			modelId: "cloud/model",
+			catalogId: "cline-cloud",
+			usedFallback: true,
+		});
+	});
+
+	it("fails when no eligible models are supplied", () => {
+		expect(() =>
+			selectCloudHandoffModel({
+				models: [MODELS[1]],
+				isOrganizationSession: true,
+			}),
+		).toThrow("No cloud models");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
@@ -13,10 +13,10 @@ const MODELS: CloudHandoffModel[] = [
 describe("selectCloudHandoffModel", () => {
 	it("keeps an available local model", () => {
 		expect(
-				selectCloudHandoffModel({
-					localModelId: "paid/model",
-					models: MODELS,
-					isOrganizationSession: false,
+			selectCloudHandoffModel({
+				localModelId: "paid/model",
+				models: MODELS,
+				isOrganizationSession: false,
 			}),
 		).toEqual({
 			modelId: "paid/model",
@@ -27,10 +27,10 @@ describe("selectCloudHandoffModel", () => {
 
 	it("falls back to Cline Cloud before the base catalog", () => {
 		expect(
-				selectCloudHandoffModel({
-					localModelId: "local-only/model",
-					models: MODELS,
-					isOrganizationSession: false,
+			selectCloudHandoffModel({
+				localModelId: "local-only/model",
+				models: MODELS,
+				isOrganizationSession: false,
 			}),
 		).toEqual({
 			modelId: "cloud/model",

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+	type CloudHandoffModel,
+	selectCloudHandoffModel,
+} from "./model-selection";
+
+const MODELS: CloudHandoffModel[] = [
+	{ id: "paid/model", name: "Paid Model", catalogId: "cline" },
+	{ id: "pass/model", name: "Pass Model", catalogId: "cline-pass" },
+	{ id: "cloud/model", name: "Cloud Model", catalogId: "cline-cloud" },
+];
+
+describe("selectCloudHandoffModel", () => {
+	it("keeps an available local model", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "paid/model",
+				models: MODELS,
+			}),
+		).toEqual({
+			modelId: "paid/model",
+			catalogId: "cline",
+			usedFallback: false,
+		});
+	});
+
+	it("falls back to Cline Cloud before the base catalog", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "local-only/model",
+				models: MODELS,
+			}),
+		).toEqual({
+			modelId: "cloud/model",
+			catalogId: "cline-cloud",
+			usedFallback: true,
+		});
+	});
+
+	it("excludes Cline Pass for organization sessions", () => {
+		expect(
+			selectCloudHandoffModel({
+				localModelId: "pass/model",
+				models: MODELS,
+				isOrganizationSession: true,
+			}),
+		).toEqual({
+			modelId: "cloud/model",
+			catalogId: "cline-cloud",
+			usedFallback: true,
+		});
+	});
+
+	it("fails when no eligible models are supplied", () => {
+		expect(() =>
+			selectCloudHandoffModel({
+				models: [MODELS[1]],
+				isOrganizationSession: true,
+			}),
+		).toThrow("No cloud models");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
@@ -1,0 +1,52 @@
+export type CloudHandoffModelCatalogId = "cline" | "cline-pass" | "cline-cloud";
+
+export type CloudHandoffModel = {
+	id: string;
+	name: string;
+	catalogId: CloudHandoffModelCatalogId;
+	description?: string;
+	tags?: string[];
+};
+
+export type CloudHandoffModelSelection = {
+	modelId: string;
+	catalogId: CloudHandoffModelCatalogId;
+	usedFallback: boolean;
+};
+
+/** Keeps the local model when cloud supports it; otherwise uses dashboard order. */
+export function selectCloudHandoffModel(input: {
+	localModelId?: string;
+	models: readonly CloudHandoffModel[];
+	isOrganizationSession: boolean;
+}): CloudHandoffModelSelection {
+	const models = input.isOrganizationSession
+		? input.models.filter((model) => model.catalogId !== "cline-pass")
+		: input.models;
+	if (models.length === 0) {
+		throw new Error(
+			"No cloud models are currently available for this account.",
+		);
+	}
+
+	const localModelId = input.localModelId?.trim();
+	const local = localModelId
+		? models.find((model) => model.id === localModelId)
+		: undefined;
+	const selected =
+		local ??
+		models.find((model) => model.catalogId === "cline-cloud") ??
+		models.find((model) => model.catalogId === "cline") ??
+		models[0];
+	if (!selected) {
+		throw new Error(
+			"No cloud models are currently available for this account.",
+		);
+	}
+
+	return {
+		modelId: selected.id,
+		catalogId: selected.catalogId,
+		usedFallback: selected.id !== localModelId,
+	};
+}

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
@@ -1,0 +1,52 @@
+export type CloudHandoffModelCatalogId = "cline" | "cline-pass" | "cline-cloud";
+
+export type CloudHandoffModel = {
+	id: string;
+	name: string;
+	catalogId: CloudHandoffModelCatalogId;
+	description?: string;
+	tags?: string[];
+};
+
+export type CloudHandoffModelSelection = {
+	modelId: string;
+	catalogId: CloudHandoffModelCatalogId;
+	usedFallback: boolean;
+};
+
+/** Keeps the local model when cloud supports it; otherwise uses dashboard order. */
+export function selectCloudHandoffModel(input: {
+	localModelId?: string;
+	models: readonly CloudHandoffModel[];
+	isOrganizationSession?: boolean;
+}): CloudHandoffModelSelection {
+	const models = input.isOrganizationSession
+		? input.models.filter((model) => model.catalogId !== "cline-pass")
+		: input.models;
+	if (models.length === 0) {
+		throw new Error(
+			"No cloud models are currently available for this account.",
+		);
+	}
+
+	const localModelId = input.localModelId?.trim();
+	const local = localModelId
+		? models.find((model) => model.id === localModelId)
+		: undefined;
+	const selected =
+		local ??
+		models.find((model) => model.catalogId === "cline-cloud") ??
+		models.find((model) => model.catalogId === "cline") ??
+		models[0];
+	if (!selected) {
+		throw new Error(
+			"No cloud models are currently available for this account.",
+		);
+	}
+
+	return {
+		modelId: selected.id,
+		catalogId: selected.catalogId,
+		usedFallback: selected.id !== localModelId,
+	};
+}

--- a/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/model-selection.ts
@@ -18,7 +18,7 @@ export type CloudHandoffModelSelection = {
 export function selectCloudHandoffModel(input: {
 	localModelId?: string;
 	models: readonly CloudHandoffModel[];
-	isOrganizationSession?: boolean;
+	isOrganizationSession: boolean;
 }): CloudHandoffModelSelection {
 	const models = input.isOrganizationSession
 		? input.models.filter((model) => model.catalogId !== "cline-pass")

--- a/sdk/packages/core/src/services/cloud-handoff/session-prompt.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/session-prompt.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCloudHandoffNotice,
+	buildCloudHandoffSystemPrompt,
+	CLOUD_GITHUB_AUTH_SYSTEM_PROMPT,
+	CLOUD_HANDOFF_WORKSPACE_ROOT,
+} from "./session-prompt";
+
+describe("cloud handoff session prompt", () => {
+	it("describes the fresh cloud clone and stale local environment", () => {
+		const notice = buildCloudHandoffNotice({
+			repoUrl: "https://github.com/cline/cline",
+			branch: "main",
+		});
+		expect(notice).toContain(
+			`https://github.com/cline/cline@main at ${CLOUD_HANDOFF_WORKSPACE_ROOT}`,
+		);
+		expect(notice).toContain("absolute paths");
+	});
+
+	it("combines the shared GitHub authentication contract with the notice", () => {
+		const prompt = buildCloudHandoffSystemPrompt({
+			repoUrl: "https://github.com/cline/cline",
+			branch: "feature/handoff",
+		});
+		expect(prompt).toContain(CLOUD_GITHUB_AUTH_SYSTEM_PROMPT);
+		expect(prompt).toContain("feature/handoff");
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/session-prompt.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/session-prompt.ts
@@ -1,0 +1,28 @@
+export const CLOUD_HANDOFF_WORKSPACE_ROOT = "/workspace";
+
+export const CLOUD_GITHUB_AUTH_SYSTEM_PROMPT =
+	"IMPORTANT: GitHub API authentication is handled automatically by the infrastructure. " +
+	"A secrets-proxy sidecar injects the necessary authentication credentials into all GitHub API requests. " +
+	"You do NOT need to set up, configure, or manage any authentication tokens, API keys, or credentials for GitHub API calls. " +
+	"Simply make your GitHub API calls normally — authentication will be injected transparently.";
+
+export function buildCloudHandoffNotice(input: {
+	repoUrl: string;
+	branch: string;
+	workspaceRoot?: string;
+}): string {
+	const workspaceRoot =
+		input.workspaceRoot?.trim() || CLOUD_HANDOFF_WORKSPACE_ROOT;
+	return (
+		`This session was handed off from a local workspace. The cloud runtime is Linux, and the repository is now a fresh clone of ${input.repoUrl}@${input.branch} at ${workspaceRoot}. ` +
+		"Statements earlier in the transcript about the prior OS, absolute paths, environment, and tool availability describe the old local runtime and are stale."
+	);
+}
+
+export function buildCloudHandoffSystemPrompt(input: {
+	repoUrl: string;
+	branch: string;
+	workspaceRoot?: string;
+}): string {
+	return `${CLOUD_GITHUB_AUTH_SYSTEM_PROMPT}\n\n${buildCloudHandoffNotice(input)}`;
+}

--- a/sdk/packages/core/src/services/cloud-handoff/transcript.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/transcript.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	CloudHandoffTranscriptMismatchError,
+	cloudHandoffTranscriptsEqual,
+} from "./transcript";
+
+describe("cloud handoff transcript comparison", () => {
+	it("compares roles and rich image content using the durable JSON shape", () => {
+		const expected = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "inspect this", optional: undefined },
+					{ type: "image", data: "abc", mediaType: "image/png" },
+				],
+				metadata: { localOnly: true },
+			},
+		];
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "inspect this" },
+						{ type: "image", data: "abc", mediaType: "image/png" },
+					],
+					metadata: { cloudOnly: true },
+				},
+			]),
+		).toBe(true);
+		expect(
+			cloudHandoffTranscriptsEqual(expected, [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "inspect this" },
+						{ type: "image", data: "xyz", mediaType: "image/png" },
+					],
+				},
+			]),
+		).toBe(false);
+	});
+
+	it("provides a typed mismatch error", () => {
+		expect(new CloudHandoffTranscriptMismatchError(2, 1).message).toContain(
+			"local 2 messages, cloud 1",
+		);
+	});
+});

--- a/sdk/packages/core/src/services/cloud-handoff/transcript.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/transcript.ts
@@ -1,0 +1,30 @@
+function comparableMessages(messages: readonly unknown[]): unknown[] {
+	return messages.map((message) => {
+		const record =
+			message && typeof message === "object"
+				? (message as Record<string, unknown>)
+				: {};
+		return { role: record.role, content: record.content };
+	});
+}
+
+/** Compares the durable JSON wire shape, including image content and order. */
+export function cloudHandoffTranscriptsEqual(
+	localMessages: readonly unknown[],
+	cloudMessages: readonly unknown[],
+): boolean {
+	return (
+		localMessages.length === cloudMessages.length &&
+		JSON.stringify(comparableMessages(localMessages)) ===
+			JSON.stringify(comparableMessages(cloudMessages))
+	);
+}
+
+export class CloudHandoffTranscriptMismatchError extends Error {
+	constructor(localCount: number, cloudCount: number) {
+		super(
+			`Cloud transcript verification failed (local ${localCount} messages, cloud ${cloudCount}).`,
+		);
+		this.name = "CloudHandoffTranscriptMismatchError";
+	}
+}

--- a/sdk/packages/core/src/services/cloud-handoff/types.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/types.ts
@@ -4,6 +4,10 @@ export type CloudHandoffFingerprint = {
 	headSha: string;
 	modelId: string;
 	organizationId?: string;
+	/** Repository-relative source cwd; omitted when the session is at repo root. */
+	workspaceRelativePath?: string;
+	/** Source interaction mode; omitted for the default Act mode. */
+	mode?: "plan" | "yolo" | "zen";
 };
 
 export type CloudHandoffMetadata = {

--- a/sdk/packages/core/src/services/cloud-handoff/types.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/types.ts
@@ -1,0 +1,43 @@
+export type CloudHandoffFingerprint = {
+	repoUrl: string;
+	branch: string;
+	headSha: string;
+	modelId: string;
+	organizationId?: string;
+};
+
+export type CloudHandoffMetadata = {
+	toCloudSessionId: string;
+	handedOffAt: string;
+	status: "pending" | "complete";
+	innerSessionId?: string;
+	dashboardUrl?: string;
+	fingerprint?: CloudHandoffFingerprint;
+};
+
+export type CloudHandoffDestination = "in_app" | "external";
+
+export type CloudHandoffProgressPhase =
+	| "checking"
+	| "creating"
+	| "provisioning"
+	| "connecting"
+	| "seeding"
+	| "verifying"
+	| "starting"
+	| "complete";
+
+export type CloudHandoffProgress = {
+	phase: CloudHandoffProgressPhase;
+	message: string;
+	sessionId?: string;
+	dashboardUrl?: string;
+};
+
+export type CloudHandoffResult = {
+	outerSessionId: string;
+	innerSessionId: string;
+	dashboardUrl: string;
+	destination: CloudHandoffDestination;
+	warning?: string;
+};

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	clearLiveModelsCatalogCache,
 	clearPrivateModelsCatalogCache,
+	isPrivateModelCatalogProvider,
 	resolveProviderConfig,
 } from "./provider-defaults";
 
@@ -10,6 +11,25 @@ afterEach(() => {
 	clearPrivateModelsCatalogCache();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+});
+
+describe("isPrivateModelCatalogProvider", () => {
+	it.each([
+		"baseten",
+		"hicap",
+		"litellm",
+		"poolside",
+	])("recognizes %s as an endpoint-specific catalog provider", (providerId) => {
+		expect(isPrivateModelCatalogProvider(providerId)).toBe(true);
+	});
+
+	it.each([
+		"openrouter",
+		"requesty",
+		"anthropic",
+	])("does not classify %s as endpoint-specific", (providerId) => {
+		expect(isPrivateModelCatalogProvider(providerId)).toBe(false);
+	});
 });
 
 describe("resolveProviderConfig", () => {
@@ -513,6 +533,8 @@ describe("resolveProviderConfig", () => {
 								model_name: "private-proxy-model",
 								litellm_params: { model: "openai/gpt-4o-mini" },
 								model_info: {
+									max_output_tokens: 64_000,
+									max_input_tokens: 500_000,
 									supports_vision: true,
 									supports_reasoning: true,
 								},
@@ -543,12 +565,16 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["openai/gpt-4o-mini"]).toEqual(
 			expect.objectContaining({
 				name: "private-proxy-model",
+				maxTokens: 64_000,
+				maxInputTokens: 500_000,
 				capabilities: expect.arrayContaining(["images", "reasoning"]),
 			}),
 		);
 		expect(resolved?.knownModels?.["private-proxy-model"]).toEqual(
 			expect.objectContaining({
 				name: "private-proxy-model",
+				maxTokens: 64_000,
+				maxInputTokens: 500_000,
 				capabilities: expect.arrayContaining(["images", "reasoning"]),
 			}),
 		);

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -654,6 +654,17 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	poolside: fetchPoolsidePrivateModels,
 };
 
+/**
+ * Whether a provider's model catalog comes from the customer's configured
+ * endpoint rather than a shared public catalog.
+ *
+ * Keep this derived from the fetcher registry so host consumers cannot drift
+ * from the providers whose live metadata is endpoint-specific.
+ */
+export function isPrivateModelCatalogProvider(providerId: string): boolean {
+	return Object.hasOwn(PRIVATE_PROVIDER_MODEL_FETCHERS, providerId);
+}
+
 const PUBLIC_MODELS_CACHE = new Map<
 	string,
 	{ data: Record<string, ModelInfo>; expiresAt: number }


### PR DESCRIPTION
## Summary

- merge current `main` into `desktop-experimental` per `EXPERIMENTAL.md`
- bring in #13175, #13293, #13337, and cloud handoff from #13351
- move Cloud selection into the existing Local / Remote / Cloud environment menu
- enable Cloud from that menu when the Cloud sessions feature flag is on; otherwise keep it disabled with `Coming soon`
- remove the redundant Local / Cloud toggle while preserving the existing repository and branch controls
- preserve beta version `0.0.14-beta.1` and beta channel configuration

## Verification

- #13351 merged into this branch with conflicts resolved against the environment-runtime architecture
- desktop typecheck and SDK build pass
- 221 focused desktop integration/UI tests pass
- 23 SDK cloud-handoff tests pass
- full desktop sidecar/webview run: 965/966 pass; the sole failure is the unchanged onboarding localStorage test from #12494 and reproduces in isolation
- Biome and `git diff --check` pass
- no desktop beta version, channel configuration, or changelog changes
