### PR TITLE
fix(llms): display billed gateway cost

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.test.ts
@@ -218,11 +218,26 @@ describe("ai-sdk usage normalization", () => {
 	});
 
 	describe("cost extraction with pricing fallback", () => {
-		it("uses market_cost when available (Vercel)", () => {
-			const vercelUsage = (fixtures as Record<string, unknown>)
-				.vercel_stream_usage as Record<string, unknown>;
-			const normalized = normalizeUsage(vercelUsage);
-			expect(normalized.totalCost).toBe(0.000641);
+		it("prefers billed cost over market_cost when Vercel applies a discount", () => {
+			const normalized = normalizeUsage({
+				inputTokens: 11,
+				outputTokens: 5,
+				raw: {
+					cost: 0.0001025,
+					market_cost: 0.000205,
+					cost_details: { upstream_inference_cost: null },
+				},
+			});
+			expect(normalized.totalCost).toBe(0.0001025);
+		});
+
+		it("uses market_cost when billed cost is unavailable", () => {
+			const normalized = normalizeUsage({
+				inputTokens: 11,
+				outputTokens: 5,
+				raw: { market_cost: 0.000205 },
+			});
+			expect(normalized.totalCost).toBe(0.000205);
 		});
 
 		it("sums BYOK fee + upstream provider cost when OpenRouter marks the request as BYOK", () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -1031,6 +1031,9 @@ function calculateUsageCostFromPricing(
  * Accepts both AI SDK's normalized shapes (AiSdkStreamTotalUsage, AiSdkStreamUsage)
  * and raw provider responses. Handles multiple naming conventions (camelCase vs snake_case),
  * extracts costs from provider-specific fields, and falls back to pricing-based calculation.
+ * Provider-reported billed cost takes precedence over market cost so gateway discounts
+ * are reflected in user-facing totals. Market cost remains a fallback when no billed
+ * cost is available.
  *
  * @param usageValue - AI SDK normalized usage or raw provider response object
  * @param providerMetadata - Provider-specific metadata for cost extraction
@@ -1091,9 +1094,13 @@ export function normalizeUsage(
 		baseCost !== undefined && baseCost > 0
 			? baseCost
 			: (upstreamInferenceCost ?? baseCost);
+	const billedCost = shouldAddUpstreamCost
+		? baseCost + upstreamInferenceCost
+		: costOrUpstream;
 	const totalCost =
-		marketCost ??
-		(shouldAddUpstreamCost ? baseCost + upstreamInferenceCost : costOrUpstream);
+		billedCost !== undefined && billedCost !== 0
+			? billedCost
+			: (marketCost ?? billedCost);
 	const normalizedUsage = {
 		inputTokens:
 			getNestedUsageValue(usage, "inputTokens", "total") ||

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -3216,7 +3216,7 @@ describe("sdk-gateway", () => {
 		expect(events.at(-1)).toEqual({ type: "finish", reason: "stop" });
 	});
 
-	it("preserves usage cost from market cost fields", async () => {
+	it("uses discounted billed cost instead of Vercel market cost", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([
 				{
@@ -3224,12 +3224,12 @@ describe("sdk-gateway", () => {
 					usage: {
 						prompt_tokens: 3793,
 						completion_tokens: 1250,
-						cost: 0,
+						cost: 0.009145675,
 						market_cost: 0.01829135,
 					},
 					providerMetadata: {
 						gateway: {
-							cost: "0.01829135",
+							cost: "0.009145675",
 							marketCost: "0.01829135",
 						},
 					},
@@ -3270,7 +3270,7 @@ describe("sdk-gateway", () => {
 				outputTokens: 1250,
 				cacheReadTokens: 0,
 				cacheWriteTokens: 0,
-				totalCost: 0.01829135,
+				totalCost: 0.009145675,
 			},
 		});
 	});


### PR DESCRIPTION
## Summary

- Prefer the provider-reported billed cost over `market_cost` when both are present.
- Keep `market_cost` as a fallback when no billed cost is available.
- Preserve OpenRouter BYOK fee-plus-upstream accounting and non-BYOK double-count protection.

## Why

Vercel's GPT-5.6 Sol response reports both the discounted billed cost and the undiscounted market cost. For example, the same request reported:

- `cost`: `$0.0001025`
- `market_cost`: `$0.000205`

The gateway charged the discounted `cost`, but Cline normalized `market_cost` first, so the task UI displayed twice the amount actually deducted from the user's credits. This patch fixes the display/session total; it does not change provider routing or backend billing.

## Behavior

| Provider usage response | Displayed cost |
| --- | --- |
| Billed cost + market cost | Billed cost |
| Market cost only | Market cost fallback |
| OpenRouter BYOK base fee + upstream cost | Sum of both |
| OpenRouter non-BYOK mirrored cost fields | Base cost only |
| Explicit zero without market cost | Zero |

## Validation

- `bun run build:sdk`
- Biome checks on all three touched files
- `bun -F @cline/llms run typecheck`
- `bun -F @cline/llms test`: 733 passed, 4 skipped
- `bun run types`: all SDK packages passed
- Downstream test suites passed for shared, UI, agents, VS Code, hub, and core

The complete SDK test command reaches one isolated failure in the CLI distribution-package guard test (`rejects direct source package packing by default`); this change does not touch CLI or package-distribution code. The affected package and downstream suites above are green.
