### PR TITLE
fix(cli): make TUI dialog colors follow theme changes live

### DIFF
--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -2,7 +2,7 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useMemo, useState } from "react";
-import { palette } from "../tui/palette";
+import { useDialogPalette } from "../tui/hooks/use-theme";
 import {
 	type DialogDismissKey,
 	isAnyKeyDismiss,
@@ -35,6 +35,7 @@ export function MigrationNoticeContent(
 	},
 ) {
 	const { dialogId, notice, resolve } = props;
+	const palette = useDialogPalette();
 	const subscriptionUrl = useMemo(() => getCliSubscriptionUrl(), []);
 	const [status, setStatus] = useState<string | undefined>();
 

--- a/apps/cli/src/tui/components/dialog-theme-sync.tsx
+++ b/apps/cli/src/tui/components/dialog-theme-sync.tsx
@@ -1,0 +1,44 @@
+import { useRenderer } from "@opentui/react";
+import { DialogContainerRenderable } from "@opentui-ui/dialog";
+import { useDialogState } from "@opentui-ui/dialog/react";
+import { useEffect } from "react";
+import { useTheme } from "../hooks/use-theme";
+import { getDialogSurface } from "../themes";
+
+/**
+ * Keeps dialog panel backgrounds in sync with the active theme.
+ *
+ * The dialog library computes a panel's style once when the dialog opens
+ * (from the container's dialogOptions), so theme changes made while a dialog
+ * is open — most visibly the live preview while scrolling the theme picker —
+ * would leave the panel on the old surface color. This component pushes the
+ * theme's dialog surface into the container (for dialogs opened later) and
+ * onto every open dialog renderable (repainting them in place).
+ *
+ * Must be mounted inside the DialogProvider. Re-runs when a dialog opens so
+ * the first dialog after mount is covered too (the container is only added
+ * to the renderer root after this component's initial effect).
+ */
+export function DialogThemeSync() {
+	const renderer = useRenderer();
+	const theme = useTheme();
+	const dialogCount = useDialogState((state: { count: number }) => state.count);
+	const surface = getDialogSurface(theme);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: dialogCount re-runs the sync when a dialog opens, covering dialogs opened before the container-level option applied (see docblock).
+	useEffect(() => {
+		const container = renderer.root
+			.getChildren()
+			.find(
+				(child): child is DialogContainerRenderable =>
+					child instanceof DialogContainerRenderable,
+			);
+		if (!container) return;
+		container.dialogOptions = { style: { backgroundColor: surface } };
+		for (const [, dialogRenderable] of container.getDialogRenderables()) {
+			dialogRenderable.backgroundColor = surface;
+		}
+	}, [renderer, surface, dialogCount]);
+
+	return null;
+}

--- a/apps/cli/src/tui/components/dialogs/account-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/account-dialog.tsx
@@ -8,7 +8,7 @@ import {
 	formatClineCredits,
 	isClineAccountAuthErrorMessage,
 } from "../../cline-account";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export type AccountDialogAction =
 	| "change-model"
@@ -121,6 +121,7 @@ function AccountActionRow(props: {
 	selected: boolean;
 	onSelect: () => void;
 }) {
+	const palette = useDialogPalette();
 	const fg = props.selected ? palette.textOnSelection : undefined;
 	return (
 		<box
@@ -161,6 +162,7 @@ function OrganizationRow(props: {
 	selected: boolean;
 	onSelect: () => void;
 }) {
+	const palette = useDialogPalette();
 	return (
 		<box
 			flexDirection="row"
@@ -234,6 +236,7 @@ export function AccountDialogContent(
 		switchAccount,
 		onAccountChange,
 	} = props;
+	const palette = useDialogPalette();
 	const [state, setState] = useState<AccountState>({
 		status: "loading",
 		message: "Loading account details...",

--- a/apps/cli/src/tui/components/dialogs/ask-question.tsx
+++ b/apps/cli/src/tui/components/dialogs/ask-question.tsx
@@ -2,7 +2,7 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useRef, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export function AskQuestionContent(
 	props: ChoiceContext<string | null> & {
@@ -11,6 +11,7 @@ export function AskQuestionContent(
 	},
 ) {
 	const { resolve, dialogId, question, options } = props;
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(0);
 	const [inputKey, setInputKey] = useState(0);
 	const customRef = useRef("");

--- a/apps/cli/src/tui/components/dialogs/checkpoint-confirm.tsx
+++ b/apps/cli/src/tui/components/dialogs/checkpoint-confirm.tsx
@@ -2,7 +2,7 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useRef, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export type CheckpointRestoreMode = "chat-only" | "chat-and-workspace";
 
@@ -29,6 +29,7 @@ export function CheckpointConfirmContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, messagePreview } = props;
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(0);
 	const selectedRef = useRef(0);
 	const selectedMode = OPTIONS[selected]?.value;

--- a/apps/cli/src/tui/components/dialogs/checkpoint-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/checkpoint-picker.tsx
@@ -2,7 +2,7 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useMemo, useRef, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export interface CheckpointPickerItem {
 	runCount: number;
@@ -36,6 +36,7 @@ export function CheckpointPickerContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, items } = props;
+	const palette = useDialogPalette();
 	const lastIndex = Math.max(0, items.length - 1);
 	const [selected, setSelected] = useState(lastIndex);
 	const selectedRef = useRef(lastIndex);

--- a/apps/cli/src/tui/components/dialogs/command-palette.tsx
+++ b/apps/cli/src/tui/components/dialogs/command-palette.tsx
@@ -3,7 +3,7 @@ import { useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useMemo, useRef, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 import {
 	buildCommandPaletteItems,
 	type CommandPaletteResult,
@@ -32,6 +32,7 @@ export function CommandPaletteContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, canForkSession, contentWidth } = props;
+	const palette = useDialogPalette();
 	const { height } = useTerminalDimensions();
 	const [query, setQuery] = useState("");
 	const [selected, setSelected] = useState(0);

--- a/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
@@ -1,12 +1,12 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useState } from "react";
+import { useDialogPalette } from "../../hooks/use-theme";
 import type {
 	InteractiveConfigData,
 	InteractiveConfigItem,
 	LoadInteractiveConfigDataOptions,
 } from "../../interactive-config";
-import { palette } from "../../palette";
 import {
 	getExtDetailFooterText,
 	getExtDetailRows,
@@ -23,6 +23,7 @@ export function ExtDetailContent(
 		) => Promise<InteractiveConfigData | undefined>;
 	},
 ) {
+	const palette = useDialogPalette();
 	const [item, setItem] = useState(props.item);
 	const [toggleError, setToggleError] = useState<string | undefined>();
 

--- a/apps/cli/src/tui/components/dialogs/help-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/help-dialog.tsx
@@ -1,7 +1,7 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 type HelpRow =
 	| { kind: "heading"; id: string; text: string }
@@ -255,6 +255,7 @@ const KEY_WIDTH = 20;
 
 export function HelpDialogContent(props: ChoiceContext<void>) {
 	const { dismiss, dialogId } = props;
+	const palette = useDialogPalette();
 
 	useDialogKeyboard((key) => {
 		if (

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
@@ -1,7 +1,7 @@
 // @jsxImportSource @opentui/react
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
 
 export interface HubUpdateRequiredDetails {
@@ -12,6 +12,7 @@ export function HubUpdateRequiredContent(
 	props: ChoiceContext<boolean> & HubUpdateRequiredDetails,
 ) {
 	const { dialogId, dismiss, hubCoreVersion, resolve } = props;
+	const palette = useDialogPalette();
 
 	useDialogKeyboard((key) => {
 		const action = resolveHubUpdateRequiredKeyAction(key);

--- a/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/mcp-manager-dialog.tsx
@@ -5,7 +5,7 @@ import {
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export interface McpEntry {
 	name: string;
@@ -70,6 +70,7 @@ export function McpManagerContent(
 		servers: McpEntry[];
 	},
 ) {
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(0);
 	const [servers, setServers] = useState(props.servers);
 	const [changed, setChanged] = useState(false);

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../../utils/codex-cli";
 import open from "../../../utils/open";
 import { listLocalProviders } from "../../../utils/provider-catalog";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 import {
 	getDefaultAwsRegion,
 	type ProviderConfigValues,
@@ -63,6 +63,7 @@ export function ProviderPickerContent(
 	props: ChoiceContext<string> & { currentProviderId: string },
 ) {
 	const { resolve, dismiss, dialogId, currentProviderId } = props;
+	const palette = useDialogPalette();
 	const [providers, setProviders] = useState<ProviderItem[]>([]);
 	const [search, setSearch] = useState("");
 	const [selected, setSelected] = useState(0);
@@ -272,6 +273,7 @@ export function UseExistingOrReconfigureContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, providerName, extraOptions } = props;
+	const palette = useDialogPalette();
 	const options: ExistingProviderOption[] = useMemo(
 		() => [
 			{ value: "use_existing", label: "Use existing configuration" },
@@ -351,6 +353,7 @@ function ClinePassBrowserPageContent(
 		url,
 		openedStatus,
 	} = props;
+	const palette = useDialogPalette();
 	const [status, setStatus] = useState("Opening browser...");
 
 	useEffect(() => {
@@ -489,6 +492,7 @@ export function ProviderConfigInputContent(
 		providerName,
 		providerSettingsManager,
 	} = props;
+	const palette = useDialogPalette();
 
 	const config = useMemo(
 		() => getProviderConfigFields(providerId),
@@ -656,6 +660,7 @@ export function CodexCliStatusContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, providerName } = props;
+	const palette = useDialogPalette();
 	const [status, setStatus] = useState<CodexCliStatus | undefined>();
 	const [checking, setChecking] = useState(false);
 
@@ -749,6 +754,7 @@ export function OAuthLoginContent(
 		providerName,
 		allowApiKeyFallback,
 	} = props;
+	const palette = useDialogPalette();
 	const [mode, setMode] = useState<"browser" | "device">(
 		providerId === "cline" ? "device" : "browser",
 	);
@@ -969,6 +975,7 @@ export function OAuthApiKeyInputContent(
 		providerName,
 		providerSettingsManager,
 	} = props;
+	const palette = useDialogPalette();
 	const [value, setValue] = useState("");
 
 	const submit = () => {

--- a/apps/cli/src/tui/components/dialogs/skills-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/skills-picker.tsx
@@ -3,7 +3,7 @@ import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useMemo, useRef, useState } from "react";
 import type { SlashCommandRegistryEntry } from "../../commands/slash-command-registry";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export const SKILLS_MARKETPLACE_ACTION = "__skills_marketplace__";
 export const SKILLS_MARKETPLACE_URL = "https://skills.sh/";
@@ -26,6 +26,7 @@ function matchesFilter(
 
 export function SkillsPickerContent(props: SkillsPickerContentProps) {
 	const { resolve, dismiss, dialogId, commands } = props;
+	const palette = useDialogPalette();
 	const { height, width } = useTerminalDimensions();
 	const [filter, setFilter] = useState("");
 	const [selected, setSelected] = useState(0);

--- a/apps/cli/src/tui/components/dialogs/theme-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/theme-picker.tsx
@@ -2,8 +2,7 @@ import { useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useEffect, useRef, useState } from "react";
-import { useThemeController } from "../../hooks/use-theme";
-import { palette } from "../../palette";
+import { useDialogPalette, useThemeController } from "../../hooks/use-theme";
 import { getThemeSwatchColors, THEMES } from "../../themes";
 
 const SWATCH_BLOCK = "\u25a0";
@@ -12,6 +11,7 @@ export function ThemePickerContent(props: ChoiceContext<string>) {
 	const { resolve, dismiss, dialogId } = props;
 	const { height } = useTerminalDimensions();
 	const controller = useThemeController();
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(() => {
 		const index = THEMES.findIndex(
 			(theme) => theme.id === controller.selectedThemeId,

--- a/apps/cli/src/tui/components/dialogs/tool-approval.tsx
+++ b/apps/cli/src/tui/components/dialogs/tool-approval.tsx
@@ -2,7 +2,7 @@ import type { ToolApprovalRequest } from "@cline/shared";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import type React from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 import {
 	buildReadFilesKeys,
 	parseApplyPatchInput,
@@ -139,6 +139,7 @@ export function formatApprovalParams(
 export function ToolApprovalContent(
 	props: ChoiceContext<boolean> & { request: ToolApprovalRequest },
 ) {
+	const palette = useDialogPalette();
 	useDialogKeyboard((key) => {
 		if (key.name === "y" || key.name === "return") {
 			props.resolve(true);

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.tsx
@@ -7,7 +7,8 @@ import {
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import "opentui-spinner/react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
+import type { DialogPalette } from "../../themes";
 import {
 	CLINE_MODEL_PICKER_TIER_LABELS,
 	type ClineModelPickerEntry,
@@ -24,7 +25,7 @@ export {
 	freeTierDescriptionFor,
 } from "./cline-model-entries";
 
-function tagColor(tag: string): string {
+function tagColor(tag: string, palette: DialogPalette): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
 	return palette.act;
@@ -58,6 +59,7 @@ export function ClineModelPicker(props: {
 	currentModelId?: string;
 }) {
 	const { entries, selected, loading, currentModelId } = props;
+	const palette = useDialogPalette();
 
 	if (loading) {
 		return (
@@ -119,7 +121,7 @@ export function ClineModelPicker(props: {
 					{tags.map((t) => (
 						<text
 							key={t}
-							fg={isSel ? palette.textOnSelection : tagColor(t)}
+							fg={isSel ? palette.textOnSelection : tagColor(t, palette)}
 							flexShrink={0}
 						>
 							{t}

--- a/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/cline-model-selector.tsx
@@ -2,7 +2,8 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
+import type { DialogPalette } from "../../themes";
 import {
 	CLINE_MODEL_PICKER_TIER_LABELS,
 	type ClineModelPickerEntry,
@@ -18,7 +19,7 @@ type ClineModelEntriesState =
 	| { status: "loaded"; entries: ClineModelPickerEntry[] }
 	| { status: "error"; message: string };
 
-function tagColor(tag: string): string {
+function tagColor(tag: string, palette: DialogPalette): string {
 	if (tag === "FREE") return palette.success;
 	if (tag === "BEST") return "magenta";
 	return palette.act;
@@ -39,6 +40,7 @@ export function ClineModelSelectorContent(
 		currentProviderName,
 		entries,
 	} = props;
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(0);
 	const [onProvider, setOnProvider] = useState(false);
 
@@ -188,7 +190,7 @@ export function ClineModelSelectorContent(
 							{row.tags.map((t) => (
 								<text
 									key={t}
-									fg={isSel ? palette.textOnSelection : tagColor(t)}
+									fg={isSel ? palette.textOnSelection : tagColor(t, palette)}
 									flexShrink={0}
 								>
 									{t}
@@ -222,6 +224,7 @@ export function ClineModelSelectorDialogContent(
 	},
 ) {
 	const { dismiss, dialogId, loadEntries } = props;
+	const palette = useDialogPalette();
 	const [state, setState] = useState<ClineModelEntriesState>({
 		status: "loading",
 		message: "Loading Cline models...",

--- a/apps/cli/src/tui/components/model-selector/model-selector.tsx
+++ b/apps/cli/src/tui/components/model-selector/model-selector.tsx
@@ -3,7 +3,7 @@ import type { Llms } from "@cline/core";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useMemo, useState } from "react";
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 import { ProviderRow } from "./provider-row";
 
 export interface ModelOption {
@@ -65,6 +65,7 @@ export function ModelIdInputContent(
 ) {
 	const { resolve, dismiss, dialogId, currentModel, currentProviderName } =
 		props;
+	const palette = useDialogPalette();
 	const [modelId, setModelId] = useState(currentModel);
 	const [error, setError] = useState("");
 	const [onProvider, setOnProvider] = useState(false);
@@ -328,6 +329,7 @@ export function ThinkingLevelContent(
 	},
 ) {
 	const { resolve, dismiss, dialogId, modelName, currentLevel } = props;
+	const palette = useDialogPalette();
 	const [selected, setSelected] = useState(() => {
 		const initialLevel = currentLevel === "none" ? "medium" : currentLevel;
 		const idx = THINKING_LEVELS.findIndex((l) => l.value === initialLevel);
@@ -516,6 +518,7 @@ function CreateCustomModelRow(props: {
 	onSelect: () => void;
 }) {
 	const { isSelected, dimmed, onSelect } = props;
+	const palette = useDialogPalette();
 	const active = isSelected && !dimmed;
 	const bg = active
 		? palette.selection
@@ -553,6 +556,7 @@ function ModelRow(props: {
 	onSelect: (key: string) => void;
 }) {
 	const { model, isSelected, dimmed, isCurrent, onSelect } = props;
+	const palette = useDialogPalette();
 	const active = isSelected && !dimmed;
 	const bg = active
 		? palette.selection

--- a/apps/cli/src/tui/components/model-selector/provider-row.tsx
+++ b/apps/cli/src/tui/components/model-selector/provider-row.tsx
@@ -1,5 +1,5 @@
 // @jsxImportSource @opentui/react
-import { palette } from "../../palette";
+import { useDialogPalette } from "../../hooks/use-theme";
 
 export function ProviderRow({
 	providerName,
@@ -8,6 +8,7 @@ export function ProviderRow({
 	providerName: string;
 	focused: boolean;
 }) {
+	const palette = useDialogPalette();
 	return (
 		<box flexDirection="row" paddingX={1} gap={1}>
 			<text fg={focused ? palette.selection : "gray"} flexShrink={0}>

--- a/apps/cli/src/tui/hooks/use-theme.ts
+++ b/apps/cli/src/tui/hooks/use-theme.ts
@@ -1,6 +1,12 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 import type { TerminalTheme } from "../palette";
-import { AUTO_THEME_ID, type ResolvedTheme, resolveTheme } from "../themes";
+import {
+	AUTO_THEME_ID,
+	type DialogPalette,
+	getDialogPalette,
+	type ResolvedTheme,
+	resolveTheme,
+} from "../themes";
 
 export interface TerminalColors {
 	background: string | null;
@@ -39,6 +45,17 @@ export function useTheme(): ResolvedTheme {
 	// Fall back to auto resolution so components render sensibly when mounted
 	// without a ThemeProvider (e.g. in isolated tests).
 	return controller?.theme ?? resolveTheme(AUTO_THEME_ID, detected);
+}
+
+/**
+ * Theme-following colors for dialog content. Unlike the static `palette`
+ * constant, this re-resolves whenever the active theme changes, so open
+ * dialogs repaint live during theme previews (e.g. scrolling the theme
+ * picker).
+ */
+export function useDialogPalette(): DialogPalette {
+	const theme = useTheme();
+	return useMemo(() => getDialogPalette(theme), [theme]);
 }
 
 /**

--- a/apps/cli/src/tui/palette.ts
+++ b/apps/cli/src/tui/palette.ts
@@ -169,6 +169,15 @@ export function getUserMessageBackground(terminalBg: string | null): string {
 	return liftedFromTerminalBg(terminalBg, BASE_LIFT, 0, 0);
 }
 
+// Dialog panels lift the theme background the same way, but a touch softer:
+// they cover a large area and sit over a dimmed backdrop, so a smaller step
+// already reads as "raised" without washing out the theme's hue.
+const DIALOG_SURFACE_LIFT = 0.16;
+
+export function getDialogSurfaceBackground(terminalBg: string | null): string {
+	return liftedFromTerminalBg(terminalBg, DIALOG_SURFACE_LIFT, 0, 0);
+}
+
 export function getModeInputForeground(
 	mode: string,
 	terminalBg: string | null,

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -23,6 +23,7 @@ import {
 } from "../utils/repo-status";
 import { buildCheckpointPickerItems } from "./checkpoint-picker-items";
 import type { TranscriptScrollHandle } from "./components/chat-message-list";
+import { DialogThemeSync } from "./components/dialog-theme-sync";
 import {
 	CheckpointConfirmContent,
 	type CheckpointRestoreMode,
@@ -1038,6 +1039,7 @@ export function Root(
 		<TerminalColorsContext value={terminalColors}>
 			<ThemeProvider initialThemeId={props.initialThemeId}>
 				<DialogProvider size="medium">
+					<DialogThemeSync />
 					<SessionProvider
 						config={props.config}
 						initialEntries={initialEntries}

--- a/apps/cli/src/tui/themes.test.ts
+++ b/apps/cli/src/tui/themes.test.ts
@@ -3,6 +3,7 @@ import { diffPalettes, themePalette } from "./palette";
 import {
 	AUTO_THEME_ID,
 	getDialogAccents,
+	getDialogPalette,
 	getThemeDefinition,
 	getThemeModeAccent,
 	getThemeSwatchColors,
@@ -163,5 +164,28 @@ describe("theme helpers", () => {
 	it("getThemeDefinition finds registered themes", () => {
 		expect(getThemeDefinition("gruvbox-dark")?.label).toBe("Gruvbox Dark");
 		expect(getThemeDefinition("missing")).toBeUndefined();
+	});
+
+	it("getDialogPalette follows the theme's dialog accents", () => {
+		const dracula = getDialogPalette(resolveTheme("dracula", noDetection));
+		expect(dracula.act).toBe("#bd93f9");
+		expect(dracula.selection).toBe("#bd93f9");
+		expect(dracula.success).toBe("#50fa7b");
+		expect(dracula.error).toBe("#ff5555");
+		expect(dracula.textOnSelection).toBe("#000000");
+
+		// Light themes fall back to dark accents (dialog surfaces stay dark).
+		const solarizedLight = getDialogPalette(
+			resolveTheme("solarized-light", noDetection),
+		);
+		expect(solarizedLight.act).toBe(themePalette.dark.act);
+
+		for (const definition of THEMES) {
+			const dialogPalette = getDialogPalette(
+				resolveTheme(definition.id, noDetection),
+			);
+			expect(dialogPalette.selection).toBe(dialogPalette.act);
+			expect(["#000000", "#ffffff"]).toContain(dialogPalette.textOnSelection);
+		}
 	});
 });

--- a/apps/cli/src/tui/themes.test.ts
+++ b/apps/cli/src/tui/themes.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { diffPalettes, themePalette } from "./palette";
 import {
 	AUTO_THEME_ID,
+	DEFAULT_DIALOG_SURFACE,
 	getDialogAccents,
 	getDialogPalette,
+	getDialogSurface,
 	getThemeDefinition,
 	getThemeModeAccent,
 	getThemeSwatchColors,
@@ -187,5 +189,44 @@ describe("theme helpers", () => {
 			expect(dialogPalette.selection).toBe(dialogPalette.act);
 			expect(["#000000", "#ffffff"]).toContain(dialogPalette.textOnSelection);
 		}
+	});
+
+	it("getDialogSurface lifts dark theme backgrounds and keeps hue", () => {
+		// Dark themes derive the panel from their own background: a different,
+		// lighter color than both the background and the neutral default.
+		for (const id of ["tokyo-night", "dracula", "gruvbox-dark", "nord"]) {
+			const theme = resolveTheme(id, noDetection);
+			const surface = getDialogSurface(theme);
+			expect(surface).toMatch(/^#[0-9a-f]{6}$/i);
+			expect(surface).not.toBe(theme.background);
+			expect(surface).not.toBe(DEFAULT_DIALOG_SURFACE);
+		}
+
+		// Auto with no detected background has nothing to derive from.
+		expect(getDialogSurface(resolveTheme(AUTO_THEME_ID, noDetection))).toBe(
+			DEFAULT_DIALOG_SURFACE,
+		);
+		// Auto on a detected dark terminal lifts the detected background.
+		expect(
+			getDialogSurface(
+				resolveTheme(AUTO_THEME_ID, {
+					background: "#000000",
+					foreground: null,
+				}),
+			),
+		).not.toBe(DEFAULT_DIALOG_SURFACE);
+
+		// Light themes keep the neutral dark panel (dialog content still uses
+		// the dark accent fallback, and hardcoded light text must stay legible).
+		expect(getDialogSurface(resolveTheme("light", noDetection))).toBe(
+			DEFAULT_DIALOG_SURFACE,
+		);
+		expect(getDialogSurface(resolveTheme("solarized-light", noDetection))).toBe(
+			DEFAULT_DIALOG_SURFACE,
+		);
+
+		// The palette exposes the same surface.
+		const dracula = resolveTheme("dracula", noDetection);
+		expect(getDialogPalette(dracula).surface).toBe(getDialogSurface(dracula));
 	});
 });

--- a/apps/cli/src/tui/themes.ts
+++ b/apps/cli/src/tui/themes.ts
@@ -567,6 +567,32 @@ export function getDialogAccents(theme: ResolvedTheme): ThemeAccents {
 	return theme.variant === "dark" ? theme.accents : baseAccents.dark;
 }
 
+/**
+ * Colors for content rendered on the always-dark dialog surface, following
+ * the active theme's accents (see getDialogAccents). Mirrors the shape of
+ * the static `palette` so dialog components can consume it as a drop-in
+ * replacement that re-resolves on every theme change (including previews).
+ */
+export interface DialogPalette extends ThemeAccents {
+	selection: string;
+	textOnSelection: string;
+	muted: string;
+}
+
+export function getDialogPalette(theme: ResolvedTheme): DialogPalette {
+	const accents = getDialogAccents(theme);
+	const selection = accents.act;
+	return {
+		...accents,
+		selection,
+		textOnSelection:
+			relativeLuminance(selection) > WHITE_TEXT_LUMINANCE_CUTOFF
+				? "#000000"
+				: "#ffffff",
+		muted: "gray",
+	};
+}
+
 /** Small color strip rendered next to each entry in the theme picker. */
 export function getThemeSwatchColors(definition: ThemeDefinition): string[] {
 	const variant = definition.variant === "auto" ? "dark" : definition.variant;

--- a/apps/cli/src/tui/themes.ts
+++ b/apps/cli/src/tui/themes.ts
@@ -1,6 +1,7 @@
 import {
 	diffPalettes,
 	getDefaultForeground,
+	getDialogSurfaceBackground,
 	getTerminalTheme,
 	hexToOklab,
 	oklabToHex,
@@ -567,6 +568,24 @@ export function getDialogAccents(theme: ResolvedTheme): ThemeAccents {
 	return theme.variant === "dark" ? theme.accents : baseAccents.dark;
 }
 
+/** Neutral dark panel used when no theme background is available to derive
+ * a surface from (auto theme on an undetected terminal, light themes). */
+export const DEFAULT_DIALOG_SURFACE = "#262626";
+
+/**
+ * Background for dialog panels. Dark themes get their own background lifted
+ * one perceptual step (OKLAB), so the panel keeps the theme's hue and reads
+ * as a raised surface of the same world. Light themes and undetectable
+ * backgrounds keep the neutral dark panel that matches the dark accent
+ * fallback in getDialogAccents.
+ */
+export function getDialogSurface(theme: ResolvedTheme): string {
+	if (theme.variant !== "dark" || !theme.background) {
+		return DEFAULT_DIALOG_SURFACE;
+	}
+	return getDialogSurfaceBackground(theme.background);
+}
+
 /**
  * Colors for content rendered on the always-dark dialog surface, following
  * the active theme's accents (see getDialogAccents). Mirrors the shape of
@@ -577,6 +596,8 @@ export interface DialogPalette extends ThemeAccents {
 	selection: string;
 	textOnSelection: string;
 	muted: string;
+	/** Panel background the dialog content is rendered on. */
+	surface: string;
 }
 
 export function getDialogPalette(theme: ResolvedTheme): DialogPalette {
@@ -590,6 +611,7 @@ export function getDialogPalette(theme: ResolvedTheme): DialogPalette {
 				? "#000000"
 				: "#ffffff",
 		muted: "gray",
+		surface: getDialogSurface(theme),
 	};
 }
 

--- a/apps/cli/src/tui/views/config-view.tsx
+++ b/apps/cli/src/tui/views/config-view.tsx
@@ -16,9 +16,8 @@ import {
 import type { CliCompactionMode, Config } from "../../utils/types";
 import { getMcpManagerEntryStatus } from "../components/dialogs/mcp-manager-dialog";
 import { resolveModelDisplayName } from "../components/status-bar";
-import { useThemeController } from "../hooks/use-theme";
-import { palette } from "../palette";
-import { getDialogAccents, getThemeDefinition } from "../themes";
+import { useDialogPalette, useThemeController } from "../hooks/use-theme";
+import { type DialogPalette, getThemeDefinition } from "../themes";
 import {
 	type ConfigAction,
 	canDeleteConfigFooterRow,
@@ -118,11 +117,13 @@ function getVisibleWindow<T>(
 	return { items: items.slice(start, end), startIndex: start };
 }
 
-const COMPACTION_MODE_COLORS: Record<CliCompactionMode, string> = {
-	agentic: palette.success,
-	basic: "yellow",
-	off: "gray",
-};
+function getCompactionModeColor(
+	mode: CliCompactionMode,
+	palette: DialogPalette,
+): string {
+	if (mode === "agentic") return palette.success;
+	return mode === "basic" ? "yellow" : "gray";
+}
 
 export interface ConfigPanelProps extends ChoiceContext<ConfigAction> {
 	config: Config;
@@ -409,7 +410,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [toggleError, setToggleError] = useState<string | undefined>();
 	const [navPos, setNavPos] = useState(0);
 	const themeController = useThemeController();
-	const dialogAccents = getDialogAccents(themeController.theme);
+	const palette = useDialogPalette();
 	const currentThemeLabel =
 		getThemeDefinition(themeController.selectedThemeId)?.label ?? "Auto";
 
@@ -823,11 +824,10 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 						let valueColor: string;
 						if (row.id === "mode") {
 							value = mode === "plan" ? "Plan" : "Act";
-							valueColor =
-								mode === "plan" ? dialogAccents.plan : dialogAccents.act;
+							valueColor = mode === "plan" ? palette.plan : palette.act;
 						} else if (row.id === "theme") {
 							value = currentThemeLabel;
-							valueColor = dialogAccents.act;
+							valueColor = palette.act;
 						} else if (row.id === "auto-approve") {
 							value = autoApprove ? "● on" : "○ off";
 							valueColor = autoApprove ? palette.success : "gray";
@@ -836,7 +836,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 							valueColor = autoUpdateEnabled ? palette.success : "gray";
 						} else if (row.id === "compaction") {
 							value = formatCliCompactionMode(compactionMode);
-							valueColor = COMPACTION_MODE_COLORS[compactionMode];
+							valueColor = getCompactionModeColor(compactionMode, palette);
 						} else {
 							value = verbose ? "● on" : "○ off";
 							valueColor = verbose ? palette.success : "gray";

--- a/apps/cli/src/tui/views/history-view.tsx
+++ b/apps/cli/src/tui/views/history-view.tsx
@@ -15,7 +15,7 @@ import { listSessions } from "../../session/session";
 import { mergeHistoryStatusRows } from "../../utils/history-format";
 import { formatUsd } from "../../utils/output";
 import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
-import { palette } from "../palette";
+import { useDialogPalette } from "../hooks/use-theme";
 import {
 	buildHistoryFooterText,
 	HISTORY_EXPORT_OPTIONS,
@@ -98,6 +98,7 @@ function HistoryListContent({
 	refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS,
 	registerKeyHandler,
 }: HistoryListContentProps) {
+	const palette = useDialogPalette();
 	const { width } = useTerminalDimensions();
 	const [rows, setRows] = useState<SessionHistoryRecord[]>(
 		() => initialRows ?? [],


### PR DESCRIPTION
### Description

When scrolling through themes in the TUI theme picker, the whole app repaints with the previewed theme, but dialogs did not: their content kept the default dark-blue accents, and the panel background stayed the dialog library's fixed `#262626`. Two causes: dialog components read colors from the static `palette` constant in `apps/cli/src/tui/palette.ts` (never changes), and `@opentui-ui/dialog` computes a panel's style once when the dialog opens.

This PR makes both dialog content and the dialog panel theme-reactive:

**Content colors**
- Adds `getDialogPalette(theme)` in `themes.ts`: builds a palette-shaped set of colors (act, plan, success, error, selection, textOnSelection, muted, surface) from the active theme's dialog accents (`getDialogAccents`, so light themes still fall back to dark accents on the dark dialog surface), with WCAG-based black/white selection text.
- Adds a `useDialogPalette()` hook in `hooks/use-theme.ts` that re-resolves whenever the active theme changes, including previews.
- Migrates every dialog-rendered component off the static `palette` constant: all of `components/dialogs/*`, `components/model-selector/*`, `views/history-view.tsx`, `views/config-view.tsx`, and `kanban-migration/notice-dialog.tsx`.

**Panel background**
- Adds `getDialogSurface(theme)`: dark themes lift their own background one perceptual OKLAB step (reusing the same adaptive-lift machinery as the input field and user bubbles), so the panel keeps the theme's hue and reads as a raised surface of the same world. Light themes and undetectable backgrounds keep the neutral dark panel, matching the dark accent fallback and the light-on-dark dialog text.
- Adds `DialogThemeSync` (mounted inside `DialogProvider`): pushes the surface into the dialog container's `dialogOptions` for dialogs opened later, and repaints already-open dialog renderables in place, so the panel follows live previews while the theme picker is open.

### Test Procedure

- `bun run typecheck` in `apps/cli` passes.
- `bun -F @cline/cli test:unit`: 1153 tests pass, including new unit tests for `getDialogPalette` (per-theme accents, selection color, contrast text, light-theme fallback) and `getDialogSurface` (hue-preserving lift for dark themes, neutral fallback for light/undetected).
- Manual TUI test via tuistory: opened `/theme` and scrolled through themes; the dialog's panel background, selection highlight, and accents all update live per previewed theme, and the settings dialog matches the applied theme afterward.

Dracula preview: violet-gray panel lifted from `#282a36`, purple selection:

![Theme picker previewing Dracula with violet-gray panel and purple selection](https://cursor.com/artifacts/c/art-b3398645-0630-4aa4-abac-2378afc4dcb1)

Gruvbox Dark preview: warm gray panel, amber accents:

![Theme picker previewing Gruvbox Dark with warm gray panel](https://cursor.com/artifacts/c/art-2194b3ef-4c63-4357-860b-59f9886f180a)

Solarized Dark preview: teal panel lifted from `#002b36`:

![Theme picker previewing Solarized Dark with teal panel](https://cursor.com/artifacts/c/art-68d13aaa-aee4-42ab-b7cc-43b2ec74dc3f)

Settings dialog after applying Catppuccin Mocha: mocha-lifted panel, themed tab highlight and value accents:

![Settings dialog with Catppuccin Mocha panel and accents](https://cursor.com/artifacts/c/art-c986056b-b139-46a0-9dcb-98d5e4de2b7c)

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Code
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📝 Documentation update
- [ ] 🔧 Chore

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (not applicable: changesets in this repo version the `claude-dev` extension; this change is CLI-only)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)