### PR TITLE
feat(desktop): show and stop active monitors

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1187,6 +1187,26 @@ export async function handleCommand(
 					: 0,
 		};
 	}
+	if (command === "stop_monitor") {
+		const sessionId = String(args?.sessionId ?? "").trim();
+		const monitorId = String(args?.monitorId ?? "").trim();
+		if (!sessionId || !monitorId) {
+			throw new Error("sessionId and monitorId are required");
+		}
+		const hubClient = await ensureSharedHubClient(
+			ctx,
+			ctx.sessionManager?.runtimeAddress,
+		);
+		const reply = await hubClient.command(
+			"run.stop_monitor",
+			{ sessionId, monitorId },
+			sessionId,
+		);
+		if (!reply.ok) {
+			throw new Error(reply.error?.message ?? "Could not stop monitor.");
+		}
+		return { stopped: reply.payload?.stopped === true };
+	}
 
 	// ── Session data reading ──────────────────────────────────────────
 	if (command === "read_session_messages") {

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -274,6 +274,31 @@ describe("Code sidecar runtime capabilities", () => {
 		);
 	});
 
+	it("forwards monitor stop requests to the hub", async () => {
+		const { createSidecarContext, initializeSessionManager } = await import(
+			"./context"
+		);
+		const { handleCommand } = await import("./commands");
+		hubCommandMock.mockResolvedValue({
+			ok: true,
+			payload: { stopped: true },
+		});
+		const ctx = createSidecarContext("/workspace/project");
+		await initializeSessionManager(ctx);
+
+		await expect(
+			handleCommand(ctx, "stop_monitor", {
+				sessionId: "session-1",
+				monitorId: "mon_1",
+			}),
+		).resolves.toEqual({ stopped: true });
+		expect(hubCommandMock).toHaveBeenCalledWith(
+			"run.stop_monitor",
+			{ sessionId: "session-1", monitorId: "mon_1" },
+			"session-1",
+		);
+	});
+
 	it("serializes queued image data when a queued prompt starts", async () => {
 		const { serializeQueuedPromptStart } = await import("./context");
 

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -81,7 +81,11 @@ import {
 	type SessionHistoryItem,
 	type SessionMetadata,
 } from "@/lib/session-history";
-import { buildActiveSessionMonitors } from "@/lib/session-monitors";
+import {
+	buildActiveSessionMonitors,
+	monitorSuppressionKey,
+	pruneMonitorSuppressions,
+} from "@/lib/session-monitors";
 import { syncHubAccent, syncHubTheme, watchSystemHubTheme } from "@/lib/theme";
 import {
 	filterWorkspacePaths,
@@ -1426,12 +1430,20 @@ function ChatThreadPane({
 	const [manuallyStoppedMonitors, setManuallyStoppedMonitors] = useState<
 		Set<string>
 	>(() => new Set());
+	// Once a stopped monitor's terminal marker lands in the transcript its
+	// suppression has done its job. Monitor ids restart at mon_1 with every
+	// runtime rebuild, so a stale key would hide an unrelated future monitor.
+	useEffect(() => {
+		setManuallyStoppedMonitors((current) =>
+			pruneMonitorSuppressions(current, activeMonitors, displayedSessionId),
+		);
+	}, [activeMonitors, displayedSessionId]);
 	const visibleActiveMonitors = useMemo(
 		() =>
 			activeMonitors.filter(
 				(monitor) =>
 					!manuallyStoppedMonitors.has(
-						`${displayedSessionId ?? ""}:${monitor.id}`,
+						monitorSuppressionKey(displayedSessionId, monitor.id),
 					),
 			),
 		[activeMonitors, displayedSessionId, manuallyStoppedMonitors],
@@ -1450,7 +1462,9 @@ function ChatThreadPane({
 					throw new Error("The monitor is no longer running.");
 				}
 				setManuallyStoppedMonitors((current) =>
-					new Set(current).add(`${displayedSessionId}:${monitorId}`),
+					new Set(current).add(
+						monitorSuppressionKey(displayedSessionId, monitorId),
+					),
 				);
 			} catch (error) {
 				toast({

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -81,6 +81,7 @@ import {
 	type SessionHistoryItem,
 	type SessionMetadata,
 } from "@/lib/session-history";
+import { buildActiveSessionMonitors } from "@/lib/session-monitors";
 import { syncHubAccent, syncHubTheme, watchSystemHubTheme } from "@/lib/theme";
 import {
 	filterWorkspacePaths,
@@ -1418,6 +1419,50 @@ function ChatThreadPane({
 			}),
 		[agents, derivedAgentActivity, isSessionActive],
 	);
+	const activeMonitors = useMemo(
+		() => buildActiveSessionMonitors(displayedMessages),
+		[displayedMessages],
+	);
+	const [manuallyStoppedMonitors, setManuallyStoppedMonitors] = useState<
+		Set<string>
+	>(() => new Set());
+	const visibleActiveMonitors = useMemo(
+		() =>
+			activeMonitors.filter(
+				(monitor) =>
+					!manuallyStoppedMonitors.has(
+						`${displayedSessionId ?? ""}:${monitor.id}`,
+					),
+			),
+		[activeMonitors, displayedSessionId, manuallyStoppedMonitors],
+	);
+	const handleStopMonitor = useCallback(
+		async (monitorId: string) => {
+			if (!displayedSessionId) {
+				throw new Error("No active session.");
+			}
+			try {
+				const response = await desktopClient.invoke<{ stopped?: boolean }>(
+					"stop_monitor",
+					{ sessionId: displayedSessionId, monitorId },
+				);
+				if (!response.stopped) {
+					throw new Error("The monitor is no longer running.");
+				}
+				setManuallyStoppedMonitors((current) =>
+					new Set(current).add(`${displayedSessionId}:${monitorId}`),
+				);
+			} catch (error) {
+				toast({
+					title: "Unable to stop monitor",
+					description: error instanceof Error ? error.message : String(error),
+					variant: "destructive",
+				});
+				throw error;
+			}
+		},
+		[displayedSessionId],
+	);
 	// A child agent has its own session row, so opening it goes through the same
 	// path as any other session — it is just never listed in the sidebar.
 	const onOpenAgentSession = useCallback(
@@ -1576,6 +1621,7 @@ function ChatThreadPane({
 				{!isWelcomeState ? (
 					<div className="cline-view-enter z-20 border-b border-border/70 bg-background/85 backdrop-blur-sm">
 						<AgentHeader
+							activeMonitors={visibleActiveMonitors}
 							agentActivity={agentActivity}
 							agents={agents}
 							agentsError={agentsError}
@@ -1583,6 +1629,7 @@ function ChatThreadPane({
 							onAgentsOpenChange={setAgentPanelOpen}
 							onOpenAgentSession={onOpenAgentSession}
 							onOpenParentSession={onOpenSessionById}
+							onStopMonitor={handleStopMonitor}
 							parentSession={hideDeletedSessionUi ? undefined : parentSession}
 							canEditTitle={Boolean(activeSessionForTitle)}
 							canDeleteSession={Boolean(activeSessionToDelete)}

--- a/apps/examples/desktop-app/webview/components/agent-header.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.test.tsx
@@ -191,6 +191,72 @@ describe("AgentHeader agent activity", () => {
 	});
 });
 
+describe("AgentHeader monitor activity", () => {
+	it("shows active monitors immediately after agent activity", async () => {
+		await act(async () => {
+			root.render(
+				<AgentHeader
+					activeMonitors={[{ id: "mon_1", name: "ci" }]}
+					agentActivity={{
+						total: 1,
+						running: 1,
+						completed: 0,
+						failed: 0,
+						cancelled: 0,
+						unresolved: 0,
+					}}
+					status="running"
+					title="S"
+				/>,
+			);
+		});
+
+		const activity = container.querySelector("#monitor-activity");
+		expect(activity?.getAttribute("aria-label")).toBe("1 monitor running: ci");
+		expect(activity?.textContent).toBe("1");
+		expect(container.querySelector("#agent-activity")?.nextElementSibling).toBe(
+			activity,
+		);
+	});
+
+	it("stays hidden when no monitor is running", async () => {
+		await act(async () => {
+			root.render(
+				<AgentHeader activeMonitors={[]} status="completed" title="S" />,
+			);
+		});
+		expect(container.querySelector("#monitor-activity")).toBeNull();
+	});
+
+	it("lets the user stop a running monitor", async () => {
+		const onStopMonitor = vi.fn().mockResolvedValue(undefined);
+		await act(async () => {
+			root.render(
+				<AgentHeader
+					activeMonitors={[{ id: "mon_7", name: "build" }]}
+					onStopMonitor={onStopMonitor}
+					status="running"
+					title="S"
+				/>,
+			);
+		});
+
+		await act(async () => {
+			(
+				container.querySelector("#monitor-activity") as HTMLButtonElement
+			).click();
+		});
+		const stop = document.querySelector<HTMLButtonElement>(
+			'button[aria-label="Stop monitor build"]',
+		);
+		expect(stop).not.toBeNull();
+		await act(async () => {
+			stop?.click();
+		});
+		expect(onStopMonitor).toHaveBeenCalledWith("mon_7");
+	});
+});
+
 describe("AgentHeader agent roster popover", () => {
 	const ACTIVITY = {
 		total: 2,

--- a/apps/examples/desktop-app/webview/components/agent-header.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-header.tsx
@@ -2,6 +2,7 @@
 
 import { SessionStatus } from "@cline/ui";
 import {
+	Activity,
 	AlertCircle,
 	Bot,
 	Check,
@@ -22,6 +23,7 @@ import {
 	type SessionAgentEntry,
 	type SessionAgentRunState,
 } from "@/lib/session-agents";
+import type { SessionMonitor } from "@/lib/session-monitors";
 import { sessionStatusColor, sessionStatusTone } from "@/lib/session-status";
 import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
@@ -52,11 +54,13 @@ type AgentHeaderProps = {
 		deletions: number;
 	};
 	agentActivity?: SessionAgentActivity;
+	activeMonitors?: SessionMonitor[];
 	agents?: SessionAgentEntry[];
 	agentsLoading?: boolean;
 	agentsError?: string | null;
 	onAgentsOpenChange?: (open: boolean) => void;
 	onOpenAgentSession?: (agentSessionId: string) => void | Promise<void>;
+	onStopMonitor?: (monitorId: string) => Promise<void> | void;
 	/** Set when the open session is itself a child agent run. */
 	parentSession?: { sessionId: string; title?: string };
 	onOpenParentSession?: (parentSessionId: string) => void | Promise<void>;
@@ -76,11 +80,13 @@ function AgentHeaderImpl({
 	status,
 	diff,
 	agentActivity,
+	activeMonitors,
 	agents,
 	agentsLoading = false,
 	agentsError = null,
 	onAgentsOpenChange,
 	onOpenAgentSession,
+	onStopMonitor,
 	parentSession,
 	onOpenParentSession,
 }: AgentHeaderProps) {
@@ -234,6 +240,10 @@ function AgentHeaderImpl({
 						onOpenAgentSession={onOpenAgentSession}
 						onOpenChange={onAgentsOpenChange}
 					/>
+					<MonitorActivityStatus
+						monitors={activeMonitors}
+						onStopMonitor={onStopMonitor}
+					/>
 					{additions !== 0 && (
 						<Button
 							aria-label={`Open diff: ${additions} additions, ${deletions} deletions`}
@@ -283,6 +293,95 @@ function AgentHeaderImpl({
 // otherwise re-render on every stream flush; its props are kept
 // referentially stable by the chat pane.
 export const AgentHeader = memo(AgentHeaderImpl);
+
+function MonitorActivityStatus({
+	monitors,
+	onStopMonitor,
+}: {
+	monitors?: SessionMonitor[];
+	onStopMonitor?: (monitorId: string) => Promise<void> | void;
+}) {
+	const [stopping, setStopping] = useState<Set<string>>(() => new Set());
+	if (!monitors?.length) {
+		return null;
+	}
+	const count = monitors.length;
+	const names = monitors.map((monitor) => monitor.name).join(", ");
+	const label = `${count} ${count === 1 ? "monitor" : "monitors"} running: ${names}`;
+
+	const stopMonitor = async (monitorId: string) => {
+		setStopping((current) => new Set(current).add(monitorId));
+		try {
+			await onStopMonitor?.(monitorId);
+		} catch {
+			// The owning view reports the failure; keep this control retryable.
+		} finally {
+			setStopping((current) => {
+				const next = new Set(current);
+				next.delete(monitorId);
+				return next;
+			});
+		}
+	};
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					aria-label={label}
+					className="flex items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-xs font-mono text-muted-foreground transition-colors hover:bg-secondary/80"
+					id="monitor-activity"
+					size="sm"
+					title={label}
+					type="button"
+					variant="secondary"
+				>
+					<Activity aria-hidden="true" className="size-3 animate-pulse" />
+					<span className="text-foreground">{count}</span>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-80 overflow-hidden p-0">
+				<div className="border-b border-border/70 px-3 py-2">
+					<div className="text-sm font-medium text-foreground">
+						Running monitors
+					</div>
+				</div>
+				<ul className="divide-y divide-border/60">
+					{monitors.map((monitor) => {
+						const isStopping = stopping.has(monitor.id);
+						return (
+							<li
+								className="flex min-w-0 items-center gap-2 px-3 py-2"
+								key={monitor.id}
+							>
+								<Activity
+									aria-hidden="true"
+									className="size-3.5 shrink-0 animate-pulse text-foreground"
+								/>
+								<span className="min-w-0 flex-1 truncate text-xs text-foreground">
+									{monitor.name}
+								</span>
+								<Button
+									aria-label={`Stop monitor ${monitor.name}`}
+									disabled={!onStopMonitor || isStopping}
+									onClick={() => void stopMonitor(monitor.id)}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									{isStopping ? (
+										<Loader2 className="size-3 animate-spin" />
+									) : null}
+									{isStopping ? "Stopping" : "Stop"}
+								</Button>
+							</li>
+						);
+					})}
+				</ul>
+			</PopoverContent>
+		</Popover>
+	);
+}
 
 /**
  * Route from a child agent run back to the session that spawned it, in the

--- a/apps/examples/desktop-app/webview/lib/session-monitors.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-monitors.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@/lib/chat-schema";
+import { buildActiveSessionMonitors } from "@/lib/session-monitors";
+
+let messageCounter = 0;
+
+function message(
+	role: ChatMessage["role"],
+	content: string,
+	toolName?: string,
+): ChatMessage {
+	messageCounter += 1;
+	return {
+		id: `message_${messageCounter}`,
+		sessionId: "session_1",
+		role,
+		content,
+		createdAt: messageCounter,
+		meta: toolName ? { toolName } : undefined,
+	};
+}
+
+function monitorResult(result: string): ChatMessage {
+	return message(
+		"tool",
+		JSON.stringify({ toolName: "monitor", result, isError: false }),
+		"monitor",
+	);
+}
+
+describe("buildActiveSessionMonitors", () => {
+	it("tracks successful monitor starts", () => {
+		expect(
+			buildActiveSessionMonitors([
+				monitorResult(
+					'Started monitor mon_1 ("ci"): Watches CI\nCommand: gh pr checks',
+				),
+			]),
+		).toEqual([{ id: "mon_1", name: "ci" }]);
+	});
+
+	it("removes explicitly stopped monitors", () => {
+		expect(
+			buildActiveSessionMonitors([
+				monitorResult('Started monitor mon_1 ("ci"): Watches CI'),
+				monitorResult('Stopped monitor mon_1 ("ci").'),
+			]),
+		).toEqual([]);
+	});
+
+	it("removes monitors after a natural exit notification", () => {
+		expect(
+			buildActiveSessionMonitors([
+				monitorResult('Started monitor mon_1 ("server"): Watches server'),
+				message(
+					"user",
+					"Background output\n[monitor mon_1 ended with exit code 0]",
+				),
+			]),
+		).toEqual([]);
+	});
+
+	it("uses list results to refine monitor status", () => {
+		expect(
+			buildActiveSessionMonitors([
+				monitorResult('Started monitor mon_1 ("old"): Old watch'),
+				monitorResult(
+					'mon_1 [exited] "old": Old watch\nmon_2 [running] "logs": Tail logs',
+				),
+			]),
+		).toEqual([{ id: "mon_2", name: "logs" }]);
+	});
+
+	it("ignores unrelated and failed tool results", () => {
+		expect(
+			buildActiveSessionMonitors([
+				message(
+					"tool",
+					JSON.stringify({
+						toolName: "monitor",
+						result: 'Started monitor mon_1 ("ci"): Watches CI',
+						isError: true,
+					}),
+					"monitor",
+				),
+				message("tool", "not json", "read_files"),
+			]),
+		).toEqual([]);
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/session-monitors.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-monitors.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "@/lib/chat-schema";
-import { buildActiveSessionMonitors } from "@/lib/session-monitors";
+import {
+	buildActiveSessionMonitors,
+	monitorSuppressionKey,
+	pruneMonitorSuppressions,
+} from "@/lib/session-monitors";
 
 let messageCounter = 0;
 
@@ -86,5 +90,45 @@ describe("buildActiveSessionMonitors", () => {
 				message("tool", "not json", "read_files"),
 			]),
 		).toEqual([]);
+	});
+});
+
+describe("pruneMonitorSuppressions", () => {
+	it("keeps a suppression while the stopped monitor still parses as active", () => {
+		const suppressed = new Set([monitorSuppressionKey("session_1", "mon_1")]);
+		expect(
+			pruneMonitorSuppressions(
+				suppressed,
+				[{ id: "mon_1", name: "ci" }],
+				"session_1",
+			),
+		).toBe(suppressed);
+	});
+
+	it("drops a suppression once its terminal marker lands", () => {
+		expect(
+			pruneMonitorSuppressions(
+				new Set([monitorSuppressionKey("session_1", "mon_1")]),
+				[],
+				"session_1",
+			),
+		).toEqual(new Set());
+	});
+
+	it("does not let a stale suppression hide a reused monitor id", () => {
+		// User stops mon_1, the marker lands, and a rebuilt runtime later hands
+		// out mon_1 again to a different monitor: the new monitor must show.
+		let suppressed = new Set([monitorSuppressionKey("session_1", "mon_1")]);
+		suppressed = pruneMonitorSuppressions(suppressed, [], "session_1");
+		expect(suppressed.has(monitorSuppressionKey("session_1", "mon_1"))).toBe(
+			false,
+		);
+	});
+
+	it("leaves other sessions' suppressions alone", () => {
+		const otherKey = monitorSuppressionKey("session_2", "mon_1");
+		expect(
+			pruneMonitorSuppressions(new Set([otherKey]), [], "session_1"),
+		).toEqual(new Set([otherKey]));
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/session-monitors.ts
+++ b/apps/examples/desktop-app/webview/lib/session-monitors.ts
@@ -1,0 +1,88 @@
+import type { ChatMessage } from "@/lib/chat-schema";
+
+export type SessionMonitor = {
+	id: string;
+	name: string;
+};
+
+type MonitorToolPayload = {
+	toolName?: string;
+	result?: unknown;
+	isError?: boolean;
+};
+
+const STARTED_MONITOR = /^Started monitor (mon_\d+) \("(.+)"\):/m;
+const MONITOR_RECORD = /^(mon_\d+) \[([^\]]+)] "(.+)":/gm;
+const TERMINAL_NOTIFICATION =
+	/\[monitor (mon_\d+) (?:stopped|failed to run:|ended on signal|ended with exit code)/g;
+
+function parseToolPayload(
+	message: ChatMessage,
+): MonitorToolPayload | undefined {
+	try {
+		return JSON.parse(message.content) as MonitorToolPayload;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Reconstruct the monitors that are still running from the durable transcript.
+ * Monitor starts and stops are tool results, while natural process exits arrive
+ * later as monitor-originated steering messages.
+ */
+export function buildActiveSessionMonitors(
+	messages: ChatMessage[],
+): SessionMonitor[] {
+	const active = new Map<string, SessionMonitor>();
+
+	for (const message of messages) {
+		if (message.role === "tool") {
+			const payload = parseToolPayload(message);
+			const toolName = (message.meta?.toolName ?? payload?.toolName)
+				?.trim()
+				.toLowerCase();
+			if (toolName !== "monitor" || payload?.isError) {
+				continue;
+			}
+			const result =
+				typeof payload?.result === "string"
+					? payload.result
+					: message.meta?.toolOutput;
+			if (!result) {
+				continue;
+			}
+
+			const started = STARTED_MONITOR.exec(result);
+			if (started?.[1] && started[2]) {
+				active.set(started[1], { id: started[1], name: started[2] });
+			}
+
+			for (const match of result.matchAll(MONITOR_RECORD)) {
+				const [, id, status, name] = match;
+				if (!id || !name) {
+					continue;
+				}
+				if (status === "running") {
+					active.set(id, { id, name });
+				} else {
+					active.delete(id);
+				}
+			}
+
+			const stopped = /^Stopped monitor (mon_\d+)\b/m.exec(result)?.[1];
+			if (stopped) {
+				active.delete(stopped);
+			}
+			continue;
+		}
+
+		for (const match of message.content.matchAll(TERMINAL_NOTIFICATION)) {
+			if (match[1]) {
+				active.delete(match[1]);
+			}
+		}
+	}
+
+	return [...active.values()];
+}

--- a/apps/examples/desktop-app/webview/lib/session-monitors.ts
+++ b/apps/examples/desktop-app/webview/lib/session-monitors.ts
@@ -86,3 +86,46 @@ export function buildActiveSessionMonitors(
 
 	return [...active.values()];
 }
+
+/** Key used to remember a user-initiated stop until the transcript reflects it. */
+export function monitorSuppressionKey(
+	sessionId: string | undefined,
+	monitorId: string,
+): string {
+	return `${sessionId ?? ""}:${monitorId}`;
+}
+
+/**
+ * Drops suppression keys whose monitor no longer appears in the parsed roster.
+ *
+ * A suppression exists only to bridge the gap between the user's stop and its
+ * terminal marker landing in the transcript; once the id is gone the marker
+ * has landed. Monitor ids are registry-local (`mon_1` restarts at 1 after
+ * every runtime rebuild), so a key kept past that point would permanently
+ * hide an unrelated future monitor that happens to reuse the id.
+ *
+ * Only the displayed session's keys are considered — other sessions' rosters
+ * are not in view, so their keys are pruned when they are displayed again.
+ * Returns the same set when nothing changed so React state stays stable.
+ */
+export function pruneMonitorSuppressions(
+	suppressed: ReadonlySet<string>,
+	activeMonitors: readonly SessionMonitor[],
+	sessionId: string | undefined,
+): Set<string> {
+	if (suppressed.size === 0) {
+		return suppressed as Set<string>;
+	}
+	const prefix = `${sessionId ?? ""}:`;
+	const activeIds = new Set(activeMonitors.map((monitor) => monitor.id));
+	const next = new Set(suppressed);
+	for (const key of suppressed) {
+		if (!key.startsWith(prefix)) {
+			continue;
+		}
+		if (!activeIds.has(key.slice(prefix.length))) {
+			next.delete(key);
+		}
+	}
+	return next.size === suppressed.size ? (suppressed as Set<string>) : next;
+}

--- a/sdk/packages/core/src/extensions/tools/executors/monitor.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/monitor.test.ts
@@ -602,6 +602,16 @@ describe("formatMonitorNotification", () => {
 		expect(formatted.split("</monitor-output>").length - 1).toBe(1);
 	});
 
+	it("attributes a UI-initiated stop to the user", () => {
+		expect(
+			formatMonitorNotification({
+				...base,
+				lines: [],
+				exit: { status: "stopped", stoppedBy: "user" },
+			}),
+		).toContain("[monitor mon_1 stopped by the user]");
+	});
+
 	it("keeps watched output from escaping the untrusted region", () => {
 		// A watched log is attacker-influenced: anything that could close the
 		// fence and resume as trusted framing has to be neutralized.

--- a/sdk/packages/core/src/extensions/tools/executors/monitor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/monitor.ts
@@ -43,6 +43,8 @@ export interface MonitorNotification {
 	/** Present only on the final notification, once the process has ended. */
 	exit?: {
 		status: Exclude<MonitorStatus, "running">;
+		/** Identifies an explicit stop initiated outside the agent tool call. */
+		stoppedBy?: "user";
 		code?: number | null;
 		signal?: NodeJS.Signals | null;
 		/** Populated when the process could not be spawned at all. */
@@ -377,7 +379,10 @@ export class MonitorRegistry {
 	 * Stops one monitor by id or name. Returns the final record, or undefined
 	 * when nothing matched.
 	 */
-	async stop(idOrName: string): Promise<MonitorRecord | undefined> {
+	async stop(
+		idOrName: string,
+		options?: { stoppedBy?: "user" },
+	): Promise<MonitorRecord | undefined> {
 		const key = idOrName.trim();
 		const entry =
 			this.monitors.get(key) ??
@@ -389,7 +394,10 @@ export class MonitorRegistry {
 			// Report anything already buffered rather than discarding it, then close
 			// the monitor out. The later `close` event finds it settled and is a
 			// no-op.
-			this.settle(entry, { status: "stopped" });
+			this.settle(entry, {
+				status: "stopped",
+				stoppedBy: options?.stoppedBy,
+			});
 		}
 		await this.terminateEntry(entry);
 		return snapshot(entry);
@@ -824,6 +832,7 @@ export class MonitorRegistry {
 		entry: MonitorEntry,
 		outcome: {
 			status: Exclude<MonitorStatus, "running">;
+			stoppedBy?: "user";
 			code?: number | null;
 			signal?: NodeJS.Signals | null;
 			error?: string;
@@ -851,6 +860,7 @@ export class MonitorRegistry {
 
 		this.flush(entry, {
 			status: outcome.status,
+			stoppedBy: outcome.stoppedBy,
 			code: outcome.code,
 			signal: outcome.signal,
 			error: outcome.error,
@@ -942,7 +952,9 @@ function formatExit(notification: MonitorNotification): string {
 	const id = notification.monitorId;
 	switch (exit.status) {
 		case "stopped":
-			return `[monitor ${id} stopped]`;
+			return exit.stoppedBy === "user"
+				? `[monitor ${id} stopped by the user]`
+				: `[monitor ${id} stopped]`;
 		case "failed":
 			return `[monitor ${id} failed to run: ${sanitizeUntrusted(
 				exit.error ?? "unknown error",

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -1264,6 +1264,15 @@ export class HubRuntimeHost implements RuntimeHost {
 			: 0;
 	}
 
+	async stopMonitor(sessionId: string, monitorId: string): Promise<boolean> {
+		const reply = await this.client.command(
+			"run.stop_monitor",
+			{ sessionId, monitorId },
+			sessionId,
+		);
+		return reply.payload?.stopped === true;
+	}
+
 	async stopSession(sessionId: string): Promise<void> {
 		this.sessionCapabilities.delete(sessionId);
 		this.disposeSessionSubscription(sessionId);

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -1578,6 +1578,22 @@ describe("HubServerTransport boundaries", () => {
 		expect(proceedWhileRunning).toHaveBeenCalledWith("session-1", "call-1");
 	});
 
+	it("stops a monitor through the hub command boundary", async () => {
+		const stopMonitor = vi.fn().mockResolvedValue(true);
+		const transport = createTransport({ sessionHost: { stopMonitor } });
+
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-stop-monitor",
+			command: "run.stop_monitor",
+			sessionId: "session-1",
+			payload: { sessionId: "session-1", monitorId: "mon_1" },
+		});
+
+		expect(reply).toMatchObject({ ok: true, payload: { stopped: true } });
+		expect(stopMonitor).toHaveBeenCalledWith("session-1", "mon_1");
+	});
+
 	it("projects an unreported non-recoverable agent error as run.failed", async () => {
 		const transport = createTransport({
 			sessionHost: {

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -11,6 +11,7 @@ import type {
 import { createSessionId } from "@cline/shared";
 import type {
 	CommandExecutionRuntimeService,
+	MonitorRuntimeService,
 	PendingPromptsRuntimeService,
 	RuntimeHost,
 	SessionConnectionRuntimeService,
@@ -66,6 +67,7 @@ export interface HubTransportContext {
 	readonly sessionHost: RuntimeHost &
 		Partial<
 			CommandExecutionRuntimeService &
+				MonitorRuntimeService &
 				PendingPromptsRuntimeService &
 				SessionUsageRuntimeService &
 				SessionConnectionRuntimeService

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
@@ -394,6 +394,33 @@ export async function handleRunProceedWhileRunning(
 	return okReply(envelope, { detachedCount });
 }
 
+export async function handleRunStopMonitor(
+	ctx: HubTransportContext,
+	envelope: HubCommandEnvelope,
+): Promise<HubReplyEnvelope> {
+	const sessionId = extractSessionId(envelope);
+	const monitorId =
+		typeof envelope.payload?.monitorId === "string"
+			? envelope.payload.monitorId.trim()
+			: "";
+	if (!sessionId || !monitorId) {
+		return errorReply(
+			envelope,
+			"invalid_monitor_request",
+			"run.stop_monitor requires a sessionId and monitorId",
+		);
+	}
+	if (typeof ctx.sessionHost.stopMonitor !== "function") {
+		return errorReply(
+			envelope,
+			"unsupported_command",
+			"This runtime does not support stopping monitors.",
+		);
+	}
+	const stopped = await ctx.sessionHost.stopMonitor(sessionId, monitorId);
+	return okReply(envelope, { stopped });
+}
+
 export async function handleSessionHook(
 	ctx: HubTransportContext,
 	envelope: HubCommandEnvelope,

--- a/sdk/packages/core/src/hub/server/hub-server-options.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-options.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../cron/service/schedule-service";
 import type {
 	CommandExecutionRuntimeService,
+	MonitorRuntimeService,
 	PendingPromptsRuntimeService,
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
@@ -18,7 +19,11 @@ export interface HubWebSocketServerOptions {
 	pathname?: string;
 	owner?: HubOwnerContext;
 	sessionHost?: RuntimeHost &
-		Partial<PendingPromptsRuntimeService & CommandExecutionRuntimeService>;
+		Partial<
+			PendingPromptsRuntimeService &
+				CommandExecutionRuntimeService &
+				MonitorRuntimeService
+		>;
 	settingsService?: CoreSettingsService;
 	runtimeHandlers: HubScheduleRuntimeHandlers;
 	scheduleOptions?: Omit<HubScheduleServiceOptions, "runtimeHandlers">;

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -12,6 +12,7 @@ import { HubScheduleService } from "../../cron/service/schedule-service";
 import { LocalRuntimeHost } from "../../runtime/host/local-runtime-host";
 import type {
 	CommandExecutionRuntimeService,
+	MonitorRuntimeService,
 	PendingPromptsRuntimeService,
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
@@ -53,6 +54,7 @@ import {
 import {
 	handleRunAbort,
 	handleRunProceedWhileRunning,
+	handleRunStopMonitor,
 	handleSessionHook,
 	handleSessionInput,
 } from "./handlers/run-handlers";
@@ -183,7 +185,11 @@ export class HubServerTransport implements NativeHubTransport {
 	private readonly settings: CoreSettingsService;
 	private readonly cronService?: CronService;
 	private readonly sessionHost: RuntimeHost &
-		Partial<PendingPromptsRuntimeService & CommandExecutionRuntimeService>;
+		Partial<
+			PendingPromptsRuntimeService &
+				CommandExecutionRuntimeService &
+				MonitorRuntimeService
+		>;
 	private readonly hubId = createSessionId("hub_");
 	private readonly ctx: HubTransportContext;
 
@@ -397,6 +403,8 @@ export class HubServerTransport implements NativeHubTransport {
 				return await handleRunAbort(this.ctx, envelope);
 			case "run.proceed_while_running":
 				return await handleRunProceedWhileRunning(this.ctx, envelope);
+			case "run.stop_monitor":
+				return await handleRunStopMonitor(this.ctx, envelope);
 			case "capability.request":
 				return await handleCapabilityRequest(this.ctx, envelope);
 			case "approval.respond":

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -451,6 +451,7 @@ export {
 export { LocalRuntimeHost } from "./runtime/host/local-runtime-host";
 export type {
 	CommandExecutionRuntimeService,
+	MonitorRuntimeService,
 	PendingPromptMutationResult,
 	PendingPromptsDeleteInput,
 	PendingPromptsListInput,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1161,6 +1161,14 @@ export class LocalRuntimeHost implements RuntimeHost {
 		);
 	}
 
+	async stopMonitor(sessionId: string, monitorId: string): Promise<boolean> {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			throw new SessionNotFoundError(sessionId);
+		}
+		return (await session.runtime.stopMonitor?.(monitorId)) ?? false;
+	}
+
 	async stopSession(sessionId: string): Promise<void> {
 		const session = this.sessions.get(sessionId);
 		if (!session) return;

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -332,6 +332,10 @@ export interface CommandExecutionRuntimeService {
 	proceedWhileRunning(sessionId: string, toolCallId?: string): Promise<number>;
 }
 
+export interface MonitorRuntimeService {
+	stopMonitor(sessionId: string, monitorId: string): Promise<boolean>;
+}
+
 export interface RuntimeHostSubscribeOptions {
 	sessionId?: string;
 }

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -818,6 +818,12 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 					);
 				}
 			},
+			stopMonitor: monitorRegistry
+				? async (monitorId) =>
+						Boolean(
+							await monitorRegistry.stop(monitorId, { stoppedBy: "user" }),
+						)
+				: undefined,
 			shutdown: async (reason: string) => {
 				shutdownTeamRuntime(teamRuntime, reason);
 				this.teamRuntimeEntries.delete(registryKey);

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
@@ -52,6 +52,7 @@ export interface BuiltRuntime {
 	extensions?: AgentConfig["extensions"];
 	completionPolicy?: AgentConfig["completionPolicy"];
 	registerLeadAgent?: (agent: LeadAgentHandle) => void;
+	stopMonitor?: (monitorId: string) => Promise<boolean>;
 	shutdown: (reason: string) => Promise<void> | void;
 }
 

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -433,6 +433,7 @@ export type HubCommandName =
 	| "session.send_input"
 	| "run.abort"
 	| "run.proceed_while_running"
+	| "run.stop_monitor"
 	| "approval.request"
 	| "approval.respond"
 	| "capability.request"


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Shows active session monitors in the desktop agent header next to sub-agent and teammate activity. The monitor indicator opens a roster with a direct Stop control for each monitor.

The stop action is routed through the sidecar and hub to the session-owned monitor registry rather than asking the LLM to stop it. UI-initiated stops are attributed in the terminal notification so the agent receives `[monitor mon_N stopped by the user]`.

Monitor activity is reconstructed from durable tool results and terminal monitor notifications, so it works for live sessions and hydrated transcripts.

### Test Procedure

- Ran `bun run build:sdk` successfully.
- Ran the desktop TypeScript typecheck successfully.
- Ran the focused desktop, sidecar, monitor-state, and agent-header tests: 55 passed.
- Ran the hub command-boundary tests: 35 passed.
- Ran focused monitor attribution and process teardown tests successfully.
- Ran Biome and `git diff --check` on the changed files.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. The monitor pill appears in the agent header and opens a popover listing active monitors with Stop controls.

<img width="1263" height="968" alt="Screenshot 2026-08-18 at 9 54 00 PM" src="https://github.com/user-attachments/assets/71b599a0-7235-4e12-9713-3e1c18029759" />

<img width="1261" height="981" alt="Screenshot 2026-08-18 at 9 54 13 PM" src="https://github.com/user-attachments/assets/6705ed74-30d7-4dfe-9e64-511dc1e8913d" />


### Additional Notes

This PR is stacked on `bee/monitor-tool` and should be reviewed after that branch.
