### PR TITLE
docs: add GLM-5.3 to ClinePass models and reference pricing

### DIFF
--- a/docs/getting-started/clinepass.mdx
+++ b/docs/getting-started/clinepass.mdx
@@ -49,6 +49,7 @@ ClinePass includes the following models, tested and benchmarked for coding agent
 
 | Model | Model ID |
 |-------|------------|
+| GLM-5.3 | `cline-pass/glm-5.3` |
 | GLM-5.2 | `cline-pass/glm-5.2` |
 | Kimi K3 | `cline-pass/kimi-k3` |
 | Kimi K2.7 Code | `cline-pass/kimi-k2.7-code` |
@@ -92,6 +93,7 @@ ClinePass is a flat monthly subscription, so you are not charged the individual 
 
 | Model | Input | Output | Cached Read | Cached Write |
 |-------|-------|--------|-------------|--------------|
+| GLM-5.3 | $1.40 | $4.40 | $0.26 | - |
 | GLM-5.2 | $1.40 | $4.40 | $0.26 | - |
 | Kimi K3 | $3.00 | $15.00 | $0.30 | - |
 | Kimi K2.7 Code | $0.95 | $4.00 | $0.19 | - |


### PR DESCRIPTION
### Related Issue

N/A (docs catch-up for the GLM 5.3 ClinePass launch)

### Description

GLM 5.3 went live on ClinePass on Aug 14 but `docs/getting-started/clinepass.mdx` was never updated. This adds GLM-5.3 (`cline-pass/glm-5.3`) to the Models table and to the Reference pricing table.

Pricing is the same as GLM-5.2 (input $1.40/M, output $4.40/M, cached read $0.26/M), as confirmed by the provider when the model launched.

Note: PR #13312 (DeepSeek peak/off-peak pricing) happens to carry the same two GLM-5.3 rows on its branch, but it is scoped to DeepSeek pricing and still open. This PR is the focused GLM-5.3 fix; whichever merges second will have a trivial adjacent-line conflict to resolve.

### Test Procedure

Ran `bun run check` (`mintlify broken-links`) in `docs/` - no broken links, page parses cleanly. Change is two markdown table rows with no links or components.

### Type of Change

-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (markdown table rows only)

### Additional Notes

Model ID matches the catalog entry `cline-pass/glm-5.3` in `sdk/packages/llms/src/catalog/catalog.generated.ts`.