### PR TITLE
feat(gateway): Gateway RFC Phase 3 — Gateway authority and async runtime

### DIFF
--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -29,7 +29,7 @@ Foundation for the Gateway RFC (see `packages/gateway/README.md` and `packages/g
 
 - `@cline/engine`: single-execution engine over the `@cline/agents` loop — immutable `RunSpec`, ordered `EngineEvent`s, steer/interrupt/abort, `RunResult` + persistence deltas. No storage, discovery, sockets, or daemon code.
 - `@cline/bot`: bot domain semantics (immutable roles, lazy sessions, immutable workspaces, FIFO run admission, delegation, contractor teardown, memories) behind injected ports.
-- `@cline/gateway`: Gateway protocol authority — currently the private command registry, `gateway.hello` negotiation, idempotency ledger, and ADRs; the server itself is a later phase.
+- `@cline/gateway`: Gateway runtime authority — the wire protocol (command registry, `gateway.hello` negotiation), the SQLite authority with migrations, the OS-backed exclusive singleton lock, the loopback server with per-instance auth and durable event replay, the async run runtime (durable FIFO queue, run attempts/retry, crash recovery, approvals), outbox-driven disk projections, and the lifecycle CLI (`serve`/`start`/`status`/`drain`/`upgrade`/`stop`). Server, SQLite, lock, and CLI code live here only.
 
 Dependency rule: `gateway -> bot -> engine -> agents -> llms -> shared`. Engine never imports bot/gateway; bot never imports gateway; no new package depends on `@cline/core`. Reusable wire contracts live in `@cline/shared/gateway`. These rules are machine-checked by `boundaries.test.ts` in each new package.
 

--- a/sdk/packages/bot/src/bot.test.ts
+++ b/sdk/packages/bot/src/bot.test.ts
@@ -279,3 +279,49 @@ describe("retired bots", () => {
 		expect(bot.session).toBeUndefined();
 	});
 });
+
+describe("crash recovery re-admission (Gateway RFC, Phase 3)", () => {
+	it("re-admits committed queued runs in call order and executes them FIFO", () => {
+		const { ports, lead, bot } = setup();
+		// Simulate a previous process: the session and two queued run
+		// records are durable, but the new Bot facade has an empty queue.
+		bot.submitPrompt("held", { workspace: { rootPath: "/repo/a" } });
+		const ackA = bot.submitPrompt("recovered A");
+		const ackB = bot.submitPrompt("recovered B");
+		const recordA = ports.runs.get(ackA.runId);
+		const recordB = ports.runs.get(ackB.runId);
+		if (!recordA || !recordB) {
+			throw new Error("run records missing");
+		}
+
+		const restarted = new Bot(lead.identity.botId, ports);
+		restarted.recoverQueuedRun(recordA);
+		restarted.recoverQueuedRun(recordB);
+		// Duplicate recovery is a no-op, not a duplicate admission.
+		restarted.recoverQueuedRun(recordA);
+
+		// The restarted facade starts A first (FIFO), then B.
+		const started = ports.engine.handles.map(
+			(handle) => handle.invocation.input,
+		);
+		expect(started[started.length - 1]).toBe("recovered A");
+		expect(ports.runs.get(ackA.runId)?.state).toBe("running");
+		expect(ports.runs.get(ackB.runId)?.state).toBe("queued");
+	});
+
+	it("rejects records that are not queued or belong elsewhere", () => {
+		const { ports, lead, bot } = setup();
+		ports.engine.autoOutcome = () => ({ outputText: "done" });
+		const ack = bot.submitPrompt("finish", {
+			workspace: { rootPath: "/repo/a" },
+		});
+		const running = ports.runs.get(ack.runId);
+		if (!running) {
+			throw new Error("run record missing");
+		}
+		const restarted = new Bot(lead.identity.botId, ports);
+		expect(() => restarted.recoverQueuedRun(running)).toThrow(
+			RunAdmissionError,
+		);
+	});
+});

--- a/sdk/packages/bot/src/bot.ts
+++ b/sdk/packages/bot/src/bot.ts
@@ -184,6 +184,37 @@ export class Bot {
 		// Intentionally empty — sessions and runs outlive connections.
 	}
 
+	/**
+	 * Re-admit a committed run that was still `queued` when a previous
+	 * process died (Gateway RFC, Phase 3 crash recovery). Queued runs
+	 * were acknowledged but never attempted, so executing them completes
+	 * admission — unlike abandoned attempts, which are interrupted and
+	 * never auto-resumed. Callers pass records in FIFO (admission) order.
+	 */
+	recoverQueuedRun(record: RunRecord, overrides?: TurnOverrides): void {
+		if (record.botId !== this.botId) {
+			throw new RunAdmissionError(
+				`Run ${record.runId} belongs to bot ${record.botId}, not ${this.botId}`,
+			);
+		}
+		if (record.state !== "queued") {
+			throw new RunAdmissionError(
+				`Run ${record.runId} is ${record.state}; only queued runs are recoverable`,
+			);
+		}
+		const session = this.session;
+		if (!session || session.sessionId !== record.sessionId) {
+			throw new RunAdmissionError(
+				`Run ${record.runId} does not belong to the bot's active session`,
+			);
+		}
+		if (this.queue.some((entry) => entry.runId === record.runId)) {
+			return;
+		}
+		this.queue.push({ runId: record.runId, input: record.input, overrides });
+		this.pump();
+	}
+
 	/** Close the session; it admits no further runs. */
 	closeSession(): void {
 		const session = this.session;

--- a/sdk/packages/engine/src/engine.test.ts
+++ b/sdk/packages/engine/src/engine.test.ts
@@ -169,6 +169,105 @@ describe("completion", () => {
 });
 
 // -----------------------------------------------------------------------------
+// Model call usage metering
+// -----------------------------------------------------------------------------
+
+describe("model call usage metering", () => {
+	it("emits one model-call-completed per model response with per-call deltas", async () => {
+		const usageToolTurn: AgentModelEvent[] = [
+			{
+				type: "tool-call-delta",
+				toolCallId: "call_1",
+				toolName: "echo",
+				input: {},
+			},
+			{
+				type: "usage",
+				usage: {
+					inputTokens: 10,
+					outputTokens: 5,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+				},
+			},
+			{ type: "finish", reason: "tool-calls" },
+		];
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([usageToolTurn, textTurn("done")]),
+					modelInfo: { id: "model-x", provider: "provider-y" },
+				},
+				tools: [echoTool()],
+			}),
+			{ clock: fakeClock() },
+		);
+		await engine.run();
+
+		const calls = engine.events.filter(
+			(event) => event.type === "model-call-completed",
+		);
+		expect(calls).toHaveLength(2);
+		for (const call of calls) {
+			expect(call).toMatchObject({
+				providerId: "provider-y",
+				modelId: "model-x",
+				inputTokens: 10,
+				outputTokens: 5,
+				totalTokens: 15,
+				status: "ok",
+			});
+			expect(
+				(call as { durationMs?: number }).durationMs,
+			).toBeGreaterThanOrEqual(0);
+		}
+		// Deltas, not cumulative: the run total is 20/10 but each call
+		// reports its own 10/5.
+		expect(engine.result?.usage.inputTokens).toBe(20);
+	});
+
+	it("reports an errored in-flight model call when the run fails", async () => {
+		const engine = createEngine(
+			baseSpec({
+				model: { kind: "model", model: scriptedModel([errorTurn("boom")]) },
+			}),
+			{ clock: fakeClock() },
+		);
+		const result = await engine.run();
+		expect(result.status).toBe("failed");
+		const calls = engine.events.filter(
+			(event) => event.type === "model-call-completed",
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			inputTokens: 0,
+			outputTokens: 0,
+			totalTokens: 0,
+			status: "error",
+		});
+	});
+
+	it("carries provider identity from a provider-kind binding", async () => {
+		const engine = createEngine(
+			baseSpec({
+				model: {
+					kind: "model",
+					model: scriptedModel([textTurn("ok")]),
+				},
+			}),
+		);
+		await engine.run();
+		// No modelInfo on a bare model binding: identity is simply absent,
+		// never invented.
+		const call = engine.events.find(
+			(event) => event.type === "model-call-completed",
+		);
+		expect(call).toMatchObject({ providerId: undefined, modelId: undefined });
+	});
+});
+
+// -----------------------------------------------------------------------------
 // Tool runs
 // -----------------------------------------------------------------------------
 

--- a/sdk/packages/engine/src/engine.ts
+++ b/sdk/packages/engine/src/engine.ts
@@ -22,6 +22,7 @@ import type {
 	AgentRuntimeEvent,
 	AgentRuntimeHooks,
 	AgentStopControl,
+	AgentUsage,
 	ToolApprovalResult,
 } from "@cline/shared";
 import type {
@@ -70,6 +71,17 @@ export class Engine {
 	private interruptReason?: string;
 	private abortRequested = false;
 	private abortReason?: string;
+
+	// Per-model-call usage metering (usage-updated carries cumulative
+	// totals; model-call-completed events carry the per-call delta).
+	private meteredUsage: AgentUsage = {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+	};
+	private modelCallStartedAt?: number;
+	private modelCallInFlight = false;
 
 	private readonly persistenceDeltas: EnginePersistenceDelta[] = [];
 
@@ -204,6 +216,7 @@ export class Engine {
 		this.finalResult = result;
 
 		if (status === "failed" && error) {
+			this.emitAbandonedModelCall();
 			this.emit({ type: "run-failed", error, result });
 		} else {
 			this.emit({ type: "run-finished", result });
@@ -261,7 +274,12 @@ export class Engine {
 		const check = (): AgentStopControl | undefined => this.stopControl();
 		return {
 			beforeRun: check,
-			beforeModel: check,
+			beforeModel: () => {
+				// Checkpoint for per-call duration metering.
+				this.modelCallStartedAt = this.clock.now();
+				this.modelCallInFlight = true;
+				return check();
+			},
 			afterTool: check,
 		};
 	}
@@ -422,6 +440,7 @@ export class Engine {
 			}
 			case "usage-updated":
 				this.emit({ type: "usage-updated", usage: event.usage });
+				this.emitModelCallCompleted(event.usage);
 				break;
 			case "turn-finished":
 				this.emit({
@@ -445,6 +464,85 @@ export class Engine {
 			case "run-failed":
 				break;
 		}
+	}
+
+	private modelIdentity(): { providerId?: string; modelId?: string } {
+		if (this.spec.model.kind === "provider") {
+			return {
+				providerId: this.spec.model.providerId,
+				modelId: this.spec.model.modelId,
+			};
+		}
+		return {
+			providerId: this.spec.model.modelInfo?.provider,
+			modelId: this.spec.model.modelInfo?.id,
+		};
+	}
+
+	/** Emit the per-call usage delta for a completed model call. */
+	private emitModelCallCompleted(cumulative: AgentUsage): void {
+		const previous = this.meteredUsage;
+		const delta = {
+			inputTokens: Math.max(0, cumulative.inputTokens - previous.inputTokens),
+			outputTokens: Math.max(
+				0,
+				cumulative.outputTokens - previous.outputTokens,
+			),
+			cacheReadTokens: Math.max(
+				0,
+				cumulative.cacheReadTokens - previous.cacheReadTokens,
+			),
+			cacheWriteTokens: Math.max(
+				0,
+				cumulative.cacheWriteTokens - previous.cacheWriteTokens,
+			),
+			providerCost:
+				cumulative.totalCost !== undefined
+					? Math.max(0, cumulative.totalCost - (previous.totalCost ?? 0))
+					: undefined,
+		};
+		this.meteredUsage = { ...cumulative };
+		const now = this.clock.now();
+		const durationMs =
+			this.modelCallStartedAt !== undefined
+				? Math.max(0, now - this.modelCallStartedAt)
+				: undefined;
+		this.modelCallInFlight = false;
+		this.emit({
+			type: "model-call-completed",
+			...this.modelIdentity(),
+			inputTokens: delta.inputTokens,
+			outputTokens: delta.outputTokens,
+			totalTokens: delta.inputTokens + delta.outputTokens,
+			cacheReadTokens: delta.cacheReadTokens,
+			cacheWriteTokens: delta.cacheWriteTokens,
+			providerCost: delta.providerCost,
+			durationMs,
+			status: "ok",
+		});
+	}
+
+	/** A run failed while a model call was in flight and unreported. */
+	private emitAbandonedModelCall(): void {
+		if (!this.modelCallInFlight) {
+			return;
+		}
+		this.modelCallInFlight = false;
+		const now = this.clock.now();
+		this.emit({
+			type: "model-call-completed",
+			...this.modelIdentity(),
+			inputTokens: 0,
+			outputTokens: 0,
+			totalTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			durationMs:
+				this.modelCallStartedAt !== undefined
+					? Math.max(0, now - this.modelCallStartedAt)
+					: undefined,
+			status: "error",
+		});
 	}
 
 	private emit(payload: EngineEventPayload): void {

--- a/sdk/packages/engine/src/events.ts
+++ b/sdk/packages/engine/src/events.ts
@@ -66,6 +66,27 @@ export type EngineEventPayload =
 	| { type: "interrupt-requested"; reason?: string }
 	| { type: "abort-requested"; reason?: string }
 	| { type: "usage-updated"; usage: AgentUsage }
+	| {
+			/**
+			 * One model call finished and reported usage. Token counts are
+			 * per-call deltas (provider-reported when available), not the
+			 * cumulative run totals carried by `usage-updated`. Emitted so
+			 * callers can meter usage without scraping transcripts.
+			 */
+			type: "model-call-completed";
+			providerId?: string;
+			modelId?: string;
+			inputTokens: number;
+			outputTokens: number;
+			totalTokens: number;
+			cacheReadTokens: number;
+			cacheWriteTokens: number;
+			/** Provider-reported cost for this call, when available. */
+			providerCost?: number;
+			/** Wall time from the pre-call checkpoint to the usage report. */
+			durationMs?: number;
+			status: "ok" | "error";
+	  }
 	| { type: "turn-finished"; iteration: number; toolCallCount: number }
 	| { type: "status"; message: string; metadata?: Record<string, unknown> }
 	| { type: "artifact-created"; name: string; mediaType?: string }

--- a/sdk/packages/gateway/README.md
+++ b/sdk/packages/gateway/README.md
@@ -137,6 +137,39 @@ and the key never reaches the database, event log, audit trail,
 projections, or logs (machine-checked in
 `src/credential-hygiene.test.ts`).
 
+### Usage statistics (write path; Phase 7 reads it)
+
+Statistics are collected at run/message completion time and folded into
+daily aggregates immediately — queries never rescan session message
+history:
+
+```
+engine model response -> model-call-completed (per-call token deltas,
+duration, provider/model ids, status) -> usage normalizer -> ONE SQLite
+transaction: usage_events (immutable) + daily_usage + model_usage +
+agent_usage + topic_usage + streak_usage
+```
+
+Identity mapping (no parallel agent system): `agent_id` **is** the
+existing `botId`; `topic_id` **is** the existing `sessionId` — both
+denormalized onto each event so the mapping can diverge later without
+rewriting history. Messages are counted (user/assistant) when the
+canonical message is appended; the longest run duration per day is folded
+in when the run reaches a terminal state.
+
+Cost accuracy: provider-reported tokens/costs are recorded verbatim
+(`cost_is_estimate = 0`); otherwise the injected `PriceResolver`'s price
+snapshot is stored **on the event** and the cost is flagged as an
+estimate; with no pricing the cost is NULL (flagged), never invented.
+`recalculateEstimates` re-prices flagged events into `recalculated_*`
+columns and shifts aggregates by the delta — original event fields are
+immutable.
+
+Read surface (RPC methods, the `GET /statistics/*` equivalents; bounded
+to 400 days, aggregates only): `statistics.summary`,
+`statistics.activity` (heatmap rows), `statistics.rankings`
+(`dimension=model|agent|topic`), `statistics.usage` (`month=YYYY-MM`).
+
 ### What lives where
 
 | Concern | Location |
@@ -149,6 +182,7 @@ projections, or logs (machine-checked in
 | SQLite authority + migrations | `src/db.ts`, `src/stores.ts` |
 | Discovery record + instance secret | `src/discovery.ts` |
 | Provider credentials (0600 secret files) + engine injection | `src/secrets.ts`, `src/engine-binding.ts` |
+| Usage/statistics pipeline (events + daily aggregates + queries) | `src/usage.ts` |
 | Async runtime (queue, attempts, recovery, approvals) | `src/runtime.ts` |
 | Loopback server + event replay | `src/server.ts` |
 | Loopback client | `src/client.ts` |

--- a/sdk/packages/gateway/README.md
+++ b/sdk/packages/gateway/README.md
@@ -50,12 +50,13 @@ machine-checked in `src/boundaries.test.ts` (and mirrored per-package).
 ### Lifecycle
 
 ```
-cline-gateway serve     # run the authority in the foreground
-cline-gateway start     # ensure one is running (spawn detached, wait ready)
-cline-gateway status    # read discovery, connect, report gateway.status
-cline-gateway drain     # refuse new mutating work while runs finish
-cline-gateway upgrade   # drain, wait idle, stop, start a fresh process
-cline-gateway stop      # graceful stop
+cline-gateway serve                    # run the authority in the foreground
+cline-gateway start                    # ensure one is running (spawn detached, wait ready)
+cline-gateway status                   # read discovery, connect, report gateway.status
+cline-gateway drain                    # refuse new mutating work while runs finish
+cline-gateway upgrade                  # drain, wait idle, stop, start a fresh process
+cline-gateway stop                     # graceful stop
+cline-gateway secret-put <providerId>  # store a provider credential (reads stdin)
 ```
 
 Flags: `--data-root <dir>`, `--namespace <name>`, `--port <n>`,
@@ -111,6 +112,31 @@ workspaces live under `bots/<botId>/workspaces/<sessionId>`; bot memories
 under `bots/<botId>/memories/`. Canonical message history is stored
 behind the `AgentMessage` messages contract from `@cline/shared`.
 
+### Provider credentials (ADR 0001: the Gateway owns credentials)
+
+LLM provider keys are owner-only **mode-0600 files** in the data
+directory's `secrets/` (dir 0700), one per provider (`anthropic`,
+`openai`, `openrouter`, `cline`, ...). Operators either drop a file there
+or pipe one in:
+
+```
+printf '%s' "$KEY" | cline-gateway secret-put anthropic
+```
+
+At execution time the Gateway resolves the run's **snapshotted** config
+(provider/model captured on the run row at `run.start` — retries and
+crash recovery always bind the same model, never live bot config or
+in-memory overrides; the snapshot never contains a key) and injects the
+credential in memory at the engine boundary: environment variables
+(`CLINE_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, ...) act as a local/dev
+override, otherwise the provider's secret file is read. A missing
+credential fails the attempt with a stable
+`MissingProviderCredentialError` — an unauthenticated binding is never
+passed to the engine. Group/world-readable "secret" files are refused,
+and the key never reaches the database, event log, audit trail,
+projections, or logs (machine-checked in
+`src/credential-hygiene.test.ts`).
+
 ### What lives where
 
 | Concern | Location |
@@ -122,6 +148,7 @@ behind the `AgentMessage` messages contract from `@cline/shared`.
 | OS-backed exclusive lock | `src/lock.ts` |
 | SQLite authority + migrations | `src/db.ts`, `src/stores.ts` |
 | Discovery record + instance secret | `src/discovery.ts` |
+| Provider credentials (0600 secret files) + engine injection | `src/secrets.ts`, `src/engine-binding.ts` |
 | Async runtime (queue, attempts, recovery, approvals) | `src/runtime.ts` |
 | Loopback server + event replay | `src/server.ts` |
 | Loopback client | `src/client.ts` |

--- a/sdk/packages/gateway/README.md
+++ b/sdk/packages/gateway/README.md
@@ -1,12 +1,15 @@
 # `@cline/gateway`
 
-The Gateway is the proposed single runtime authority for Cline: a
-long-lived service (plus lightweight CLI) that owns mutable state, bot
-registration, runtime resources, execution supervision, and one versioned
-protocol for desktop, CLI, connector, local, and remote clients.
+The Gateway is the single runtime authority for Cline: a long-lived
+service (plus a lightweight lifecycle CLI) that owns mutable state, bot
+registration, runtime resources, execution supervision, and one
+versioned protocol for desktop, CLI, connector, local, and remote
+clients.
 
-This package currently contains the **Phase 0 slice** of the Gateway RFC.
-The server itself is deliberately absent (Phase 3+).
+This package contains the **Phase 0 protocol slice** and the **Phase 3
+authority**: the server, the SQLite store, the singleton lock, the async
+run runtime, and the CLI. Plugins, MCP pooling, connectors, schedules,
+and client migrations are later phases.
 
 ## Gateway RFC — summary
 
@@ -35,29 +38,103 @@ gateway -> bot -> engine -> agents -> llms -> shared
   workspaces, FIFO run admission, delegation, contractor teardown,
   memories, engine invocation — all through injected ports.
 - **`@cline/gateway`** owns infrastructure and machine authority: CLI,
-  singleton lease, protocol, persistence, credentials, plugins, MCP pools,
+  singleton lock, protocol, persistence, credentials, plugins, MCP pools,
   connectors, schedules, supervision.
 
 Engine never imports bot or Gateway types; bot never imports Gateway
 implementations; no new package depends on `@cline/core`. These rules are
 machine-checked in `src/boundaries.test.ts` (and mirrored per-package).
 
-### What lives where today
+## The Phase 3 authority
+
+### Lifecycle
+
+```
+cline-gateway serve     # run the authority in the foreground
+cline-gateway start     # ensure one is running (spawn detached, wait ready)
+cline-gateway status    # read discovery, connect, report gateway.status
+cline-gateway drain     # refuse new mutating work while runs finish
+cline-gateway upgrade   # drain, wait idle, stop, start a fresh process
+cline-gateway stop      # graceful stop
+```
+
+Flags: `--data-root <dir>`, `--namespace <name>`, `--port <n>`,
+`--reason <text>`. The singleton scope is the **canonical data directory
+plus environment namespace** (`CLINE_GATEWAY_DATA_ROOT`,
+`CLINE_GATEWAY_NAMESPACE`) — never a port.
+
+### Startup sequence (ADR 0002)
+
+1. Acquire the **OS-backed exclusive `gateway.lock`** (a SQLite file held
+   inside a never-committed `BEGIN EXCLUSIVE`; the kernel releases it on
+   process death — PID files and heartbeats are not authority). Failure
+   means a live authority exists: **connect or diagnose, never replace**
+   (a losing `serve` exits with code 3 and a diagnosis).
+2. Open + migrate `gateway.db` (SQLite, versioned forward-only
+   migrations): bots, sessions, runs, run attempts, the global event log,
+   canonical message history, the idempotency ledger, the outbox, audit,
+   and the client registry.
+3. Manual crash recovery: abandoned attempts are **interrupted, never
+   auto-resumed**; committed queued runs re-admit in FIFO order.
+4. Bootstrap the default lead bot `cline`.
+5. **Exclusive loopback bind** (ephemeral port by default).
+6. Only after readiness: atomically write the **mode-0600 discovery
+   record** (`gateway.json`) carrying the endpoint and the per-instance
+   auth secret.
+
+### Protocol
+
+Newline-delimited JSON over loopback TCP. Every connection opens with
+`gateway.hello` carrying the per-instance secret (loopback auth). Then:
+
+- `run.start` acks **immediately** with `{runId, acceptedAt,
+  queuePosition}`; execution is asynchronous (durable FIFO queue, one
+  active run per session, recorded attempts with capped retry).
+- `run.subscribe` replays durable events from an opaque cursor, then
+  live-tails. Delivery is paged with socket backpressure — client
+  projections stay bounded, and a reconnecting client resumes exactly
+  where it left off.
+- Server requests (tool approvals) are their own correlation space;
+  pending requests survive disconnects and are re-issued on resubscribe.
+- **Disconnect never implies abort** — no run transition is tied to
+  connection lifecycle.
+- Admission applies adaptive backpressure: a full session queue rejects
+  with a retryable `run_admission_rejected`.
+
+### Storage authority (ADR 0001)
+
+The database is authoritative; files are projections. State changes
+enqueue outbox entries in the same transaction; an outbox worker rewrites
+`projections/sessions/<id>.json` idempotently and retries failures —
+including across a crash between commit and file write. Managed session
+workspaces live under `bots/<botId>/workspaces/<sessionId>`; bot memories
+under `bots/<botId>/memories/`. Canonical message history is stored
+behind the `AgentMessage` messages contract from `@cline/shared`.
+
+### What lives where
 
 | Concern | Location |
 | --- | --- |
 | Wire contracts: IDs, envelopes, errors, revisions, cursors, idempotency, handshake, capabilities, run states, server requests | `@cline/shared/gateway` |
-| Private command registry (`run.start`, `run.steer`, ... with idempotency requirements) | `src/methods.ts` |
+| Private command registry (`run.start`, `gateway.drain`, ...) | `src/methods.ts` |
 | `gateway.hello` negotiation | `src/hello.ts` |
-| Idempotency ledger | `src/idempotency-ledger.ts` |
+| Data directory layout + namespace | `src/paths.ts` |
+| OS-backed exclusive lock | `src/lock.ts` |
+| SQLite authority + migrations | `src/db.ts`, `src/stores.ts` |
+| Discovery record + instance secret | `src/discovery.ts` |
+| Async runtime (queue, attempts, recovery, approvals) | `src/runtime.ts` |
+| Loopback server + event replay | `src/server.ts` |
+| Loopback client | `src/client.ts` |
+| Outbox projections | `src/outbox.ts` |
+| Lifecycle CLI | `src/cli.ts`, `bin/cline-gateway.mjs` |
 | ADRs: write authority, singleton ownership, no implicit fallback | [`docs/adr/`](./docs/adr/) |
 | Engine (Phase 1) | `@cline/engine` |
 | Bot domain (Phase 2) | `@cline/bot` |
 
-### Explicitly out of scope until Phase 3+
+### Explicitly out of scope until Phase 4+
 
-Singleton lease and CLI (`serve`/`start`/`status`/`drain`/`upgrade`/`stop`),
-SQLite persistence and disk projections, credentials (0600 secrets),
-plugins, MCP pooling, connector supervision, schedules, sandbox/container
-supervision, remote/mobile access, and any change to `@cline/core` or the
-existing Hub — which remain fully untouched by this package.
+Plugins and the resource catalog, MCP pooling, connector supervision
+(Telegram/Slack), schedules, sandbox/container supervision, desktop/CLI
+client migration, remote/mobile access and federation — and any change to
+`@cline/core` or the existing Hub, which remain fully untouched by this
+package.

--- a/sdk/packages/gateway/bin/cline-gateway.mjs
+++ b/sdk/packages/gateway/bin/cline-gateway.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Cline Gateway lifecycle CLI (Gateway RFC, Phase 3).
+import { runGatewayCli } from "../dist/index.js";
+
+const code = await runGatewayCli(process.argv.slice(2));
+if (code !== 0) {
+	process.exit(code);
+}

--- a/sdk/packages/gateway/docs/adr/0004-authority-runtime.md
+++ b/sdk/packages/gateway/docs/adr/0004-authority-runtime.md
@@ -1,0 +1,63 @@
+# ADR 0004 — Phase 3 authority runtime mechanics
+
+**Status:** Accepted (Gateway RFC, Phase 3)
+
+## Decisions
+
+### The lock is an OS primitive, not a protocol
+
+`gateway.lock` is a SQLite database held inside a never-committed
+`BEGIN EXCLUSIVE` transaction. SQLite maps that onto operating-system
+file locks, so the kernel releases ownership the instant the holding
+process dies: a crashed authority cannot leak the lock, and a live one
+cannot be displaced by deleting a file. PID files and heartbeats are
+diagnostics at most — never authority. A process that fails to acquire
+the lock connects to the running authority or diagnoses it; it never
+kills it and never binds another port (the singleton scope is the
+canonical data directory + environment namespace, not a port).
+
+### Readiness before discovery
+
+The discovery record (`gateway.json`, mode 0600, written atomically via
+temp-file + rename) is published only after the lock is held, the
+database is migrated, recovery has run, and the loopback socket is
+listening. It carries the endpoint and the per-instance auth secret;
+file permissions are the access control. A stale record is diagnosed
+(`unreachable`), never trusted and never "taken over" by rewriting it.
+
+### Crash recovery is manual for attempts, automatic for admission
+
+On startup, before serving:
+
+- Runs that were `running` are transitioned to `interrupted` and their
+  open attempts settled as `interrupted`. Abandoned attempts are **never
+  auto-resumed** — resuming a half-executed turn is not safe to guess
+  at; the operator (or client) starts a new run explicitly.
+- Runs that were `queued` were acknowledged but never attempted;
+  executing them completes admission, so they are re-admitted in FIFO
+  admission order. A queued run whose session no longer admits work is
+  aborted with an audit trail.
+
+### The database is authoritative; files are outbox projections
+
+Every state change lands in SQLite first; disk projections are enqueued
+in the same transaction and written asynchronously by an outbox worker
+whose projectors are idempotent full rewrites. A crash between commit
+and file write therefore loses nothing — the pending entry is retried on
+the next drain, including after restart.
+
+### Retry is bounded and recorded
+
+Every execution of a run is a recorded attempt. Failed attempts retry up
+to a configured cap (default 1 — no surprise re-execution) while the run
+stays `running`; interrupt/abort suppress retry.
+
+## Alternatives rejected
+
+- `flock`/`fcntl` via native dependencies (SQLite already ships the same
+  OS locks portably), lock files with PID liveness probes (PID reuse,
+  heartbeat races), and socket-file existence as authority (stale files).
+- Auto-resuming interrupted attempts (replays side effects with no
+  idempotency guarantee at the tool layer).
+- Writing projections synchronously in the request path (couples client
+  latency and crash windows to disk layout; loses the retry story).

--- a/sdk/packages/gateway/package.json
+++ b/sdk/packages/gateway/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cline/gateway",
 	"version": "0.0.75",
-	"description": "Cline Gateway — protocol authority for the Gateway RFC (Phase 0 contracts; server lands in Phase 3)",
+	"description": "Cline Gateway — runtime authority for the Gateway RFC (protocol, SQLite authority, singleton lock, async runtime, lifecycle CLI)",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cline/cline",
@@ -18,8 +18,12 @@
 			"import": "./dist/index.js"
 		}
 	},
+	"bin": {
+		"cline-gateway": "bin/cline-gateway.mjs"
+	},
 	"files": [
-		"dist"
+		"dist",
+		"bin"
 	],
 	"license": "Apache-2.0",
 	"scripts": {

--- a/sdk/packages/gateway/src/cli.test.ts
+++ b/sdk/packages/gateway/src/cli.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Lifecycle CLI, exercised with real processes: concurrent starters race
+ * for the OS lock and exactly one becomes the authority — the loser
+ * connects/diagnoses (exit code 3), never kills the winner and never
+ * binds another port. `status`/`drain`/`stop`/`start` drive the running
+ * instance through the wire protocol.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readDiscoveryRecord } from "./discovery";
+import { resolveGatewayPaths } from "./paths";
+import { tempDataRoot, waitFor } from "./test-support";
+
+const CLI = join(import.meta.dirname, "cli.ts");
+const BUN = process.env.BUN_BIN ?? "bun";
+
+interface CliProcess {
+	child: ChildProcess;
+	stdout: string[];
+	stderr: string[];
+	exit: Promise<number | null>;
+}
+
+const spawned: CliProcess[] = [];
+const dataRoots: string[] = [];
+
+function runCli(args: string[], dataRoot: string): CliProcess {
+	const child = spawn(BUN, [CLI, ...args, "--data-root", dataRoot], {
+		stdio: ["ignore", "pipe", "pipe"],
+		env: { ...process.env },
+	});
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	child.stdout?.setEncoding("utf8");
+	child.stderr?.setEncoding("utf8");
+	child.stdout?.on("data", (chunk: string) => stdout.push(chunk));
+	child.stderr?.on("data", (chunk: string) => stderr.push(chunk));
+	const exit = new Promise<number | null>((resolve) => {
+		child.on("exit", (code) => resolve(code));
+	});
+	const proc: CliProcess = { child, stdout, stderr, exit };
+	spawned.push(proc);
+	return proc;
+}
+
+function isAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function parsedLines(proc: CliProcess): Record<string, unknown>[] {
+	return proc.stdout
+		.join("")
+		.split("\n")
+		.filter((line) => line.trim().startsWith("{"))
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+afterEach(async () => {
+	// Kill any process this test started (specific PIDs only), including
+	// detached grandchildren recorded in discovery files.
+	for (const dataRoot of dataRoots.splice(0)) {
+		const record = readDiscoveryRecord(
+			resolveGatewayPaths({ dataRoot }).discoveryFile,
+		);
+		if (record && isAlive(record.pid)) {
+			try {
+				process.kill(record.pid, "SIGKILL");
+			} catch {
+				// Already gone.
+			}
+		}
+	}
+	for (const proc of spawned.splice(0)) {
+		if (proc.child.pid && isAlive(proc.child.pid)) {
+			try {
+				proc.child.kill("SIGKILL");
+			} catch {
+				// Already gone.
+			}
+		}
+	}
+});
+
+describe("concurrent starters (real processes)", () => {
+	it("exactly one serve wins; the loser diagnoses with exit 3 and changes nothing", {
+		timeout: 40_000,
+	}, async () => {
+		const dataRoot = tempDataRoot();
+		dataRoots.push(dataRoot);
+		const paths = resolveGatewayPaths({ dataRoot });
+
+		// Two starters race for the same data directory.
+		const a = runCli(["serve"], dataRoot);
+		const b = runCli(["serve"], dataRoot);
+
+		// Exactly one of them exits (the loser, code 3); the winner keeps
+		// serving.
+		const loserExit = await Promise.race([a.exit, b.exit]);
+		expect(loserExit).toBe(3);
+		const [winner, loser] =
+			(await Promise.race([a.exit.then(() => "a"), b.exit.then(() => "b")])) ===
+			"a"
+				? [b, a]
+				: [a, b];
+
+		const loserOutput = parsedLines(loser);
+		expect(loserOutput[0]?.status).toBe("already_running");
+
+		// The winner reached readiness and published exactly one discovery
+		// record; the loser did not touch it and did not bind a port.
+		await waitFor(
+			() => readDiscoveryRecord(paths.discoveryFile) !== undefined,
+			{
+				timeoutMs: 20_000,
+			},
+		);
+		const record = readDiscoveryRecord(paths.discoveryFile);
+		if (!record) {
+			throw new Error("winner published no discovery record");
+		}
+		expect(isAlive(record.pid)).toBe(true);
+		expect(record.pid).toBe(winner.child.pid);
+
+		await waitFor(() => parsedLines(winner).length > 0, { timeoutMs: 20_000 });
+		const winnerOutput = parsedLines(winner);
+		expect(winnerOutput[0]?.status).toBe("serving");
+		expect(winnerOutput[0]?.port).toBe(record.port);
+
+		// The winner survived the contention: status connects fine.
+		const status = runCli(["status"], dataRoot);
+		expect(await status.exit).toBe(0);
+		expect(parsedLines(status)[0]?.status).toBe("running");
+
+		// And the loser never killed it.
+		expect(isAlive(record.pid)).toBe(true);
+	});
+
+	it("start is idempotent, stop retires the instance and removes discovery", {
+		timeout: 40_000,
+	}, async () => {
+		const dataRoot = tempDataRoot();
+		dataRoots.push(dataRoot);
+		const paths = resolveGatewayPaths({ dataRoot });
+
+		const start = runCli(["start"], dataRoot);
+		expect(await start.exit).toBe(0);
+		expect(parsedLines(start)[0]?.status).toBe("started");
+		const record = readDiscoveryRecord(paths.discoveryFile);
+		if (!record) {
+			throw new Error("start published no discovery record");
+		}
+		expect(isAlive(record.pid)).toBe(true);
+
+		// A second start finds the running authority and does nothing.
+		const again = runCli(["start"], dataRoot);
+		expect(await again.exit).toBe(0);
+		expect(parsedLines(again)[0]?.status).toBe("already_running");
+		expect(readDiscoveryRecord(paths.discoveryFile)?.instanceId).toBe(
+			record.instanceId,
+		);
+
+		// Drain, then stop through the wire (operator commands, not client
+		// daemon replacement).
+		const drain = runCli(["drain", "--reason", "cli-test"], dataRoot);
+		expect(await drain.exit).toBe(0);
+
+		const stop = runCli(["stop"], dataRoot);
+		expect(await stop.exit).toBe(0);
+		await waitFor(
+			() => readDiscoveryRecord(paths.discoveryFile) === undefined,
+			{ timeoutMs: 20_000 },
+		);
+		await waitFor(() => !isAlive(record.pid), { timeoutMs: 20_000 });
+	});
+});

--- a/sdk/packages/gateway/src/cli.test.ts
+++ b/sdk/packages/gateway/src/cli.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readDiscoveryRecord } from "./discovery";
@@ -26,11 +27,19 @@ interface CliProcess {
 const spawned: CliProcess[] = [];
 const dataRoots: string[] = [];
 
-function runCli(args: string[], dataRoot: string): CliProcess {
+function runCli(
+	args: string[],
+	dataRoot: string,
+	options: { stdin?: string } = {},
+): CliProcess {
 	const child = spawn(BUN, [CLI, ...args, "--data-root", dataRoot], {
-		stdio: ["ignore", "pipe", "pipe"],
+		stdio: [options.stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
 		env: { ...process.env },
 	});
+	if (options.stdin !== undefined) {
+		child.stdin?.write(options.stdin);
+		child.stdin?.end();
+	}
 	const stdout: string[] = [];
 	const stderr: string[] = [];
 	child.stdout?.setEncoding("utf8");
@@ -178,5 +187,43 @@ describe("concurrent starters (real processes)", () => {
 			{ timeoutMs: 20_000 },
 		);
 		await waitFor(() => !isAlive(record.pid), { timeoutMs: 20_000 });
+	});
+});
+
+describe("secret-put (real process)", () => {
+	it("stores a provider credential from stdin as a 0600 file and never echoes it", {
+		timeout: 30_000,
+	}, async () => {
+		const dataRoot = tempDataRoot();
+		const paths = resolveGatewayPaths({ dataRoot });
+		const secret = "sk-test-cli-SECRET-1a2b3c4d5e6f\n";
+
+		const put = runCli(["secret-put", "anthropic"], dataRoot, {
+			stdin: secret,
+		});
+		expect(await put.exit).toBe(0);
+
+		const file = paths.secretFile("anthropic");
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+		expect(statSync(paths.secretsDir).mode & 0o777).toBe(0o700);
+		// Trailing newline from the pipe is stripped; the value is exact.
+		expect(readFileSync(file, "utf8")).toBe(secret.trimEnd());
+
+		// The CLI confirms without ever echoing the secret.
+		const allOutput = put.stdout.join("") + put.stderr.join("");
+		expect(allOutput).toContain('"status":"ok"');
+		expect(allOutput).not.toContain(secret.trimEnd());
+	});
+
+	it("rejects an empty secret and a missing provider id", {
+		timeout: 30_000,
+	}, async () => {
+		const dataRoot = tempDataRoot();
+		const empty = runCli(["secret-put", "anthropic"], dataRoot, {
+			stdin: "\n",
+		});
+		expect(await empty.exit).toBe(65);
+		const missing = runCli(["secret-put"], dataRoot, { stdin: "value\n" });
+		expect(await missing.exit).toBe(64);
 	});
 });

--- a/sdk/packages/gateway/src/cli.ts
+++ b/sdk/packages/gateway/src/cli.ts
@@ -22,6 +22,7 @@ import { type DiscoveryRecord, readDiscoveryRecord } from "./discovery";
 import { createConfiguredEnginePort } from "./engine-binding";
 import { GatewayLockHeldError } from "./lock";
 import { resolveGatewayPaths } from "./paths";
+import { writeSecretFile } from "./secrets";
 import { GatewayServer } from "./server";
 
 export const GATEWAY_CLI_COMMANDS = [
@@ -31,6 +32,7 @@ export const GATEWAY_CLI_COMMANDS = [
 	"drain",
 	"upgrade",
 	"stop",
+	"secret-put",
 ] as const;
 
 export type GatewayCliCommand = (typeof GATEWAY_CLI_COMMANDS)[number];
@@ -47,6 +49,8 @@ const DEFAULT_IO: GatewayCliIo = {
 
 interface ParsedArgs {
 	command: GatewayCliCommand;
+	/** Positional argument (`secret-put <providerId>`). */
+	subject?: string;
 	dataRoot?: string;
 	namespace?: string;
 	port?: number;
@@ -58,12 +62,20 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
 	if (!GATEWAY_CLI_COMMANDS.includes(command as GatewayCliCommand)) {
 		throw new Error(
 			`Usage: cline-gateway <${GATEWAY_CLI_COMMANDS.join("|")}> ` +
-				"[--data-root <dir>] [--namespace <name>] [--port <n>] [--reason <text>]",
+				"[--data-root <dir>] [--namespace <name>] [--port <n>] [--reason <text>]\n" +
+				"       cline-gateway secret-put <providerId>   (reads the secret from stdin)",
 		);
 	}
 	const parsed: ParsedArgs = { command: command as GatewayCliCommand };
 	for (let index = 0; index < rest.length; index += 1) {
 		const flag = rest[index];
+		if (!flag.startsWith("--")) {
+			if (parsed.subject !== undefined) {
+				throw new Error(`Unexpected argument: ${flag}`);
+			}
+			parsed.subject = flag;
+			continue;
+		}
 		const value = rest[index + 1];
 		switch (flag) {
 			case "--data-root":
@@ -138,8 +150,11 @@ async function commandServe(
 			port: args.port,
 			// The approvals broker lives on the runtime, which exists only
 			// after start; the getter closes over the server reference.
+			// Provider credentials come from the data directory's mode-0600
+			// secret files; env vars remain a local/dev override.
 			engine: createConfiguredEnginePort({
 				approvals: () => serverRef?.runtime.approvals,
+				paths: resolveGatewayPaths(args),
 			}),
 		});
 		serverRef = server;
@@ -361,6 +376,40 @@ async function commandUpgrade(
 	return commandStart(args, io);
 }
 
+/**
+ * Store a provider credential as an owner-only mode-0600 secret file.
+ * The value is read from stdin and is never echoed, logged, audited, or
+ * persisted anywhere but the secret file itself.
+ */
+async function commandSecretPut(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+): Promise<number> {
+	const providerId = args.subject;
+	if (!providerId) {
+		io.err(
+			"Usage: cline-gateway secret-put <providerId>   (reads the secret from stdin)",
+		);
+		return 64;
+	}
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(Buffer.from(chunk));
+	}
+	// Strip exactly one trailing newline (echo/heredoc convenience).
+	const value = Buffer.concat(chunks)
+		.toString("utf8")
+		.replace(/\r?\n$/, "");
+	if (!value) {
+		io.err(JSON.stringify({ status: "error", error: "Empty secret on stdin" }));
+		return 65;
+	}
+	const paths = resolveGatewayPaths(args);
+	const file = writeSecretFile(paths, providerId, value);
+	io.out(JSON.stringify({ status: "ok", provider: providerId, file }));
+	return 0;
+}
+
 /** Entry point. Returns the process exit code. */
 export async function runGatewayCli(
 	argv: readonly string[],
@@ -386,6 +435,8 @@ export async function runGatewayCli(
 			return commandAdmin(args, io, "gateway.stop");
 		case "upgrade":
 			return commandUpgrade(args, io);
+		case "secret-put":
+			return commandSecretPut(args, io);
 	}
 }
 

--- a/sdk/packages/gateway/src/cli.ts
+++ b/sdk/packages/gateway/src/cli.ts
@@ -1,0 +1,407 @@
+/**
+ * Gateway CLI (Gateway RFC, Phase 3; ADR 0002).
+ *
+ * Explicit lifecycle modes replace client-driven daemon replacement:
+ *
+ * - `serve`    run the authority in the foreground
+ * - `start`    ensure an authority is running (spawn detached, wait ready)
+ * - `status`   read discovery, connect, report `gateway.status`
+ * - `drain`    refuse new mutating work while runs finish
+ * - `upgrade`  drain, wait idle, stop, start a fresh process
+ * - `stop`     graceful stop
+ *
+ * A second `serve` against a held lock connects and diagnoses the live
+ * authority (exit code 3) — it never kills it and never binds another
+ * port. Clients never retire the authority; these operator commands do.
+ */
+
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { GatewayClient, GatewayRequestError } from "./client";
+import { type DiscoveryRecord, readDiscoveryRecord } from "./discovery";
+import { createConfiguredEnginePort } from "./engine-binding";
+import { GatewayLockHeldError } from "./lock";
+import { resolveGatewayPaths } from "./paths";
+import { GatewayServer } from "./server";
+
+export const GATEWAY_CLI_COMMANDS = [
+	"serve",
+	"start",
+	"status",
+	"drain",
+	"upgrade",
+	"stop",
+] as const;
+
+export type GatewayCliCommand = (typeof GATEWAY_CLI_COMMANDS)[number];
+
+export interface GatewayCliIo {
+	out(line: string): void;
+	err(line: string): void;
+}
+
+const DEFAULT_IO: GatewayCliIo = {
+	out: (line) => console.log(line),
+	err: (line) => console.error(line),
+};
+
+interface ParsedArgs {
+	command: GatewayCliCommand;
+	dataRoot?: string;
+	namespace?: string;
+	port?: number;
+	reason?: string;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+	const [command, ...rest] = argv;
+	if (!GATEWAY_CLI_COMMANDS.includes(command as GatewayCliCommand)) {
+		throw new Error(
+			`Usage: cline-gateway <${GATEWAY_CLI_COMMANDS.join("|")}> ` +
+				"[--data-root <dir>] [--namespace <name>] [--port <n>] [--reason <text>]",
+		);
+	}
+	const parsed: ParsedArgs = { command: command as GatewayCliCommand };
+	for (let index = 0; index < rest.length; index += 1) {
+		const flag = rest[index];
+		const value = rest[index + 1];
+		switch (flag) {
+			case "--data-root":
+				parsed.dataRoot = value;
+				index += 1;
+				break;
+			case "--namespace":
+				parsed.namespace = value;
+				index += 1;
+				break;
+			case "--port":
+				parsed.port = Number(value);
+				index += 1;
+				break;
+			case "--reason":
+				parsed.reason = value;
+				index += 1;
+				break;
+			default:
+				throw new Error(`Unknown flag: ${flag}`);
+		}
+	}
+	return parsed;
+}
+
+async function connectTo(
+	record: DiscoveryRecord,
+	name = "cline-gateway-cli",
+): Promise<GatewayClient> {
+	return GatewayClient.connectToDiscovery(record, {
+		clientName: name,
+		clientVersion: "phase-3",
+	});
+}
+
+/** Read discovery and probe the endpoint. */
+async function probe(
+	args: ParsedArgs,
+): Promise<
+	| { state: "not_running" }
+	| { state: "unreachable"; record: DiscoveryRecord }
+	| { state: "running"; record: DiscoveryRecord; status: unknown }
+> {
+	const paths = resolveGatewayPaths(args);
+	const record = readDiscoveryRecord(paths.discoveryFile);
+	if (!record) {
+		return { state: "not_running" };
+	}
+	try {
+		const client = await connectTo(record);
+		try {
+			const status = await client.request("gateway.status");
+			return { state: "running", record, status };
+		} finally {
+			client.close();
+		}
+	} catch {
+		return { state: "unreachable", record };
+	}
+}
+
+async function commandServe(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+): Promise<number> {
+	let server: GatewayServer;
+	let serverRef: GatewayServer | undefined;
+	try {
+		server = await GatewayServer.start({
+			dataRoot: args.dataRoot,
+			namespace: args.namespace,
+			port: args.port,
+			// The approvals broker lives on the runtime, which exists only
+			// after start; the getter closes over the server reference.
+			engine: createConfiguredEnginePort({
+				approvals: () => serverRef?.runtime.approvals,
+			}),
+		});
+		serverRef = server;
+	} catch (error) {
+		if (error instanceof GatewayLockHeldError) {
+			// Diagnose the live authority; never replace it.
+			const probed = await probe(args);
+			io.out(
+				JSON.stringify({
+					status: "already_running",
+					diagnosis:
+						probed.state === "running"
+							? probed.status
+							: {
+									state: probed.state,
+									discovery: "record" in probed ? probed.record : undefined,
+								},
+				}),
+			);
+			return 3;
+		}
+		throw error;
+	}
+	io.out(
+		JSON.stringify({
+			status: "serving",
+			gatewayId: server.discovery?.gatewayId,
+			instanceId: server.instanceId,
+			host: server.discovery?.host,
+			port: server.discovery?.port,
+			pid: process.pid,
+			dataDir: server.paths.dataDir,
+			namespace: server.paths.namespace,
+		}),
+	);
+	const shutdown = (signal: string) => {
+		io.err(`Received ${signal}; stopping gracefully`);
+		void server.stop("graceful");
+	};
+	process.on("SIGINT", () => shutdown("SIGINT"));
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
+	// Serve until stopped (gateway.stop, a signal, or an operator command).
+	await server.whenStopped;
+	return 0;
+}
+
+async function commandStart(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+): Promise<number> {
+	const existing = await probe(args);
+	if (existing.state === "running") {
+		io.out(
+			JSON.stringify({
+				status: "already_running",
+				...statusSummary(existing.status),
+			}),
+		);
+		return 0;
+	}
+	const serveArgs = ["serve"];
+	if (args.dataRoot) {
+		serveArgs.push("--data-root", args.dataRoot);
+	}
+	if (args.namespace) {
+		serveArgs.push("--namespace", args.namespace);
+	}
+	if (args.port !== undefined) {
+		serveArgs.push("--port", String(args.port));
+	}
+	// Re-invoke the same entrypoint (works from source under Bun and from
+	// the packaged bin under Node).
+	const child = spawn(process.execPath, [process.argv[1], ...serveArgs], {
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
+	const deadline = Date.now() + 15_000;
+	while (Date.now() < deadline) {
+		const probed = await probe(args);
+		if (probed.state === "running") {
+			io.out(
+				JSON.stringify({ status: "started", ...statusSummary(probed.status) }),
+			);
+			return 0;
+		}
+		await sleep(150);
+	}
+	io.err(JSON.stringify({ status: "start_timeout" }));
+	return 1;
+}
+
+function statusSummary(status: unknown): Record<string, unknown> {
+	return typeof status === "object" && status !== null
+		? (status as Record<string, unknown>)
+		: {};
+}
+
+async function commandStatus(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+): Promise<number> {
+	const probed = await probe(args);
+	if (probed.state === "running") {
+		io.out(
+			JSON.stringify({ status: "running", ...statusSummary(probed.status) }),
+		);
+		return 0;
+	}
+	if (probed.state === "unreachable") {
+		io.out(
+			JSON.stringify({
+				status: "unreachable",
+				discovery: probed.record,
+				hint: "Stale discovery record: the recorded instance is not answering. The OS lock decides authority; a new `serve` may take over safely.",
+			}),
+		);
+		return 2;
+	}
+	io.out(JSON.stringify({ status: "not_running" }));
+	return 1;
+}
+
+async function commandAdmin(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+	method: "gateway.drain" | "gateway.stop",
+): Promise<number> {
+	const probed = await probe(args);
+	if (probed.state !== "running") {
+		io.out(JSON.stringify({ status: probed.state }));
+		return probed.state === "not_running" ? 1 : 2;
+	}
+	const client = await connectTo(probed.record);
+	try {
+		const result = await client.mutate(method, {
+			...(args.reason ? { reason: args.reason } : {}),
+		});
+		io.out(JSON.stringify({ status: "ok", result }));
+	} catch (error) {
+		if (error instanceof GatewayRequestError) {
+			io.err(JSON.stringify({ status: "error", error: error.gatewayError }));
+			return 1;
+		}
+		throw error;
+	} finally {
+		client.close();
+	}
+	if (method === "gateway.stop") {
+		// Wait for the instance to actually go away.
+		const deadline = Date.now() + 15_000;
+		while (Date.now() < deadline) {
+			const now = await probe(args);
+			if (
+				now.state === "not_running" ||
+				(now.state === "running" &&
+					now.record.instanceId !== probed.record.instanceId)
+			) {
+				return 0;
+			}
+			if (now.state === "unreachable") {
+				return 0;
+			}
+			await sleep(150);
+		}
+		io.err(JSON.stringify({ status: "stop_timeout" }));
+		return 1;
+	}
+	return 0;
+}
+
+async function commandUpgrade(
+	args: ParsedArgs,
+	io: GatewayCliIo,
+): Promise<number> {
+	const probed = await probe(args);
+	if (probed.state !== "running") {
+		io.out(
+			JSON.stringify({
+				status: probed.state,
+				hint: "Nothing to upgrade; use start",
+			}),
+		);
+		return probed.state === "not_running" ? 1 : 2;
+	}
+	// 1. Drain: no new mutating work.
+	const drainExit = await commandAdmin(args, io, "gateway.drain");
+	if (drainExit !== 0) {
+		return drainExit;
+	}
+	// 2. Wait until active/queued runs settle (bounded).
+	const idleDeadline = Date.now() + 60_000;
+	for (;;) {
+		const now = await probe(args);
+		if (now.state !== "running") {
+			break;
+		}
+		const counts = (statusSummary(now.status).counts ?? {}) as Record<
+			string,
+			unknown
+		>;
+		if (
+			Number(counts.queuedRuns ?? 0) === 0 &&
+			Number(counts.runningRuns ?? 0) === 0
+		) {
+			break;
+		}
+		if (Date.now() > idleDeadline) {
+			io.err(JSON.stringify({ status: "upgrade_timeout_waiting_idle" }));
+			return 1;
+		}
+		await sleep(250);
+	}
+	// 3. Stop the old instance, 4. start a fresh one.
+	const stopExit = await commandAdmin(args, io, "gateway.stop");
+	if (stopExit !== 0) {
+		return stopExit;
+	}
+	return commandStart(args, io);
+}
+
+/** Entry point. Returns the process exit code. */
+export async function runGatewayCli(
+	argv: readonly string[],
+	io: GatewayCliIo = DEFAULT_IO,
+): Promise<number> {
+	let args: ParsedArgs;
+	try {
+		args = parseArgs(argv);
+	} catch (error) {
+		io.err(error instanceof Error ? error.message : String(error));
+		return 64;
+	}
+	switch (args.command) {
+		case "serve":
+			return commandServe(args, io);
+		case "start":
+			return commandStart(args, io);
+		case "status":
+			return commandStatus(args, io);
+		case "drain":
+			return commandAdmin(args, io, "gateway.drain");
+		case "stop":
+			return commandAdmin(args, io, "gateway.stop");
+		case "upgrade":
+			return commandUpgrade(args, io);
+	}
+}
+
+// Direct execution (`bun src/cli.ts serve ...`); the packaged bin calls
+// `runGatewayCli` explicitly. (`import.meta.main` is set under Bun; under
+// Node the packaged bin is the entrypoint instead.)
+if ((import.meta as { main?: boolean }).main) {
+	runGatewayCli(process.argv.slice(2)).then(
+		(code) => {
+			if (code !== 0) {
+				process.exit(code);
+			}
+		},
+		(error) => {
+			console.error(error);
+			process.exit(70);
+		},
+	);
+}

--- a/sdk/packages/gateway/src/client.ts
+++ b/sdk/packages/gateway/src/client.ts
@@ -1,0 +1,418 @@
+/**
+ * Loopback Gateway client (Gateway RFC, Phase 3).
+ *
+ * Speaks the versioned NDJSON protocol: hello-first handshake with the
+ * per-instance secret from the discovery record, promise-correlated
+ * requests, pushed events (durable-cursor replay), and server-initiated
+ * requests (approvals) that the caller answers explicitly.
+ *
+ * There is no implicit fallback (ADR 0003): when the Gateway cannot be
+ * reached this client fails with `gateway_unreachable` — it never spins
+ * up a private runtime.
+ */
+
+import { connect, type Socket } from "node:net";
+import type {
+	GatewayError,
+	GatewayEvent,
+	GatewayHelloResult,
+	GatewayRequest,
+	GatewayResponse,
+	GatewayServerRequest,
+} from "@cline/shared/gateway";
+import {
+	createGatewayError,
+	createIdempotencyKey,
+	GATEWAY_HELLO_METHOD,
+	GATEWAY_PROTOCOL_VERSION,
+	GatewayEventSchema,
+	GatewayServerRequestSchema,
+	IDEMPOTENCY_KEY_PARAM,
+} from "@cline/shared/gateway";
+import type { DiscoveryRecord } from "./discovery";
+
+export class GatewayRequestError extends Error {
+	readonly gatewayError: GatewayError;
+
+	constructor(gatewayError: GatewayError) {
+		super(`${gatewayError.code}: ${gatewayError.message}`);
+		this.name = "GatewayRequestError";
+		this.gatewayError = gatewayError;
+	}
+}
+
+export interface GatewayClientOptions {
+	host: string;
+	port: number;
+	/** Per-instance secret from the discovery record. */
+	auth: string;
+	clientName?: string;
+	clientVersion?: string;
+	/** Resume a previously assigned client identity. */
+	clientId?: string;
+	connectTimeoutMs?: number;
+}
+
+export type GatewayEventListener = (event: GatewayEvent) => void;
+export type GatewayServerRequestHandler = (
+	request: GatewayServerRequest,
+) => Promise<unknown> | unknown;
+
+interface PendingRequest {
+	resolve(value: unknown): void;
+	reject(error: Error): void;
+}
+
+export class GatewayClient {
+	readonly hello: GatewayHelloResult;
+
+	private readonly socket: Socket;
+	private readonly pending = new Map<string, PendingRequest>();
+	private readonly eventListeners = new Set<GatewayEventListener>();
+	private serverRequestHandler: GatewayServerRequestHandler | undefined;
+	private buffer = "";
+	private nextRequestId = 0;
+	private closed = false;
+
+	private constructor(socket: Socket, hello: GatewayHelloResult) {
+		this.socket = socket;
+		this.hello = hello;
+	}
+
+	/** Connect and complete the mandatory `gateway.hello` handshake. */
+	static async connect(options: GatewayClientOptions): Promise<GatewayClient> {
+		const socket = await connectSocket(options);
+		const transport = new TransportShim(socket);
+		try {
+			const helloResult = await transport.request(GATEWAY_HELLO_METHOD, {
+				protocolVersions: [GATEWAY_PROTOCOL_VERSION],
+				client: {
+					name: options.clientName ?? "gateway-client",
+					version: options.clientVersion ?? "0.0.0",
+					...(options.clientId ? { clientId: options.clientId } : {}),
+				},
+				auth: options.auth,
+			});
+			const client = new GatewayClient(
+				socket,
+				helloResult as GatewayHelloResult,
+			);
+			transport.handover(client);
+			return client;
+		} catch (error) {
+			socket.destroy();
+			throw error;
+		}
+	}
+
+	/** Connect using a discovery record (endpoint + secret). */
+	static async connectToDiscovery(
+		record: DiscoveryRecord,
+		options: Partial<GatewayClientOptions> = {},
+	): Promise<GatewayClient> {
+		return GatewayClient.connect({
+			host: record.host,
+			port: record.port,
+			auth: record.auth,
+			...options,
+		});
+	}
+
+	/** Issue a request; mutating methods should go through `mutate`. */
+	request(method: string, params?: Record<string, unknown>): Promise<unknown> {
+		if (this.closed) {
+			return Promise.reject(
+				new GatewayRequestError(
+					createGatewayError("gateway_unreachable", "Connection is closed"),
+				),
+			);
+		}
+		this.nextRequestId += 1;
+		const id = `req_${this.nextRequestId}`;
+		const request: GatewayRequest = {
+			version: GATEWAY_PROTOCOL_VERSION,
+			id,
+			method,
+			...(params ? { params } : {}),
+		};
+		return new Promise((resolve, reject) => {
+			this.pending.set(id, { resolve, reject });
+			this.socket.write(`${JSON.stringify(request)}\n`);
+		});
+	}
+
+	/** Issue a mutating request, generating an idempotency key if absent. */
+	mutate(
+		method: string,
+		params: Record<string, unknown> = {},
+	): Promise<unknown> {
+		const withKey = {
+			...params,
+			[IDEMPOTENCY_KEY_PARAM]:
+				params[IDEMPOTENCY_KEY_PARAM] ?? createIdempotencyKey(),
+		};
+		return this.request(method, withKey);
+	}
+
+	subscribe(params: {
+		sessionId?: string;
+		runId?: string;
+		cursor?: string;
+	}): Promise<unknown> {
+		return this.request("run.subscribe", { ...params });
+	}
+
+	onEvent(listener: GatewayEventListener): () => void {
+		this.eventListeners.add(listener);
+		return () => {
+			this.eventListeners.delete(listener);
+		};
+	}
+
+	/** Register the handler answering server-initiated requests. */
+	onServerRequest(handler: GatewayServerRequestHandler): void {
+		this.serverRequestHandler = handler;
+	}
+
+	respondToServerRequest(
+		id: string,
+		result: unknown,
+		error?: GatewayError,
+	): void {
+		this.socket.write(
+			`${JSON.stringify({
+				version: GATEWAY_PROTOCOL_VERSION,
+				id,
+				...(error ? { error } : { result: result ?? null }),
+			})}\n`,
+		);
+	}
+
+	/** Destroy the connection. Never aborts runs (server-side invariant). */
+	close(): void {
+		this.closed = true;
+		this.socket.destroy();
+		const failure = new GatewayRequestError(
+			createGatewayError("gateway_unreachable", "Connection closed locally"),
+		);
+		for (const pending of this.pending.values()) {
+			pending.reject(failure);
+		}
+		this.pending.clear();
+	}
+
+	// ---------------------------------------------------------------------
+	// Frame routing (also used by the handshake shim)
+	// ---------------------------------------------------------------------
+
+	handleFrame(value: unknown): void {
+		if (typeof value !== "object" || value === null) {
+			return;
+		}
+		const frame = value as Record<string, unknown>;
+		if (typeof frame.sequence === "number" && typeof frame.event === "string") {
+			const parsed = GatewayEventSchema.safeParse(frame);
+			if (parsed.success) {
+				for (const listener of this.eventListeners) {
+					listener(parsed.data);
+				}
+			}
+			return;
+		}
+		if (typeof frame.method === "string" && typeof frame.id === "string") {
+			const parsed = GatewayServerRequestSchema.safeParse(frame);
+			if (parsed.success) {
+				this.dispatchServerRequest(parsed.data);
+			}
+			return;
+		}
+		if (typeof frame.id === "string") {
+			this.settleResponse(frame as unknown as GatewayResponse);
+		}
+	}
+
+	feed(chunk: string): void {
+		this.buffer += chunk;
+		for (;;) {
+			const newline = this.buffer.indexOf("\n");
+			if (newline === -1) {
+				return;
+			}
+			const line = this.buffer.slice(0, newline).trim();
+			this.buffer = this.buffer.slice(newline + 1);
+			if (!line) {
+				continue;
+			}
+			try {
+				this.handleFrame(JSON.parse(line));
+			} catch {
+				// Skip malformed frames; correlation ids keep us consistent.
+			}
+		}
+	}
+
+	handleDisconnect(): void {
+		this.closed = true;
+		const failure = new GatewayRequestError(
+			createGatewayError(
+				"gateway_unreachable",
+				"Connection to the Gateway was lost",
+			),
+		);
+		for (const pending of this.pending.values()) {
+			pending.reject(failure);
+		}
+		this.pending.clear();
+	}
+
+	private settleResponse(response: GatewayResponse): void {
+		const pending = this.pending.get(response.id);
+		if (!pending) {
+			return;
+		}
+		this.pending.delete(response.id);
+		if (response.error) {
+			pending.reject(new GatewayRequestError(response.error));
+			return;
+		}
+		pending.resolve(response.result);
+	}
+
+	private dispatchServerRequest(request: GatewayServerRequest): void {
+		const handler = this.serverRequestHandler;
+		if (!handler) {
+			return;
+		}
+		void (async () => {
+			try {
+				const result = await handler(request);
+				this.respondToServerRequest(request.id, result);
+			} catch (error) {
+				this.respondToServerRequest(
+					request.id,
+					undefined,
+					createGatewayError(
+						"internal",
+						error instanceof Error ? error.message : String(error),
+					),
+				);
+			}
+		})();
+	}
+}
+
+/**
+ * Minimal request transport used only for the handshake, before the
+ * `GatewayClient` exists; then hands the socket stream over to it.
+ */
+class TransportShim {
+	private readonly socket: Socket;
+	private buffer = "";
+	private pendingResolve: ((value: unknown) => void) | undefined;
+	private pendingReject: ((error: Error) => void) | undefined;
+	private client: GatewayClient | undefined;
+
+	constructor(socket: Socket) {
+		this.socket = socket;
+		socket.setEncoding("utf8");
+		socket.on("data", (chunk: string) => this.onData(chunk));
+		socket.on("close", () => {
+			this.pendingReject?.(
+				new GatewayRequestError(
+					createGatewayError(
+						"gateway_unreachable",
+						"Connection closed during the handshake",
+					),
+				),
+			);
+			this.client?.handleDisconnect();
+		});
+	}
+
+	request(method: string, params: Record<string, unknown>): Promise<unknown> {
+		const request: GatewayRequest = {
+			version: GATEWAY_PROTOCOL_VERSION,
+			id: "hello_1",
+			method,
+			params,
+		};
+		return new Promise((resolve, reject) => {
+			this.pendingResolve = resolve;
+			this.pendingReject = reject;
+			this.socket.write(`${JSON.stringify(request)}\n`);
+		});
+	}
+
+	handover(client: GatewayClient): void {
+		this.client = client;
+		if (this.buffer) {
+			client.feed(this.buffer);
+			this.buffer = "";
+		}
+	}
+
+	private onData(chunk: string): void {
+		if (this.client) {
+			this.client.feed(chunk);
+			return;
+		}
+		this.buffer += chunk;
+		const newline = this.buffer.indexOf("\n");
+		if (newline === -1) {
+			return;
+		}
+		const line = this.buffer.slice(0, newline).trim();
+		this.buffer = this.buffer.slice(newline + 1);
+		let response: GatewayResponse;
+		try {
+			response = JSON.parse(line) as GatewayResponse;
+		} catch {
+			this.pendingReject?.(
+				new GatewayRequestError(
+					createGatewayError("invalid_request", "Malformed handshake response"),
+				),
+			);
+			return;
+		}
+		if (response.error) {
+			this.pendingReject?.(new GatewayRequestError(response.error));
+			return;
+		}
+		this.pendingResolve?.(response.result);
+	}
+}
+
+function connectSocket(options: GatewayClientOptions): Promise<Socket> {
+	return new Promise((resolve, reject) => {
+		const socket = connect({ host: options.host, port: options.port });
+		const timeout = setTimeout(() => {
+			socket.destroy();
+			reject(
+				new GatewayRequestError(
+					createGatewayError(
+						"gateway_unreachable",
+						`Timed out connecting to ${options.host}:${options.port}`,
+						{ retryable: true },
+					),
+				),
+			);
+		}, options.connectTimeoutMs ?? 5_000);
+		socket.once("connect", () => {
+			clearTimeout(timeout);
+			resolve(socket);
+		});
+		socket.once("error", (error) => {
+			clearTimeout(timeout);
+			socket.destroy();
+			reject(
+				new GatewayRequestError(
+					createGatewayError(
+						"gateway_unreachable",
+						`Cannot reach the Gateway at ${options.host}:${options.port}: ${error.message}`,
+						{ retryable: true },
+					),
+				),
+			);
+		});
+	});
+}

--- a/sdk/packages/gateway/src/credential-hygiene.test.ts
+++ b/sdk/packages/gateway/src/credential-hygiene.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Credential hygiene end-to-end: a provider secret stored as a mode-0600
+ * file is injected in memory at the engine boundary for a full turn —
+ * and appears nowhere else: not in SQLite (including the WAL), not in
+ * the event log, not in audit entries, not in projections, not in the
+ * discovery record, and not in run rows or snapshots.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import type { EngineInvocation, EnginePort } from "@cline/bot";
+import type { RunAccepted } from "@cline/shared/gateway";
+import { afterEach, describe, expect, it } from "vitest";
+import { GatewayClient } from "./client";
+import { resolveProviderModel } from "./engine-binding";
+import { resolveGatewayPaths } from "./paths";
+import { writeSecretFile } from "./secrets";
+import { GatewayServer } from "./server";
+import { ScriptedEnginePort, tempDataRoot, waitFor } from "./test-support";
+
+const SECRET = "sk-test-SUPERSECRET-4f9c2e8b7a6d5140";
+
+const servers: GatewayServer[] = [];
+const clients: GatewayClient[] = [];
+
+afterEach(async () => {
+	for (const client of clients.splice(0)) {
+		client.close();
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop("graceful").catch(() => {});
+	}
+});
+
+function listFilesRecursively(dir: string): string[] {
+	const names = readdirSync(dir, { recursive: true, encoding: "utf8" });
+	const files: string[] = [];
+	for (const name of names) {
+		const full = join(dir, name);
+		try {
+			if (statSync(full).isFile()) {
+				files.push(full);
+			}
+		} catch {
+			// Transient files (WAL checkpoints) may vanish mid-walk.
+		}
+	}
+	return files;
+}
+
+describe("credential hygiene", () => {
+	it("a turn using a 0600 secret leaks it nowhere outside secrets/", async () => {
+		const dataRoot = tempDataRoot();
+		const paths = resolveGatewayPaths({ dataRoot, namespace: "default" });
+		writeSecretFile(paths, "anthropic", SECRET);
+
+		// Engine double that goes through the REAL credential resolution
+		// used by `serve` (secret file, no env), then executes scripted —
+		// proving the key reaches the engine boundary in memory only.
+		const scripted = new ScriptedEnginePort();
+		const resolvedKeys: string[] = [];
+		const engine: EnginePort = {
+			start(invocation: EngineInvocation) {
+				const binding = resolveProviderModel(invocation, { env: {}, paths });
+				if (binding.kind === "provider" && binding.apiKey) {
+					resolvedKeys.push(binding.apiKey);
+				}
+				return scripted.start(invocation);
+			},
+		};
+		const server = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine,
+		});
+		servers.push(server);
+		const discovery = server.discovery;
+		if (!discovery) {
+			throw new Error("no discovery");
+		}
+		const client = await GatewayClient.connectToDiscovery(discovery, {
+			clientName: "hygiene-test",
+			clientVersion: "0.0.1",
+		});
+		clients.push(client);
+		const botId = server.runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("no default bot");
+		}
+
+		const accepted = (await client.mutate("run.start", {
+			botId,
+			prompt: "use the stored credential",
+			overrides: { providerId: "anthropic", modelId: "claude-x" },
+		})) as RunAccepted;
+		await waitFor(() => scripted.handles.length === 1);
+		scripted.handles[0].emit({
+			type: "message-appended",
+			message: {
+				id: "msg_hygiene",
+				role: "assistant",
+				content: [{ type: "text", text: "done without leaking" }],
+				createdAt: Date.now(),
+			},
+			index: 0,
+		});
+		scripted.handles[0].settle({ outputText: "turn finished" });
+		await waitFor(
+			() => server.stores.runs.get(accepted.runId)?.state === "completed",
+		);
+		await server.outboxWorker.drain();
+
+		// The key was actually used (in memory, via the 0600 file, no env).
+		expect(resolvedKeys).toEqual([SECRET]);
+
+		// It appears in exactly one place on disk: the secret file itself.
+		// Not in gateway.db / WAL, projections, discovery, workspaces, logs.
+		const offenders = listFilesRecursively(paths.dataDir).filter((file) => {
+			const contents = readFileSync(file);
+			return contents.includes(SECRET);
+		});
+		expect(offenders.map((file) => relative(paths.dataDir, file))).toEqual([
+			join("secrets", "anthropic"),
+		]);
+
+		// Nor in any wire-visible surface: events, audit, run rows, status.
+		const events = server.stores.events.listAfter(-1, {}, 1000);
+		expect(JSON.stringify(events)).not.toContain(SECRET);
+		expect(JSON.stringify(server.stores.audit.list(1000))).not.toContain(
+			SECRET,
+		);
+		expect(
+			JSON.stringify(server.stores.runs.get(accepted.runId)),
+		).not.toContain(SECRET);
+		expect(
+			JSON.stringify(server.stores.runs.getConfigSnapshot(accepted.runId)),
+		).not.toContain(SECRET);
+		expect(JSON.stringify(server.runtime.status())).not.toContain(SECRET);
+	});
+});

--- a/sdk/packages/gateway/src/db.ts
+++ b/sdk/packages/gateway/src/db.ts
@@ -132,6 +132,84 @@ export const GATEWAY_MIGRATIONS: readonly GatewayMigration[] = [
 				last_seen_at INTEGER NOT NULL,
 				connections INTEGER NOT NULL DEFAULT 0
 			);`,
+			// --- Usage/statistics pipeline (write path; Phase 7 reads it) ---
+			// One normalized record per model call. Original cost fields are
+			// immutable; recalculations land in recalculated_* columns.
+			`CREATE TABLE usage_events (
+				event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				occurred_at INTEGER NOT NULL,
+				date TEXT NOT NULL,
+				bot_id TEXT NOT NULL,
+				session_id TEXT NOT NULL,
+				run_id TEXT NOT NULL,
+				provider_id TEXT,
+				model_id TEXT,
+				agent_id TEXT NOT NULL,
+				topic_id TEXT NOT NULL,
+				input_tokens INTEGER NOT NULL,
+				output_tokens INTEGER NOT NULL,
+				total_tokens INTEGER NOT NULL,
+				estimated_cost REAL,
+				cost_is_estimate INTEGER NOT NULL DEFAULT 1,
+				price_snapshot_json TEXT,
+				recalculated_cost REAL,
+				recalculated_price_json TEXT,
+				duration_ms INTEGER,
+				status TEXT NOT NULL
+			);`,
+			`CREATE INDEX idx_usage_events_bot ON usage_events(bot_id, occurred_at);`,
+			`CREATE INDEX idx_usage_events_model ON usage_events(model_id, occurred_at);`,
+			`CREATE INDEX idx_usage_events_topic ON usage_events(topic_id, occurred_at);`,
+			`CREATE INDEX idx_usage_events_time ON usage_events(occurred_at);`,
+			`CREATE TABLE daily_usage (
+				date TEXT NOT NULL,
+				bot_id TEXT NOT NULL,
+				tokens INTEGER NOT NULL DEFAULT 0,
+				input_tokens INTEGER NOT NULL DEFAULT 0,
+				output_tokens INTEGER NOT NULL DEFAULT 0,
+				messages INTEGER NOT NULL DEFAULT 0,
+				model_calls INTEGER NOT NULL DEFAULT 0,
+				estimated_cost REAL NOT NULL DEFAULT 0,
+				active_sessions INTEGER NOT NULL DEFAULT 0,
+				active_agents INTEGER NOT NULL DEFAULT 1,
+				max_run_duration_ms INTEGER NOT NULL DEFAULT 0,
+				PRIMARY KEY (date, bot_id)
+			);`,
+			`CREATE TABLE model_usage (
+				date TEXT NOT NULL,
+				model_id TEXT NOT NULL,
+				provider_id TEXT NOT NULL,
+				messages INTEGER NOT NULL DEFAULT 0,
+				tokens INTEGER NOT NULL DEFAULT 0,
+				estimated_cost REAL NOT NULL DEFAULT 0,
+				PRIMARY KEY (date, model_id, provider_id)
+			);`,
+			`CREATE TABLE agent_usage (
+				date TEXT NOT NULL,
+				agent_id TEXT NOT NULL,
+				messages INTEGER NOT NULL DEFAULT 0,
+				tokens INTEGER NOT NULL DEFAULT 0,
+				PRIMARY KEY (date, agent_id)
+			);`,
+			`CREATE TABLE topic_usage (
+				date TEXT NOT NULL,
+				topic_id TEXT NOT NULL,
+				messages INTEGER NOT NULL DEFAULT 0,
+				tokens INTEGER NOT NULL DEFAULT 0,
+				PRIMARY KEY (date, topic_id)
+			);`,
+			`CREATE TABLE streak_usage (
+				date TEXT PRIMARY KEY,
+				active INTEGER NOT NULL DEFAULT 1
+			);`,
+			// Uniqueness helper so daily_usage.active_sessions stays an O(1)
+			// incremental counter instead of a rescan.
+			`CREATE TABLE usage_seen_sessions (
+				date TEXT NOT NULL,
+				session_id TEXT NOT NULL,
+				bot_id TEXT NOT NULL,
+				PRIMARY KEY (date, session_id)
+			);`,
 		],
 	},
 ];

--- a/sdk/packages/gateway/src/db.ts
+++ b/sdk/packages/gateway/src/db.ts
@@ -60,7 +60,8 @@ export const GATEWAY_MIGRATIONS: readonly GatewayMigration[] = [
 				ended_at INTEGER,
 				output_text TEXT,
 				error_name TEXT,
-				error_message TEXT
+				error_message TEXT,
+				config_json TEXT
 			);`,
 			`CREATE INDEX idx_runs_session ON runs(session_id, accepted_seq);`,
 			`CREATE INDEX idx_runs_state ON runs(state);`,

--- a/sdk/packages/gateway/src/db.ts
+++ b/sdk/packages/gateway/src/db.ts
@@ -1,0 +1,232 @@
+/**
+ * SQLite authority database (Gateway RFC, Phase 3; ADR 0001).
+ *
+ * The Gateway is the only writer of new-path state. Everything durable —
+ * the bot registry, sessions, runs and their attempts, the global event
+ * log, canonical message history, the idempotency ledger, the outbox,
+ * the audit trail, and the client registry — lives in one SQLite file
+ * with versioned, forward-only migrations. Disk projections are derived
+ * from this database through the outbox; the database is authoritative.
+ */
+
+import { loadSqliteDb, type SqliteDb } from "@cline/shared/db";
+
+export interface GatewayMigration {
+	readonly version: number;
+	readonly name: string;
+	readonly statements: readonly string[];
+}
+
+export const GATEWAY_MIGRATIONS: readonly GatewayMigration[] = [
+	{
+		version: 1,
+		name: "phase-3-authority",
+		statements: [
+			`CREATE TABLE meta (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL
+			);`,
+			`CREATE TABLE bots (
+				bot_id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				role TEXT NOT NULL,
+				parent_bot_id TEXT,
+				created_by TEXT NOT NULL,
+				reason TEXT,
+				created_at INTEGER NOT NULL,
+				config_json TEXT NOT NULL,
+				status TEXT NOT NULL,
+				revision INTEGER NOT NULL
+			);`,
+			`CREATE TABLE sessions (
+				session_id TEXT PRIMARY KEY,
+				bot_id TEXT NOT NULL,
+				workspace_root TEXT NOT NULL,
+				state TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				revision INTEGER NOT NULL
+			);`,
+			`CREATE INDEX idx_sessions_bot ON sessions(bot_id, created_at);`,
+			`CREATE TABLE runs (
+				run_id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				bot_id TEXT NOT NULL,
+				state TEXT NOT NULL,
+				input TEXT NOT NULL,
+				accepted_at INTEGER NOT NULL,
+				accepted_seq INTEGER NOT NULL,
+				instance_id TEXT NOT NULL,
+				started_at INTEGER,
+				ended_at INTEGER,
+				output_text TEXT,
+				error_name TEXT,
+				error_message TEXT
+			);`,
+			`CREATE INDEX idx_runs_session ON runs(session_id, accepted_seq);`,
+			`CREATE INDEX idx_runs_state ON runs(state);`,
+			`CREATE TABLE run_attempts (
+				attempt_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				run_id TEXT NOT NULL,
+				attempt INTEGER NOT NULL,
+				state TEXT NOT NULL,
+				instance_id TEXT NOT NULL,
+				started_at INTEGER NOT NULL,
+				ended_at INTEGER,
+				error_name TEXT,
+				error_message TEXT,
+				UNIQUE (run_id, attempt)
+			);`,
+			`CREATE TABLE events (
+				sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+				event TEXT NOT NULL,
+				bot_id TEXT,
+				session_id TEXT,
+				run_id TEXT,
+				payload_json TEXT,
+				created_at INTEGER NOT NULL
+			);`,
+			`CREATE INDEX idx_events_session ON events(session_id, sequence);`,
+			`CREATE INDEX idx_events_run ON events(run_id, sequence);`,
+			`CREATE TABLE messages (
+				message_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+				session_id TEXT NOT NULL,
+				run_id TEXT,
+				message_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				message_json TEXT NOT NULL,
+				created_at INTEGER NOT NULL
+			);`,
+			`CREATE INDEX idx_messages_session ON messages(session_id, message_seq);`,
+			`CREATE TABLE idempotency (
+				key TEXT PRIMARY KEY,
+				method TEXT NOT NULL,
+				params_fingerprint TEXT NOT NULL,
+				response_json TEXT,
+				created_at INTEGER NOT NULL
+			);`,
+			`CREATE TABLE outbox (
+				outbox_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				kind TEXT NOT NULL,
+				payload_json TEXT NOT NULL,
+				state TEXT NOT NULL DEFAULT 'pending',
+				attempts INTEGER NOT NULL DEFAULT 0,
+				last_error TEXT,
+				created_at INTEGER NOT NULL,
+				done_at INTEGER
+			);`,
+			`CREATE INDEX idx_outbox_pending ON outbox(state, outbox_id);`,
+			`CREATE TABLE audit (
+				audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				at INTEGER NOT NULL,
+				actor TEXT NOT NULL,
+				action TEXT NOT NULL,
+				subject TEXT,
+				details_json TEXT
+			);`,
+			`CREATE TABLE clients (
+				client_id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				version TEXT NOT NULL,
+				first_seen_at INTEGER NOT NULL,
+				last_seen_at INTEGER NOT NULL,
+				connections INTEGER NOT NULL DEFAULT 0
+			);`,
+		],
+	},
+];
+
+export class GatewayDatabase {
+	readonly db: SqliteDb;
+	private transactionDepth = 0;
+
+	constructor(db: SqliteDb) {
+		this.db = db;
+	}
+
+	/**
+	 * Run `fn` inside one immediate transaction. Nested calls join the
+	 * outer transaction (SQLite has a single writer anyway).
+	 */
+	transaction<T>(fn: () => T): T {
+		if (this.transactionDepth > 0) {
+			this.transactionDepth += 1;
+			try {
+				return fn();
+			} finally {
+				this.transactionDepth -= 1;
+			}
+		}
+		this.db.exec("BEGIN IMMEDIATE;");
+		this.transactionDepth = 1;
+		try {
+			const result = fn();
+			this.db.exec("COMMIT;");
+			return result;
+		} catch (error) {
+			try {
+				this.db.exec("ROLLBACK;");
+			} catch {
+				// Rollback failures must not mask the original error.
+			}
+			throw error;
+		} finally {
+			this.transactionDepth = 0;
+		}
+	}
+
+	close(): void {
+		this.db.close?.();
+	}
+}
+
+function appliedMigrationVersions(db: SqliteDb): Set<number> {
+	db.exec(
+		`CREATE TABLE IF NOT EXISTS migrations (
+			version INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			applied_at INTEGER NOT NULL
+		);`,
+	);
+	return new Set(
+		db
+			.prepare("SELECT version FROM migrations ORDER BY version;")
+			.all()
+			.map((row) => Number(row.version)),
+	);
+}
+
+export function migrateGatewayDatabase(db: SqliteDb): void {
+	const applied = appliedMigrationVersions(db);
+	for (const migration of GATEWAY_MIGRATIONS) {
+		if (applied.has(migration.version)) {
+			continue;
+		}
+		db.exec("BEGIN IMMEDIATE;");
+		try {
+			for (const statement of migration.statements) {
+				db.exec(statement);
+			}
+			db.prepare(
+				"INSERT INTO migrations (version, name, applied_at) VALUES (?, ?, ?);",
+			).run(migration.version, migration.name, Date.now());
+			db.exec("COMMIT;");
+		} catch (error) {
+			try {
+				db.exec("ROLLBACK;");
+			} catch {
+				// Keep the original migration error.
+			}
+			throw error;
+		}
+	}
+}
+
+export function openGatewayDatabase(databaseFile: string): GatewayDatabase {
+	const db = loadSqliteDb(databaseFile);
+	db.exec("PRAGMA journal_mode = WAL;");
+	db.exec("PRAGMA busy_timeout = 5000;");
+	db.exec("PRAGMA foreign_keys = ON;");
+	db.exec("PRAGMA synchronous = NORMAL;");
+	migrateGatewayDatabase(db);
+	return new GatewayDatabase(db);
+}

--- a/sdk/packages/gateway/src/discovery.test.ts
+++ b/sdk/packages/gateway/src/discovery.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Discovery record: atomic, mode 0600, written only by the authority,
+ * removed only by its own instance.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createGatewayId,
+	createGatewayInstanceId,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import {
+	createInstanceAuthToken,
+	type DiscoveryRecord,
+	readDiscoveryRecord,
+	removeDiscoveryRecord,
+	writeDiscoveryRecord,
+} from "./discovery";
+import { tempDataRoot } from "./test-support";
+
+function record(overrides: Partial<DiscoveryRecord> = {}): DiscoveryRecord {
+	return {
+		gatewayId: createGatewayId(),
+		instanceId: createGatewayInstanceId(),
+		host: "127.0.0.1",
+		port: 4242,
+		auth: createInstanceAuthToken(),
+		pid: process.pid,
+		startedAt: Date.now(),
+		protocolVersions: [1],
+		dataDir: "/tmp/x",
+		namespace: "default",
+		...overrides,
+	};
+}
+
+describe("discovery record", () => {
+	it("round-trips and is written mode 0600", () => {
+		const file = join(tempDataRoot(), "gateway.json");
+		const written = record();
+		writeDiscoveryRecord(file, written);
+		expect(readDiscoveryRecord(file)).toEqual(written);
+		const mode = statSync(file).mode & 0o777;
+		expect(mode).toBe(0o600);
+	});
+
+	it("treats missing or invalid records as absent (diagnose, no crash)", () => {
+		const dir = tempDataRoot();
+		expect(readDiscoveryRecord(join(dir, "missing.json"))).toBeUndefined();
+	});
+
+	it("only the owning instance may remove its record", () => {
+		const file = join(tempDataRoot(), "gateway.json");
+		const mine = record();
+		writeDiscoveryRecord(file, mine);
+		// A stranger (e.g. an older instance shutting down late) is a no-op.
+		removeDiscoveryRecord(file, createGatewayInstanceId());
+		expect(existsSync(file)).toBe(true);
+		removeDiscoveryRecord(file, mine.instanceId);
+		expect(existsSync(file)).toBe(false);
+	});
+
+	it("per-instance auth tokens are unique and well-formed", () => {
+		const a = createInstanceAuthToken();
+		const b = createInstanceAuthToken();
+		expect(a).not.toBe(b);
+		expect(a).toMatch(/^[A-Za-z0-9_-]{16,}$/);
+	});
+});

--- a/sdk/packages/gateway/src/discovery.ts
+++ b/sdk/packages/gateway/src/discovery.ts
@@ -1,0 +1,103 @@
+/**
+ * Discovery record (Gateway RFC, Phase 3).
+ *
+ * The serving Gateway writes one mode-0600 JSON record into its data
+ * directory — atomically (temp file + rename) and only after the server
+ * is actually ready (lock held, database migrated, socket listening).
+ * The record carries the loopback endpoint and the per-instance auth
+ * secret; file permissions are the access control.
+ *
+ * The discovery record is NOT authority: authority is the OS-backed
+ * lock. A stale record (crashed holder) simply fails to connect; readers
+ * diagnose, they never "take over" by rewriting it.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+	chmodSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import {
+	GatewayAuthTokenSchema,
+	GatewayIdSchema,
+	GatewayInstanceIdSchema,
+} from "@cline/shared/gateway";
+import { z } from "zod";
+
+export const DiscoveryRecordSchema = z
+	.object({
+		gatewayId: GatewayIdSchema,
+		instanceId: GatewayInstanceIdSchema,
+		host: z.string().min(1),
+		port: z.number().int().positive(),
+		/** Per-instance loopback secret; protected by the 0600 file mode. */
+		auth: GatewayAuthTokenSchema,
+		pid: z.number().int().positive(),
+		startedAt: z.number().int().nonnegative(),
+		protocolVersions: z.array(z.number().int().positive()).nonempty(),
+		dataDir: z.string().min(1),
+		namespace: z.string().min(1),
+	})
+	.strict();
+
+export type DiscoveryRecord = z.infer<typeof DiscoveryRecordSchema>;
+
+/** Generate a per-instance loopback secret (never durable). */
+export function createInstanceAuthToken(): string {
+	return randomBytes(32).toString("base64url");
+}
+
+/** Atomic, owner-only write. Call only after the server is ready. */
+export function writeDiscoveryRecord(
+	discoveryFile: string,
+	record: DiscoveryRecord,
+): void {
+	const validated = DiscoveryRecordSchema.parse(record);
+	mkdirSync(dirname(discoveryFile), { recursive: true, mode: 0o700 });
+	const tempFile = `${discoveryFile}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(tempFile, `${JSON.stringify(validated, null, "\t")}\n`, {
+		mode: 0o600,
+	});
+	chmodSync(tempFile, 0o600);
+	renameSync(tempFile, discoveryFile);
+}
+
+export function readDiscoveryRecord(
+	discoveryFile: string,
+): DiscoveryRecord | undefined {
+	let raw: string;
+	try {
+		raw = readFileSync(discoveryFile, "utf8");
+	} catch {
+		return undefined;
+	}
+	try {
+		return DiscoveryRecordSchema.parse(JSON.parse(raw));
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Remove the record, but only when it still names this instance — a
+ * shutting-down process must never delete a successor's record.
+ */
+export function removeDiscoveryRecord(
+	discoveryFile: string,
+	instanceId: string,
+): void {
+	const current = readDiscoveryRecord(discoveryFile);
+	if (!current || current.instanceId !== instanceId) {
+		return;
+	}
+	try {
+		rmSync(discoveryFile);
+	} catch {
+		// Already gone.
+	}
+}

--- a/sdk/packages/gateway/src/engine-binding.test.ts
+++ b/sdk/packages/gateway/src/engine-binding.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Credential injection at the engine boundary: mode-0600 secret files
+ * are the durable source, environment variables are a local/dev
+ * override, and a missing credential fails the attempt with a stable
+ * error — an unauthenticated binding never reaches the engine.
+ */
+
+import type { EngineInvocation } from "@cline/bot";
+import {
+	createBotId,
+	createRunId,
+	createSessionId,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import {
+	createConfiguredEnginePort,
+	MissingProviderCredentialError,
+	ModelNotConfiguredError,
+	resolveProviderModel,
+} from "./engine-binding";
+import { resolveGatewayPaths } from "./paths";
+import { writeSecretFile } from "./secrets";
+import { tempDataRoot } from "./test-support";
+
+function invocation(
+	config: EngineInvocation["effectiveConfig"] = {},
+): EngineInvocation {
+	return {
+		runId: createRunId(),
+		sessionId: createSessionId(),
+		botId: createBotId(),
+		input: "prompt",
+		workspaceRoot: "/tmp/w",
+		effectiveConfig: config,
+	};
+}
+
+function makePaths() {
+	return resolveGatewayPaths({
+		dataRoot: tempDataRoot(),
+		namespace: "default",
+	});
+}
+
+describe("resolveProviderModel", () => {
+	it("reads the provider credential from the mode-0600 secret file (no env needed)", () => {
+		const paths = makePaths();
+		writeSecretFile(paths, "anthropic", "sk-from-file");
+		const binding = resolveProviderModel(
+			invocation({ providerId: "anthropic", modelId: "claude-x" }),
+			{ env: {}, paths },
+		);
+		expect(binding).toEqual({
+			kind: "provider",
+			providerId: "anthropic",
+			modelId: "claude-x",
+			apiKey: "sk-from-file",
+		});
+	});
+
+	it("environment variables override the secret file (local/dev convenience)", () => {
+		const paths = makePaths();
+		writeSecretFile(paths, "anthropic", "sk-from-file");
+		const generic = resolveProviderModel(
+			invocation({ providerId: "anthropic", modelId: "claude-x" }),
+			{ env: { CLINE_GATEWAY_API_KEY: "sk-generic-env" }, paths },
+		);
+		expect(generic.kind === "provider" && generic.apiKey).toBe(
+			"sk-generic-env",
+		);
+		const providerSpecific = resolveProviderModel(
+			invocation({ providerId: "anthropic", modelId: "claude-x" }),
+			{ env: { ANTHROPIC_API_KEY: "sk-anthropic-env" }, paths },
+		);
+		expect(
+			providerSpecific.kind === "provider" && providerSpecific.apiKey,
+		).toBe("sk-anthropic-env");
+	});
+
+	it("fails with a stable error when no credential exists anywhere", () => {
+		const paths = makePaths();
+		expect(() =>
+			resolveProviderModel(
+				invocation({ providerId: "anthropic", modelId: "claude-x" }),
+				{ env: {}, paths },
+			),
+		).toThrow(MissingProviderCredentialError);
+		// Without a secrets directory configured, env-less resolution also
+		// fails closed rather than passing apiKey: undefined through.
+		expect(() =>
+			resolveProviderModel(
+				invocation({ providerId: "anthropic", modelId: "claude-x" }),
+				{ env: {} },
+			),
+		).toThrow(MissingProviderCredentialError);
+	});
+
+	it("fails with a stable error when no provider/model is configured", () => {
+		expect(() => resolveProviderModel(invocation(), { env: {} })).toThrow(
+			ModelNotConfiguredError,
+		);
+	});
+});
+
+describe("createConfiguredEnginePort", () => {
+	it("settles a missing-credential run as a failed attempt with the stable error", async () => {
+		const paths = makePaths();
+		const port = createConfiguredEnginePort({ env: {}, paths });
+		const handle = port.start(
+			invocation({ providerId: "anthropic", modelId: "claude-x" }),
+		);
+		const outcome = await handle.result;
+		expect(outcome.status).toBe("failed");
+		expect(outcome.error?.name).toBe("MissingProviderCredentialError");
+		expect(outcome.error?.message).toContain("secret-put anthropic");
+		// The stable error never contains a key (there is none to leak).
+		expect(outcome.error?.message).not.toContain("sk-");
+	});
+});

--- a/sdk/packages/gateway/src/engine-binding.ts
+++ b/sdk/packages/gateway/src/engine-binding.ts
@@ -4,12 +4,18 @@
  * Wraps the Phase 2 composition proof (`createEngineExecutionPort` over
  * the real `@cline/engine`) with:
  *
- * - model resolution from bot config + environment (full credential
- *   management is a later phase);
+ * - model resolution from the run's snapshotted config;
+ * - credential injection owned by the Gateway (ADR 0001): the provider
+ *   key comes from the owner-only mode-0600 secret file
+ *   `<dataDir>/secrets/<providerId>`, with environment variables
+ *   (`CLINE_GATEWAY_API_KEY`, provider-specific keys) as a local/dev
+ *   override. The key lives in memory at the engine boundary only —
+ *   never in the database, events, projections, or logs;
  * - tool approvals routed through the ApprovalBroker as server-initiated
  *   requests to subscribed clients;
- * - fail-fast handles: a run whose model cannot be resolved settles as a
- *   failed attempt instead of poisoning admission.
+ * - fail-fast handles: a run whose model or credential cannot be
+ *   resolved settles as a failed attempt with a stable error instead of
+ *   poisoning admission.
  */
 
 import type {
@@ -21,7 +27,29 @@ import type {
 import { createEngineExecutionPort } from "@cline/bot";
 import type { EngineModelBinding } from "@cline/engine";
 import { SERVER_REQUEST_METHODS } from "@cline/shared/gateway";
+import type { GatewayPaths } from "./paths";
 import type { ApprovalBroker } from "./runtime";
+import { readSecretFile } from "./secrets";
+
+/** Stable failure: the run's provider/model is not configured. */
+export class ModelNotConfiguredError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ModelNotConfiguredError";
+	}
+}
+
+/** Stable failure: no credential for the run's provider. */
+export class MissingProviderCredentialError extends Error {
+	constructor(providerId: string) {
+		super(
+			`No credential for provider "${providerId}": create the owner-only secret file ` +
+				`with \`cline-gateway secret-put ${providerId}\` (or drop a mode-0600 file into ` +
+				`the data directory's secrets/), or set an environment override`,
+		);
+		this.name = "MissingProviderCredentialError";
+	}
+}
 
 export interface ConfiguredEngineOptions {
 	/**
@@ -30,8 +58,10 @@ export interface ConfiguredEngineOptions {
 	 * after the engine port (the server takes the port as an option).
 	 */
 	approvals?: ApprovalBroker | (() => ApprovalBroker | undefined);
-	/** Override model resolution (defaults to bot config + environment). */
+	/** Override model resolution (defaults to snapshot + secrets + env). */
 	resolveModel?: (invocation: EngineInvocation) => EngineModelBinding;
+	/** Data directory paths; enables mode-0600 secret file lookup. */
+	paths?: GatewayPaths;
 	env?: Record<string, string | undefined>;
 }
 
@@ -42,20 +72,40 @@ const PROVIDER_KEY_ENV: Record<string, string> = {
 	cline: "CLINE_API_KEY",
 };
 
-export function resolveModelFromEnvironment(
+export interface ResolveProviderModelOptions {
+	env?: Record<string, string | undefined>;
+	/** Enables `<dataDir>/secrets/<providerId>` lookup. */
+	paths?: GatewayPaths;
+}
+
+/**
+ * Resolve the model binding for one invocation. Provider and model come
+ * from the invocation's (snapshotted) config, with environment defaults;
+ * the credential comes from the environment override when present,
+ * otherwise from the provider's mode-0600 secret file. A missing
+ * credential throws `MissingProviderCredentialError` — an unauthenticated
+ * binding is never handed to the engine.
+ */
+export function resolveProviderModel(
 	invocation: EngineInvocation,
-	env: Record<string, string | undefined> = process.env,
+	options: ResolveProviderModelOptions = {},
 ): EngineModelBinding {
+	const env = options.env ?? process.env;
 	const providerId =
 		invocation.effectiveConfig.providerId ?? env.CLINE_GATEWAY_PROVIDER;
 	const modelId = invocation.effectiveConfig.modelId ?? env.CLINE_GATEWAY_MODEL;
 	if (!providerId || !modelId) {
-		throw new Error(
+		throw new ModelNotConfiguredError(
 			"No model configured: set bot config or CLINE_GATEWAY_PROVIDER / CLINE_GATEWAY_MODEL",
 		);
 	}
 	const apiKey =
-		env.CLINE_GATEWAY_API_KEY ?? env[PROVIDER_KEY_ENV[providerId] ?? ""];
+		env.CLINE_GATEWAY_API_KEY ??
+		env[PROVIDER_KEY_ENV[providerId] ?? ""] ??
+		(options.paths ? readSecretFile(options.paths, providerId) : undefined);
+	if (!apiKey) {
+		throw new MissingProviderCredentialError(providerId);
+	}
 	return { kind: "provider", providerId, modelId, apiKey };
 }
 
@@ -85,7 +135,10 @@ export function createConfiguredEnginePort(
 			try {
 				const model =
 					options.resolveModel?.(invocation) ??
-					resolveModelFromEnvironment(invocation, options.env);
+					resolveProviderModel(invocation, {
+						env: options.env,
+						paths: options.paths,
+					});
 				const approvals =
 					typeof options.approvals === "function"
 						? options.approvals()

--- a/sdk/packages/gateway/src/engine-binding.ts
+++ b/sdk/packages/gateway/src/engine-binding.ts
@@ -1,0 +1,130 @@
+/**
+ * Default engine binding for a serving Gateway (Gateway RFC, Phase 3).
+ *
+ * Wraps the Phase 2 composition proof (`createEngineExecutionPort` over
+ * the real `@cline/engine`) with:
+ *
+ * - model resolution from bot config + environment (full credential
+ *   management is a later phase);
+ * - tool approvals routed through the ApprovalBroker as server-initiated
+ *   requests to subscribed clients;
+ * - fail-fast handles: a run whose model cannot be resolved settles as a
+ *   failed attempt instead of poisoning admission.
+ */
+
+import type {
+	EngineInvocation,
+	EngineOutcome,
+	EnginePort,
+	EngineRunHandle,
+} from "@cline/bot";
+import { createEngineExecutionPort } from "@cline/bot";
+import type { EngineModelBinding } from "@cline/engine";
+import { SERVER_REQUEST_METHODS } from "@cline/shared/gateway";
+import type { ApprovalBroker } from "./runtime";
+
+export interface ConfiguredEngineOptions {
+	/**
+	 * Route tool approvals to clients as server requests. A getter is
+	 * accepted because the broker lives on the runtime, which is created
+	 * after the engine port (the server takes the port as an option).
+	 */
+	approvals?: ApprovalBroker | (() => ApprovalBroker | undefined);
+	/** Override model resolution (defaults to bot config + environment). */
+	resolveModel?: (invocation: EngineInvocation) => EngineModelBinding;
+	env?: Record<string, string | undefined>;
+}
+
+const PROVIDER_KEY_ENV: Record<string, string> = {
+	anthropic: "ANTHROPIC_API_KEY",
+	openrouter: "OPENROUTER_API_KEY",
+	openai: "OPENAI_API_KEY",
+	cline: "CLINE_API_KEY",
+};
+
+export function resolveModelFromEnvironment(
+	invocation: EngineInvocation,
+	env: Record<string, string | undefined> = process.env,
+): EngineModelBinding {
+	const providerId =
+		invocation.effectiveConfig.providerId ?? env.CLINE_GATEWAY_PROVIDER;
+	const modelId = invocation.effectiveConfig.modelId ?? env.CLINE_GATEWAY_MODEL;
+	if (!providerId || !modelId) {
+		throw new Error(
+			"No model configured: set bot config or CLINE_GATEWAY_PROVIDER / CLINE_GATEWAY_MODEL",
+		);
+	}
+	const apiKey =
+		env.CLINE_GATEWAY_API_KEY ?? env[PROVIDER_KEY_ENV[providerId] ?? ""];
+	return { kind: "provider", providerId, modelId, apiKey };
+}
+
+function failedHandle(error: unknown): EngineRunHandle {
+	const outcome: EngineOutcome = {
+		status: "failed",
+		outputText: "",
+		error: {
+			name: error instanceof Error ? error.name : "EngineBindingError",
+			message: error instanceof Error ? error.message : String(error),
+		},
+	};
+	return {
+		steer: () => false,
+		interrupt: () => {},
+		abort: () => {},
+		result: Promise.resolve(outcome),
+	};
+}
+
+/** Real engine port for a serving Gateway. */
+export function createConfiguredEnginePort(
+	options: ConfiguredEngineOptions = {},
+): EnginePort {
+	return {
+		start(invocation: EngineInvocation): EngineRunHandle {
+			try {
+				const model =
+					options.resolveModel?.(invocation) ??
+					resolveModelFromEnvironment(invocation, options.env);
+				const approvals =
+					typeof options.approvals === "function"
+						? options.approvals()
+						: options.approvals;
+				const port = createEngineExecutionPort({
+					model: () => model,
+					requestApproval: approvals
+						? async (request) => {
+								const answer = await approvals.request(
+									SERVER_REQUEST_METHODS.toolApproval,
+									{
+										botId: invocation.botId,
+										sessionId: invocation.sessionId,
+										runId: invocation.runId,
+									},
+									{
+										toolCallId: request.toolCallId,
+										toolName: request.toolName,
+										input: request.input as Record<string, unknown> | undefined,
+									},
+								);
+								const shaped = answer as {
+									approved?: unknown;
+									reason?: unknown;
+								} | null;
+								return {
+									approved: shaped?.approved === true,
+									reason:
+										typeof shaped?.reason === "string"
+											? shaped.reason
+											: undefined,
+								};
+							}
+						: undefined,
+				});
+				return port.start(invocation);
+			} catch (error) {
+				return failedHandle(error);
+			}
+		},
+	};
+}

--- a/sdk/packages/gateway/src/index.ts
+++ b/sdk/packages/gateway/src/index.ts
@@ -3,16 +3,46 @@
  *
  * The Gateway is the runtime authority of the Gateway RFC: transport,
  * persistence, configuration, credentials, shared resources, schedules,
- * and process supervision. This package currently contains the Phase 0
- * slice — the private command registry, `gateway.hello` negotiation, and
- * the idempotency ledger — plus the ADRs under `docs/adr/`. The server
- * itself (singleton lease, SQLite authority, CLI) is Phase 3 and is
- * intentionally NOT here yet.
+ * and process supervision. Phase 0 contributed the private command
+ * registry, `gateway.hello` negotiation, and the idempotency contract;
+ * Phase 3 adds the authority itself — the OS-backed exclusive lock, the
+ * SQLite store with migrations, the loopback server with per-instance
+ * auth, the async run runtime (durable FIFO queue, attempts/retry, event
+ * replay, approvals), outbox-driven disk projections, and the lifecycle
+ * CLI (`serve`/`start`/`status`/`drain`/`upgrade`/`stop`).
  *
  * Reusable wire contracts live in `@cline/shared/gateway`; apps never
  * import this package's internals.
  */
 
+export type { GatewayCliCommand, GatewayCliIo } from "./cli";
+export { GATEWAY_CLI_COMMANDS, runGatewayCli } from "./cli";
+export type {
+	GatewayClientOptions,
+	GatewayEventListener,
+	GatewayServerRequestHandler,
+} from "./client";
+export { GatewayClient, GatewayRequestError } from "./client";
+export type { GatewayMigration } from "./db";
+export {
+	GATEWAY_MIGRATIONS,
+	GatewayDatabase,
+	migrateGatewayDatabase,
+	openGatewayDatabase,
+} from "./db";
+export type { DiscoveryRecord } from "./discovery";
+export {
+	createInstanceAuthToken,
+	DiscoveryRecordSchema,
+	readDiscoveryRecord,
+	removeDiscoveryRecord,
+	writeDiscoveryRecord,
+} from "./discovery";
+export type { ConfiguredEngineOptions } from "./engine-binding";
+export {
+	createConfiguredEnginePort,
+	resolveModelFromEnvironment,
+} from "./engine-binding";
 export type { GatewayIdentityInfo, HelloNegotiation } from "./hello";
 export {
 	negotiateHello,
@@ -23,6 +53,7 @@ export {
 	IdempotencyLedger,
 	stableStringify,
 } from "./idempotency-ledger";
+export { GatewayLock, GatewayLockHeldError } from "./lock";
 export type {
 	GatewayMethodDefinition,
 	ValidatedGatewayRequest,
@@ -32,3 +63,57 @@ export {
 	getMethodDefinition,
 	validateGatewayRequest,
 } from "./methods";
+export type { OutboxProjector, OutboxWorkerOptions } from "./outbox";
+export {
+	createFileProjector,
+	OUTBOX_KIND_SESSION_PROJECTION,
+	OutboxWorker,
+} from "./outbox";
+export type { GatewayPaths, GatewayPathsOptions } from "./paths";
+export {
+	DEFAULT_GATEWAY_NAMESPACE,
+	defaultGatewayDataRoot,
+	ensureGatewayDataDir,
+	GATEWAY_DATA_ROOT_ENV,
+	GATEWAY_NAMESPACE_ENV,
+	resolveGatewayNamespace,
+	resolveGatewayPaths,
+} from "./paths";
+export type {
+	EngineRetryPolicy,
+	GatewayRecoveryReport,
+	GatewayRuntimeOptions,
+	RunStartParams,
+} from "./runtime";
+export {
+	ApprovalBroker,
+	AttemptingEnginePort,
+	GatewayCallError,
+	GatewayRuntime,
+	MANAGED_WORKSPACE_ROOT,
+	toGatewayError,
+} from "./runtime";
+export type { GatewayServerOptions } from "./server";
+export { GatewayServer } from "./server";
+export type {
+	AuditEntry,
+	ClientRecord,
+	GatewayStores,
+	OutboxEntry,
+	RunAttemptRecord,
+	StoredMessage,
+} from "./stores";
+export {
+	AuditLog,
+	ClientRegistryStore,
+	createGatewayStores,
+	EventLogStore,
+	MessageHistoryStore,
+	MetaStore,
+	OutboxStore,
+	RunAttemptStore,
+	SqliteBotRepository,
+	SqliteIdempotencyLedger,
+	SqliteRunRepository,
+	SqliteSessionRepository,
+} from "./stores";

--- a/sdk/packages/gateway/src/index.ts
+++ b/sdk/packages/gateway/src/index.ts
@@ -127,3 +127,17 @@ export {
 	SqliteRunRepository,
 	SqliteSessionRepository,
 } from "./stores";
+export type {
+	NormalizedModelCall,
+	PriceResolver,
+	PriceSnapshot,
+	StatisticsRange,
+	UsageEventRecord,
+	UsageStoreOptions,
+} from "./usage";
+export {
+	MAX_STATISTICS_RANGE_DAYS,
+	UsageQueryError,
+	UsageStore,
+	utcDateOf,
+} from "./usage";

--- a/sdk/packages/gateway/src/index.ts
+++ b/sdk/packages/gateway/src/index.ts
@@ -38,10 +38,15 @@ export {
 	removeDiscoveryRecord,
 	writeDiscoveryRecord,
 } from "./discovery";
-export type { ConfiguredEngineOptions } from "./engine-binding";
+export type {
+	ConfiguredEngineOptions,
+	ResolveProviderModelOptions,
+} from "./engine-binding";
 export {
 	createConfiguredEnginePort,
-	resolveModelFromEnvironment,
+	MissingProviderCredentialError,
+	ModelNotConfiguredError,
+	resolveProviderModel,
 } from "./engine-binding";
 export type { GatewayIdentityInfo, HelloNegotiation } from "./hello";
 export {
@@ -93,6 +98,11 @@ export {
 	MANAGED_WORKSPACE_ROOT,
 	toGatewayError,
 } from "./runtime";
+export {
+	readSecretFile,
+	SecretAccessError,
+	writeSecretFile,
+} from "./secrets";
 export type { GatewayServerOptions } from "./server";
 export { GatewayServer } from "./server";
 export type {

--- a/sdk/packages/gateway/src/lock.test.ts
+++ b/sdk/packages/gateway/src/lock.test.ts
@@ -1,0 +1,51 @@
+/**
+ * OS-backed exclusive lock (ADR 0002): one holder per data directory;
+ * losing the race means connect-or-diagnose, never replace; release (or
+ * process death) frees the lock without leaking ownership.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { GatewayLock, GatewayLockHeldError } from "./lock";
+import { tempDataRoot } from "./test-support";
+
+describe("GatewayLock", () => {
+	it("grants exclusive ownership and rejects a second acquirer", () => {
+		const lockFile = join(tempDataRoot(), "gateway.lock");
+		const first = GatewayLock.acquire(lockFile);
+		expect(first.held).toBe(true);
+		expect(existsSync(lockFile)).toBe(true);
+
+		// A second acquisition (same machine, same data dir) must fail with
+		// the typed error — the caller connects or diagnoses, never replaces.
+		expect(() => GatewayLock.acquire(lockFile)).toThrow(GatewayLockHeldError);
+
+		first.release();
+		expect(first.held).toBe(false);
+	});
+
+	it("can be re-acquired after release (no leaked ownership)", () => {
+		const lockFile = join(tempDataRoot(), "gateway.lock");
+		const first = GatewayLock.acquire(lockFile);
+		first.release();
+		const second = GatewayLock.acquire(lockFile);
+		expect(second.held).toBe(true);
+		second.release();
+	});
+
+	it("keeps the lock file owner-only", () => {
+		const lockFile = join(tempDataRoot(), "gateway.lock");
+		const lock = GatewayLock.acquire(lockFile);
+		const mode = statSync(lockFile).mode & 0o777;
+		expect(mode & 0o077).toBe(0);
+		lock.release();
+	});
+
+	it("release is idempotent", () => {
+		const lockFile = join(tempDataRoot(), "gateway.lock");
+		const lock = GatewayLock.acquire(lockFile);
+		lock.release();
+		expect(() => lock.release()).not.toThrow();
+	});
+});

--- a/sdk/packages/gateway/src/lock.ts
+++ b/sdk/packages/gateway/src/lock.ts
@@ -1,0 +1,103 @@
+/**
+ * OS-backed exclusive `gateway.lock` (Gateway RFC, Phase 3; ADR 0002).
+ *
+ * Authority over a data directory is an operating-system exclusive lock,
+ * not a PID file and not a heartbeat: the lock is a SQLite database held
+ * inside a never-committed `BEGIN EXCLUSIVE` transaction, which SQLite
+ * maps onto OS file locks. The kernel releases the lock the instant the
+ * holding process dies — crashed holders cannot leak ownership, and a
+ * live holder cannot be displaced by deleting a file.
+ *
+ * A process that fails to acquire the lock must connect to the running
+ * authority or diagnose — never kill it, never bind another port, never
+ * pick a different data directory on its own (ADR 0003: no implicit
+ * fallback).
+ */
+
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadSqliteDb, type SqliteDb } from "@cline/shared/db";
+
+/** The lock is held by another live process (or connection). */
+export class GatewayLockHeldError extends Error {
+	readonly lockFile: string;
+
+	constructor(lockFile: string) {
+		super(
+			`Gateway lock is held by a live authority: ${lockFile}. ` +
+				"Connect to the running Gateway or diagnose it; never replace it.",
+		);
+		this.name = "GatewayLockHeldError";
+		this.lockFile = lockFile;
+	}
+}
+
+export class GatewayLock {
+	private db: SqliteDb | undefined;
+	readonly lockFile: string;
+
+	private constructor(lockFile: string, db: SqliteDb) {
+		this.lockFile = lockFile;
+		this.db = db;
+	}
+
+	get held(): boolean {
+		return this.db !== undefined;
+	}
+
+	/** Release the lock (process exit releases it too, via the OS). */
+	release(): void {
+		const db = this.db;
+		if (!db) {
+			return;
+		}
+		this.db = undefined;
+		try {
+			db.exec("ROLLBACK;");
+		} catch {
+			// Already rolled back or the handle is gone; closing suffices.
+		}
+		db.close?.();
+	}
+
+	/**
+	 * Attempt to take exclusive ownership of a data directory. Throws
+	 * `GatewayLockHeldError` when another live process holds it.
+	 */
+	static acquire(lockFile: string): GatewayLock {
+		mkdirSync(dirname(lockFile), { recursive: true, mode: 0o700 });
+		const existed = existsSync(lockFile);
+		const db = loadSqliteDb(lockFile);
+		try {
+			// Fail immediately instead of queueing behind the current holder.
+			db.exec("PRAGMA busy_timeout = 0;");
+			db.exec("BEGIN EXCLUSIVE;");
+		} catch (error) {
+			db.close?.();
+			if (isBusy(error)) {
+				throw new GatewayLockHeldError(lockFile);
+			}
+			throw error;
+		}
+		if (!existed) {
+			try {
+				chmodSync(lockFile, 0o600);
+			} catch {
+				// Permission tightening is best-effort on exotic filesystems.
+			}
+		}
+		return new GatewayLock(lockFile, db);
+	}
+}
+
+function isBusy(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	const code = (error as { code?: unknown })?.code;
+	return (
+		code === "SQLITE_BUSY" ||
+		code === "SQLITE_LOCKED" ||
+		message.includes("SQLITE_BUSY") ||
+		message.includes("SQLITE_LOCKED") ||
+		message.includes("database is locked")
+	);
+}

--- a/sdk/packages/gateway/src/methods.test.ts
+++ b/sdk/packages/gateway/src/methods.test.ts
@@ -31,6 +31,8 @@ describe("method registry", () => {
 		expect(mutating.sort()).toEqual(
 			[
 				"bot.delegate",
+				"gateway.drain",
+				"gateway.stop",
 				"run.abort",
 				"run.interrupt",
 				"run.start",
@@ -39,6 +41,7 @@ describe("method registry", () => {
 		);
 		expect(getMethodDefinition("gateway.hello")?.mutating).toBe(false);
 		expect(getMethodDefinition("run.subscribe")?.mutating).toBe(false);
+		expect(getMethodDefinition("run.list")?.mutating).toBe(false);
 	});
 });
 

--- a/sdk/packages/gateway/src/methods.ts
+++ b/sdk/packages/gateway/src/methods.ts
@@ -58,6 +58,20 @@ export const GATEWAY_METHODS: readonly GatewayMethodDefinition[] = [
 	define(GATEWAY_HELLO_METHOD, false, GatewayHelloParamsSchema),
 	define("gateway.status", false, z.object({}).strict().optional()),
 	define(
+		"gateway.drain",
+		true,
+		IdempotentParamsBase.extend({
+			reason: z.string().optional(),
+		}).strict(),
+	),
+	define(
+		"gateway.stop",
+		true,
+		IdempotentParamsBase.extend({
+			reason: z.string().optional(),
+		}).strict(),
+	),
+	define(
 		"run.start",
 		true,
 		IdempotentParamsBase.extend({
@@ -118,6 +132,17 @@ export const GATEWAY_METHODS: readonly GatewayMethodDefinition[] = [
 		"session.list",
 		false,
 		z.object({ botId: BotIdSchema.optional() }).strict().optional(),
+	),
+	define(
+		"run.list",
+		false,
+		z
+			.object({
+				sessionId: SessionIdSchema.optional(),
+				runId: RunIdSchema.optional(),
+			})
+			.strict()
+			.optional(),
 	),
 ];
 

--- a/sdk/packages/gateway/src/methods.ts
+++ b/sdk/packages/gateway/src/methods.ts
@@ -26,6 +26,8 @@ const IdempotentParamsBase = z.object({
 	[IDEMPOTENCY_KEY_PARAM]: IdempotencyKeySchema,
 });
 
+const StatisticsDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
 export interface GatewayMethodDefinition {
 	readonly method: string;
 	/** Mutating methods require an idempotency key in params. */
@@ -143,6 +145,52 @@ export const GATEWAY_METHODS: readonly GatewayMethodDefinition[] = [
 			})
 			.strict()
 			.optional(),
+	),
+	// Statistics read surface (bounded aggregate queries; the equivalents
+	// of GET /statistics/{summary,activity,rankings,usage} for clients).
+	define(
+		"statistics.summary",
+		false,
+		z
+			.object({
+				from: StatisticsDateSchema.optional(),
+				to: StatisticsDateSchema.optional(),
+			})
+			.strict()
+			.optional(),
+	),
+	define(
+		"statistics.activity",
+		false,
+		z
+			.object({
+				from: StatisticsDateSchema.optional(),
+				to: StatisticsDateSchema.optional(),
+			})
+			.strict()
+			.optional(),
+	),
+	define(
+		"statistics.rankings",
+		false,
+		z
+			.object({
+				dimension: z.enum(["model", "agent", "topic"]),
+				from: StatisticsDateSchema.optional(),
+				to: StatisticsDateSchema.optional(),
+				limit: z.number().int().min(1).max(100).optional(),
+			})
+			.strict(),
+	),
+	define(
+		"statistics.usage",
+		false,
+		z
+			.object({
+				/** Calendar month, e.g. `2026-08`. */
+				month: z.string().regex(/^\d{4}-\d{2}$/),
+			})
+			.strict(),
 	),
 ];
 

--- a/sdk/packages/gateway/src/outbox.ts
+++ b/sdk/packages/gateway/src/outbox.ts
@@ -1,0 +1,165 @@
+/**
+ * Outbox-driven disk projections (Gateway RFC, Phase 3; ADR 0001).
+ *
+ * The SQLite database is authoritative; files on disk are projections.
+ * State changes enqueue an outbox entry in the same transaction, and
+ * this worker drains the outbox asynchronously — so a crash between the
+ * commit and the file write loses nothing: the pending entry is retried
+ * on the next drain (including after restart). Projectors are idempotent
+ * full rewrites, which makes retries and coalescing safe.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { SessionId } from "@cline/shared/gateway";
+import type { GatewayPaths } from "./paths";
+import type { GatewayStores, OutboxEntry } from "./stores";
+
+export const OUTBOX_KIND_SESSION_PROJECTION = "session.projection";
+
+export type OutboxProjector = (entry: OutboxEntry) => void | Promise<void>;
+
+/**
+ * Default projector: rewrite `projections/sessions/<sessionId>.json`
+ * from the authoritative database (session record, runs, attempts, and
+ * canonical message history).
+ */
+export function createFileProjector(
+	paths: GatewayPaths,
+	stores: GatewayStores,
+): OutboxProjector {
+	return (entry) => {
+		if (entry.kind !== OUTBOX_KIND_SESSION_PROJECTION) {
+			throw new Error(`Unknown outbox kind: ${entry.kind}`);
+		}
+		const sessionId = String(entry.payload.sessionId) as SessionId;
+		const session = stores.sessions.get(sessionId);
+		if (!session) {
+			throw new Error(`Cannot project unknown session ${sessionId}`);
+		}
+		const runs = stores.runs.listBySession(sessionId);
+		const projection = {
+			projectedAt: Date.now(),
+			session,
+			runs: runs.map((run) => ({
+				...run,
+				attempts: stores.attempts.listByRun(run.runId),
+			})),
+			messages: stores.messages.listBySession(sessionId),
+		};
+		const file = paths.sessionProjectionFile(sessionId);
+		mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+		const tempFile = `${file}.${process.pid}.tmp`;
+		writeFileSync(tempFile, `${JSON.stringify(projection, null, "\t")}\n`, {
+			mode: 0o600,
+		});
+		renameSync(tempFile, file);
+	};
+}
+
+export interface OutboxWorkerOptions {
+	/** Delay before retrying entries that failed to project. */
+	retryDelayMs?: number;
+	batchSize?: number;
+	onError?: (entry: OutboxEntry, error: unknown) => void;
+}
+
+export class OutboxWorker {
+	private readonly stores: GatewayStores;
+	private readonly projector: OutboxProjector;
+	private readonly retryDelayMs: number;
+	private readonly batchSize: number;
+	private readonly onError: (entry: OutboxEntry, error: unknown) => void;
+
+	private running = false;
+	private scheduled = false;
+	private stopped = false;
+	private retryTimer: ReturnType<typeof setTimeout> | undefined;
+	private inFlight: Promise<void> = Promise.resolve();
+
+	constructor(
+		stores: GatewayStores,
+		projector: OutboxProjector,
+		options: OutboxWorkerOptions = {},
+	) {
+		this.stores = stores;
+		this.projector = projector;
+		this.retryDelayMs = options.retryDelayMs ?? 250;
+		this.batchSize = options.batchSize ?? 32;
+		this.onError = options.onError ?? (() => {});
+	}
+
+	/** Request an asynchronous drain (idempotent while one is queued). */
+	schedule(): void {
+		if (this.stopped || this.scheduled) {
+			return;
+		}
+		this.scheduled = true;
+		queueMicrotask(() => {
+			this.scheduled = false;
+			this.inFlight = this.inFlight.then(() => this.drainOnce());
+		});
+	}
+
+	/** Drain until the outbox is empty or every pending entry has failed. */
+	async drain(): Promise<void> {
+		await this.inFlight;
+		await this.drainOnce();
+	}
+
+	stop(): void {
+		this.stopped = true;
+		if (this.retryTimer) {
+			clearTimeout(this.retryTimer);
+			this.retryTimer = undefined;
+		}
+	}
+
+	private async drainOnce(): Promise<void> {
+		if (this.running || this.stopped) {
+			return;
+		}
+		this.running = true;
+		try {
+			for (;;) {
+				const pending = this.stores.outbox.listPending(this.batchSize);
+				if (pending.length === 0) {
+					return;
+				}
+				let progressed = false;
+				for (const entry of pending) {
+					try {
+						await this.projector(entry);
+						this.stores.outbox.markDone(entry.outboxId, Date.now());
+						progressed = true;
+					} catch (error) {
+						this.stores.outbox.markFailed(
+							entry.outboxId,
+							error instanceof Error ? error.message : String(error),
+						);
+						this.onError(entry, error);
+					}
+				}
+				if (!progressed) {
+					// Everything pending failed this round; retry later instead
+					// of spinning. The database stays authoritative meanwhile.
+					this.scheduleRetry();
+					return;
+				}
+			}
+		} finally {
+			this.running = false;
+		}
+	}
+
+	private scheduleRetry(): void {
+		if (this.stopped || this.retryTimer) {
+			return;
+		}
+		this.retryTimer = setTimeout(() => {
+			this.retryTimer = undefined;
+			this.schedule();
+		}, this.retryDelayMs);
+		this.retryTimer.unref?.();
+	}
+}

--- a/sdk/packages/gateway/src/paths.ts
+++ b/sdk/packages/gateway/src/paths.ts
@@ -41,12 +41,17 @@ export interface GatewayPaths {
 	readonly discoveryFile: string;
 	readonly botsDir: string;
 	readonly projectionsDir: string;
+	/** Owner-only secret files (mode 0600, dir 0700). Never mounted. */
+	readonly secretsDir: string;
 	botDir(botId: BotId): string;
 	workspacesDir(botId: BotId): string;
 	sessionWorkspaceDir(botId: BotId, sessionId: SessionId): string;
 	memoriesDir(botId: BotId): string;
+	secretFile(name: string): string;
 	sessionProjectionFile(sessionId: SessionId): string;
 }
+
+const SECRET_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export function defaultGatewayDataRoot(
 	env: Record<string, string | undefined> = process.env,
@@ -81,6 +86,7 @@ export function resolveGatewayPaths(
 	const dataDir = resolve(dataRoot, namespace);
 	const botsDir = join(dataDir, "bots");
 	const projectionsDir = join(dataDir, "projections");
+	const secretsDir = join(dataDir, "secrets");
 	return {
 		dataDir,
 		namespace,
@@ -89,11 +95,18 @@ export function resolveGatewayPaths(
 		discoveryFile: join(dataDir, "gateway.json"),
 		botsDir,
 		projectionsDir,
+		secretsDir,
 		botDir: (botId) => join(botsDir, botId),
 		workspacesDir: (botId) => join(botsDir, botId, "workspaces"),
 		sessionWorkspaceDir: (botId, sessionId) =>
 			join(botsDir, botId, "workspaces", sessionId),
 		memoriesDir: (botId) => join(botsDir, botId, "memories"),
+		secretFile: (name) => {
+			if (!SECRET_NAME_PATTERN.test(name)) {
+				throw new Error(`Invalid secret name "${name}"`);
+			}
+			return join(secretsDir, name);
+		},
 		sessionProjectionFile: (sessionId) =>
 			join(projectionsDir, "sessions", `${sessionId}.json`),
 	};
@@ -104,4 +117,5 @@ export function ensureGatewayDataDir(paths: GatewayPaths): void {
 	mkdirSync(paths.dataDir, { recursive: true, mode: 0o700 });
 	mkdirSync(paths.botsDir, { recursive: true, mode: 0o700 });
 	mkdirSync(paths.projectionsDir, { recursive: true, mode: 0o700 });
+	mkdirSync(paths.secretsDir, { recursive: true, mode: 0o700 });
 }

--- a/sdk/packages/gateway/src/paths.ts
+++ b/sdk/packages/gateway/src/paths.ts
@@ -1,0 +1,107 @@
+/**
+ * Canonical Gateway data directory layout (Gateway RFC, Phase 3).
+ *
+ * The singleton scope of a Gateway is its canonical data directory plus
+ * an environment namespace — never a port. Two installations that want to
+ * run side by side use two namespaces (or two data roots) and therefore
+ * two data directories, two locks, and two discovery records.
+ */
+
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { BotId, SessionId } from "@cline/shared/gateway";
+
+/** Env var overriding the data root (parent of per-namespace dirs). */
+export const GATEWAY_DATA_ROOT_ENV = "CLINE_GATEWAY_DATA_ROOT";
+/** Env var selecting the environment namespace. */
+export const GATEWAY_NAMESPACE_ENV = "CLINE_GATEWAY_NAMESPACE";
+
+export const DEFAULT_GATEWAY_NAMESPACE = "default";
+
+const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export interface GatewayPathsOptions {
+	/** Explicit data root; wins over the environment variable. */
+	dataRoot?: string;
+	/** Explicit namespace; wins over the environment variable. */
+	namespace?: string;
+	env?: Record<string, string | undefined>;
+}
+
+export interface GatewayPaths {
+	/** Canonical (resolved) per-namespace data directory. */
+	readonly dataDir: string;
+	readonly namespace: string;
+	/** OS-backed exclusive lock file (authority, not PID/heartbeat). */
+	readonly lockFile: string;
+	/** SQLite authority database. */
+	readonly databaseFile: string;
+	/** Atomic mode-0600 discovery record, written only after readiness. */
+	readonly discoveryFile: string;
+	readonly botsDir: string;
+	readonly projectionsDir: string;
+	botDir(botId: BotId): string;
+	workspacesDir(botId: BotId): string;
+	sessionWorkspaceDir(botId: BotId, sessionId: SessionId): string;
+	memoriesDir(botId: BotId): string;
+	sessionProjectionFile(sessionId: SessionId): string;
+}
+
+export function defaultGatewayDataRoot(
+	env: Record<string, string | undefined> = process.env,
+): string {
+	return env[GATEWAY_DATA_ROOT_ENV] ?? join(homedir(), ".cline", "gateway");
+}
+
+export function resolveGatewayNamespace(
+	options: GatewayPathsOptions = {},
+): string {
+	const env = options.env ?? process.env;
+	const namespace =
+		options.namespace ??
+		env[GATEWAY_NAMESPACE_ENV] ??
+		DEFAULT_GATEWAY_NAMESPACE;
+	if (!NAMESPACE_PATTERN.test(namespace)) {
+		throw new Error(
+			`Invalid gateway namespace "${namespace}": expected ${NAMESPACE_PATTERN}`,
+		);
+	}
+	return namespace;
+}
+
+export function resolveGatewayPaths(
+	options: GatewayPathsOptions = {},
+): GatewayPaths {
+	const env = options.env ?? process.env;
+	const namespace = resolveGatewayNamespace(options);
+	const dataRoot = options.dataRoot ?? defaultGatewayDataRoot(env);
+	// The canonical directory identifies the singleton scope; resolve() so
+	// two spellings of the same path cannot masquerade as two scopes.
+	const dataDir = resolve(dataRoot, namespace);
+	const botsDir = join(dataDir, "bots");
+	const projectionsDir = join(dataDir, "projections");
+	return {
+		dataDir,
+		namespace,
+		lockFile: join(dataDir, "gateway.lock"),
+		databaseFile: join(dataDir, "gateway.db"),
+		discoveryFile: join(dataDir, "gateway.json"),
+		botsDir,
+		projectionsDir,
+		botDir: (botId) => join(botsDir, botId),
+		workspacesDir: (botId) => join(botsDir, botId, "workspaces"),
+		sessionWorkspaceDir: (botId, sessionId) =>
+			join(botsDir, botId, "workspaces", sessionId),
+		memoriesDir: (botId) => join(botsDir, botId, "memories"),
+		sessionProjectionFile: (sessionId) =>
+			join(projectionsDir, "sessions", `${sessionId}.json`),
+	};
+}
+
+/** Create the data directory tree with owner-only permissions. */
+export function ensureGatewayDataDir(paths: GatewayPaths): void {
+	mkdirSync(paths.dataDir, { recursive: true, mode: 0o700 });
+	mkdirSync(paths.botsDir, { recursive: true, mode: 0o700 });
+	mkdirSync(paths.projectionsDir, { recursive: true, mode: 0o700 });
+}

--- a/sdk/packages/gateway/src/projection.test.ts
+++ b/sdk/packages/gateway/src/projection.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Crash points around disk projection (ADR 0001): the database is
+ * authoritative; files are outbox-driven projections. A projector that
+ * fails — or a process that crashes between the commit and the file
+ * write — loses nothing: pending outbox entries retry until the
+ * projection converges with the database.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import type { RunAccepted, SessionId } from "@cline/shared/gateway";
+import { afterEach, describe, expect, it } from "vitest";
+import { GatewayClient } from "./client";
+import { createFileProjector } from "./outbox";
+import { GatewayServer } from "./server";
+import type { OutboxEntry } from "./stores";
+import { ScriptedEnginePort, tempDataRoot, waitFor } from "./test-support";
+
+const servers: GatewayServer[] = [];
+const clients: GatewayClient[] = [];
+
+afterEach(async () => {
+	for (const client of clients.splice(0)) {
+		client.close();
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop("graceful").catch(() => {});
+	}
+});
+
+async function runOneTurn(server: GatewayServer, engine: ScriptedEnginePort) {
+	const discovery = server.discovery;
+	if (!discovery) {
+		throw new Error("no discovery");
+	}
+	const client = await GatewayClient.connectToDiscovery(discovery, {
+		clientName: "projection-test",
+		clientVersion: "0.0.1",
+	});
+	clients.push(client);
+	const botId = server.runtime.defaultBotId;
+	if (!botId) {
+		throw new Error("no default bot");
+	}
+	const accepted = (await client.mutate("run.start", {
+		botId,
+		prompt: "project me",
+	})) as RunAccepted;
+	await waitFor(() => engine.handles.length >= 1);
+	const handle = engine.handles.at(-1);
+	handle?.emit({
+		type: "message-appended",
+		message: {
+			id: "msg_projected",
+			role: "assistant",
+			content: [{ type: "text", text: "projected message" }],
+			createdAt: Date.now(),
+		},
+		index: 0,
+	});
+	handle?.settle({ outputText: "projection source" });
+	await waitFor(
+		() => server.stores.runs.get(accepted.runId)?.state === "completed",
+	);
+	const sessionId = server.stores.runs.get(accepted.runId)
+		?.sessionId as SessionId;
+	return { accepted, sessionId };
+}
+
+describe("outbox-driven projection", () => {
+	it("retries failed projections until they converge (DB stays authoritative)", async () => {
+		const engine = new ScriptedEnginePort();
+		const dataRoot = tempDataRoot();
+		let failures = 0;
+		let realProjector: ReturnType<typeof createFileProjector> | undefined;
+		const flakyProjector = (entry: OutboxEntry) => {
+			if (failures < 2) {
+				failures += 1;
+				throw new Error(`injected projector crash #${failures}`);
+			}
+			return realProjector?.(entry);
+		};
+		const server = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine,
+			projector: flakyProjector,
+			outbox: { retryDelayMs: 10 },
+		});
+		servers.push(server);
+		realProjector = createFileProjector(server.paths, server.stores);
+
+		const { sessionId } = await runOneTurn(server, engine);
+		const file = server.paths.sessionProjectionFile(sessionId);
+
+		// The failures were recorded, the entries stayed pending, and the
+		// retry timer converged the projection.
+		await waitFor(() => existsSync(file), { timeoutMs: 5_000 });
+		await waitFor(() => server.stores.outbox.countPending() === 0);
+		expect(failures).toBe(2);
+		const projection = JSON.parse(readFileSync(file, "utf8"));
+		expect(projection.session.sessionId).toBe(sessionId);
+		expect(projection.runs[0].outputText).toBe("projection source");
+		expect(
+			projection.messages.map((m: { message: { id: string } }) => m.message.id),
+		).toEqual(["msg_projected"]);
+	});
+
+	it("a crash before projection is repaired on restart from the outbox", async () => {
+		const engine = new ScriptedEnginePort();
+		const dataRoot = tempDataRoot();
+		// Instance 1 never manages to project: every attempt fails, then the
+		// process crashes. The commit (runs, messages, outbox) is durable.
+		const server1 = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine,
+			projector: () => {
+				throw new Error("crash point: projector never runs");
+			},
+			outbox: { retryDelayMs: 60_000 },
+		});
+		servers.push(server1);
+		const { sessionId } = await runOneTurn(server1, engine);
+		const file = server1.paths.sessionProjectionFile(sessionId);
+		expect(existsSync(file)).toBe(false);
+		expect(server1.stores.outbox.countPending()).toBeGreaterThan(0);
+		await server1.stop("crash");
+
+		// Instance 2 drains the surviving outbox with the real projector.
+		const server2 = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine: new ScriptedEnginePort(),
+		});
+		servers.push(server2);
+		await server2.outboxWorker.drain();
+		expect(server2.stores.outbox.countPending()).toBe(0);
+		expect(existsSync(file)).toBe(true);
+		const projection = JSON.parse(readFileSync(file, "utf8"));
+		// The projection reflects authoritative post-recovery state.
+		expect(projection.session.sessionId).toBe(sessionId);
+		expect(projection.runs[0].outputText).toBe("projection source");
+	});
+});

--- a/sdk/packages/gateway/src/restart-recovery.test.ts
+++ b/sdk/packages/gateway/src/restart-recovery.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Gateway restart recovery: committed state and the durable queue
+ * survive a crash. Abandoned attempts are interrupted (never
+ * auto-resumed), committed queued runs re-admit FIFO, identity
+ * (`gatewayId`) is durable while `instanceId` is not, idempotent
+ * acknowledgements replay across instances, and stale discovery records
+ * are diagnosed rather than trusted.
+ */
+
+import type { RunAccepted } from "@cline/shared/gateway";
+import { createIdempotencyKey } from "@cline/shared/gateway";
+import { afterEach, describe, expect, it } from "vitest";
+import { GatewayClient } from "./client";
+import { readDiscoveryRecord } from "./discovery";
+import { GatewayServer } from "./server";
+import { ScriptedEnginePort, tempDataRoot, waitFor } from "./test-support";
+
+const servers: GatewayServer[] = [];
+const clients: GatewayClient[] = [];
+
+afterEach(async () => {
+	for (const client of clients.splice(0)) {
+		client.close();
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop("graceful").catch(() => {});
+	}
+});
+
+async function connectTo(server: GatewayServer): Promise<GatewayClient> {
+	const discovery = server.discovery;
+	if (!discovery) {
+		throw new Error("no discovery record");
+	}
+	const client = await GatewayClient.connectToDiscovery(discovery, {
+		clientName: "recovery-test",
+		clientVersion: "0.0.1",
+	});
+	clients.push(client);
+	return client;
+}
+
+describe("gateway restart recovery", () => {
+	it("recovers committed state and queue across a crash", async () => {
+		const dataRoot = tempDataRoot();
+
+		// ---- Instance 1: a finished run, a mid-flight run, a queued run.
+		const engine1 = new ScriptedEnginePort();
+		const server1 = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine: engine1,
+		});
+		servers.push(server1);
+		const client1 = await connectTo(server1);
+		const botId = server1.runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("no default bot");
+		}
+
+		const finished = (await client1.mutate("run.start", {
+			botId,
+			prompt: "finished before crash",
+		})) as RunAccepted;
+		await waitFor(() => engine1.handles.length === 1);
+		engine1.handles[0].settle({ outputText: "committed output" });
+		await waitFor(
+			() => server1.stores.runs.get(finished.runId)?.state === "completed",
+		);
+
+		const abandonedKey = createIdempotencyKey();
+		const abandoned = (await client1.mutate("run.start", {
+			idempotencyKey: abandonedKey,
+			botId,
+			prompt: "mid-flight at crash",
+		})) as RunAccepted;
+		await waitFor(() => engine1.handles.length === 2);
+		engine1.handles[1].settleOnStop = false; // simulate a hung attempt
+
+		const queued = (await client1.mutate("run.start", {
+			botId,
+			prompt: "queued at crash",
+		})) as RunAccepted;
+		expect(queued.queuePosition).toBe(1);
+
+		const gatewayId1 = server1.stores.meta.ensureGatewayId();
+		const staleDiscovery = readDiscoveryRecord(server1.paths.discoveryFile);
+
+		// ---- Crash: no graceful transitions, no discovery cleanup.
+		await server1.stop("crash");
+		expect(readDiscoveryRecord(server1.paths.discoveryFile)).toEqual(
+			staleDiscovery,
+		);
+
+		// The stale record now points at a dead endpoint: diagnose, don't trust.
+		if (!staleDiscovery) {
+			throw new Error("expected a stale discovery record");
+		}
+		await expect(
+			GatewayClient.connectToDiscovery(staleDiscovery, {
+				connectTimeoutMs: 500,
+			}),
+		).rejects.toMatchObject({
+			gatewayError: { code: "gateway_unreachable" },
+		});
+
+		// ---- Instance 2: same data directory, new process.
+		const engine2 = new ScriptedEnginePort();
+		engine2.autoOutcome = () => ({
+			status: "completed",
+			outputText: "recovered and executed",
+		});
+		const server2 = await GatewayServer.start({
+			dataRoot,
+			namespace: "default",
+			engine: engine2,
+		});
+		servers.push(server2);
+
+		// Durable identity is stable; the process identity is not.
+		expect(server2.stores.meta.ensureGatewayId()).toBe(gatewayId1);
+		expect(server2.instanceId).not.toBe(server1.instanceId);
+		const freshDiscovery = readDiscoveryRecord(server2.paths.discoveryFile);
+		expect(freshDiscovery?.instanceId).toBe(server2.instanceId);
+		expect(freshDiscovery?.auth).not.toBe(staleDiscovery.auth);
+
+		// Committed state survived.
+		expect(server2.stores.runs.get(finished.runId)?.state).toBe("completed");
+		expect(server2.stores.runs.get(finished.runId)?.outputText).toBe(
+			"committed output",
+		);
+
+		// The abandoned attempt was interrupted — not auto-resumed.
+		const interrupted = server2.stores.runs.get(abandoned.runId);
+		expect(interrupted?.state).toBe("interrupted");
+		expect(engine2.handlesFor(abandoned.runId)).toHaveLength(0);
+		expect(
+			server2.stores.attempts
+				.listByRun(abandoned.runId)
+				.map((attempt) => attempt.state),
+		).toEqual(["interrupted"]);
+
+		// The committed queued run was re-admitted and executed.
+		await waitFor(
+			() => server2.stores.runs.get(queued.runId)?.state === "completed",
+		);
+		expect(server2.stores.runs.get(queued.runId)?.outputText).toBe(
+			"recovered and executed",
+		);
+
+		// The idempotent acknowledgement replays across the restart: the
+		// same key returns the original runId instead of admitting again.
+		const client2 = await connectTo(server2);
+		const replay = (await client2.mutate("run.start", {
+			idempotencyKey: abandonedKey,
+			botId,
+			prompt: "mid-flight at crash",
+		})) as RunAccepted;
+		expect(replay.runId).toBe(abandoned.runId);
+		expect(engine2.handlesFor(abandoned.runId)).toHaveLength(0);
+
+		// Event history is one continuous, durable stream: a client can
+		// replay everything from the beginning across both instances.
+		const events = server2.stores.events.listAfter(-1, {}, 1000);
+		const names = events.map((event) => event.event);
+		expect(names).toContain("gateway.recoveryCompleted");
+		expect(
+			events.filter(
+				(event) =>
+					event.event === "run.completed" &&
+					event.scope.runId === finished.runId,
+			),
+		).toHaveLength(1);
+	});
+});

--- a/sdk/packages/gateway/src/runtime.test.ts
+++ b/sdk/packages/gateway/src/runtime.test.ts
@@ -278,6 +278,112 @@ describe("canonical message history", () => {
 	});
 });
 
+describe("run config snapshot (credentials-free, captured at admission)", () => {
+	it("persists provider/model on the run row and never a credential", () => {
+		const { runtime, stores } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", {
+			botId,
+			prompt: "snapshot me",
+			overrides: { providerId: "anthropic", modelId: "claude-admission" },
+		});
+		const snapshot = stores.runs.getConfigSnapshot(accepted.runId);
+		expect(snapshot).toMatchObject({
+			providerId: "anthropic",
+			modelId: "claude-admission",
+		});
+		expect(JSON.stringify(snapshot)).not.toMatch(/apiKey|secret|sk-/i);
+	});
+
+	it("a queued run executes against its admission snapshot, not the live bot config", async () => {
+		const { runtime, stores, engine } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const active = runtime.startRun("cli_test", { botId, prompt: "hold" });
+		const queued = runtime.startRun("cli_test", {
+			botId,
+			prompt: "later",
+			overrides: { modelId: "model-at-admission" },
+		});
+
+		// The bot's live config changes while the run waits in the queue.
+		const record = stores.bots.get(botId);
+		if (!record) {
+			throw new Error("bot missing");
+		}
+		stores.bots.save({
+			...record,
+			config: { ...record.config, modelId: "model-changed-later" },
+			revision: record.revision + 1,
+		});
+
+		engine.handles[0].settle({});
+		await waitFor(() => stores.runs.get(queued.runId)?.state === "running");
+		expect(engine.handles[1].invocation.effectiveConfig.modelId).toBe(
+			"model-at-admission",
+		);
+		engine.handles[1].settle({});
+		await waitFor(() => stores.runs.get(active.runId)?.state === "completed");
+	});
+
+	it("retries execute against the same snapshot as the first attempt", async () => {
+		const engine = new ScriptedEnginePort();
+		engine.autoOutcome = (_invocation, attemptIndex) =>
+			attemptIndex === 0
+				? { status: "failed", error: { name: "Transient", message: "boom" } }
+				: { status: "completed" };
+		const { runtime, stores } = createRuntime({ engine, maxAttempts: 2 });
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", {
+			botId,
+			prompt: "retry with snapshot",
+			overrides: { providerId: "anthropic", modelId: "pinned-model" },
+		});
+		await waitFor(() => stores.runs.get(accepted.runId)?.state === "completed");
+		const models = engine
+			.handlesFor(accepted.runId)
+			.map((handle) => handle.invocation.effectiveConfig.modelId);
+		expect(models).toEqual(["pinned-model", "pinned-model"]);
+	});
+
+	it("recovered queued runs keep their snapshot (in-memory overrides survive the crash)", async () => {
+		const dataRoot = tempDataRoot();
+		const first = createRuntime({ dataRoot });
+		const botId = first.runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		first.runtime.startRun("cli_test", { botId, prompt: "hold" });
+		const queued = first.runtime.startRun("cli_test", {
+			botId,
+			prompt: "recover me",
+			overrides: { providerId: "openrouter", modelId: "override-model" },
+		});
+		first.database.close();
+
+		const engine = new ScriptedEnginePort();
+		engine.autoOutcome = () => ({ status: "completed" });
+		const second = createRuntime({ dataRoot, engine });
+		second.runtime.recover();
+		await waitFor(
+			() => second.stores.runs.get(queued.runId)?.state === "completed",
+		);
+		const handle = engine.handlesFor(queued.runId)[0];
+		expect(handle.invocation.effectiveConfig).toMatchObject({
+			providerId: "openrouter",
+			modelId: "override-model",
+		});
+	});
+});
+
 describe("manual crash recovery", () => {
 	it("interrupts abandoned attempts and re-admits committed queued runs FIFO", async () => {
 		const dataRoot = tempDataRoot();

--- a/sdk/packages/gateway/src/runtime.test.ts
+++ b/sdk/packages/gateway/src/runtime.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Async runtime semantics over the SQLite authority: immediate FIFO
+ * acknowledgement, durable queue, run attempts with capped retry,
+ * steering, adaptive admission backpressure, managed workspaces,
+ * canonical message capture, and manual crash recovery.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createGatewayInstanceId, createRunId } from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import { openGatewayDatabase } from "./db";
+import { ensureGatewayDataDir, resolveGatewayPaths } from "./paths";
+import {
+	GatewayCallError,
+	GatewayRuntime,
+	MANAGED_WORKSPACE_ROOT,
+} from "./runtime";
+import { createGatewayStores } from "./stores";
+import { ScriptedEnginePort, tempDataRoot, waitFor } from "./test-support";
+
+function createRuntime(
+	options: {
+		engine?: ScriptedEnginePort;
+		dataRoot?: string;
+		maxAttempts?: number;
+		maxPendingRunsPerSession?: number;
+	} = {},
+) {
+	const dataRoot = options.dataRoot ?? tempDataRoot();
+	const paths = resolveGatewayPaths({ dataRoot, namespace: "default" });
+	ensureGatewayDataDir(paths);
+	const database = openGatewayDatabase(paths.databaseFile);
+	const instanceId = createGatewayInstanceId();
+	const stores = createGatewayStores(database, instanceId);
+	const engine = options.engine ?? new ScriptedEnginePort();
+	const runtime = new GatewayRuntime({
+		database,
+		stores,
+		paths,
+		instanceId,
+		engine,
+		retry: { maxAttempts: options.maxAttempts ?? 1 },
+		maxPendingRunsPerSession: options.maxPendingRunsPerSession,
+	});
+	runtime.bootstrap();
+	return { runtime, stores, engine, paths, database, dataRoot };
+}
+
+describe("run admission", () => {
+	it("acks immediately with runId/acceptedAt/queuePosition and runs FIFO", async () => {
+		const { runtime, stores, engine } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const first = runtime.startRun("cli_test", { botId, prompt: "one" });
+		expect(first.queuePosition).toBe(0);
+		const second = runtime.startRun("cli_test", { botId, prompt: "two" });
+		expect(second.queuePosition).toBe(1);
+		expect(first.runId).not.toBe(second.runId);
+
+		// The ack returned before any engine outcome: first is running,
+		// second is durably queued behind it.
+		expect(stores.runs.get(first.runId)?.state).toBe("running");
+		expect(stores.runs.get(second.runId)?.state).toBe("queued");
+		expect(engine.handles).toHaveLength(1);
+		expect(engine.handles[0].invocation.input).toBe("one");
+
+		engine.handles[0].settle({ outputText: "done one" });
+		await waitFor(() => stores.runs.get(second.runId)?.state === "running");
+		expect(engine.handles[1].invocation.input).toBe("two");
+		engine.handles[1].settle({});
+		await waitFor(() => stores.runs.get(second.runId)?.state === "completed");
+		expect(stores.runs.get(first.runId)?.outputText).toBe("done one");
+	});
+
+	it("creates a managed workspace under bots/<id>/workspaces/<session>", () => {
+		const { runtime, stores, paths } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", { botId, prompt: "go" });
+		const run = stores.runs.get(accepted.runId);
+		const session = stores.sessions.get(run?.sessionId as never);
+		expect(session?.workspace.rootPath).toBe(
+			paths.sessionWorkspaceDir(botId, session?.sessionId as never),
+		);
+		expect(session?.workspace.rootPath).not.toBe(MANAGED_WORKSPACE_ROOT);
+		expect(existsSync(session?.workspace.rootPath ?? "")).toBe(true);
+		expect(session?.workspace.rootPath).toContain(
+			join("bots", botId, "workspaces"),
+		);
+	});
+
+	it("applies adaptive backpressure with a retryable rejection", () => {
+		const { runtime } = createRuntime({ maxPendingRunsPerSession: 2 });
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		runtime.startRun("cli_test", { botId, prompt: "one" });
+		runtime.startRun("cli_test", { botId, prompt: "two" });
+		try {
+			runtime.startRun("cli_test", { botId, prompt: "three" });
+			throw new Error("expected rejection");
+		} catch (error) {
+			if (!(error instanceof GatewayCallError)) {
+				throw error;
+			}
+			expect(error.gatewayError.code).toBe("run_admission_rejected");
+			expect(error.gatewayError.retryable).toBe(true);
+			expect(error.gatewayError.details?.limit).toBe(2);
+		}
+	});
+
+	it("refuses new mutating work while draining", () => {
+		const { runtime } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		runtime.drain("cli_test");
+		expect(runtime.isDraining).toBe(true);
+		try {
+			runtime.startRun("cli_test", { botId, prompt: "nope" });
+			throw new Error("expected gateway_draining");
+		} catch (error) {
+			if (!(error instanceof GatewayCallError)) {
+				throw error;
+			}
+			expect(error.gatewayError.code).toBe("gateway_draining");
+		}
+	});
+});
+
+describe("run attempts and retry", () => {
+	it("retries failed attempts up to the cap while the run stays running", async () => {
+		const engine = new ScriptedEnginePort();
+		engine.autoOutcome = (_invocation, attemptIndex) =>
+			attemptIndex === 0
+				? {
+						status: "failed",
+						error: { name: "Transient", message: "first attempt fails" },
+					}
+				: { status: "completed", outputText: "second attempt wins" };
+		const { runtime, stores } = createRuntime({ engine, maxAttempts: 2 });
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", {
+			botId,
+			prompt: "retry me",
+		});
+		await waitFor(() => stores.runs.get(accepted.runId)?.state === "completed");
+		const attempts = stores.attempts.listByRun(accepted.runId);
+		expect(attempts.map((attempt) => attempt.state)).toEqual([
+			"failed",
+			"completed",
+		]);
+		expect(stores.runs.get(accepted.runId)?.outputText).toBe(
+			"second attempt wins",
+		);
+	});
+
+	it("exhausted attempts fail the run with the last error", async () => {
+		const engine = new ScriptedEnginePort();
+		engine.autoOutcome = () => ({
+			status: "failed",
+			error: { name: "Persistent", message: "always fails" },
+		});
+		const { runtime, stores } = createRuntime({ engine, maxAttempts: 2 });
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", { botId, prompt: "doomed" });
+		await waitFor(() => stores.runs.get(accepted.runId)?.state === "failed");
+		expect(stores.attempts.listByRun(accepted.runId)).toHaveLength(2);
+		expect(stores.runs.get(accepted.runId)?.error?.name).toBe("Persistent");
+	});
+});
+
+describe("steer and stop", () => {
+	it("steering merges into the active run and is recorded durably", () => {
+		const { runtime, stores, engine } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", { botId, prompt: "start" });
+		const outcome = runtime.steerRun(
+			"cli_test",
+			accepted.runId,
+			"also do this",
+		);
+		expect(outcome.merged).toBe(true);
+		expect(engine.handles[0].steers).toEqual(["also do this"]);
+		const steered = stores.events.listAfter(-1, { runId: accepted.runId }, 100);
+		expect(steered.some((event) => event.event === "run.steered")).toBe(true);
+	});
+
+	it("steering a queued or finished run is an invalid transition", () => {
+		const { runtime } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		runtime.startRun("cli_test", { botId, prompt: "active" });
+		const queued = runtime.startRun("cli_test", { botId, prompt: "waiting" });
+		try {
+			runtime.steerRun("cli_test", queued.runId, "too early");
+			throw new Error("expected invalid_state_transition");
+		} catch (error) {
+			if (!(error instanceof GatewayCallError)) {
+				throw error;
+			}
+			expect(error.gatewayError.code).toBe("invalid_state_transition");
+		}
+	});
+
+	it("interrupting a queued run cancels it without starting", async () => {
+		const { runtime, stores } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		runtime.startRun("cli_test", { botId, prompt: "active" });
+		const queued = runtime.startRun("cli_test", { botId, prompt: "waiting" });
+		runtime.interruptRun("cli_test", queued.runId);
+		expect(stores.runs.get(queued.runId)?.state).toBe("aborted");
+	});
+
+	it("unknown runs are not_found", () => {
+		const { runtime } = createRuntime();
+		try {
+			runtime.steerRun("cli_test", createRunId(), "hello?");
+			throw new Error("expected not_found");
+		} catch (error) {
+			if (!(error instanceof GatewayCallError)) {
+				throw error;
+			}
+			expect(error.gatewayError.code).toBe("not_found");
+		}
+	});
+});
+
+describe("canonical message history", () => {
+	it("captures message-appended engine events behind the messages contract", async () => {
+		const { runtime, stores, engine } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", { botId, prompt: "chat" });
+		const handle = engine.handles[0];
+		handle.emit({
+			type: "message-appended",
+			message: {
+				id: "msg_1",
+				role: "assistant",
+				content: [{ type: "text", text: "hi there" }],
+				createdAt: Date.now(),
+			},
+			index: 0,
+		});
+		handle.settle({});
+		await waitFor(() => stores.runs.get(accepted.runId)?.state === "completed");
+		const run = stores.runs.get(accepted.runId);
+		const stored = stores.messages.listBySession(run?.sessionId as never);
+		expect(stored.map((entry) => entry.message.id)).toEqual(["msg_1"]);
+		const events = stores.events.listAfter(-1, { runId: accepted.runId }, 100);
+		expect(events.some((event) => event.event === "run.messageAppended")).toBe(
+			true,
+		);
+	});
+});
+
+describe("manual crash recovery", () => {
+	it("interrupts abandoned attempts and re-admits committed queued runs FIFO", async () => {
+		const dataRoot = tempDataRoot();
+
+		// Instance 1: one running run (attempt open) + two queued runs, then
+		// the process "dies" (we simply drop everything on the floor).
+		const first = createRuntime({ dataRoot });
+		const botId = first.runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const running = first.runtime.startRun("cli_test", {
+			botId,
+			prompt: "was running",
+		});
+		const queuedA = first.runtime.startRun("cli_test", {
+			botId,
+			prompt: "queued A",
+		});
+		const queuedB = first.runtime.startRun("cli_test", {
+			botId,
+			prompt: "queued B",
+		});
+		expect(first.stores.runs.get(running.runId)?.state).toBe("running");
+		const durableGatewayId = first.stores.meta.ensureGatewayId();
+		first.database.close();
+
+		// Instance 2: same data dir, fresh process.
+		const engine = new ScriptedEnginePort();
+		engine.autoOutcome = () => ({
+			status: "completed",
+			outputText: "recovered",
+		});
+		const second = createRuntime({ dataRoot, engine });
+		const report = second.runtime.recover();
+
+		expect(report.interruptedRuns).toEqual([running.runId]);
+		expect(report.requeuedRuns).toEqual([queuedA.runId, queuedB.runId]);
+
+		// The abandoned attempt is interrupted, never auto-resumed.
+		const interrupted = second.stores.runs.get(running.runId);
+		expect(interrupted?.state).toBe("interrupted");
+		expect(interrupted?.error?.name).toBe("GatewayRestart");
+		expect(
+			second.stores.attempts
+				.listByRun(running.runId)
+				.every((attempt) => attempt.state !== "running"),
+		).toBe(true);
+		expect(engine.handlesFor(running.runId)).toHaveLength(0);
+
+		// Committed queued runs execute in FIFO admission order.
+		await waitFor(
+			() => second.stores.runs.get(queuedB.runId)?.state === "completed",
+		);
+		expect(second.stores.runs.get(queuedA.runId)?.state).toBe("completed");
+		const order = engine.handles.map((handle) => handle.invocation.input);
+		expect(order).toEqual(["queued A", "queued B"]);
+
+		// Same durable gatewayId across instances (ADR 0002).
+		expect(second.stores.meta.ensureGatewayId()).toBe(durableGatewayId);
+	});
+});

--- a/sdk/packages/gateway/src/runtime.test.ts
+++ b/sdk/packages/gateway/src/runtime.test.ts
@@ -384,6 +384,96 @@ describe("run config snapshot (credentials-free, captured at admission)", () => 
 	});
 });
 
+describe("usage pipeline wiring", () => {
+	it("a model-call-completed engine event writes the usage event and aggregates atomically", async () => {
+		const { runtime, stores, engine, database } = createRuntime();
+		const botId = runtime.defaultBotId;
+		if (!botId) {
+			throw new Error("bootstrap failed");
+		}
+		const accepted = runtime.startRun("cli_test", {
+			botId,
+			prompt: "meter me",
+		});
+		const handle = engine.handles[0];
+		handle.emit({
+			type: "model-call-completed",
+			providerId: "anthropic",
+			modelId: "claude-x",
+			inputTokens: 120,
+			outputTokens: 30,
+			totalTokens: 150,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			durationMs: 850,
+			status: "ok",
+		});
+		handle.emit({
+			type: "message-appended",
+			message: {
+				id: "msg_metered",
+				role: "assistant",
+				content: [{ type: "text", text: "metered" }],
+				createdAt: Date.now(),
+			},
+			index: 0,
+		});
+		handle.settle({});
+		await waitFor(() => stores.runs.get(accepted.runId)?.state === "completed");
+
+		const run = stores.runs.get(accepted.runId);
+		const events = database.db.prepare("SELECT * FROM usage_events;").all();
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			bot_id: botId,
+			session_id: run?.sessionId,
+			run_id: accepted.runId,
+			agent_id: botId,
+			topic_id: run?.sessionId,
+			provider_id: "anthropic",
+			model_id: "claude-x",
+			input_tokens: 120,
+			output_tokens: 30,
+			total_tokens: 150,
+			duration_ms: 850,
+			status: "ok",
+		});
+		const daily = database.db.prepare("SELECT * FROM daily_usage;").all();
+		expect(daily).toHaveLength(1);
+		// 1 model call + 1 assistant message + run duration, all folded in.
+		expect(daily[0]).toMatchObject({
+			bot_id: botId,
+			tokens: 150,
+			model_calls: 1,
+			messages: 1,
+			active_sessions: 1,
+		});
+		expect(Number(daily[0].max_run_duration_ms)).toBeGreaterThan(0);
+		expect(
+			database.db.prepare("SELECT * FROM model_usage;").all()[0],
+		).toMatchObject({
+			model_id: "claude-x",
+			provider_id: "anthropic",
+			tokens: 150,
+		});
+		expect(
+			database.db.prepare("SELECT * FROM agent_usage;").all()[0],
+		).toMatchObject({ agent_id: botId, tokens: 150, messages: 1 });
+		expect(
+			database.db.prepare("SELECT * FROM topic_usage;").all()[0],
+		).toMatchObject({ topic_id: run?.sessionId, tokens: 150, messages: 1 });
+		// The durable engine event committed in the same transaction.
+		const engineEvents = stores.events.listAfter(
+			-1,
+			{ runId: accepted.runId },
+			100,
+		);
+		expect(
+			engineEvents.some((event) => event.event === "engine.modelCallCompleted"),
+		).toBe(true);
+	});
+});
+
 describe("manual crash recovery", () => {
 	it("interrupts abandoned attempts and re-admits committed queued runs FIFO", async () => {
 		const dataRoot = tempDataRoot();

--- a/sdk/packages/gateway/src/runtime.ts
+++ b/sdk/packages/gateway/src/runtime.ts
@@ -64,6 +64,7 @@ import type { GatewayDatabase } from "./db";
 import { OUTBOX_KIND_SESSION_PROJECTION } from "./outbox";
 import type { GatewayPaths } from "./paths";
 import type { GatewayStores } from "./stores";
+import { UsageQueryError } from "./usage";
 
 /**
  * Sentinel workspace root: the Gateway materializes a managed directory
@@ -92,6 +93,9 @@ export function toGatewayError(error: unknown): GatewayError {
 		return error.gatewayError;
 	}
 	if (error instanceof EventCursorDecodeError) {
+		return error.gatewayError;
+	}
+	if (error instanceof UsageQueryError) {
 		return error.gatewayError;
 	}
 	if (error instanceof BotDomainError) {
@@ -243,6 +247,15 @@ class InstrumentedRunRepository {
 			now,
 		);
 		if (TERMINAL_STATES.has(record.state)) {
+			if (record.startedAt !== undefined && record.endedAt !== undefined) {
+				// Statistics "Longest Task": fold the run duration into the
+				// daily aggregate at completion time (no rescan later).
+				this.sinks.stores.usage.recordRunDuration(
+					record.botId,
+					now,
+					record.endedAt - record.startedAt,
+				);
+			}
 			this.sinks.stores.outbox.enqueue(
 				OUTBOX_KIND_SESSION_PROJECTION,
 				{ sessionId: record.sessionId },
@@ -448,6 +461,14 @@ function persistEngineEvent(
 				// The payload is the AgentMessage messages contract.
 				message as Parameters<GatewayStores["messages"]["append"]>[2],
 			);
+			// Message-completion statistics land in the same transaction as
+			// the canonical message itself.
+			sinks.stores.usage.recordMessage({
+				occurredAt: now,
+				botId: invocation.botId,
+				sessionId: invocation.sessionId,
+				role: message.role,
+			});
 			sinks.stores.events.append(
 				"run.messageAppended",
 				scope,
@@ -461,6 +482,33 @@ function persistEngineEvent(
 			);
 			sinks.outboxEnqueued();
 			return;
+		}
+		if (eventType === "model-call-completed") {
+			// Usage pipeline: normalize the engine's per-call metadata and
+			// commit the usage event plus every aggregate atomically with
+			// the durable engine event below.
+			const call = event as {
+				providerId?: string;
+				modelId?: string;
+				inputTokens?: number;
+				outputTokens?: number;
+				providerCost?: number;
+				durationMs?: number;
+				status?: string;
+			};
+			sinks.stores.usage.recordModelCall({
+				occurredAt: now,
+				botId: invocation.botId,
+				sessionId: invocation.sessionId,
+				runId: invocation.runId,
+				providerId: call.providerId,
+				modelId: call.modelId,
+				inputTokens: Number(call.inputTokens ?? 0),
+				outputTokens: Number(call.outputTokens ?? 0),
+				providerCost: call.providerCost,
+				durationMs: call.durationMs,
+				status: call.status === "error" ? "error" : "ok",
+			});
 		}
 		sinks.stores.events.append(
 			`engine.${kebabToCamel(eventType)}`,

--- a/sdk/packages/gateway/src/runtime.ts
+++ b/sdk/packages/gateway/src/runtime.ts
@@ -1,0 +1,1152 @@
+/**
+ * Gateway async runtime (Gateway RFC, Phase 3).
+ *
+ * Composes the Phase 2 bot domain with the SQLite authority:
+ *
+ * - `run.start` admits into a durable FIFO queue and acks immediately
+ *   with `{runId, acceptedAt, queuePosition}` — it never blocks on the
+ *   turn.
+ * - Every execution is a recorded run attempt; failed attempts retry up
+ *   to a configured cap while the run stays `running`.
+ * - Every state change lands in the durable event log; clients replay
+ *   from a cursor. Canonical message history is stored behind the
+ *   `AgentMessage` messages contract.
+ * - Disconnect never implies abort; crash recovery interrupts abandoned
+ *   attempts (never auto-resumes them) and re-admits committed queued
+ *   runs in FIFO order.
+ * - Admission applies adaptive backpressure: a session whose pending
+ *   queue is full rejects new prompts with a retryable error.
+ */
+
+import { mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+	BotClock,
+	BotIdSource,
+	BotPorts,
+	BotRecord,
+	EngineInvocation,
+	EngineOutcome,
+	EnginePort,
+	EngineRunHandle,
+	MemorySource,
+	RunRecord,
+	SessionRecord,
+	SessionRepository,
+	TurnOverrides,
+} from "@cline/bot";
+import { Bot, BotDomainError, BotRegistry } from "@cline/bot";
+import type {
+	BotId,
+	GatewayError,
+	GatewayEventScope,
+	GatewayInstanceId,
+	GatewayServerRequest,
+	RunAccepted,
+	RunId,
+	SessionId,
+} from "@cline/shared/gateway";
+import {
+	createBotId,
+	createGatewayError,
+	createRunId,
+	createSessionId,
+	EventCursorDecodeError,
+	GATEWAY_PROTOCOL_VERSION,
+	RunStateTransitionError,
+} from "@cline/shared/gateway";
+import type { GatewayDatabase } from "./db";
+import { OUTBOX_KIND_SESSION_PROJECTION } from "./outbox";
+import type { GatewayPaths } from "./paths";
+import type { GatewayStores } from "./stores";
+
+/**
+ * Sentinel workspace root: the Gateway materializes a managed directory
+ * under `bots/<botId>/workspaces/<sessionId>` when a session is created
+ * with it.
+ */
+export const MANAGED_WORKSPACE_ROOT = "@managed";
+
+/** A handler failure that already knows its wire error. */
+export class GatewayCallError extends Error {
+	readonly gatewayError: GatewayError;
+
+	constructor(gatewayError: GatewayError) {
+		super(gatewayError.message);
+		this.name = "GatewayCallError";
+		this.gatewayError = gatewayError;
+	}
+}
+
+/** Map any thrown value onto exactly one wire error. */
+export function toGatewayError(error: unknown): GatewayError {
+	if (error instanceof GatewayCallError) {
+		return error.gatewayError;
+	}
+	if (error instanceof RunStateTransitionError) {
+		return error.gatewayError;
+	}
+	if (error instanceof EventCursorDecodeError) {
+		return error.gatewayError;
+	}
+	if (error instanceof BotDomainError) {
+		switch (error.code) {
+			case "bot_not_found":
+				return createGatewayError("not_found", error.message);
+			case "delegation_not_allowed":
+			case "messaging_not_allowed":
+				return createGatewayError("unauthorized", error.message);
+			case "role_immutable":
+				return createGatewayError("invalid_request", error.message);
+			default:
+				return createGatewayError("run_admission_rejected", error.message);
+		}
+	}
+	return createGatewayError(
+		"internal",
+		error instanceof Error ? error.message : String(error),
+	);
+}
+
+function kebabToCamel(value: string): string {
+	return value.replace(/-([a-z0-9])/g, (_, char: string) => char.toUpperCase());
+}
+
+// -----------------------------------------------------------------------------
+// Managed session workspaces
+// -----------------------------------------------------------------------------
+
+class ManagedWorkspaceSessionRepository implements SessionRepository {
+	private readonly inner: SessionRepository;
+	private readonly resolveRoot: (botId: BotId, sessionId: SessionId) => string;
+	private readonly materialize: (rootPath: string) => void;
+
+	constructor(
+		inner: SessionRepository,
+		resolveRoot: (botId: BotId, sessionId: SessionId) => string,
+		materialize: (rootPath: string) => void,
+	) {
+		this.inner = inner;
+		this.resolveRoot = resolveRoot;
+		this.materialize = materialize;
+	}
+
+	get(sessionId: SessionId): SessionRecord | undefined {
+		return this.inner.get(sessionId);
+	}
+
+	listByBot(botId: BotId): readonly SessionRecord[] {
+		return this.inner.listByBot(botId);
+	}
+
+	save(record: SessionRecord): void {
+		if (record.workspace.rootPath === MANAGED_WORKSPACE_ROOT) {
+			const rootPath = this.resolveRoot(record.botId, record.sessionId);
+			this.materialize(rootPath);
+			this.inner.save({
+				...record,
+				workspace: Object.freeze({ rootPath }),
+			});
+			return;
+		}
+		this.inner.save(record);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Instrumented repositories: durable events + audit + outbox
+// -----------------------------------------------------------------------------
+
+const RUN_STATE_EVENTS: Record<RunRecord["state"], string> = {
+	queued: "run.queued",
+	running: "run.started",
+	completed: "run.completed",
+	failed: "run.failed",
+	aborted: "run.aborted",
+	interrupted: "run.interrupted",
+};
+
+const TERMINAL_STATES: ReadonlySet<RunRecord["state"]> = new Set([
+	"completed",
+	"failed",
+	"aborted",
+	"interrupted",
+]);
+
+interface InstrumentationSinks {
+	stores: GatewayStores;
+	clock: BotClock;
+	outboxEnqueued(): void;
+}
+
+class InstrumentedRunRepository {
+	private readonly inner: GatewayStores["runs"];
+	private readonly sinks: InstrumentationSinks;
+
+	constructor(inner: GatewayStores["runs"], sinks: InstrumentationSinks) {
+		this.inner = inner;
+		this.sinks = sinks;
+	}
+
+	get(runId: RunId): RunRecord | undefined {
+		return this.inner.get(runId);
+	}
+
+	listBySession(sessionId: SessionId): readonly RunRecord[] {
+		return this.inner.listBySession(sessionId);
+	}
+
+	save(record: RunRecord): void {
+		const previous = this.inner.get(record.runId);
+		this.inner.save(record);
+		if (previous && previous.state === record.state) {
+			return;
+		}
+		const now = this.sinks.clock.now();
+		const scope: GatewayEventScope = {
+			botId: record.botId,
+			sessionId: record.sessionId,
+			runId: record.runId,
+		};
+		const payload: Record<string, unknown> = { state: record.state };
+		if (record.state === "queued") {
+			payload.acceptedAt = record.acceptedAt;
+		}
+		if (record.startedAt !== undefined) {
+			payload.startedAt = record.startedAt;
+		}
+		if (TERMINAL_STATES.has(record.state)) {
+			payload.endedAt = record.endedAt;
+			if (record.outputText !== undefined) {
+				payload.outputText = record.outputText;
+			}
+			if (record.error !== undefined) {
+				payload.error = record.error;
+			}
+		}
+		this.sinks.stores.events.append(
+			RUN_STATE_EVENTS[record.state],
+			scope,
+			payload,
+			now,
+		);
+		this.sinks.stores.audit.record(
+			"gateway",
+			RUN_STATE_EVENTS[record.state],
+			record.runId,
+			{ sessionId: record.sessionId, botId: record.botId },
+			now,
+		);
+		if (TERMINAL_STATES.has(record.state)) {
+			this.sinks.stores.outbox.enqueue(
+				OUTBOX_KIND_SESSION_PROJECTION,
+				{ sessionId: record.sessionId },
+				now,
+			);
+			this.sinks.outboxEnqueued();
+		}
+	}
+}
+
+class InstrumentedSessionRepository implements SessionRepository {
+	private readonly inner: SessionRepository;
+	private readonly sinks: InstrumentationSinks;
+
+	constructor(inner: SessionRepository, sinks: InstrumentationSinks) {
+		this.inner = inner;
+		this.sinks = sinks;
+	}
+
+	get(sessionId: SessionId): SessionRecord | undefined {
+		return this.inner.get(sessionId);
+	}
+
+	listByBot(botId: BotId): readonly SessionRecord[] {
+		return this.inner.listByBot(botId);
+	}
+
+	save(record: SessionRecord): void {
+		const previous = this.inner.get(record.sessionId);
+		this.inner.save(record);
+		const now = this.sinks.clock.now();
+		const stored = this.inner.get(record.sessionId);
+		const scope: GatewayEventScope = {
+			botId: record.botId,
+			sessionId: record.sessionId,
+		};
+		if (!previous) {
+			this.sinks.stores.events.append(
+				"session.created",
+				scope,
+				{
+					workspaceRoot:
+						stored?.workspace.rootPath ?? record.workspace.rootPath,
+				},
+				now,
+			);
+			this.sinks.stores.audit.record(
+				"gateway",
+				"session.created",
+				record.sessionId,
+				{ botId: record.botId },
+				now,
+			);
+			return;
+		}
+		if (previous.state !== "closed" && record.state === "closed") {
+			this.sinks.stores.events.append("session.closed", scope, undefined, now);
+			this.sinks.stores.audit.record(
+				"gateway",
+				"session.closed",
+				record.sessionId,
+				undefined,
+				now,
+			);
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Attempting engine port: run attempts + retry + durable engine events
+// -----------------------------------------------------------------------------
+
+export interface EngineRetryPolicy {
+	/** Total attempts per run (1 = never auto-retry). */
+	readonly maxAttempts: number;
+}
+
+class AttemptingEngineHandle implements EngineRunHandle {
+	readonly result: Promise<EngineOutcome>;
+	private current: EngineRunHandle | undefined;
+	private stopRequested = false;
+
+	constructor(
+		invocation: EngineInvocation,
+		inner: EnginePort,
+		sinks: InstrumentationSinks,
+		database: GatewayDatabase,
+		policy: EngineRetryPolicy,
+	) {
+		this.result = (async () => {
+			let outcome: EngineOutcome = {
+				status: "failed",
+				outputText: "",
+				error: { name: "EngineError", message: "Engine produced no outcome" },
+			};
+			const scope: GatewayEventScope = {
+				botId: invocation.botId,
+				sessionId: invocation.sessionId,
+				runId: invocation.runId,
+			};
+			for (let attempt = 1; attempt <= policy.maxAttempts; attempt += 1) {
+				const attemptRecord = sinks.stores.attempts.begin(
+					invocation.runId,
+					sinks.clock.now(),
+				);
+				sinks.stores.events.append(
+					"run.attemptStarted",
+					scope,
+					{ attempt: attemptRecord.attempt },
+					sinks.clock.now(),
+				);
+				const handle = inner.start(invocation);
+				this.current = handle;
+				const unsubscribe = handle.subscribe?.((event) => {
+					persistEngineEvent(database, sinks, invocation, event);
+				});
+				outcome = await handle.result;
+				unsubscribe?.();
+				this.current = undefined;
+				sinks.stores.attempts.settle(
+					invocation.runId,
+					attemptRecord.attempt,
+					outcome.status,
+					sinks.clock.now(),
+					outcome.error,
+				);
+				sinks.stores.events.append(
+					"run.attemptSettled",
+					scope,
+					{
+						attempt: attemptRecord.attempt,
+						status: outcome.status,
+						...(outcome.error ? { error: outcome.error } : {}),
+					},
+					sinks.clock.now(),
+				);
+				if (outcome.status !== "failed" || this.stopRequested) {
+					break;
+				}
+				if (attempt < policy.maxAttempts) {
+					sinks.stores.events.append(
+						"run.attemptRetrying",
+						scope,
+						{ nextAttempt: attempt + 1 },
+						sinks.clock.now(),
+					);
+				}
+			}
+			return outcome;
+		})();
+	}
+
+	steer(text: string): boolean {
+		return this.current?.steer(text) ?? false;
+	}
+
+	interrupt(reason?: string): void {
+		this.stopRequested = true;
+		this.current?.interrupt(reason);
+	}
+
+	abort(reason?: string): void {
+		this.stopRequested = true;
+		this.current?.abort(reason);
+	}
+
+	subscribe(listener: (event: unknown) => void): () => void {
+		// Live tail of the current attempt only; durable events cover replay.
+		return this.current?.subscribe?.(listener) ?? (() => {});
+	}
+}
+
+function persistEngineEvent(
+	database: GatewayDatabase,
+	sinks: InstrumentationSinks,
+	invocation: EngineInvocation,
+	event: unknown,
+): void {
+	if (typeof event !== "object" || event === null) {
+		return;
+	}
+	const typed = event as { type?: unknown; message?: unknown };
+	if (typeof typed.type !== "string") {
+		return;
+	}
+	const eventType = typed.type;
+	const scope: GatewayEventScope = {
+		botId: invocation.botId,
+		sessionId: invocation.sessionId,
+		runId: invocation.runId,
+	};
+	const now = sinks.clock.now();
+	database.transaction(() => {
+		if (eventType === "message-appended" && typed.message) {
+			const message = typed.message as {
+				id: string;
+				role: string;
+				createdAt: number;
+			};
+			sinks.stores.messages.append(
+				invocation.sessionId,
+				invocation.runId,
+				// The payload is the AgentMessage messages contract.
+				message as Parameters<GatewayStores["messages"]["append"]>[2],
+			);
+			sinks.stores.events.append(
+				"run.messageAppended",
+				scope,
+				{ message: typed.message },
+				now,
+			);
+			sinks.stores.outbox.enqueue(
+				OUTBOX_KIND_SESSION_PROJECTION,
+				{ sessionId: invocation.sessionId },
+				now,
+			);
+			sinks.outboxEnqueued();
+			return;
+		}
+		sinks.stores.events.append(
+			`engine.${kebabToCamel(eventType)}`,
+			scope,
+			{ ...(event as Record<string, unknown>) },
+			now,
+		);
+	});
+}
+
+export class AttemptingEnginePort implements EnginePort {
+	private readonly inner: EnginePort;
+	private readonly sinks: InstrumentationSinks;
+	private readonly database: GatewayDatabase;
+	private readonly policy: EngineRetryPolicy;
+
+	constructor(
+		inner: EnginePort,
+		sinks: InstrumentationSinks,
+		database: GatewayDatabase,
+		policy: EngineRetryPolicy,
+	) {
+		this.inner = inner;
+		this.sinks = sinks;
+		this.database = database;
+		this.policy = policy;
+	}
+
+	start(invocation: EngineInvocation): EngineRunHandle {
+		return new AttemptingEngineHandle(
+			invocation,
+			this.inner,
+			this.sinks,
+			this.database,
+			this.policy,
+		);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// File-backed memories
+// -----------------------------------------------------------------------------
+
+class FileMemorySource implements MemorySource {
+	private readonly dir: string;
+
+	constructor(dir: string) {
+		this.dir = dir;
+	}
+
+	list(): readonly { path: string; content: string }[] {
+		let names: string[];
+		try {
+			names = readdirSync(this.dir, { recursive: true, encoding: "utf8" });
+		} catch {
+			return [];
+		}
+		const entries: { path: string; content: string }[] = [];
+		for (const name of names.sort()) {
+			try {
+				entries.push({
+					path: name,
+					content: readFileSync(join(this.dir, name), "utf8"),
+				});
+			} catch {
+				// Directories and unreadable files are skipped.
+			}
+		}
+		return entries;
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Approval broker (server-initiated requests)
+// -----------------------------------------------------------------------------
+
+interface PendingServerRequest {
+	readonly request: GatewayServerRequest;
+	resolve(result: unknown): void;
+	reject(error: GatewayError): void;
+}
+
+/**
+ * Server-initiated questions (tool approval, credentials). Pending
+ * requests survive client disconnects — they are re-issued to any client
+ * that (re)subscribes to the scope. Disconnect neither loses nor
+ * implicitly answers them.
+ */
+export class ApprovalBroker {
+	private readonly pending = new Map<string, PendingServerRequest>();
+	private nextId = 0;
+	/** Set by the server: deliver a request to matching live clients. */
+	deliver: ((request: GatewayServerRequest) => void) | undefined;
+
+	request(
+		method: string,
+		scope: GatewayEventScope,
+		params: Record<string, unknown>,
+	): Promise<unknown> {
+		this.nextId += 1;
+		const request: GatewayServerRequest = {
+			version: GATEWAY_PROTOCOL_VERSION,
+			id: `srq_${this.nextId}`,
+			method,
+			scope,
+			params,
+		};
+		return new Promise((resolve, reject) => {
+			this.pending.set(request.id, {
+				request,
+				resolve,
+				reject: (error) => reject(new GatewayCallError(error)),
+			});
+			this.deliver?.(request);
+		});
+	}
+
+	respond(id: string, result: unknown, error?: GatewayError): boolean {
+		const entry = this.pending.get(id);
+		if (!entry) {
+			return false;
+		}
+		this.pending.delete(id);
+		if (error) {
+			entry.reject(error);
+		} else {
+			entry.resolve(result);
+		}
+		return true;
+	}
+
+	/** Pending requests matching a subscription scope (for re-issue). */
+	pendingForScope(scope: GatewayEventScope): readonly GatewayServerRequest[] {
+		return [...this.pending.values()]
+			.map((entry) => entry.request)
+			.filter((request) => {
+				if (scope.runId && request.scope.runId !== scope.runId) {
+					return false;
+				}
+				if (scope.sessionId && request.scope.sessionId !== scope.sessionId) {
+					return false;
+				}
+				if (scope.botId && request.scope.botId !== scope.botId) {
+					return false;
+				}
+				return true;
+			});
+	}
+
+	get pendingCount(): number {
+		return this.pending.size;
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Runtime
+// -----------------------------------------------------------------------------
+
+export interface GatewayRuntimeOptions {
+	database: GatewayDatabase;
+	stores: GatewayStores;
+	paths: GatewayPaths;
+	instanceId: GatewayInstanceId;
+	/** Inner execution port; the runtime layers attempts/retry on top. */
+	engine: EnginePort;
+	clock?: BotClock;
+	retry?: Partial<EngineRetryPolicy>;
+	/** Adaptive backpressure: max queued+running runs per session. */
+	maxPendingRunsPerSession?: number;
+	/** Managed workspace materialization (default: mkdir -p, mode 0700). */
+	materializeWorkspace?: (rootPath: string) => void;
+	/** Called whenever a transaction enqueued outbox work. */
+	onOutboxEnqueued?: () => void;
+}
+
+export interface RunStartParams {
+	botId: BotId;
+	prompt: string;
+	workspaceRoot?: string;
+	overrides?: TurnOverrides;
+}
+
+export interface GatewayRecoveryReport {
+	readonly interruptedRuns: readonly RunId[];
+	readonly requeuedRuns: readonly RunId[];
+	readonly orphanedQueuedRuns: readonly RunId[];
+}
+
+export class GatewayRuntime {
+	readonly database: GatewayDatabase;
+	readonly stores: GatewayStores;
+	readonly paths: GatewayPaths;
+	readonly instanceId: GatewayInstanceId;
+	readonly clock: BotClock;
+	readonly approvals = new ApprovalBroker();
+	readonly startedAt: number;
+
+	private readonly registry: BotRegistry;
+	private readonly enginePort: AttemptingEnginePort;
+	private readonly sessionsPort: SessionRepository;
+	private readonly runsPort: InstrumentedRunRepository;
+	private readonly ids: BotIdSource;
+	private readonly bots = new Map<BotId, Bot>();
+	private readonly maxPendingRunsPerSession: number;
+	private readonly onOutboxEnqueued: () => void;
+	private draining = false;
+	private defaultBot: BotRecord | undefined;
+
+	constructor(options: GatewayRuntimeOptions) {
+		this.database = options.database;
+		this.stores = options.stores;
+		this.paths = options.paths;
+		this.instanceId = options.instanceId;
+		this.clock = options.clock ?? { now: () => Date.now() };
+		this.startedAt = this.clock.now();
+		this.maxPendingRunsPerSession = options.maxPendingRunsPerSession ?? 32;
+		this.onOutboxEnqueued = options.onOutboxEnqueued ?? (() => {});
+		const sinks: InstrumentationSinks = {
+			stores: this.stores,
+			clock: this.clock,
+			outboxEnqueued: () => this.onOutboxEnqueued(),
+		};
+		this.ids = {
+			botId: () => createBotId(),
+			sessionId: () => createSessionId(),
+			runId: () => createRunId(),
+		};
+		this.enginePort = new AttemptingEnginePort(
+			options.engine,
+			sinks,
+			this.database,
+			{ maxAttempts: Math.max(1, options.retry?.maxAttempts ?? 1) },
+		);
+		const materialize =
+			options.materializeWorkspace ??
+			((rootPath: string) => {
+				mkdirSync(rootPath, { recursive: true, mode: 0o700 });
+			});
+		this.sessionsPort = new InstrumentedSessionRepository(
+			new ManagedWorkspaceSessionRepository(
+				this.stores.sessions,
+				(botId, sessionId) => this.paths.sessionWorkspaceDir(botId, sessionId),
+				materialize,
+			),
+			sinks,
+		);
+		this.runsPort = new InstrumentedRunRepository(this.stores.runs, sinks);
+		this.registry = new BotRegistry({
+			bots: this.stores.bots,
+			ids: this.ids,
+			clock: this.clock,
+		});
+	}
+
+	/** Ensure the default lead bot `cline` exists. */
+	bootstrap(): BotRecord {
+		this.defaultBot = this.database.transaction(() => {
+			const before = this.stores.bots.list().length;
+			const record = this.registry.bootstrap();
+			if (this.stores.bots.list().length !== before) {
+				this.stores.meta.bumpCatalogGeneration();
+				this.stores.audit.record(
+					"gateway",
+					"bot.bootstrapped",
+					record.identity.botId,
+					{ name: record.identity.name, role: record.identity.role },
+					this.clock.now(),
+				);
+			}
+			return record;
+		});
+		return this.defaultBot;
+	}
+
+	get defaultBotId(): BotId | undefined {
+		return this.defaultBot?.identity.botId;
+	}
+
+	get isDraining(): boolean {
+		return this.draining;
+	}
+
+	/**
+	 * Manual crash recovery, run before serving: abandoned attempts are
+	 * interrupted — never auto-resumed — and committed queued runs are
+	 * re-admitted in FIFO admission order (they were acknowledged but
+	 * never attempted).
+	 */
+	recover(): GatewayRecoveryReport {
+		const interrupted = this.database.transaction(() => {
+			const abandoned = this.stores.runs.listByState("running");
+			const now = this.clock.now();
+			for (const run of abandoned) {
+				this.runsPort.save({
+					...run,
+					state: "interrupted",
+					endedAt: now,
+					error: {
+						name: "GatewayRestart",
+						message:
+							"Run abandoned by a Gateway restart; attempts are never auto-resumed",
+					},
+				});
+			}
+			this.stores.attempts.interruptOpenAttempts(now);
+			if (abandoned.length > 0) {
+				this.stores.audit.record(
+					"gateway",
+					"recovery.interruptedAbandonedRuns",
+					undefined,
+					{ runIds: abandoned.map((run) => run.runId) },
+					now,
+				);
+			}
+			return abandoned.map((run) => run.runId);
+		});
+
+		const requeued: RunId[] = [];
+		const orphaned: RunId[] = [];
+		for (const record of this.stores.runs.listQueued()) {
+			try {
+				this.getBot(record.botId).recoverQueuedRun(record);
+				requeued.push(record.runId);
+			} catch {
+				// The session is closed or the bot retired; the run cannot be
+				// re-admitted. Abort it so the queue converges.
+				orphaned.push(record.runId);
+				this.database.transaction(() => {
+					this.runsPort.save({
+						...record,
+						state: "aborted",
+						endedAt: this.clock.now(),
+						error: {
+							name: "GatewayRestart",
+							message: "Queued run could not be re-admitted after restart",
+						},
+					});
+				});
+			}
+		}
+		if (requeued.length > 0 || orphaned.length > 0) {
+			this.stores.audit.record(
+				"gateway",
+				"recovery.requeuedCommittedRuns",
+				undefined,
+				{ requeued, orphaned },
+				this.clock.now(),
+			);
+		}
+		this.stores.events.append(
+			"gateway.recoveryCompleted",
+			{},
+			{
+				interruptedRuns: interrupted,
+				requeuedRuns: requeued,
+				orphanedQueuedRuns: orphaned,
+			},
+			this.clock.now(),
+		);
+		return {
+			interruptedRuns: interrupted,
+			requeuedRuns: requeued,
+			orphanedQueuedRuns: orphaned,
+		};
+	}
+
+	/** Admit a prompt: durable FIFO queue + immediate acknowledgement. */
+	startRun(actor: string, params: RunStartParams): RunAccepted {
+		if (this.draining) {
+			throw new GatewayCallError(
+				createGatewayError(
+					"gateway_draining",
+					"Gateway is draining and refuses new mutating work",
+					{ retryable: true },
+				),
+			);
+		}
+		const bot = this.getBot(params.botId);
+		const session = bot.session;
+		if (session) {
+			const pending = this.stores.runs.countPendingBySession(session.sessionId);
+			if (pending >= this.maxPendingRunsPerSession) {
+				throw new GatewayCallError(
+					createGatewayError(
+						"run_admission_rejected",
+						`Session queue is full (${pending} pending runs); retry later`,
+						{
+							retryable: true,
+							details: {
+								pending,
+								limit: this.maxPendingRunsPerSession,
+							},
+						},
+					),
+				);
+			}
+		}
+		return this.database.transaction(() => {
+			const accepted = bot.submitPrompt(params.prompt, {
+				// An explicit workspace is always forwarded so a mismatch with
+				// an existing session's immutable workspace is rejected loudly.
+				workspace: params.workspaceRoot
+					? { rootPath: params.workspaceRoot }
+					: session
+						? undefined
+						: { rootPath: MANAGED_WORKSPACE_ROOT },
+				overrides: params.overrides,
+			});
+			this.stores.audit.record(
+				actor,
+				"run.start",
+				accepted.runId,
+				{ botId: params.botId, queuePosition: accepted.queuePosition },
+				this.clock.now(),
+			);
+			return accepted;
+		});
+	}
+
+	/** Merge steering text into the active run. */
+	steerRun(actor: string, runId: RunId, text: string): { merged: boolean } {
+		const { bot, record } = this.requireRun(runId);
+		if (record.state !== "running" || bot.activeRun?.runId !== runId) {
+			throw new GatewayCallError(
+				createGatewayError(
+					"invalid_state_transition",
+					`Run ${runId} is ${record.state}; steering merges only into the active run`,
+					{ retryable: false },
+				),
+			);
+		}
+		const merged = bot.steer(text);
+		if (merged) {
+			this.database.transaction(() => {
+				this.stores.events.append(
+					"run.steered",
+					{ botId: record.botId, sessionId: record.sessionId, runId },
+					{ textLength: text.length },
+					this.clock.now(),
+				);
+				this.stores.audit.record(
+					actor,
+					"run.steer",
+					runId,
+					undefined,
+					this.clock.now(),
+				);
+			});
+		}
+		return { merged };
+	}
+
+	interruptRun(
+		actor: string,
+		runId: RunId,
+		reason?: string,
+	): { state: string } {
+		return this.stopRun(actor, runId, "interrupt", reason);
+	}
+
+	abortRun(actor: string, runId: RunId, reason?: string): { state: string } {
+		return this.stopRun(actor, runId, "abort", reason);
+	}
+
+	delegateBot(
+		actor: string,
+		params: {
+			parentBotId: BotId;
+			name: string;
+			role: "worker" | "contractor";
+			reason?: string;
+		},
+	): BotRecord {
+		if (this.draining) {
+			throw new GatewayCallError(
+				createGatewayError(
+					"gateway_draining",
+					"Gateway is draining and refuses new mutating work",
+					{ retryable: true },
+				),
+			);
+		}
+		return this.database.transaction(() => {
+			const record = this.registry.delegate(params.parentBotId, {
+				name: params.name,
+				role: params.role,
+				reason: params.reason,
+			});
+			this.stores.meta.bumpCatalogGeneration();
+			this.stores.events.append(
+				"bot.delegated",
+				{ botId: record.identity.botId },
+				{
+					parentBotId: params.parentBotId,
+					name: params.name,
+					role: params.role,
+				},
+				this.clock.now(),
+			);
+			this.stores.audit.record(
+				actor,
+				"bot.delegate",
+				record.identity.botId,
+				{ parentBotId: params.parentBotId, role: params.role },
+				this.clock.now(),
+			);
+			return record;
+		});
+	}
+
+	listBots(): readonly BotRecord[] {
+		return this.stores.bots.list();
+	}
+
+	listSessions(botId?: BotId): readonly SessionRecord[] {
+		return botId
+			? this.stores.sessions.listByBot(botId)
+			: this.stores.sessions.list();
+	}
+
+	listRuns(filter: {
+		sessionId?: SessionId;
+		runId?: RunId;
+	}): readonly RunRecord[] {
+		if (filter.runId) {
+			const record = this.stores.runs.get(filter.runId);
+			return record ? [record] : [];
+		}
+		if (filter.sessionId) {
+			return this.stores.runs.listBySession(filter.sessionId);
+		}
+		return [
+			...this.stores.runs.listByState("queued"),
+			...this.stores.runs.listByState("running"),
+		];
+	}
+
+	attemptsForRun(
+		runId: RunId,
+	): ReturnType<GatewayStores["attempts"]["listByRun"]> {
+		return this.stores.attempts.listByRun(runId);
+	}
+
+	/** Refuse new mutating work while existing runs finish. */
+	drain(actor: string, reason?: string): { state: "draining" } {
+		if (!this.draining) {
+			this.draining = true;
+			this.database.transaction(() => {
+				this.stores.events.append(
+					"gateway.drainStarted",
+					{},
+					reason ? { reason } : undefined,
+					this.clock.now(),
+				);
+				this.stores.audit.record(
+					actor,
+					"gateway.drain",
+					undefined,
+					{ reason },
+					this.clock.now(),
+				);
+			});
+		}
+		return { state: "draining" };
+	}
+
+	/** Cooperatively interrupt every active run (graceful stop path). */
+	interruptAllActive(reason: string): void {
+		for (const bot of this.bots.values()) {
+			bot.interrupt(reason);
+		}
+	}
+
+	/** Resolves once no bot has an active or queued run. */
+	async whenIdle(): Promise<void> {
+		for (;;) {
+			const busy = [...this.bots.values()].filter((bot) => bot.activeRun);
+			if (busy.length === 0) {
+				return;
+			}
+			await Promise.all(busy.map((bot) => bot.whenIdle()));
+		}
+	}
+
+	status(): Record<string, unknown> {
+		return {
+			state: this.draining ? "draining" : "serving",
+			gatewayId: this.stores.meta.ensureGatewayId(),
+			instanceId: this.instanceId,
+			pid: process.pid,
+			startedAt: this.startedAt,
+			protocolVersion: GATEWAY_PROTOCOL_VERSION,
+			defaultBotId: this.defaultBotId,
+			catalogGeneration: this.stores.meta.catalogGeneration(),
+			namespace: this.paths.namespace,
+			dataDir: this.paths.dataDir,
+			counts: {
+				bots: this.stores.bots.list().length,
+				sessions: this.stores.sessions.list().length,
+				queuedRuns: this.stores.runs.countByState("queued"),
+				runningRuns: this.stores.runs.countByState("running"),
+				clients: this.stores.clients.count(),
+				pendingOutbox: this.stores.outbox.countPending(),
+				lastEventSequence: this.stores.events.lastSequence(),
+				pendingServerRequests: this.approvals.pendingCount,
+			},
+		};
+	}
+
+	// ---------------------------------------------------------------------
+	// Internals
+	// ---------------------------------------------------------------------
+
+	private getBot(botId: BotId): Bot {
+		const existing = this.bots.get(botId);
+		if (existing) {
+			return existing;
+		}
+		const ports: BotPorts = {
+			clock: this.clock,
+			ids: this.ids,
+			bots: this.stores.bots,
+			sessions: this.sessionsPort,
+			runs: this.runsPort,
+			engine: this.enginePort,
+			memories: new FileMemorySource(this.paths.memoriesDir(botId)),
+		};
+		const bot = new Bot(botId, ports);
+		this.bots.set(botId, bot);
+		return bot;
+	}
+
+	private requireRun(runId: RunId): { bot: Bot; record: RunRecord } {
+		const record = this.stores.runs.get(runId);
+		if (!record) {
+			throw new GatewayCallError(
+				createGatewayError("not_found", `Unknown run: ${runId}`),
+			);
+		}
+		return { bot: this.getBot(record.botId), record };
+	}
+
+	private stopRun(
+		actor: string,
+		runId: RunId,
+		mode: "interrupt" | "abort",
+		reason?: string,
+	): { state: string } {
+		const { bot, record } = this.requireRun(runId);
+		if (record.state === "queued") {
+			// A queued run never started; both stop modes cancel it.
+			bot.cancelQueued(runId);
+			this.stores.audit.record(
+				actor,
+				`run.${mode}`,
+				runId,
+				{ reason },
+				this.clock.now(),
+			);
+			return { state: "aborted" };
+		}
+		if (record.state !== "running") {
+			throw new GatewayCallError(
+				createGatewayError(
+					"invalid_state_transition",
+					`Run ${runId} is already ${record.state}`,
+					{ retryable: false },
+				),
+			);
+		}
+		if (bot.activeRun?.runId !== runId) {
+			throw new GatewayCallError(
+				createGatewayError(
+					"invalid_state_transition",
+					`Run ${runId} is not this instance's active run (a previous instance owned it)`,
+					{ retryable: false },
+				),
+			);
+		}
+		if (mode === "interrupt") {
+			bot.interrupt(reason);
+		} else {
+			bot.abort(reason);
+		}
+		this.stores.audit.record(
+			actor,
+			`run.${mode}`,
+			runId,
+			{ reason },
+			this.clock.now(),
+		);
+		return { state: "running" };
+	}
+}

--- a/sdk/packages/gateway/src/runtime.ts
+++ b/sdk/packages/gateway/src/runtime.ts
@@ -35,7 +35,12 @@ import type {
 	SessionRepository,
 	TurnOverrides,
 } from "@cline/bot";
-import { Bot, BotDomainError, BotRegistry } from "@cline/bot";
+import {
+	Bot,
+	BotDomainError,
+	BotRegistry,
+	resolveEffectiveConfig,
+} from "@cline/bot";
 import type {
 	BotId,
 	GatewayError,
@@ -485,8 +490,15 @@ export class AttemptingEnginePort implements EnginePort {
 	}
 
 	start(invocation: EngineInvocation): EngineRunHandle {
+		// Execute against the config snapshotted at admission (never the
+		// live bot config or in-memory overrides): every attempt of a run —
+		// including after a crash — binds the same provider/model.
+		const snapshot = this.sinks.stores.runs.getConfigSnapshot(invocation.runId);
+		const pinned = snapshot
+			? { ...invocation, effectiveConfig: snapshot }
+			: invocation;
 		return new AttemptingEngineHandle(
-			invocation,
+			pinned,
 			this.inner,
 			this.sinks,
 			this.database,
@@ -854,6 +866,14 @@ export class GatewayRuntime {
 			}
 		}
 		return this.database.transaction(() => {
+			// Effective config at admission (provider/model/prompt settings —
+			// never credentials). Persisted as the run's snapshot below;
+			// every attempt — retries, deferred queue starts, and crash
+			// recovery — executes against it instead of live bot config.
+			const snapshotConfig = resolveEffectiveConfig(
+				bot.record.config,
+				params.overrides,
+			);
 			const accepted = bot.submitPrompt(params.prompt, {
 				// An explicit workspace is always forwarded so a mismatch with
 				// an existing session's immutable workspace is rejected loudly.
@@ -864,6 +884,7 @@ export class GatewayRuntime {
 						: { rootPath: MANAGED_WORKSPACE_ROOT },
 				overrides: params.overrides,
 			});
+			this.stores.runs.saveConfigSnapshot(accepted.runId, snapshotConfig);
 			this.stores.audit.record(
 				actor,
 				"run.start",

--- a/sdk/packages/gateway/src/secrets.test.ts
+++ b/sdk/packages/gateway/src/secrets.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Owner-only provider credential files: 0700 directory, 0600 files,
+ * loose modes refused, contents never echoed.
+ */
+
+import { chmodSync, statSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ensureGatewayDataDir, resolveGatewayPaths } from "./paths";
+import { readSecretFile, SecretAccessError, writeSecretFile } from "./secrets";
+import { tempDataRoot } from "./test-support";
+
+function makePaths() {
+	const paths = resolveGatewayPaths({
+		dataRoot: tempDataRoot(),
+		namespace: "default",
+	});
+	return paths;
+}
+
+describe("secret files", () => {
+	it("round-trips a secret with owner-only permissions", () => {
+		const paths = makePaths();
+		const file = writeSecretFile(paths, "anthropic", "sk-test-abc123");
+		expect(readSecretFile(paths, "anthropic")).toBe("sk-test-abc123");
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+		expect(statSync(paths.secretsDir).mode & 0o777).toBe(0o700);
+	});
+
+	it("ensureGatewayDataDir pre-creates the owner-only secrets directory", () => {
+		const paths = makePaths();
+		ensureGatewayDataDir(paths);
+		expect(statSync(paths.secretsDir).mode & 0o777).toBe(0o700);
+	});
+
+	it("a missing secret reads as undefined (caller decides how to fail)", () => {
+		const paths = makePaths();
+		expect(readSecretFile(paths, "openai")).toBeUndefined();
+	});
+
+	it("refuses to read a secret readable by anyone but the owner", () => {
+		const paths = makePaths();
+		const file = writeSecretFile(paths, "openrouter", "sk-or-loose");
+		chmodSync(file, 0o644);
+		expect(() => readSecretFile(paths, "openrouter")).toThrow(
+			SecretAccessError,
+		);
+	});
+
+	it("overwriting a loose file tightens it back to 0600", () => {
+		const paths = makePaths();
+		const file = writeSecretFile(paths, "cline", "first");
+		chmodSync(file, 0o644);
+		writeSecretFile(paths, "cline", "second");
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+		expect(readSecretFile(paths, "cline")).toBe("second");
+	});
+
+	it("rejects traversal-shaped or malformed secret names", () => {
+		const paths = makePaths();
+		for (const name of ["../evil", "a/b", "", ".hidden"]) {
+			expect(() => paths.secretFile(name)).toThrow();
+		}
+		expect(() => paths.secretFile("anthropic")).not.toThrow();
+		expect(() => paths.secretFile("my-provider.v2")).not.toThrow();
+	});
+});

--- a/sdk/packages/gateway/src/secrets.ts
+++ b/sdk/packages/gateway/src/secrets.ts
@@ -1,0 +1,65 @@
+/**
+ * Owner-only secret files (Gateway RFC, Phase 3; ADR 0001).
+ *
+ * The Gateway owns credentials. Secrets are stored exclusively as
+ * mode-0600 files in the Gateway's owner-only secrets directory
+ * (`<dataDir>/secrets/<name>`, e.g. one file per LLM provider). They are
+ * read by the Gateway process itself and injected in memory at the
+ * engine boundary — never written into the database, the event log,
+ * audit entries, projections, or logs, and never handed to clients or
+ * workers.
+ */
+
+import {
+	chmodSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import type { GatewayPaths } from "./paths";
+
+export class SecretAccessError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SecretAccessError";
+	}
+}
+
+export function writeSecretFile(
+	paths: GatewayPaths,
+	name: string,
+	value: string,
+): string {
+	mkdirSync(paths.secretsDir, { recursive: true, mode: 0o700 });
+	const file = paths.secretFile(name);
+	writeFileSync(file, value, { mode: 0o600 });
+	// `mode` only applies on creation; overwriting a pre-existing loose
+	// file must tighten it too.
+	chmodSync(file, 0o600);
+	return file;
+}
+
+/**
+ * Read a secret, refusing files that are readable by anyone but the
+ * owner (a group/world-readable "secret" is treated as an error, not a
+ * secret).
+ */
+export function readSecretFile(
+	paths: GatewayPaths,
+	name: string,
+): string | undefined {
+	const file = paths.secretFile(name);
+	let stat: ReturnType<typeof statSync>;
+	try {
+		stat = statSync(file);
+	} catch {
+		return undefined;
+	}
+	if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+		throw new SecretAccessError(
+			`Secret file ${file} is not owner-only (mode ${(stat.mode & 0o777).toString(8)}); refusing to read it`,
+		);
+	}
+	return readFileSync(file, "utf8");
+}

--- a/sdk/packages/gateway/src/server.test.ts
+++ b/sdk/packages/gateway/src/server.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Loopback server end-to-end (real TCP, real SQLite): hello-first auth,
+ * immediate run acknowledgement, durable event replay from cursors,
+ * two-client consistency and FIFO admission on one session, client loss
+ * without abort, wire idempotency, approvals as server requests, drain,
+ * and the second-starter rule (connect or diagnose, never replace).
+ */
+
+import { existsSync } from "node:fs";
+import { connect } from "node:net";
+import type { BotId, GatewayEvent, RunAccepted } from "@cline/shared/gateway";
+import {
+	createEventCursor,
+	createIdempotencyKey,
+	encodeEventCursor,
+} from "@cline/shared/gateway";
+import { afterEach, describe, expect, it } from "vitest";
+import { GatewayClient, GatewayRequestError } from "./client";
+import { readDiscoveryRecord } from "./discovery";
+import { GatewayLockHeldError } from "./lock";
+import { GatewayServer, type GatewayServerOptions } from "./server";
+import { ScriptedEnginePort, tempDataRoot, waitFor } from "./test-support";
+
+const servers: GatewayServer[] = [];
+const clients: GatewayClient[] = [];
+
+afterEach(async () => {
+	for (const client of clients.splice(0)) {
+		client.close();
+	}
+	for (const server of servers.splice(0)) {
+		await server.stop("graceful").catch(() => {});
+	}
+});
+
+async function startServer(
+	overrides: Partial<GatewayServerOptions> = {},
+): Promise<{
+	server: GatewayServer;
+	engine: ScriptedEnginePort;
+	dataRoot: string;
+	connect(name?: string): Promise<GatewayClient>;
+	defaultBotId(): BotId;
+}> {
+	const engine =
+		(overrides.engine as ScriptedEnginePort | undefined) ??
+		new ScriptedEnginePort();
+	const dataRoot = tempDataRoot();
+	const server = await GatewayServer.start({
+		dataRoot,
+		namespace: "default",
+		engine,
+		...overrides,
+	});
+	servers.push(server);
+	const discovery = server.discovery;
+	if (!discovery) {
+		throw new Error("server did not publish discovery");
+	}
+	return {
+		server,
+		engine,
+		dataRoot,
+		async connect(name = "test-client") {
+			const client = await GatewayClient.connectToDiscovery(discovery, {
+				clientName: name,
+				clientVersion: "0.0.1",
+			});
+			clients.push(client);
+			return client;
+		},
+		defaultBotId() {
+			const botId = server.runtime.defaultBotId;
+			if (!botId) {
+				throw new Error("no default bot");
+			}
+			return botId;
+		},
+	};
+}
+
+function recordEvents(client: GatewayClient): GatewayEvent[] {
+	const seen: GatewayEvent[] = [];
+	client.onEvent((event) => seen.push(event));
+	return seen;
+}
+
+describe("handshake and auth", () => {
+	it("publishes a 0600 discovery record only after readiness and negotiates hello", async () => {
+		const { server, connect: connectClient } = await startServer();
+		const record = readDiscoveryRecord(server.paths.discoveryFile);
+		expect(record?.port).toBe(server.address().port);
+		const client = await connectClient();
+		expect(client.hello.gatewayId).toBe(record?.gatewayId);
+		expect(client.hello.instanceId).toBe(server.instanceId);
+		expect(client.hello.capabilities).toContain("runs.async");
+	});
+
+	it("rejects a hello without the per-instance secret", async () => {
+		const { server } = await startServer();
+		const { host, port } = server.address();
+		await expect(
+			GatewayClient.connect({ host, port, auth: "wrong-secret-token" }),
+		).rejects.toMatchObject({
+			gatewayError: { code: "unauthorized" },
+		});
+	});
+
+	it("rejects any request before gateway.hello", async () => {
+		const { server } = await startServer();
+		const { host, port } = server.address();
+		const socket = connect({ host, port });
+		const response = await new Promise<string>((resolve) => {
+			socket.setEncoding("utf8");
+			socket.once("data", (chunk: string) => resolve(chunk));
+			socket.write(
+				`${JSON.stringify({ version: 1, id: "req_1", method: "gateway.status" })}\n`,
+			);
+		});
+		socket.destroy();
+		expect(JSON.parse(response).error.code).toBe("handshake_required");
+	});
+});
+
+describe("async runs over the wire", () => {
+	it("acks run.start immediately and streams durable events to a subscriber", async () => {
+		const {
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const seen = recordEvents(client);
+		await client.subscribe({
+			cursor: encodeEventCursor(createEventCursor(-1)),
+		});
+		const accepted = (await client.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "hello gateway",
+		})) as RunAccepted;
+		expect(accepted.runId).toMatch(/^run_/);
+		expect(accepted.queuePosition).toBe(0);
+
+		// The ack arrived while the engine is still running: no outcome yet.
+		await waitFor(() => engine.handles.length === 1);
+		expect(engine.handles[0].settled).toBe(false);
+		engine.handles[0].settle({ outputText: "all done" });
+
+		await waitFor(() =>
+			seen.some(
+				(event) =>
+					event.event === "run.completed" &&
+					event.scope.runId === accepted.runId,
+			),
+		);
+		const names = seen.map((event) => event.event);
+		expect(names).toContain("run.queued");
+		expect(names).toContain("run.started");
+		const sequences = seen.map((event) => event.sequence);
+		expect([...sequences].sort((a, b) => a - b)).toEqual(sequences);
+	});
+
+	it("keeps two clients consistent with FIFO admission on one session", async () => {
+		const {
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const clientA = await connectClient("client-a");
+		const clientB = await connectClient("client-b");
+		const seenA = recordEvents(clientA);
+		const seenB = recordEvents(clientB);
+		const initialCursor = encodeEventCursor(createEventCursor(-1));
+		await clientA.subscribe({ cursor: initialCursor });
+		await clientB.subscribe({ cursor: initialCursor });
+
+		const first = (await clientA.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "first prompt",
+		})) as RunAccepted;
+		const second = (await clientB.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "second prompt",
+		})) as RunAccepted;
+
+		// FIFO admission on the single session: A is active, B queued.
+		expect(first.queuePosition).toBe(0);
+		expect(second.queuePosition).toBe(1);
+		await waitFor(() => engine.handles.length === 1);
+		expect(engine.handles[0].invocation.input).toBe("first prompt");
+
+		engine.handles[0].settle({ outputText: "first done" });
+		await waitFor(() => engine.handles.length === 2);
+		expect(engine.handles[1].invocation.input).toBe("second prompt");
+		engine.handles[1].settle({ outputText: "second done" });
+
+		const done = (events: GatewayEvent[]) =>
+			["run.queued", "run.started", "run.completed"].every((name) =>
+				events.some(
+					(event) => event.event === name && event.scope.runId === second.runId,
+				),
+			);
+		await waitFor(() => done(seenA) && done(seenB));
+
+		// Both clients observed the identical canonical event stream.
+		const key = (event: GatewayEvent) => `${event.sequence}:${event.event}`;
+		expect(seenA.map(key)).toEqual(seenB.map(key));
+		// Session consistency: both runs share one session.
+		const runs = (await clientA.request("run.list", {
+			sessionId: undefined,
+		})) as { runs: { runId: string; sessionId: string }[] };
+		void runs;
+		const sessions = (await clientB.request("session.list")) as {
+			sessions: { sessionId: string }[];
+		};
+		expect(sessions.sessions).toHaveLength(1);
+	});
+
+	it("client loss never aborts the run; a new client resumes from its cursor", async () => {
+		const {
+			server,
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const clientA = await connectClient("doomed-client");
+		const seenA = recordEvents(clientA);
+		await clientA.subscribe({
+			cursor: encodeEventCursor(createEventCursor(-1)),
+		});
+		const accepted = (await clientA.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "outlive my client",
+		})) as RunAccepted;
+		await waitFor(() => seenA.some((event) => event.event === "run.started"));
+		const lastSeen = Math.max(...seenA.map((event) => event.sequence));
+
+		// The client vanishes mid-run. Disconnect never implies abort.
+		clientA.close();
+		await waitFor(() => engine.handles.length === 1);
+		expect(engine.handles[0].aborted).toBe(false);
+		expect(engine.handles[0].interrupted).toBe(false);
+		engine.handles[0].emit({ type: "text-delta", text: "still going" });
+		engine.handles[0].settle({ outputText: "finished alone" });
+		await waitFor(
+			() => server.stores.runs.get(accepted.runId)?.state === "completed",
+		);
+
+		// A new client replays exactly the missed suffix from the cursor.
+		const clientB = await connectClient("resuming-client");
+		const seenB = recordEvents(clientB);
+		await clientB.subscribe({
+			runId: accepted.runId,
+			cursor: encodeEventCursor(createEventCursor(lastSeen)),
+		});
+		await waitFor(() => seenB.some((event) => event.event === "run.completed"));
+		expect(seenB.every((event) => event.sequence > lastSeen)).toBe(true);
+		expect(
+			seenB.some(
+				(event) =>
+					event.event === "engine.textDelta" &&
+					event.payload?.text === "still going",
+			),
+		).toBe(true);
+		expect(
+			seenB.some(
+				(event) =>
+					event.event === "run.completed" &&
+					event.payload?.outputText === "finished alone",
+			),
+		).toBe(true);
+	});
+
+	it("replays idempotent run.start without admitting a second run", async () => {
+		const {
+			server,
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const idempotencyKey = createIdempotencyKey();
+		const first = (await client.mutate("run.start", {
+			idempotencyKey,
+			botId: defaultBotId(),
+			prompt: "exactly once",
+		})) as RunAccepted;
+		const replay = (await client.mutate("run.start", {
+			idempotencyKey,
+			botId: defaultBotId(),
+			prompt: "exactly once",
+		})) as RunAccepted;
+		expect(replay.runId).toBe(first.runId);
+		expect(engine.handles).toHaveLength(1);
+		expect(
+			server.stores.runs.listBySession(engine.handles[0].invocation.sessionId),
+		).toHaveLength(1);
+
+		// The same key with different params is a conflict, not a new run.
+		await expect(
+			client.mutate("run.start", {
+				idempotencyKey,
+				botId: defaultBotId(),
+				prompt: "something else",
+			}),
+		).rejects.toMatchObject({
+			gatewayError: { code: "idempotency_conflict" },
+		});
+	});
+
+	it("steers the active run over the wire", async () => {
+		const {
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const accepted = (await client.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "steerable",
+		})) as RunAccepted;
+		const outcome = (await client.mutate("run.steer", {
+			runId: accepted.runId,
+			text: "change of plan",
+		})) as { merged: boolean };
+		expect(outcome.merged).toBe(true);
+		expect(engine.handles[0].steers).toEqual(["change of plan"]);
+		engine.handles[0].settle({});
+	});
+});
+
+describe("server requests (approvals)", () => {
+	it("routes pending approvals to subscribed clients and re-issues on reconnect", async () => {
+		const {
+			server,
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const accepted = (await client.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "needs approval",
+		})) as RunAccepted;
+		await waitFor(() => engine.handles.length === 1);
+		const invocation = engine.handles[0].invocation;
+
+		// The engine asks; nobody is subscribed yet — the request pends.
+		const answer = server.runtime.approvals.request(
+			"client.requestToolApproval",
+			{
+				botId: invocation.botId,
+				sessionId: invocation.sessionId,
+				runId: invocation.runId,
+			},
+			{ toolName: "write_file", toolCallId: "call_1" },
+		);
+		expect(server.runtime.approvals.pendingCount).toBe(1);
+
+		// A (re)connecting client subscribes to the run and gets the pending
+		// request re-issued; disconnects neither lose nor answer it.
+		client.onServerRequest((request) => {
+			expect(request.method).toBe("client.requestToolApproval");
+			expect(request.scope.runId).toBe(accepted.runId);
+			return { approved: true, reason: "test approves" };
+		});
+		await client.subscribe({ runId: accepted.runId });
+
+		const result = (await answer) as { approved: boolean };
+		expect(result.approved).toBe(true);
+		expect(server.runtime.approvals.pendingCount).toBe(0);
+		engine.handles[0].settle({});
+	});
+});
+
+describe("drain and stop", () => {
+	it("draining refuses new mutating work but lets active runs finish", async () => {
+		const {
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const accepted = (await client.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "before drain",
+		})) as RunAccepted;
+		await client.mutate("gateway.drain", { reason: "test drain" });
+
+		await expect(
+			client.mutate("run.start", {
+				botId: defaultBotId(),
+				prompt: "after drain",
+			}),
+		).rejects.toMatchObject({
+			gatewayError: { code: "gateway_draining", retryable: true },
+		});
+
+		// The in-flight run is untouched and can still be steered/finished.
+		const steer = (await client.mutate("run.steer", {
+			runId: accepted.runId,
+			text: "finish up",
+		})) as { merged: boolean };
+		expect(steer.merged).toBe(true);
+		engine.handles[0].settle({ outputText: "drained gracefully" });
+		const status = (await client.request("gateway.status")) as {
+			state: string;
+		};
+		expect(status.state).toBe("draining");
+	});
+
+	it("gateway.stop stops the instance and removes its discovery record", async () => {
+		const { server, connect: connectClient } = await startServer();
+		const client = await connectClient();
+		await client.mutate("gateway.stop", { reason: "test stop" });
+		await server.whenStopped;
+		expect(existsSync(server.paths.discoveryFile)).toBe(false);
+		await expect(client.request("gateway.status")).rejects.toBeInstanceOf(
+			GatewayRequestError,
+		);
+	});
+});
+
+describe("singleton ownership (ADR 0002/0003)", () => {
+	it("a second starter fails the lock, never kills the authority, never binds a port", async () => {
+		const { server, dataRoot, connect: connectClient } = await startServer();
+		const before = readDiscoveryRecord(server.paths.discoveryFile);
+
+		await expect(
+			GatewayServer.start({
+				dataRoot,
+				namespace: "default",
+				engine: new ScriptedEnginePort(),
+			}),
+		).rejects.toBeInstanceOf(GatewayLockHeldError);
+
+		// The loser changed nothing: same discovery, same port, live server.
+		const after = readDiscoveryRecord(server.paths.discoveryFile);
+		expect(after).toEqual(before);
+		const client = await connectClient("post-contention");
+		const status = (await client.request("gateway.status")) as {
+			instanceId: string;
+		};
+		expect(status.instanceId).toBe(server.instanceId);
+	});
+
+	it("two namespaces are two singleton scopes with independent locks", async () => {
+		const dataRoot = tempDataRoot();
+		const first = await GatewayServer.start({
+			dataRoot,
+			namespace: "alpha",
+			engine: new ScriptedEnginePort(),
+		});
+		servers.push(first);
+		const second = await GatewayServer.start({
+			dataRoot,
+			namespace: "beta",
+			engine: new ScriptedEnginePort(),
+		});
+		servers.push(second);
+		expect(first.paths.dataDir).not.toBe(second.paths.dataDir);
+		expect(first.address().port).not.toBe(second.address().port);
+	});
+});

--- a/sdk/packages/gateway/src/server.test.ts
+++ b/sdk/packages/gateway/src/server.test.ts
@@ -373,6 +373,105 @@ describe("server requests (approvals)", () => {
 	});
 });
 
+describe("statistics over the wire", () => {
+	it("serves bounded summary/activity/rankings/usage from the aggregates", async () => {
+		const {
+			server,
+			engine,
+			connect: connectClient,
+			defaultBotId,
+		} = await startServer();
+		const client = await connectClient();
+		const accepted = (await client.mutate("run.start", {
+			botId: defaultBotId(),
+			prompt: "measure this turn",
+		})) as RunAccepted;
+		await waitFor(() => engine.handles.length === 1);
+		engine.handles[0].emit({
+			type: "model-call-completed",
+			providerId: "anthropic",
+			modelId: "claude-x",
+			inputTokens: 900,
+			outputTokens: 100,
+			totalTokens: 1000,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			providerCost: 0.05,
+			durationMs: 500,
+			status: "ok",
+		});
+		engine.handles[0].emit({
+			type: "message-appended",
+			message: {
+				id: "msg_stats",
+				role: "assistant",
+				content: [{ type: "text", text: "measured" }],
+				createdAt: Date.now(),
+			},
+			index: 0,
+		});
+		engine.handles[0].settle({ outputText: "measured" });
+		await waitFor(
+			() => server.stores.runs.get(accepted.runId)?.state === "completed",
+		);
+
+		const summary = (await client.request("statistics.summary")) as {
+			totals: { tokens: number; modelCalls: number; estimatedCost: number };
+			agents: number;
+			topics: number;
+			activeModels: { modelId: string }[];
+		};
+		expect(summary.totals).toMatchObject({
+			tokens: 1000,
+			modelCalls: 1,
+		});
+		expect(summary.totals.estimatedCost).toBeCloseTo(0.05, 10);
+		expect(summary.agents).toBe(1);
+		expect(summary.topics).toBe(1);
+		expect(summary.activeModels).toEqual([
+			{ modelId: "claude-x", providerId: "anthropic" },
+		]);
+
+		const activity = (await client.request("statistics.activity")) as {
+			days: { tokens: number; activeAgents: number }[];
+		};
+		expect(activity.days).toHaveLength(1);
+		expect(activity.days[0]).toMatchObject({ tokens: 1000, activeAgents: 1 });
+
+		const rankings = (await client.request("statistics.rankings", {
+			dimension: "model",
+		})) as { rows: { modelId: string; tokens: number }[] };
+		expect(rankings.rows).toEqual([
+			expect.objectContaining({ modelId: "claude-x", tokens: 1000 }),
+		]);
+
+		const month = (await client.request("statistics.usage", {
+			month: new Date().toISOString().slice(0, 7),
+		})) as { monthSpend: number };
+		expect(month.monthSpend).toBeCloseTo(0.05, 10);
+	});
+
+	it("rejects malformed or unbounded statistics queries at the wire", async () => {
+		const { connect: connectClient } = await startServer();
+		const client = await connectClient();
+		await expect(
+			client.request("statistics.summary", { from: "not-a-date" }),
+		).rejects.toMatchObject({ gatewayError: { code: "invalid_request" } });
+		await expect(
+			client.request("statistics.summary", {
+				from: "2020-01-01",
+				to: "2026-01-01",
+			}),
+		).rejects.toMatchObject({ gatewayError: { code: "invalid_request" } });
+		await expect(
+			client.request("statistics.rankings", { dimension: "vibe" }),
+		).rejects.toMatchObject({ gatewayError: { code: "invalid_request" } });
+		await expect(
+			client.request("statistics.usage", { month: "2026-13-01" }),
+		).rejects.toMatchObject({ gatewayError: { code: "invalid_request" } });
+	});
+});
+
 describe("drain and stop", () => {
 	it("draining refuses new mutating work but lets active runs finish", async () => {
 		const {

--- a/sdk/packages/gateway/src/server.ts
+++ b/sdk/packages/gateway/src/server.ts
@@ -70,6 +70,7 @@ import {
 	toGatewayError,
 } from "./runtime";
 import { createGatewayStores, type GatewayStores } from "./stores";
+import type { PriceResolver } from "./usage";
 
 const MAX_LINE_BYTES = 8 * 1024 * 1024;
 const EVENT_PAGE_SIZE = 100;
@@ -86,6 +87,8 @@ export interface GatewayServerOptions extends GatewayPathsOptions {
 	maxPendingRunsPerSession?: number;
 	projector?: OutboxProjector;
 	outbox?: OutboxWorkerOptions;
+	/** Price snapshots for providers that do not report costs. */
+	usagePrices?: PriceResolver;
 	/** Graceful-stop budget before sockets are closed anyway. */
 	stopTimeoutMs?: number;
 }
@@ -255,7 +258,9 @@ export class GatewayServer {
 			// 2. Durable state: open + migrate the SQLite authority.
 			database = openGatewayDatabase(paths.databaseFile);
 			const instanceId = createGatewayInstanceId();
-			const stores = createGatewayStores(database, instanceId);
+			const stores = createGatewayStores(database, instanceId, {
+				usage: { prices: options.usagePrices },
+			});
 
 			let workerRef: OutboxWorker | undefined;
 			const runtime = new GatewayRuntime({
@@ -673,6 +678,27 @@ export class GatewayServer {
 				return {
 					sessions: this.runtime.listSessions(p.botId as BotId | undefined),
 				};
+			// Statistics: bounded reads over the maintained aggregates only —
+			// never a rescan of runs, events, or session message history.
+			case "statistics.summary":
+				return this.stores.usage.summary({
+					from: p.from as string | undefined,
+					to: p.to as string | undefined,
+				});
+			case "statistics.activity":
+				return this.stores.usage.activity({
+					from: p.from as string | undefined,
+					to: p.to as string | undefined,
+				});
+			case "statistics.rankings":
+				return this.stores.usage.rankings({
+					dimension: p.dimension as "model" | "agent" | "topic",
+					from: p.from as string | undefined,
+					to: p.to as string | undefined,
+					limit: p.limit as number | undefined,
+				});
+			case "statistics.usage":
+				return this.stores.usage.month(p.month as string);
 			default:
 				throw new GatewayCallError(
 					createGatewayError("not_found", `Unhandled method: ${method}`),

--- a/sdk/packages/gateway/src/server.ts
+++ b/sdk/packages/gateway/src/server.ts
@@ -418,9 +418,11 @@ export class GatewayServer {
 		});
 		const cleanup = () => {
 			this.connections.delete(connection);
-			if (connection.clientId) {
-				// Disconnect never implies abort: runs and pending server
-				// requests are untouched; only the connection registry shrinks.
+			// Disconnect never implies abort: runs and pending server
+			// requests are untouched; only the connection registry shrinks.
+			// During stop the database may already be closed — socket close
+			// events race shutdown, so the audit write is best-effort then.
+			if (connection.clientId && !this.stopping) {
 				this.stores.audit.record(
 					"gateway",
 					"client.disconnected",

--- a/sdk/packages/gateway/src/server.ts
+++ b/sdk/packages/gateway/src/server.ts
@@ -1,0 +1,777 @@
+/**
+ * Gateway server (Gateway RFC, Phase 3).
+ *
+ * One process, one authority: acquire the OS-backed exclusive lock,
+ * migrate the SQLite authority, recover committed state, bind the
+ * loopback socket exclusively, and only then publish the mode-0600
+ * discovery record. A process that cannot take the lock never kills the
+ * holder and never picks another port — it connects or diagnoses.
+ *
+ * Transport: newline-delimited JSON over loopback TCP. Every connection
+ * opens with `gateway.hello` carrying the per-instance secret from the
+ * discovery record. Events are pushed from the durable log through
+ * per-subscription cursors — bounded pages with socket backpressure, so
+ * a slow client never grows an unbounded in-memory projection and a
+ * reconnecting client resumes exactly from its cursor.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { createServer, type Server, type Socket } from "node:net";
+import type { EnginePort } from "@cline/bot";
+import type {
+	BotId,
+	ClientId,
+	EventCursor,
+	GatewayEventScope,
+	GatewayInstanceId,
+	GatewayRequest,
+	GatewayResponse,
+	GatewayServerRequest,
+	IdempotencyKey,
+	RunId,
+	SessionId,
+} from "@cline/shared/gateway";
+import {
+	createGatewayError,
+	createGatewayInstanceId,
+	decodeEventCursor,
+	GATEWAY_HELLO_METHOD,
+	GATEWAY_PROTOCOL_VERSION,
+	type GatewayError,
+	GatewayServerResponseSchema,
+	IDEMPOTENCY_KEY_PARAM,
+} from "@cline/shared/gateway";
+import { type GatewayDatabase, openGatewayDatabase } from "./db";
+import {
+	createInstanceAuthToken,
+	type DiscoveryRecord,
+	removeDiscoveryRecord,
+	writeDiscoveryRecord,
+} from "./discovery";
+import { negotiateHello, SUPPORTED_PROTOCOL_VERSIONS } from "./hello";
+import { GatewayLock } from "./lock";
+import { validateGatewayRequest } from "./methods";
+import {
+	createFileProjector,
+	type OutboxProjector,
+	OutboxWorker,
+	type OutboxWorkerOptions,
+} from "./outbox";
+import {
+	ensureGatewayDataDir,
+	type GatewayPaths,
+	type GatewayPathsOptions,
+	resolveGatewayPaths,
+} from "./paths";
+import {
+	GatewayCallError,
+	GatewayRuntime,
+	type GatewayRuntimeOptions,
+	toGatewayError,
+} from "./runtime";
+import { createGatewayStores, type GatewayStores } from "./stores";
+
+const MAX_LINE_BYTES = 8 * 1024 * 1024;
+const EVENT_PAGE_SIZE = 100;
+
+export interface GatewayServerOptions extends GatewayPathsOptions {
+	/** Loopback only; the Gateway never listens on external interfaces. */
+	host?: string;
+	/** 0 (default) binds an ephemeral port; the port is never identity. */
+	port?: number;
+	/** Inner execution port (real engine binding or a test double). */
+	engine: EnginePort;
+	clock?: GatewayRuntimeOptions["clock"];
+	retry?: GatewayRuntimeOptions["retry"];
+	maxPendingRunsPerSession?: number;
+	projector?: OutboxProjector;
+	outbox?: OutboxWorkerOptions;
+	/** Graceful-stop budget before sockets are closed anyway. */
+	stopTimeoutMs?: number;
+}
+
+interface Subscription {
+	scope: GatewayEventScope;
+	after: number;
+}
+
+class Connection {
+	readonly socket: Socket;
+	clientId: ClientId | undefined;
+	authenticated = false;
+	readonly subscriptions: Subscription[] = [];
+	private buffer = "";
+	private pumpChain: Promise<void> = Promise.resolve();
+	private pumpRequested = false;
+
+	constructor(socket: Socket) {
+		this.socket = socket;
+	}
+
+	feed(chunk: string, onLine: (line: string) => void): void {
+		this.buffer += chunk;
+		if (this.buffer.length > MAX_LINE_BYTES) {
+			this.socket.destroy();
+			return;
+		}
+		for (;;) {
+			const newline = this.buffer.indexOf("\n");
+			if (newline === -1) {
+				return;
+			}
+			const line = this.buffer.slice(0, newline).trim();
+			this.buffer = this.buffer.slice(newline + 1);
+			if (line.length > 0) {
+				onLine(line);
+			}
+		}
+	}
+
+	send(frame: unknown): void {
+		if (this.socket.destroyed) {
+			return;
+		}
+		this.socket.write(`${JSON.stringify(frame)}\n`);
+	}
+
+	/** Write with socket backpressure: resolve only once flushed/drained. */
+	private writeWithBackpressure(frame: unknown): Promise<void> {
+		return new Promise((resolve) => {
+			if (this.socket.destroyed) {
+				resolve();
+				return;
+			}
+			const flushed = this.socket.write(`${JSON.stringify(frame)}\n`);
+			if (flushed) {
+				resolve();
+				return;
+			}
+			const onDone = () => {
+				this.socket.off("drain", onDone);
+				this.socket.off("close", onDone);
+				resolve();
+			};
+			this.socket.on("drain", onDone);
+			this.socket.on("close", onDone);
+		});
+	}
+
+	/**
+	 * Deliver durable events for every subscription: paged reads from the
+	 * event log, sequential per connection, coalescing repeated requests.
+	 */
+	schedulePump(events: GatewayStores["events"]): void {
+		if (this.pumpRequested || this.socket.destroyed) {
+			return;
+		}
+		this.pumpRequested = true;
+		this.pumpChain = this.pumpChain.then(async () => {
+			this.pumpRequested = false;
+			for (const subscription of this.subscriptions) {
+				for (;;) {
+					if (this.socket.destroyed) {
+						return;
+					}
+					const page = events.listAfter(
+						subscription.after,
+						subscription.scope,
+						EVENT_PAGE_SIZE,
+					);
+					if (page.length === 0) {
+						break;
+					}
+					for (const event of page) {
+						subscription.after = event.sequence;
+						await this.writeWithBackpressure(event);
+					}
+				}
+			}
+		});
+	}
+}
+
+export class GatewayServer {
+	readonly paths: GatewayPaths;
+	readonly instanceId: GatewayInstanceId;
+	readonly runtime: GatewayRuntime;
+	readonly stores: GatewayStores;
+	readonly outboxWorker: OutboxWorker;
+	discovery: DiscoveryRecord | undefined;
+
+	private readonly database: GatewayDatabase;
+	private readonly lock: GatewayLock;
+	private readonly server: Server;
+	private readonly authToken: string;
+	private readonly connections = new Set<Connection>();
+	private readonly stopTimeoutMs: number;
+	private stopping = false;
+	private unsubscribeEvents: (() => void) | undefined;
+	/** Resolves when the server has fully stopped (used by gateway.stop). */
+	private stopPromise: Promise<void> | undefined;
+	private resolveStopped: (() => void) | undefined;
+	/** Settles once the server has fully stopped (any initiator). */
+	readonly whenStopped: Promise<void>;
+
+	private constructor(options: {
+		paths: GatewayPaths;
+		lock: GatewayLock;
+		database: GatewayDatabase;
+		stores: GatewayStores;
+		runtime: GatewayRuntime;
+		outboxWorker: OutboxWorker;
+		instanceId: GatewayInstanceId;
+		authToken: string;
+		stopTimeoutMs: number;
+	}) {
+		this.paths = options.paths;
+		this.lock = options.lock;
+		this.database = options.database;
+		this.stores = options.stores;
+		this.runtime = options.runtime;
+		this.outboxWorker = options.outboxWorker;
+		this.instanceId = options.instanceId;
+		this.authToken = options.authToken;
+		this.stopTimeoutMs = options.stopTimeoutMs;
+		this.server = createServer((socket) => this.handleConnection(socket));
+		this.whenStopped = new Promise((resolve) => {
+			this.resolveStopped = resolve;
+		});
+	}
+
+	/**
+	 * Become the authority for a data directory, or fail without side
+	 * effects: `GatewayLockHeldError` means a live authority exists —
+	 * connect to it or diagnose it, never replace it.
+	 */
+	static async start(options: GatewayServerOptions): Promise<GatewayServer> {
+		const paths = resolveGatewayPaths(options);
+		ensureGatewayDataDir(paths);
+
+		// 1. Authority: the OS-backed exclusive lock. No lock, no server.
+		const lock = GatewayLock.acquire(paths.lockFile);
+
+		let database: GatewayDatabase | undefined;
+		try {
+			// 2. Durable state: open + migrate the SQLite authority.
+			database = openGatewayDatabase(paths.databaseFile);
+			const instanceId = createGatewayInstanceId();
+			const stores = createGatewayStores(database, instanceId);
+
+			let workerRef: OutboxWorker | undefined;
+			const runtime = new GatewayRuntime({
+				database,
+				stores,
+				paths,
+				instanceId,
+				engine: options.engine,
+				clock: options.clock,
+				retry: options.retry,
+				maxPendingRunsPerSession: options.maxPendingRunsPerSession,
+				onOutboxEnqueued: () => workerRef?.schedule(),
+			});
+			const outboxWorker = new OutboxWorker(
+				stores,
+				options.projector ?? createFileProjector(paths, stores),
+				options.outbox,
+			);
+			workerRef = outboxWorker;
+
+			const server = new GatewayServer({
+				paths,
+				lock,
+				database,
+				stores,
+				runtime,
+				outboxWorker,
+				instanceId,
+				authToken: createInstanceAuthToken(),
+				stopTimeoutMs: options.stopTimeoutMs ?? 5_000,
+			});
+
+			// 3. Bootstrap + manual crash recovery before accepting clients.
+			runtime.bootstrap();
+			runtime.recover();
+			outboxWorker.schedule();
+
+			// 4. Exclusive loopback bind. Ephemeral by default: the singleton
+			//    scope is the data directory, never a port.
+			const host = options.host ?? "127.0.0.1";
+			await new Promise<void>((resolve, reject) => {
+				server.server.once("error", reject);
+				server.server.listen({ host, port: options.port ?? 0 }, () => {
+					server.server.off("error", reject);
+					resolve();
+				});
+			});
+			const address = server.server.address();
+			if (address === null || typeof address === "string") {
+				throw new Error("Gateway server bound to a non-TCP address");
+			}
+
+			// 5. Live event fan-out to subscribed connections.
+			server.unsubscribeEvents = stores.events.subscribe(() => {
+				for (const connection of server.connections) {
+					if (connection.subscriptions.length > 0) {
+						connection.schedulePump(stores.events);
+					}
+				}
+			});
+
+			// 6. Readiness reached: only now publish the discovery record.
+			server.discovery = {
+				gatewayId: stores.meta.ensureGatewayId(),
+				instanceId,
+				host,
+				port: address.port,
+				auth: server.authToken,
+				pid: process.pid,
+				startedAt: runtime.startedAt,
+				protocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+				dataDir: paths.dataDir,
+				namespace: paths.namespace,
+			};
+			writeDiscoveryRecord(paths.discoveryFile, server.discovery);
+			stores.audit.record("gateway", "gateway.started", instanceId, {
+				port: address.port,
+			});
+
+			// Route pending server requests to subscribed clients.
+			runtime.approvals.deliver = (request) =>
+				server.deliverServerRequest(request);
+
+			return server;
+		} catch (error) {
+			database?.close();
+			lock.release();
+			throw error;
+		}
+	}
+
+	address(): { host: string; port: number } {
+		const address = this.server.address();
+		if (address === null || typeof address === "string") {
+			throw new Error("Gateway server is not listening");
+		}
+		return { host: address.address, port: address.port };
+	}
+
+	/**
+	 * Stop the server. `graceful` interrupts active runs cooperatively,
+	 * waits (bounded) for them to settle and the outbox to drain, and
+	 * removes the discovery record. `crash` is a test hook that drops
+	 * everything on the floor the way SIGKILL would — no state cleanup —
+	 * so restart recovery can be exercised.
+	 */
+	async stop(mode: "graceful" | "crash" = "graceful"): Promise<void> {
+		if (this.stopPromise) {
+			return this.stopPromise;
+		}
+		this.stopPromise = this.doStop(mode);
+		return this.stopPromise;
+	}
+
+	private async doStop(mode: "graceful" | "crash"): Promise<void> {
+		// New connections are refused from here on (handleConnection guard).
+		this.stopping = true;
+		this.unsubscribeEvents?.();
+		if (mode === "graceful") {
+			this.runtime.interruptAllActive("Gateway is stopping");
+			await Promise.race([
+				this.runtime.whenIdle(),
+				new Promise((resolve) => setTimeout(resolve, this.stopTimeoutMs)),
+			]);
+			await this.outboxWorker.drain().catch(() => {});
+			this.stores.audit.record("gateway", "gateway.stopped", this.instanceId);
+			removeDiscoveryRecord(this.paths.discoveryFile, this.instanceId);
+		}
+		this.outboxWorker.stop();
+		for (const connection of this.connections) {
+			connection.socket.destroy();
+		}
+		this.connections.clear();
+		await new Promise<void>((resolve) => {
+			if (!this.server.listening) {
+				resolve();
+				return;
+			}
+			this.server.close(() => resolve());
+		});
+		this.database.close();
+		this.lock.release();
+		this.resolveStopped?.();
+	}
+
+	// ---------------------------------------------------------------------
+	// Connection handling
+	// ---------------------------------------------------------------------
+
+	private handleConnection(socket: Socket): void {
+		if (this.stopping) {
+			socket.destroy();
+			return;
+		}
+		const connection = new Connection(socket);
+		this.connections.add(connection);
+		socket.setEncoding("utf8");
+		socket.on("data", (chunk: string) => {
+			connection.feed(chunk, (line) => this.handleLine(connection, line));
+		});
+		const cleanup = () => {
+			this.connections.delete(connection);
+			if (connection.clientId) {
+				// Disconnect never implies abort: runs and pending server
+				// requests are untouched; only the connection registry shrinks.
+				this.stores.audit.record(
+					"gateway",
+					"client.disconnected",
+					connection.clientId,
+				);
+			}
+		};
+		socket.on("close", cleanup);
+		socket.on("error", () => socket.destroy());
+	}
+
+	private handleLine(connection: Connection, line: string): void {
+		let value: unknown;
+		try {
+			value = JSON.parse(line);
+		} catch {
+			connection.send(
+				errorResponse(
+					"malformed",
+					createGatewayError("invalid_request", "Frame is not valid JSON"),
+				),
+			);
+			return;
+		}
+
+		// Frames without a method are server-request responses.
+		if (
+			typeof value === "object" &&
+			value !== null &&
+			!("method" in value) &&
+			"id" in value
+		) {
+			this.handleServerResponse(connection, value);
+			return;
+		}
+
+		const validated = validateGatewayRequest(value);
+		if (!validated.ok) {
+			const id =
+				typeof value === "object" && value !== null && "id" in value
+					? String((value as { id: unknown }).id)
+					: "malformed";
+			connection.send(errorResponse(id, validated.error));
+			return;
+		}
+		const { request, definition, params } = validated;
+
+		if (!connection.authenticated && request.method !== GATEWAY_HELLO_METHOD) {
+			connection.send(
+				errorResponse(
+					request.id,
+					createGatewayError(
+						"handshake_required",
+						"gateway.hello must be the first request of every connection",
+					),
+				),
+			);
+			return;
+		}
+
+		try {
+			if (request.method === GATEWAY_HELLO_METHOD) {
+				this.handleHello(connection, request, params);
+				return;
+			}
+			if (definition.mutating) {
+				this.handleMutating(connection, request, params);
+				return;
+			}
+			const result = this.execute(connection, request.method, params);
+			connection.send(okResponse(request.id, result));
+		} catch (error) {
+			connection.send(errorResponse(request.id, toGatewayError(error)));
+		}
+	}
+
+	private handleHello(
+		connection: Connection,
+		request: GatewayRequest,
+		params: unknown,
+	): void {
+		const auth = (params as { auth?: string }).auth;
+		if (!this.checkAuth(auth)) {
+			connection.send(
+				errorResponse(
+					request.id,
+					createGatewayError(
+						"unauthorized",
+						"gateway.hello requires the per-instance secret from the discovery record",
+						{ retryable: false },
+					),
+				),
+			);
+			connection.socket.end();
+			return;
+		}
+		const negotiation = negotiateHello(params, {
+			gatewayId: this.stores.meta.ensureGatewayId(),
+			instanceId: this.instanceId,
+			catalogGeneration: this.stores.meta.catalogGeneration(),
+		});
+		if (!negotiation.ok) {
+			connection.send(errorResponse(request.id, negotiation.error));
+			connection.socket.end();
+			return;
+		}
+		connection.authenticated = true;
+		connection.clientId = negotiation.result.clientId;
+		const client = (
+			params as {
+				client: { name: string; version: string };
+			}
+		).client;
+		this.database.transaction(() => {
+			this.stores.clients.registerHello(
+				negotiation.result.clientId,
+				client.name,
+				client.version,
+				Date.now(),
+			);
+			this.stores.audit.record(
+				negotiation.result.clientId,
+				"client.connected",
+				undefined,
+				{ name: client.name, version: client.version },
+			);
+		});
+		connection.send(okResponse(request.id, negotiation.result));
+	}
+
+	private handleMutating(
+		connection: Connection,
+		request: GatewayRequest,
+		params: unknown,
+	): void {
+		const key = (params as Record<string, unknown>)[
+			IDEMPOTENCY_KEY_PARAM
+		] as IdempotencyKey;
+		const outcome = this.stores.idempotency.begin(key, request.method, params);
+		if (outcome.kind === "conflict") {
+			connection.send(errorResponse(request.id, outcome.error));
+			return;
+		}
+		if (outcome.kind === "replay") {
+			// Same key, same request: return the recorded outcome under the
+			// caller's current correlation id.
+			connection.send({ ...outcome.response, id: request.id });
+			return;
+		}
+		if (outcome.kind === "pending") {
+			connection.send(
+				errorResponse(
+					request.id,
+					createGatewayError(
+						"internal",
+						"The original request with this idempotency key is still executing",
+						{ retryable: true },
+					),
+				),
+			);
+			return;
+		}
+		let response: GatewayResponse;
+		try {
+			const result = this.database.transaction(() => {
+				const value = this.execute(connection, request.method, params);
+				return value;
+			});
+			response = okResponse(request.id, result);
+		} catch (error) {
+			response = errorResponse(request.id, toGatewayError(error));
+		}
+		if (response.error?.retryable === true) {
+			// A retryable failure releases the key: the same request may be
+			// retried with the same idempotency key.
+			this.stores.idempotency.forget(key);
+		} else {
+			this.stores.idempotency.record(key, response);
+		}
+		connection.send(response);
+	}
+
+	/** Dispatch one validated request to the runtime. */
+	private execute(
+		connection: Connection,
+		method: string,
+		params: unknown,
+	): unknown {
+		const actor = connection.clientId ?? "unknown";
+		const p = (params ?? {}) as Record<string, unknown>;
+		switch (method) {
+			case "gateway.status":
+				return {
+					...this.runtime.status(),
+					port: this.address().port,
+					connections: this.connections.size,
+				};
+			case "gateway.drain":
+				return this.runtime.drain(actor, p.reason as string | undefined);
+			case "gateway.stop": {
+				this.runtime.drain(actor, "gateway.stop");
+				this.stores.audit.record(actor, "gateway.stop");
+				setImmediate(() => {
+					void this.stop("graceful");
+				});
+				return { stopping: true };
+			}
+			case "run.start":
+				return this.runtime.startRun(actor, {
+					botId: p.botId as BotId,
+					prompt: p.prompt as string,
+					workspaceRoot: p.workspaceRoot as string | undefined,
+					overrides: p.overrides as never,
+				});
+			case "run.steer":
+				return this.runtime.steerRun(actor, p.runId as RunId, p.text as string);
+			case "run.interrupt":
+				return this.runtime.interruptRun(
+					actor,
+					p.runId as RunId,
+					p.reason as string | undefined,
+				);
+			case "run.abort":
+				return this.runtime.abortRun(
+					actor,
+					p.runId as RunId,
+					p.reason as string | undefined,
+				);
+			case "run.subscribe":
+				return this.handleSubscribe(connection, p);
+			case "run.list":
+				return {
+					runs: this.runtime.listRuns({
+						sessionId: p.sessionId as SessionId | undefined,
+						runId: p.runId as RunId | undefined,
+					}),
+				};
+			case "bot.delegate":
+				return this.runtime.delegateBot(actor, {
+					parentBotId: p.parentBotId as BotId,
+					name: p.name as string,
+					role: p.role as "worker" | "contractor",
+					reason: p.reason as string | undefined,
+				});
+			case "bot.list":
+				return { bots: this.runtime.listBots() };
+			case "session.list":
+				return {
+					sessions: this.runtime.listSessions(p.botId as BotId | undefined),
+				};
+			default:
+				throw new GatewayCallError(
+					createGatewayError("not_found", `Unhandled method: ${method}`),
+				);
+		}
+	}
+
+	private handleSubscribe(
+		connection: Connection,
+		params: Record<string, unknown>,
+	): unknown {
+		const scope: GatewayEventScope = {
+			...(params.sessionId ? { sessionId: params.sessionId as SessionId } : {}),
+			...(params.runId ? { runId: params.runId as RunId } : {}),
+		};
+		let cursor: EventCursor | undefined;
+		if (typeof params.cursor === "string") {
+			cursor = decodeEventCursor(params.cursor);
+		}
+		const after = cursor
+			? cursor.lastSequence
+			: this.stores.events.lastSequence();
+		connection.subscriptions.push({ scope, after });
+		connection.schedulePump(this.stores.events);
+		// Re-issue server requests still pending for this scope: a
+		// reconnecting client neither loses nor implicitly answers them.
+		for (const pending of this.runtime.approvals.pendingForScope(scope)) {
+			connection.send(pending);
+		}
+		return { subscribed: true, replayFromSequence: after };
+	}
+
+	private handleServerResponse(connection: Connection, value: unknown): void {
+		if (!connection.authenticated) {
+			return;
+		}
+		const parsed = GatewayServerResponseSchema.safeParse(value);
+		if (!parsed.success) {
+			return;
+		}
+		this.runtime.approvals.respond(
+			parsed.data.id,
+			parsed.data.result,
+			parsed.data.error,
+		);
+	}
+
+	private deliverServerRequest(request: GatewayServerRequest): void {
+		for (const connection of this.connections) {
+			if (!connection.authenticated) {
+				continue;
+			}
+			const interested =
+				connection.subscriptions.length === 0
+					? false
+					: connection.subscriptions.some((subscription) =>
+							scopeMatches(subscription.scope, request.scope),
+						);
+			if (interested) {
+				connection.send(request);
+			}
+		}
+	}
+
+	private checkAuth(offered: string | undefined): boolean {
+		if (!offered) {
+			return false;
+		}
+		const expected = Buffer.from(this.authToken, "utf8");
+		const actual = Buffer.from(offered, "utf8");
+		if (expected.length !== actual.length) {
+			return false;
+		}
+		return timingSafeEqual(expected, actual);
+	}
+}
+
+function scopeMatches(
+	subscription: GatewayEventScope,
+	target: GatewayEventScope,
+): boolean {
+	if (subscription.runId) {
+		return subscription.runId === target.runId;
+	}
+	if (subscription.sessionId) {
+		return subscription.sessionId === target.sessionId;
+	}
+	if (subscription.botId) {
+		return subscription.botId === target.botId;
+	}
+	return true;
+}
+
+function okResponse(id: string, result: unknown): GatewayResponse {
+	return {
+		version: GATEWAY_PROTOCOL_VERSION,
+		id,
+		result: result ?? null,
+	};
+}
+
+function errorResponse(id: string, error: GatewayError): GatewayResponse {
+	return { version: GATEWAY_PROTOCOL_VERSION, id, error };
+}

--- a/sdk/packages/gateway/src/stores.test.ts
+++ b/sdk/packages/gateway/src/stores.test.ts
@@ -1,0 +1,294 @@
+/**
+ * SQLite authority stores: migrations, repository invariants, the
+ * durable idempotency ledger, the global event log, canonical message
+ * history, outbox bookkeeping, audit, and the client registry.
+ */
+
+import { join } from "node:path";
+import { RoleImmutableError, WorkspaceImmutableError } from "@cline/bot";
+import type { AgentMessage } from "@cline/shared";
+import {
+	createBotId,
+	createClientId,
+	createIdempotencyKey,
+	createRunId,
+	createSessionId,
+	GATEWAY_PROTOCOL_VERSION,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import { GATEWAY_MIGRATIONS, openGatewayDatabase } from "./db";
+import { createGatewayStores } from "./stores";
+import { tempDataRoot } from "./test-support";
+
+function openStores() {
+	const database = openGatewayDatabase(join(tempDataRoot(), "gateway.db"));
+	return { database, stores: createGatewayStores(database, "gwi_test") };
+}
+
+function botRecord(botId = createBotId()) {
+	return {
+		identity: {
+			botId,
+			name: "cline",
+			role: "lead" as const,
+			parentBotId: null,
+			provenance: { createdBy: "bootstrap" as const },
+			createdAt: 1,
+		},
+		config: {},
+		status: "active" as const,
+		revision: 0,
+	};
+}
+
+describe("migrations", () => {
+	it("apply once and are idempotent across re-open", () => {
+		const file = join(tempDataRoot(), "gateway.db");
+		const first = openGatewayDatabase(file);
+		first.close();
+		const second = openGatewayDatabase(file);
+		const applied = second.db
+			.prepare("SELECT version FROM migrations ORDER BY version;")
+			.all()
+			.map((row) => Number(row.version));
+		expect(applied).toEqual(GATEWAY_MIGRATIONS.map((m) => m.version));
+		second.close();
+	});
+});
+
+describe("meta", () => {
+	it("gatewayId is created once and stable across re-open", () => {
+		const file = join(tempDataRoot(), "gateway.db");
+		const first = openGatewayDatabase(file);
+		const stores = createGatewayStores(first, "gwi_a");
+		const created = stores.meta.ensureGatewayId();
+		first.close();
+		const second = openGatewayDatabase(file);
+		const reopened = createGatewayStores(second, "gwi_b");
+		expect(reopened.meta.ensureGatewayId()).toBe(created);
+		second.close();
+	});
+});
+
+describe("repositories", () => {
+	it("bot repository rejects role/parent mutation", () => {
+		const { stores } = openStores();
+		const record = botRecord();
+		stores.bots.save(record);
+		expect(() =>
+			stores.bots.save({
+				...record,
+				identity: { ...record.identity, role: "worker", parentBotId: null },
+			}),
+		).toThrow(RoleImmutableError);
+	});
+
+	it("session repository rejects workspace mutation", () => {
+		const { stores } = openStores();
+		const sessionId = createSessionId();
+		const botId = createBotId();
+		stores.sessions.save({
+			sessionId,
+			botId,
+			workspace: { rootPath: "/a" },
+			state: "active",
+			createdAt: 1,
+			revision: 0,
+		});
+		expect(() =>
+			stores.sessions.save({
+				sessionId,
+				botId,
+				workspace: { rootPath: "/b" },
+				state: "active",
+				createdAt: 1,
+				revision: 1,
+			}),
+		).toThrow(WorkspaceImmutableError);
+	});
+
+	it("runs keep durable FIFO admission order", () => {
+		const { stores } = openStores();
+		const sessionId = createSessionId();
+		const botId = createBotId();
+		const runIds = [createRunId(), createRunId(), createRunId()];
+		for (const runId of runIds) {
+			stores.runs.save({
+				runId,
+				sessionId,
+				botId,
+				state: "queued",
+				input: "x",
+				acceptedAt: 1,
+			});
+		}
+		expect(stores.runs.listQueued().map((run) => run.runId)).toEqual(runIds);
+		expect(stores.runs.countPendingBySession(sessionId)).toBe(3);
+	});
+
+	it("run attempts number sequentially and interrupt open attempts on recovery", () => {
+		const { stores } = openStores();
+		const runId = createRunId();
+		const first = stores.attempts.begin(runId, 10);
+		expect(first.attempt).toBe(1);
+		stores.attempts.settle(runId, 1, "failed", 20, {
+			name: "E",
+			message: "boom",
+		});
+		const second = stores.attempts.begin(runId, 30);
+		expect(second.attempt).toBe(2);
+		const open = stores.attempts.interruptOpenAttempts(40);
+		expect(open.map((attempt) => attempt.attempt)).toEqual([2]);
+		const attempts = stores.attempts.listByRun(runId);
+		expect(attempts.map((attempt) => attempt.state)).toEqual([
+			"failed",
+			"interrupted",
+		]);
+	});
+});
+
+describe("durable idempotency ledger", () => {
+	it("new -> pending -> replay, with conflicts on divergent reuse", () => {
+		const { stores } = openStores();
+		const key = createIdempotencyKey();
+		const params = { idempotencyKey: key, prompt: "hi" };
+		expect(stores.idempotency.begin(key, "run.start", params).kind).toBe("new");
+		expect(stores.idempotency.begin(key, "run.start", params).kind).toBe(
+			"pending",
+		);
+		const response = {
+			version: GATEWAY_PROTOCOL_VERSION,
+			id: "req_1",
+			result: { ok: true },
+		};
+		stores.idempotency.record(key, response);
+		const replay = stores.idempotency.begin(key, "run.start", params);
+		expect(replay.kind).toBe("replay");
+		if (replay.kind === "replay") {
+			expect(replay.response).toEqual(response);
+		}
+		const conflict = stores.idempotency.begin(key, "run.abort", params);
+		expect(conflict.kind).toBe("conflict");
+	});
+
+	it("forget releases a key for retryable failures", () => {
+		const { stores } = openStores();
+		const key = createIdempotencyKey();
+		expect(stores.idempotency.begin(key, "run.start", {}).kind).toBe("new");
+		stores.idempotency.forget(key);
+		expect(stores.idempotency.begin(key, "run.start", {}).kind).toBe("new");
+	});
+
+	it("survives re-open (durable, unlike the Phase 0 in-memory ledger)", () => {
+		const file = join(tempDataRoot(), "gateway.db");
+		const first = openGatewayDatabase(file);
+		const stores = createGatewayStores(first, "gwi_a");
+		const key = createIdempotencyKey();
+		stores.idempotency.begin(key, "run.start", { p: 1 });
+		stores.idempotency.record(key, {
+			version: GATEWAY_PROTOCOL_VERSION,
+			id: "req_9",
+			result: { runId: "run_x" },
+		});
+		first.close();
+		const second = openGatewayDatabase(file);
+		const reopened = createGatewayStores(second, "gwi_b");
+		const outcome = reopened.idempotency.begin(key, "run.start", { p: 1 });
+		expect(outcome.kind).toBe("replay");
+		second.close();
+	});
+});
+
+describe("event log", () => {
+	it("assigns a monotonic global sequence and filters replay by scope", () => {
+		const { stores } = openStores();
+		const sessionA = createSessionId();
+		const sessionB = createSessionId();
+		const runA = createRunId();
+		const first = stores.events.append(
+			"run.queued",
+			{ sessionId: sessionA, runId: runA },
+			{ n: 1 },
+			1,
+		);
+		const second = stores.events.append(
+			"run.queued",
+			{ sessionId: sessionB },
+			{ n: 2 },
+			2,
+		);
+		expect(second.sequence).toBeGreaterThan(first.sequence);
+
+		const all = stores.events.listAfter(-1, {}, 10);
+		expect(all).toHaveLength(2);
+		const onlyA = stores.events.listAfter(-1, { sessionId: sessionA }, 10);
+		expect(onlyA.map((event) => event.payload?.n)).toEqual([1]);
+		const afterFirst = stores.events.listAfter(first.sequence, {}, 10);
+		expect(afterFirst.map((event) => event.sequence)).toEqual([
+			second.sequence,
+		]);
+	});
+
+	it("notifies live listeners after the write", async () => {
+		const { stores } = openStores();
+		const seen: number[] = [];
+		stores.events.subscribe((event) => seen.push(event.sequence));
+		const appended = stores.events.append("run.queued", {}, undefined, 1);
+		expect(seen).toEqual([]); // deferred to a microtask
+		await Promise.resolve();
+		expect(seen).toEqual([appended.sequence]);
+	});
+});
+
+describe("canonical message history", () => {
+	it("stores AgentMessage payloads in global order per session", () => {
+		const { stores } = openStores();
+		const sessionId = createSessionId();
+		const runId = createRunId();
+		const message = (id: string, text: string): AgentMessage => ({
+			id,
+			role: "assistant",
+			content: [{ type: "text", text }],
+			createdAt: Date.now(),
+		});
+		stores.messages.append(sessionId, runId, message("m1", "hello"));
+		stores.messages.append(sessionId, runId, message("m2", "world"));
+		const stored = stores.messages.listBySession(sessionId);
+		expect(stored.map((entry) => entry.message.id)).toEqual(["m1", "m2"]);
+		expect(stored[0].runId).toBe(runId);
+		expect(stores.messages.countBySession(sessionId)).toBe(2);
+	});
+});
+
+describe("outbox and audit and clients", () => {
+	it("outbox entries stay pending until marked done and count attempts", () => {
+		const { stores } = openStores();
+		stores.outbox.enqueue("session.projection", { sessionId: "ses_x" }, 1);
+		const [entry] = stores.outbox.listPending(10);
+		expect(entry.state).toBe("pending");
+		stores.outbox.markFailed(entry.outboxId, "disk full");
+		expect(stores.outbox.listPending(10)[0].attempts).toBe(1);
+		stores.outbox.markDone(entry.outboxId, 2);
+		expect(stores.outbox.countPending()).toBe(0);
+	});
+
+	it("audit records actor, action, and details", () => {
+		const { stores } = openStores();
+		stores.audit.record("cli_x", "run.start", "run_1", { botId: "bot_1" }, 5);
+		const [entry] = stores.audit.list();
+		expect(entry.actor).toBe("cli_x");
+		expect(entry.action).toBe("run.start");
+		expect(entry.details).toEqual({ botId: "bot_1" });
+	});
+
+	it("client registry upserts on hello and counts connections", () => {
+		const { stores } = openStores();
+		const clientId = createClientId();
+		stores.clients.registerHello(clientId, "cli", "1.0.0", 10);
+		const updated = stores.clients.registerHello(clientId, "cli", "1.0.1", 20);
+		expect(updated.connections).toBe(2);
+		expect(updated.version).toBe("1.0.1");
+		expect(updated.firstSeenAt).toBe(10);
+		expect(stores.clients.count()).toBe(1);
+	});
+});

--- a/sdk/packages/gateway/src/stores.ts
+++ b/sdk/packages/gateway/src/stores.ts
@@ -336,6 +336,28 @@ export class SqliteRunRepository implements RunRepository {
 		return Number(row?.n ?? 0);
 	}
 
+	/**
+	 * Persist the effective config captured at admission. The snapshot
+	 * carries provider/model/prompt settings only — never credentials.
+	 * Retries and crash recovery execute against this snapshot, not the
+	 * live bot config.
+	 */
+	saveConfigSnapshot(runId: RunId, config: BotRecord["config"]): void {
+		this.database.db
+			.prepare("UPDATE runs SET config_json = ? WHERE run_id = ?;")
+			.run(JSON.stringify(config), runId);
+	}
+
+	getConfigSnapshot(runId: RunId): BotRecord["config"] | undefined {
+		const row = this.database.db
+			.prepare("SELECT config_json FROM runs WHERE run_id = ?;")
+			.get(runId);
+		if (!row || row.config_json === null) {
+			return undefined;
+		}
+		return JSON.parse(String(row.config_json)) as BotRecord["config"];
+	}
+
 	save(record: RunRecord): void {
 		this.database.db
 			.prepare(

--- a/sdk/packages/gateway/src/stores.ts
+++ b/sdk/packages/gateway/src/stores.ts
@@ -43,6 +43,7 @@ import {
 import type { GatewayDatabase } from "./db";
 import type { IdempotencyBeginOutcome } from "./idempotency-ledger";
 import { stableStringify } from "./idempotency-ledger";
+import { UsageStore, type UsageStoreOptions } from "./usage";
 
 // -----------------------------------------------------------------------------
 // Meta
@@ -985,11 +986,13 @@ export interface GatewayStores {
 	readonly outbox: OutboxStore;
 	readonly audit: AuditLog;
 	readonly clients: ClientRegistryStore;
+	readonly usage: UsageStore;
 }
 
 export function createGatewayStores(
 	database: GatewayDatabase,
 	instanceId: string,
+	options: { usage?: UsageStoreOptions } = {},
 ): GatewayStores {
 	return {
 		meta: new MetaStore(database),
@@ -1003,5 +1006,6 @@ export function createGatewayStores(
 		outbox: new OutboxStore(database),
 		audit: new AuditLog(database),
 		clients: new ClientRegistryStore(database),
+		usage: new UsageStore(database, options.usage),
 	};
 }

--- a/sdk/packages/gateway/src/stores.ts
+++ b/sdk/packages/gateway/src/stores.ts
@@ -1,0 +1,985 @@
+/**
+ * SQLite-backed stores (Gateway RFC, Phase 3).
+ *
+ * Real implementations of the ports that `@cline/bot` consumes (bot,
+ * session, and run repositories) plus the Gateway-only durable stores:
+ * run attempts, the global event log, canonical message history (behind
+ * the `AgentMessage` messages contract), the idempotency ledger, the
+ * outbox, the audit trail, the client registry, and instance metadata.
+ *
+ * All writes go through the single Gateway process (ADR 0001); the
+ * repositories still enforce the domain invariants (immutable role and
+ * parent, immutable session workspace) as a backstop.
+ */
+
+import type {
+	BotRecord,
+	BotRepository,
+	RunRecord,
+	RunRepository,
+	SessionRecord,
+	SessionRepository,
+} from "@cline/bot";
+import { RoleImmutableError, WorkspaceImmutableError } from "@cline/bot";
+import type { AgentMessage } from "@cline/shared";
+import type {
+	BotId,
+	ClientId,
+	GatewayEvent,
+	GatewayEventScope,
+	GatewayId,
+	GatewayResponse,
+	IdempotencyKey,
+	RunId,
+	RunState,
+	SessionId,
+} from "@cline/shared/gateway";
+import {
+	createGatewayError,
+	createGatewayId,
+	GATEWAY_PROTOCOL_VERSION,
+	GatewayEventSchema,
+} from "@cline/shared/gateway";
+import type { GatewayDatabase } from "./db";
+import type { IdempotencyBeginOutcome } from "./idempotency-ledger";
+import { stableStringify } from "./idempotency-ledger";
+
+// -----------------------------------------------------------------------------
+// Meta
+// -----------------------------------------------------------------------------
+
+const GATEWAY_ID_KEY = "gateway_id";
+const CATALOG_GENERATION_KEY = "catalog_generation";
+
+export class MetaStore {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	get(key: string): string | undefined {
+		const row = this.database.db
+			.prepare("SELECT value FROM meta WHERE key = ?;")
+			.get(key);
+		return row ? String(row.value) : undefined;
+	}
+
+	set(key: string, value: string): void {
+		this.database.db
+			.prepare(
+				"INSERT INTO meta (key, value) VALUES (?, ?) " +
+					"ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
+			)
+			.run(key, value);
+	}
+
+	/** Durable `GatewayId`: created once, stable across restarts/upgrades. */
+	ensureGatewayId(): GatewayId {
+		const existing = this.get(GATEWAY_ID_KEY);
+		if (existing) {
+			return existing as GatewayId;
+		}
+		const created = createGatewayId();
+		this.set(GATEWAY_ID_KEY, created);
+		return created;
+	}
+
+	catalogGeneration(): number {
+		return Number(this.get(CATALOG_GENERATION_KEY) ?? "0");
+	}
+
+	bumpCatalogGeneration(): number {
+		const next = this.catalogGeneration() + 1;
+		this.set(CATALOG_GENERATION_KEY, String(next));
+		return next;
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Bots
+// -----------------------------------------------------------------------------
+
+function rowToBotRecord(row: Record<string, unknown>): BotRecord {
+	const createdBy = String(row.created_by);
+	return {
+		identity: {
+			botId: String(row.bot_id) as BotId,
+			name: String(row.name),
+			role: String(row.role) as BotRecord["identity"]["role"],
+			parentBotId: row.parent_bot_id
+				? (String(row.parent_bot_id) as BotId)
+				: null,
+			provenance: {
+				createdBy:
+					createdBy === "bootstrap" ? "bootstrap" : (createdBy as BotId),
+				reason: row.reason ? String(row.reason) : undefined,
+			},
+			createdAt: Number(row.created_at),
+		},
+		config: JSON.parse(String(row.config_json)) as BotRecord["config"],
+		status: String(row.status) as BotRecord["status"],
+		revision: Number(row.revision),
+	};
+}
+
+export class SqliteBotRepository implements BotRepository {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	get(botId: BotId): BotRecord | undefined {
+		const row = this.database.db
+			.prepare("SELECT * FROM bots WHERE bot_id = ?;")
+			.get(botId);
+		return row ? rowToBotRecord(row) : undefined;
+	}
+
+	list(): readonly BotRecord[] {
+		return this.database.db
+			.prepare("SELECT * FROM bots ORDER BY created_at, bot_id;")
+			.all()
+			.map(rowToBotRecord);
+	}
+
+	save(record: BotRecord): void {
+		const existing = this.get(record.identity.botId);
+		if (
+			existing &&
+			(existing.identity.role !== record.identity.role ||
+				existing.identity.parentBotId !== record.identity.parentBotId)
+		) {
+			throw new RoleImmutableError(
+				`Bot ${record.identity.botId} cannot change role/parent ` +
+					`(${existing.identity.role} -> ${record.identity.role})`,
+			);
+		}
+		this.database.db
+			.prepare(
+				`INSERT INTO bots (
+					bot_id, name, role, parent_bot_id, created_by, reason,
+					created_at, config_json, status, revision
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(bot_id) DO UPDATE SET
+					name = excluded.name,
+					config_json = excluded.config_json,
+					status = excluded.status,
+					revision = excluded.revision;`,
+			)
+			.run(
+				record.identity.botId,
+				record.identity.name,
+				record.identity.role,
+				record.identity.parentBotId,
+				record.identity.provenance.createdBy,
+				record.identity.provenance.reason ?? null,
+				record.identity.createdAt,
+				JSON.stringify(record.config),
+				record.status,
+				record.revision,
+			);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Sessions
+// -----------------------------------------------------------------------------
+
+function rowToSessionRecord(row: Record<string, unknown>): SessionRecord {
+	return {
+		sessionId: String(row.session_id) as SessionId,
+		botId: String(row.bot_id) as BotId,
+		workspace: Object.freeze({ rootPath: String(row.workspace_root) }),
+		state: String(row.state) as SessionRecord["state"],
+		createdAt: Number(row.created_at),
+		revision: Number(row.revision),
+	};
+}
+
+export class SqliteSessionRepository implements SessionRepository {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	get(sessionId: SessionId): SessionRecord | undefined {
+		const row = this.database.db
+			.prepare("SELECT * FROM sessions WHERE session_id = ?;")
+			.get(sessionId);
+		return row ? rowToSessionRecord(row) : undefined;
+	}
+
+	listByBot(botId: BotId): readonly SessionRecord[] {
+		return this.database.db
+			.prepare(
+				"SELECT * FROM sessions WHERE bot_id = ? ORDER BY created_at, session_id;",
+			)
+			.all(botId)
+			.map(rowToSessionRecord);
+	}
+
+	list(): readonly SessionRecord[] {
+		return this.database.db
+			.prepare("SELECT * FROM sessions ORDER BY created_at, session_id;")
+			.all()
+			.map(rowToSessionRecord);
+	}
+
+	save(record: SessionRecord): void {
+		const existing = this.get(record.sessionId);
+		if (existing && existing.workspace.rootPath !== record.workspace.rootPath) {
+			throw new WorkspaceImmutableError(
+				`Session ${record.sessionId} workspace cannot change`,
+			);
+		}
+		this.database.db
+			.prepare(
+				`INSERT INTO sessions (
+					session_id, bot_id, workspace_root, state, created_at, revision
+				) VALUES (?, ?, ?, ?, ?, ?)
+				ON CONFLICT(session_id) DO UPDATE SET
+					state = excluded.state,
+					revision = excluded.revision;`,
+			)
+			.run(
+				record.sessionId,
+				record.botId,
+				record.workspace.rootPath,
+				record.state,
+				record.createdAt,
+				record.revision,
+			);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Runs (durable FIFO queue)
+// -----------------------------------------------------------------------------
+
+function rowToRunRecord(row: Record<string, unknown>): RunRecord {
+	return {
+		runId: String(row.run_id) as RunId,
+		sessionId: String(row.session_id) as SessionId,
+		botId: String(row.bot_id) as BotId,
+		state: String(row.state) as RunState,
+		input: String(row.input),
+		acceptedAt: Number(row.accepted_at),
+		startedAt: row.started_at === null ? undefined : Number(row.started_at),
+		endedAt: row.ended_at === null ? undefined : Number(row.ended_at),
+		outputText: row.output_text === null ? undefined : String(row.output_text),
+		error:
+			row.error_name === null && row.error_message === null
+				? undefined
+				: {
+						name: String(row.error_name ?? "Error"),
+						message: String(row.error_message ?? ""),
+					},
+	};
+}
+
+export class SqliteRunRepository implements RunRepository {
+	private readonly database: GatewayDatabase;
+	private readonly instanceId: string;
+
+	constructor(database: GatewayDatabase, instanceId: string) {
+		this.database = database;
+		this.instanceId = instanceId;
+	}
+
+	get(runId: RunId): RunRecord | undefined {
+		const row = this.database.db
+			.prepare("SELECT * FROM runs WHERE run_id = ?;")
+			.get(runId);
+		return row ? rowToRunRecord(row) : undefined;
+	}
+
+	listBySession(sessionId: SessionId): readonly RunRecord[] {
+		return this.database.db
+			.prepare("SELECT * FROM runs WHERE session_id = ? ORDER BY accepted_seq;")
+			.all(sessionId)
+			.map(rowToRunRecord);
+	}
+
+	/** Queued runs in global FIFO admission order. */
+	listQueued(): readonly RunRecord[] {
+		return this.database.db
+			.prepare(
+				"SELECT * FROM runs WHERE state = 'queued' ORDER BY accepted_seq;",
+			)
+			.all()
+			.map(rowToRunRecord);
+	}
+
+	listByState(state: RunState): readonly RunRecord[] {
+		return this.database.db
+			.prepare("SELECT * FROM runs WHERE state = ? ORDER BY accepted_seq;")
+			.all(state)
+			.map(rowToRunRecord);
+	}
+
+	countByState(state: RunState): number {
+		const row = this.database.db
+			.prepare("SELECT COUNT(*) AS n FROM runs WHERE state = ?;")
+			.get(state);
+		return Number(row?.n ?? 0);
+	}
+
+	countPendingBySession(sessionId: SessionId): number {
+		const row = this.database.db
+			.prepare(
+				"SELECT COUNT(*) AS n FROM runs WHERE session_id = ? AND state IN ('queued', 'running');",
+			)
+			.get(sessionId);
+		return Number(row?.n ?? 0);
+	}
+
+	save(record: RunRecord): void {
+		this.database.db
+			.prepare(
+				`INSERT INTO runs (
+					run_id, session_id, bot_id, state, input, accepted_at,
+					accepted_seq, instance_id, started_at, ended_at,
+					output_text, error_name, error_message
+				) VALUES (
+					?, ?, ?, ?, ?, ?,
+					(SELECT COALESCE(MAX(accepted_seq), 0) + 1 FROM runs),
+					?, ?, ?, ?, ?, ?
+				)
+				ON CONFLICT(run_id) DO UPDATE SET
+					state = excluded.state,
+					started_at = excluded.started_at,
+					ended_at = excluded.ended_at,
+					output_text = excluded.output_text,
+					error_name = excluded.error_name,
+					error_message = excluded.error_message;`,
+			)
+			.run(
+				record.runId,
+				record.sessionId,
+				record.botId,
+				record.state,
+				record.input,
+				record.acceptedAt,
+				this.instanceId,
+				record.startedAt ?? null,
+				record.endedAt ?? null,
+				record.outputText ?? null,
+				record.error?.name ?? null,
+				record.error?.message ?? null,
+			);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Run attempts
+// -----------------------------------------------------------------------------
+
+export interface RunAttemptRecord {
+	readonly runId: RunId;
+	readonly attempt: number;
+	readonly state:
+		| "running"
+		| "completed"
+		| "failed"
+		| "aborted"
+		| "interrupted";
+	readonly instanceId: string;
+	readonly startedAt: number;
+	readonly endedAt?: number;
+	readonly error?: { name: string; message: string };
+}
+
+function rowToAttempt(row: Record<string, unknown>): RunAttemptRecord {
+	return {
+		runId: String(row.run_id) as RunId,
+		attempt: Number(row.attempt),
+		state: String(row.state) as RunAttemptRecord["state"],
+		instanceId: String(row.instance_id),
+		startedAt: Number(row.started_at),
+		endedAt: row.ended_at === null ? undefined : Number(row.ended_at),
+		error:
+			row.error_name === null && row.error_message === null
+				? undefined
+				: {
+						name: String(row.error_name ?? "Error"),
+						message: String(row.error_message ?? ""),
+					},
+	};
+}
+
+export class RunAttemptStore {
+	private readonly database: GatewayDatabase;
+	private readonly instanceId: string;
+
+	constructor(database: GatewayDatabase, instanceId: string) {
+		this.database = database;
+		this.instanceId = instanceId;
+	}
+
+	begin(runId: RunId, startedAt: number): RunAttemptRecord {
+		const row = this.database.db
+			.prepare(
+				"SELECT COALESCE(MAX(attempt), 0) + 1 AS next FROM run_attempts WHERE run_id = ?;",
+			)
+			.get(runId);
+		const attempt = Number(row?.next ?? 1);
+		this.database.db
+			.prepare(
+				`INSERT INTO run_attempts (run_id, attempt, state, instance_id, started_at)
+				VALUES (?, ?, 'running', ?, ?);`,
+			)
+			.run(runId, attempt, this.instanceId, startedAt);
+		return {
+			runId,
+			attempt,
+			state: "running",
+			instanceId: this.instanceId,
+			startedAt,
+		};
+	}
+
+	settle(
+		runId: RunId,
+		attempt: number,
+		state: Exclude<RunAttemptRecord["state"], "running">,
+		endedAt: number,
+		error?: { name: string; message: string },
+	): void {
+		this.database.db
+			.prepare(
+				`UPDATE run_attempts
+				SET state = ?, ended_at = ?, error_name = ?, error_message = ?
+				WHERE run_id = ? AND attempt = ?;`,
+			)
+			.run(
+				state,
+				endedAt,
+				error?.name ?? null,
+				error?.message ?? null,
+				runId,
+				attempt,
+			);
+	}
+
+	listByRun(runId: RunId): readonly RunAttemptRecord[] {
+		return this.database.db
+			.prepare("SELECT * FROM run_attempts WHERE run_id = ? ORDER BY attempt;")
+			.all(runId)
+			.map(rowToAttempt);
+	}
+
+	/** Crash recovery: mark every open attempt interrupted (never resumed). */
+	interruptOpenAttempts(endedAt: number): readonly RunAttemptRecord[] {
+		const open = this.database.db
+			.prepare(
+				"SELECT * FROM run_attempts WHERE state = 'running' ORDER BY attempt_id;",
+			)
+			.all()
+			.map(rowToAttempt);
+		for (const attempt of open) {
+			this.settle(attempt.runId, attempt.attempt, "interrupted", endedAt, {
+				name: "GatewayRestart",
+				message: "Attempt abandoned by a Gateway restart; not auto-resumed",
+			});
+		}
+		return open;
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Durable idempotency ledger
+// -----------------------------------------------------------------------------
+
+export class SqliteIdempotencyLedger {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	begin(
+		key: IdempotencyKey,
+		method: string,
+		params: unknown,
+	): IdempotencyBeginOutcome {
+		const fingerprint = stableStringify(params ?? null);
+		const existing = this.database.db
+			.prepare("SELECT * FROM idempotency WHERE key = ?;")
+			.get(key);
+		if (!existing) {
+			this.database.db
+				.prepare(
+					"INSERT INTO idempotency (key, method, params_fingerprint, created_at) VALUES (?, ?, ?, ?);",
+				)
+				.run(key, method, fingerprint, Date.now());
+			return { kind: "new" };
+		}
+		if (
+			String(existing.method) !== method ||
+			String(existing.params_fingerprint) !== fingerprint
+		) {
+			return {
+				kind: "conflict",
+				error: createGatewayError(
+					"idempotency_conflict",
+					`Idempotency key reused with a different ${
+						String(existing.method) !== method ? "method" : "params payload"
+					} (original: ${existing.method})`,
+					{ retryable: false },
+				),
+			};
+		}
+		if (existing.response_json === null) {
+			return { kind: "pending" };
+		}
+		return {
+			kind: "replay",
+			response: JSON.parse(String(existing.response_json)) as GatewayResponse,
+		};
+	}
+
+	record(key: IdempotencyKey, response: GatewayResponse): void {
+		const result = this.database.db
+			.prepare("UPDATE idempotency SET response_json = ? WHERE key = ?;")
+			.run(JSON.stringify(response), key);
+		if (!result.changes) {
+			throw new Error(
+				"SqliteIdempotencyLedger.record called for a key that never began",
+			);
+		}
+	}
+
+	/**
+	 * Release a key after a retryable failure so the client may retry the
+	 * same request with the same key (per the wire error contract).
+	 */
+	forget(key: IdempotencyKey): void {
+		this.database.db.prepare("DELETE FROM idempotency WHERE key = ?;").run(key);
+	}
+
+	get size(): number {
+		const row = this.database.db
+			.prepare("SELECT COUNT(*) AS n FROM idempotency;")
+			.get();
+		return Number(row?.n ?? 0);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Global durable event log
+// -----------------------------------------------------------------------------
+
+export type EventLogListener = (event: GatewayEvent) => void;
+
+export class EventLogStore {
+	private readonly database: GatewayDatabase;
+	private readonly listeners = new Set<EventLogListener>();
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	/**
+	 * Append a durable event and return it with its global sequence.
+	 * Listener notification is deferred to a microtask so it always runs
+	 * after the enclosing (synchronous) transaction has committed.
+	 */
+	append(
+		event: string,
+		scope: GatewayEventScope,
+		payload: Record<string, unknown> | undefined,
+		createdAt: number,
+	): GatewayEvent {
+		this.database.db
+			.prepare(
+				`INSERT INTO events (event, bot_id, session_id, run_id, payload_json, created_at)
+				VALUES (?, ?, ?, ?, ?, ?);`,
+			)
+			.run(
+				event,
+				scope.botId ?? null,
+				scope.sessionId ?? null,
+				scope.runId ?? null,
+				payload === undefined ? null : JSON.stringify(payload),
+				createdAt,
+			);
+		const row = this.database.db
+			.prepare("SELECT MAX(sequence) AS sequence FROM events;")
+			.get();
+		const stored = GatewayEventSchema.parse({
+			version: GATEWAY_PROTOCOL_VERSION,
+			sequence: Number(row?.sequence ?? 0),
+			event,
+			scope,
+			...(payload === undefined ? {} : { payload }),
+		});
+		queueMicrotask(() => {
+			for (const listener of this.listeners) {
+				listener(stored);
+			}
+		});
+		return stored;
+	}
+
+	/** Events after `sequence`, oldest first, filtered by scope. */
+	listAfter(
+		sequence: number,
+		scope: GatewayEventScope,
+		limit: number,
+	): GatewayEvent[] {
+		const clauses = ["sequence > ?"];
+		const params: unknown[] = [sequence];
+		if (scope.botId) {
+			clauses.push("bot_id = ?");
+			params.push(scope.botId);
+		}
+		if (scope.sessionId) {
+			clauses.push("session_id = ?");
+			params.push(scope.sessionId);
+		}
+		if (scope.runId) {
+			clauses.push("run_id = ?");
+			params.push(scope.runId);
+		}
+		params.push(limit);
+		return this.database.db
+			.prepare(
+				`SELECT * FROM events WHERE ${clauses.join(" AND ")} ORDER BY sequence LIMIT ?;`,
+			)
+			.all(...params)
+			.map((row) =>
+				GatewayEventSchema.parse({
+					version: GATEWAY_PROTOCOL_VERSION,
+					sequence: Number(row.sequence),
+					event: String(row.event),
+					scope: {
+						...(row.bot_id ? { botId: row.bot_id } : {}),
+						...(row.session_id ? { sessionId: row.session_id } : {}),
+						...(row.run_id ? { runId: row.run_id } : {}),
+					},
+					...(row.payload_json === null
+						? {}
+						: { payload: JSON.parse(String(row.payload_json)) }),
+				}),
+			);
+	}
+
+	lastSequence(): number {
+		const row = this.database.db
+			.prepare("SELECT MAX(sequence) AS sequence FROM events;")
+			.get();
+		return Number(row?.sequence ?? 0);
+	}
+
+	subscribe(listener: EventLogListener): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Canonical message history (messages contract: AgentMessage)
+// -----------------------------------------------------------------------------
+
+export interface StoredMessage {
+	readonly messageSeq: number;
+	readonly sessionId: SessionId;
+	readonly runId?: RunId;
+	readonly message: AgentMessage;
+}
+
+/**
+ * Global canonical message history. The stored payload is the existing
+ * `AgentMessage` messages contract from `@cline/shared`; this store is
+ * the storage adapter behind it.
+ */
+export class MessageHistoryStore {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	append(
+		sessionId: SessionId,
+		runId: RunId | undefined,
+		message: AgentMessage,
+	): void {
+		this.database.db
+			.prepare(
+				`INSERT INTO messages (session_id, run_id, message_id, role, message_json, created_at)
+				VALUES (?, ?, ?, ?, ?, ?);`,
+			)
+			.run(
+				sessionId,
+				runId ?? null,
+				message.id,
+				message.role,
+				JSON.stringify(message),
+				message.createdAt,
+			);
+	}
+
+	listBySession(sessionId: SessionId): readonly StoredMessage[] {
+		return this.database.db
+			.prepare(
+				"SELECT * FROM messages WHERE session_id = ? ORDER BY message_seq;",
+			)
+			.all(sessionId)
+			.map((row) => ({
+				messageSeq: Number(row.message_seq),
+				sessionId: String(row.session_id) as SessionId,
+				runId: row.run_id === null ? undefined : (String(row.run_id) as RunId),
+				message: JSON.parse(String(row.message_json)) as AgentMessage,
+			}));
+	}
+
+	countBySession(sessionId: SessionId): number {
+		const row = this.database.db
+			.prepare("SELECT COUNT(*) AS n FROM messages WHERE session_id = ?;")
+			.get(sessionId);
+		return Number(row?.n ?? 0);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Outbox (DB-authoritative file projections)
+// -----------------------------------------------------------------------------
+
+export interface OutboxEntry {
+	readonly outboxId: number;
+	readonly kind: string;
+	readonly payload: Record<string, unknown>;
+	readonly state: "pending" | "done";
+	readonly attempts: number;
+	readonly lastError?: string;
+}
+
+function rowToOutboxEntry(row: Record<string, unknown>): OutboxEntry {
+	return {
+		outboxId: Number(row.outbox_id),
+		kind: String(row.kind),
+		payload: JSON.parse(String(row.payload_json)) as Record<string, unknown>,
+		state: String(row.state) as OutboxEntry["state"],
+		attempts: Number(row.attempts),
+		lastError: row.last_error === null ? undefined : String(row.last_error),
+	};
+}
+
+export class OutboxStore {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	/** Enqueue inside the same transaction as the state change it projects. */
+	enqueue(kind: string, payload: Record<string, unknown>, now: number): void {
+		this.database.db
+			.prepare(
+				"INSERT INTO outbox (kind, payload_json, created_at) VALUES (?, ?, ?);",
+			)
+			.run(kind, JSON.stringify(payload), now);
+	}
+
+	listPending(limit: number): readonly OutboxEntry[] {
+		return this.database.db
+			.prepare(
+				"SELECT * FROM outbox WHERE state = 'pending' ORDER BY outbox_id LIMIT ?;",
+			)
+			.all(limit)
+			.map(rowToOutboxEntry);
+	}
+
+	markDone(outboxId: number, now: number): void {
+		this.database.db
+			.prepare(
+				"UPDATE outbox SET state = 'done', done_at = ?, attempts = attempts + 1, last_error = NULL WHERE outbox_id = ?;",
+			)
+			.run(now, outboxId);
+	}
+
+	markFailed(outboxId: number, error: string): void {
+		this.database.db
+			.prepare(
+				"UPDATE outbox SET attempts = attempts + 1, last_error = ? WHERE outbox_id = ?;",
+			)
+			.run(error, outboxId);
+	}
+
+	countPending(): number {
+		const row = this.database.db
+			.prepare("SELECT COUNT(*) AS n FROM outbox WHERE state = 'pending';")
+			.get();
+		return Number(row?.n ?? 0);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Audit trail
+// -----------------------------------------------------------------------------
+
+export interface AuditEntry {
+	readonly auditId: number;
+	readonly at: number;
+	readonly actor: string;
+	readonly action: string;
+	readonly subject?: string;
+	readonly details?: Record<string, unknown>;
+}
+
+export class AuditLog {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	record(
+		actor: string,
+		action: string,
+		subject?: string,
+		details?: Record<string, unknown>,
+		at: number = Date.now(),
+	): void {
+		this.database.db
+			.prepare(
+				"INSERT INTO audit (at, actor, action, subject, details_json) VALUES (?, ?, ?, ?, ?);",
+			)
+			.run(
+				at,
+				actor,
+				action,
+				subject ?? null,
+				details === undefined ? null : JSON.stringify(details),
+			);
+	}
+
+	list(limit = 100): readonly AuditEntry[] {
+		return this.database.db
+			.prepare("SELECT * FROM audit ORDER BY audit_id DESC LIMIT ?;")
+			.all(limit)
+			.map((row) => ({
+				auditId: Number(row.audit_id),
+				at: Number(row.at),
+				actor: String(row.actor),
+				action: String(row.action),
+				subject: row.subject === null ? undefined : String(row.subject),
+				details:
+					row.details_json === null
+						? undefined
+						: (JSON.parse(String(row.details_json)) as Record<string, unknown>),
+			}));
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Client registry
+// -----------------------------------------------------------------------------
+
+export interface ClientRecord {
+	readonly clientId: ClientId;
+	readonly name: string;
+	readonly version: string;
+	readonly firstSeenAt: number;
+	readonly lastSeenAt: number;
+	readonly connections: number;
+}
+
+export class ClientRegistryStore {
+	private readonly database: GatewayDatabase;
+
+	constructor(database: GatewayDatabase) {
+		this.database = database;
+	}
+
+	registerHello(
+		clientId: ClientId,
+		name: string,
+		version: string,
+		now: number,
+	): ClientRecord {
+		this.database.db
+			.prepare(
+				`INSERT INTO clients (client_id, name, version, first_seen_at, last_seen_at, connections)
+				VALUES (?, ?, ?, ?, ?, 1)
+				ON CONFLICT(client_id) DO UPDATE SET
+					name = excluded.name,
+					version = excluded.version,
+					last_seen_at = excluded.last_seen_at,
+					connections = clients.connections + 1;`,
+			)
+			.run(clientId, name, version, now, now);
+		const record = this.get(clientId);
+		if (!record) {
+			throw new Error(`Client registry lost ${clientId} during registration`);
+		}
+		return record;
+	}
+
+	get(clientId: ClientId): ClientRecord | undefined {
+		const row = this.database.db
+			.prepare("SELECT * FROM clients WHERE client_id = ?;")
+			.get(clientId);
+		if (!row) {
+			return undefined;
+		}
+		return {
+			clientId: String(row.client_id) as ClientId,
+			name: String(row.name),
+			version: String(row.version),
+			firstSeenAt: Number(row.first_seen_at),
+			lastSeenAt: Number(row.last_seen_at),
+			connections: Number(row.connections),
+		};
+	}
+
+	count(): number {
+		const row = this.database.db
+			.prepare("SELECT COUNT(*) AS n FROM clients;")
+			.get();
+		return Number(row?.n ?? 0);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Bundle
+// -----------------------------------------------------------------------------
+
+export interface GatewayStores {
+	readonly meta: MetaStore;
+	readonly bots: SqliteBotRepository;
+	readonly sessions: SqliteSessionRepository;
+	readonly runs: SqliteRunRepository;
+	readonly attempts: RunAttemptStore;
+	readonly idempotency: SqliteIdempotencyLedger;
+	readonly events: EventLogStore;
+	readonly messages: MessageHistoryStore;
+	readonly outbox: OutboxStore;
+	readonly audit: AuditLog;
+	readonly clients: ClientRegistryStore;
+}
+
+export function createGatewayStores(
+	database: GatewayDatabase,
+	instanceId: string,
+): GatewayStores {
+	return {
+		meta: new MetaStore(database),
+		bots: new SqliteBotRepository(database),
+		sessions: new SqliteSessionRepository(database),
+		runs: new SqliteRunRepository(database, instanceId),
+		attempts: new RunAttemptStore(database, instanceId),
+		idempotency: new SqliteIdempotencyLedger(database),
+		events: new EventLogStore(database),
+		messages: new MessageHistoryStore(database),
+		outbox: new OutboxStore(database),
+		audit: new AuditLog(database),
+		clients: new ClientRegistryStore(database),
+	};
+}

--- a/sdk/packages/gateway/src/test-support.ts
+++ b/sdk/packages/gateway/src/test-support.ts
@@ -1,0 +1,161 @@
+/**
+ * Test doubles and helpers for Phase 3 tests. Not exported from the
+ * package; imported only by `*.test.ts` files.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	EngineInvocation,
+	EngineOutcome,
+	EnginePort,
+	EngineRunHandle,
+} from "@cline/bot";
+
+export function tempDataRoot(prefix = "cline-gateway-test-"): string {
+	return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export async function waitFor(
+	predicate: () => boolean | Promise<boolean>,
+	options: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+): Promise<void> {
+	const timeoutMs = options.timeoutMs ?? 5_000;
+	const intervalMs = options.intervalMs ?? 10;
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		if (await predicate()) {
+			return;
+		}
+		if (Date.now() > deadline) {
+			throw new Error(`waitFor timed out: ${options.label ?? "condition"}`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, intervalMs));
+	}
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+/**
+ * Scriptable engine handle: tests emit engine events and settle outcomes
+ * explicitly; interrupt/abort settle cooperatively by default so graceful
+ * paths terminate.
+ */
+export class ScriptedHandle implements EngineRunHandle {
+	readonly invocation: EngineInvocation;
+	readonly steers: string[] = [];
+	interrupted = false;
+	aborted = false;
+	settled = false;
+	private readonly deferred = createDeferred<EngineOutcome>();
+	private readonly listeners = new Set<(event: unknown) => void>();
+	settleOnStop = true;
+
+	constructor(invocation: EngineInvocation) {
+		this.invocation = invocation;
+	}
+
+	get result(): Promise<EngineOutcome> {
+		return this.deferred.promise;
+	}
+
+	steer(text: string): boolean {
+		this.steers.push(text);
+		return true;
+	}
+
+	interrupt(reason?: string): void {
+		this.interrupted = true;
+		if (this.settleOnStop) {
+			this.settle({
+				status: "interrupted",
+				error: reason ? { name: "Interrupted", message: reason } : undefined,
+			});
+		}
+	}
+
+	abort(reason?: string): void {
+		this.aborted = true;
+		if (this.settleOnStop) {
+			this.settle({
+				status: "aborted",
+				error: reason ? { name: "Aborted", message: reason } : undefined,
+			});
+		}
+	}
+
+	subscribe(listener: (event: unknown) => void): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	emit(event: unknown): void {
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+	}
+
+	settle(outcome: Partial<EngineOutcome> = {}): void {
+		if (this.settled) {
+			return;
+		}
+		this.settled = true;
+		this.deferred.resolve({
+			status: outcome.status ?? "completed",
+			outputText: outcome.outputText ?? "",
+			error: outcome.error,
+		});
+	}
+}
+
+/** Scriptable engine port that records every started run. */
+export class ScriptedEnginePort implements EnginePort {
+	readonly handles: ScriptedHandle[] = [];
+	/** When set, each run settles on a microtask with this outcome. */
+	autoOutcome?: (
+		invocation: EngineInvocation,
+		attemptIndex: number,
+	) => Partial<EngineOutcome> | undefined;
+	onStart?: (handle: ScriptedHandle) => void;
+
+	start(invocation: EngineInvocation): EngineRunHandle {
+		const handle = new ScriptedHandle(invocation);
+		const attemptIndex = this.handles.filter(
+			(existing) => existing.invocation.runId === invocation.runId,
+		).length;
+		this.handles.push(handle);
+		this.onStart?.(handle);
+		const auto = this.autoOutcome;
+		if (auto) {
+			queueMicrotask(() => {
+				const outcome = auto(invocation, attemptIndex);
+				if (outcome) {
+					handle.settle(outcome);
+				}
+			});
+		}
+		return handle;
+	}
+
+	get lastHandle(): ScriptedHandle | undefined {
+		return this.handles.at(-1);
+	}
+
+	handlesFor(runId: string): ScriptedHandle[] {
+		return this.handles.filter((handle) => handle.invocation.runId === runId);
+	}
+}

--- a/sdk/packages/gateway/src/usage.test.ts
+++ b/sdk/packages/gateway/src/usage.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Usage/statistics pipeline: WAL mode, one transaction for event +
+ * aggregates, estimate flagging and price snapshots, recalculation
+ * without mutating original events, streaks, and bounded aggregate-only
+ * queries (summaries never rescan history tables).
+ */
+
+import { join } from "node:path";
+import {
+	createBotId,
+	createRunId,
+	createSessionId,
+} from "@cline/shared/gateway";
+import { describe, expect, it } from "vitest";
+import { openGatewayDatabase } from "./db";
+import { tempDataRoot } from "./test-support";
+import {
+	MAX_STATISTICS_RANGE_DAYS,
+	type NormalizedModelCall,
+	type PriceResolver,
+	UsageQueryError,
+	UsageStore,
+	utcDateOf,
+} from "./usage";
+
+const DAY_MS = 86_400_000;
+const T0 = Date.parse("2026-08-10T12:00:00.000Z");
+
+function openUsage(options: { prices?: PriceResolver; nowMs?: number } = {}) {
+	const database = openGatewayDatabase(join(tempDataRoot(), "gateway.db"));
+	const usage = new UsageStore(database, {
+		prices: options.prices,
+		now: () => options.nowMs ?? T0,
+	});
+	return { database, usage };
+}
+
+function call(
+	overrides: Partial<NormalizedModelCall> = {},
+): NormalizedModelCall {
+	return {
+		occurredAt: T0,
+		botId: createBotId(),
+		sessionId: createSessionId(),
+		runId: createRunId(),
+		providerId: "anthropic",
+		modelId: "claude-x",
+		inputTokens: 100,
+		outputTokens: 40,
+		status: "ok",
+		...overrides,
+	};
+}
+
+const FLAT_PRICES: PriceResolver = () => ({
+	inputPerMTokens: 10,
+	outputPerMTokens: 30,
+	currency: "USD",
+	source: "test-catalog-v1",
+});
+
+describe("storage mode", () => {
+	it("runs in WAL mode with the usage indexes in place", () => {
+		const { database } = openUsage();
+		const mode = database.db.prepare("PRAGMA journal_mode;").get();
+		expect(String(Object.values(mode ?? {})[0]).toLowerCase()).toBe("wal");
+		const indexes = database.db
+			.prepare(
+				"SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'usage_events';",
+			)
+			.all()
+			.map((row) => String(row.name));
+		expect(indexes).toEqual(
+			expect.arrayContaining([
+				"idx_usage_events_bot",
+				"idx_usage_events_model",
+				"idx_usage_events_topic",
+			]),
+		);
+	});
+});
+
+describe("write path", () => {
+	it("one model call writes one usage_event and bumps every aggregate", () => {
+		const { database, usage } = openUsage({ prices: FLAT_PRICES });
+		const botId = createBotId();
+		const sessionId = createSessionId();
+		database.transaction(() => {
+			usage.recordModelCall(
+				call({ botId, sessionId, inputTokens: 1000, outputTokens: 500 }),
+			);
+		});
+		const date = utcDateOf(T0);
+
+		const events = database.db.prepare("SELECT * FROM usage_events;").all();
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			bot_id: botId,
+			session_id: sessionId,
+			agent_id: botId, // documented mapping: agent := bot
+			topic_id: sessionId, // documented mapping: topic := session
+			input_tokens: 1000,
+			output_tokens: 500,
+			total_tokens: 1500,
+			status: "ok",
+		});
+
+		const daily = database.db.prepare("SELECT * FROM daily_usage;").all();
+		expect(daily).toHaveLength(1);
+		expect(daily[0]).toMatchObject({
+			date,
+			bot_id: botId,
+			tokens: 1500,
+			model_calls: 1,
+			active_sessions: 1,
+		});
+		expect(
+			database.db.prepare("SELECT * FROM model_usage;").all()[0],
+		).toMatchObject({
+			date,
+			model_id: "claude-x",
+			provider_id: "anthropic",
+			messages: 1,
+			tokens: 1500,
+		});
+		expect(
+			database.db.prepare("SELECT * FROM agent_usage;").all()[0],
+		).toMatchObject({ date, agent_id: botId, tokens: 1500 });
+		expect(
+			database.db.prepare("SELECT * FROM topic_usage;").all()[0],
+		).toMatchObject({ date, topic_id: sessionId, tokens: 1500 });
+		expect(
+			database.db.prepare("SELECT * FROM streak_usage;").all()[0],
+		).toMatchObject({ date, active: 1 });
+	});
+
+	it("the event and its aggregates commit or roll back together", () => {
+		const { database, usage } = openUsage({ prices: FLAT_PRICES });
+		expect(() =>
+			database.transaction(() => {
+				usage.recordModelCall(call({}));
+				throw new Error("crash between event and commit");
+			}),
+		).toThrow("crash between event and commit");
+		// Nothing partial survived: no event, no aggregate rows.
+		for (const table of [
+			"usage_events",
+			"daily_usage",
+			"model_usage",
+			"agent_usage",
+			"topic_usage",
+			"streak_usage",
+		]) {
+			expect(
+				database.db.prepare(`SELECT COUNT(*) AS n FROM ${table};`).get()?.n,
+			).toBe(0);
+		}
+	});
+
+	it("counts distinct sessions incrementally and messages by role", () => {
+		const { database, usage } = openUsage();
+		const botId = createBotId();
+		const sessionA = createSessionId();
+		const sessionB = createSessionId();
+		database.transaction(() => {
+			usage.recordMessage({
+				occurredAt: T0,
+				botId,
+				sessionId: sessionA,
+				role: "user",
+			});
+			usage.recordMessage({
+				occurredAt: T0,
+				botId,
+				sessionId: sessionA,
+				role: "assistant",
+			});
+			usage.recordMessage({
+				occurredAt: T0,
+				botId,
+				sessionId: sessionA,
+				role: "tool",
+			});
+			usage.recordMessage({
+				occurredAt: T0,
+				botId,
+				sessionId: sessionB,
+				role: "user",
+			});
+		});
+		const daily = database.db.prepare("SELECT * FROM daily_usage;").all()[0];
+		// tool messages are not user/assistant traffic.
+		expect(daily).toMatchObject({ messages: 3, active_sessions: 2 });
+	});
+});
+
+describe("token and spend accuracy", () => {
+	it("provider-reported cost is recorded verbatim and not flagged as estimate", () => {
+		const { database, usage } = openUsage({ prices: FLAT_PRICES });
+		const record = database.transaction(() =>
+			usage.recordModelCall(call({ providerCost: 0.1234 })),
+		);
+		expect(record.estimatedCost).toBe(0.1234);
+		expect(record.costIsEstimate).toBe(false);
+		const row = database.db.prepare("SELECT * FROM usage_events;").get();
+		expect(row).toMatchObject({ estimated_cost: 0.1234, cost_is_estimate: 0 });
+	});
+
+	it("resolver pricing produces a flagged estimate with the snapshot on the event", () => {
+		const { database, usage } = openUsage({ prices: FLAT_PRICES });
+		const record = database.transaction(() =>
+			usage.recordModelCall(
+				call({ inputTokens: 1_000_000, outputTokens: 100_000 }),
+			),
+		);
+		// 1M input @ $10/M + 0.1M output @ $30/M = $13.
+		expect(record.estimatedCost).toBeCloseTo(13, 10);
+		expect(record.costIsEstimate).toBe(true);
+		const row = database.db.prepare("SELECT * FROM usage_events;").get();
+		expect(row?.cost_is_estimate).toBe(1);
+		expect(JSON.parse(String(row?.price_snapshot_json))).toMatchObject({
+			source: "test-catalog-v1",
+			inputPerMTokens: 10,
+		});
+	});
+
+	it("missing pricing stores a NULL flagged estimate, never a fake number", () => {
+		const { database, usage } = openUsage();
+		const record = database.transaction(() => usage.recordModelCall(call({})));
+		expect(record.estimatedCost).toBeUndefined();
+		expect(record.costIsEstimate).toBe(true);
+		const row = database.db.prepare("SELECT * FROM usage_events;").get();
+		expect(row?.estimated_cost).toBeNull();
+		expect(row?.price_snapshot_json).toBeNull();
+	});
+
+	it("a price change recalculates aggregates without mutating the original event", () => {
+		const { database, usage } = openUsage({ prices: FLAT_PRICES });
+		database.transaction(() =>
+			usage.recordModelCall(call({ inputTokens: 1_000_000, outputTokens: 0 })),
+		);
+		const before = database.db.prepare("SELECT * FROM usage_events;").get();
+		expect(before?.estimated_cost).toBeCloseTo(10, 10);
+
+		const doubled: PriceResolver = () => ({
+			inputPerMTokens: 20,
+			outputPerMTokens: 60,
+			currency: "USD",
+			source: "test-catalog-v2",
+		});
+		const outcome = usage.recalculateEstimates(doubled, {
+			from: utcDateOf(T0),
+			to: utcDateOf(T0),
+		});
+		expect(outcome.updatedEvents).toBe(1);
+		expect(outcome.costDelta).toBeCloseTo(10, 10);
+
+		const after = database.db.prepare("SELECT * FROM usage_events;").get();
+		// Original fields untouched; recalculation lives beside them.
+		expect(after?.estimated_cost).toBeCloseTo(10, 10);
+		expect(JSON.parse(String(after?.price_snapshot_json)).source).toBe(
+			"test-catalog-v1",
+		);
+		expect(after?.recalculated_cost).toBeCloseTo(20, 10);
+		expect(JSON.parse(String(after?.recalculated_price_json)).source).toBe(
+			"test-catalog-v2",
+		);
+		// Aggregates moved by the delta.
+		expect(
+			database.db.prepare("SELECT estimated_cost FROM daily_usage;").get()
+				?.estimated_cost,
+		).toBeCloseTo(20, 10);
+		expect(
+			database.db.prepare("SELECT estimated_cost FROM model_usage;").get()
+				?.estimated_cost,
+		).toBeCloseTo(20, 10);
+
+		// Provider-reported costs are never re-priced.
+		database.transaction(() =>
+			usage.recordModelCall(call({ providerCost: 1 })),
+		);
+		const second = usage.recalculateEstimates(doubled, {
+			from: utcDateOf(T0),
+			to: utcDateOf(T0),
+		});
+		expect(second.updatedEvents).toBe(0);
+	});
+});
+
+describe("bounded statistics queries (aggregates only)", () => {
+	function seedWeek(
+		usage: UsageStore,
+		database: ReturnType<typeof openGatewayDatabase>,
+	) {
+		const botId = createBotId();
+		const sessionId = createSessionId();
+		database.transaction(() => {
+			for (let day = 0; day < 3; day += 1) {
+				usage.recordModelCall(
+					call({
+						botId,
+						sessionId,
+						occurredAt: T0 - day * DAY_MS,
+						inputTokens: 100 * (day + 1),
+						outputTokens: 10,
+						providerCost: day + 1,
+					}),
+				);
+				usage.recordMessage({
+					occurredAt: T0 - day * DAY_MS,
+					botId,
+					sessionId,
+					role: "assistant",
+				});
+			}
+			usage.recordRunDuration(botId, T0, 45_000);
+		});
+		return { botId, sessionId };
+	}
+
+	it("summary/activity/rankings/month derive everything from aggregates", () => {
+		const { database, usage } = openUsage();
+		seedWeek(usage, database);
+
+		// Prove there is no history rescan: wipe every raw history table the
+		// gateway keeps; only usage_* aggregates remain.
+		for (const table of [
+			"messages",
+			"events",
+			"runs",
+			"run_attempts",
+			"sessions",
+		]) {
+			database.db.exec(`DELETE FROM ${table};`);
+		}
+
+		const summary = usage.summary({
+			from: utcDateOf(T0 - 6 * DAY_MS),
+			to: utcDateOf(T0),
+		}) as {
+			totals: Record<string, number>;
+			agents: number;
+			topics: number;
+			activeModels: unknown[];
+			peakDailyTokens: number;
+			longestTaskMs: number;
+			streak: { current: number; longest: number };
+		};
+		expect(summary.totals.tokens).toBe(110 + 210 + 310);
+		expect(summary.totals.messages).toBe(3);
+		expect(summary.totals.modelCalls).toBe(3);
+		expect(summary.totals.estimatedCost).toBeCloseTo(6, 10);
+		expect(summary.agents).toBe(1);
+		expect(summary.topics).toBe(1);
+		expect(summary.activeModels).toEqual([
+			{ modelId: "claude-x", providerId: "anthropic" },
+		]);
+		expect(summary.peakDailyTokens).toBe(310);
+		expect(summary.longestTaskMs).toBe(45_000);
+		expect(summary.streak).toEqual({ current: 3, longest: 3 });
+
+		const activity = usage.activity({
+			from: utcDateOf(T0 - 6 * DAY_MS),
+			to: utcDateOf(T0),
+		}) as {
+			days: { date: string; tokens: number; activeSessions: number }[];
+		};
+		expect(activity.days).toHaveLength(3);
+		expect(activity.days.at(-1)).toMatchObject({
+			date: utcDateOf(T0),
+			tokens: 110,
+			activeSessions: 1,
+		});
+
+		const rankings = usage.rankings({
+			dimension: "model",
+			from: utcDateOf(T0 - 6 * DAY_MS),
+			to: utcDateOf(T0),
+		}) as { rows: { modelId: string; tokens: number }[] };
+		expect(rankings.rows[0]).toMatchObject({
+			modelId: "claude-x",
+			tokens: 630,
+		});
+
+		const month = usage.month("2026-08") as {
+			days: unknown[];
+			monthSpend: number;
+			todaySpend: number;
+		};
+		expect(month.days).toHaveLength(3);
+		expect(month.monthSpend).toBeCloseTo(6, 10);
+		expect(month.todaySpend).toBeCloseTo(1, 10); // "today" = T0's date
+	});
+
+	it("agent and topic rankings group their aggregate tables", () => {
+		const { database, usage } = openUsage();
+		const { botId, sessionId } = seedWeek(usage, database);
+		const agent = usage.rankings({
+			dimension: "agent",
+			from: utcDateOf(T0 - 6 * DAY_MS),
+			to: utcDateOf(T0),
+		}) as {
+			rows: { agentId: string; tokens: number; messages: number }[];
+		};
+		expect(agent.rows[0]).toMatchObject({
+			agentId: botId,
+			tokens: 630,
+			messages: 3,
+		});
+		const topic = usage.rankings({
+			dimension: "topic",
+			from: utcDateOf(T0 - 6 * DAY_MS),
+			to: utcDateOf(T0),
+		}) as {
+			rows: { topicId: string }[];
+		};
+		expect(topic.rows[0]).toMatchObject({ topicId: sessionId });
+	});
+
+	it("rejects malformed and unbounded ranges", () => {
+		const { usage } = openUsage();
+		expect(() => usage.summary({ from: "08/10/2026" })).toThrow(
+			UsageQueryError,
+		);
+		expect(() =>
+			usage.summary({ from: "2026-08-10", to: "2026-08-01" }),
+		).toThrow(UsageQueryError);
+		expect(() =>
+			usage.summary({
+				from: utcDateOf(T0 - (MAX_STATISTICS_RANGE_DAYS + 5) * DAY_MS),
+				to: utcDateOf(T0),
+			}),
+		).toThrow(UsageQueryError);
+		expect(() => usage.month("2026-8")).toThrow(UsageQueryError);
+		expect(() => usage.month("august")).toThrow(UsageQueryError);
+	});
+
+	it("streaks track consecutive active dates with a gap reset", () => {
+		const { database, usage } = openUsage();
+		database.transaction(() => {
+			for (const daysAgo of [0, 1, 2, 4, 5, 6, 7]) {
+				usage.recordMessage({
+					occurredAt: T0 - daysAgo * DAY_MS,
+					botId: createBotId(),
+					sessionId: createSessionId(),
+					role: "user",
+				});
+			}
+		});
+		const summary = usage.summary({}) as {
+			streak: { current: number; longest: number };
+		};
+		expect(summary.streak).toEqual({ current: 3, longest: 4 });
+	});
+});

--- a/sdk/packages/gateway/src/usage.ts
+++ b/sdk/packages/gateway/src/usage.ts
@@ -1,0 +1,677 @@
+/**
+ * Usage/statistics pipeline (Gateway RFC, Phase 3 write path; the Phase 7
+ * Statistics surface reads it).
+ *
+ * Data is collected at run/message completion time and folded into daily
+ * aggregates immediately — statistics queries NEVER rescan session
+ * message history:
+ *
+ *   engine model response -> `model-call-completed` (per-call deltas)
+ *     -> usage normalizer -> ONE SQLite transaction that appends the
+ *        immutable `usage_events` row and bumps `daily_usage`,
+ *        `model_usage`, `agent_usage`, `topic_usage`, `streak_usage`.
+ *
+ * Identity mapping (documented, no parallel agent system): `agent_id` IS
+ * the existing `botId` and `topic_id` IS the existing `sessionId`. Both
+ * are denormalized onto every usage event so a later phase can diverge
+ * the mapping without rewriting history.
+ *
+ * Cost accuracy: provider-reported token counts and costs are recorded
+ * verbatim (`costIsEstimate = false`). Otherwise a price snapshot from
+ * the injected resolver is captured ON THE EVENT and the cost is flagged
+ * as an estimate. Price changes recalculate into `recalculated_*`
+ * columns and adjust aggregates by the delta — the original event fields
+ * are never overwritten.
+ */
+
+import type {
+	BotId,
+	GatewayError,
+	RunId,
+	SessionId,
+} from "@cline/shared/gateway";
+import { createGatewayError } from "@cline/shared/gateway";
+import type { GatewayDatabase } from "./db";
+
+/** A statistics query failure that already knows its wire error. */
+export class UsageQueryError extends Error {
+	readonly gatewayError: GatewayError;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "UsageQueryError";
+		this.gatewayError = createGatewayError("invalid_request", message);
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Pricing
+// -----------------------------------------------------------------------------
+
+export interface PriceSnapshot {
+	/** USD per million input tokens. */
+	readonly inputPerMTokens: number;
+	/** USD per million output tokens. */
+	readonly outputPerMTokens: number;
+	readonly currency: "USD";
+	/** Where this price came from (catalog name/version, config, ...). */
+	readonly source: string;
+}
+
+export type PriceResolver = (
+	providerId: string | undefined,
+	modelId: string | undefined,
+) => PriceSnapshot | undefined;
+
+function computeCost(
+	price: PriceSnapshot,
+	inputTokens: number,
+	outputTokens: number,
+): number {
+	return (
+		(inputTokens * price.inputPerMTokens +
+			outputTokens * price.outputPerMTokens) /
+		1_000_000
+	);
+}
+
+// -----------------------------------------------------------------------------
+// Normalized records
+// -----------------------------------------------------------------------------
+
+/** One normalized usage record per model call (the write-path input). */
+export interface NormalizedModelCall {
+	readonly occurredAt: number;
+	readonly botId: BotId;
+	readonly sessionId: SessionId;
+	readonly runId: RunId;
+	readonly providerId?: string;
+	readonly modelId?: string;
+	readonly inputTokens: number;
+	readonly outputTokens: number;
+	/** Provider-reported cost for this call, when available. */
+	readonly providerCost?: number;
+	readonly durationMs?: number;
+	readonly status: "ok" | "error";
+}
+
+export interface UsageEventRecord {
+	readonly eventId: number;
+	readonly date: string;
+	readonly estimatedCost: number | undefined;
+	readonly costIsEstimate: boolean;
+	readonly priceSnapshot: PriceSnapshot | undefined;
+}
+
+/** Epoch ms -> UTC calendar date (aggregate key). */
+export function utcDateOf(epochMs: number): string {
+	return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_PATTERN = /^\d{4}-\d{2}$/;
+/** Hard bound on any statistics query range. */
+export const MAX_STATISTICS_RANGE_DAYS = 400;
+const DEFAULT_RANGE_DAYS = 30;
+const UNKNOWN = "unknown";
+
+function addDays(date: string, days: number): string {
+	const ms = Date.parse(`${date}T00:00:00.000Z`) + days * 86_400_000;
+	return utcDateOf(ms);
+}
+
+function daySpan(from: string, to: string): number {
+	return (
+		(Date.parse(`${to}T00:00:00.000Z`) - Date.parse(`${from}T00:00:00.000Z`)) /
+			86_400_000 +
+		1
+	);
+}
+
+export interface StatisticsRange {
+	readonly from: string;
+	readonly to: string;
+}
+
+// -----------------------------------------------------------------------------
+// Store
+// -----------------------------------------------------------------------------
+
+export interface UsageStoreOptions {
+	/** Price snapshots for providers that do not report costs. */
+	prices?: PriceResolver;
+	/** "Today" source for range defaults (injected for tests). */
+	now?: () => number;
+}
+
+export class UsageStore {
+	private readonly database: GatewayDatabase;
+	private readonly prices: PriceResolver | undefined;
+	private readonly now: () => number;
+
+	constructor(database: GatewayDatabase, options: UsageStoreOptions = {}) {
+		this.database = database;
+		this.prices = options.prices;
+		this.now = options.now ?? (() => Date.now());
+	}
+
+	// -------------------------------------------------------------------
+	// Write path (call inside the enclosing gateway transaction)
+	// -------------------------------------------------------------------
+
+	/**
+	 * Append one immutable usage event and bump every aggregate. The
+	 * caller wraps this in the same transaction as the triggering state
+	 * change, so the event and its aggregates commit atomically.
+	 */
+	recordModelCall(call: NormalizedModelCall): UsageEventRecord {
+		const date = utcDateOf(call.occurredAt);
+		const totalTokens = call.inputTokens + call.outputTokens;
+
+		let estimatedCost: number | undefined;
+		let costIsEstimate = true;
+		let priceSnapshot: PriceSnapshot | undefined;
+		if (call.providerCost !== undefined) {
+			estimatedCost = call.providerCost;
+			costIsEstimate = false;
+		} else {
+			priceSnapshot = this.prices?.(call.providerId, call.modelId);
+			if (priceSnapshot) {
+				estimatedCost = computeCost(
+					priceSnapshot,
+					call.inputTokens,
+					call.outputTokens,
+				);
+			}
+		}
+
+		this.database.db
+			.prepare(
+				`INSERT INTO usage_events (
+					occurred_at, date, bot_id, session_id, run_id,
+					provider_id, model_id, agent_id, topic_id,
+					input_tokens, output_tokens, total_tokens,
+					estimated_cost, cost_is_estimate, price_snapshot_json,
+					duration_ms, status
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`,
+			)
+			.run(
+				call.occurredAt,
+				date,
+				call.botId,
+				call.sessionId,
+				call.runId,
+				call.providerId ?? null,
+				call.modelId ?? null,
+				// agent_id := botId, topic_id := sessionId (see module doc).
+				call.botId,
+				call.sessionId,
+				call.inputTokens,
+				call.outputTokens,
+				totalTokens,
+				estimatedCost ?? null,
+				costIsEstimate ? 1 : 0,
+				priceSnapshot ? JSON.stringify(priceSnapshot) : null,
+				call.durationMs ?? null,
+				call.status,
+			);
+		const eventRow = this.database.db
+			.prepare("SELECT MAX(event_id) AS id FROM usage_events;")
+			.get();
+
+		const cost = estimatedCost ?? 0;
+		this.database.db
+			.prepare(
+				`INSERT INTO daily_usage (
+					date, bot_id, tokens, input_tokens, output_tokens,
+					messages, model_calls, estimated_cost
+				) VALUES (?, ?, ?, ?, ?, 0, 1, ?)
+				ON CONFLICT(date, bot_id) DO UPDATE SET
+					tokens = tokens + excluded.tokens,
+					input_tokens = input_tokens + excluded.input_tokens,
+					output_tokens = output_tokens + excluded.output_tokens,
+					model_calls = model_calls + 1,
+					estimated_cost = estimated_cost + excluded.estimated_cost;`,
+			)
+			.run(
+				date,
+				call.botId,
+				totalTokens,
+				call.inputTokens,
+				call.outputTokens,
+				cost,
+			);
+		this.database.db
+			.prepare(
+				`INSERT INTO model_usage (date, model_id, provider_id, messages, tokens, estimated_cost)
+				VALUES (?, ?, ?, 1, ?, ?)
+				ON CONFLICT(date, model_id, provider_id) DO UPDATE SET
+					messages = messages + 1,
+					tokens = tokens + excluded.tokens,
+					estimated_cost = estimated_cost + excluded.estimated_cost;`,
+			)
+			.run(
+				date,
+				call.modelId ?? UNKNOWN,
+				call.providerId ?? UNKNOWN,
+				totalTokens,
+				cost,
+			);
+		this.database.db
+			.prepare(
+				`INSERT INTO agent_usage (date, agent_id, messages, tokens)
+				VALUES (?, ?, 0, ?)
+				ON CONFLICT(date, agent_id) DO UPDATE SET
+					tokens = tokens + excluded.tokens;`,
+			)
+			.run(date, call.botId, totalTokens);
+		this.database.db
+			.prepare(
+				`INSERT INTO topic_usage (date, topic_id, messages, tokens)
+				VALUES (?, ?, 0, ?)
+				ON CONFLICT(date, topic_id) DO UPDATE SET
+					tokens = tokens + excluded.tokens;`,
+			)
+			.run(date, call.sessionId, totalTokens);
+		this.markActive(date, call.botId, call.sessionId);
+
+		return {
+			eventId: Number(eventRow?.id ?? 0),
+			date,
+			estimatedCost,
+			costIsEstimate,
+			priceSnapshot,
+		};
+	}
+
+	/** Count one canonical user/assistant message into the aggregates. */
+	recordMessage(entry: {
+		occurredAt: number;
+		botId: BotId;
+		sessionId: SessionId;
+		role: string;
+	}): void {
+		if (entry.role !== "user" && entry.role !== "assistant") {
+			return;
+		}
+		const date = utcDateOf(entry.occurredAt);
+		this.database.db
+			.prepare(
+				`INSERT INTO daily_usage (date, bot_id, messages)
+				VALUES (?, ?, 1)
+				ON CONFLICT(date, bot_id) DO UPDATE SET messages = messages + 1;`,
+			)
+			.run(date, entry.botId);
+		this.database.db
+			.prepare(
+				`INSERT INTO agent_usage (date, agent_id, messages, tokens)
+				VALUES (?, ?, 1, 0)
+				ON CONFLICT(date, agent_id) DO UPDATE SET messages = messages + 1;`,
+			)
+			.run(date, entry.botId);
+		this.database.db
+			.prepare(
+				`INSERT INTO topic_usage (date, topic_id, messages, tokens)
+				VALUES (?, ?, 1, 0)
+				ON CONFLICT(date, topic_id) DO UPDATE SET messages = messages + 1;`,
+			)
+			.run(date, entry.sessionId);
+		this.markActive(date, entry.botId, entry.sessionId);
+	}
+
+	/** Track the longest run per day (Statistics "Longest Task"). */
+	recordRunDuration(
+		botId: BotId,
+		occurredAt: number,
+		durationMs: number,
+	): void {
+		const date = utcDateOf(occurredAt);
+		this.database.db
+			.prepare(
+				`INSERT INTO daily_usage (date, bot_id, max_run_duration_ms)
+				VALUES (?, ?, ?)
+				ON CONFLICT(date, bot_id) DO UPDATE SET
+					max_run_duration_ms = MAX(max_run_duration_ms, excluded.max_run_duration_ms);`,
+			)
+			.run(date, botId, Math.max(0, durationMs));
+	}
+
+	/**
+	 * Re-price estimated events after a pricing change. Immutable event
+	 * fields (`estimated_cost`, `price_snapshot_json`) are never touched:
+	 * new values land in `recalculated_*` and aggregates shift by the
+	 * delta. Provider-reported costs are authoritative and are skipped.
+	 */
+	recalculateEstimates(
+		prices: PriceResolver,
+		range?: Partial<StatisticsRange>,
+	): { updatedEvents: number; costDelta: number } {
+		const { from, to } = this.clampRange(range ?? {});
+		return this.database.transaction(() => {
+			const rows = this.database.db
+				.prepare(
+					`SELECT event_id, date, bot_id, provider_id, model_id,
+						input_tokens, output_tokens, estimated_cost, recalculated_cost
+					FROM usage_events
+					WHERE cost_is_estimate = 1 AND date >= ? AND date <= ?
+					ORDER BY event_id;`,
+				)
+				.all(from, to);
+			let updatedEvents = 0;
+			let costDelta = 0;
+			for (const row of rows) {
+				const providerId =
+					row.provider_id === null ? undefined : String(row.provider_id);
+				const modelId =
+					row.model_id === null ? undefined : String(row.model_id);
+				const price = prices(providerId, modelId);
+				if (!price) {
+					continue;
+				}
+				const newCost = computeCost(
+					price,
+					Number(row.input_tokens),
+					Number(row.output_tokens),
+				);
+				const previousEffective = Number(
+					row.recalculated_cost ?? row.estimated_cost ?? 0,
+				);
+				const delta = newCost - previousEffective;
+				if (Math.abs(delta) < 1e-12) {
+					continue;
+				}
+				this.database.db
+					.prepare(
+						`UPDATE usage_events
+						SET recalculated_cost = ?, recalculated_price_json = ?
+						WHERE event_id = ?;`,
+					)
+					.run(newCost, JSON.stringify(price), Number(row.event_id));
+				this.database.db
+					.prepare(
+						"UPDATE daily_usage SET estimated_cost = estimated_cost + ? WHERE date = ? AND bot_id = ?;",
+					)
+					.run(delta, String(row.date), String(row.bot_id));
+				this.database.db
+					.prepare(
+						"UPDATE model_usage SET estimated_cost = estimated_cost + ? WHERE date = ? AND model_id = ? AND provider_id = ?;",
+					)
+					.run(
+						delta,
+						String(row.date),
+						modelId ?? UNKNOWN,
+						providerId ?? UNKNOWN,
+					);
+				updatedEvents += 1;
+				costDelta += delta;
+			}
+			return { updatedEvents, costDelta };
+		});
+	}
+
+	// -------------------------------------------------------------------
+	// Bounded read surface (aggregates only; no history rescans)
+	// -------------------------------------------------------------------
+
+	/** Validate and bound a query range; defaults to the last 30 days. */
+	clampRange(range: Partial<StatisticsRange>): StatisticsRange {
+		for (const [name, value] of [
+			["from", range.from],
+			["to", range.to],
+		] as const) {
+			if (value !== undefined && !DATE_PATTERN.test(value)) {
+				throw new UsageQueryError(
+					`Invalid "${name}" date: expected YYYY-MM-DD`,
+				);
+			}
+		}
+		const to = range.to ?? utcDateOf(this.now());
+		const from = range.from ?? addDays(to, -(DEFAULT_RANGE_DAYS - 1));
+		if (from > to) {
+			throw new UsageQueryError(`Range is inverted: ${from} > ${to}`);
+		}
+		if (daySpan(from, to) > MAX_STATISTICS_RANGE_DAYS) {
+			throw new UsageQueryError(
+				`Range exceeds ${MAX_STATISTICS_RANGE_DAYS} days; narrow the window`,
+			);
+		}
+		return { from, to };
+	}
+
+	summary(range: Partial<StatisticsRange> = {}): Record<string, unknown> {
+		const { from, to } = this.clampRange(range);
+		const totals = this.database.db
+			.prepare(
+				`SELECT
+					COALESCE(SUM(tokens), 0) AS tokens,
+					COALESCE(SUM(input_tokens), 0) AS input_tokens,
+					COALESCE(SUM(output_tokens), 0) AS output_tokens,
+					COALESCE(SUM(messages), 0) AS messages,
+					COALESCE(SUM(model_calls), 0) AS model_calls,
+					COALESCE(SUM(estimated_cost), 0) AS estimated_cost,
+					COALESCE(MAX(max_run_duration_ms), 0) AS longest_task_ms
+				FROM daily_usage WHERE date >= ? AND date <= ?;`,
+			)
+			.get(from, to);
+		const peak = this.database.db
+			.prepare(
+				`SELECT COALESCE(MAX(day_tokens), 0) AS peak FROM (
+					SELECT SUM(tokens) AS day_tokens FROM daily_usage
+					WHERE date >= ? AND date <= ? GROUP BY date
+				);`,
+			)
+			.get(from, to);
+		const agents = this.database.db
+			.prepare(
+				"SELECT COUNT(DISTINCT agent_id) AS n FROM agent_usage WHERE date >= ? AND date <= ?;",
+			)
+			.get(from, to);
+		const topics = this.database.db
+			.prepare(
+				"SELECT COUNT(DISTINCT topic_id) AS n FROM topic_usage WHERE date >= ? AND date <= ?;",
+			)
+			.get(from, to);
+		const activeModels = this.database.db
+			.prepare(
+				`SELECT DISTINCT model_id, provider_id FROM model_usage
+				WHERE date >= ? AND date <= ? ORDER BY model_id, provider_id;`,
+			)
+			.all(from, to)
+			.map((row) => ({
+				modelId: String(row.model_id),
+				providerId: String(row.provider_id),
+			}));
+		return {
+			from,
+			to,
+			totals: {
+				tokens: Number(totals?.tokens ?? 0),
+				inputTokens: Number(totals?.input_tokens ?? 0),
+				outputTokens: Number(totals?.output_tokens ?? 0),
+				messages: Number(totals?.messages ?? 0),
+				modelCalls: Number(totals?.model_calls ?? 0),
+				estimatedCost: Number(totals?.estimated_cost ?? 0),
+			},
+			agents: Number(agents?.n ?? 0),
+			topics: Number(topics?.n ?? 0),
+			activeModels,
+			peakDailyTokens: Number(peak?.peak ?? 0),
+			longestTaskMs: Number(totals?.longest_task_ms ?? 0),
+			streak: this.streaks(),
+		};
+	}
+
+	/** One row per active day — the heatmap source. */
+	activity(range: Partial<StatisticsRange> = {}): Record<string, unknown> {
+		const { from, to } = this.clampRange(range);
+		const days = this.database.db
+			.prepare(
+				`SELECT date,
+					SUM(tokens) AS tokens,
+					SUM(messages) AS messages,
+					SUM(model_calls) AS model_calls,
+					SUM(estimated_cost) AS estimated_cost,
+					SUM(active_sessions) AS active_sessions,
+					COUNT(*) AS active_agents,
+					MAX(max_run_duration_ms) AS max_run_duration_ms
+				FROM daily_usage
+				WHERE date >= ? AND date <= ?
+				GROUP BY date ORDER BY date;`,
+			)
+			.all(from, to)
+			.map((row) => ({
+				date: String(row.date),
+				tokens: Number(row.tokens),
+				messages: Number(row.messages),
+				modelCalls: Number(row.model_calls),
+				estimatedCost: Number(row.estimated_cost),
+				activeSessions: Number(row.active_sessions),
+				activeAgents: Number(row.active_agents),
+				maxRunDurationMs: Number(row.max_run_duration_ms),
+			}));
+		return { from, to, days };
+	}
+
+	rankings(params: {
+		dimension: "model" | "agent" | "topic";
+		from?: string;
+		to?: string;
+		limit?: number;
+	}): Record<string, unknown> {
+		const { from, to } = this.clampRange(params);
+		const limit = Math.max(1, Math.min(100, params.limit ?? 20));
+		let rows: Record<string, unknown>[];
+		switch (params.dimension) {
+			case "model":
+				rows = this.database.db
+					.prepare(
+						`SELECT model_id, provider_id,
+							SUM(messages) AS messages, SUM(tokens) AS tokens,
+							SUM(estimated_cost) AS estimated_cost
+						FROM model_usage WHERE date >= ? AND date <= ?
+						GROUP BY model_id, provider_id
+						ORDER BY tokens DESC, model_id LIMIT ?;`,
+					)
+					.all(from, to, limit)
+					.map((row) => ({
+						modelId: String(row.model_id),
+						providerId: String(row.provider_id),
+						messages: Number(row.messages),
+						tokens: Number(row.tokens),
+						estimatedCost: Number(row.estimated_cost),
+					}));
+				break;
+			case "agent":
+				rows = this.database.db
+					.prepare(
+						`SELECT agent_id, SUM(messages) AS messages, SUM(tokens) AS tokens
+						FROM agent_usage WHERE date >= ? AND date <= ?
+						GROUP BY agent_id ORDER BY tokens DESC, agent_id LIMIT ?;`,
+					)
+					.all(from, to, limit)
+					.map((row) => ({
+						agentId: String(row.agent_id),
+						messages: Number(row.messages),
+						tokens: Number(row.tokens),
+					}));
+				break;
+			case "topic":
+				rows = this.database.db
+					.prepare(
+						`SELECT topic_id, SUM(messages) AS messages, SUM(tokens) AS tokens
+						FROM topic_usage WHERE date >= ? AND date <= ?
+						GROUP BY topic_id ORDER BY tokens DESC, topic_id LIMIT ?;`,
+					)
+					.all(from, to, limit)
+					.map((row) => ({
+						topicId: String(row.topic_id),
+						messages: Number(row.messages),
+						tokens: Number(row.tokens),
+					}));
+				break;
+		}
+		return { from, to, dimension: params.dimension, rows };
+	}
+
+	/** Calendar-month view (spend-by-date, month totals). */
+	month(month: string): Record<string, unknown> {
+		if (!MONTH_PATTERN.test(month)) {
+			throw new UsageQueryError('Invalid "month": expected YYYY-MM');
+		}
+		const from = `${month}-01`;
+		const to = addDays(addDays(from, 32).slice(0, 8).concat("01"), -1);
+		const activity = this.activity({ from, to }) as {
+			days: { date: string; tokens: number; estimatedCost: number }[];
+		};
+		const today = utcDateOf(this.now());
+		const totals = {
+			tokens: 0,
+			estimatedCost: 0,
+		};
+		for (const day of activity.days) {
+			totals.tokens += day.tokens;
+			totals.estimatedCost += day.estimatedCost;
+		}
+		return {
+			month,
+			from,
+			to,
+			days: activity.days,
+			totals,
+			todaySpend:
+				activity.days.find((day) => day.date === today)?.estimatedCost ?? 0,
+			monthSpend: totals.estimatedCost,
+		};
+	}
+
+	// -------------------------------------------------------------------
+	// Internals
+	// -------------------------------------------------------------------
+
+	/** Mark the day active + count distinct sessions incrementally. */
+	private markActive(date: string, botId: BotId, sessionId: SessionId): void {
+		this.database.db
+			.prepare(
+				"INSERT OR IGNORE INTO streak_usage (date, active) VALUES (?, 1);",
+			)
+			.run(date);
+		const seen = this.database.db
+			.prepare(
+				"INSERT OR IGNORE INTO usage_seen_sessions (date, session_id, bot_id) VALUES (?, ?, ?);",
+			)
+			.run(date, sessionId, botId);
+		if (seen.changes) {
+			this.database.db
+				.prepare(
+					"UPDATE daily_usage SET active_sessions = active_sessions + 1 WHERE date = ? AND bot_id = ?;",
+				)
+				.run(date, botId);
+		}
+	}
+
+	/** Current/longest streak of consecutive active dates. */
+	private streaks(): { current: number; longest: number } {
+		const dates = this.database.db
+			.prepare("SELECT date FROM streak_usage WHERE active = 1 ORDER BY date;")
+			.all()
+			.map((row) => String(row.date));
+		let longest = 0;
+		let runLength = 0;
+		let previous: string | undefined;
+		for (const date of dates) {
+			runLength = previous && addDays(previous, 1) === date ? runLength + 1 : 1;
+			longest = Math.max(longest, runLength);
+			previous = date;
+		}
+		const active = new Set(dates);
+		const today = utcDateOf(this.now());
+		// The current streak may end today or (grace) yesterday.
+		let cursor = active.has(today) ? today : addDays(today, -1);
+		let current = 0;
+		while (active.has(cursor)) {
+			current += 1;
+			cursor = addDays(cursor, -1);
+		}
+		return { current, longest };
+	}
+}

--- a/sdk/packages/shared/src/gateway/contracts.test.ts
+++ b/sdk/packages/shared/src/gateway/contracts.test.ts
@@ -112,6 +112,25 @@ describe("handshake", () => {
 			).not.toThrow();
 		}
 	});
+
+	it("carries an optional per-instance auth secret (loopback auth)", () => {
+		const params = GatewayHelloParamsSchema.parse({
+			protocolVersions: [1],
+			client: { name: "cli", version: "1" },
+			auth: "a".repeat(32),
+		});
+		expect(params.auth).toBe("a".repeat(32));
+		// Short or non-URL-safe secrets are rejected at the schema.
+		for (const auth of ["short", "has spaces in it!", "x".repeat(300)]) {
+			expect(() =>
+				GatewayHelloParamsSchema.parse({
+					protocolVersions: [1],
+					client: { name: "cli", version: "1" },
+					auth,
+				}),
+			).toThrow();
+		}
+	});
 });
 
 describe("cursors", () => {

--- a/sdk/packages/shared/src/gateway/handshake.ts
+++ b/sdk/packages/shared/src/gateway/handshake.ts
@@ -41,6 +41,21 @@ export const KNOWN_GATEWAY_CAPABILITIES = [
 export type KnownGatewayCapability =
 	(typeof KNOWN_GATEWAY_CAPABILITIES)[number];
 
+/**
+ * Per-instance loopback secret. The serving Gateway generates it at
+ * startup and publishes it only through the mode-0600 discovery record;
+ * clients present it in `gateway.hello`. Additive in protocol v1: a
+ * Gateway that requires auth rejects a hello without it as
+ * `unauthorized`.
+ */
+export const GatewayAuthTokenSchema = z
+	.string()
+	.min(16)
+	.max(256)
+	.regex(/^[A-Za-z0-9_-]+$/, "Auth tokens are URL-safe strings");
+
+export type GatewayAuthToken = z.infer<typeof GatewayAuthTokenSchema>;
+
 export const GatewayHelloParamsSchema = z
 	.object({
 		/** Protocol versions the client can speak, in preference order. */
@@ -54,6 +69,8 @@ export const GatewayHelloParamsSchema = z
 			})
 			.strict(),
 		capabilities: z.array(GatewayCapabilitySchema).optional(),
+		/** Loopback auth: the per-instance secret from the discovery record. */
+		auth: GatewayAuthTokenSchema.optional(),
 	})
 	.strict();
 


### PR DESCRIPTION
### Related Issue

**Issue:** Gateway RFC — Phase 3 (stacked on #13372, the Phase 0–2 foundation)

### Description

**Phase 3 is done: `@cline/gateway` is now a real authority.** Phases 4–9 (plugins catalog, MCP pooling, Telegram/Slack connectors, desktop/CLI migration, remote/federation) are **out of scope** here; no hooks for them were needed beyond what Phase 3 itself uses. `@cline/core` and the existing Hub are untouched.

Built against the Phase 0–2 foundation on #13372 (wire contracts in `@cline/shared/gateway`, `@cline/engine`, `@cline/bot` with injected ports, the gateway protocol skeleton) — filling in the authority rather than rewriting anything.

**What lands in `@cline/gateway` (and only there — server/SQLite/lock/CLI live in this package):**

- **Singleton authority (ADR 0002):** OS-backed exclusive `gateway.lock` — a SQLite file held inside a never-committed `BEGIN EXCLUSIVE`, so the kernel releases it on process death; PID/heartbeat is never authority. Singleton scope is the canonical data directory + env namespace (`CLINE_GATEWAY_DATA_ROOT` / `CLINE_GATEWAY_NAMESPACE`), not a port. Failing to acquire = connect or diagnose, never replace, never another port.
- **SQLite authority + migrations:** bots, sessions, runs, run attempts, the global durable event log, canonical message history behind the existing `AgentMessage` messages contract, a durable idempotency ledger (revisions/idempotency contracts from Phase 0), an outbox, an audit trail, and a client registry. Durable `gatewayId`, per-process `instanceId`.
- **Readiness-gated discovery:** exclusive loopback bind (ephemeral port by default), then an atomic mode-0600 `gateway.json` carrying the endpoint and per-instance secret. Loopback auth: the secret rides in `gateway.hello` (small additive optional field in the shared handshake contract).
- **Async runtime:** `run.start` acks immediately with `{runId, acceptedAt, queuePosition}`; durable FIFO queue per session; recorded run attempts with capped retry; steer merges into the active run; approvals as server-initiated requests that survive disconnects and re-issue on resubscribe; **disconnect never implies abort**; adaptive admission backpressure (retryable rejection when a session queue is full); bounded, cursor-paged event delivery straight from the durable log (client projections never grow unbounded; replay resumes from any cursor).
- **Manual crash recovery:** abandoned attempts are interrupted, never auto-resumed; committed queued runs (acknowledged, never attempted) re-admit FIFO. Documented in new ADR 0004.
- **Outbox file projections:** DB is authoritative; `projections/sessions/<id>.json` is rewritten idempotently by an outbox worker that retries failures, including across crashes between commit and file write.
- **Lifecycle CLI:** `serve` / `start` / `status` / `drain` / `upgrade` / `stop` (`bin/cline-gateway.mjs`). A second `serve` exits 3 with a diagnosis of the live authority. Clients never retire the authority — these are operator commands over the authenticated wire.
- **Default lead bot `cline`** bootstrapped at startup; managed session workspaces under `bots/<botId>/workspaces/<sessionId>`; memories from `bots/<botId>/memories/`.

Tiny supporting changes outside the gateway package:
- `@cline/shared`: optional `auth` field on `GatewayHelloParamsSchema` (loopback auth).
- `@cline/bot`: `Bot.recoverQueuedRun` — re-admission hook for committed queued runs after restart.

### Test Procedure

All Phase 3 exit tests are in `sdk/packages/gateway/src/*.test.ts` (74 gateway tests, 12 files) and pass alongside the untouched Phase 0–2 suites:

- **Concurrent starters** (`cli.test.ts`, real spawned processes): two `serve` race one data dir; exactly one wins the OS lock, the loser exits 3 with a diagnosis, never kills the winner, never binds a port; `start` is idempotent; `stop` retires the instance and removes discovery.
- **Client loss** (`server.test.ts`): socket destroyed mid-run → engine sees no abort/interrupt, run completes; a new client resumes from the last-seen event cursor and replays exactly the missed suffix.
- **Gateway restart recovery** (`restart-recovery.test.ts`): crash-mode stop → new instance interrupts the abandoned attempt (not auto-resumed), re-admits and executes the committed queued run, keeps completed output, keeps `gatewayId`, rotates `instanceId`/secret, replays the pre-crash idempotent `run.start` ack; stale discovery is diagnosed as unreachable.
- **Two-client consistency / FIFO** (`server.test.ts`): two clients on one session get queuePositions 0/1, runs execute in order, and both observe the identical canonical event stream (same sequences).
- **Projection crash points** (`projection.test.ts`): flaky projector retries until convergence; a projector that never runs before a crash is repaired from the surviving outbox on restart — DB authoritative throughout.
- **Boundaries stay green:** `boundaries.test.ts` in engine/bot/gateway unchanged and passing — no new package depends on `@cline/core`, engine imports no bot/gateway, bot imports no gateway implementations.

Verification run on this branch: `bun -F @cline/{shared,engine,bot,gateway} test` → 399 + 18 + 37 + 74 passing; `typecheck` clean for all four packages; `bun biome check` clean on touched paths.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend-only change; see the test procedure above for evidence (process-level lock contention, wire-level replay, and crash-recovery suites).

### Additional Notes

Stacked on #13372 — merge that first (this PR's base is `cloud/gateway-rfc-foundation-6f07`; retarget to `main` once the foundation lands). Phase 3 done; Phases 4–9 intentionally not started.