### PR TITLE
fix(ci): lock the legacy publish workflow to the legacy-extension branch

### DIFF
--- a/.cline/skills/publish-extension/SKILL.md
+++ b/.cline/skills/publish-extension/SKILL.md
@@ -158,7 +158,9 @@ For shipping a fix on the `legacy-extension` branch — or as the **structural r
 # versions, e.g. combined 4.1.0 live -> hotfix is 4.1.1, not 4.0.13),
 # add the matching `## [x.y.z]` entry to root CHANGELOG.md, push.
 gh workflow run ext-vscode-publish-legacy.yml --ref main \
-  -f release-type=release -f branch=legacy-extension
+  -f release-type=release
+# (the branch is hardcoded to legacy-extension in the workflow; it is
+# deliberately not an input)
 ```
 
 npm test suite runs ungated; the publish job waits on the `Publish` environment. This workflow derives + pushes the `v<version>` tag itself and creates the GitHub release — no manual tagging. Publishes to Marketplace **and** Open VSX. The branch is the npm codebase: use `npm`, never `bun`, and expect the old monolith layout (`apps/vscode/src/core/...`).

--- a/.github/workflows/ext-vscode-publish-legacy.yml
+++ b/.github/workflows/ext-vscode-publish-legacy.yml
@@ -21,20 +21,17 @@ on:
                 options:
                     - pre-release
                     - release
-            branch:
-                description: "Branch holding the legacy extension code"
-                required: true
-                default: "legacy-extension"
-                type: string
 
+# Read-only by default. The publish job elevates itself to contents: write for
+# the tag push and GitHub release; nothing here needs packages/checks/PR
+# write. Keeping the default minimal matters doubly in this workflow because
+# the test job runs BEFORE any environment approval — it must never hold a
+# write token while executing checked-out code.
 permissions:
-    contents: write
-    packages: write
-    checks: write
-    pull-requests: write
+    contents: read
 
 concurrency:
-    group: ext-vscode-publish-legacy-${{ github.event.inputs.branch }}
+    group: ext-vscode-publish-legacy
     cancel-in-progress: false
 
 jobs:
@@ -50,9 +47,16 @@ jobs:
           run:
             working-directory: apps/vscode
         steps:
+            # Always the protected legacy-extension branch — deliberately not
+            # an input. This job runs full npm lifecycle scripts from the
+            # checked-out code with no environment approval, and the publish
+            # job below does the same next to the marketplace PATs; an
+            # arbitrary ref here would hand both of them attacker-controlled
+            # code. Hardcoding the branch makes its protection rules
+            # load-bearing for releases.
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.inputs.branch }}
+                  ref: legacy-extension
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -99,16 +103,20 @@ jobs:
         name: Publish Legacy Extension
         runs-on: ubuntu-latest
         environment: publish
+        # For the tag push in Resolve Release Tag and the GitHub release.
+        permissions:
+            contents: write
         defaults:
           run:
             working-directory: apps/vscode
 
         steps:
-            # Check out the legacy branch (NOT main). fetch-depth: 0 + tags so we
-            # can create/push the release tag and compute the previous tag.
+            # Check out the legacy branch (NOT main; hardcoded — see the test
+            # job's checkout comment). fetch-depth: 0 + tags so we can
+            # create/push the release tag and compute the previous tag.
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.inputs.branch }}
+                  ref: legacy-extension
                   fetch-depth: 0
                   fetch-tags: true
                   lfs: true
@@ -117,7 +125,7 @@ jobs:
               id: resolve_tag
               working-directory: ${{ github.workspace }}
               env:
-                  BRANCH: ${{ github.event.inputs.branch }}
+                  BRANCH: legacy-extension
               run: |
                   # Tag is derived from the package version on the legacy branch.
                   VERSION=$(node -p "require('./apps/vscode/package.json').version")


### PR DESCRIPTION
### Related Issue

From the workflow security audit (2026-08-18) — the top-ranked finding, and the sibling of #13349. This is the legacy-hotfix publish path (4.0.x → the `saoudrizwan.claude-dev` marketplace listing).

### Description

`ext-vscode-publish-legacy.yml` took `branch` — "Branch holding the legacy extension code" — as a **free-form string input with no validation anywhere**. Both jobs checked it out and ran full `npm` lifecycle scripts from it (`npm ci` / `npm install` run every dependency's `preinstall`/`postinstall`, and a `package.json` on the chosen ref can define its own — Bun's `trustedDependencies` allowlist is bun-only and does not apply here):

- **`publish` job** holds `VSCE_PAT` + `OVSX_PAT`. It checks out `branch`, runs `npm install`, then `npm run publish:marketplace` — which executes a script *defined by that same ref* with both PATs in `env`. One `publish` environment approval stands between a dispatch and outside-contributor code running with the marketplace keys, and the approver only sees a ref string in the inputs (`refs/pull/N/head` doesn't look hostile).
- **`test` job** is worse: it runs *before* any approval, declared no `permissions:` of its own, and so inherited the workflow-level `contents: write` + `packages: write` + `checks: write` + `pull-requests: write`. It checked out the same unvalidated `branch` and ran `npm ci` — arbitrary code with a repo-write token and **no human in the loop**.

`workflow_dispatch` requires write access, so this isn't a drive-by — but it's exactly the defense-in-depth that matters.

### Test Procedure

- YAML parses (strict mode); no `inputs.branch` references remain in the workflow.
- Confirmed by reading the full publish job that `contents: write` is the only elevated scope needed (tag push + `action-gh-release`), and that `packages`/`checks`/`pull-requests` are unreferenced.
- Behavior-preserving for real publishes: the removed input's only legitimate value was its default.

### Type of Change

-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Remaining audit items still open: desktop-publish TOCTOU (checkout by SHA), SHA-pinning the actions in the desktop signing job (`dtolnay/rust-toolchain@stable` is a branch ref next to the Apple cert), a `github-actions` dependabot block, and GitHub-UI changes (release-tag ruleset, `prevent_self_review`, Actions default-permission check).
