### PR TITLE
docs: correct image-output filter comments to match mergeKnownModels behavior

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -209,8 +209,9 @@ async function mergeKnownModels(
 		// models are temporarily unavailable through Cline's inference backend,
 		// so filter them only at the Cline catalog boundary. buildClineModels
 		// applies the same restriction to the bundled catalog. User overrides are
-		// intentionally added after this filter. Remove both filter call sites
-		// together when the backend gains image-output support.
+		// also subject to this filter — the backend rejects image output
+		// regardless of where the model was configured. Remove both filter call
+		// sites together when the backend gains image-output support.
 		return Llms.sortModelsByReleaseDate(
 			Llms.filterImageOutputModels({
 				...Llms.preferCanonicalModelIds(

--- a/sdk/packages/llms/src/catalog/model-filters.ts
+++ b/sdk/packages/llms/src/catalog/model-filters.ts
@@ -6,9 +6,10 @@ import type { ModelInfo } from "./types";
  * This includes both dedicated image-generation models and language models
  * that can return mixed text-and-image output. Cline deliberately applies
  * this temporary backend limitation in both `buildClineModels` (the bundled
- * catalog) and `mergeKnownModels` (the merged non-user runtime sources). User
- * model overrides are added after the runtime filter. Remove both filter call
- * sites together when the inference backend supports image output.
+ * catalog) and `mergeKnownModels` (the merged runtime sources, including
+ * user model overrides — the backend rejects image output regardless of
+ * where the model was configured). Remove both filter call sites together
+ * when the inference backend supports image output.
  */
 export function filterImageOutputModels(
 	models: Record<string, ModelInfo>,


### PR DESCRIPTION
### Related Issue

Review feedback from @mkondratek on #13368.

### Description

Addresses the review comment on #13368: the new comments in `provider-defaults.ts` and `model-filters.ts` claimed "User overrides are intentionally added after this filter", but in `mergeKnownModels` the `...userKnownModels` spread sits inside the `filterImageOutputModels` call, so user overrides are filtered too. That filtered behavior is the intent — the PR description states image-output models are excluded "including user-configured models", and `provider-defaults.test.ts` asserts `vendor/custom-image-model` (a user-configured model) is removed.

This PR fixes only the wording, per the reviewer's suggestion:

- `sdk/packages/core/src/services/llms/provider-defaults.ts`: the `mergeKnownModels` comment now says user overrides are also subject to the filter because the backend rejects image output regardless of where the model was configured.
- `sdk/packages/llms/src/catalog/model-filters.ts`: the `filterImageOutputModels` docstring no longer describes `mergeKnownModels` as covering "the merged non-user runtime sources"; it now says the merge includes user model overrides and that they are subject to the same filter.

No behavior change — comment-only edits.

### Test Procedure

- `bun -F @cline/llms test`: 732 passed, 4 skipped.
- `bun -F @cline/core test:unit -- src/services/llms/provider-defaults.test.ts`: 25 passed, including the assertions that user-configured image-output models are filtered.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Targets `bee/cleanup-provider-model-catalog` so #13368 picks up the fix on merge.