### PR TITLE
docs: replace stale 'Cline: Open In New Tab' command with 'View: Show Cline'

### DIFF
--- a/docs/getting-started/installing-cline.mdx
+++ b/docs/getting-started/installing-cline.mdx
@@ -27,7 +27,7 @@ Use this if you want Cline inside your editor UI.
         Click **Install** on the Cline extension.
       </Step>
       <Step title="Open Cline">
-        Use the Cline activity bar icon, or run `Cline: Open In New Tab` from Command Palette.
+        Use the Cline activity bar icon, or run `View: Show Cline` from the Command Palette.
       </Step>
       <Step title="Authorize with Cline">
         After installing the extension, complete provider setup in Cline settings. Use the Cline Provider for pay-as-you-go access, ClinePass for a flat monthly subscription, or bring your own provider key.

--- a/docs/usage/ide.mdx
+++ b/docs/usage/ide.mdx
@@ -52,7 +52,7 @@ The Cline panel is a chat interface where you communicate with Cline. You need t
     - A **settings gear icon** in the top-right corner of the panel
 
     <Tip>
-    **Can't find the Cline icon?** Open the Command Palette with `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux), type **"Cline: Open In New Tab"**, and press Enter. This opens Cline in a full editor tab, which also gives it more screen space.
+    **Can't find the Cline icon?** Open the Command Palette with `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux), type **"View: Show Cline"**, and press Enter. You can also right-click the activity bar and make sure **Cline** is checked.
     </Tip>
   </Tab>
   <Tab title="JetBrains">


### PR DESCRIPTION
### Related Issue

**Issue:** #13344

### Description

The docs tell users to run `Cline: Open In New Tab` from the Command Palette, but that command does not exist in the VS Code extension — `apps/vscode/package.json` contributes no such command (verified against current `main`), so following the docs leads to a dead end during setup.

VS Code auto-generates a **View: Show Cline** palette command for the contributed `Cline` activity-bar view container, which is the correct way to reveal the sidebar from the palette.

Changes (docs only):
- `docs/getting-started/installing-cline.mdx`: point the install step at `View: Show Cline`.
- `docs/usage/ide.mdx`: fix the "Can't find the Cline icon?" tip to use `View: Show Cline`, and drop the inaccurate "opens Cline in a full editor tab" claim (the command reveals the sidebar; right-clicking the activity bar also works).

### Test Procedure

- `grep -rn 'Open In New Tab' docs/` returns nothing after this change.
- Confirmed `apps/vscode/package.json` contributes no `openInNewTab` command on `main`, and that the `Cline` view container in `contributes.viewsContainers.activitybar` makes `View: Show Cline` available in the Command Palette.
- Docs-only change; no runtime code affected.