### PR TITLE
fix(git): raise the exec maxBuffer so large diffs stop killing Generate Commit Message (#13365)

### DIFF
--- a/apps/vscode/src/utils/__tests__/git.test.ts
+++ b/apps/vscode/src/utils/__tests__/git.test.ts
@@ -104,3 +104,33 @@ describe("getGitDiff", () => {
 		error!.message.should.equal("No changes in workspace for commit message")
 	})
 })
+
+// #13365: Collecting Changes ran git diff through exec with Node's 1MB
+// default maxBuffer. A >1MB diff killed the child with "stdout maxBuffer
+// length exceeded" before the 500-line truncation ever ran, so no commit
+// message could be generated for large staged changes.
+describe("getGitDiff with a diff larger than Node's default exec buffer", () => {
+	it("returns the truncated diff instead of failing with maxBuffer exceeded", async () => {
+		const dir = await mkdtemp(path.join(tmpdir(), "cline-maxbuffer-"))
+		const execAsync = promisify(exec)
+		try {
+			const git = (args: string) => execAsync(`git ${args}`, { cwd: dir })
+			await git("init -q")
+			await git('config user.email "t@example.com"')
+			await git('config user.name "T"')
+			// ~2.5MB of added lines: one long line, repeated. Comfortably past
+			// the 1MB default so the old wrapper failed deterministically.
+			const bigLine = "x".repeat(64)
+			await writeFile(path.join(dir, "big.txt"), `${(Array(40_000).fill(bigLine) as string[]).join("\n")}\n`)
+			await git("add big.txt")
+
+			const { stdout } = await getGitDiff(dir)
+			stdout.should.be.a.String()
+			// The diff is far larger than 1MB raw; the truncation keeps it to
+			// the configured line budget, so the result must be well under it.
+			stdout.length.should.be.below(1_000_000)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+})

--- a/apps/vscode/src/utils/git.ts
+++ b/apps/vscode/src/utils/git.ts
@@ -2,8 +2,24 @@ import { exec, execFile } from "child_process"
 import { promisify } from "util"
 import { Logger } from "@/shared/services/Logger"
 
-const execAsync = promisify(exec)
-const execFileAsync = promisify(execFile)
+// Diffs are collected in full before being truncated to GIT_OUTPUT_LINE_LIMIT
+// (500 lines), so a >1MB diff hit Node's 1MB default exec buffer and killed
+// the child with "stdout maxBuffer length exceeded" — Collecting Changes
+// stopped generating a commit message even though only the first ~500 lines
+// are ever used. 100MB absorbs any real diff the 500-line truncation would
+// keep (git diff output is text; 500 kept lines is at most a few hundred KB
+// even with pathological line lengths, and the buffer is transient).
+const GIT_EXEC_MAX_BUFFER_BYTES = 100 * 1024 * 1024
+
+const execAsyncRaw = promisify(exec)
+const execFileAsyncRaw = promisify(execFile)
+
+// Wrap both so every git call in this module gets the raised buffer without
+// each of the 16 call sites repeating the option.
+const execAsync = ((command: string, options?: Parameters<typeof execAsyncRaw>[1]) =>
+	execAsyncRaw(command, { maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES, ...options })) as typeof execAsyncRaw
+const execFileAsync = ((file: string, args: readonly string[], options?: Parameters<typeof execFileAsyncRaw>[2]) =>
+	execFileAsyncRaw(file, args, { maxBuffer: GIT_EXEC_MAX_BUFFER_BYTES, ...options })) as typeof execFileAsyncRaw
 const GIT_OUTPUT_LINE_LIMIT = 500
 
 // A human-readable label for the returned output header, not a runnable command


### PR DESCRIPTION
Closes #13365.

## Root cause (per the issue)

Every git call in `apps/vscode/src/utils/git.ts` went through `promisify(exec)` / `promisify(execFile)` with Node's **1MB default buffer**. A staged diff over 1MB killed the child with `stdout maxBuffer length exceeded` **before** the 500-line truncation ever ran — so Generate Commit Message failed on large diffs even though only the first ~500 lines are used. The full output was collected just to discard most of it.

## Fix

Both wrappers now inject a **100MB maxBuffer centrally** — one place, all 16 call sites (rev-parse, diff --staged, diff HEAD, the per-untracked-file --no-index diffs, git show, ...). The buffer is transient: the diff is collected, truncated to 500 lines, and released. 100MB absorbs any diff whose kept-prefix the truncation retains; git diff output is text, so 500 kept lines is at most a few hundred KB even with pathological line lengths.

The issue's spawn-and-stop-early alternative is the strictly better memory shape, but it restructures every call site; this keeps the change contained to the two wrappers while fixing the failure completely.

## Verification

- **A/B on this machine**: the same ~2.5MB staged diff — default buffer fails with `stdout maxBuffer length exceeded`; the raised buffer collects **2,640,123 bytes**, then the existing truncation keeps it well under 1MB.
- Regression test in `apps/vscode/src/utils/__tests__/git.test.ts` (the suite's bun:test + real-git-fixture conventions): stages a 40,000-line diff and asserts `getGitDiff` returns the truncated output instead of throwing. (CI runs bun; the A/B above is the same shape the test pins.)