### PR TITLE
fix(core): strip ANSI escapes from run_commands tool results

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -863,6 +863,100 @@ describe("default run_commands tool", () => {
 		]);
 	});
 
+	it("strips ANSI escape sequences from command results", async () => {
+		const execute = vi.fn(async () => "\u001b[31;1mRED\u001b[0m OK");
+		const tool = createShellTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["echo"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "echo",
+				result: "RED OK",
+				success: true,
+			},
+		]);
+	});
+
+	it("strips ANSI escape sequences from non-zero exit results", async () => {
+		const execute = vi.fn(async () => {
+			throw new CommandExitError(
+				1,
+				"[Command exited with code 1]\n\u001b[31mboom\u001b[0m",
+			);
+		});
+		const tool = createShellTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["bun test"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+			},
+		);
+
+		expect(result).toEqual([
+			{
+				query: "bun test",
+				result: "[Command exited with code 1]\nboom",
+				error: "Command exited with code 1",
+				success: false,
+			},
+		]);
+	});
+
+	it("keeps streamed chunks ANSI-bearing while stripping the result", async () => {
+		const updates: unknown[] = [];
+		const execute = vi.fn(
+			async (
+				_command: string | { command: string; args?: string[] },
+				_cwd: string,
+				context: AgentToolContext,
+			) => {
+				context.emitUpdate?.({
+					stream: "stdout",
+					chunk: "\u001b[31mred\u001b[0m",
+				});
+				return "\u001b[31mred\u001b[0m";
+			},
+		);
+		const tool = createShellTool(execute);
+
+		const result = await tool.execute(
+			{ commands: ["npm run build"] },
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 1,
+				emitUpdate: (update) => updates.push(update),
+			},
+		);
+
+		expect(updates).toEqual([
+			{
+				stream: "stdout",
+				chunk: "\u001b[31mred\u001b[0m",
+				commandIndex: 0,
+				query: "npm run build",
+			},
+		]);
+		expect(result).toEqual([
+			{
+				query: "npm run build",
+				result: "red",
+				success: true,
+			},
+		]);
+	});
+
 	it("coalesces split heredoc command arrays before execution", async () => {
 		const execute = vi.fn(
 			async (command: string | { command: string }) =>

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -31,6 +31,7 @@ import {
 	getEditorSizeError,
 	getReadFileRangeError,
 	normalizeRunCommandsInput,
+	stripAnsi,
 	TimeoutError,
 	withTimeout,
 } from "./helpers";
@@ -220,7 +221,7 @@ async function executeShellCommands(
 					);
 					return {
 						query,
-						result: output,
+						result: stripAnsi(output),
 						success: true,
 					};
 				} catch (error) {
@@ -235,7 +236,7 @@ async function executeShellCommands(
 					if (error instanceof CommandExitError) {
 						return {
 							query,
-							result: error.output,
+							result: stripAnsi(error.output),
 							error: error.message,
 							success: false,
 						};

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -17,6 +17,19 @@ export function formatError(error: unknown): string {
 	return String(error);
 }
 
+const ANSI_ST = "(?:\\u0007|\\u001B\\u005C|\\u009C)";
+const ANSI_REGEX = new RegExp(
+	[
+		`[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?${ANSI_ST})`,
+		"(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+	].join("|"),
+	"g",
+);
+
+export function stripAnsi(value: string): string {
+	return value.replace(ANSI_REGEX, "");
+}
+
 export function getEditorSizeError(input: EditFileInput): string | null {
 	if (
 		typeof input.old_text === "string" &&


### PR DESCRIPTION
### Related Issue

Fixes #13346

### Description

Commands run in background mode return their output to the model with ANSI escape sequences intact, so every coloured CLI puts raw control characters into the conversation.

The same `run_commands` tool already strips them on its other path. Foreground execution goes through `VscodeTerminalProcess.ts:298`, which calls `stripAnsi` from `apps/vscode/src/hosts/vscode/terminal/ansiUtils.ts`. Background execution goes through `createShellExecutor` in `@cline/core`, which collects piped bytes with a `StringDecoder` and returns them verbatim, and the result is then passed through untouched at `sdk/packages/core/src/extensions/tools/definitions.ts:223` (success) and `:238` (non-zero exit). Same tool, two modes, only one of them strips.

This adds a `stripAnsi` helper to `sdk/packages/core/src/extensions/tools/helpers.ts` and applies it at those two lines. The regex is character-identical to the one `ansiUtils.ts` already uses, so both modes now strip the same way.

**Where the fix lives, and why:** I put it at the tool boundary rather than in the executor. Three options were available:

* `definitions.ts` (chosen): covers the VS Code background path and `apps/cli` in one place, since the CLI always uses the SDK executor. Also avoids `executors/bash.ts`, which open PR #11428 is currently rewriting.
* `executors/bash.ts`: closer to the source, but it collides with #11428 and only covers callers of that one executor.
* The VS Code wrapper: fixes one surface and leaves the CLI broken.

Stripping further downstream at the message-builder boundary was not an option, since `ToolOperationResult` is shared by every tool and a blanket strip would corrupt `read_files` output. That is why this is scoped to `run_commands`.

**What did not change:**

* The streamed `emitUpdate` chunks keep their escapes. This looks deliberate: `bash.test.ts` asserts streamed chunks arrive as `\u001b[31mred\u001b[0m`, `boundary.test.ts` asserts the hub `tool.updated` projection keeps them, and `bash.ts:497` injects `\u001b[0m` into the truncation marker on purpose. Both suites still pass unchanged, and a new test locks the split explicitly.
* `error.message` on the failure path. `CommandExitError` builds it from a fixed template (`Command exited with code ${exitCode}`), so it cannot carry escapes.
* No new dependency, no lockfile change.

**Out of scope:** this does not resolve #9693 (intermediate TTY progress-bar frames). Those frames are separated by carriage returns rather than escape sequences, so they survive an ANSI strip. #9693 was closed NOT_PLANNED by the stale bot on 2026-08-05 with no maintainer comment, so I mention it only as prior demand for the same class of noise, not as something this closes.

### Test Procedure

Three tests added to `definitions.test.ts`, all written before the fix and confirmed failing against current `main`:

1. `strips ANSI escape sequences from command results` covers `:223`
2. `strips ANSI escape sequences from non-zero exit results` covers `:238`, and asserts `error` is still `Command exited with code 1`
3. `keeps streamed chunks ANSI-bearing while stripping the result` asserts both halves at once: the `emitUpdate` chunk keeps its escapes while the returned result is stripped

Before the fix: `3 failed | 63 passed (66)`. After: `66 passed (66)`.

```
bun -F @cline/core test:unit src/extensions/tools/definitions.test.ts
bun -F @cline/core test:unit src/extensions/tools/executors/bash.test.ts
bun -F @cline/core test:unit src/hub/server/boundary.test.ts
bun run types
bun run lint

```

Results on `dfa34ece`:

* `definitions.test.ts` 66 passed (63 before this change, 3 added)
* `bash.test.ts` 39 passed, 4 skipped, unchanged from baseline
* `boundary.test.ts` 34 passed, unchanged from baseline
* `bun run types` clean
* `bun run lint` exit 0

The full `bun -F @cline/core test:unit` run has 4 pre-existing failures on my machine (`checkpoint-hooks`, `workspace-manifest` x2, `runtime-builder`). They reproduce identically with this branch stashed, so they are unrelated to this change. `bun run check` also reports formatting drift in `apps/examples` and `sdk/packages/ui/stories`, which is pre-existing and untouched here.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] ♻️ Refactor Changes
* [ ] 💅 Cosmetic Changes
* [ ] 📚 Documentation update
* [ ] 🏃 Workflow Changes

### Pre-flight Checklist

* [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
* [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
* [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

`ANSI_REGEX` is compiled once at module scope with the `g` flag. That is safe to reuse here because `stripAnsi` only calls `String.prototype.replace`, which resets `lastIndex` for a global regex. It would not be safe if the same regex were used with `.test()` or `.exec()`.