### PR TITLE
ci(ui-publish): build @cline/shared before ui typecheck

### DIFF
--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # @cline/ui imports @cline/shared/browser (generated-media), which
+      # resolves to dist output — build it before anything typechecks or
+      # builds the ui package.
+      - name: Build shared package
+        run: bun -F @cline/shared build
+
       - name: Typecheck UI
         run: bun -F @cline/ui typecheck
 
@@ -57,11 +63,6 @@ jobs:
 
       - name: Build UI package
         run: bun -F @cline/ui build
-
-      # The desktop chat test imports @cline/shared/browser, which resolves to
-      # dist output that nothing else in this job builds.
-      - name: Build shared package
-        run: bun -F @cline/shared build
 
       - name: Test desktop chat integration
         run: bun -F @cline/code test:chat-ui


### PR DESCRIPTION
First `ui-publish` dispatch since #13025 failed at the **Typecheck UI** step ([run](https://github.com/cline/cline/actions/runs/32202918254)):

```
components/generated-media.tsx(9,8): error TS2307: Cannot find module '@cline/shared/browser'
```

`generated-media` (added in #13025) imports `@cline/shared/browser`, which resolves to shared's **dist** output — but the workflow only built `@cline/shared` late in the job (just before the desktop chat test). Every earlier step that compiles the ui package (typecheck, tests, Storybook, build) now needs it, so this moves the build-shared step to immediately after install. Same fix I needed locally to build the package at all.

Blocking the `@cline/ui@0.2.0-next.5` publish; once merged I'll re-dispatch.