### PR TITLE
draft

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
     },
     "apps/examples/desktop-app": {
       "name": "@cline/code",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@cline/core": "workspace:*",
@@ -642,6 +642,14 @@
         "nanoid": "^5.1.7",
       },
     },
+    "sdk/packages/bot": {
+      "name": "@cline/bot",
+      "version": "0.0.75",
+      "dependencies": {
+        "@cline/engine": "workspace:*",
+        "@cline/shared": "workspace:*",
+      },
+    },
     "sdk/packages/core": {
       "name": "@cline/core",
       "version": "0.0.75",
@@ -679,6 +687,24 @@
       "optionalPeers": [
         "posthog-node",
       ],
+    },
+    "sdk/packages/engine": {
+      "name": "@cline/engine",
+      "version": "0.0.75",
+      "dependencies": {
+        "@cline/agents": "workspace:*",
+        "@cline/shared": "workspace:*",
+      },
+    },
+    "sdk/packages/gateway": {
+      "name": "@cline/gateway",
+      "version": "0.0.75",
+      "dependencies": {
+        "@cline/bot": "workspace:*",
+        "@cline/engine": "workspace:*",
+        "@cline/shared": "workspace:*",
+        "zod": "^4.3.6",
+      },
     },
     "sdk/packages/llms": {
       "name": "@cline/llms",
@@ -1072,6 +1098,8 @@
 
     "@cline/agents": ["@cline/agents@workspace:sdk/packages/agents"],
 
+    "@cline/bot": ["@cline/bot@workspace:sdk/packages/bot"],
+
     "@cline/cli": ["@cline/cli@workspace:apps/cli"],
 
     "@cline/cline-hub": ["@cline/cline-hub@workspace:apps/cline-hub"],
@@ -1082,6 +1110,8 @@
 
     "@cline/core": ["@cline/core@workspace:sdk/packages/core"],
 
+    "@cline/engine": ["@cline/engine@workspace:sdk/packages/engine"],
+
     "@cline/example-cli-agent": ["@cline/example-cli-agent@workspace:apps/examples/cli-agent"],
 
     "@cline/example-cline-core-cli-agent": ["@cline/example-cline-core-cli-agent@workspace:apps/examples/cline-core-cli-agent"],
@@ -1091,6 +1121,8 @@
     "@cline/example-multi-agent": ["@cline/example-multi-agent@workspace:apps/examples/multi-agent"],
 
     "@cline/example-quickstart": ["@cline/example-quickstart@workspace:apps/examples/quickstart"],
+
+    "@cline/gateway": ["@cline/gateway@workspace:sdk/packages/gateway"],
 
     "@cline/llms": ["@cline/llms@workspace:sdk/packages/llms"],
 

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -23,6 +23,16 @@ Run SDK commands from `sdk/`, not from the legacy repository root. Do not run di
 - `@cline/agents`: stateless agent loop, tool orchestration, hook/extension runtime, event streaming
 - `@cline/core`: stateful orchestration, session lifecycle, storage, config watching, plugin loading, default tools, telemetry. Exposes `@cline/core/hub` for discovery, the detached daemon entry, WebSocket clients, and session/UI client adapters, plus `@cline/core/hub/daemon-entry` for launching the shared daemon
 
+### Internal Gateway RFC Packages (not published)
+
+Foundation for the Gateway RFC (see `packages/gateway/README.md` and `packages/gateway/docs/adr/`). `@cline/core` and the existing Hub are untouched by these packages.
+
+- `@cline/engine`: single-execution engine over the `@cline/agents` loop — immutable `RunSpec`, ordered `EngineEvent`s, steer/interrupt/abort, `RunResult` + persistence deltas. No storage, discovery, sockets, or daemon code.
+- `@cline/bot`: bot domain semantics (immutable roles, lazy sessions, immutable workspaces, FIFO run admission, delegation, contractor teardown, memories) behind injected ports.
+- `@cline/gateway`: Gateway protocol authority — currently the private command registry, `gateway.hello` negotiation, idempotency ledger, and ADRs; the server itself is a later phase.
+
+Dependency rule: `gateway -> bot -> engine -> agents -> llms -> shared`. Engine never imports bot/gateway; bot never imports gateway; no new package depends on `@cline/core`. Reusable wire contracts live in `@cline/shared/gateway`. These rules are machine-checked by `boundaries.test.ts` in each new package.
+
 ### Dependency Direction
 
 ```mermaid

--- a/sdk/biome.json
+++ b/sdk/biome.json
@@ -71,7 +71,8 @@
 									"!@cline/shared/node",
 									"!@cline/shared/types",
 									"!@cline/shared/storage",
-									"!@cline/shared/db"
+									"!@cline/shared/db",
+									"!@cline/shared/gateway"
 								],
 								"message": "Use package entrypoints for cross-package imports. Do not import from another package's internal files."
 							}

--- a/sdk/packages/bot/README.md
+++ b/sdk/packages/bot/README.md
@@ -1,0 +1,40 @@
+# `@cline/bot`
+
+Bot domain semantics — **Phase 2 of the Gateway RFC** (see
+`sdk/packages/gateway/README.md` for the full design).
+
+## What it owns
+
+Domain semantics for one bot, entirely behind injected ports:
+
+- **Identity**: immutable ID, role, parent, provenance. Roles are `lead`,
+  `worker`, `contractor` (`sandbox` is not a role). The first bot is
+  `cline` with role `lead`. Roles are immutable — there is no promotion
+  path, and the repositories reject identity mutations.
+- **Topology**: only a lead delegates (workers/contractors, never a new
+  lead). Workers message their lead; worker-to-worker messaging is
+  disabled by default.
+- **Sessions**: created lazily, only with the first *accepted* prompt. The
+  session workspace is immutable after creation.
+- **Runs**: one mutating root run per session, FIFO admission with an
+  immediate `{runId, acceptedAt, queuePosition}` acknowledgement (shared
+  contract). Steering merges into the active run. Disconnect never
+  implies abort.
+- **Contractors**: exactly one task; on completion the bot is retired
+  (record retained) and its session closed.
+- **Per-turn overrides**: merge over the bot config for a single run.
+- **Memories**: file-backed discovery from `memories/` via a
+  `MemorySource` port.
+- **Execution**: engine invocation through an `EnginePort`;
+  `createEngineExecutionPort` adapts the port onto the real
+  `@cline/engine`.
+
+## What it deliberately does not do
+
+No SQLite, no file watching, no sockets, no spawned children. Repositories,
+resource bindings, clocks, IDs, and worker execution arrive as ports whose
+real implementations belong to the Gateway (Phase 3+). All domain tests run
+with the in-memory ports in [`src/in-memory.ts`](./src/in-memory.ts).
+
+The dependency rules (`bot -> engine`, never `bot -> gateway` or
+`bot -> core`) are machine-checked in [`src/boundaries.test.ts`](./src/boundaries.test.ts).

--- a/sdk/packages/bot/bun.mts
+++ b/sdk/packages/bot/bun.mts
@@ -1,0 +1,22 @@
+/// <reference types="@types/bun" />
+export {};
+
+const external = ["@cline/engine", "@cline/shared", "@cline/shared/gateway"];
+const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
+
+const result = await Bun.build({
+	entrypoints: ["./src/index.ts"],
+	outdir: "./dist",
+	target: "node",
+	minify,
+	sourcemap,
+	packages: "bundle",
+	external,
+});
+
+if (result.logs.length > 0) {
+	for (const log of result.logs) {
+		console.warn(log);
+	}
+}

--- a/sdk/packages/bot/package.json
+++ b/sdk/packages/bot/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@cline/bot",
+	"version": "0.0.75",
+	"description": "Bot domain semantics — identity, sessions, runs, delegation, memories — behind injected ports (Gateway RFC, Phase 2)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cline/cline",
+		"directory": "sdk/packages/bot"
+	},
+	"private": true,
+	"internal": true,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"license": "Apache-2.0",
+	"scripts": {
+		"build": "bun run bun.mts && bun tsc -p tsconfig.build.json",
+		"typecheck": "bun tsc -p tsconfig.dev.json --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"engines": {
+		"node": ">=22"
+	},
+	"dependencies": {
+		"@cline/engine": "workspace:*",
+		"@cline/shared": "workspace:*"
+	}
+}

--- a/sdk/packages/bot/src/bot.test.ts
+++ b/sdk/packages/bot/src/bot.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import { Bot } from "./bot";
+import {
+	ContractorTaskError,
+	RunAdmissionError,
+	WorkspaceImmutableError,
+} from "./errors";
+import { createInMemoryPorts, type InMemoryBotPorts } from "./in-memory";
+import { BotRegistry } from "./registry";
+
+function setup() {
+	const ports: InMemoryBotPorts = createInMemoryPorts();
+	const registry = new BotRegistry(ports);
+	const lead = registry.bootstrap();
+	const bot = new Bot(lead.identity.botId, ports);
+	return { ports, registry, lead, bot };
+}
+
+describe("lazy sessions", () => {
+	it("a new bot has no session until a prompt is accepted", () => {
+		const { bot } = setup();
+		expect(bot.session).toBeUndefined();
+	});
+
+	it("a rejected prompt never creates a session", () => {
+		const { ports, bot } = setup();
+		expect(() => bot.submitPrompt("   ")).toThrow(RunAdmissionError);
+		expect(bot.session).toBeUndefined();
+		expect(ports.sessions.listByBot(bot.record.identity.botId)).toHaveLength(0);
+	});
+
+	it("the first accepted prompt creates the session with its workspace", () => {
+		const { bot } = setup();
+		const ack = bot.submitPrompt("hello", {
+			workspace: { rootPath: "/repo/a" },
+		});
+		expect(ack.queuePosition).toBe(0);
+		expect(ack.acceptedAt).toBeGreaterThan(0);
+		expect(bot.session?.workspace.rootPath).toBe("/repo/a");
+		expect(bot.session?.state).toBe("active");
+	});
+
+	it("a closed session admits no further runs", async () => {
+		const { ports, bot } = setup();
+		ports.engine.autoOutcome = () => ({ outputText: "ok" });
+		bot.submitPrompt("hello");
+		await bot.whenIdle();
+		bot.closeSession();
+		expect(() => bot.submitPrompt("again")).toThrow(RunAdmissionError);
+	});
+});
+
+describe("immutable workspace", () => {
+	it("rejects a prompt naming a different workspace after session creation", () => {
+		const { bot } = setup();
+		bot.submitPrompt("first", { workspace: { rootPath: "/repo/a" } });
+		expect(() =>
+			bot.submitPrompt("second", { workspace: { rootPath: "/repo/b" } }),
+		).toThrow(WorkspaceImmutableError);
+		// Same workspace (or none) is fine.
+		expect(() =>
+			bot.submitPrompt("third", { workspace: { rootPath: "/repo/a" } }),
+		).not.toThrow();
+		expect(() => bot.submitPrompt("fourth")).not.toThrow();
+	});
+
+	it("the session repository is a backstop against workspace mutation", () => {
+		const { ports, bot } = setup();
+		bot.submitPrompt("first", { workspace: { rootPath: "/repo/a" } });
+		const session = bot.session;
+		if (!session) throw new Error("expected session");
+		expect(() =>
+			ports.sessions.save({
+				...session,
+				workspace: { rootPath: "/repo/hijacked" },
+				revision: session.revision + 1,
+			}),
+		).toThrow(WorkspaceImmutableError);
+	});
+});
+
+describe("FIFO run admission", () => {
+	it("acks immediately with increasing queue positions and runs in order", async () => {
+		const { ports, bot } = setup();
+		const first = bot.submitPrompt("one");
+		const second = bot.submitPrompt("two");
+		const third = bot.submitPrompt("three");
+		expect(first.queuePosition).toBe(0);
+		expect(second.queuePosition).toBe(1);
+		expect(third.queuePosition).toBe(2);
+		expect(first.runId).not.toBe(second.runId);
+
+		// Only the first run started; the rest are queued.
+		expect(ports.engine.handles).toHaveLength(1);
+		expect(ports.runs.get(first.runId)?.state).toBe("running");
+		expect(ports.runs.get(second.runId)?.state).toBe("queued");
+		expect(ports.runs.get(third.runId)?.state).toBe("queued");
+
+		// Settle them one at a time; admission stays FIFO.
+		ports.engine.handles[0].settle({ outputText: "done one" });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(ports.engine.handles).toHaveLength(2);
+		expect(ports.engine.handles[1].invocation.input).toBe("two");
+		expect(ports.runs.get(first.runId)?.state).toBe("completed");
+		expect(ports.runs.get(first.runId)?.outputText).toBe("done one");
+
+		ports.engine.handles[1].settle({});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(ports.engine.handles[2].invocation.input).toBe("three");
+		ports.engine.handles[2].settle({});
+		await bot.whenIdle();
+		expect(ports.runs.get(third.runId)?.state).toBe("completed");
+	});
+
+	it("cancelQueued aborts a queued run without starting it", async () => {
+		const { ports, bot } = setup();
+		bot.submitPrompt("one");
+		const second = bot.submitPrompt("two");
+		expect(bot.cancelQueued(second.runId)).toBe(true);
+		expect(ports.runs.get(second.runId)?.state).toBe("aborted");
+		ports.engine.handles[0].settle({});
+		await bot.whenIdle();
+		// The cancelled run never reached the engine.
+		expect(ports.engine.handles).toHaveLength(1);
+	});
+});
+
+describe("steering, interruption, disconnects", () => {
+	it("steering merges into the active run", () => {
+		const { ports, bot } = setup();
+		bot.submitPrompt("go");
+		expect(bot.steer("also check tests")).toBe(true);
+		expect(ports.engine.handles[0].steers).toEqual(["also check tests"]);
+	});
+
+	it("steering with no active run is refused", () => {
+		const { bot } = setup();
+		expect(bot.steer("into the void")).toBe(false);
+	});
+
+	it("interrupt and abort forward to the active run and settle its state", async () => {
+		const { ports, bot } = setup();
+		const ack = bot.submitPrompt("go");
+		expect(bot.interrupt("pause please")).toBe(true);
+		const handle = ports.engine.handles[0];
+		expect(handle.interrupted).toBe(true);
+		handle.settle({ status: "interrupted" });
+		await bot.whenIdle();
+		expect(ports.runs.get(ack.runId)?.state).toBe("interrupted");
+	});
+
+	it("disconnect never implies abort", async () => {
+		const { ports, bot } = setup();
+		const ack = bot.submitPrompt("long task");
+		bot.clientDisconnected();
+		const handle = ports.engine.handles[0];
+		expect(handle.aborted).toBe(false);
+		expect(handle.interrupted).toBe(false);
+		expect(ports.runs.get(ack.runId)?.state).toBe("running");
+		handle.settle({ outputText: "survived the disconnect" });
+		await bot.whenIdle();
+		expect(ports.runs.get(ack.runId)?.state).toBe("completed");
+	});
+});
+
+describe("per-turn overrides", () => {
+	it("apply to one run only and never mutate the bot config", async () => {
+		const { ports, registry, lead } = setup();
+		ports.bots.save({
+			...registry.get(lead.identity.botId),
+			config: { modelId: "base-model", systemPrompt: "base prompt" },
+		});
+		const bot = new Bot(lead.identity.botId, ports);
+
+		bot.submitPrompt("one", { overrides: { modelId: "fancy-model" } });
+		bot.submitPrompt("two");
+
+		expect(ports.engine.handles[0].invocation.effectiveConfig.modelId).toBe(
+			"fancy-model",
+		);
+		expect(
+			ports.engine.handles[0].invocation.effectiveConfig.systemPrompt,
+		).toBe("base prompt");
+
+		ports.engine.handles[0].settle({});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		// The next run reverts to the bot config.
+		expect(ports.engine.handles[1].invocation.effectiveConfig.modelId).toBe(
+			"base-model",
+		);
+		expect(registry.get(lead.identity.botId).config.modelId).toBe("base-model");
+	});
+});
+
+describe("contractor lifecycle", () => {
+	function contractorSetup() {
+		const ports = createInMemoryPorts();
+		const registry = new BotRegistry(ports);
+		const lead = registry.bootstrap();
+		const contractorRecord = registry.delegate(lead.identity.botId, {
+			name: "one-off",
+			role: "contractor",
+		});
+		const contractor = new Bot(contractorRecord.identity.botId, ports);
+		return { ports, registry, contractor, contractorRecord };
+	}
+
+	it("accepts exactly one task", () => {
+		const { contractor } = contractorSetup();
+		contractor.submitPrompt("the one task");
+		expect(() => contractor.submitPrompt("a second task")).toThrow(
+			ContractorTaskError,
+		);
+	});
+
+	it("tears down after its run: retired with retention, session closed", async () => {
+		const { ports, registry, contractor, contractorRecord } = contractorSetup();
+		contractor.submitPrompt("the one task");
+		ports.engine.handles[0].settle({ outputText: "task done" });
+		await contractor.whenIdle();
+
+		const after = registry.get(contractorRecord.identity.botId);
+		expect(after.status).toBe("retired");
+		// Retention: identity and provenance survive teardown.
+		expect(after.identity.provenance.createdBy).toBe(
+			contractorRecord.identity.parentBotId,
+		);
+		expect(contractor.session?.state).toBe("closed");
+		expect(() => contractor.submitPrompt("anything else")).toThrow(
+			RunAdmissionError,
+		);
+	});
+});
+
+describe("memories", () => {
+	it("discovers markdown memories under memories/ through the port", () => {
+		const ports = createInMemoryPorts({
+			memories: {
+				list: () => [
+					{ path: "memories/style.md", content: "# Style" },
+					{ path: "memories/nested/decisions.md", content: "# Decisions" },
+					{ path: "memories/notes.txt", content: "not markdown" },
+					{ path: "docs/style.md", content: "outside memories/" },
+				],
+			},
+		});
+		const registry = new BotRegistry(ports);
+		const lead = registry.bootstrap();
+		const bot = new Bot(lead.identity.botId, ports);
+		const memories = bot.discoverMemories();
+		expect(memories.map((memory) => memory.name)).toEqual([
+			"nested/decisions",
+			"style",
+		]);
+		expect(memories[1].content).toBe("# Style");
+	});
+
+	it("returns nothing when no memory port is bound", () => {
+		const { bot } = setup();
+		expect(bot.discoverMemories()).toEqual([]);
+	});
+});
+
+describe("identity survives reattachment", () => {
+	it("a new Bot facade reattaches to the existing active session", () => {
+		const { ports, lead, bot } = setup();
+		bot.submitPrompt("start", { workspace: { rootPath: "/repo/a" } });
+		const reattached = new Bot(lead.identity.botId, ports);
+		expect(reattached.session?.sessionId).toBe(bot.session?.sessionId);
+		expect(reattached.session?.workspace.rootPath).toBe("/repo/a");
+	});
+});
+
+describe("retired bots", () => {
+	it("reject prompt admission", () => {
+		const { registry, lead, bot } = setup();
+		registry.retire(lead.identity.botId);
+		expect(() => bot.submitPrompt("anything")).toThrow(RunAdmissionError);
+		expect(bot.session).toBeUndefined();
+	});
+});

--- a/sdk/packages/bot/src/bot.ts
+++ b/sdk/packages/bot/src/bot.ts
@@ -1,0 +1,293 @@
+/**
+ * Bot session/run orchestration (Gateway RFC, Phase 2).
+ *
+ * Semantics encoded here:
+ * - A session is allocated only with its first ACCEPTED prompt (lazy).
+ *   A rejected prompt never creates a session.
+ * - The session workspace is immutable after creation.
+ * - One mutating root run per session; admission is FIFO with an
+ *   immediate `{runId, acceptedAt, queuePosition}` acknowledgement.
+ * - Steering merges into the active run.
+ * - Disconnect never implies abort.
+ * - A contractor accepts exactly one task, then tears down: its record is
+ *   retired (retained) and its session closed.
+ */
+
+import {
+	assertRunStateTransition,
+	type RunAccepted,
+	RunAcceptedSchema,
+	type RunId,
+} from "@cline/shared/gateway";
+import {
+	ContractorTaskError,
+	RunAdmissionError,
+	WorkspaceImmutableError,
+} from "./errors";
+import type { BotRecord } from "./identity";
+import { type BotMemory, discoverMemories } from "./memories";
+import { resolveEffectiveConfig, type TurnOverrides } from "./overrides";
+import type {
+	BotPorts,
+	EngineOutcome,
+	EngineRunHandle,
+	RunRecord,
+	SessionRecord,
+	WorkspaceRef,
+} from "./ports";
+import { BotRegistry } from "./registry";
+
+export interface SubmitPromptOptions {
+	/**
+	 * Workspace for the session. Only honored on the first accepted prompt;
+	 * afterwards it must match the session's immutable workspace.
+	 */
+	workspace?: WorkspaceRef;
+	overrides?: TurnOverrides;
+}
+
+const DEFAULT_WORKSPACE: WorkspaceRef = { rootPath: "." };
+
+interface QueuedRun {
+	runId: RunId;
+	input: string;
+	overrides?: TurnOverrides;
+}
+
+export class Bot {
+	private readonly botId: BotRecord["identity"]["botId"];
+	private readonly ports: BotPorts;
+	private readonly registry: BotRegistry;
+
+	private sessionId?: SessionRecord["sessionId"];
+	private readonly queue: QueuedRun[] = [];
+	private active?: { runId: RunId; handle: EngineRunHandle };
+
+	constructor(botId: BotRecord["identity"]["botId"], ports: BotPorts) {
+		this.botId = botId;
+		this.ports = ports;
+		this.registry = new BotRegistry(ports);
+		// Fail fast on unknown bots.
+		this.registry.get(botId);
+		// Reattach to an existing active session, if any (identity survives
+		// process and connection lifecycles).
+		this.sessionId = ports.sessions
+			.listByBot(botId)
+			.find((session) => session.state === "active")?.sessionId;
+	}
+
+	get record(): BotRecord {
+		return this.registry.get(this.botId);
+	}
+
+	get session(): SessionRecord | undefined {
+		return this.sessionId ? this.ports.sessions.get(this.sessionId) : undefined;
+	}
+
+	get activeRun(): RunRecord | undefined {
+		return this.active ? this.ports.runs.get(this.active.runId) : undefined;
+	}
+
+	/**
+	 * Admit a prompt. On acceptance this lazily creates the session (first
+	 * prompt only), records a queued run, and acks immediately.
+	 */
+	submitPrompt(text: string, options: SubmitPromptOptions = {}): RunAccepted {
+		const record = this.record;
+		if (record.status !== "active") {
+			throw new RunAdmissionError(`Bot ${this.botId} is retired`);
+		}
+		if (!text.trim()) {
+			throw new RunAdmissionError("Prompt must not be empty");
+		}
+		const session = this.session;
+		if (session?.state === "closed") {
+			throw new RunAdmissionError("Session is closed and admits no runs");
+		}
+		if (record.identity.role === "contractor" && session) {
+			// The contractor's single task was accepted when its session was
+			// created; a second prompt is rejected, not queued.
+			throw new ContractorTaskError();
+		}
+		if (
+			session &&
+			options.workspace &&
+			options.workspace.rootPath !== session.workspace.rootPath
+		) {
+			throw new WorkspaceImmutableError(
+				`Session workspace ${session.workspace.rootPath} cannot change to ${options.workspace.rootPath}`,
+			);
+		}
+
+		// ---- Prompt accepted: only now may a session come into existence.
+		const acceptedAt = this.ports.clock.now();
+		const sessionRecord = session ?? this.createSession(options.workspace);
+		const runId = this.ports.ids.runId();
+		const queuePosition = (this.active ? 1 : 0) + this.queue.length;
+
+		this.ports.runs.save({
+			runId,
+			sessionId: sessionRecord.sessionId,
+			botId: this.botId,
+			state: "queued",
+			input: text,
+			acceptedAt,
+		});
+		this.queue.push({ runId, input: text, overrides: options.overrides });
+		this.pump();
+
+		return RunAcceptedSchema.parse({ runId, acceptedAt, queuePosition });
+	}
+
+	/** Merge steering text into the active run. False when nothing is active. */
+	steer(text: string): boolean {
+		if (!this.active) {
+			return false;
+		}
+		return this.active.handle.steer(text);
+	}
+
+	/** Cooperatively interrupt the active run. */
+	interrupt(reason?: string): boolean {
+		if (!this.active) {
+			return false;
+		}
+		this.active.handle.interrupt(reason);
+		return true;
+	}
+
+	/** Hard-abort the active run. */
+	abort(reason?: string): boolean {
+		if (!this.active) {
+			return false;
+		}
+		this.active.handle.abort(reason);
+		return true;
+	}
+
+	/** Abort a run that is still queued (never started). */
+	cancelQueued(runId: RunId): boolean {
+		const index = this.queue.findIndex((entry) => entry.runId === runId);
+		if (index === -1) {
+			return false;
+		}
+		this.queue.splice(index, 1);
+		this.transitionRun(runId, "aborted");
+		return true;
+	}
+
+	/**
+	 * A client connection went away. Deliberately a no-op for runs:
+	 * disconnect never implies abort.
+	 */
+	clientDisconnected(): void {
+		// Intentionally empty — sessions and runs outlive connections.
+	}
+
+	/** Close the session; it admits no further runs. */
+	closeSession(): void {
+		const session = this.session;
+		if (!session || session.state === "closed") {
+			return;
+		}
+		this.ports.sessions.save({
+			...session,
+			state: "closed",
+			revision: session.revision + 1,
+		});
+	}
+
+	/** Discover file-backed memories through the memory port. */
+	discoverMemories(): BotMemory[] {
+		if (!this.ports.memories) {
+			return [];
+		}
+		return discoverMemories(this.ports.memories);
+	}
+
+	/** Resolves once no run is active and the queue is drained. */
+	async whenIdle(): Promise<void> {
+		while (this.active) {
+			await this.active.handle.result;
+			// Let the completion continuation (state transitions, pump) run.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Internals
+	// ---------------------------------------------------------------------
+
+	private createSession(workspace?: WorkspaceRef): SessionRecord {
+		const record: SessionRecord = {
+			sessionId: this.ports.ids.sessionId(),
+			botId: this.botId,
+			workspace: Object.freeze({ ...(workspace ?? DEFAULT_WORKSPACE) }),
+			state: "active",
+			createdAt: this.ports.clock.now(),
+			revision: 0,
+		};
+		this.ports.sessions.save(record);
+		this.sessionId = record.sessionId;
+		return record;
+	}
+
+	private pump(): void {
+		if (this.active) {
+			return;
+		}
+		const next = this.queue.shift();
+		if (!next) {
+			return;
+		}
+		const session = this.session;
+		if (!session) {
+			throw new Error("invariant violation: run queued without a session");
+		}
+		this.transitionRun(next.runId, "running", {
+			startedAt: this.ports.clock.now(),
+		});
+		const record = this.record;
+		const handle = this.ports.engine.start({
+			runId: next.runId,
+			sessionId: session.sessionId,
+			botId: this.botId,
+			input: next.input,
+			workspaceRoot: session.workspace.rootPath,
+			effectiveConfig: resolveEffectiveConfig(record.config, next.overrides),
+			overrides: next.overrides,
+		});
+		this.active = { runId: next.runId, handle };
+		void handle.result.then((outcome) => this.settleRun(next.runId, outcome));
+	}
+
+	private settleRun(runId: RunId, outcome: EngineOutcome): void {
+		this.transitionRun(runId, outcome.status, {
+			endedAt: this.ports.clock.now(),
+			outputText: outcome.outputText,
+			error: outcome.error,
+		});
+		this.active = undefined;
+		if (this.record.identity.role === "contractor") {
+			// Contractor teardown: one task + retention. The record stays
+			// (retired), the session closes, queued extras cannot exist.
+			this.registry.retire(this.botId);
+			this.closeSession();
+			return;
+		}
+		this.pump();
+	}
+
+	private transitionRun(
+		runId: RunId,
+		to: RunRecord["state"],
+		patch: Partial<Omit<RunRecord, "runId" | "state">> = {},
+	): void {
+		const record = this.ports.runs.get(runId);
+		if (!record) {
+			throw new Error(`invariant violation: unknown run ${runId}`);
+		}
+		assertRunStateTransition(record.state, to);
+		this.ports.runs.save({ ...record, ...patch, state: to });
+	}
+}

--- a/sdk/packages/bot/src/boundaries.test.ts
+++ b/sdk/packages/bot/src/boundaries.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Machine-checked package boundaries (Gateway RFC dependency rules).
+ *
+ * `@cline/bot` never imports Gateway implementations (`@cline/gateway`),
+ * never depends on `@cline/core`, and — since the Gateway is the only
+ * new-path writer — never opens SQLite, watches files, exposes sockets,
+ * or spawns processes. Everything stateful arrives through ports.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC_DIR = join(import.meta.dirname, ".");
+const PACKAGE_JSON = join(import.meta.dirname, "..", "package.json");
+
+const FORBIDDEN_IMPORTS: readonly { pattern: RegExp; why: string }[] = [
+	{
+		pattern: /^@cline\/gateway(\/|$)/,
+		why: "bot never imports Gateway implementations",
+	},
+	{
+		pattern: /^@cline\/core(\/|$)/,
+		why: "no new package depends on @cline/core",
+	},
+	{
+		pattern: /^(node:)?fs(\/|$)/,
+		why: "no file watching / direct file access",
+	},
+	{ pattern: /^(bun:)?sqlite$/, why: "bot never opens SQLite" },
+	{ pattern: /^better-sqlite3$/, why: "bot never opens SQLite" },
+	{ pattern: /^(node:)?net$/, why: "no sockets" },
+	{ pattern: /^(node:)?tls$/, why: "no sockets" },
+	{ pattern: /^(node:)?dgram$/, why: "no sockets" },
+	{ pattern: /^(node:)?http2?$/, why: "no listeners" },
+	{ pattern: /^(node:)?https$/, why: "no listeners" },
+	{ pattern: /^ws$/, why: "no sockets" },
+	{ pattern: /^(node:)?child_process$/, why: "no unsupervised children" },
+	{ pattern: /^(node:)?cluster$/, why: "no daemons" },
+	{ pattern: /^(node:)?worker_threads$/, why: "no daemons" },
+];
+
+function listSourceFiles(): string[] {
+	return readdirSync(SRC_DIR)
+		.filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+		.map((name) => join(SRC_DIR, name));
+}
+
+function extractImportSpecifiers(source: string): string[] {
+	const specifiers: string[] = [];
+	const patterns = [
+		/from\s+["']([^"']+)["']/g,
+		/import\s+["']([^"']+)["']/g,
+		/import\s*\(\s*["']([^"']+)["']\s*\)/g,
+		/require\s*\(\s*["']([^"']+)["']\s*\)/g,
+	];
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) {
+			specifiers.push(match[1]);
+		}
+	}
+	return specifiers;
+}
+
+describe("@cline/bot boundaries", () => {
+	it("source files import no gateway/core, storage, socket, or process code", () => {
+		const files = listSourceFiles();
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			const specifiers = extractImportSpecifiers(readFileSync(file, "utf8"));
+			for (const specifier of specifiers) {
+				for (const { pattern, why } of FORBIDDEN_IMPORTS) {
+					expect(
+						pattern.test(specifier),
+						`${file} imports "${specifier}" (${why})`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+
+	it("package.json declares no dependency on @cline/core or @cline/gateway", () => {
+		const manifest = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+		};
+		const declared = [
+			...Object.keys(manifest.dependencies ?? {}),
+			...Object.keys(manifest.devDependencies ?? {}),
+			...Object.keys(manifest.peerDependencies ?? {}),
+		];
+		expect(declared).not.toContain("@cline/core");
+		expect(declared).not.toContain("@cline/gateway");
+		// The dependency direction bot -> engine is allowed and expected.
+		expect(declared).toContain("@cline/engine");
+	});
+});

--- a/sdk/packages/bot/src/engine-adapter.test.ts
+++ b/sdk/packages/bot/src/engine-adapter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Composition proof: the bot domain drives the REAL `@cline/engine`
+ * through its execution port, with a scripted model (no providers).
+ */
+
+import type { AgentModel, AgentModelEvent } from "@cline/engine";
+import { describe, expect, it } from "vitest";
+import { Bot } from "./bot";
+import { createEngineExecutionPort } from "./engine-adapter";
+import {
+	createSequentialIdSource,
+	createStepClock,
+	InMemoryBotRepository,
+	InMemoryRunRepository,
+	InMemorySessionRepository,
+} from "./in-memory";
+import type { BotPorts } from "./ports";
+import { BotRegistry } from "./registry";
+
+function scriptedModel(turns: AgentModelEvent[][]): AgentModel {
+	let call = 0;
+	return {
+		stream() {
+			const turn = turns[Math.min(call, turns.length - 1)];
+			call += 1;
+			return (async function* () {
+				for (const event of turn) {
+					yield event;
+				}
+			})();
+		},
+	};
+}
+
+function textTurn(text: string): AgentModelEvent[] {
+	return [
+		{ type: "text-delta", text },
+		{ type: "finish", reason: "stop" },
+	];
+}
+
+function setup(model: AgentModel) {
+	const engine = createEngineExecutionPort({
+		model: () => ({ kind: "model", model }),
+	});
+	const ports: BotPorts = {
+		clock: createStepClock(),
+		ids: createSequentialIdSource(),
+		bots: new InMemoryBotRepository(),
+		sessions: new InMemorySessionRepository(),
+		runs: new InMemoryRunRepository(),
+		engine,
+	};
+	const registry = new BotRegistry(ports);
+	const lead = registry.bootstrap();
+	const bot = new Bot(lead.identity.botId, ports);
+	return { ports, bot };
+}
+
+describe("bot -> engine composition", () => {
+	it("runs a prompt end-to-end through the real engine", async () => {
+		const { ports, bot } = setup(scriptedModel([textTurn("engine says hi")]));
+		const ack = bot.submitPrompt("hello engine", {
+			workspace: { rootPath: "/repo/x" },
+		});
+		expect(ack.queuePosition).toBe(0);
+
+		await bot.whenIdle();
+
+		const run = ports.runs.get(ack.runId);
+		expect(run?.state).toBe("completed");
+		expect(run?.outputText).toBe("engine says hi");
+		expect(bot.session?.state).toBe("active");
+	});
+
+	it("processes queued prompts sequentially through separate engines", async () => {
+		const { ports, bot } = setup(scriptedModel([textTurn("answer")]));
+		const first = bot.submitPrompt("one");
+		const second = bot.submitPrompt("two");
+		expect(second.queuePosition).toBe(1);
+
+		await bot.whenIdle();
+
+		expect(ports.runs.get(first.runId)?.state).toBe("completed");
+		expect(ports.runs.get(second.runId)?.state).toBe("completed");
+		const firstRun = ports.runs.get(first.runId);
+		const secondRun = ports.runs.get(second.runId);
+		if (!firstRun?.endedAt || !secondRun?.startedAt) {
+			throw new Error("expected run timing to be recorded");
+		}
+		// Strict FIFO: the second run starts only after the first ends.
+		expect(secondRun.startedAt).toBeGreaterThan(firstRun.endedAt);
+	});
+
+	it("engine failures surface as failed runs with the error retained", async () => {
+		const { ports, bot } = setup(
+			scriptedModel([
+				[{ type: "finish", reason: "error", error: "model blew up" }],
+			]),
+		);
+		const ack = bot.submitPrompt("doomed");
+		await bot.whenIdle();
+		const run = ports.runs.get(ack.runId);
+		expect(run?.state).toBe("failed");
+		expect(run?.error?.message).toContain("model blew up");
+	});
+});

--- a/sdk/packages/bot/src/engine-adapter.ts
+++ b/sdk/packages/bot/src/engine-adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * Engine execution port over the real `@cline/engine` (Gateway RFC,
+ * Phase 2).
+ *
+ * `@cline/bot` invokes execution only through `EnginePort`; this adapter
+ * is the composition proof that the port maps onto `@cline/engine`
+ * one-to-one. Resource bindings (model, tools, approvals) stay
+ * caller-supplied: the Gateway provides real ones, tests provide fakes.
+ * The dependency direction is bot -> engine, never the reverse.
+ */
+
+import {
+	type AgentTool,
+	createEngine,
+	type EngineApprovalPort,
+	type EngineClock,
+	type EngineModelBinding,
+	type EngineOptions,
+} from "@cline/engine";
+import type { EngineInvocation, EnginePort, EngineRunHandle } from "./ports";
+
+export interface EngineExecutionBindings {
+	/** Resolve the model binding for an invocation (per-turn overrides apply). */
+	model(invocation: EngineInvocation): EngineModelBinding;
+	// biome-ignore lint/suspicious/noExplicitAny: tool input/output types vary per tool
+	tools?(invocation: EngineInvocation): readonly AgentTool<any, any>[];
+	requestApproval?: EngineApprovalPort;
+	clock?: EngineClock;
+	telemetry?: EngineOptions["telemetry"];
+	logger?: EngineOptions["logger"];
+	artifacts?: EngineOptions["artifacts"];
+}
+
+export function createEngineExecutionPort(
+	bindings: EngineExecutionBindings,
+): EnginePort {
+	return {
+		start(invocation: EngineInvocation): EngineRunHandle {
+			const engine = createEngine(
+				{
+					runId: invocation.runId,
+					sessionId: invocation.sessionId,
+					botId: invocation.botId,
+					input: invocation.input,
+					systemPrompt: invocation.effectiveConfig.systemPrompt,
+					model: bindings.model(invocation),
+					tools: bindings.tools?.(invocation),
+					toolPolicies: invocation.effectiveConfig.toolPolicies,
+					maxIterations: invocation.effectiveConfig.maxIterations,
+					requestApproval: bindings.requestApproval,
+					metadata: { workspaceRoot: invocation.workspaceRoot },
+				},
+				{
+					clock: bindings.clock,
+					telemetry: bindings.telemetry,
+					logger: bindings.logger,
+					artifacts: bindings.artifacts,
+				},
+			);
+			const result = engine.run().then((runResult) => ({
+				status: runResult.status,
+				outputText: runResult.outputText,
+				error: runResult.error,
+			}));
+			return {
+				steer: (text) => engine.steer(text),
+				interrupt: (reason) => engine.interrupt(reason),
+				abort: (reason) => engine.abort(reason),
+				result,
+				subscribe: (listener) => engine.subscribe(listener),
+			};
+		},
+	};
+}

--- a/sdk/packages/bot/src/errors.ts
+++ b/sdk/packages/bot/src/errors.ts
@@ -1,0 +1,75 @@
+/**
+ * Bot domain errors (Gateway RFC, Phase 2).
+ *
+ * Each error carries a stable `code` so the Gateway can map domain
+ * failures onto wire errors without string matching.
+ */
+
+export type BotDomainErrorCode =
+	| "run_admission_rejected"
+	| "role_immutable"
+	| "delegation_not_allowed"
+	| "workspace_immutable"
+	| "messaging_not_allowed"
+	| "contractor_task_exhausted"
+	| "bot_not_found"
+	| "bot_retired";
+
+export class BotDomainError extends Error {
+	readonly code: BotDomainErrorCode;
+
+	constructor(code: BotDomainErrorCode, message: string) {
+		super(message);
+		this.name = "BotDomainError";
+		this.code = code;
+	}
+}
+
+export class RunAdmissionError extends BotDomainError {
+	constructor(message: string) {
+		super("run_admission_rejected", message);
+		this.name = "RunAdmissionError";
+	}
+}
+
+export class RoleImmutableError extends BotDomainError {
+	constructor(message = "Bot role and parent are immutable") {
+		super("role_immutable", message);
+		this.name = "RoleImmutableError";
+	}
+}
+
+export class DelegationNotAllowedError extends BotDomainError {
+	constructor(message: string) {
+		super("delegation_not_allowed", message);
+		this.name = "DelegationNotAllowedError";
+	}
+}
+
+export class WorkspaceImmutableError extends BotDomainError {
+	constructor(message = "Session workspace is immutable after creation") {
+		super("workspace_immutable", message);
+		this.name = "WorkspaceImmutableError";
+	}
+}
+
+export class MessagingNotAllowedError extends BotDomainError {
+	constructor(message: string) {
+		super("messaging_not_allowed", message);
+		this.name = "MessagingNotAllowedError";
+	}
+}
+
+export class ContractorTaskError extends BotDomainError {
+	constructor(message = "A contractor accepts exactly one task") {
+		super("contractor_task_exhausted", message);
+		this.name = "ContractorTaskError";
+	}
+}
+
+export class BotNotFoundError extends BotDomainError {
+	constructor(botId: string) {
+		super("bot_not_found", `Unknown bot: ${botId}`);
+		this.name = "BotNotFoundError";
+	}
+}

--- a/sdk/packages/bot/src/identity.ts
+++ b/sdk/packages/bot/src/identity.ts
@@ -1,0 +1,63 @@
+/**
+ * Bot identity (Gateway RFC, Phase 2).
+ *
+ * A bot's ID, role, parent, and provenance are fixed at creation. Roles:
+ *
+ * - `lead`: persistent, delegates, inspects children. The first bot is
+ *   `cline` with role `lead`.
+ * - `worker`: persistent, messages its lead. Never promoted to lead.
+ * - `contractor`: an ephemeral, task-scoped worker — one task, then
+ *   teardown with record retention. Cannot delegate by default.
+ *
+ * `sandbox` is intentionally NOT a role.
+ */
+
+import type { ToolPolicy } from "@cline/engine";
+import type { BotId } from "@cline/shared/gateway";
+
+export const BOT_ROLES = ["lead", "worker", "contractor"] as const;
+export type BotRole = (typeof BOT_ROLES)[number];
+
+/** Name and role of the bootstrap bot. */
+export const FIRST_BOT_NAME = "cline";
+export const FIRST_BOT_ROLE: BotRole = "lead";
+
+export interface BotProvenance {
+	/** `bootstrap` for the first bot; otherwise the creating bot's ID. */
+	readonly createdBy: "bootstrap" | BotId;
+	readonly reason?: string;
+}
+
+export interface BotIdentity {
+	readonly botId: BotId;
+	readonly name: string;
+	/** Immutable. There is no promotion path. */
+	readonly role: BotRole;
+	/** Immutable. `null` only for the bootstrap lead. */
+	readonly parentBotId: BotId | null;
+	readonly provenance: BotProvenance;
+	readonly createdAt: number;
+}
+
+/** Bot-level configuration; per-turn overrides layer on top of this. */
+export interface BotConfig {
+	providerId?: string;
+	modelId?: string;
+	systemPrompt?: string;
+	toolPolicies?: Record<string, ToolPolicy>;
+	maxIterations?: number;
+}
+
+export type BotStatus = "active" | "retired";
+
+export interface BotRecord {
+	readonly identity: BotIdentity;
+	readonly config: BotConfig;
+	readonly status: BotStatus;
+	readonly revision: number;
+}
+
+export function freezeIdentity(identity: BotIdentity): BotIdentity {
+	Object.freeze(identity.provenance);
+	return Object.freeze(identity);
+}

--- a/sdk/packages/bot/src/in-memory.ts
+++ b/sdk/packages/bot/src/in-memory.ts
@@ -1,0 +1,239 @@
+/**
+ * In-memory port implementations (Gateway RFC, Phase 2 exit criterion:
+ * all domain tests run with in-memory ports).
+ *
+ * The repositories are also invariant backstops: they reject identity
+ * mutations (role/parent) and workspace mutations even if a future caller
+ * bypasses the domain checks.
+ */
+
+import {
+	type BotId,
+	createBotId,
+	createRunId,
+	createSessionId,
+	type RunId,
+	type SessionId,
+} from "@cline/shared/gateway";
+import { RoleImmutableError, WorkspaceImmutableError } from "./errors";
+import type { BotRecord } from "./identity";
+import type {
+	BotClock,
+	BotIdSource,
+	BotPorts,
+	BotRepository,
+	EngineInvocation,
+	EngineOutcome,
+	EnginePort,
+	EngineRunHandle,
+	MemorySource,
+	RunRecord,
+	RunRepository,
+	SessionRecord,
+	SessionRepository,
+} from "./ports";
+
+export class InMemoryBotRepository implements BotRepository {
+	private readonly records = new Map<BotId, BotRecord>();
+
+	get(botId: BotId): BotRecord | undefined {
+		return this.records.get(botId);
+	}
+
+	list(): readonly BotRecord[] {
+		return [...this.records.values()];
+	}
+
+	save(record: BotRecord): void {
+		const existing = this.records.get(record.identity.botId);
+		if (
+			existing &&
+			(existing.identity.role !== record.identity.role ||
+				existing.identity.parentBotId !== record.identity.parentBotId)
+		) {
+			throw new RoleImmutableError(
+				`Bot ${record.identity.botId} cannot change role/parent ` +
+					`(${existing.identity.role} -> ${record.identity.role})`,
+			);
+		}
+		this.records.set(record.identity.botId, record);
+	}
+}
+
+export class InMemorySessionRepository implements SessionRepository {
+	private readonly records = new Map<SessionId, SessionRecord>();
+
+	get(sessionId: SessionId): SessionRecord | undefined {
+		return this.records.get(sessionId);
+	}
+
+	listByBot(botId: BotId): readonly SessionRecord[] {
+		return [...this.records.values()].filter(
+			(record) => record.botId === botId,
+		);
+	}
+
+	save(record: SessionRecord): void {
+		const existing = this.records.get(record.sessionId);
+		if (existing && existing.workspace.rootPath !== record.workspace.rootPath) {
+			throw new WorkspaceImmutableError(
+				`Session ${record.sessionId} workspace cannot change`,
+			);
+		}
+		this.records.set(record.sessionId, record);
+	}
+}
+
+export class InMemoryRunRepository implements RunRepository {
+	private readonly records = new Map<RunId, RunRecord>();
+
+	get(runId: RunId): RunRecord | undefined {
+		return this.records.get(runId);
+	}
+
+	listBySession(sessionId: SessionId): readonly RunRecord[] {
+		return [...this.records.values()].filter(
+			(record) => record.sessionId === sessionId,
+		);
+	}
+
+	save(record: RunRecord): void {
+		this.records.set(record.runId, record);
+	}
+}
+
+export class InMemoryMemorySource implements MemorySource {
+	private readonly entries: { path: string; content: string }[];
+
+	constructor(entries: { path: string; content: string }[] = []) {
+		this.entries = entries;
+	}
+
+	list(): readonly { path: string; content: string }[] {
+		return this.entries;
+	}
+}
+
+/** Deterministic clock for tests. */
+export function createStepClock(start = 1_000): BotClock {
+	let now = start;
+	return {
+		now: () => {
+			now += 1;
+			return now;
+		},
+	};
+}
+
+/** Deterministic, ordered ID source for tests. */
+export function createSequentialIdSource(): BotIdSource {
+	let counter = 0;
+	const body = () => `test${String((counter += 1)).padStart(6, "0")}`;
+	return {
+		botId: () => createBotId(body),
+		sessionId: () => createSessionId(body),
+		runId: () => createRunId(body),
+	};
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+export class ManualEngineHandle implements EngineRunHandle {
+	readonly invocation: EngineInvocation;
+	readonly steers: string[] = [];
+	interruptReason: string | undefined;
+	interrupted = false;
+	aborted = false;
+	abortReason: string | undefined;
+	private readonly deferred = createDeferred<EngineOutcome>();
+
+	constructor(invocation: EngineInvocation) {
+		this.invocation = invocation;
+	}
+
+	get result(): Promise<EngineOutcome> {
+		return this.deferred.promise;
+	}
+
+	steer(text: string): boolean {
+		this.steers.push(text);
+		return true;
+	}
+
+	interrupt(reason?: string): void {
+		this.interrupted = true;
+		this.interruptReason = reason;
+	}
+
+	abort(reason?: string): void {
+		this.aborted = true;
+		this.abortReason = reason;
+	}
+
+	settle(outcome: Partial<EngineOutcome> = {}): void {
+		this.deferred.resolve({
+			status: outcome.status ?? "completed",
+			outputText: outcome.outputText ?? "",
+			error: outcome.error,
+		});
+	}
+}
+
+/**
+ * Scriptable engine port. By default runs stay pending until the test
+ * settles them; set `autoOutcome` to settle each run on a microtask.
+ */
+export class ManualEnginePort implements EnginePort {
+	readonly handles: ManualEngineHandle[] = [];
+	autoOutcome?: (invocation: EngineInvocation) => Partial<EngineOutcome>;
+
+	start(invocation: EngineInvocation): EngineRunHandle {
+		const handle = new ManualEngineHandle(invocation);
+		this.handles.push(handle);
+		const auto = this.autoOutcome;
+		if (auto) {
+			queueMicrotask(() => handle.settle(auto(invocation)));
+		}
+		return handle;
+	}
+
+	get lastHandle(): ManualEngineHandle | undefined {
+		return this.handles.at(-1);
+	}
+
+	handleFor(runId: string): ManualEngineHandle | undefined {
+		return this.handles.find((handle) => handle.invocation.runId === runId);
+	}
+}
+
+export interface InMemoryBotPorts extends BotPorts {
+	bots: InMemoryBotRepository;
+	sessions: InMemorySessionRepository;
+	runs: InMemoryRunRepository;
+	engine: ManualEnginePort;
+}
+
+export function createInMemoryPorts(
+	options: { engine?: ManualEnginePort; memories?: MemorySource } = {},
+): InMemoryBotPorts {
+	return {
+		clock: createStepClock(),
+		ids: createSequentialIdSource(),
+		bots: new InMemoryBotRepository(),
+		sessions: new InMemorySessionRepository(),
+		runs: new InMemoryRunRepository(),
+		engine: options.engine ?? new ManualEnginePort(),
+		memories: options.memories,
+	};
+}

--- a/sdk/packages/bot/src/index.ts
+++ b/sdk/packages/bot/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * `@cline/bot`
+ *
+ * Domain semantics for one bot (Gateway RFC, Phase 2): immutable identity
+ * and roles, lead/worker/contractor topology, lazy sessions, immutable
+ * session workspaces, FIFO run admission with immediate acknowledgement,
+ * per-turn overrides, steering into the active run, contractor teardown,
+ * file-backed memory discovery, and engine invocation — all through
+ * injected ports.
+ *
+ * This package never opens SQLite, watches files, exposes sockets, or
+ * spawns processes, and never imports `@cline/gateway` or `@cline/core`.
+ * See `src/boundaries.test.ts` for the machine-checked rules.
+ */
+
+export type { SubmitPromptOptions } from "./bot";
+export { Bot } from "./bot";
+export type { EngineExecutionBindings } from "./engine-adapter";
+export { createEngineExecutionPort } from "./engine-adapter";
+export type { BotDomainErrorCode } from "./errors";
+export {
+	BotDomainError,
+	BotNotFoundError,
+	ContractorTaskError,
+	DelegationNotAllowedError,
+	MessagingNotAllowedError,
+	RoleImmutableError,
+	RunAdmissionError,
+	WorkspaceImmutableError,
+} from "./errors";
+export type {
+	BotConfig,
+	BotIdentity,
+	BotProvenance,
+	BotRecord,
+	BotRole,
+	BotStatus,
+} from "./identity";
+export {
+	BOT_ROLES,
+	FIRST_BOT_NAME,
+	FIRST_BOT_ROLE,
+	freezeIdentity,
+} from "./identity";
+export type { InMemoryBotPorts } from "./in-memory";
+export {
+	createInMemoryPorts,
+	createSequentialIdSource,
+	createStepClock,
+	InMemoryBotRepository,
+	InMemoryMemorySource,
+	InMemoryRunRepository,
+	InMemorySessionRepository,
+	ManualEngineHandle,
+	ManualEnginePort,
+} from "./in-memory";
+export type { BotMemory } from "./memories";
+export { discoverMemories, MEMORIES_DIR } from "./memories";
+export type { TurnOverrides } from "./overrides";
+export { resolveEffectiveConfig } from "./overrides";
+export type {
+	BotClock,
+	BotIdSource,
+	BotPorts,
+	BotRepository,
+	EngineInvocation,
+	EngineOutcome,
+	EnginePort,
+	EngineRunHandle,
+	MemorySource,
+	RunRecord,
+	RunRepository,
+	SessionRecord,
+	SessionRepository,
+	WorkspaceRef,
+} from "./ports";
+export type { BotMessage, BotRegistryPorts, DelegationSpec } from "./registry";
+export { BotRegistry } from "./registry";

--- a/sdk/packages/bot/src/memories.ts
+++ b/sdk/packages/bot/src/memories.ts
@@ -1,0 +1,40 @@
+/**
+ * File-backed memory discovery (Gateway RFC, Phase 2).
+ *
+ * Memories live under a bot's `memories/` directory as Markdown files.
+ * The domain discovers them through a `MemorySource` port — it never
+ * touches a filesystem itself.
+ */
+
+import type { MemorySource } from "./ports";
+
+export const MEMORIES_DIR = "memories/";
+
+export interface BotMemory {
+	/** Memory name: the file path under `memories/` without the extension. */
+	readonly name: string;
+	/** Path relative to the bot directory, e.g. `memories/style.md`. */
+	readonly path: string;
+	readonly content: string;
+}
+
+export function discoverMemories(source: MemorySource): BotMemory[] {
+	const memories: BotMemory[] = [];
+	for (const entry of source.list()) {
+		const normalized = entry.path.replaceAll("\\", "/");
+		if (!normalized.startsWith(MEMORIES_DIR)) {
+			continue;
+		}
+		if (!normalized.endsWith(".md")) {
+			continue;
+		}
+		const relative = normalized.slice(MEMORIES_DIR.length);
+		memories.push({
+			name: relative.slice(0, -".md".length),
+			path: normalized,
+			content: entry.content,
+		});
+	}
+	memories.sort((a, b) => a.path.localeCompare(b.path));
+	return memories;
+}

--- a/sdk/packages/bot/src/overrides.ts
+++ b/sdk/packages/bot/src/overrides.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-turn overrides (Gateway RFC, Phase 2).
+ *
+ * A prompt may override parts of the bot's effective configuration for
+ * that run only. Overrides never mutate the bot's stored config.
+ */
+
+import type { BotConfig } from "./identity";
+
+export interface TurnOverrides {
+	providerId?: string;
+	modelId?: string;
+	systemPrompt?: string;
+	toolPolicies?: BotConfig["toolPolicies"];
+	maxIterations?: number;
+}
+
+/** Merge per-turn overrides over the bot config into a frozen copy. */
+export function resolveEffectiveConfig(
+	config: BotConfig,
+	overrides?: TurnOverrides,
+): BotConfig {
+	const effective: BotConfig = {
+		...config,
+		...(overrides?.providerId !== undefined
+			? { providerId: overrides.providerId }
+			: {}),
+		...(overrides?.modelId !== undefined ? { modelId: overrides.modelId } : {}),
+		...(overrides?.systemPrompt !== undefined
+			? { systemPrompt: overrides.systemPrompt }
+			: {}),
+		...(overrides?.maxIterations !== undefined
+			? { maxIterations: overrides.maxIterations }
+			: {}),
+		...(overrides?.toolPolicies !== undefined
+			? {
+					toolPolicies: {
+						...config.toolPolicies,
+						...overrides.toolPolicies,
+					},
+				}
+			: {}),
+	};
+	return Object.freeze(effective);
+}

--- a/sdk/packages/bot/src/ports.ts
+++ b/sdk/packages/bot/src/ports.ts
@@ -1,0 +1,150 @@
+/**
+ * Injected ports (Gateway RFC, Phase 2).
+ *
+ * `@cline/bot` owns domain semantics only. Repositories, resource
+ * bindings, clocks, IDs, memory sources, and execution arrive as ports;
+ * the real implementations live in the Gateway (Phase 3+). This package
+ * never opens SQLite, watches files, exposes sockets, or spawns an
+ * unsupervised child — see `boundaries.test.ts`.
+ */
+
+import type {
+	BotId,
+	RunId,
+	RunState,
+	SessionId,
+	SessionState,
+} from "@cline/shared/gateway";
+import type { BotConfig, BotRecord } from "./identity";
+import type { TurnOverrides } from "./overrides";
+
+export interface BotClock {
+	now(): number;
+}
+
+export interface BotIdSource {
+	botId(): BotId;
+	sessionId(): SessionId;
+	runId(): RunId;
+}
+
+// -----------------------------------------------------------------------------
+// Repositories
+// -----------------------------------------------------------------------------
+
+export interface BotRepository {
+	get(botId: BotId): BotRecord | undefined;
+	list(): readonly BotRecord[];
+	/**
+	 * Persist a record. Implementations MUST reject a save that changes an
+	 * existing bot's role or parent (`RoleImmutableError`); config, name,
+	 * and status changes are allowed.
+	 */
+	save(record: BotRecord): void;
+}
+
+/** A session's workspace binding. Immutable after session creation. */
+export interface WorkspaceRef {
+	readonly rootPath: string;
+}
+
+export interface SessionRecord {
+	readonly sessionId: SessionId;
+	readonly botId: BotId;
+	readonly workspace: WorkspaceRef;
+	readonly state: SessionState;
+	readonly createdAt: number;
+	readonly revision: number;
+}
+
+export interface SessionRepository {
+	get(sessionId: SessionId): SessionRecord | undefined;
+	listByBot(botId: BotId): readonly SessionRecord[];
+	/**
+	 * Persist a record. Implementations MUST reject a save that changes an
+	 * existing session's workspace (`WorkspaceImmutableError`).
+	 */
+	save(record: SessionRecord): void;
+}
+
+export interface RunRecord {
+	readonly runId: RunId;
+	readonly sessionId: SessionId;
+	readonly botId: BotId;
+	readonly state: RunState;
+	readonly input: string;
+	readonly acceptedAt: number;
+	readonly startedAt?: number;
+	readonly endedAt?: number;
+	readonly outputText?: string;
+	readonly error?: { name: string; message: string };
+}
+
+export interface RunRepository {
+	get(runId: RunId): RunRecord | undefined;
+	listBySession(sessionId: SessionId): readonly RunRecord[];
+	save(record: RunRecord): void;
+}
+
+// -----------------------------------------------------------------------------
+// Memories
+// -----------------------------------------------------------------------------
+
+/**
+ * Source of memory files. The Gateway's implementation reads the bot's
+ * `memories/` directory; tests use an in-memory listing. The domain only
+ * sees relative paths and contents.
+ */
+export interface MemorySource {
+	list(): readonly { path: string; content: string }[];
+}
+
+// -----------------------------------------------------------------------------
+// Engine execution port
+// -----------------------------------------------------------------------------
+
+export interface EngineInvocation {
+	readonly runId: RunId;
+	readonly sessionId: SessionId;
+	readonly botId: BotId;
+	readonly input: string;
+	readonly workspaceRoot: string;
+	/** Bot config with per-turn overrides already applied. */
+	readonly effectiveConfig: BotConfig;
+	readonly overrides?: TurnOverrides;
+}
+
+export interface EngineOutcome {
+	readonly status: "completed" | "failed" | "aborted" | "interrupted";
+	readonly outputText: string;
+	readonly error?: { name: string; message: string };
+}
+
+export interface EngineRunHandle {
+	/** Merge steering text into the active run. */
+	steer(text: string): boolean;
+	interrupt(reason?: string): void;
+	abort(reason?: string): void;
+	/** Settles when the execution reaches a terminal state. Never rejects. */
+	readonly result: Promise<EngineOutcome>;
+	/** Optional ordered event feed (engine events, opaque to the domain). */
+	subscribe?(listener: (event: unknown) => void): () => void;
+}
+
+export interface EnginePort {
+	start(invocation: EngineInvocation): EngineRunHandle;
+}
+
+// -----------------------------------------------------------------------------
+// Port bundle
+// -----------------------------------------------------------------------------
+
+export interface BotPorts {
+	clock: BotClock;
+	ids: BotIdSource;
+	bots: BotRepository;
+	sessions: SessionRepository;
+	runs: RunRepository;
+	engine: EnginePort;
+	memories?: MemorySource;
+}

--- a/sdk/packages/bot/src/registry.test.ts
+++ b/sdk/packages/bot/src/registry.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+	DelegationNotAllowedError,
+	MessagingNotAllowedError,
+	RoleImmutableError,
+} from "./errors";
+import type { BotRole } from "./identity";
+import { createInMemoryPorts } from "./in-memory";
+import { BotRegistry } from "./registry";
+
+function setup() {
+	const ports = createInMemoryPorts();
+	const registry = new BotRegistry(ports);
+	return { ports, registry };
+}
+
+describe("bootstrap", () => {
+	it("the first bot is `cline` with role `lead` and no parent", () => {
+		const { registry } = setup();
+		const first = registry.bootstrap();
+		expect(first.identity.name).toBe("cline");
+		expect(first.identity.role).toBe("lead");
+		expect(first.identity.parentBotId).toBeNull();
+		expect(first.identity.provenance.createdBy).toBe("bootstrap");
+	});
+
+	it("is idempotent — a second bootstrap returns the same lead", () => {
+		const { registry } = setup();
+		const first = registry.bootstrap();
+		const again = registry.bootstrap();
+		expect(again.identity.botId).toBe(first.identity.botId);
+		expect(registry.list()).toHaveLength(1);
+	});
+
+	it("identity records are frozen", () => {
+		const { registry } = setup();
+		const first = registry.bootstrap();
+		expect(Object.isFrozen(first.identity)).toBe(true);
+		expect(Object.isFrozen(first.identity.provenance)).toBe(true);
+	});
+});
+
+describe("role immutability", () => {
+	it("the repository rejects saves that change role or parent — no worker promotion", () => {
+		const { ports, registry } = setup();
+		const lead = registry.bootstrap();
+		const worker = registry.delegate(lead.identity.botId, {
+			name: "helper",
+			role: "worker",
+		});
+		expect(() =>
+			ports.bots.save({
+				...worker,
+				identity: { ...worker.identity, role: "lead" as BotRole },
+			}),
+		).toThrow(RoleImmutableError);
+		expect(() =>
+			ports.bots.save({
+				...worker,
+				identity: { ...worker.identity, parentBotId: null },
+			}),
+		).toThrow(RoleImmutableError);
+		// Status/config changes remain allowed.
+		expect(() =>
+			ports.bots.save({ ...worker, status: "retired", revision: 1 }),
+		).not.toThrow();
+	});
+
+	it("the registry exposes no role mutation API", () => {
+		const { registry } = setup();
+		const surface = Object.getOwnPropertyNames(Object.getPrototypeOf(registry));
+		expect(surface).not.toContain("setRole");
+		expect(surface).not.toContain("promote");
+		expect(surface).not.toContain("changeRole");
+	});
+});
+
+describe("delegation", () => {
+	it("a lead delegates workers and contractors", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		const worker = registry.delegate(lead.identity.botId, {
+			name: "helper",
+			role: "worker",
+		});
+		const contractor = registry.delegate(lead.identity.botId, {
+			name: "one-off",
+			role: "contractor",
+			reason: "single refactor task",
+		});
+		expect(worker.identity.role).toBe("worker");
+		expect(worker.identity.parentBotId).toBe(lead.identity.botId);
+		expect(contractor.identity.role).toBe("contractor");
+		expect(contractor.identity.provenance.createdBy).toBe(lead.identity.botId);
+	});
+
+	it("workers and contractors cannot delegate by default", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		const worker = registry.delegate(lead.identity.botId, {
+			name: "helper",
+			role: "worker",
+		});
+		const contractor = registry.delegate(lead.identity.botId, {
+			name: "one-off",
+			role: "contractor",
+		});
+		expect(() =>
+			registry.delegate(worker.identity.botId, { name: "sub", role: "worker" }),
+		).toThrow(DelegationNotAllowedError);
+		expect(() =>
+			registry.delegate(contractor.identity.botId, {
+				name: "sub",
+				role: "contractor",
+			}),
+		).toThrow(DelegationNotAllowedError);
+	});
+
+	it("delegation never creates a lead", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		expect(() =>
+			registry.delegate(lead.identity.botId, {
+				name: "usurper",
+				// biome-ignore lint/suspicious/noExplicitAny: deliberately bypassing the type guard
+				role: "lead" as any,
+			}),
+		).toThrow(DelegationNotAllowedError);
+	});
+
+	it("retired bots cannot delegate", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		registry.retire(lead.identity.botId);
+		expect(() =>
+			registry.delegate(lead.identity.botId, { name: "x", role: "worker" }),
+		).toThrow(DelegationNotAllowedError);
+	});
+});
+
+describe("messaging topology", () => {
+	it("a worker messages its lead; a lead messages its children", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		const worker = registry.delegate(lead.identity.botId, {
+			name: "helper",
+			role: "worker",
+		});
+		const up = registry.routeMessage(
+			worker.identity.botId,
+			lead.identity.botId,
+			"status: done",
+		);
+		expect(up.toBotId).toBe(lead.identity.botId);
+		const down = registry.routeMessage(
+			lead.identity.botId,
+			worker.identity.botId,
+			"please continue",
+		);
+		expect(down.toBotId).toBe(worker.identity.botId);
+	});
+
+	it("worker-to-worker messaging is rejected by default", () => {
+		const { registry } = setup();
+		const lead = registry.bootstrap();
+		const workerA = registry.delegate(lead.identity.botId, {
+			name: "a",
+			role: "worker",
+		});
+		const workerB = registry.delegate(lead.identity.botId, {
+			name: "b",
+			role: "worker",
+		});
+		expect(() =>
+			registry.routeMessage(
+				workerA.identity.botId,
+				workerB.identity.botId,
+				"psst",
+			),
+		).toThrow(MessagingNotAllowedError);
+	});
+});

--- a/sdk/packages/bot/src/registry.ts
+++ b/sdk/packages/bot/src/registry.ts
@@ -1,0 +1,178 @@
+/**
+ * Bot registry and topology (Gateway RFC, Phase 2).
+ *
+ * Registration semantics:
+ * - The first bot is `cline` with role `lead` (bootstrap).
+ * - Role and parent are immutable; there is no promotion path — the
+ *   registry exposes no role mutation, and repositories reject saves that
+ *   change identity.
+ * - Delegation: only a lead delegates; it creates workers and contractors.
+ *   Workers and contractors cannot delegate by default, and nothing can
+ *   delegate a new lead.
+ * - Messaging: a bot may message its parent (worker/contractor -> lead)
+ *   and a lead may message its children. Worker-to-worker messaging is
+ *   rejected by default.
+ */
+
+import type { BotId } from "@cline/shared/gateway";
+import {
+	BotNotFoundError,
+	DelegationNotAllowedError,
+	MessagingNotAllowedError,
+} from "./errors";
+import {
+	type BotConfig,
+	type BotRecord,
+	type BotRole,
+	FIRST_BOT_NAME,
+	FIRST_BOT_ROLE,
+	freezeIdentity,
+} from "./identity";
+import type { BotClock, BotIdSource, BotRepository } from "./ports";
+
+export interface DelegationSpec {
+	name: string;
+	role: Exclude<BotRole, "lead">;
+	config?: BotConfig;
+	reason?: string;
+}
+
+export interface BotMessage {
+	readonly fromBotId: BotId;
+	readonly toBotId: BotId;
+	readonly text: string;
+	readonly sentAt: number;
+}
+
+export interface BotRegistryPorts {
+	bots: BotRepository;
+	ids: BotIdSource;
+	clock: BotClock;
+}
+
+export class BotRegistry {
+	private readonly ports: BotRegistryPorts;
+
+	constructor(ports: BotRegistryPorts) {
+		this.ports = ports;
+	}
+
+	/**
+	 * Ensure the first bot exists: `cline`, role `lead`, no parent.
+	 * Idempotent — returns the existing bootstrap lead when present.
+	 */
+	bootstrap(): BotRecord {
+		const existing = this.ports.bots
+			.list()
+			.find(
+				(record) =>
+					record.identity.role === "lead" &&
+					record.identity.provenance.createdBy === "bootstrap",
+			);
+		if (existing) {
+			return existing;
+		}
+		const record: BotRecord = {
+			identity: freezeIdentity({
+				botId: this.ports.ids.botId(),
+				name: FIRST_BOT_NAME,
+				role: FIRST_BOT_ROLE,
+				parentBotId: null,
+				provenance: { createdBy: "bootstrap" },
+				createdAt: this.ports.clock.now(),
+			}),
+			config: {},
+			status: "active",
+			revision: 0,
+		};
+		this.ports.bots.save(record);
+		return record;
+	}
+
+	get(botId: BotId): BotRecord {
+		const record = this.ports.bots.get(botId);
+		if (!record) {
+			throw new BotNotFoundError(botId);
+		}
+		return record;
+	}
+
+	list(): readonly BotRecord[] {
+		return this.ports.bots.list();
+	}
+
+	/** Create a worker or contractor under a lead. */
+	delegate(parentBotId: BotId, spec: DelegationSpec): BotRecord {
+		const parent = this.get(parentBotId);
+		if (parent.status !== "active") {
+			throw new DelegationNotAllowedError(
+				`Bot ${parentBotId} is retired and cannot delegate`,
+			);
+		}
+		if (parent.identity.role !== "lead") {
+			throw new DelegationNotAllowedError(
+				`Only a lead delegates; ${parent.identity.role} bots cannot delegate by default`,
+			);
+		}
+		// The spec type already excludes "lead"; guard the runtime hole too.
+		if ((spec.role as BotRole) === "lead") {
+			throw new DelegationNotAllowedError(
+				"Delegation never creates a lead; the bootstrap lead is the only lead",
+			);
+		}
+		const record: BotRecord = {
+			identity: freezeIdentity({
+				botId: this.ports.ids.botId(),
+				name: spec.name,
+				role: spec.role,
+				parentBotId,
+				provenance: { createdBy: parentBotId, reason: spec.reason },
+				createdAt: this.ports.clock.now(),
+			}),
+			config: spec.config ?? {},
+			status: "active",
+			revision: 0,
+		};
+		this.ports.bots.save(record);
+		return record;
+	}
+
+	/** Retire a bot, retaining its record (contractor teardown). */
+	retire(botId: BotId): BotRecord {
+		const record = this.get(botId);
+		if (record.status === "retired") {
+			return record;
+		}
+		const retired: BotRecord = {
+			...record,
+			status: "retired",
+			revision: record.revision + 1,
+		};
+		this.ports.bots.save(retired);
+		return retired;
+	}
+
+	/**
+	 * Route a message along the allowed topology: child -> its parent, or
+	 * lead -> its direct child. Anything else is rejected by default.
+	 */
+	routeMessage(fromBotId: BotId, toBotId: BotId, text: string): BotMessage {
+		const from = this.get(fromBotId);
+		const to = this.get(toBotId);
+		const childToParent = from.identity.parentBotId === toBotId;
+		const parentToChild =
+			from.identity.role === "lead" && to.identity.parentBotId === fromBotId;
+		if (!childToParent && !parentToChild) {
+			throw new MessagingNotAllowedError(
+				`Bot ${fromBotId} (${from.identity.role}) may not message ${toBotId} (${to.identity.role}); ` +
+					"workers message their lead, and worker-to-worker communication is disabled by default",
+			);
+		}
+		return {
+			fromBotId,
+			toBotId,
+			text,
+			sentAt: this.ports.clock.now(),
+		};
+	}
+}

--- a/sdk/packages/bot/tsconfig.build.json
+++ b/sdk/packages/bot/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": false,
+		"emitDeclarationOnly": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"incremental": false
+	},
+	"include": ["src/index.ts"]
+}

--- a/sdk/packages/bot/tsconfig.dev.json
+++ b/sdk/packages/bot/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false
+	}
+}

--- a/sdk/packages/bot/tsconfig.json
+++ b/sdk/packages/bot/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/sdk/packages/bot/vitest.config.ts
+++ b/sdk/packages/bot/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		passWithNoTests: false,
+	},
+});

--- a/sdk/packages/engine/README.md
+++ b/sdk/packages/engine/README.md
@@ -1,0 +1,54 @@
+# `@cline/engine`
+
+Single-execution engine over the Cline agent loop — **Phase 1 of the Gateway
+RFC** (see `sdk/packages/gateway/README.md` for the full design).
+
+## What it owns
+
+Exactly one execution:
+
+- consumes an immutable [`RunSpec`](./src/run-spec.ts);
+- drives the existing `@cline/agents` loop with `@cline/llms` handlers;
+- binds caller-supplied tools, hooks, approval port, artifact sink, clock,
+  and telemetry;
+- emits canonical, ordered [`EngineEvent`](./src/events.ts) values
+  (per-run `sequence` starting at 0);
+- supports cooperative `steer(text)` (merges into the active run before the
+  next model call), cooperative `interrupt(reason?)`, and hard
+  `abort(reason?)`;
+- returns an [`EngineRunResult`](./src/result.ts) plus persistence deltas
+  the caller applies to its own stores.
+
+## What it deliberately does not own
+
+No database, config watcher, filesystem discovery, listener, daemon, global
+singleton, connector, or process supervisor. Multiple engines run
+concurrently without shared mutable module state.
+
+These rules are machine-checked in [`src/boundaries.test.ts`](./src/boundaries.test.ts):
+the engine never imports `@cline/bot`, `@cline/gateway`, or `@cline/core`,
+and never imports storage, socket, or process-spawning modules.
+
+## Usage
+
+```ts
+import { createEngine } from "@cline/engine";
+
+const engine = createEngine(
+	{
+		runId: "run_abc12345",
+		input: "summarize the diff",
+		model: { kind: "provider", providerId: "anthropic", modelId: "claude-sonnet-4-5", apiKey },
+		tools: [myTool],
+		requestApproval: async (request) => ({ approved: true }),
+	},
+	{ clock, telemetry, artifacts },
+);
+
+engine.subscribe((event) => console.log(event.sequence, event.type));
+engine.steer("also check the tests");
+const result = await engine.run();
+// result.persistence -> deltas for the caller's canonical stores
+```
+
+An engine owns exactly one execution — calling `run()` twice throws.

--- a/sdk/packages/engine/bun.mts
+++ b/sdk/packages/engine/bun.mts
@@ -1,0 +1,22 @@
+/// <reference types="@types/bun" />
+export {};
+
+const external = ["@cline/agents", "@cline/llms", "@cline/shared"];
+const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
+
+const result = await Bun.build({
+	entrypoints: ["./src/index.ts"],
+	outdir: "./dist",
+	target: "node",
+	minify,
+	sourcemap,
+	packages: "bundle",
+	external,
+});
+
+if (result.logs.length > 0) {
+	for (const log of result.logs) {
+		console.warn(log);
+	}
+}

--- a/sdk/packages/engine/package.json
+++ b/sdk/packages/engine/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@cline/engine",
+	"version": "0.0.75",
+	"description": "Single-execution engine over the Cline agent loop (Gateway RFC, Phase 1)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cline/cline",
+		"directory": "sdk/packages/engine"
+	},
+	"private": true,
+	"internal": true,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"license": "Apache-2.0",
+	"scripts": {
+		"build": "bun run bun.mts && bun tsc -p tsconfig.build.json",
+		"typecheck": "bun tsc -p tsconfig.dev.json --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"engines": {
+		"node": ">=22"
+	},
+	"dependencies": {
+		"@cline/agents": "workspace:*",
+		"@cline/shared": "workspace:*"
+	}
+}

--- a/sdk/packages/engine/src/boundaries.test.ts
+++ b/sdk/packages/engine/src/boundaries.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Machine-checked package boundaries (Gateway RFC dependency rules).
+ *
+ * `@cline/engine` never imports bot or Gateway types, never depends on
+ * `@cline/core`, and contains no storage, discovery, socket, or daemon
+ * code. The Gateway is the only new-path writer: this package cannot even
+ * name a database or a filesystem.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC_DIR = join(import.meta.dirname, ".");
+const PACKAGE_JSON = join(import.meta.dirname, "..", "package.json");
+
+const FORBIDDEN_IMPORTS: readonly { pattern: RegExp; why: string }[] = [
+	{ pattern: /^@cline\/bot(\/|$)/, why: "engine never imports bot types" },
+	{
+		pattern: /^@cline\/gateway(\/|$)/,
+		why: "engine never imports Gateway types",
+	},
+	{
+		pattern: /^@cline\/core(\/|$)/,
+		why: "no new package depends on @cline/core",
+	},
+	{ pattern: /^(node:)?fs(\/|$)/, why: "no storage: filesystem" },
+	{ pattern: /^(bun:)?sqlite$/, why: "no storage: sqlite" },
+	{ pattern: /^better-sqlite3$/, why: "no storage: sqlite" },
+	{ pattern: /^(node:)?net$/, why: "no sockets" },
+	{ pattern: /^(node:)?tls$/, why: "no sockets" },
+	{ pattern: /^(node:)?dgram$/, why: "no sockets" },
+	{ pattern: /^(node:)?http2?$/, why: "no listeners" },
+	{ pattern: /^(node:)?https$/, why: "no listeners" },
+	{ pattern: /^ws$/, why: "no sockets" },
+	{ pattern: /^(node:)?child_process$/, why: "no daemon / process spawning" },
+	{ pattern: /^(node:)?cluster$/, why: "no daemon" },
+	{ pattern: /^(node:)?worker_threads$/, why: "no daemon" },
+];
+
+function listSourceFiles(): string[] {
+	return readdirSync(SRC_DIR)
+		.filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+		.map((name) => join(SRC_DIR, name));
+}
+
+function extractImportSpecifiers(source: string): string[] {
+	const specifiers: string[] = [];
+	const patterns = [
+		/from\s+["']([^"']+)["']/g,
+		/import\s+["']([^"']+)["']/g,
+		/import\s*\(\s*["']([^"']+)["']\s*\)/g,
+		/require\s*\(\s*["']([^"']+)["']\s*\)/g,
+	];
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) {
+			specifiers.push(match[1]);
+		}
+	}
+	return specifiers;
+}
+
+describe("@cline/engine boundaries", () => {
+	it("source files import no bot/gateway/core, storage, discovery, socket, or daemon code", () => {
+		const files = listSourceFiles();
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			const specifiers = extractImportSpecifiers(readFileSync(file, "utf8"));
+			for (const specifier of specifiers) {
+				for (const { pattern, why } of FORBIDDEN_IMPORTS) {
+					expect(
+						pattern.test(specifier),
+						`${file} imports "${specifier}" (${why})`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+
+	it("package.json declares no dependency on @cline/core, @cline/bot, or @cline/gateway", () => {
+		const manifest = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+		};
+		const declared = [
+			...Object.keys(manifest.dependencies ?? {}),
+			...Object.keys(manifest.devDependencies ?? {}),
+			...Object.keys(manifest.peerDependencies ?? {}),
+		];
+		expect(declared).not.toContain("@cline/core");
+		expect(declared).not.toContain("@cline/bot");
+		expect(declared).not.toContain("@cline/gateway");
+	});
+});

--- a/sdk/packages/engine/src/engine.test.ts
+++ b/sdk/packages/engine/src/engine.test.ts
@@ -1,0 +1,522 @@
+import type { AgentModel, AgentModelEvent, AgentTool } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { createEngine, type Engine, EngineStateError } from "./engine";
+import type { EngineEvent } from "./events";
+import type { EngineArtifact, EngineClock, RunSpec } from "./run-spec";
+
+// -----------------------------------------------------------------------------
+// Test doubles (no network, no providers)
+// -----------------------------------------------------------------------------
+
+function scriptedModel(turns: AgentModelEvent[][]): AgentModel {
+	let call = 0;
+	return {
+		stream() {
+			const turn = turns[Math.min(call, turns.length - 1)];
+			call += 1;
+			return (async function* () {
+				for (const event of turn) {
+					// Yield to the scheduler so concurrent engines interleave.
+					await Promise.resolve();
+					yield event;
+				}
+			})();
+		},
+	};
+}
+
+function textTurn(text: string): AgentModelEvent[] {
+	return [
+		{ type: "text-delta", text },
+		{
+			type: "usage",
+			usage: {
+				inputTokens: 10,
+				outputTokens: 5,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+			},
+		},
+		{ type: "finish", reason: "stop" },
+	];
+}
+
+function toolTurn(
+	toolName: string,
+	input: unknown,
+	toolCallId = `call_${toolName}`,
+): AgentModelEvent[] {
+	return [
+		{ type: "tool-call-delta", toolCallId, toolName, input },
+		{ type: "finish", reason: "tool-calls" },
+	];
+}
+
+function errorTurn(error: string): AgentModelEvent[] {
+	return [{ type: "finish", reason: "error", error }];
+}
+
+function echoTool(
+	onExecute?: (input: unknown, context: unknown) => void,
+): AgentTool {
+	return {
+		name: "echo",
+		description: "Echoes its input",
+		inputSchema: { type: "object" },
+		execute: (input, context) => {
+			onExecute?.(input, context);
+			return { echoed: input };
+		},
+	};
+}
+
+function fakeClock(start = 1_000_000): EngineClock {
+	let now = start;
+	return {
+		now: () => {
+			now += 1;
+			return now;
+		},
+	};
+}
+
+function baseSpec(overrides: Partial<RunSpec>): RunSpec {
+	return {
+		runId: "run_test0001",
+		input: "do the thing",
+		model: { kind: "model", model: scriptedModel([textTurn("done")]) },
+		...overrides,
+	};
+}
+
+function eventTypes(events: readonly EngineEvent[]): string[] {
+	return events.map((event) => event.type);
+}
+
+// -----------------------------------------------------------------------------
+// Completion
+// -----------------------------------------------------------------------------
+
+describe("completion", () => {
+	it("runs to completion and reports transcript, usage, and deltas", async () => {
+		const engine = createEngine(baseSpec({}), { clock: fakeClock() });
+		const seen: EngineEvent[] = [];
+		engine.subscribe((event) => seen.push(event));
+
+		const result = await engine.run();
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("done");
+		expect(result.runId).toBe("run_test0001");
+		expect(result.iterations).toBe(1);
+		expect(result.usage.inputTokens).toBe(10);
+		expect(result.endedAt).toBeGreaterThan(result.startedAt);
+
+		// user prompt + assistant answer
+		expect(result.messages).toHaveLength(2);
+		expect(result.messages[0].role).toBe("user");
+		expect(result.messages[1].role).toBe("assistant");
+
+		const types = eventTypes(seen);
+		expect(types).toContain("run-started");
+		expect(types).toContain("text-delta");
+		expect(types.at(-1)).toBe("run-finished");
+
+		// Ordered: sequences are contiguous from 0.
+		expect(seen.map((event) => event.sequence)).toEqual(
+			seen.map((_, index) => index),
+		);
+		// Every event names the run.
+		expect(seen.every((event) => event.runId === "run_test0001")).toBe(true);
+
+		// Persistence deltas: both messages appended, usage, terminal status.
+		const kinds = result.persistence.map((delta) => delta.kind);
+		expect(kinds.filter((kind) => kind === "message-appended")).toHaveLength(2);
+		expect(kinds).toContain("usage-updated");
+		expect(kinds.at(-1)).toBe("run-status-changed");
+		const appended = result.persistence.filter(
+			(delta) => delta.kind === "message-appended",
+		);
+		expect(appended.map((delta) => delta.index)).toEqual([0, 1]);
+	});
+
+	it("uses the injected clock for timestamps", async () => {
+		const engine = createEngine(baseSpec({}), { clock: fakeClock(5_000_000) });
+		const result = await engine.run();
+		expect(result.startedAt).toBeGreaterThan(5_000_000);
+		for (const event of engine.events) {
+			expect(event.timestamp).toBeGreaterThan(5_000_000);
+		}
+	});
+
+	it("continues from initial messages and indexes deltas after them", async () => {
+		const initialMessages = [
+			{
+				id: "msg_prior",
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "earlier" }],
+				createdAt: 1,
+			},
+		];
+		const engine = createEngine(baseSpec({ initialMessages }));
+		const result = await engine.run();
+		expect(result.messages).toHaveLength(3);
+		const appended = result.persistence.filter(
+			(delta) => delta.kind === "message-appended",
+		);
+		expect(appended.map((delta) => delta.index)).toEqual([1, 2]);
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Tool runs
+// -----------------------------------------------------------------------------
+
+describe("tool runs", () => {
+	it("executes tools and emits tool lifecycle events", async () => {
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([
+						toolTurn("echo", { value: 42 }),
+						textTurn("finished with tools"),
+					]),
+				},
+				tools: [echoTool()],
+			}),
+		);
+		const result = await engine.run();
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("finished with tools");
+		const types = eventTypes(engine.events);
+		expect(types).toContain("tool-started");
+		expect(types).toContain("tool-finished");
+
+		const finished = engine.events.find(
+			(event) => event.type === "tool-finished",
+		);
+		expect(
+			finished && finished.type === "tool-finished" && finished.output,
+		).toEqual({ echoed: { value: 42 } });
+
+		const toolMessage = result.messages.find(
+			(message) => message.role === "tool",
+		);
+		expect(toolMessage).toBeDefined();
+	});
+
+	it("exposes the artifact sink to tools and emits artifact events", async () => {
+		const stored: EngineArtifact[] = [];
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([toolTurn("echo", {}), textTurn("ok")]),
+				},
+				tools: [
+					echoTool((_input, context) => {
+						const metadata = (context as { metadata?: Record<string, unknown> })
+							.metadata;
+						const artifacts = metadata?.artifacts as {
+							put: (artifact: EngineArtifact) => Promise<void>;
+						};
+						void artifacts.put({ name: "report.txt", data: "hello" });
+					}),
+				],
+			}),
+			{ artifacts: { put: (artifact) => void stored.push(artifact) } },
+		);
+		const result = await engine.run();
+		expect(result.status).toBe("completed");
+		expect(stored).toHaveLength(1);
+		expect(stored[0].name).toBe("report.txt");
+		expect(eventTypes(engine.events)).toContain("artifact-created");
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Approval
+// -----------------------------------------------------------------------------
+
+describe("approval", () => {
+	function approvalSpec(approved: boolean): RunSpec {
+		return baseSpec({
+			model: {
+				kind: "model",
+				model: scriptedModel([toolTurn("echo", { x: 1 }), textTurn("after")]),
+			},
+			tools: [echoTool()],
+			toolPolicies: { echo: { autoApprove: false } },
+			requestApproval: () => ({
+				approved,
+				reason: approved ? undefined : "not on my watch",
+			}),
+		});
+	}
+
+	it("denied approvals skip the tool with an error result", async () => {
+		const engine = createEngine(approvalSpec(false));
+		const result = await engine.run();
+		expect(result.status).toBe("completed");
+
+		const types = eventTypes(engine.events);
+		expect(types).toContain("approval-requested");
+		expect(types).toContain("approval-resolved");
+		const resolved = engine.events.find(
+			(event) => event.type === "approval-resolved",
+		);
+		expect(
+			resolved && resolved.type === "approval-resolved" && resolved.approved,
+		).toBe(false);
+
+		const finished = engine.events.find(
+			(event) => event.type === "tool-finished",
+		);
+		expect(
+			finished && finished.type === "tool-finished" && finished.isError,
+		).toBe(true);
+	});
+
+	it("granted approvals execute the tool", async () => {
+		const engine = createEngine(approvalSpec(true));
+		const result = await engine.run();
+		expect(result.status).toBe("completed");
+		const finished = engine.events.find(
+			(event) => event.type === "tool-finished",
+		);
+		expect(
+			finished && finished.type === "tool-finished" && finished.isError,
+		).toBeFalsy();
+		expect(
+			finished && finished.type === "tool-finished" && finished.output,
+		).toEqual({ echoed: { x: 1 } });
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Steer
+// -----------------------------------------------------------------------------
+
+describe("steer", () => {
+	it("merges queued steering text into the active run before the next model call", async () => {
+		let engineRef: Engine | undefined;
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([
+						toolTurn("echo", {}),
+						textTurn("steered done"),
+					]),
+				},
+				tools: [
+					echoTool(() => {
+						expect(engineRef?.steer("also update the docs")).toBe(true);
+					}),
+				],
+			}),
+		);
+		engineRef = engine;
+		const result = await engine.run();
+
+		expect(result.status).toBe("completed");
+		const types = eventTypes(engine.events);
+		expect(types).toContain("steer-queued");
+		expect(types).toContain("steer-merged");
+		expect(types.indexOf("steer-queued")).toBeLessThan(
+			types.indexOf("steer-merged"),
+		);
+
+		const steeredMessage = result.messages.find(
+			(message) =>
+				message.role === "user" &&
+				message.content.some(
+					(part) =>
+						part.type === "text" && part.text === "also update the docs",
+				),
+		);
+		expect(steeredMessage).toBeDefined();
+	});
+
+	it("rejects steering once the run is terminal", async () => {
+		const engine = createEngine(baseSpec({}));
+		await engine.run();
+		expect(engine.steer("too late")).toBe(false);
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Interrupt and abort
+// -----------------------------------------------------------------------------
+
+describe("interrupt", () => {
+	it("cooperatively stops the run at the next control point", async () => {
+		let engineRef: Engine | undefined;
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([toolTurn("echo", {}), textTurn("never")]),
+				},
+				tools: [
+					echoTool(() => {
+						engineRef?.interrupt("user paused");
+					}),
+				],
+			}),
+		);
+		engineRef = engine;
+		const result = await engine.run();
+
+		expect(result.status).toBe("interrupted");
+		expect(result.error).toBeUndefined();
+		const types = eventTypes(engine.events);
+		expect(types).toContain("interrupt-requested");
+		expect(types.at(-1)).toBe("run-finished");
+		// The second model turn never ran.
+		expect(result.outputText).not.toBe("never");
+	});
+
+	it("an interrupt before run() stops the run before any model call", async () => {
+		const engine = createEngine(baseSpec({}));
+		engine.interrupt("changed my mind");
+		const result = await engine.run();
+		expect(result.status).toBe("interrupted");
+		expect(
+			result.messages.every((message) => message.role !== "assistant"),
+		).toBe(true);
+	});
+});
+
+describe("abort", () => {
+	it("hard-stops the run with aborted status", async () => {
+		let engineRef: Engine | undefined;
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([toolTurn("echo", {}), textTurn("never")]),
+				},
+				tools: [
+					echoTool(() => {
+						engineRef?.abort("stop now");
+					}),
+				],
+			}),
+		);
+		engineRef = engine;
+		const result = await engine.run();
+		expect(result.status).toBe("aborted");
+		expect(eventTypes(engine.events)).toContain("abort-requested");
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Failure
+// -----------------------------------------------------------------------------
+
+describe("failure", () => {
+	it("reports model failures with the error and a run-failed event", async () => {
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([errorTurn("provider exploded")]),
+				},
+			}),
+		);
+		const result = await engine.run();
+		expect(result.status).toBe("failed");
+		expect(result.error?.message).toContain("provider exploded");
+		const last = engine.events.at(-1);
+		expect(last?.type).toBe("run-failed");
+		expect(last && last.type === "run-failed" && last.result.status).toBe(
+			"failed",
+		);
+		const statusDelta = result.persistence.at(-1);
+		expect(statusDelta).toEqual({
+			kind: "run-status-changed",
+			status: "failed",
+		});
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Single execution & concurrency
+// -----------------------------------------------------------------------------
+
+describe("execution ownership", () => {
+	it("owns exactly one execution", async () => {
+		const engine = createEngine(baseSpec({}));
+		await engine.run();
+		await expect(engine.run()).rejects.toThrow(EngineStateError);
+	});
+
+	it("concurrent engines share no mutable state", async () => {
+		const engines = ["run_alpha001", "run_beta0001", "run_gamma001"].map(
+			(runId, index) =>
+				createEngine(
+					baseSpec({
+						runId,
+						input: `prompt ${index}`,
+						model: {
+							kind: "model",
+							model: scriptedModel([
+								toolTurn("echo", { engine: index }),
+								textTurn(`answer ${index}`),
+							]),
+						},
+						tools: [echoTool()],
+					}),
+					{ clock: fakeClock((index + 1) * 10_000_000) },
+				),
+		);
+
+		const results = await Promise.all(engines.map((engine) => engine.run()));
+
+		for (const [index, engine] of engines.entries()) {
+			const result = results[index];
+			expect(result.status).toBe("completed");
+			expect(result.outputText).toBe(`answer ${index}`);
+			// Sequences are per-engine, contiguous from 0.
+			expect(engine.events.map((event) => event.sequence)).toEqual(
+				engine.events.map((_, position) => position),
+			);
+			// No cross-contamination: every event names this engine's run.
+			expect(engine.events.every((event) => event.runId === result.runId)).toBe(
+				true,
+			);
+			// Transcripts never leak across engines.
+			for (const [otherIndex, otherResult] of results.entries()) {
+				if (otherIndex === index) {
+					continue;
+				}
+				expect(result.outputText).not.toBe(otherResult.outputText);
+				expect(
+					result.messages.some((message) =>
+						message.content.some(
+							(part) =>
+								part.type === "text" && part.text === `prompt ${otherIndex}`,
+						),
+					),
+				).toBe(false);
+			}
+		}
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Event subscription
+// -----------------------------------------------------------------------------
+
+describe("event subscription", () => {
+	it("replays past events to late subscribers on request", async () => {
+		const engine = createEngine(baseSpec({}));
+		await engine.run();
+		const replayed: EngineEvent[] = [];
+		engine.subscribe((event) => replayed.push(event), { replay: true });
+		expect(replayed).toEqual([...engine.events]);
+	});
+});

--- a/sdk/packages/engine/src/engine.ts
+++ b/sdk/packages/engine/src/engine.ts
@@ -1,0 +1,467 @@
+/**
+ * `Engine` — owns exactly one execution (Gateway RFC, Phase 1).
+ *
+ * The engine composes one validated run around the existing `@cline/agents`
+ * loop (which drives `@cline/llms` handlers). It binds caller-supplied
+ * tools, hooks, approval port, artifact sink, clock, and telemetry; emits a
+ * canonical ordered `EngineEvent` stream; supports cooperative steer,
+ * interrupt, and hard abort; and returns a `RunResult` plus persistence
+ * deltas.
+ *
+ * Deliberately absent: databases, config watchers, filesystem discovery,
+ * listeners, daemons, global singletons, connectors, process supervisors.
+ * All state is per-instance; concurrent engines share no mutable module
+ * state.
+ */
+
+import type { AgentRuntimeConfig } from "@cline/agents";
+import { AgentRuntime } from "@cline/agents";
+import type {
+	AgentMessage,
+	AgentRunResult,
+	AgentRuntimeEvent,
+	AgentRuntimeHooks,
+	AgentStopControl,
+	ToolApprovalResult,
+} from "@cline/shared";
+import type {
+	EngineEvent,
+	EngineEventListener,
+	EngineEventPayload,
+} from "./events";
+import type {
+	EngineErrorInfo,
+	EnginePersistenceDelta,
+	EngineRunResult,
+	EngineRunStatus,
+} from "./result";
+import {
+	type EngineArtifact,
+	type EngineClock,
+	type EngineOptions,
+	type RunSpec,
+	SYSTEM_CLOCK,
+} from "./run-spec";
+
+/** Thrown when an engine is asked to violate its single-execution contract. */
+export class EngineStateError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EngineStateError";
+	}
+}
+
+export type EngineStatus = "created" | "running" | EngineRunStatus;
+
+export class Engine {
+	private readonly spec: RunSpec;
+	private readonly clock: EngineClock;
+	private readonly options: EngineOptions;
+	private readonly listeners = new Set<EngineEventListener>();
+	private readonly eventLog: EngineEvent[] = [];
+	private sequence = 0;
+
+	private executionStarted = false;
+	private runtime?: AgentRuntime;
+	private finalResult?: EngineRunResult;
+
+	private readonly steerQueue: string[] = [];
+	private interruptRequested = false;
+	private interruptReason?: string;
+	private abortRequested = false;
+	private abortReason?: string;
+
+	private readonly persistenceDeltas: EnginePersistenceDelta[] = [];
+
+	constructor(spec: RunSpec, options: EngineOptions = {}) {
+		this.spec = spec;
+		this.options = options;
+		this.clock = options.clock ?? SYSTEM_CLOCK;
+	}
+
+	get runId(): string {
+		return this.spec.runId;
+	}
+
+	get status(): EngineStatus {
+		if (this.finalResult) {
+			return this.finalResult.status;
+		}
+		return this.executionStarted ? "running" : "created";
+	}
+
+	/** Events emitted so far, in sequence order. */
+	get events(): readonly EngineEvent[] {
+		return [...this.eventLog];
+	}
+
+	get result(): EngineRunResult | undefined {
+		return this.finalResult;
+	}
+
+	subscribe(
+		listener: EngineEventListener,
+		options: { replay?: boolean } = {},
+	): () => void {
+		if (options.replay) {
+			for (const event of this.eventLog) {
+				listener(event);
+			}
+		}
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	/**
+	 * Queue steering text that merges into the active run before its next
+	 * model request. Returns false once the run is terminal.
+	 */
+	steer(text: string): boolean {
+		if (this.finalResult) {
+			return false;
+		}
+		this.steerQueue.push(text);
+		this.emit({ type: "steer-queued", text });
+		return true;
+	}
+
+	/**
+	 * Request a cooperative interruption: the run stops at the next control
+	 * point (before a model call or after a tool) instead of mid-flight.
+	 */
+	interrupt(reason?: string): void {
+		if (this.finalResult || this.interruptRequested) {
+			return;
+		}
+		this.interruptRequested = true;
+		this.interruptReason = reason;
+		this.emit({ type: "interrupt-requested", reason });
+	}
+
+	/** Hard-stop the run immediately. */
+	abort(reason?: string): void {
+		if (this.finalResult || this.abortRequested) {
+			return;
+		}
+		this.abortRequested = true;
+		this.abortReason = reason;
+		this.emit({ type: "abort-requested", reason });
+		this.runtime?.abort(reason ?? "Run aborted");
+	}
+
+	/** Execute the run. An engine owns exactly one execution. */
+	async run(): Promise<EngineRunResult> {
+		if (this.executionStarted) {
+			throw new EngineStateError(
+				"Engine owns exactly one execution; create a new engine for a new run",
+			);
+		}
+		this.executionStarted = true;
+		const startedAt = this.clock.now();
+
+		const runtime = new AgentRuntime(this.buildRuntimeConfig());
+		this.runtime = runtime;
+		const unsubscribe = runtime.subscribe((event) =>
+			this.translateRuntimeEvent(event),
+		);
+
+		let agentResult: AgentRunResult;
+		try {
+			agentResult = await runtime.run(
+				this.spec.input as string | readonly AgentMessage[],
+			);
+		} finally {
+			unsubscribe();
+			this.runtime = undefined;
+		}
+
+		const endedAt = this.clock.now();
+		const status = this.mapStatus(agentResult);
+		const error: EngineErrorInfo | undefined =
+			status === "failed" && agentResult.error
+				? { name: agentResult.error.name, message: agentResult.error.message }
+				: undefined;
+
+		this.persistenceDeltas.push(
+			{ kind: "usage-updated", usage: agentResult.usage },
+			{ kind: "run-status-changed", status },
+		);
+
+		const result: EngineRunResult = {
+			runId: this.spec.runId,
+			status,
+			outputText: agentResult.outputText,
+			messages: agentResult.messages,
+			usage: agentResult.usage,
+			iterations: agentResult.iterations,
+			startedAt,
+			endedAt,
+			error,
+			persistence: [...this.persistenceDeltas],
+		};
+		this.finalResult = result;
+
+		if (status === "failed" && error) {
+			this.emit({ type: "run-failed", error, result });
+		} else {
+			this.emit({ type: "run-finished", result });
+		}
+		return result;
+	}
+
+	// ---------------------------------------------------------------------
+	// Internals
+	// ---------------------------------------------------------------------
+
+	private buildRuntimeConfig(): AgentRuntimeConfig {
+		const spec = this.spec;
+		const base = {
+			sessionId: spec.sessionId,
+			agentId: spec.botId,
+			conversationId: spec.sessionId,
+			systemPrompt: spec.systemPrompt,
+			tools: spec.tools,
+			hooks: spec.hooks,
+			plugins: [
+				{
+					name: "engine-controls",
+					setup: () => ({ hooks: this.controlHooks() }),
+				},
+			],
+			initialMessages: spec.initialMessages,
+			maxIterations: spec.maxIterations,
+			toolPolicies: spec.toolPolicies,
+			toolContextMetadata: this.buildToolContextMetadata(),
+			requestToolApproval: this.buildApprovalPort(),
+			consumePendingUserMessage: () => this.consumeSteerText(),
+			logger: this.options.logger,
+			telemetry: this.options.telemetry,
+		};
+		if (spec.model.kind === "model") {
+			return {
+				...base,
+				model: spec.model.model,
+				messageModelInfo: spec.model.modelInfo,
+			};
+		}
+		return {
+			...base,
+			providerId: spec.model.providerId,
+			modelId: spec.model.modelId,
+			apiKey: spec.model.apiKey,
+			baseUrl: spec.model.baseUrl,
+			headers: spec.model.headers,
+		};
+	}
+
+	/** Cooperative stop checkpoints for interrupt/abort. */
+	private controlHooks(): Partial<AgentRuntimeHooks> {
+		const check = (): AgentStopControl | undefined => this.stopControl();
+		return {
+			beforeRun: check,
+			beforeModel: check,
+			afterTool: check,
+		};
+	}
+
+	private stopControl(): AgentStopControl | undefined {
+		if (this.abortRequested) {
+			return { stop: true, reason: this.abortReason ?? "Run aborted" };
+		}
+		if (this.interruptRequested) {
+			return { stop: true, reason: this.interruptReason ?? "Run interrupted" };
+		}
+		return undefined;
+	}
+
+	private consumeSteerText(): string | undefined {
+		if (this.steerQueue.length === 0) {
+			return undefined;
+		}
+		const text = this.steerQueue.splice(0).join("\n\n");
+		this.emit({ type: "steer-merged", text });
+		return text;
+	}
+
+	private buildToolContextMetadata(): Record<string, unknown> {
+		const sink = this.options.artifacts;
+		if (!sink) {
+			return { ...this.spec.metadata };
+		}
+		return {
+			...this.spec.metadata,
+			artifacts: {
+				put: async (artifact: EngineArtifact) => {
+					await sink.put(artifact);
+					this.emit({
+						type: "artifact-created",
+						name: artifact.name,
+						mediaType: artifact.mediaType,
+					});
+				},
+			},
+		};
+	}
+
+	private buildApprovalPort(): AgentRuntimeConfig["requestToolApproval"] {
+		const port = this.spec.requestApproval;
+		if (!port) {
+			return undefined;
+		}
+		return async (request) => {
+			this.emit({
+				type: "approval-requested",
+				toolCallId: request.toolCallId,
+				toolName: request.toolName,
+				input: request.input,
+			});
+			let result: ToolApprovalResult;
+			try {
+				result = await port(request);
+			} catch (error) {
+				result = {
+					approved: false,
+					reason: `Approval request failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				};
+			}
+			this.emit({
+				type: "approval-resolved",
+				toolCallId: request.toolCallId,
+				toolName: request.toolName,
+				approved: result.approved,
+				reason: result.reason,
+			});
+			return result;
+		};
+	}
+
+	private mapStatus(agentResult: AgentRunResult): EngineRunStatus {
+		switch (agentResult.status) {
+			case "completed":
+				return "completed";
+			case "failed":
+				return "failed";
+			case "aborted":
+				return this.interruptRequested && !this.abortRequested
+					? "interrupted"
+					: "aborted";
+		}
+	}
+
+	private translateRuntimeEvent(event: AgentRuntimeEvent): void {
+		switch (event.type) {
+			case "run-started":
+				this.emit({ type: "run-started" });
+				break;
+			case "turn-started":
+				this.emit({ type: "turn-started", iteration: event.iteration });
+				break;
+			case "message-added": {
+				const index = event.snapshot.messages.length - 1;
+				this.persistenceDeltas.push({
+					kind: "message-appended",
+					index,
+					message: event.message,
+				});
+				this.emit({
+					type: "message-appended",
+					message: event.message,
+					index,
+				});
+				break;
+			}
+			case "assistant-text-delta":
+				this.emit({ type: "text-delta", text: event.text });
+				break;
+			case "assistant-reasoning-delta":
+				this.emit({
+					type: "reasoning-delta",
+					text: event.text,
+					redacted: event.redacted,
+				});
+				break;
+			case "assistant-media":
+				this.emit({ type: "media", media: event.media });
+				break;
+			case "tool-started":
+				this.emit({
+					type: "tool-started",
+					toolCallId: event.toolCall.toolCallId,
+					toolName: event.toolCall.toolName,
+					input: event.toolCall.input,
+				});
+				break;
+			case "tool-updated":
+				this.emit({
+					type: "tool-updated",
+					toolCallId: event.toolCall.toolCallId,
+					toolName: event.toolCall.toolName,
+					update: event.update,
+				});
+				break;
+			case "tool-finished": {
+				const resultPart = event.message.content.find(
+					(part) =>
+						part.type === "tool-result" &&
+						part.toolCallId === event.toolCall.toolCallId,
+				);
+				this.emit({
+					type: "tool-finished",
+					toolCallId: event.toolCall.toolCallId,
+					toolName: event.toolCall.toolName,
+					output:
+						resultPart?.type === "tool-result" ? resultPart.output : undefined,
+					isError:
+						resultPart?.type === "tool-result" ? resultPart.isError : undefined,
+				});
+				break;
+			}
+			case "usage-updated":
+				this.emit({ type: "usage-updated", usage: event.usage });
+				break;
+			case "turn-finished":
+				this.emit({
+					type: "turn-finished",
+					iteration: event.iteration,
+					toolCallCount: event.toolCallCount,
+				});
+				break;
+			case "status-notice":
+				this.emit({
+					type: "status",
+					message: event.message,
+					metadata: event.metadata,
+				});
+				break;
+			// Terminal events are emitted by the engine itself with the final
+			// EngineRunResult; the runtime's assistant-message duplicates
+			// message-added and is dropped.
+			case "assistant-message":
+			case "run-finished":
+			case "run-failed":
+				break;
+		}
+	}
+
+	private emit(payload: EngineEventPayload): void {
+		const event: EngineEvent = {
+			...payload,
+			sequence: this.sequence,
+			runId: this.spec.runId,
+			timestamp: this.clock.now(),
+		};
+		this.sequence += 1;
+		this.eventLog.push(event);
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+	}
+}
+
+export function createEngine(spec: RunSpec, options?: EngineOptions): Engine {
+	return new Engine(spec, options);
+}

--- a/sdk/packages/engine/src/events.ts
+++ b/sdk/packages/engine/src/events.ts
@@ -1,0 +1,77 @@
+/**
+ * `EngineEvent` — the canonical, ordered event stream of one execution
+ * (Gateway RFC, Phase 1).
+ *
+ * Every event carries the run's ID and a per-run monotonically increasing
+ * `sequence` starting at 0. Ordering is total within a run and meaningless
+ * across runs.
+ */
+
+import type { AgentMessage, AgentUsage, GeneratedMedia } from "@cline/shared";
+import type { EngineErrorInfo, EngineRunResult } from "./result";
+
+export interface EngineEventBase {
+	sequence: number;
+	runId: string;
+	/** Injected-clock timestamp (epoch ms). */
+	timestamp: number;
+}
+
+export type EngineEventPayload =
+	| { type: "run-started" }
+	| { type: "turn-started"; iteration: number }
+	| {
+			type: "message-appended";
+			message: AgentMessage;
+			/** Position in the canonical transcript (incl. initial messages). */
+			index: number;
+	  }
+	| { type: "text-delta"; text: string }
+	| { type: "reasoning-delta"; text: string; redacted?: boolean }
+	| { type: "media"; media: GeneratedMedia }
+	| {
+			type: "tool-started";
+			toolCallId: string;
+			toolName: string;
+			input: unknown;
+	  }
+	| {
+			type: "tool-updated";
+			toolCallId: string;
+			toolName: string;
+			update: unknown;
+	  }
+	| {
+			type: "tool-finished";
+			toolCallId: string;
+			toolName: string;
+			output: unknown;
+			isError?: boolean;
+	  }
+	| {
+			type: "approval-requested";
+			toolCallId: string;
+			toolName: string;
+			input: unknown;
+	  }
+	| {
+			type: "approval-resolved";
+			toolCallId: string;
+			toolName: string;
+			approved: boolean;
+			reason?: string;
+	  }
+	| { type: "steer-queued"; text: string }
+	| { type: "steer-merged"; text: string }
+	| { type: "interrupt-requested"; reason?: string }
+	| { type: "abort-requested"; reason?: string }
+	| { type: "usage-updated"; usage: AgentUsage }
+	| { type: "turn-finished"; iteration: number; toolCallCount: number }
+	| { type: "status"; message: string; metadata?: Record<string, unknown> }
+	| { type: "artifact-created"; name: string; mediaType?: string }
+	| { type: "run-finished"; result: EngineRunResult }
+	| { type: "run-failed"; error: EngineErrorInfo; result: EngineRunResult };
+
+export type EngineEvent = EngineEventBase & EngineEventPayload;
+
+export type EngineEventListener = (event: EngineEvent) => void;

--- a/sdk/packages/engine/src/index.ts
+++ b/sdk/packages/engine/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * `@cline/engine`
+ *
+ * Owns exactly one execution (Gateway RFC, Phase 1): consumes an immutable
+ * `RunSpec`, drives the `@cline/agents` loop with `@cline/llms` handlers,
+ * emits canonical ordered `EngineEvent` values, supports cooperative steer,
+ * interrupt, and abort, and returns an `EngineRunResult` plus persistence
+ * deltas.
+ *
+ * This package never imports `@cline/bot`, `@cline/gateway`, or
+ * `@cline/core`, and contains no storage, discovery, socket, or daemon
+ * code. See `src/boundaries.test.ts` for the machine-checked rules.
+ */
+
+// Convenience re-exports so consumers (e.g. `@cline/bot`) can build specs
+// without importing `@cline/agents` directly.
+export type {
+	AgentMessage,
+	AgentMessagePart,
+	AgentModel,
+	AgentModelEvent,
+	AgentRuntimeHooks,
+	AgentTool,
+	AgentUsage,
+	ToolApprovalRequest,
+	ToolApprovalResult,
+	ToolPolicy,
+} from "@cline/shared";
+export type { EngineStatus } from "./engine";
+export { createEngine, Engine, EngineStateError } from "./engine";
+export type {
+	EngineEvent,
+	EngineEventBase,
+	EngineEventListener,
+	EngineEventPayload,
+} from "./events";
+export type {
+	EngineErrorInfo,
+	EnginePersistenceDelta,
+	EngineRunResult,
+	EngineRunStatus,
+} from "./result";
+export type {
+	EngineApprovalPort,
+	EngineArtifact,
+	EngineArtifactSink,
+	EngineClock,
+	EngineModelBinding,
+	EngineOptions,
+	RunSpec,
+} from "./run-spec";
+export { SYSTEM_CLOCK } from "./run-spec";

--- a/sdk/packages/engine/src/result.ts
+++ b/sdk/packages/engine/src/result.ts
@@ -1,0 +1,45 @@
+/**
+ * `RunResult` and persistence deltas (Gateway RFC, Phase 1).
+ *
+ * The engine never persists anything. It returns what happened plus the
+ * minimal set of deltas a caller (the Gateway, eventually) must apply to
+ * its canonical stores to make the run durable.
+ */
+
+import type { AgentMessage, AgentUsage } from "@cline/shared";
+
+export type EngineRunStatus =
+	| "completed"
+	| "failed"
+	| "aborted"
+	| "interrupted";
+
+export interface EngineErrorInfo {
+	name: string;
+	message: string;
+}
+
+export type EnginePersistenceDelta =
+	| {
+			kind: "message-appended";
+			/** Position in the canonical transcript (incl. initial messages). */
+			index: number;
+			message: AgentMessage;
+	  }
+	| { kind: "usage-updated"; usage: AgentUsage }
+	| { kind: "run-status-changed"; status: EngineRunStatus };
+
+export interface EngineRunResult {
+	runId: string;
+	status: EngineRunStatus;
+	outputText: string;
+	/** Full canonical transcript after the run. */
+	messages: readonly AgentMessage[];
+	usage: AgentUsage;
+	iterations: number;
+	startedAt: number;
+	endedAt: number;
+	error?: EngineErrorInfo;
+	/** Ordered deltas the caller applies to its stores. */
+	persistence: readonly EnginePersistenceDelta[];
+}

--- a/sdk/packages/engine/src/run-spec.ts
+++ b/sdk/packages/engine/src/run-spec.ts
@@ -1,0 +1,100 @@
+/**
+ * `RunSpec` — the immutable description of exactly one execution
+ * (Gateway RFC, Phase 1).
+ *
+ * Everything an engine touches is supplied by the caller: model binding,
+ * tools, hooks, approval port, artifact sink, clock, telemetry. The engine
+ * owns no storage, no discovery, no sockets, no daemon, and no global
+ * singleton; a caller that wants persistence applies the `RunResult`'s
+ * persistence deltas itself.
+ */
+
+import type {
+	AgentMessage,
+	AgentModel,
+	AgentRuntimeHooks,
+	AgentTool,
+	BasicLogger,
+	ITelemetryService,
+	ToolApprovalRequest,
+	ToolApprovalResult,
+	ToolPolicy,
+} from "@cline/shared";
+
+/**
+ * How the engine binds a model. Either the caller injects a pre-built
+ * `AgentModel`, or it names a provider/model and the underlying
+ * `@cline/agents` + `@cline/llms` stack constructs the handler.
+ */
+export type EngineModelBinding =
+	| {
+			kind: "model";
+			model: AgentModel;
+			/** Optional attribution stamped onto assistant messages. */
+			modelInfo?: { id: string; provider: string };
+	  }
+	| {
+			kind: "provider";
+			providerId: string;
+			modelId: string;
+			apiKey?: string;
+			baseUrl?: string;
+			headers?: Record<string, string>;
+	  };
+
+/** Injected clock so engines are deterministic under test. */
+export interface EngineClock {
+	now(): number;
+}
+
+/** Artifact produced by tools or hooks during a run. */
+export interface EngineArtifact {
+	name: string;
+	mediaType?: string;
+	data: string | Uint8Array;
+	metadata?: Record<string, unknown>;
+}
+
+/** Caller-supplied artifact sink; the engine never touches a filesystem. */
+export interface EngineArtifactSink {
+	put(artifact: EngineArtifact): void | Promise<void>;
+}
+
+/** Caller-supplied approval port for tools that are not auto-approved. */
+export type EngineApprovalPort = (
+	request: ToolApprovalRequest,
+) => Promise<ToolApprovalResult> | ToolApprovalResult;
+
+export interface RunSpec {
+	/** Run identity, issued by the caller (e.g. at Gateway admission). */
+	runId: string;
+	/** Session/bot attribution passed through to tools and telemetry. */
+	sessionId?: string;
+	botId?: string;
+	/** The prompt (or pre-normalized messages) that starts this run. */
+	input: string | readonly AgentMessage[];
+	/** Canonical history the run continues from. */
+	initialMessages?: readonly AgentMessage[];
+	systemPrompt?: string;
+	model: EngineModelBinding;
+	// biome-ignore lint/suspicious/noExplicitAny: tool input/output types vary per tool
+	tools?: readonly AgentTool<any, any>[];
+	hooks?: Partial<AgentRuntimeHooks>;
+	toolPolicies?: Record<string, ToolPolicy>;
+	/** Required whenever a tool policy disables auto-approval. */
+	requestApproval?: EngineApprovalPort;
+	maxIterations?: number;
+	/** Opaque metadata forwarded to tool execution contexts. */
+	metadata?: Record<string, unknown>;
+}
+
+export interface EngineOptions {
+	clock?: EngineClock;
+	telemetry?: ITelemetryService;
+	logger?: BasicLogger;
+	artifacts?: EngineArtifactSink;
+}
+
+export const SYSTEM_CLOCK: EngineClock = {
+	now: () => Date.now(),
+};

--- a/sdk/packages/engine/tsconfig.build.json
+++ b/sdk/packages/engine/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": false,
+		"emitDeclarationOnly": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"incremental": false
+	},
+	"include": ["src/index.ts"]
+}

--- a/sdk/packages/engine/tsconfig.dev.json
+++ b/sdk/packages/engine/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false
+	}
+}

--- a/sdk/packages/engine/tsconfig.json
+++ b/sdk/packages/engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/sdk/packages/engine/vitest.config.ts
+++ b/sdk/packages/engine/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		passWithNoTests: false,
+	},
+});

--- a/sdk/packages/gateway/README.md
+++ b/sdk/packages/gateway/README.md
@@ -1,0 +1,63 @@
+# `@cline/gateway`
+
+The Gateway is the proposed single runtime authority for Cline: a
+long-lived service (plus lightweight CLI) that owns mutable state, bot
+registration, runtime resources, execution supervision, and one versioned
+protocol for desktop, CLI, connector, local, and remote clients.
+
+This package currently contains the **Phase 0 slice** of the Gateway RFC.
+The server itself is deliberately absent (Phase 3+).
+
+## Gateway RFC — summary
+
+The current Hub is a detached daemon discovered and sometimes launched by
+clients; normal operations (abort, reconnect, upgrade, two installations)
+have exposed lifecycle coupling: daemon replacement, stale discovery, port
+collisions, lost attachments, duplicate history, unknown sessions.
+
+The Gateway keeps Hub's durable multi-client sessions, schedules,
+connectors, and remote access while adopting the strongest app-server
+ideas: one named server artifact, immediate run acknowledgement,
+independent events and server requests, explicit process ownership, and a
+compatibility-tested wire contract.
+
+### Package boundaries (dependency direction)
+
+```
+gateway -> bot -> engine -> agents -> llms -> shared
+```
+
+- **`@cline/engine`** owns exactly one execution: immutable `RunSpec`,
+  ordered `EngineEvent`s, steer/interrupt/abort, `RunResult` + persistence
+  deltas. No storage, discovery, sockets, or daemon code.
+- **`@cline/bot`** owns domain semantics for one bot: immutable identity
+  and roles (lead/worker/contractor), lazy sessions, immutable session
+  workspaces, FIFO run admission, delegation, contractor teardown,
+  memories, engine invocation — all through injected ports.
+- **`@cline/gateway`** owns infrastructure and machine authority: CLI,
+  singleton lease, protocol, persistence, credentials, plugins, MCP pools,
+  connectors, schedules, supervision.
+
+Engine never imports bot or Gateway types; bot never imports Gateway
+implementations; no new package depends on `@cline/core`. These rules are
+machine-checked in `src/boundaries.test.ts` (and mirrored per-package).
+
+### What lives where today
+
+| Concern | Location |
+| --- | --- |
+| Wire contracts: IDs, envelopes, errors, revisions, cursors, idempotency, handshake, capabilities, run states, server requests | `@cline/shared/gateway` |
+| Private command registry (`run.start`, `run.steer`, ... with idempotency requirements) | `src/methods.ts` |
+| `gateway.hello` negotiation | `src/hello.ts` |
+| Idempotency ledger | `src/idempotency-ledger.ts` |
+| ADRs: write authority, singleton ownership, no implicit fallback | [`docs/adr/`](./docs/adr/) |
+| Engine (Phase 1) | `@cline/engine` |
+| Bot domain (Phase 2) | `@cline/bot` |
+
+### Explicitly out of scope until Phase 3+
+
+Singleton lease and CLI (`serve`/`start`/`status`/`drain`/`upgrade`/`stop`),
+SQLite persistence and disk projections, credentials (0600 secrets),
+plugins, MCP pooling, connector supervision, schedules, sandbox/container
+supervision, remote/mobile access, and any change to `@cline/core` or the
+existing Hub — which remain fully untouched by this package.

--- a/sdk/packages/gateway/bun.mts
+++ b/sdk/packages/gateway/bun.mts
@@ -1,0 +1,28 @@
+/// <reference types="@types/bun" />
+export {};
+
+const external = [
+	"@cline/bot",
+	"@cline/engine",
+	"@cline/shared",
+	"@cline/shared/gateway",
+	"zod",
+];
+const sourcemap = Bun.env.CLINE_SOURCEMAPS === "1" ? "linked" : "none";
+const minify = Bun.env.CLINE_SOURCEMAPS !== "1";
+
+const result = await Bun.build({
+	entrypoints: ["./src/index.ts"],
+	outdir: "./dist",
+	target: "node",
+	minify,
+	sourcemap,
+	packages: "bundle",
+	external,
+});
+
+if (result.logs.length > 0) {
+	for (const log of result.logs) {
+		console.warn(log);
+	}
+}

--- a/sdk/packages/gateway/docs/adr/0001-gateway-write-authority.md
+++ b/sdk/packages/gateway/docs/adr/0001-gateway-write-authority.md
@@ -1,0 +1,28 @@
+# ADR 0001 — The Gateway is the only new-path writer
+
+**Status:** Accepted (Gateway RFC, Phase 0)
+
+## Decision
+
+Exactly one process — the Gateway — writes new-path state: the bot
+registry, sessions, runs, credentials, configs, plugins, schedules, and
+memory indexes. Clients and bots never write Gateway-owned files or
+databases directly.
+
+## Consequences
+
+- `@cline/engine` and `@cline/bot` contain no storage code at all. They
+  mutate state only through injected ports (`RunResult` persistence deltas,
+  repository interfaces) whose real implementations live in the Gateway.
+- The invariant is machine-checked: boundary tests in `@cline/engine`,
+  `@cline/bot`, and `@cline/gateway` fail if any new package imports
+  filesystem, SQLite, socket, or process-spawning modules, and the shared
+  contract exports `GATEWAY_WRITE_AUTHORITY = "gateway"`.
+- The durable store itself (SQLite, disk projections, 0600 secrets) arrives
+  in Phase 3 behind these same ports.
+
+## Alternatives rejected
+
+Shared-database access from clients (the source of duplicate history and
+unknown-session bugs in the current Hub), and per-client local stores with
+sync (multiplies conflict-resolution surface).

--- a/sdk/packages/gateway/docs/adr/0002-singleton-ownership.md
+++ b/sdk/packages/gateway/docs/adr/0002-singleton-ownership.md
@@ -1,0 +1,30 @@
+# ADR 0002 — Singleton ownership per data directory
+
+**Status:** Accepted (Gateway RFC, Phase 0)
+
+## Decision
+
+Exactly one production Gateway owns a canonical local Cline data directory
+(`gatewayId`). Ownership is taken via a lease; a second authority must not
+attach to the same directory. A Gateway process has a distinct, non-durable
+`instanceId`, so "same data, new process" is observable to clients across
+restarts and upgrades.
+
+Explicit lifecycle modes — `serve`, `start`, `status`, `drain`, `upgrade`,
+`stop` — replace client-driven daemon replacement. Clients never retire the
+authority.
+
+## Consequences
+
+- The shared contracts split `GatewayId` (durable, data directory) from
+  `GatewayInstanceId` (process). Both are returned by `gateway.hello`.
+- `GATEWAY_SINGLETON_OWNERSHIP = "lease"` is exported from the shared
+  contracts; the lease implementation itself is Phase 3.
+- Two installations running together get two data directories and two
+  Gateways — never two authorities over one directory.
+
+## Alternatives rejected
+
+Port-file discovery with last-writer-wins (the current Hub's stale
+discovery and port-collision failure modes), and PID-file locks without
+lease expiry (leaks ownership across crashes).

--- a/sdk/packages/gateway/docs/adr/0003-no-implicit-fallback.md
+++ b/sdk/packages/gateway/docs/adr/0003-no-implicit-fallback.md
@@ -1,0 +1,27 @@
+# ADR 0003 — No implicit in-process fallback
+
+**Status:** Accepted (Gateway RFC, Phase 0)
+
+## Decision
+
+When a client's selected Gateway cannot be reached, the client surfaces
+`gateway_unreachable` and stops. It never silently falls back to a hidden
+in-process runtime.
+
+## Rationale
+
+An implicit fallback forks state: runs started against a private runtime
+are invisible to the authority, producing exactly the duplicate-history and
+unknown-session classes of bugs the Gateway exists to eliminate. Fail-closed
+beats fail-diverged.
+
+## Consequences
+
+- The shared contracts export `GATEWAY_CONNECT_FALLBACK = "none"` and a
+  `GatewayConnectPolicySchema` whose `fallback` field is the literal
+  `"none"` — a policy permitting any other value does not parse.
+- The error registry reserves `gateway_unreachable`; contract tests assert
+  the schema rejects every non-`"none"` fallback, and the cross-package
+  boundary test rejects any new-package source that defines one.
+- Deliberate in-process embedding (e.g. tests composing `@cline/bot` with
+  in-memory ports) remains possible — explicitly, never as a fallback.

--- a/sdk/packages/gateway/package.json
+++ b/sdk/packages/gateway/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "@cline/gateway",
+	"version": "0.0.75",
+	"description": "Cline Gateway — protocol authority for the Gateway RFC (Phase 0 contracts; server lands in Phase 3)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cline/cline",
+		"directory": "sdk/packages/gateway"
+	},
+	"private": true,
+	"internal": true,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"license": "Apache-2.0",
+	"scripts": {
+		"build": "bun run bun.mts && bun tsc -p tsconfig.build.json",
+		"typecheck": "bun tsc -p tsconfig.dev.json --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"engines": {
+		"node": ">=22"
+	},
+	"dependencies": {
+		"@cline/bot": "workspace:*",
+		"@cline/engine": "workspace:*",
+		"@cline/shared": "workspace:*",
+		"zod": "^4.3.6"
+	}
+}

--- a/sdk/packages/gateway/src/boundaries.test.ts
+++ b/sdk/packages/gateway/src/boundaries.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Cross-package dependency rules of the Gateway RFC, machine-checked:
+ *
+ *     gateway -> bot -> engine -> agents -> llms -> shared
+ *
+ * - Engine never imports bot or Gateway types.
+ * - Bot never imports Gateway implementations.
+ * - No new package (engine, bot, gateway) depends on `@cline/core`.
+ * - `@cline/core` is untouched: it gains no dependency on the new packages.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PACKAGES_DIR = join(import.meta.dirname, "..", "..");
+
+function sourceFiles(packageName: string): string[] {
+	const dir = join(PACKAGES_DIR, packageName, "src");
+	return readdirSync(dir, { recursive: true, encoding: "utf8" })
+		.filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+		.map((name) => join(dir, name));
+}
+
+function importsOf(file: string): string[] {
+	const source = readFileSync(file, "utf8");
+	const specifiers: string[] = [];
+	const patterns = [
+		/from\s+["']([^"']+)["']/g,
+		/import\s+["']([^"']+)["']/g,
+		/import\s*\(\s*["']([^"']+)["']\s*\)/g,
+		/require\s*\(\s*["']([^"']+)["']\s*\)/g,
+	];
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) {
+			specifiers.push(match[1]);
+		}
+	}
+	return specifiers;
+}
+
+function assertNeverImports(
+	packageName: string,
+	forbidden: readonly RegExp[],
+): void {
+	const files = sourceFiles(packageName);
+	expect(files.length).toBeGreaterThan(0);
+	for (const file of files) {
+		for (const specifier of importsOf(file)) {
+			for (const pattern of forbidden) {
+				expect(
+					pattern.test(specifier),
+					`${file} imports "${specifier}" which violates the Gateway RFC dependency rules`,
+				).toBe(false);
+			}
+		}
+	}
+}
+
+function dependenciesOf(packageName: string): string[] {
+	const manifest = JSON.parse(
+		readFileSync(join(PACKAGES_DIR, packageName, "package.json"), "utf8"),
+	) as {
+		dependencies?: Record<string, string>;
+		devDependencies?: Record<string, string>;
+		peerDependencies?: Record<string, string>;
+	};
+	return [
+		...Object.keys(manifest.dependencies ?? {}),
+		...Object.keys(manifest.devDependencies ?? {}),
+		...Object.keys(manifest.peerDependencies ?? {}),
+	];
+}
+
+describe("Gateway RFC dependency direction", () => {
+	it("engine never imports bot or Gateway types", () => {
+		assertNeverImports("engine", [
+			/^@cline\/bot(\/|$)/,
+			/^@cline\/gateway(\/|$)/,
+		]);
+	});
+
+	it("bot never imports Gateway implementations", () => {
+		assertNeverImports("bot", [/^@cline\/gateway(\/|$)/]);
+	});
+
+	it("no new package imports or depends on @cline/core", () => {
+		for (const packageName of ["engine", "bot", "gateway"]) {
+			assertNeverImports(packageName, [/^@cline\/core(\/|$)/]);
+			expect(
+				dependenciesOf(packageName),
+				`${packageName} must not depend on @cline/core`,
+			).not.toContain("@cline/core");
+		}
+	});
+
+	it("declared dependencies only point down the stack", () => {
+		expect(dependenciesOf("engine")).not.toContain("@cline/bot");
+		expect(dependenciesOf("engine")).not.toContain("@cline/gateway");
+		expect(dependenciesOf("bot")).not.toContain("@cline/gateway");
+	});
+
+	it("@cline/core gains no dependency on the new packages (core untouched)", () => {
+		const coreDependencies = dependenciesOf("core");
+		expect(coreDependencies).not.toContain("@cline/engine");
+		expect(coreDependencies).not.toContain("@cline/bot");
+		expect(coreDependencies).not.toContain("@cline/gateway");
+	});
+
+	it("there is no implicit in-process fallback anywhere in the new packages", () => {
+		// The only sanctioned fallback value is the literal "none" in the
+		// shared connect policy; no new-package source mentions an in-process
+		// fallback path.
+		for (const packageName of ["engine", "bot", "gateway"]) {
+			for (const file of sourceFiles(packageName)) {
+				const source = readFileSync(file, "utf8");
+				expect(
+					/fallback\s*[:=]\s*["'](?!none)/.test(source),
+					`${file} defines a non-"none" fallback`,
+				).toBe(false);
+			}
+		}
+	});
+});

--- a/sdk/packages/gateway/src/hello.test.ts
+++ b/sdk/packages/gateway/src/hello.test.ts
@@ -1,0 +1,60 @@
+import {
+	createClientId,
+	createGatewayId,
+	createGatewayInstanceId,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import { type GatewayIdentityInfo, negotiateHello } from "./hello";
+
+const gateway: GatewayIdentityInfo = {
+	gatewayId: createGatewayId(),
+	instanceId: createGatewayInstanceId(),
+	catalogGeneration: 7,
+};
+
+describe("gateway.hello negotiation", () => {
+	it("negotiates the shared protocol version and assigns a client ID", () => {
+		const outcome = negotiateHello(
+			{ protocolVersions: [1], client: { name: "cli", version: "1.0.0" } },
+			gateway,
+		);
+		expect(outcome.ok).toBe(true);
+		if (outcome.ok) {
+			expect(outcome.result.protocolVersion).toBe(1);
+			expect(outcome.result.gatewayId).toBe(gateway.gatewayId);
+			expect(outcome.result.instanceId).toBe(gateway.instanceId);
+			expect(outcome.result.catalogGeneration).toBe(7);
+			expect(outcome.result.clientId).toMatch(/^cli_/);
+			expect(outcome.result.capabilities.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("keeps a resuming client's registered identity", () => {
+		const clientId = createClientId();
+		const outcome = negotiateHello(
+			{
+				protocolVersions: [1],
+				client: { name: "desktop", version: "2.0.0", clientId },
+			},
+			gateway,
+		);
+		expect(outcome.ok && outcome.result.clientId).toBe(clientId);
+	});
+
+	it("fails closed when no protocol version is shared", () => {
+		const outcome = negotiateHello(
+			{ protocolVersions: [99], client: { name: "future", version: "9.9.9" } },
+			gateway,
+		);
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) {
+			expect(outcome.error.code).toBe("protocol_version_unsupported");
+			expect(outcome.error.retryable).toBe(false);
+		}
+	});
+
+	it("rejects malformed hello params", () => {
+		const outcome = negotiateHello({ client: { name: "cli" } }, gateway);
+		expect(!outcome.ok && outcome.error.code).toBe("invalid_request");
+	});
+});

--- a/sdk/packages/gateway/src/hello.ts
+++ b/sdk/packages/gateway/src/hello.ts
@@ -1,0 +1,79 @@
+/**
+ * `gateway.hello` negotiation (Gateway RFC, Phase 0).
+ *
+ * Pure protocol logic: given the client's offered versions and the
+ * Gateway's identity, either negotiate the connection or fail with
+ * `protocol_version_unsupported`. No transport here.
+ */
+
+import {
+	type CatalogGeneration,
+	type ClientId,
+	createClientId,
+	createGatewayError,
+	GATEWAY_PROTOCOL_VERSION,
+	type GatewayError,
+	GatewayHelloParamsSchema,
+	type GatewayHelloResult,
+	GatewayHelloResultSchema,
+	type GatewayId,
+	type GatewayInstanceId,
+	KNOWN_GATEWAY_CAPABILITIES,
+} from "@cline/shared/gateway";
+
+/** Protocol versions this Gateway build can speak. */
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly number[] = [
+	GATEWAY_PROTOCOL_VERSION,
+];
+
+export interface GatewayIdentityInfo {
+	gatewayId: GatewayId;
+	instanceId: GatewayInstanceId;
+	catalogGeneration: CatalogGeneration;
+	capabilities?: readonly string[];
+}
+
+export type HelloNegotiation =
+	| { ok: true; result: GatewayHelloResult }
+	| { ok: false; error: GatewayError };
+
+export function negotiateHello(
+	rawParams: unknown,
+	gateway: GatewayIdentityInfo,
+	options: { assignClientId?: () => ClientId } = {},
+): HelloNegotiation {
+	const params = GatewayHelloParamsSchema.safeParse(rawParams);
+	if (!params.success) {
+		return {
+			ok: false,
+			error: createGatewayError(
+				"invalid_request",
+				`Malformed gateway.hello params: ${params.error.issues[0]?.message ?? "unknown"}`,
+			),
+		};
+	}
+	const shared = params.data.protocolVersions.filter((version) =>
+		SUPPORTED_PROTOCOL_VERSIONS.includes(version),
+	);
+	if (shared.length === 0) {
+		return {
+			ok: false,
+			error: createGatewayError(
+				"protocol_version_unsupported",
+				`No shared protocol version; client offered [${params.data.protocolVersions.join(", ")}], gateway supports [${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}]`,
+				{ retryable: false },
+			),
+		};
+	}
+	const result = GatewayHelloResultSchema.parse({
+		protocolVersion: Math.max(...shared),
+		gatewayId: gateway.gatewayId,
+		instanceId: gateway.instanceId,
+		clientId:
+			params.data.client.clientId ??
+			(options.assignClientId ?? (() => createClientId()))(),
+		capabilities: [...(gateway.capabilities ?? KNOWN_GATEWAY_CAPABILITIES)],
+		catalogGeneration: gateway.catalogGeneration,
+	});
+	return { ok: true, result };
+}

--- a/sdk/packages/gateway/src/idempotency-ledger.test.ts
+++ b/sdk/packages/gateway/src/idempotency-ledger.test.ts
@@ -1,0 +1,57 @@
+import { createIdempotencyKey } from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import { IdempotencyLedger, stableStringify } from "./idempotency-ledger";
+
+describe("stableStringify", () => {
+	it("is key-order independent", () => {
+		expect(stableStringify({ b: 1, a: { d: 2, c: 3 } })).toBe(
+			stableStringify({ a: { c: 3, d: 2 }, b: 1 }),
+		);
+	});
+});
+
+describe("IdempotencyLedger", () => {
+	it("executes new keys, replays recorded outcomes, and reports pending", () => {
+		const ledger = new IdempotencyLedger();
+		const key = createIdempotencyKey();
+		const params = { botId: "bot_deadbeef", prompt: "go" };
+
+		expect(ledger.begin(key, "run.start", params)).toEqual({ kind: "new" });
+		// Same request again before the mutation finished: pending.
+		expect(ledger.begin(key, "run.start", params)).toEqual({ kind: "pending" });
+
+		const response = { version: 1 as const, id: "req_1", result: { ok: true } };
+		ledger.record(key, response);
+		const replay = ledger.begin(key, "run.start", { ...params });
+		expect(replay.kind).toBe("replay");
+		if (replay.kind === "replay") {
+			expect(replay.response).toEqual(response);
+		}
+	});
+
+	it("conflicts when a key is reused with a different method or params", () => {
+		const ledger = new IdempotencyLedger();
+		const key = createIdempotencyKey();
+		ledger.begin(key, "run.start", { prompt: "go" });
+
+		const differentMethod = ledger.begin(key, "run.abort", { prompt: "go" });
+		expect(differentMethod.kind).toBe("conflict");
+		if (differentMethod.kind === "conflict") {
+			expect(differentMethod.error.code).toBe("idempotency_conflict");
+		}
+
+		const differentParams = ledger.begin(key, "run.start", { prompt: "stop" });
+		expect(differentParams.kind).toBe("conflict");
+	});
+
+	it("refuses to record outcomes for keys that never began", () => {
+		const ledger = new IdempotencyLedger();
+		expect(() =>
+			ledger.record(createIdempotencyKey(), {
+				version: 1,
+				id: "req_x",
+				result: {},
+			}),
+		).toThrow();
+	});
+});

--- a/sdk/packages/gateway/src/idempotency-ledger.ts
+++ b/sdk/packages/gateway/src/idempotency-ledger.ts
@@ -1,0 +1,101 @@
+/**
+ * In-memory idempotency ledger (Gateway RFC, Phase 0).
+ *
+ * Pure bookkeeping, no persistence (a durable ledger arrives with the
+ * Phase 3 SQLite authority behind the same interface): replaying a key
+ * with the same method+params returns the recorded response; replaying it
+ * with different method or params is a conflict.
+ */
+
+import type { GatewayError } from "@cline/shared/gateway";
+import {
+	createGatewayError,
+	type GatewayResponse,
+	type IdempotencyKey,
+} from "@cline/shared/gateway";
+
+export type IdempotencyBeginOutcome =
+	| { kind: "new" }
+	| { kind: "pending" }
+	| { kind: "replay"; response: GatewayResponse }
+	| { kind: "conflict"; error: GatewayError };
+
+interface LedgerEntry {
+	method: string;
+	paramsFingerprint: string;
+	response?: GatewayResponse;
+}
+
+/** Deterministic JSON with sorted object keys. */
+export function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(",")}]`;
+	}
+	if (value !== null && typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>)
+			.filter(([, entryValue]) => entryValue !== undefined)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(
+				([key, entryValue]) =>
+					`${JSON.stringify(key)}:${stableStringify(entryValue)}`,
+			);
+		return `{${entries.join(",")}}`;
+	}
+	return JSON.stringify(value) ?? "null";
+}
+
+export class IdempotencyLedger {
+	private readonly entries = new Map<IdempotencyKey, LedgerEntry>();
+
+	/**
+	 * Begin a mutating request. Callers execute the mutation only for
+	 * `new`; `replay` short-circuits with the recorded response; `pending`
+	 * means the original request is still executing.
+	 */
+	begin(
+		key: IdempotencyKey,
+		method: string,
+		params: unknown,
+	): IdempotencyBeginOutcome {
+		const fingerprint = stableStringify(params ?? null);
+		const existing = this.entries.get(key);
+		if (!existing) {
+			this.entries.set(key, { method, paramsFingerprint: fingerprint });
+			return { kind: "new" };
+		}
+		if (
+			existing.method !== method ||
+			existing.paramsFingerprint !== fingerprint
+		) {
+			return {
+				kind: "conflict",
+				error: createGatewayError(
+					"idempotency_conflict",
+					`Idempotency key reused with a different ${
+						existing.method !== method ? "method" : "params payload"
+					} (original: ${existing.method})`,
+					{ retryable: false },
+				),
+			};
+		}
+		if (!existing.response) {
+			return { kind: "pending" };
+		}
+		return { kind: "replay", response: existing.response };
+	}
+
+	/** Record the outcome of a mutation begun with `begin`. */
+	record(key: IdempotencyKey, response: GatewayResponse): void {
+		const entry = this.entries.get(key);
+		if (!entry) {
+			throw new Error(
+				"IdempotencyLedger.record called for a key that never began",
+			);
+		}
+		entry.response = response;
+	}
+
+	get size(): number {
+		return this.entries.size;
+	}
+}

--- a/sdk/packages/gateway/src/index.ts
+++ b/sdk/packages/gateway/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@cline/gateway`
+ *
+ * The Gateway is the runtime authority of the Gateway RFC: transport,
+ * persistence, configuration, credentials, shared resources, schedules,
+ * and process supervision. This package currently contains the Phase 0
+ * slice — the private command registry, `gateway.hello` negotiation, and
+ * the idempotency ledger — plus the ADRs under `docs/adr/`. The server
+ * itself (singleton lease, SQLite authority, CLI) is Phase 3 and is
+ * intentionally NOT here yet.
+ *
+ * Reusable wire contracts live in `@cline/shared/gateway`; apps never
+ * import this package's internals.
+ */
+
+export type { GatewayIdentityInfo, HelloNegotiation } from "./hello";
+export {
+	negotiateHello,
+	SUPPORTED_PROTOCOL_VERSIONS,
+} from "./hello";
+export type { IdempotencyBeginOutcome } from "./idempotency-ledger";
+export {
+	IdempotencyLedger,
+	stableStringify,
+} from "./idempotency-ledger";
+export type {
+	GatewayMethodDefinition,
+	ValidatedGatewayRequest,
+} from "./methods";
+export {
+	GATEWAY_METHODS,
+	getMethodDefinition,
+	validateGatewayRequest,
+} from "./methods";

--- a/sdk/packages/gateway/src/methods.test.ts
+++ b/sdk/packages/gateway/src/methods.test.ts
@@ -1,0 +1,101 @@
+import {
+	createBotId,
+	createIdempotencyKey,
+	createRunId,
+	createSessionId,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import {
+	GATEWAY_METHODS,
+	getMethodDefinition,
+	validateGatewayRequest,
+} from "./methods";
+
+function request(method: string, params?: Record<string, unknown>) {
+	return { version: 1, id: "req_1", method, params };
+}
+
+describe("method registry", () => {
+	it("registers every method exactly once with a dotted name", () => {
+		const names = GATEWAY_METHODS.map((definition) => definition.method);
+		expect(new Set(names).size).toBe(names.length);
+		for (const name of names) {
+			expect(name).toMatch(/^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)+$/);
+		}
+	});
+
+	it("every run/bot mutation is marked mutating; reads and hello are not", () => {
+		const mutating = GATEWAY_METHODS.filter((d) => d.mutating).map(
+			(d) => d.method,
+		);
+		expect(mutating.sort()).toEqual(
+			[
+				"bot.delegate",
+				"run.abort",
+				"run.interrupt",
+				"run.start",
+				"run.steer",
+			].sort(),
+		);
+		expect(getMethodDefinition("gateway.hello")?.mutating).toBe(false);
+		expect(getMethodDefinition("run.subscribe")?.mutating).toBe(false);
+	});
+});
+
+describe("request validation", () => {
+	it("accepts a valid mutating request carrying an idempotency key", () => {
+		const outcome = validateGatewayRequest(
+			request("run.start", {
+				idempotencyKey: createIdempotencyKey(),
+				botId: createBotId(),
+				prompt: "do it",
+			}),
+		);
+		expect(outcome.ok).toBe(true);
+		if (outcome.ok) {
+			expect(outcome.definition.method).toBe("run.start");
+		}
+	});
+
+	it("rejects mutating requests without an idempotency key", () => {
+		const outcome = validateGatewayRequest(
+			request("run.start", { botId: createBotId(), prompt: "do it" }),
+		);
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) {
+			expect(outcome.error.code).toBe("idempotency_key_required");
+		}
+	});
+
+	it("rejects malformed envelopes and unknown methods", () => {
+		const malformed = validateGatewayRequest({
+			id: "req_1",
+			method: "run.start",
+		});
+		expect(!malformed.ok && malformed.error.code).toBe("invalid_request");
+
+		const unknown = validateGatewayRequest(request("run.hijack", {}));
+		expect(!unknown.ok && unknown.error.code).toBe("not_found");
+	});
+
+	it("rejects params carrying the wrong ID kind — IDs are not interchangeable", () => {
+		const outcome = validateGatewayRequest(
+			request("run.steer", {
+				idempotencyKey: createIdempotencyKey(),
+				runId: createSessionId(),
+				text: "steer",
+			}),
+		);
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) {
+			expect(outcome.error.code).toBe("invalid_request");
+		}
+	});
+
+	it("validates read methods without an idempotency key", () => {
+		const outcome = validateGatewayRequest(
+			request("run.subscribe", { runId: createRunId() }),
+		);
+		expect(outcome.ok).toBe(true);
+	});
+});

--- a/sdk/packages/gateway/src/methods.ts
+++ b/sdk/packages/gateway/src/methods.ts
@@ -1,0 +1,198 @@
+/**
+ * Gateway-internal command registry (Gateway RFC, Phase 0).
+ *
+ * Reusable wire schemas (envelopes, IDs, errors) live in
+ * `@cline/shared/gateway`; the per-method command surface stays private to
+ * the Gateway. Every mutating method requires an idempotency key. Adding a
+ * method is an additive protocol change.
+ */
+
+import {
+	BotIdSchema,
+	createGatewayError,
+	GATEWAY_HELLO_METHOD,
+	type GatewayError,
+	GatewayHelloParamsSchema,
+	type GatewayRequest,
+	GatewayRequestSchema,
+	IDEMPOTENCY_KEY_PARAM,
+	IdempotencyKeySchema,
+	RunIdSchema,
+	SessionIdSchema,
+} from "@cline/shared/gateway";
+import { z } from "zod";
+
+const IdempotentParamsBase = z.object({
+	[IDEMPOTENCY_KEY_PARAM]: IdempotencyKeySchema,
+});
+
+export interface GatewayMethodDefinition {
+	readonly method: string;
+	/** Mutating methods require an idempotency key in params. */
+	readonly mutating: boolean;
+	readonly params: z.ZodType<unknown>;
+}
+
+const TurnOverridesSchema = z
+	.object({
+		providerId: z.string().min(1).optional(),
+		modelId: z.string().min(1).optional(),
+		systemPrompt: z.string().optional(),
+		maxIterations: z.number().int().positive().optional(),
+	})
+	.strict();
+
+function define(
+	method: string,
+	mutating: boolean,
+	params: z.ZodType<unknown>,
+): GatewayMethodDefinition {
+	return { method, mutating, params };
+}
+
+/**
+ * Protocol v1 command surface. `run.start` acks immediately with
+ * `{runId, acceptedAt, queuePosition}` — it never stays open for the turn.
+ */
+export const GATEWAY_METHODS: readonly GatewayMethodDefinition[] = [
+	define(GATEWAY_HELLO_METHOD, false, GatewayHelloParamsSchema),
+	define("gateway.status", false, z.object({}).strict().optional()),
+	define(
+		"run.start",
+		true,
+		IdempotentParamsBase.extend({
+			botId: BotIdSchema,
+			prompt: z.string().min(1),
+			workspaceRoot: z.string().min(1).optional(),
+			overrides: TurnOverridesSchema.optional(),
+		}).strict(),
+	),
+	define(
+		"run.steer",
+		true,
+		IdempotentParamsBase.extend({
+			runId: RunIdSchema,
+			text: z.string().min(1),
+		}).strict(),
+	),
+	define(
+		"run.interrupt",
+		true,
+		IdempotentParamsBase.extend({
+			runId: RunIdSchema,
+			reason: z.string().optional(),
+		}).strict(),
+	),
+	define(
+		"run.abort",
+		true,
+		IdempotentParamsBase.extend({
+			runId: RunIdSchema,
+			reason: z.string().optional(),
+		}).strict(),
+	),
+	define(
+		"run.subscribe",
+		false,
+		z
+			.object({
+				sessionId: SessionIdSchema.optional(),
+				runId: RunIdSchema.optional(),
+				/** Opaque replay cursor from `@cline/shared/gateway`. */
+				cursor: z.string().optional(),
+			})
+			.strict(),
+	),
+	define(
+		"bot.delegate",
+		true,
+		IdempotentParamsBase.extend({
+			parentBotId: BotIdSchema,
+			name: z.string().min(1),
+			role: z.enum(["worker", "contractor"]),
+			reason: z.string().optional(),
+		}).strict(),
+	),
+	define("bot.list", false, z.object({}).strict().optional()),
+	define(
+		"session.list",
+		false,
+		z.object({ botId: BotIdSchema.optional() }).strict().optional(),
+	),
+];
+
+const METHODS_BY_NAME = new Map(
+	GATEWAY_METHODS.map((definition) => [definition.method, definition]),
+);
+
+export function getMethodDefinition(
+	method: string,
+): GatewayMethodDefinition | undefined {
+	return METHODS_BY_NAME.get(method);
+}
+
+export type ValidatedGatewayRequest =
+	| {
+			ok: true;
+			request: GatewayRequest;
+			definition: GatewayMethodDefinition;
+			params: unknown;
+	  }
+	| { ok: false; error: GatewayError };
+
+/**
+ * Validate a raw inbound value against the envelope, the method registry,
+ * the idempotency requirement, and the method's param schema.
+ */
+export function validateGatewayRequest(
+	value: unknown,
+): ValidatedGatewayRequest {
+	const envelope = GatewayRequestSchema.safeParse(value);
+	if (!envelope.success) {
+		return {
+			ok: false,
+			error: createGatewayError(
+				"invalid_request",
+				`Malformed request envelope: ${envelope.error.issues[0]?.message ?? "unknown"}`,
+			),
+		};
+	}
+	const definition = METHODS_BY_NAME.get(envelope.data.method);
+	if (!definition) {
+		return {
+			ok: false,
+			error: createGatewayError(
+				"not_found",
+				`Unknown method: ${envelope.data.method}`,
+			),
+		};
+	}
+	if (definition.mutating) {
+		const key = envelope.data.params?.[IDEMPOTENCY_KEY_PARAM];
+		if (!IdempotencyKeySchema.safeParse(key).success) {
+			return {
+				ok: false,
+				error: createGatewayError(
+					"idempotency_key_required",
+					`Mutating method ${definition.method} requires a valid "${IDEMPOTENCY_KEY_PARAM}" param`,
+				),
+			};
+		}
+	}
+	const params = definition.params.safeParse(envelope.data.params);
+	if (!params.success) {
+		return {
+			ok: false,
+			error: createGatewayError(
+				"invalid_request",
+				`Invalid params for ${definition.method}: ${params.error.issues[0]?.message ?? "unknown"}`,
+			),
+		};
+	}
+	return {
+		ok: true,
+		request: envelope.data,
+		definition,
+		params: params.data,
+	};
+}

--- a/sdk/packages/gateway/tsconfig.build.json
+++ b/sdk/packages/gateway/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": false,
+		"emitDeclarationOnly": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"incremental": false
+	},
+	"include": ["src/index.ts"]
+}

--- a/sdk/packages/gateway/tsconfig.dev.json
+++ b/sdk/packages/gateway/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false
+	}
+}

--- a/sdk/packages/gateway/tsconfig.json
+++ b/sdk/packages/gateway/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/sdk/packages/gateway/vitest.config.ts
+++ b/sdk/packages/gateway/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		passWithNoTests: false,
+	},
+});

--- a/sdk/packages/shared/bun.mts
+++ b/sdk/packages/shared/bun.mts
@@ -37,6 +37,7 @@ await runBuild("node", {
 		"./src/index.ts",
 		"./src/automation/index.ts",
 		"./src/db/index.ts",
+		"./src/gateway/index.ts",
 		"./src/node.ts",
 		"./src/remote-config/index.ts",
 		"./src/storage/index.ts",

--- a/sdk/packages/shared/package.json
+++ b/sdk/packages/shared/package.json
@@ -33,6 +33,10 @@
 			"types": "./dist/db/index.d.ts",
 			"import": "./dist/db/index.js"
 		},
+		"./gateway": {
+			"types": "./dist/gateway/index.d.ts",
+			"import": "./dist/gateway/index.js"
+		},
 		"./node": {
 			"types": "./dist/node.d.ts",
 			"import": "./dist/node.js"

--- a/sdk/packages/shared/src/gateway/authority.ts
+++ b/sdk/packages/shared/src/gateway/authority.ts
@@ -1,0 +1,48 @@
+/**
+ * Machine-readable authority invariants (Gateway RFC, Phase 0).
+ *
+ * These constants encode the ADR decisions that other packages and tests
+ * assert against. Changing any of them is a deliberate protocol/authority
+ * change, not a refactor.
+ */
+
+import { z } from "zod";
+
+/**
+ * ADR: the Gateway process is the ONLY writer of new-path state (bot
+ * registry, sessions, runs, credentials, configs, memory indexes).
+ * Clients and bots never write Gateway-owned files directly; `@cline/bot`
+ * and `@cline/engine` mutate state only through injected ports whose real
+ * implementations live in the Gateway.
+ */
+export const GATEWAY_WRITE_AUTHORITY = "gateway" as const;
+
+/**
+ * ADR: there is no implicit in-process fallback. When the selected Gateway
+ * cannot be reached, clients surface `gateway_unreachable` — they never
+ * silently spin up a private runtime.
+ */
+export const GATEWAY_CONNECT_FALLBACK = "none" as const;
+
+/**
+ * ADR: exactly one production Gateway per canonical local data directory.
+ * Ownership is taken via a lease; a second authority must not attach.
+ */
+export const GATEWAY_SINGLETON_OWNERSHIP = "lease" as const;
+
+/** Disconnect never implies abort. */
+export const DISCONNECT_IMPLIES_ABORT = false as const;
+
+/**
+ * How a client selects and connects to a Gateway. `fallback` is a literal:
+ * the schema rejects any policy that permits an implicit fallback.
+ */
+export const GatewayConnectPolicySchema = z
+	.object({
+		/** Explicitly selected endpoint (loopback address, SSH tunnel, WSS URL). */
+		endpoint: z.string().min(1),
+		fallback: z.literal(GATEWAY_CONNECT_FALLBACK),
+	})
+	.strict();
+
+export type GatewayConnectPolicy = z.infer<typeof GatewayConnectPolicySchema>;

--- a/sdk/packages/shared/src/gateway/contracts.test.ts
+++ b/sdk/packages/shared/src/gateway/contracts.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+	DISCONNECT_IMPLIES_ABORT,
+	GATEWAY_CONNECT_FALLBACK,
+	GATEWAY_SINGLETON_OWNERSHIP,
+	GATEWAY_WRITE_AUTHORITY,
+	GatewayConnectPolicySchema,
+} from "./authority";
+import {
+	createEventCursor,
+	decodeEventCursor,
+	EventCursorDecodeError,
+	encodeEventCursor,
+	INITIAL_EVENT_CURSOR,
+} from "./cursors";
+import {
+	GATEWAY_HELLO_METHOD,
+	GatewayHelloParamsSchema,
+	GatewayHelloResultSchema,
+	KNOWN_GATEWAY_CAPABILITIES,
+} from "./handshake";
+import { createIdempotencyKey, IdempotencyKeySchema } from "./idempotency";
+import {
+	createBotId,
+	createClientId,
+	createGatewayId,
+	createGatewayInstanceId,
+} from "./ids";
+import { checkRevision, INITIAL_REVISION, nextRevision } from "./revisions";
+
+describe("authority invariants (ADR-encoded)", () => {
+	it("the Gateway is the only new-path writer", () => {
+		expect(GATEWAY_WRITE_AUTHORITY).toBe("gateway");
+	});
+
+	it("there is no implicit in-process fallback", () => {
+		expect(GATEWAY_CONNECT_FALLBACK).toBe("none");
+		expect(
+			GatewayConnectPolicySchema.parse({
+				endpoint: "ws://127.0.0.1:7777",
+				fallback: "none",
+			}).fallback,
+		).toBe("none");
+		// Any policy that would permit a fallback is rejected at the schema.
+		for (const fallback of ["in-process", "local", "auto", true, undefined]) {
+			expect(() =>
+				GatewayConnectPolicySchema.parse({
+					endpoint: "ws://127.0.0.1:7777",
+					fallback,
+				}),
+			).toThrow();
+		}
+	});
+
+	it("singleton ownership is lease-based and disconnect never implies abort", () => {
+		expect(GATEWAY_SINGLETON_OWNERSHIP).toBe("lease");
+		expect(DISCONNECT_IMPLIES_ABORT).toBe(false);
+	});
+});
+
+describe("handshake", () => {
+	it("gateway.hello is the fixed first method of every connection", () => {
+		expect(GATEWAY_HELLO_METHOD).toBe("gateway.hello");
+	});
+
+	it("validates hello params and result", () => {
+		const params = GatewayHelloParamsSchema.parse({
+			protocolVersions: [1],
+			client: { name: "cline-cli", version: "1.2.3" },
+			capabilities: ["events.replay"],
+		});
+		expect(params.protocolVersions).toEqual([1]);
+
+		const result = GatewayHelloResultSchema.parse({
+			protocolVersion: 1,
+			gatewayId: createGatewayId(),
+			instanceId: createGatewayInstanceId(),
+			clientId: createClientId(),
+			capabilities: [...KNOWN_GATEWAY_CAPABILITIES],
+			catalogGeneration: 3,
+		});
+		expect(result.protocolVersion).toBe(1);
+	});
+
+	it("rejects a hello with no offered versions or swapped ID kinds", () => {
+		expect(() =>
+			GatewayHelloParamsSchema.parse({
+				protocolVersions: [],
+				client: { name: "cli", version: "1" },
+			}),
+		).toThrow();
+		expect(() =>
+			GatewayHelloResultSchema.parse({
+				protocolVersion: 1,
+				gatewayId: createBotId(),
+				instanceId: createGatewayInstanceId(),
+				clientId: createClientId(),
+				capabilities: [],
+				catalogGeneration: 0,
+			}),
+		).toThrow();
+	});
+
+	it("capability names are dotted lowerCamel and the known set matches", () => {
+		for (const capability of KNOWN_GATEWAY_CAPABILITIES) {
+			expect(() =>
+				GatewayHelloParamsSchema.parse({
+					protocolVersions: [1],
+					client: { name: "cli", version: "1" },
+					capabilities: [capability],
+				}),
+			).not.toThrow();
+		}
+	});
+});
+
+describe("cursors", () => {
+	it("round-trips through the opaque encoding", () => {
+		const cursor = createEventCursor(41);
+		expect(decodeEventCursor(encodeEventCursor(cursor))).toEqual(cursor);
+		expect(decodeEventCursor(encodeEventCursor(INITIAL_EVENT_CURSOR))).toEqual(
+			INITIAL_EVENT_CURSOR,
+		);
+	});
+
+	it("rejects tampered or foreign cursors", () => {
+		expect(() => decodeEventCursor("not-a-cursor")).toThrow(
+			EventCursorDecodeError,
+		);
+		const foreign = Buffer.from(
+			JSON.stringify({ v: 2, lastSequence: 0 }),
+			"utf8",
+		).toString("base64url");
+		expect(() => decodeEventCursor(foreign)).toThrow(EventCursorDecodeError);
+		expect(() => createEventCursor(-2)).toThrow();
+	});
+});
+
+describe("idempotency", () => {
+	it("accepts URL-safe keys and rejects short or unsafe ones", () => {
+		expect(IdempotencyKeySchema.parse("abcd1234")).toBe("abcd1234");
+		expect(() => IdempotencyKeySchema.parse("short")).toThrow();
+		expect(() => IdempotencyKeySchema.parse("has spaces here")).toThrow();
+		expect(() => IdempotencyKeySchema.parse("x".repeat(129))).toThrow();
+	});
+
+	it("generates valid keys", () => {
+		const key = createIdempotencyKey();
+		expect(IdempotencyKeySchema.parse(key)).toBe(key);
+	});
+});
+
+describe("revisions", () => {
+	it("increment monotonically from the initial revision", () => {
+		expect(INITIAL_REVISION).toBe(0);
+		expect(nextRevision(INITIAL_REVISION)).toBe(1);
+		expect(nextRevision(41)).toBe(42);
+	});
+
+	it("mismatches produce a revision_conflict wire error", () => {
+		expect(checkRevision(3, 3)).toBeUndefined();
+		const error = checkRevision(3, 4);
+		expect(error?.code).toBe("revision_conflict");
+		expect(error?.retryable).toBe(false);
+	});
+});

--- a/sdk/packages/shared/src/gateway/cursors.ts
+++ b/sdk/packages/shared/src/gateway/cursors.ts
@@ -1,0 +1,63 @@
+/**
+ * Event replay cursors (Gateway RFC, Phase 0).
+ *
+ * A cursor names a position in a scope's ordered event stream: "deliver
+ * events with `sequence` greater than `lastSequence`". Cursors are opaque
+ * strings on the wire (base64url JSON) so their internals can evolve;
+ * decoding validates structure and rejects tampered values.
+ */
+
+import { z } from "zod";
+import { createGatewayError, type GatewayError } from "./errors";
+
+const CURSOR_VERSION = 1 as const;
+
+export const EventCursorSchema = z
+	.object({
+		v: z.literal(CURSOR_VERSION),
+		/** Highest event sequence already seen; -1 means "from the beginning". */
+		lastSequence: z.number().int().min(-1),
+	})
+	.strict();
+
+export type EventCursor = z.infer<typeof EventCursorSchema>;
+
+/** Cursor that replays a stream from its first event. */
+export const INITIAL_EVENT_CURSOR: EventCursor = {
+	v: CURSOR_VERSION,
+	lastSequence: -1,
+};
+
+export function createEventCursor(lastSequence: number): EventCursor {
+	return EventCursorSchema.parse({ v: CURSOR_VERSION, lastSequence });
+}
+
+export function encodeEventCursor(cursor: EventCursor): string {
+	const json = JSON.stringify(EventCursorSchema.parse(cursor));
+	return Buffer.from(json, "utf8").toString("base64url");
+}
+
+export class EventCursorDecodeError extends Error {
+	readonly gatewayError: GatewayError;
+
+	constructor(reason: string) {
+		const message = `Invalid event cursor: ${reason}`;
+		super(message);
+		this.name = "EventCursorDecodeError";
+		this.gatewayError = createGatewayError("invalid_request", message);
+	}
+}
+
+export function decodeEventCursor(encoded: string): EventCursor {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+	} catch {
+		throw new EventCursorDecodeError("not base64url-encoded JSON");
+	}
+	const result = EventCursorSchema.safeParse(parsed);
+	if (!result.success) {
+		throw new EventCursorDecodeError("structure does not match the contract");
+	}
+	return result.data;
+}

--- a/sdk/packages/shared/src/gateway/envelopes.test.ts
+++ b/sdk/packages/shared/src/gateway/envelopes.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+	GATEWAY_PROTOCOL_VERSION,
+	GatewayEventSchema,
+	GatewayRequestSchema,
+	GatewayResponseSchema,
+} from "./envelopes";
+import { createGatewayError } from "./errors";
+import { createRunId, createSessionId } from "./ids";
+import {
+	GatewayServerRequestSchema,
+	GatewayServerResponseSchema,
+} from "./server-requests";
+
+describe("request envelope", () => {
+	it("accepts a versioned request with a dotted method", () => {
+		const request = GatewayRequestSchema.parse({
+			version: 1,
+			id: "req_1",
+			method: "run.start",
+			params: { prompt: "hello" },
+		});
+		expect(request.method).toBe("run.start");
+	});
+
+	it("rejects missing/foreign versions and malformed methods", () => {
+		expect(() =>
+			GatewayRequestSchema.parse({ id: "req_1", method: "run.start" }),
+		).toThrow();
+		expect(() =>
+			GatewayRequestSchema.parse({
+				version: 2,
+				id: "req_1",
+				method: "run.start",
+			}),
+		).toThrow();
+		for (const method of ["run", "Run.Start", "run..start", "run.start!", ""]) {
+			expect(() =>
+				GatewayRequestSchema.parse({ version: 1, id: "req_1", method }),
+			).toThrow();
+		}
+	});
+
+	it("rejects unknown envelope fields (per-version compatibility surface)", () => {
+		expect(() =>
+			GatewayRequestSchema.parse({
+				version: 1,
+				id: "req_1",
+				method: "run.start",
+				extra: true,
+			}),
+		).toThrow();
+	});
+});
+
+describe("response envelope", () => {
+	it("carries exactly one of result or error", () => {
+		expect(
+			GatewayResponseSchema.parse({ version: 1, id: "req_1", result: {} }),
+		).toBeTruthy();
+		expect(
+			GatewayResponseSchema.parse({
+				version: 1,
+				id: "req_1",
+				error: createGatewayError("not_found", "no such run"),
+			}),
+		).toBeTruthy();
+		expect(() =>
+			GatewayResponseSchema.parse({ version: 1, id: "req_1" }),
+		).toThrow();
+		expect(() =>
+			GatewayResponseSchema.parse({
+				version: 1,
+				id: "req_1",
+				result: {},
+				error: createGatewayError("internal", "boom"),
+			}),
+		).toThrow();
+	});
+
+	it("rejects errors with unknown codes", () => {
+		expect(() =>
+			GatewayResponseSchema.parse({
+				version: 1,
+				id: "req_1",
+				error: { code: "spooky", message: "??" },
+			}),
+		).toThrow();
+	});
+});
+
+describe("event envelope", () => {
+	it("orders events by non-negative integer sequence and validates scope IDs", () => {
+		const event = GatewayEventSchema.parse({
+			version: GATEWAY_PROTOCOL_VERSION,
+			sequence: 7,
+			event: "run.textDelta",
+			scope: { sessionId: createSessionId(), runId: createRunId() },
+			payload: { text: "hi" },
+		});
+		expect(event.sequence).toBe(7);
+	});
+
+	it("rejects fractional or negative sequences", () => {
+		for (const sequence of [-1, 1.5, Number.NaN]) {
+			expect(() =>
+				GatewayEventSchema.parse({
+					version: 1,
+					sequence,
+					event: "run.textDelta",
+					scope: {},
+				}),
+			).toThrow();
+		}
+	});
+
+	it("rejects scope IDs of the wrong kind — IDs are not interchangeable", () => {
+		expect(() =>
+			GatewayEventSchema.parse({
+				version: 1,
+				sequence: 0,
+				event: "run.textDelta",
+				scope: { runId: createSessionId() },
+			}),
+		).toThrow();
+	});
+});
+
+describe("server requests", () => {
+	it("are independent envelopes: correlated by id, not ordered by sequence", () => {
+		const request = GatewayServerRequestSchema.parse({
+			version: 1,
+			id: "srq_1",
+			method: "client.requestToolApproval",
+			scope: { runId: createRunId() },
+			params: { toolName: "write_file" },
+		});
+		expect("sequence" in request).toBe(false);
+		expect(
+			GatewayServerResponseSchema.parse({
+				version: 1,
+				id: "srq_1",
+				result: { approved: true },
+			}),
+		).toBeTruthy();
+		expect(() =>
+			GatewayServerResponseSchema.parse({ version: 1, id: "srq_1" }),
+		).toThrow();
+	});
+});

--- a/sdk/packages/shared/src/gateway/envelopes.ts
+++ b/sdk/packages/shared/src/gateway/envelopes.ts
@@ -1,0 +1,78 @@
+/**
+ * Gateway protocol envelopes (Gateway RFC, Phase 0).
+ *
+ * One versioned protocol for desktop, CLI, connector, local, and remote
+ * clients. Three independent wire shapes:
+ *
+ * - `GatewayRequest` / `GatewayResponse`: client-initiated RPC, correlated
+ *   by `id`. `run.start` acks immediately; it never stays open for a turn.
+ * - `GatewayEvent`: server-pushed progress, ordered by `sequence` within a
+ *   connection subscription and scoped to bot/session/run.
+ * - Server requests (see `server-requests.ts`): server-initiated questions
+ *   (approvals, credentials) that are NOT events and carry their own `id`.
+ *
+ * Protocol evolution is additive: unknown envelope fields are rejected
+ * (strict schemas define the compatibility surface per version), while
+ * unknown event names and capabilities are tolerated by clients.
+ */
+
+import { z } from "zod";
+import { GatewayErrorSchema } from "./errors";
+import { BotIdSchema, RunIdSchema, SessionIdSchema } from "./ids";
+
+/** Current (and only) protocol version. */
+export const GATEWAY_PROTOCOL_VERSION = 1 as const;
+
+/** Dotted lowerCamel segments, e.g. `gateway.hello`, `run.start`. */
+export const GATEWAY_METHOD_PATTERN =
+	/^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)+$/;
+
+export const GatewayRequestSchema = z
+	.object({
+		version: z.literal(GATEWAY_PROTOCOL_VERSION),
+		id: z.string().min(1),
+		method: z.string().regex(GATEWAY_METHOD_PATTERN),
+		params: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
+
+export type GatewayRequest = z.infer<typeof GatewayRequestSchema>;
+
+export const GatewayResponseSchema = z
+	.object({
+		version: z.literal(GATEWAY_PROTOCOL_VERSION),
+		id: z.string().min(1),
+		result: z.unknown().optional(),
+		error: GatewayErrorSchema.optional(),
+	})
+	.strict()
+	.refine(
+		(value) => (value.result === undefined) !== (value.error === undefined),
+		{
+			message: "A response carries exactly one of `result` or `error`",
+		},
+	);
+
+export type GatewayResponse = z.infer<typeof GatewayResponseSchema>;
+
+export const GatewayEventScopeSchema = z
+	.object({
+		botId: BotIdSchema.optional(),
+		sessionId: SessionIdSchema.optional(),
+		runId: RunIdSchema.optional(),
+	})
+	.strict();
+
+export type GatewayEventScope = z.infer<typeof GatewayEventScopeSchema>;
+
+export const GatewayEventSchema = z
+	.object({
+		version: z.literal(GATEWAY_PROTOCOL_VERSION),
+		sequence: z.number().int().nonnegative(),
+		event: z.string().regex(GATEWAY_METHOD_PATTERN),
+		scope: GatewayEventScopeSchema,
+		payload: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
+
+export type GatewayEvent = z.infer<typeof GatewayEventSchema>;

--- a/sdk/packages/shared/src/gateway/errors.ts
+++ b/sdk/packages/shared/src/gateway/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Gateway wire error contract (Gateway RFC, Phase 0).
+ *
+ * Every failed request resolves to exactly one `GatewayError`. Codes are a
+ * closed set per protocol version; adding a code is an additive protocol
+ * change. `retryable` tells clients whether the same request (same
+ * idempotency key) may be retried against the same Gateway.
+ */
+
+import { z } from "zod";
+
+export const GATEWAY_ERROR_CODES = [
+	/** Envelope or params failed schema validation. */
+	"invalid_request",
+	/** No protocol version shared between client and Gateway. */
+	"protocol_version_unsupported",
+	/** A request other than `gateway.hello` arrived before the handshake. */
+	"handshake_required",
+	/** Principal is not allowed to perform the request. */
+	"unauthorized",
+	/** Referenced bot/session/run/worker does not exist for this principal. */
+	"not_found",
+	/** A mutating method was called without an idempotency key. */
+	"idempotency_key_required",
+	/** An idempotency key was reused with a different method or params. */
+	"idempotency_conflict",
+	/** Optimistic concurrency check failed; reload and retry. */
+	"revision_conflict",
+	/** Run admission rejected the prompt (no session is created). */
+	"run_admission_rejected",
+	/** Attempted transition violates the run/session state machine. */
+	"invalid_state_transition",
+	/**
+	 * The selected Gateway cannot be reached. Clients MUST surface this
+	 * error; falling back to an implicit in-process runtime is forbidden
+	 * (see `GATEWAY_CONNECT_FALLBACK`).
+	 */
+	"gateway_unreachable",
+	/** Gateway is draining and refuses new mutating work. */
+	"gateway_draining",
+	/** Unexpected server-side failure. */
+	"internal",
+] as const;
+
+export type GatewayErrorCode = (typeof GATEWAY_ERROR_CODES)[number];
+
+export const GatewayErrorSchema = z
+	.object({
+		code: z.enum(GATEWAY_ERROR_CODES),
+		message: z.string().min(1),
+		retryable: z.boolean().optional(),
+		details: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
+
+export type GatewayError = z.infer<typeof GatewayErrorSchema>;
+
+export function createGatewayError(
+	code: GatewayErrorCode,
+	message: string,
+	options: { retryable?: boolean; details?: Record<string, unknown> } = {},
+): GatewayError {
+	return GatewayErrorSchema.parse({
+		code,
+		message,
+		...(options.retryable !== undefined
+			? { retryable: options.retryable }
+			: {}),
+		...(options.details !== undefined ? { details: options.details } : {}),
+	});
+}

--- a/sdk/packages/shared/src/gateway/handshake.ts
+++ b/sdk/packages/shared/src/gateway/handshake.ts
@@ -1,0 +1,73 @@
+/**
+ * Connection handshake contract (Gateway RFC, Phase 0).
+ *
+ * Every connection starts with `gateway.hello`, before any other request.
+ * The client offers the protocol versions it speaks and its identity; the
+ * Gateway answers with the negotiated version, its durable and process
+ * identities, and its capability set. Capabilities are advisory strings:
+ * clients must tolerate unknown capabilities (additive evolution).
+ */
+
+import { z } from "zod";
+import {
+	CatalogGenerationSchema,
+	ClientIdSchema,
+	GatewayIdSchema,
+	GatewayInstanceIdSchema,
+} from "./ids";
+
+export const GATEWAY_HELLO_METHOD = "gateway.hello";
+
+/** Dotted capability names, e.g. `runs.steer`. */
+export const GATEWAY_CAPABILITY_PATTERN =
+	/^[a-z][a-zA-Z0-9]*(\.[a-z][a-zA-Z0-9]*)*$/;
+
+export const GatewayCapabilitySchema = z
+	.string()
+	.regex(GATEWAY_CAPABILITY_PATTERN);
+
+/** Capabilities defined by protocol version 1. The set is additive. */
+export const KNOWN_GATEWAY_CAPABILITIES = [
+	"runs.async",
+	"runs.steer",
+	"runs.interrupt",
+	"runs.abort",
+	"events.replay",
+	"serverRequests",
+	"bots.delegation",
+	"sessions.lazy",
+] as const;
+
+export type KnownGatewayCapability =
+	(typeof KNOWN_GATEWAY_CAPABILITIES)[number];
+
+export const GatewayHelloParamsSchema = z
+	.object({
+		/** Protocol versions the client can speak, in preference order. */
+		protocolVersions: z.array(z.number().int().positive()).nonempty(),
+		client: z
+			.object({
+				name: z.string().min(1),
+				version: z.string().min(1),
+				/** Present when the client resumes a registered identity. */
+				clientId: ClientIdSchema.optional(),
+			})
+			.strict(),
+		capabilities: z.array(GatewayCapabilitySchema).optional(),
+	})
+	.strict();
+
+export type GatewayHelloParams = z.infer<typeof GatewayHelloParamsSchema>;
+
+export const GatewayHelloResultSchema = z
+	.object({
+		protocolVersion: z.number().int().positive(),
+		gatewayId: GatewayIdSchema,
+		instanceId: GatewayInstanceIdSchema,
+		clientId: ClientIdSchema,
+		capabilities: z.array(GatewayCapabilitySchema),
+		catalogGeneration: CatalogGenerationSchema,
+	})
+	.strict();
+
+export type GatewayHelloResult = z.infer<typeof GatewayHelloResultSchema>;

--- a/sdk/packages/shared/src/gateway/idempotency.ts
+++ b/sdk/packages/shared/src/gateway/idempotency.ts
@@ -1,0 +1,30 @@
+/**
+ * Idempotency contract (Gateway RFC, Phase 0).
+ *
+ * Every mutating request carries an idempotency key. Replaying a key with
+ * the same method returns the recorded outcome; replaying it with a
+ * different method (or materially different params) is an
+ * `idempotency_conflict`. Keys are client-generated.
+ */
+
+import { z } from "zod";
+
+/** Name of the params field carrying the key on mutating requests. */
+export const IDEMPOTENCY_KEY_PARAM = "idempotencyKey";
+
+export const IdempotencyKeySchema = z
+	.string()
+	.min(8)
+	.max(128)
+	.regex(
+		/^[A-Za-z0-9_-]+$/,
+		"Idempotency keys are URL-safe tokens of 8-128 characters",
+	);
+
+export type IdempotencyKey = z.infer<typeof IdempotencyKeySchema>;
+
+export function createIdempotencyKey(
+	random: () => string = () => globalThis.crypto.randomUUID(),
+): IdempotencyKey {
+	return IdempotencyKeySchema.parse(random().replaceAll("-", ""));
+}

--- a/sdk/packages/shared/src/gateway/ids.test.ts
+++ b/sdk/packages/shared/src/gateway/ids.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	CatalogGenerationSchema,
+	createBotId,
+	createRunId,
+	createSessionId,
+	ID_CONTRACTS,
+} from "./ids";
+
+describe("gateway ID contracts", () => {
+	it("uses a distinct prefix per ID kind", () => {
+		const prefixes = Object.values(ID_CONTRACTS).map(
+			(contract) => contract.prefix,
+		);
+		expect(new Set(prefixes).size).toBe(prefixes.length);
+	});
+
+	it("creates IDs that round-trip through their own schema", () => {
+		for (const contract of Object.values(ID_CONTRACTS)) {
+			const id = contract.create();
+			expect(contract.is(id)).toBe(true);
+			expect(contract.parse(id)).toBe(id);
+			expect(id.startsWith(`${contract.prefix}_`)).toBe(true);
+		}
+	});
+
+	it("IDs are not interchangeable: every schema rejects every other kind", () => {
+		const entries = Object.entries(ID_CONTRACTS);
+		for (const [kind, contract] of entries) {
+			const id = contract.create();
+			for (const [otherKind, otherContract] of entries) {
+				if (otherKind === kind) {
+					continue;
+				}
+				expect(otherContract.is(id), `${otherKind} accepted a ${kind}`).toBe(
+					false,
+				);
+				expect(() => otherContract.parse(id)).toThrow();
+			}
+		}
+	});
+
+	it("rejects malformed bodies", () => {
+		for (const contract of Object.values(ID_CONTRACTS)) {
+			expect(contract.is(`${contract.prefix}_`)).toBe(false);
+			expect(contract.is(`${contract.prefix}_short`)).toBe(false);
+			expect(contract.is(`${contract.prefix}_has spaces here!`)).toBe(false);
+			expect(contract.is(`${contract.prefix}_${"x".repeat(65)}`)).toBe(false);
+			expect(contract.is(42)).toBe(false);
+			expect(contract.is(undefined)).toBe(false);
+		}
+	});
+
+	it("supports injected entropy sources", () => {
+		expect(createBotId(() => "deadbeef")).toBe("bot_deadbeef");
+		expect(createSessionId(() => "deadbeef")).toBe("ses_deadbeef");
+		expect(createRunId(() => "deadbeef")).toBe("run_deadbeef");
+		expect(() => createBotId(() => "bad body!")).toThrow();
+	});
+
+	it("catalogGeneration is a monotonic number, not an ID", () => {
+		expect(CatalogGenerationSchema.parse(0)).toBe(0);
+		expect(CatalogGenerationSchema.parse(41)).toBe(41);
+		expect(() => CatalogGenerationSchema.parse(-1)).toThrow();
+		expect(() => CatalogGenerationSchema.parse("cat_deadbeef")).toThrow();
+		expect(() => CatalogGenerationSchema.parse(1.5)).toThrow();
+	});
+});

--- a/sdk/packages/shared/src/gateway/ids.ts
+++ b/sdk/packages/shared/src/gateway/ids.ts
@@ -1,0 +1,140 @@
+/**
+ * Gateway identity contracts (Gateway RFC, Phase 0).
+ *
+ * Every durable Gateway concept gets its own branded ID type with a distinct
+ * wire prefix. The brands make the IDs non-interchangeable at the type level
+ * (a `BotId` is not assignable where a `SessionId` is expected), and the
+ * per-prefix schemas make them non-interchangeable at the wire level (the
+ * `BotId` schema rejects a serialized `SessionId`).
+ *
+ * Identity semantics from the RFC:
+ * - `GatewayId` is durable and names a canonical data directory.
+ * - `InstanceId` names one Gateway process and is NOT durable.
+ * - `SessionId` is allocated only with the first accepted prompt.
+ * - `RunId` is issued at admission time, before the run starts.
+ * - `catalogGeneration` is a monotonic number, not an ID.
+ */
+
+import { z } from "zod";
+
+declare const idBrand: unique symbol;
+
+/** Nominal (branded) string. Brands are erased at runtime. */
+export type BrandedId<TBrand extends string> = string & {
+	readonly [idBrand]: TBrand;
+};
+
+/** Durable identity of a canonical local Cline data directory. */
+export type GatewayId = BrandedId<"GatewayId">;
+/** Identity of one Gateway process. Not durable across restarts. */
+export type GatewayInstanceId = BrandedId<"GatewayInstanceId">;
+/** Identity of an authenticated principal (human or automation). */
+export type PrincipalId = BrandedId<"PrincipalId">;
+/** Identity of one connected client (per connection registry entry). */
+export type ClientId = BrandedId<"ClientId">;
+/** Durable identity of a registered bot. */
+export type BotId = BrandedId<"BotId">;
+/** Durable identity of a session. Allocated on first accepted prompt. */
+export type SessionId = BrandedId<"SessionId">;
+/** Durable identity of a run. Issued at admission. */
+export type RunId = BrandedId<"RunId">;
+/** Identity of a supervised worker process. */
+export type WorkerId = BrandedId<"WorkerId">;
+
+const ID_BODY_PATTERN = "[A-Za-z0-9_-]{8,64}";
+
+export interface IdContract<TId extends string> {
+	/** Wire prefix, e.g. `bot` for `bot_<body>`. */
+	readonly prefix: string;
+	/** Validating schema. Rejects IDs carrying any other prefix. */
+	readonly schema: z.ZodType<TId>;
+	/** Create a new ID from an injected entropy source. */
+	create(random?: () => string): TId;
+	/** Runtime type guard. */
+	is(value: unknown): value is TId;
+	/** Parse or throw. */
+	parse(value: unknown): TId;
+}
+
+function defaultRandomIdBody(): string {
+	// 128 bits of entropy, hex, no separator dependence.
+	return globalThis.crypto.randomUUID().replaceAll("-", "");
+}
+
+export function defineIdContract<TId extends string>(
+	prefix: string,
+): IdContract<TId> {
+	const pattern = new RegExp(`^${prefix}_${ID_BODY_PATTERN}$`);
+	const schema = z
+		.string()
+		.regex(
+			pattern,
+			`Expected an ID with prefix "${prefix}_"; IDs are not interchangeable across kinds`,
+		) as unknown as z.ZodType<TId>;
+	const is = (value: unknown): value is TId =>
+		typeof value === "string" && pattern.test(value);
+	return {
+		prefix,
+		schema,
+		create(random = defaultRandomIdBody): TId {
+			const id = `${prefix}_${random()}`;
+			if (!is(id)) {
+				throw new Error(
+					`Injected entropy source produced an invalid ID body for prefix "${prefix}_"`,
+				);
+			}
+			return id;
+		},
+		is,
+		parse(value: unknown): TId {
+			return schema.parse(value);
+		},
+	};
+}
+
+export const gatewayIdContract = defineIdContract<GatewayId>("gw");
+export const gatewayInstanceIdContract =
+	defineIdContract<GatewayInstanceId>("gwi");
+export const principalIdContract = defineIdContract<PrincipalId>("prn");
+export const clientIdContract = defineIdContract<ClientId>("cli");
+export const botIdContract = defineIdContract<BotId>("bot");
+export const sessionIdContract = defineIdContract<SessionId>("ses");
+export const runIdContract = defineIdContract<RunId>("run");
+export const workerIdContract = defineIdContract<WorkerId>("wrk");
+
+export const GatewayIdSchema = gatewayIdContract.schema;
+export const GatewayInstanceIdSchema = gatewayInstanceIdContract.schema;
+export const PrincipalIdSchema = principalIdContract.schema;
+export const ClientIdSchema = clientIdContract.schema;
+export const BotIdSchema = botIdContract.schema;
+export const SessionIdSchema = sessionIdContract.schema;
+export const RunIdSchema = runIdContract.schema;
+export const WorkerIdSchema = workerIdContract.schema;
+
+export const createGatewayId = gatewayIdContract.create;
+export const createGatewayInstanceId = gatewayInstanceIdContract.create;
+export const createPrincipalId = principalIdContract.create;
+export const createClientId = clientIdContract.create;
+export const createBotId = botIdContract.create;
+export const createSessionId = sessionIdContract.create;
+export const createRunId = runIdContract.create;
+export const createWorkerId = workerIdContract.create;
+
+/** All ID contracts, keyed by kind. Used by exhaustive contract tests. */
+export const ID_CONTRACTS = {
+	gatewayId: gatewayIdContract,
+	instanceId: gatewayInstanceIdContract,
+	principalId: principalIdContract,
+	clientId: clientIdContract,
+	botId: botIdContract,
+	sessionId: sessionIdContract,
+	runId: runIdContract,
+	workerId: workerIdContract,
+} as const;
+
+/**
+ * Monotonic generation counter for the Gateway's resource catalog.
+ * A number, not an ID: it orders catalog snapshots, it does not name one.
+ */
+export const CatalogGenerationSchema = z.number().int().nonnegative();
+export type CatalogGeneration = z.infer<typeof CatalogGenerationSchema>;

--- a/sdk/packages/shared/src/gateway/index.ts
+++ b/sdk/packages/shared/src/gateway/index.ts
@@ -1,0 +1,20 @@
+/**
+ * `@cline/shared/gateway` — reusable wire contracts for the Cline Gateway
+ * (Gateway RFC, Phase 0).
+ *
+ * This subpath holds only what every party to the protocol needs: IDs,
+ * envelopes, errors, revisions, cursors, idempotency, the handshake,
+ * capabilities, async-run states, and server requests. Gateway-internal
+ * command schemas stay private to `@cline/gateway`.
+ */
+
+export * from "./authority";
+export * from "./cursors";
+export * from "./envelopes";
+export * from "./errors";
+export * from "./handshake";
+export * from "./idempotency";
+export * from "./ids";
+export * from "./revisions";
+export * from "./run-states";
+export * from "./server-requests";

--- a/sdk/packages/shared/src/gateway/revisions.ts
+++ b/sdk/packages/shared/src/gateway/revisions.ts
@@ -1,0 +1,39 @@
+/**
+ * Revisions for optimistic concurrency (Gateway RFC, Phase 0).
+ *
+ * Gateway-owned mutable records (bot registry entries, session metadata,
+ * configs) carry a monotonically increasing revision. Mutations state the
+ * revision they were computed against; a mismatch is a `revision_conflict`
+ * and the client must reload before retrying.
+ */
+
+import { z } from "zod";
+import { createGatewayError, type GatewayError } from "./errors";
+
+export const RevisionSchema = z.number().int().nonnegative();
+
+export type Revision = z.infer<typeof RevisionSchema>;
+
+export const INITIAL_REVISION: Revision = 0;
+
+export function nextRevision(revision: Revision): Revision {
+	return RevisionSchema.parse(revision + 1);
+}
+
+/**
+ * Returns a `revision_conflict` error when `expected` does not match
+ * `actual`, or `undefined` when the mutation may proceed.
+ */
+export function checkRevision(
+	expected: Revision,
+	actual: Revision,
+): GatewayError | undefined {
+	if (expected === actual) {
+		return undefined;
+	}
+	return createGatewayError(
+		"revision_conflict",
+		`Revision mismatch: expected ${expected}, actual ${actual}`,
+		{ retryable: false, details: { expected, actual } },
+	);
+}

--- a/sdk/packages/shared/src/gateway/run-states.test.ts
+++ b/sdk/packages/shared/src/gateway/run-states.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { createRunId, createSessionId } from "./ids";
+import {
+	assertRunStateTransition,
+	canTransitionRunState,
+	canTransitionSessionState,
+	isTerminalRunState,
+	RUN_STATE_TRANSITIONS,
+	RUN_STATES,
+	RunAcceptedSchema,
+	RunStateTransitionError,
+	SESSION_STATES,
+	TERMINAL_RUN_STATES,
+} from "./run-states";
+
+describe("run state machine", () => {
+	it("covers every state in the transition table", () => {
+		expect(Object.keys(RUN_STATE_TRANSITIONS).sort()).toEqual(
+			[...RUN_STATES].sort(),
+		);
+	});
+
+	it("only allows the documented transitions (full matrix)", () => {
+		for (const from of RUN_STATES) {
+			for (const to of RUN_STATES) {
+				const allowed = RUN_STATE_TRANSITIONS[from].includes(to);
+				expect(canTransitionRunState(from, to)).toBe(allowed);
+			}
+		}
+	});
+
+	it("queued runs may start or be aborted, never complete directly", () => {
+		expect(canTransitionRunState("queued", "running")).toBe(true);
+		expect(canTransitionRunState("queued", "aborted")).toBe(true);
+		expect(canTransitionRunState("queued", "completed")).toBe(false);
+		expect(canTransitionRunState("queued", "interrupted")).toBe(false);
+	});
+
+	it("terminal states admit no transitions, including self-loops", () => {
+		for (const state of TERMINAL_RUN_STATES) {
+			expect(isTerminalRunState(state)).toBe(true);
+			for (const to of RUN_STATES) {
+				expect(canTransitionRunState(state, to)).toBe(false);
+			}
+		}
+		expect(isTerminalRunState("queued")).toBe(false);
+		expect(isTerminalRunState("running")).toBe(false);
+	});
+
+	it("assertRunStateTransition throws a typed error carrying a wire error", () => {
+		expect(() => assertRunStateTransition("queued", "running")).not.toThrow();
+		try {
+			assertRunStateTransition("completed", "running");
+			expect.unreachable("transition should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(RunStateTransitionError);
+			expect((error as RunStateTransitionError).gatewayError.code).toBe(
+				"invalid_state_transition",
+			);
+		}
+	});
+});
+
+describe("run admission ack", () => {
+	it("acks with runId, acceptedAt, and queuePosition", () => {
+		const ack = RunAcceptedSchema.parse({
+			runId: createRunId(),
+			acceptedAt: Date.now(),
+			queuePosition: 0,
+		});
+		expect(ack.queuePosition).toBe(0);
+	});
+
+	it("rejects non-run IDs and negative queue positions", () => {
+		expect(() =>
+			RunAcceptedSchema.parse({
+				runId: createSessionId(),
+				acceptedAt: Date.now(),
+				queuePosition: 0,
+			}),
+		).toThrow();
+		expect(() =>
+			RunAcceptedSchema.parse({
+				runId: createRunId(),
+				acceptedAt: Date.now(),
+				queuePosition: -1,
+			}),
+		).toThrow();
+	});
+});
+
+describe("session state machine", () => {
+	it("sessions only move from active to closed", () => {
+		for (const from of SESSION_STATES) {
+			for (const to of SESSION_STATES) {
+				expect(canTransitionSessionState(from, to)).toBe(
+					from === "active" && to === "closed",
+				);
+			}
+		}
+	});
+});

--- a/sdk/packages/shared/src/gateway/run-states.ts
+++ b/sdk/packages/shared/src/gateway/run-states.ts
@@ -1,0 +1,127 @@
+/**
+ * Async run and session state machines (Gateway RFC, Phase 0).
+ *
+ * `run.start` acknowledges immediately with `{runId, acceptedAt,
+ * queuePosition}` and the run proceeds through these states. One mutating
+ * root run per session; admission is FIFO. Steering merges into the active
+ * run (it is not a state change). Disconnect never implies abort: no
+ * transition is triggered by connection lifecycle.
+ */
+
+import { z } from "zod";
+import { createGatewayError, type GatewayError } from "./errors";
+import { RunIdSchema } from "./ids";
+
+// -----------------------------------------------------------------------------
+// Runs
+// -----------------------------------------------------------------------------
+
+export const RUN_STATES = [
+	/** Accepted at admission, waiting behind the active run (FIFO). */
+	"queued",
+	/** The engine is executing the run. */
+	"running",
+	/** Terminal: run finished normally. */
+	"completed",
+	/** Terminal: run failed with an error. */
+	"failed",
+	/** Terminal: run was aborted (hard stop). */
+	"aborted",
+	/** Terminal: run was cooperatively interrupted. */
+	"interrupted",
+] as const;
+
+export type RunState = (typeof RUN_STATES)[number];
+
+export const RunStateSchema = z.enum(RUN_STATES);
+
+export const RUN_STATE_TRANSITIONS: Readonly<
+	Record<RunState, readonly RunState[]>
+> = {
+	queued: ["running", "aborted"],
+	running: ["completed", "failed", "aborted", "interrupted"],
+	completed: [],
+	failed: [],
+	aborted: [],
+	interrupted: [],
+};
+
+export const TERMINAL_RUN_STATES = [
+	"completed",
+	"failed",
+	"aborted",
+	"interrupted",
+] as const satisfies readonly RunState[];
+
+export function isTerminalRunState(state: RunState): boolean {
+	return RUN_STATE_TRANSITIONS[state].length === 0;
+}
+
+export function canTransitionRunState(from: RunState, to: RunState): boolean {
+	return RUN_STATE_TRANSITIONS[from].includes(to);
+}
+
+export class RunStateTransitionError extends Error {
+	readonly gatewayError: GatewayError;
+
+	constructor(from: RunState, to: RunState) {
+		const message = `Illegal run state transition: ${from} -> ${to}`;
+		super(message);
+		this.name = "RunStateTransitionError";
+		this.gatewayError = createGatewayError(
+			"invalid_state_transition",
+			message,
+			{
+				details: { from, to },
+			},
+		);
+	}
+}
+
+export function assertRunStateTransition(from: RunState, to: RunState): void {
+	if (!canTransitionRunState(from, to)) {
+		throw new RunStateTransitionError(from, to);
+	}
+}
+
+/** Immediate acknowledgement returned by `run.start`. */
+export const RunAcceptedSchema = z
+	.object({
+		runId: RunIdSchema,
+		/** Epoch milliseconds at admission. */
+		acceptedAt: z.number().int().nonnegative(),
+		/** 0 = active now; N = N runs ahead in the session's FIFO queue. */
+		queuePosition: z.number().int().nonnegative(),
+	})
+	.strict();
+
+export type RunAccepted = z.infer<typeof RunAcceptedSchema>;
+
+// -----------------------------------------------------------------------------
+// Sessions
+// -----------------------------------------------------------------------------
+
+export const SESSION_STATES = [
+	/** Created (only ever with a first accepted prompt) and usable. */
+	"active",
+	/** Terminal: closed; admits no further runs. */
+	"closed",
+] as const;
+
+export type SessionState = (typeof SESSION_STATES)[number];
+
+export const SessionStateSchema = z.enum(SESSION_STATES);
+
+export const SESSION_STATE_TRANSITIONS: Readonly<
+	Record<SessionState, readonly SessionState[]>
+> = {
+	active: ["closed"],
+	closed: [],
+};
+
+export function canTransitionSessionState(
+	from: SessionState,
+	to: SessionState,
+): boolean {
+	return SESSION_STATE_TRANSITIONS[from].includes(to);
+}

--- a/sdk/packages/shared/src/gateway/server-requests.ts
+++ b/sdk/packages/shared/src/gateway/server-requests.ts
@@ -1,0 +1,54 @@
+/**
+ * Server-initiated requests (Gateway RFC, Phase 0).
+ *
+ * The Gateway can ask a connected client a question — tool approval,
+ * credential entry, elicitation — while a run is in flight. These are NOT
+ * events: they demand an answer, carry their own `id` correlation space,
+ * and are not ordered by the event `sequence`. A disconnected client
+ * neither loses nor implicitly answers them; the Gateway re-issues pending
+ * server requests on reconnection.
+ */
+
+import { z } from "zod";
+import {
+	GATEWAY_METHOD_PATTERN,
+	GATEWAY_PROTOCOL_VERSION,
+	GatewayEventScopeSchema,
+} from "./envelopes";
+import { GatewayErrorSchema } from "./errors";
+
+export const GatewayServerRequestSchema = z
+	.object({
+		version: z.literal(GATEWAY_PROTOCOL_VERSION),
+		id: z.string().min(1),
+		method: z.string().regex(GATEWAY_METHOD_PATTERN),
+		scope: GatewayEventScopeSchema,
+		params: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
+
+export type GatewayServerRequest = z.infer<typeof GatewayServerRequestSchema>;
+
+export const GatewayServerResponseSchema = z
+	.object({
+		version: z.literal(GATEWAY_PROTOCOL_VERSION),
+		id: z.string().min(1),
+		result: z.unknown().optional(),
+		error: GatewayErrorSchema.optional(),
+	})
+	.strict()
+	.refine(
+		(value) => (value.result === undefined) !== (value.error === undefined),
+		{
+			message:
+				"A server-request response carries exactly one of `result` or `error`",
+		},
+	);
+
+export type GatewayServerResponse = z.infer<typeof GatewayServerResponseSchema>;
+
+/** Well-known server-request methods (additive registry). */
+export const SERVER_REQUEST_METHODS = {
+	toolApproval: "client.requestToolApproval",
+	credential: "client.requestCredential",
+} as const;


### PR DESCRIPTION
### Related Issue

**Issue:** Implements Phases 0–2 of the Gateway RFC (internal design doc, `GOAL.md`; not committed to the repo — its content lives on as `sdk/packages/gateway/README.md` and the ADRs under `sdk/packages/gateway/docs/adr/`).

### Description

This PR lands the foundation of the Gateway RFC: one explicit, portable runtime authority for Cline. It is the first, self-contained slice — contracts and the two lower layers — with the actual Gateway server deliberately deferred.

**What landed**

**Phase 0 — shared wire contracts** (`@cline/shared/gateway`, new subpath):
- Branded, prefix-validated IDs (`gatewayId`, `instanceId`, `principalId`, `clientId`, `botId`, `sessionId`, `runId`, `workerId`) that are non-interchangeable at both the type and schema level; `catalogGeneration` as a number, not an ID.
- Versioned request/response/event envelopes (strict, `version: 1`), the closed `GatewayError` code registry, revisions (optimistic concurrency), opaque replay cursors, idempotency keys, the `gateway.hello` handshake + capability set, async run/session state machines with a full transition table, and server-initiated requests (independent of events).
- ADR-encoded authority invariants as machine-readable constants: `GATEWAY_WRITE_AUTHORITY = "gateway"`, `GATEWAY_CONNECT_FALLBACK = "none"` (a connect policy permitting any other fallback does not parse), lease-based singleton ownership, disconnect-never-implies-abort.

**Phase 1 — `@cline/engine`** (new package): owns exactly one execution. Immutable `RunSpec`, canonical ordered `EngineEvent` stream (per-run contiguous `sequence`), cooperative `steer`/`interrupt` + hard `abort`, `EngineRunResult` with persistence deltas for the caller's stores, injected tools/hooks/approval port/artifact sink/clock/telemetry. It is an adapter over the existing `@cline/agents` + `@cline/llms` loop, with zero storage/discovery/socket/daemon code and no shared mutable module state.

**Phase 2 — `@cline/bot`** (new package): domain semantics for one bot behind injected ports. Immutable identity/roles (lead/worker/contractor; first bot is `cline` lead; no promotion path), lazy session on the first *accepted* prompt, immutable session workspace, one mutating root run per session with FIFO admission and an immediate `{runId, acceptedAt, queuePosition}` ack, steering into the active run, per-turn overrides, delegation topology (only leads delegate; worker-to-worker messaging off by default), contractor one-task teardown with record retention, `memories/` discovery via a port, and engine invocation through an execution port (with a real adapter over `@cline/engine` as the composition proof). All domain tests run on in-memory ports.

**`@cline/gateway`** (new package, Phase 0 slice only): the private command registry (mutating methods require idempotency keys), pure `gateway.hello` negotiation, an in-memory idempotency ledger, the three ADRs, and the cross-package dependency tests. **No server, no SQLite, no CLI, no lease** — that is Phase 3+.

**Boundary enforcement (machine-checked)**

`boundaries.test.ts` in each new package fails if: engine imports bot/gateway/core, bot imports gateway/core, any new package imports storage (`fs`, sqlite), sockets (`net`/`http`/`ws`/...), or process-spawning modules, any new package depends on `@cline/core`, or `@cline/core` gains a dependency on the new packages. Dependency direction: `gateway -> bot -> engine -> agents -> llms -> shared`.

**Explicitly out of scope (unchanged)**

- `@cline/core` and the existing Hub: **zero functional edits** (verified — no core files touched).
- Phases 3–9: Gateway server/singleton lease/SQLite/CLI, plugins, MCP pooling, connectors/schedules, client SDK migration, remote/containers/federation.
- The three new packages are marked `private` + `internal` (not published, skipped by `check-publish`), matching `@cline/ui`.

Shared changes are additive only: a new `./gateway` export subpath, one build entrypoint, and a biome restricted-imports allow-list entry.

### Test Procedure

- New suites, all green: `@cline/shared` 398 (incl. 36 new gateway-contract tests), `@cline/engine` 18, `@cline/bot` 35, `@cline/gateway` 21. Engine tests cover tool runs, approval grant/deny, steering, cooperative interrupt, hard abort, model failure, completion, single-execution ownership, and concurrent-engine isolation with scripted models (no providers/network).
- Regression: `bun run build:sdk` (all packages), `bun --parallel -F './sdk/packages/**' typecheck`, `@cline/agents` (68 tests), `@cline/llms`, `@cline/cli` typecheck, and `bun sdk/scripts/check-publish.ts` all pass.
- `@cline/core test:unit`: 1932 passed; the 2 failures on this branch (`workspace-manifest`, `checkpoint-diff`) also fail (plus one more) on a clean `main` checkout in this environment — the documented cloud-VM git `insteadOf` artifact and checkpoint/git flakiness under parallel load, not caused by this change (both pass in isolation on this branch).
- Formatting/lint: `bun biome check` is clean for all new/modified files; the 8 remaining sdk errors pre-exist in untouched `core`/`ui` files.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend-only change; evidence is the test suites above (472 passing tests across the four touched packages).

### Additional Notes

Reviewing bottom-up is easiest: `sdk/packages/shared/src/gateway/` (contracts) → `sdk/packages/engine/` → `sdk/packages/bot/` → `sdk/packages/gateway/` (README carries the RFC summary; `docs/adr/` carries the three accepted decisions).