### PR TITLE
fix(desktop): strip user_input envelope when copying a user message

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -801,6 +801,28 @@ describe("ChatMessages tool disclosures", () => {
 		);
 	});
 
+	it("copies a user message without its transport envelope", async () => {
+		const writeText = vi.fn(async () => undefined);
+		Object.assign(navigator, { clipboard: { writeText } });
+		await renderMessages([
+			{
+				id: "copyable-user",
+				sessionId: "session-1",
+				role: "user",
+				content: '<user_input mode="act">Original prompt</user_input>',
+				createdAt: 1,
+			},
+		]);
+
+		const copyButton = container.querySelector<HTMLButtonElement>(
+			'button[aria-label="Copy user message"]',
+		);
+		await act(async () => copyButton?.click());
+
+		expect(writeText).toHaveBeenCalledOnce();
+		expect(writeText).toHaveBeenCalledWith("Original prompt");
+	});
+
 	it("counts folded system-displayed runs before an editable user message", async () => {
 		const onEditMessage = vi.fn(async () => undefined);
 		await renderMessages(

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
@@ -309,7 +309,7 @@ export const MessageBubble = memo(function MessageBubble({
 						{onCopyMessage ? (
 							<MessageAction
 								label={wasCopied ? "Copied user message" : "Copy user message"}
-								onClick={() => void onCopyMessage(message.id, message.content)}
+								onClick={() => void onCopyMessage(message.id, displayContent)}
 								title={wasCopied ? "Copied" : "Copy message"}
 							>
 								{wasCopied ? (


### PR DESCRIPTION
### Related Issue

N/A — small bug fix (per the limited-exceptions note above).

### Description

Copying a user message in the desktop app chat put the raw stored message body on the clipboard, including the internal transport envelope, e.g. `<user_input mode="act">...</user_input>`. Those wrapper tags are an implementation detail and should not appear in what the user pastes.

Root cause: in `apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx`, the bubble already computes `displayContent` via `formatChatMessageContent` (which unwraps `user_input` envelopes and mode notices for user messages via the shared `formatDisplayUserInput`) and renders that — but the user copy action passed the raw `message.content` instead. The fix makes the copy action pass the same `displayContent` the UI shows, so no new stripping logic (and no brittle regex) is introduced.

The assistant copy button is intentionally left unchanged: it is titled "Copy raw assistant output", and `formatChatMessageContent` does not strip anything for assistant messages anyway (assistant text that legitimately mentions these tags is preserved).

### Test Procedure

- Added a unit test in `chat-messages.test.tsx` ("copies a user message without its transport envelope"): renders a user message with content `<user_input mode="act">Original prompt</user_input>`, clicks the "Copy user message" action, and asserts `navigator.clipboard.writeText` receives exactly `Original prompt`.
- Verified the test catches the bug: with the one-line fix reverted, it fails with the clipboard receiving `<user_input mode="act">Original prompt</user_input>`.
- `bun run test:chat-ui` in `apps/examples/desktop-app`: 115/115 tests pass (3 files), plus `message-content.test.ts` 4/4.
- `bun run typecheck` in `apps/examples/desktop-app`: clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no visual change; the fix only changes the string handed to the clipboard. Behavior is covered by the added unit test.

### Additional Notes

Edit-and-restart already used `displayContent`, so copy was the only action leaking the raw envelope.