### PR TITLE
fix(llms): stop sending an explicit thinking disable to Claude Fable

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
@@ -47,6 +47,32 @@ describe("resolvePortableReasoning", () => {
 		).toBe("none");
 	});
 
+	it("never sends an explicit disable for models whose thinking is mandatory", () => {
+		expect(
+			resolvePortableReasoning({
+				...request({ enabled: false }),
+				modelId: "claude-fable-5",
+			}),
+		).toBeUndefined();
+	});
+
+	it("leaves a mandatory-thinking disable for the model-aware normalizer", () => {
+		const normalized = withoutPortableReasoning({
+			...request({ enabled: false }),
+			modelId: "claude-fable-5",
+		});
+		expect(normalized.reasoning).toEqual({ enabled: false });
+	});
+
+	it("omits stream reasoning for a mandatory-thinking disable", () => {
+		expect(
+			buildAiSdkStreamConfig(
+				{ ...request({ enabled: false }), modelId: "claude-fable-5" },
+				undefined as never,
+			),
+		).not.toHaveProperty("reasoning");
+	});
+
 	it("removes conflicting controls from native disable requests", () => {
 		const normalized = withoutPortableReasoning({
 			...request({ enabled: false, effort: "high", budgetTokens: 12_000 }),

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -1,5 +1,6 @@
 import type { GatewayStreamRequest } from "@cline/shared";
 import type { CallSettings } from "ai";
+import { isClaudeFableModelId } from "../model-facts";
 
 export type AiSdkReasoning = NonNullable<CallSettings["reasoning"]>;
 
@@ -36,6 +37,12 @@ export function resolvePortableReasoning(
 	}
 	const fullySupported = PORTABLE_REASONING_PROVIDERS.has(request.providerId);
 	if (reasoning.enabled === false) {
+		// Fable reasoning is mandatory and the backend rejects an explicit
+		// disable, so leave the intent on the request for the model-aware
+		// normalizer instead of putting "none" on the wire.
+		if (isClaudeFableModelId(request.modelId)) {
+			return undefined;
+		}
 		return fullySupported ? "none" : undefined;
 	}
 	if (typeof reasoning.budgetTokens === "number") {


### PR DESCRIPTION
### Related Issue
Fixes #13203

### Description
Selecting **Adaptive Thinking: None** on a direct-Anthropic `claude-fable-5` model fails every request with `"thinking.type.disabled" is not supported for this model.` Fable's thinking is mandatory and the API rejects an explicit disable.

 ## The problem
Two reasoning paths disagree, and only one of them can see the model.

`resolvePortableReasoning` (`routing/portable-reasoning.ts`) takes only the request, so it never reads `modelId`. `"anthropic"` is in `PORTABLE_REASONING_PROVIDERS`, so `{ enabled: false }` resolves to a top-level `reasoning: "none"`, which AI SDK 7 hands to `@ai-sdk/anthropic` as `thinking: { type: "disabled" }`.

The model-aware normalizer already knows better. `normalizeReasoningRequest` (`routing/reasoning-options.ts`) drops the disable when `controls.supportsOff` is false, and Fable advertises effort values only, no toggle and no `"none"`. But `withoutPortableReasoning` strips `reasoning` off the request before it gets there, so the normalizer never sees it.

The repo already states this fact. `reasoning-options.ts` carries the comment "Fable reasoning is mandatory and the backend rejects an explicit disable" and drops the disable, but only behind `isClineProvider(request.providerId)`. The direct-Anthropic path never reaches that guard, which is why this reproduces on `provider=Anthropic` and not when routing through Cline.

Introduced in #12946.

## The fix
Guard the disable branch on the existing `isClaudeFableModelId` helper and return `undefined`.

Returning `undefined` is doing real work here, not just avoiding the crash: `withoutPortableReasoning` strips `reasoning` only when `resolvePortableReasoning` is truthy, so `undefined` leaves `{ enabled: false }` on the request and lets `normalizeReasoningRequest` drop it the way it already does for the Cline-routed path. The result is no thinking field from either route, and the model keeps its mandatory default.

Because the guard keys on `modelId` rather than provider, it also covers Fable served through `bedrock` and `vertex`, which are both in `PORTABLE_REASONING_PROVIDERS`.

## What did not change
- Every non-Fable model is untouched. `claude-sonnet-5` still emits `thinking: { type: "disabled" }`, and the existing `claude-sonnet-4-6` disable rows still resolve to `"none"`.
- The guard is inside the `enabled === false` branch, so effort, budget and enable requests cannot reach it.
- `buildAnthropicProviderOptions` already ignores an explicit disable (it only emits `thinking` for a numeric budget), so nothing new is emitted into `providerOptions`.
- No behaviour change for Gemini, Ollama or any openai-compatible provider.

## Alternatives considered
**Thread `GatewayProviderContext` into `resolvePortableReasoning` and gate on `getModelReasoningControls().supportsOff`.** This is the more general fix and it would cover any model whose catalog entry lacks an off control, not just Fable. I deliberately did not take it: it is 60 to 80 lines across three files and it changes behaviour for Gemini too, which felt like a call for you to make rather than me. I'm to switch if you would prefer that shape.

**Extracting a shared predicate** so the Fable rule lives in one place instead of both `reasoning-options.ts` and `portable-reasoning.ts`. Skipped to keep the diff to the two files the bug actually touches, but glad to do it if you want it consolidated.

### Test Procedure
Three cases added to the existing `ai-sdk-reasoning.test.ts`, one per seam. Nothing existing was edited.

All three fail on `main` and pass with this change. Before the fix the third reports `expected { temperature: undefined, ...(1) } to not have property "reasoning"` / `Received: "none"`, which is the exact value that becomes `thinking: { type: "disabled" }` on the wire.

```
bun install
bun run build:sdk
bun -F @cline/llms test src/providers/ai-sdk-reasoning.test.ts
```

- On `main`: `Tests  3 failed | 14 passed (17)`
- With this change: `Tests  17 passed (17)`

Full package suite, to confirm nothing regressed:

```
bun -F @cline/llms test
```

- `Test Files  42 passed | 4 skipped (46)`, `Tests  735 passed | 4 skipped (739)`

Gate:

```
bun run types    # clean
bun run lint     # exit 0
```

`bun run check` exits 1 on this branch, but it does so identically on a pristine `main` checkout (same 11 errors, all in `apps/cli`, `sdk/packages/core` and `sdk/packages/ui/stories`). `bunx biome check` scoped to the two files in this PR exits 0.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Screenshots

No visual change is intended.

### Additional Notes

There is a coverage gap worth naming: the provider-options matrix covers `cline` + Fable + disable in two cases, but has no `anthropic` + Fable + disable case. That gap is why this shipped, and the first test closes it.