### PR TITLE
fix(ci): always build the legacy bundle from the legacy-extension branch

### DIFF
--- a/.cline/skills/publish-extension/SKILL.md
+++ b/.cline/skills/publish-extension/SKILL.md
@@ -93,7 +93,9 @@ Release prep on `main` (PR, not direct push):
 
 ```bash
 gh workflow run ext-vscode-ab-package.yml --ref main \
-  -f version=<VERSION> -f next-ref=main -f legacy-ref=legacy-extension -f publish=true
+  -f version=<VERSION> -f next-ref=main -f publish=true
+# (the legacy bundle always builds from the protected legacy-extension branch;
+# it is deliberately not an input)
 # publish=false builds an installable .vsix artifact without publishing and
 # needs NO environment approval — the ungated build job uploads the artifact
 # and the run completes.

--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -23,11 +23,6 @@ on:
                 required: true
                 default: "main"
                 type: string
-            legacy-ref:
-                description: "Ref to build the legacy bundle from"
-                required: true
-                default: "legacy-extension"
-                type: string
             publish:
                 description: "Publish to the VS Code Marketplace and Open VSX (unchecked: just build the .vsix artifact)"
                 required: true
@@ -130,18 +125,26 @@ jobs:
         name: Test legacy bundle
         runs-on: ubuntu-latest
         # The tested revision, exported so the build job builds EXACTLY what
-        # this suite ran against. legacy-ref is a mutable branch name and the
-        # build job starts later — re-resolving the name there could pick up
-        # commits this gate never saw.
+        # this suite ran against. legacy-extension is a mutable branch name and
+        # the build job starts later — re-resolving the name there could pick
+        # up commits this gate never saw.
         outputs:
             tested-sha: ${{ steps.rev.outputs.sha }}
         defaults:
             run:
                 working-directory: apps/vscode
         steps:
+            # Always the protected legacy-extension branch — deliberately not
+            # an input. An arbitrary ref here would be built into the published
+            # VSIX by the environment-less build job, and the publish
+            # environment approver only ever sees an opaque prebuilt artifact:
+            # the approval would protect the marketplace PAT but not the
+            # shipped bytes. Hardcoding the branch makes its protection rules
+            # load-bearing for releases. Legacy hotfix testing has its own
+            # workflow (ext-vscode-publish-legacy.yml).
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.inputs.legacy-ref }}
+                  ref: legacy-extension
 
             - name: Record tested revision
               id: rev


### PR DESCRIPTION
### Related Issue

From the workflow security audit (2026-08-18): the combined-VSIX publish's approval gate protected the marketplace PAT but not the shipped bytes.

### Description

`ext-vscode-ab-package.yml` built the legacy half of the stable VSIX from a free-form `legacy-ref` dispatch input. `next-ref` has a publish-time guard (`publish=true` requires `next-ref=main`), but `legacy-ref` had none — any string typed into the dispatch form (`refs/pull/N/head`, an unprotected branch) was checked out and built by the **environment-less** `build` job, and the `publish` environment approver then approved a run whose artifact was already fixed: an opaque prebuilt VSIX, with only a ref string in the inputs as a hint.

Rather than adding a mirror refusal check, this removes the input entirely: the legacy bundle now **always** builds from the `legacy-extension` branch, which is covered by the "Main branch protection" ruleset (no deletion, no force-push, PRs required). Hardcoding the branch is what makes that protection load-bearing for releases — before this, the protection was bypassable by simply not using the branch.

Not changed: the existing `tested-sha` pinning (`test-legacy` exports the exact revision it tested; `build` checks out that SHA, never re-resolving the branch name) — that TOCTOU defense was already right. Build-only rehearsals of *next* bundles still work via `next-ref`; legacy hotfix testing has its own workflow (`ext-vscode-publish-legacy.yml` — which has a related, worse issue with its `branch` input, tracked separately from the audit).

The `publish-extension` skill's dispatch command dropped `-f legacy-ref=...` to match (it would now be rejected as an unexpected input).

### Test Procedure

- YAML parses (strict mode); `grep legacy-ref` over the workflow returns nothing.
- The removed input defaulted to `legacy-extension`, so a normal publish behaves identically — only the ability to deviate is removed.

### Type of Change

-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

