### PR TITLE
feat: render monitor reports as clean cards instead of fenced text

### DIFF
--- a/apps/cli/src/runtime/session-events.ts
+++ b/apps/cli/src/runtime/session-events.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import type {
 	AgentEvent,
 	CoreSessionEvent,
+	PendingPromptOrigin,
 	RuntimeHostSubscribeOptions,
 	TeamEvent,
 } from "@cline/core";
@@ -16,6 +17,7 @@ export interface PendingPromptSnapshot {
 		prompt: string;
 		delivery: "queue" | "steer";
 		attachmentCount: number;
+		origin?: PendingPromptOrigin;
 	}>;
 }
 
@@ -25,6 +27,7 @@ export interface PendingPromptSubmittedEvent {
 	prompt: string;
 	delivery: "queue" | "steer";
 	attachmentCount: number;
+	origin?: PendingPromptOrigin;
 }
 
 /**

--- a/apps/cli/src/tui/components/chat-entry-monitor.test.ts
+++ b/apps/cli/src/tui/components/chat-entry-monitor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatMonitorExitLine } from "../utils/monitor-entry";
+
+describe("formatMonitorExitLine", () => {
+	it("is absent while the monitor still runs", () => {
+		expect(formatMonitorExitLine(undefined)).toBeUndefined();
+	});
+
+	it("attributes user-initiated stops", () => {
+		expect(
+			formatMonitorExitLine({ status: "stopped", stoppedBy: "user" }),
+		).toBe("stopped by you");
+		expect(formatMonitorExitLine({ status: "stopped" })).toBe("stopped");
+	});
+
+	it("describes failures and exits", () => {
+		expect(formatMonitorExitLine({ status: "failed", error: "boom" })).toBe(
+			"failed: boom",
+		);
+		expect(formatMonitorExitLine({ status: "failed" })).toBe("failed");
+		expect(formatMonitorExitLine({ status: "exited", code: 2 })).toBe(
+			"ended with exit code 2",
+		);
+		expect(formatMonitorExitLine({ status: "exited" })).toBe("ended");
+	});
+});

--- a/apps/cli/src/tui/components/chat-entry-monitor.test.ts
+++ b/apps/cli/src/tui/components/chat-entry-monitor.test.ts
@@ -1,4 +1,6 @@
+import type { MessageWithMetadata } from "@cline/shared";
 import { describe, expect, it } from "vitest";
+import { hydrateSessionMessages } from "../utils/hydrate-messages";
 import { formatMonitorExitLine } from "../utils/monitor-entry";
 
 describe("formatMonitorExitLine", () => {
@@ -22,5 +24,95 @@ describe("formatMonitorExitLine", () => {
 			"ended with exit code 2",
 		);
 		expect(formatMonitorExitLine({ status: "exited" })).toBe("ended");
+		expect(formatMonitorExitLine({ status: "exited", signal: "SIGTERM" })).toBe(
+			"ended on signal SIGTERM",
+		);
+	});
+});
+
+describe("hydrating persisted monitor steer messages", () => {
+	const fencedText =
+		'<user_input mode="act">Background monitor "ci" (CI status) produced new output.\n<monitor-output>\nbuild failed\n</monitor-output></user_input>';
+
+	function monitorMessage(
+		metadata: Record<string, unknown>,
+	): MessageWithMetadata {
+		return {
+			role: "user",
+			content: [{ type: "text", text: fencedText }],
+			ts: 1,
+			metadata,
+		};
+	}
+
+	it("renders cards from persisted origin metadata instead of the fence", () => {
+		const entries = hydrateSessionMessages([
+			monitorMessage({
+				userRunSpan: 0,
+				monitorOrigin: {
+					kind: "monitor",
+					droppedUpdates: 3,
+					updates: [
+						{
+							monitorId: "mon_1",
+							name: "ci",
+							description: "CI status",
+							lines: ["build failed"],
+							droppedLines: 2,
+							exit: { status: "exited", code: 1 },
+						},
+						{
+							monitorId: "mon_1",
+							name: "ci",
+							description: "CI status",
+							lines: ["retrying"],
+						},
+					],
+				},
+			}),
+		]);
+
+		expect(entries).toEqual([
+			{
+				kind: "monitor_update",
+				name: "ci",
+				description: "CI status",
+				lines: ["build failed"],
+				droppedLines: 2,
+				omittedEarlierUpdates: 3,
+				exit: {
+					status: "exited",
+					stoppedBy: undefined,
+					code: 1,
+					signal: undefined,
+					error: undefined,
+				},
+			},
+			{
+				kind: "monitor_update",
+				name: "ci",
+				description: "CI status",
+				lines: ["retrying"],
+				droppedLines: undefined,
+				omittedEarlierUpdates: undefined,
+				exit: undefined,
+			},
+		]);
+		// The fenced model-facing text must never surface as a user bubble.
+		expect(
+			entries.some(
+				(entry) => "text" in entry && entry.text.includes("monitor-output"),
+			),
+		).toBe(false);
+	});
+
+	it("falls back to the user bubble when the metadata is malformed", () => {
+		const entries = hydrateSessionMessages([
+			monitorMessage({
+				monitorOrigin: { kind: "monitor", updates: [{ bogus: true }] },
+			}),
+		]);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.kind).toBe("user_submitted");
 	});
 });

--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -25,6 +25,7 @@ import { getUserMessageBackground } from "../palette";
 import type { ResolvedTheme } from "../themes";
 import type { ChatEntry } from "../types";
 import { formatCompactionDividerLabel } from "../utils/compaction-status";
+import { formatMonitorExitLine } from "../utils/monitor-entry";
 import { getSyntaxStyle, type SyntaxAccentMode } from "../utils/syntax-style";
 import { isWarningToolError } from "../utils/tool-errors";
 import {
@@ -776,6 +777,58 @@ export function ChatEntryView(props: {
 					<text fg="gray" selectable content={entry.text} />
 				</box>
 			);
+
+		case "monitor_update": {
+			// A compact card built from structured fields. The fenced,
+			// guidance-wrapped text the model receives is intentionally never
+			// shown to the user.
+			const exitLine = formatMonitorExitLine(entry.exit);
+			const running = !entry.exit;
+			return (
+				<box
+					flexDirection="column"
+					backgroundColor={userMsgBg}
+					marginX={-1}
+					paddingLeft={1}
+					paddingRight={2}
+				>
+					<box flexDirection="row">
+						<box width={2}>
+							<text fg={running ? theme.accents.success : "gray"}>{"◉"}</text>
+						</box>
+						<text fg={defaultFg}>{entry.name}</text>
+						<text fg="gray"> — {entry.description}</text>
+					</box>
+					{entry.lines.map((line, index) => (
+						<box
+							flexDirection="row"
+							// biome-ignore lint/suspicious/noArrayIndexKey: static snapshot list
+							key={`${index}-${line.slice(0, 24)}`}
+						>
+							<box width={2} />
+							<text fg={defaultFg} selectable>
+								{line}
+							</text>
+						</box>
+					))}
+					{entry.droppedLines ? (
+						<box flexDirection="row">
+							<box width={2} />
+							<text fg="gray">
+								[{entry.droppedLines} more line
+								{entry.droppedLines === 1 ? "" : "s"} not shown]
+							</text>
+						</box>
+					) : null}
+					{exitLine ? (
+						<box flexDirection="row">
+							<box width={2} />
+							<text fg="gray">{exitLine}</text>
+						</box>
+					) : null}
+				</box>
+			);
+		}
 
 		case "compaction":
 			return <CompactionDividerRow entry={entry} />;

--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -799,6 +799,15 @@ export function ChatEntryView(props: {
 						<text fg={defaultFg}>{entry.name}</text>
 						<text fg="gray"> — {entry.description}</text>
 					</box>
+					{entry.omittedEarlierUpdates ? (
+						<box flexDirection="row">
+							<box width={2} />
+							<text fg="gray">
+								[{entry.omittedEarlierUpdates} earlier update
+								{entry.omittedEarlierUpdates === 1 ? "" : "s"} not shown]
+							</text>
+						</box>
+					) : null}
 					{entry.lines.map((line, index) => (
 						<box
 							flexDirection="row"

--- a/apps/cli/src/tui/components/queued-prompts.tsx
+++ b/apps/cli/src/tui/components/queued-prompts.tsx
@@ -121,7 +121,7 @@ function QueuedPromptRow(props: {
 					fg={selected ? theme.textOnSelection : theme.defaultForeground}
 					flexGrow={1}
 				>
-					{truncatePrompt(item.prompt)}
+					{truncatePrompt(item.displayLabel ?? item.prompt)}
 				</text>
 			)}
 			{!editing && item.attachmentCount > 0 && (

--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -417,6 +417,29 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 	const handlePendingPromptSubmitted = useCallback(
 		(event: PendingPromptSubmittedEvent) => {
 			knownPendingPromptIdsRef.current.delete(event.id);
+			// Monitor reports carry structured provenance; render them as
+			// compact cards instead of echoing the model-facing fenced text
+			// (untrusted-content guidance and all) at the user.
+			if (event.origin?.kind === "monitor") {
+				for (const update of event.origin.updates) {
+					appendEntry({
+						kind: "monitor_update",
+						name: update.name,
+						description: update.description,
+						lines: update.lines,
+						droppedLines: update.droppedLines,
+						exit: update.exit
+							? {
+									status: update.exit.status,
+									stoppedBy: update.exit.stoppedBy,
+									code: update.exit.code,
+									error: update.exit.error,
+								}
+							: undefined,
+					});
+				}
+				return;
+			}
 			// Display boundary: formatDisplayUserInput strips runtime-generated
 			// notice elements (e.g. mode_notice) that normalizeUserInput must
 			// preserve, since the latter also sanitizes model-bound prompts.

--- a/apps/cli/src/tui/hooks/use-agent-events.ts
+++ b/apps/cli/src/tui/hooks/use-agent-events.ts
@@ -421,23 +421,29 @@ export function useAgentEventHandlers(deps: AgentEventDeps) {
 			// compact cards instead of echoing the model-facing fenced text
 			// (untrusted-content guidance and all) at the user.
 			if (event.origin?.kind === "monitor") {
-				for (const update of event.origin.updates) {
+				event.origin.updates.forEach((update, index) => {
 					appendEntry({
 						kind: "monitor_update",
 						name: update.name,
 						description: update.description,
 						lines: update.lines,
 						droppedLines: update.droppedLines,
+						// Earlier whole updates were dropped to bound the card
+						// set; announce them on the first card so the user is
+						// never shown less than the model received.
+						omittedEarlierUpdates:
+							index === 0 ? event.origin?.droppedUpdates : undefined,
 						exit: update.exit
 							? {
 									status: update.exit.status,
 									stoppedBy: update.exit.stoppedBy,
 									code: update.exit.code,
+									signal: update.exit.signal,
 									error: update.exit.error,
 								}
 							: undefined,
 					});
-				}
+				});
 				return;
 			}
 			// Display boundary: formatDisplayUserInput strips runtime-generated

--- a/apps/cli/src/tui/hooks/use-queued-prompts.test.ts
+++ b/apps/cli/src/tui/hooks/use-queued-prompts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PendingPromptSnapshot } from "../../runtime/session-events";
 import {
+	monitorPromptLabel,
 	resolveQueuedPromptSelection,
 	toQueuedPromptItems,
 } from "./use-queued-prompts";
@@ -76,5 +77,55 @@ describe("queued prompt helpers", () => {
 				direction: "down",
 			}),
 		).toBeNull();
+	});
+});
+
+describe("monitorPromptLabel", () => {
+	it("summarizes monitor origins with names and line counts", () => {
+		expect(
+			monitorPromptLabel({
+				kind: "monitor",
+				updates: [
+					{
+						monitorId: "mon_1",
+						name: "ci",
+						description: "CI status",
+						lines: ["one", "two"],
+					},
+					{
+						monitorId: "mon_1",
+						name: "ci",
+						description: "CI status",
+						lines: ["three"],
+					},
+				],
+			}),
+		).toBe("Monitor update from ci (3 lines)");
+	});
+
+	it("labels queue items from monitor origins", () => {
+		const items = toQueuedPromptItems({
+			sessionId: "sess-1",
+			prompts: [
+				{
+					id: "pending-1",
+					prompt: "<monitor-output>fenced</monitor-output>",
+					delivery: "steer",
+					attachmentCount: 0,
+					origin: {
+						kind: "monitor",
+						updates: [
+							{
+								monitorId: "mon_1",
+								name: "applog",
+								description: "watching",
+								lines: ["hello"],
+							},
+						],
+					},
+				},
+			],
+		});
+		expect(items[0]?.displayLabel).toBe("Monitor update from applog (1 line)");
 	});
 });

--- a/apps/cli/src/tui/hooks/use-queued-prompts.ts
+++ b/apps/cli/src/tui/hooks/use-queued-prompts.ts
@@ -2,6 +2,22 @@ import { useCallback, useState } from "react";
 import type { PendingPromptSnapshot } from "../../runtime/session-events";
 import type { QueuedPromptItem } from "../types";
 
+export function monitorPromptLabel(
+	origin: NonNullable<PendingPromptSnapshot["prompts"][number]["origin"]>,
+): string {
+	if (origin.kind !== "monitor" || origin.updates.length === 0) {
+		return "Monitor update";
+	}
+	const names = [...new Set(origin.updates.map((update) => update.name))];
+	const lineCount = origin.updates.reduce(
+		(total, update) => total + update.lines.length,
+		0,
+	);
+	return `Monitor update from ${names.join(", ")} (${lineCount} line${
+		lineCount === 1 ? "" : "s"
+	})`;
+}
+
 export function toQueuedPromptItems(
 	event: PendingPromptSnapshot,
 ): QueuedPromptItem[] {
@@ -10,6 +26,7 @@ export function toQueuedPromptItems(
 		prompt: entry.prompt,
 		steer: entry.delivery === "steer",
 		attachmentCount: entry.attachmentCount,
+		displayLabel: entry.origin ? monitorPromptLabel(entry.origin) : undefined,
 	}));
 }
 

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -75,10 +75,18 @@ export type ChatEntry = (
 			description: string;
 			lines: string[];
 			droppedLines?: number;
+			/**
+			 * Whole earlier updates dropped from this prompt's card set to
+			 * bound it. The model still saw their text (bounded separately by
+			 * characters), so the card must say they exist rather than
+			 * silently underreport.
+			 */
+			omittedEarlierUpdates?: number;
 			exit?: {
 				status: "exited" | "stopped" | "failed";
 				stoppedBy?: "user";
 				code?: number | null;
+				signal?: string | null;
 				error?: string;
 			};
 	  }

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -65,6 +65,24 @@ export type ChatEntry = (
 	| { kind: "team"; text: string }
 	| { kind: "user_submitted"; text: string; delivery?: "queue" | "steer" }
 	| {
+			/**
+			 * A monitor report delivered to the agent. Rendered as a compact
+			 * card from structured fields; the fenced model-facing text is
+			 * deliberately not shown to the user.
+			 */
+			kind: "monitor_update";
+			name: string;
+			description: string;
+			lines: string[];
+			droppedLines?: number;
+			exit?: {
+				status: "exited" | "stopped" | "failed";
+				stoppedBy?: "user";
+				code?: number | null;
+				error?: string;
+			};
+	  }
+	| {
 			kind: "done";
 			tokens: number;
 			cost: number;
@@ -121,6 +139,12 @@ export interface QueuedPromptItem {
 	prompt: string;
 	steer: boolean;
 	attachmentCount: number;
+	/**
+	 * Compact label shown instead of the raw prompt for runtime-generated
+	 * entries (monitor reports carry fenced model-facing text the user should
+	 * not have to read). Editing still operates on the raw prompt.
+	 */
+	displayLabel?: string;
 }
 
 /** One background monitor as shown in the roster UI. */

--- a/apps/cli/src/tui/utils/hydrate-messages.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages.ts
@@ -15,6 +15,74 @@ function getDisplayRole(msg: MessageWithMetadata): string | undefined {
 	return typeof role === "string" ? role.trim().toLowerCase() : undefined;
 }
 
+type MonitorUpdateEntry = Extract<ChatEntry, { kind: "monitor_update" }>;
+
+function parseMonitorExit(value: unknown): MonitorUpdateEntry["exit"] {
+	if (!value || typeof value !== "object") return undefined;
+	const exit = value as Record<string, unknown>;
+	if (
+		exit.status !== "exited" &&
+		exit.status !== "stopped" &&
+		exit.status !== "failed"
+	) {
+		return undefined;
+	}
+	return {
+		status: exit.status,
+		stoppedBy: exit.stoppedBy === "user" ? "user" : undefined,
+		code: typeof exit.code === "number" ? exit.code : null,
+		signal: typeof exit.signal === "string" ? exit.signal : undefined,
+		error: typeof exit.error === "string" ? exit.error : undefined,
+	};
+}
+
+/**
+ * Rebuilds monitor cards from the display metadata persisted with a
+ * monitor-originated steer message. Without it a resumed transcript would
+ * fall back to echoing the fenced model-facing text at the user. The
+ * metadata round-trips through JSON, so every field is validated.
+ */
+function readMonitorOriginEntries(
+	msg: MessageWithMetadata,
+): MonitorUpdateEntry[] | undefined {
+	if (msg.role !== "user") return undefined;
+	const origin = msg.metadata?.monitorOrigin as
+		| { kind?: unknown; updates?: unknown; droppedUpdates?: unknown }
+		| undefined;
+	if (!origin || origin.kind !== "monitor" || !Array.isArray(origin.updates)) {
+		return undefined;
+	}
+	const entries: MonitorUpdateEntry[] = [];
+	for (const update of origin.updates) {
+		if (!update || typeof update !== "object") continue;
+		const fields = update as Record<string, unknown>;
+		if (typeof fields.name !== "string" || !Array.isArray(fields.lines)) {
+			continue;
+		}
+		entries.push({
+			kind: "monitor_update",
+			name: fields.name,
+			description:
+				typeof fields.description === "string" ? fields.description : "",
+			lines: fields.lines.filter(
+				(line): line is string => typeof line === "string",
+			),
+			droppedLines:
+				typeof fields.droppedLines === "number" && fields.droppedLines > 0
+					? fields.droppedLines
+					: undefined,
+			omittedEarlierUpdates:
+				entries.length === 0 &&
+				typeof origin.droppedUpdates === "number" &&
+				origin.droppedUpdates > 0
+					? origin.droppedUpdates
+					: undefined,
+			exit: parseMonitorExit(fields.exit),
+		});
+	}
+	return entries.length > 0 ? entries : undefined;
+}
+
 // The act-mode continuation prompt is runtime-generated, not typed by the
 // user, so it should not surface as a user bubble in the transcript.
 function isSyntheticUserText(text: string): boolean {
@@ -66,6 +134,14 @@ export function hydrateSessionMessages(
 	for (const { message: msg } of projectSessionMessagesForDisplay(messages)) {
 		const displayRole = getDisplayRole(msg);
 		if (displayRole === "system" || displayRole === "status") {
+			continue;
+		}
+
+		// Monitor-originated steer prompts render as the same compact cards
+		// they had live; the fenced model-facing text is never shown.
+		const monitorEntries = readMonitorOriginEntries(msg);
+		if (monitorEntries) {
+			entries.push(...monitorEntries);
 			continue;
 		}
 

--- a/apps/cli/src/tui/utils/monitor-entry.ts
+++ b/apps/cli/src/tui/utils/monitor-entry.ts
@@ -1,0 +1,20 @@
+import type { ChatEntry } from "../types";
+
+export type MonitorUpdateEntry = Extract<ChatEntry, { kind: "monitor_update" }>;
+
+/** Terminal line for a monitor card; absent while the monitor still runs. */
+export function formatMonitorExitLine(
+	exit: MonitorUpdateEntry["exit"],
+): string | undefined {
+	if (!exit) return undefined;
+	switch (exit.status) {
+		case "stopped":
+			return exit.stoppedBy === "user" ? "stopped by you" : "stopped";
+		case "failed":
+			return exit.error ? `failed: ${exit.error}` : "failed";
+		default:
+			return exit.code !== undefined && exit.code !== null
+				? `ended with exit code ${exit.code}`
+				: "ended";
+	}
+}

--- a/apps/cli/src/tui/utils/monitor-entry.ts
+++ b/apps/cli/src/tui/utils/monitor-entry.ts
@@ -13,8 +13,9 @@ export function formatMonitorExitLine(
 		case "failed":
 			return exit.error ? `failed: ${exit.error}` : "failed";
 		default:
-			return exit.code !== undefined && exit.code !== null
-				? `ended with exit code ${exit.code}`
-				: "ended";
+			if (exit.code !== undefined && exit.code !== null) {
+				return `ended with exit code ${exit.code}`;
+			}
+			return exit.signal ? `ended on signal ${exit.signal}` : "ended";
 	}
 }

--- a/apps/vscode/proto/cline/ui.proto
+++ b/apps/vscode/proto/cline/ui.proto
@@ -76,6 +76,7 @@ enum ClineSay {
   SUBAGENT_USAGE = 36;
   COMPACTION = 37;
   PLAN_COMPLETION_RESULT = 38;
+  MONITOR_UPDATE = 39;
 }
 
 // Enum for ClineSayTool tool types

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -229,6 +229,43 @@ describe("translateSessionEvent — pending prompts", () => {
 		])
 	})
 
+	it("renders monitor-origin prompts as monitor_update cards instead of fenced user bubbles", () => {
+		const state = new MessageTranslatorState()
+		const event: CoreSessionEvent = {
+			type: "pending_prompt_submitted",
+			payload: {
+				sessionId: "session-1",
+				id: "pending-1",
+				prompt: "<monitor-output>ERROR: disk full</monitor-output>",
+				delivery: "steer",
+				attachmentCount: 0,
+				origin: {
+					kind: "monitor",
+					updates: [
+						{
+							monitorId: "mon_1",
+							name: "applog",
+							description: "watching the app log",
+							lines: ["ERROR: disk full"],
+							exit: { status: "stopped", stoppedBy: "user" },
+						},
+					],
+				},
+			},
+		}
+
+		const result = translateSessionEvent(event, state)
+
+		expect(result.messages).toHaveLength(1)
+		expect(result.messages[0]).toEqual(expect.objectContaining({ type: "say", say: "monitor_update", partial: false }))
+		expect(JSON.parse(result.messages[0]?.text ?? "{}")).toEqual({
+			name: "applog",
+			description: "watching the app log",
+			lines: ["ERROR: disk full"],
+			exit: { status: "stopped", stoppedBy: "user" },
+		})
+	})
+
 	it("does not echo a synthetic resumption prompt that was auto-queued behind a settling abort", () => {
 		// A bare Resume that races the abort settling is auto-queued by the
 		// runtime; when it drains, the submitted-prompt echo must not leak the

--- a/apps/vscode/src/sdk/message-translator.test.ts
+++ b/apps/vscode/src/sdk/message-translator.test.ts
@@ -266,6 +266,68 @@ describe("translateSessionEvent — pending prompts", () => {
 		})
 	})
 
+	it("rehydrates persisted monitor-origin messages as monitor_update cards", () => {
+		// The structured origin persists as display metadata on the steer
+		// message; a resumed transcript must render the same cards it had
+		// live instead of echoing the fenced model-facing text.
+		const messages: MessageWithMetadata[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "text",
+						text: '<user_input mode="act"><monitor-output>ERROR: disk full</monitor-output></user_input>',
+					},
+				],
+				metadata: {
+					userRunSpan: 0,
+					monitorOrigin: {
+						kind: "monitor",
+						droppedUpdates: 2,
+						updates: [
+							{
+								monitorId: "mon_1",
+								name: "applog",
+								description: "watching the app log",
+								lines: ["ERROR: disk full"],
+								exit: { status: "exited", signal: "SIGTERM" },
+							},
+						],
+					},
+				},
+			},
+		]
+
+		const clineMessages = sdkMessagesToClineMessages(messages)
+		const cards = clineMessages.filter((message) => message.say === "monitor_update")
+		expect(cards).toHaveLength(1)
+		expect(JSON.parse(cards[0]?.text ?? "{}")).toEqual({
+			name: "applog",
+			description: "watching the app log",
+			lines: ["ERROR: disk full"],
+			omittedEarlierUpdates: 2,
+			exit: { status: "exited", code: null, signal: "SIGTERM" },
+		})
+		// The fenced text must not also render as a user bubble.
+		expect(clineMessages.some((message) => (message.say === "task" || message.say === "user_feedback") && message.text)).toBe(
+			false,
+		)
+	})
+
+	it("falls back to the user bubble when persisted monitor metadata is malformed", () => {
+		const messages: MessageWithMetadata[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "plain user words" }],
+				metadata: { monitorOrigin: { kind: "monitor", updates: [{ bogus: true }] } },
+			},
+		]
+
+		const clineMessages = sdkMessagesToClineMessages(messages)
+		expect(clineMessages.some((message) => message.say === "monitor_update")).toBe(false)
+		expect(clineMessages.some((message) => message.text === "plain user words")).toBe(true)
+	})
+
 	it("does not echo a synthetic resumption prompt that was auto-queued behind a settling abort", () => {
 		// A bare Resume that races the abort settling is auto-queued by the
 		// runtime; when it drains, the submitted-prompt echo must not leak the

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -2114,17 +2114,22 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			// compact cards instead of echoing the model-facing fenced text
 			// (untrusted-content guidance and all) as a user bubble.
 			if (origin?.kind === "monitor") {
-				for (const update of origin.updates) {
+				origin.updates.forEach((update, index) => {
 					const payload: MonitorUpdatePayload = {
 						name: update.name,
 						description: update.description,
 						lines: update.lines,
 						droppedLines: update.droppedLines,
+						// Earlier whole updates were dropped to bound the card
+						// set; announce them on the first card so the user is
+						// never shown less than the model received.
+						omittedEarlierUpdates: index === 0 ? origin.droppedUpdates : undefined,
 						exit: update.exit
 							? {
 									status: update.exit.status,
 									stoppedBy: update.exit.stoppedBy,
 									code: update.exit.code,
+									signal: update.exit.signal,
 									error: update.exit.error,
 								}
 							: undefined,
@@ -2136,7 +2141,7 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 						text: JSON.stringify(payload),
 						partial: false,
 					})
-				}
+				})
 				break
 			}
 			// Synthetic prompts (task resumption, plan -> act auto-continue) are
@@ -2324,6 +2329,51 @@ export interface SdkMessagesToClineMessagesOptions {
 }
 
 /**
+ * Rebuilds monitor card payloads from the display metadata persisted with a
+ * monitor-originated steer message. The metadata round-trips through JSON, so
+ * every field is validated before use.
+ */
+function readPersistedMonitorUpdates(metadata: Record<string, unknown> | undefined): MonitorUpdatePayload[] | undefined {
+	const origin = metadata?.monitorOrigin as { kind?: unknown; updates?: unknown; droppedUpdates?: unknown } | undefined
+	if (!origin || origin.kind !== "monitor" || !Array.isArray(origin.updates)) {
+		return undefined
+	}
+	const payloads: MonitorUpdatePayload[] = []
+	for (const update of origin.updates) {
+		if (!update || typeof update !== "object") {
+			continue
+		}
+		const fields = update as Record<string, unknown>
+		if (typeof fields.name !== "string" || !Array.isArray(fields.lines)) {
+			continue
+		}
+		const exit = fields.exit as Record<string, unknown> | undefined
+		const exitStatus =
+			exit?.status === "exited" || exit?.status === "stopped" || exit?.status === "failed" ? exit.status : undefined
+		payloads.push({
+			name: fields.name,
+			description: typeof fields.description === "string" ? fields.description : "",
+			lines: fields.lines.filter((line): line is string => typeof line === "string"),
+			droppedLines: typeof fields.droppedLines === "number" && fields.droppedLines > 0 ? fields.droppedLines : undefined,
+			omittedEarlierUpdates:
+				payloads.length === 0 && typeof origin.droppedUpdates === "number" && origin.droppedUpdates > 0
+					? origin.droppedUpdates
+					: undefined,
+			exit: exitStatus
+				? {
+						status: exitStatus,
+						stoppedBy: exit?.stoppedBy === "user" ? "user" : undefined,
+						code: typeof exit?.code === "number" ? exit.code : null,
+						signal: typeof exit?.signal === "string" ? exit.signal : undefined,
+						error: typeof exit?.error === "string" ? exit.error : undefined,
+					}
+				: undefined,
+		})
+	}
+	return payloads.length > 0 ? payloads : undefined
+}
+
+/**
  * Convert SDK-persisted LLM messages back into the ClineMessage format used by
  * the webview. Keep this in the live message translator so history rendering
  * and streaming rendering share the same SDK tool → Cline UI mapping.
@@ -2384,6 +2434,28 @@ export function sdkMessagesToClineMessages(
 
 	for (const { message, sourceIndex } of projectSessionMessagesForDisplay(messages)) {
 		const sourceMessage = messages[sourceIndex]
+
+		// Monitor-originated steer prompts persist their structured origin as
+		// display metadata; rehydrate the same compact cards they had live
+		// instead of echoing the fenced model-facing text as a user bubble.
+		if (message.role === "user") {
+			const monitorUpdates = readPersistedMonitorUpdates(sourceMessage?.metadata ?? message.metadata)
+			if (monitorUpdates) {
+				state.clearTurnOutcome()
+				currentMode = sourceMessage?.uiMode ?? currentMode
+				for (const payload of monitorUpdates) {
+					clineMessages.push({
+						ts: state.nextTs(),
+						type: "say",
+						say: "monitor_update",
+						text: JSON.stringify(payload),
+						partial: false,
+					})
+				}
+				continue
+			}
+		}
+
 		if (message.role === "assistant") {
 			flushUnmatchedToolUses()
 

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -41,6 +41,7 @@ import type {
 	ClineSaySubagentStatus,
 	ClineSayTool,
 	ClineSubagentUsageInfo,
+	MonitorUpdatePayload,
 	SubagentStatusItem,
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
@@ -2108,7 +2109,36 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 		}
 
 		case "pending_prompt_submitted": {
-			const { prompt, userImages, userFiles } = event.payload
+			const { prompt, userImages, userFiles, origin } = event.payload
+			// Monitor reports carry structured provenance; render them as
+			// compact cards instead of echoing the model-facing fenced text
+			// (untrusted-content guidance and all) as a user bubble.
+			if (origin?.kind === "monitor") {
+				for (const update of origin.updates) {
+					const payload: MonitorUpdatePayload = {
+						name: update.name,
+						description: update.description,
+						lines: update.lines,
+						droppedLines: update.droppedLines,
+						exit: update.exit
+							? {
+									status: update.exit.status,
+									stoppedBy: update.exit.stoppedBy,
+									code: update.exit.code,
+									error: update.exit.error,
+								}
+							: undefined,
+					}
+					result.messages.push({
+						ts: state.nextTs(),
+						type: "say",
+						say: "monitor_update",
+						text: JSON.stringify(payload),
+						partial: false,
+					})
+				}
+				break
+			}
 			// Synthetic prompts (task resumption, plan -> act auto-continue) are
 			// hidden from every other transcript surface, and this echo must
 			// hide them too: a send that races a settling abort is auto-queued

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -221,10 +221,17 @@ export interface MonitorUpdatePayload {
 	description: string
 	lines: string[]
 	droppedLines?: number
+	/**
+	 * Whole earlier updates dropped from this prompt's card set to bound it.
+	 * The model still saw their text (bounded separately by characters), so
+	 * the card says they exist instead of silently underreporting.
+	 */
+	omittedEarlierUpdates?: number
 	exit?: {
 		status: "exited" | "stopped" | "failed"
 		stoppedBy?: "user"
 		code?: number | null
+		signal?: string | null
 		error?: string
 	}
 }

--- a/apps/vscode/src/shared/ExtensionMessage.ts
+++ b/apps/vscode/src/shared/ExtensionMessage.ts
@@ -178,6 +178,20 @@ export interface QueuedPrompt {
 	prompt: string
 	delivery: "queue" | "steer"
 	attachmentCount: number
+	/**
+	 * Structured provenance for runtime-generated prompts (mirrors the SDK's
+	 * PendingPromptOrigin). Monitor entries render as a compact label instead
+	 * of their fenced model-facing text.
+	 */
+	origin?: {
+		kind: "monitor"
+		updates: Array<{
+			monitorId: string
+			name: string
+			description: string
+			lines: string[]
+		}>
+	}
 }
 
 /** One background monitor shown in the webview roster. */
@@ -189,6 +203,24 @@ export interface ActiveMonitor {
 	startedAt: number
 	status: "running" | "exited" | "stopped" | "failed"
 	linesEmitted: number
+}
+
+/**
+ * JSON payload carried in a `say: "monitor_update"` message's text. Built from
+ * the structured origin metadata on monitor steer prompts so the webview
+ * renders a clean card; the fenced model-facing text is never shown.
+ */
+export interface MonitorUpdatePayload {
+	name: string
+	description: string
+	lines: string[]
+	droppedLines?: number
+	exit?: {
+		status: "exited" | "stopped" | "failed"
+		stoppedBy?: "user"
+		code?: number | null
+		error?: string
+	}
 }
 
 export interface ClineMessage {
@@ -265,6 +297,7 @@ export type ClineSay =
 	| "mcp_server_request_started"
 	| "mcp_server_response"
 	| "mcp_notification"
+	| "monitor_update" // background monitor report card; text is a JSON MonitorUpdatePayload
 	| "use_mcp_server"
 	| "diff_error"
 	| "deleted_api_reqs"

--- a/apps/vscode/src/shared/proto-conversions/cline-message.ts
+++ b/apps/vscode/src/shared/proto-conversions/cline-message.ts
@@ -108,6 +108,7 @@ function convertClineSayToProtoEnum(say: AppClineSay | undefined): ClineSay | un
 		use_subagents: ClineSay.USE_SUBAGENTS_SAY,
 		subagent_usage: ClineSay.SUBAGENT_USAGE,
 		compaction: ClineSay.COMPACTION,
+		monitor_update: ClineSay.MONITOR_UPDATE,
 	}
 
 	const result = mapping[say]
@@ -158,6 +159,7 @@ function convertProtoEnumToClineSay(say: ClineSay): AppClineSay | undefined {
 		[ClineSay.USE_SUBAGENTS_SAY]: "use_subagents",
 		[ClineSay.SUBAGENT_USAGE]: "subagent_usage",
 		[ClineSay.COMPACTION]: "compaction",
+		[ClineSay.MONITOR_UPDATE]: "monitor_update",
 	}
 
 	return mapping[say]

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -859,6 +859,12 @@ export const ChatRowContent = memo(
 										<span className="font-medium">{update.name}</span>
 										<span className="text-description"> {update.description}</span>
 									</div>
+									{update.omittedEarlierUpdates ? (
+										<div className="text-description text-sm">
+											[{update.omittedEarlierUpdates} earlier update
+											{update.omittedEarlierUpdates === 1 ? "" : "s"} not shown]
+										</div>
+									) : null}
 									{update.lines.length > 0 && (
 										<pre className="ph-no-capture mt-1 mb-0 max-h-40 overflow-y-auto whitespace-pre-wrap break-words font-code text-sm text-foreground/90">
 											{update.lines.join("\n")}

--- a/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatRow.tsx
@@ -35,6 +35,7 @@ import {
 import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
 import { canRestoreWorkspaceFromMessage } from "@/components/chat/chat-view/utils/messageUtils"
+import { formatMonitorUpdateExit, parseMonitorUpdate } from "@/components/chat/monitor-update"
 import { OptionsButtons } from "@/components/chat/OptionsButtons"
 import { WithCopyButton } from "@/components/common/CopyButton"
 import Thumbnails from "@/components/common/Thumbnails"
@@ -842,6 +843,39 @@ export const ChatRowContent = memo(
 								</div>
 							</div>
 						)
+					case "monitor_update": {
+						const update = parseMonitorUpdate(message.text)
+						if (!update) {
+							return null
+						}
+						return (
+							<div className="flex items-start gap-2 py-2.5 px-3 bg-quote rounded-sm text-base text-foreground opacity-90 mb-2">
+								<span
+									aria-hidden="true"
+									className="codicon codicon-pulse mt-0.5 text-[13px] text-notification-foreground shrink-0"
+								/>
+								<div className="break-words flex-1 min-w-0">
+									<div>
+										<span className="font-medium">{update.name}</span>
+										<span className="text-description"> {update.description}</span>
+									</div>
+									{update.lines.length > 0 && (
+										<pre className="ph-no-capture mt-1 mb-0 max-h-40 overflow-y-auto whitespace-pre-wrap break-words font-code text-sm text-foreground/90">
+											{update.lines.join("\n")}
+										</pre>
+									)}
+									{update.droppedLines ? (
+										<div className="text-description text-sm">
+											[{update.droppedLines} more line{update.droppedLines === 1 ? "" : "s"} not shown]
+										</div>
+									) : null}
+									{update.exit && (
+										<div className="text-description text-sm">{formatMonitorUpdateExit(update.exit)}</div>
+									)}
+								</div>
+							</div>
+						)
+					}
 					case "text": {
 						const hasText = !!message.text?.trim()
 						return (

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
@@ -8,6 +8,19 @@ function truncatePrompt(prompt: string): string {
 	return trimmed.length > 96 ? `${trimmed.slice(0, 96)}...` : trimmed
 }
 
+/**
+ * Runtime-generated prompts carry fenced model-facing text the user should
+ * not have to read; show a compact provenance label instead.
+ */
+export function queuedPromptDisplayText(item: QueuedPrompt): string {
+	if (item.origin?.kind === "monitor" && item.origin.updates.length > 0) {
+		const names = [...new Set(item.origin.updates.map((update) => update.name))]
+		const lineCount = item.origin.updates.reduce((total, update) => total + update.lines.length, 0)
+		return `Monitor update from ${names.join(", ")} (${lineCount} line${lineCount === 1 ? "" : "s"})`
+	}
+	return truncatePrompt(item.prompt)
+}
+
 function attachmentLabel(count: number): string | undefined {
 	if (count <= 0) {
 		return undefined
@@ -74,7 +87,7 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 							className="flex items-start gap-2 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs"
 							key={item.id}>
 							<span aria-hidden="true" className="mt-1.75 size-1.5 shrink-0 rounded-full bg-description/70" />
-							<span className="min-w-0 flex-1 break-words text-foreground">{truncatePrompt(item.prompt)}</span>
+							<span className="min-w-0 flex-1 break-words text-foreground">{queuedPromptDisplayText(item)}</span>
 							{isSteer && (
 								<span className="flex h-5 shrink-0 items-center rounded-[3px] border border-editor-group-border px-1.5 text-[10px] leading-none text-description">
 									Steer

--- a/apps/vscode/webview-ui/src/components/chat/monitor-update.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/monitor-update.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { formatMonitorUpdateExit, parseMonitorUpdate } from "./monitor-update"
+
+describe("parseMonitorUpdate", () => {
+	it("parses a well-formed payload", () => {
+		expect(
+			parseMonitorUpdate(
+				JSON.stringify({
+					name: "applog",
+					description: "watching",
+					lines: ["one", "two"],
+					droppedLines: 3,
+				}),
+			),
+		).toEqual({
+			name: "applog",
+			description: "watching",
+			lines: ["one", "two"],
+			droppedLines: 3,
+			exit: undefined,
+		})
+	})
+
+	it("rejects malformed payloads instead of throwing", () => {
+		expect(parseMonitorUpdate(undefined)).toBeUndefined()
+		expect(parseMonitorUpdate("not json")).toBeUndefined()
+		expect(parseMonitorUpdate(JSON.stringify({ lines: ["x"] }))).toBeUndefined()
+		expect(parseMonitorUpdate(JSON.stringify({ name: "a" }))).toBeUndefined()
+	})
+})
+
+describe("formatMonitorUpdateExit", () => {
+	it("mirrors the CLI wording", () => {
+		expect(formatMonitorUpdateExit({ status: "stopped", stoppedBy: "user" })).toBe("stopped by you")
+		expect(formatMonitorUpdateExit({ status: "stopped" })).toBe("stopped")
+		expect(formatMonitorUpdateExit({ status: "failed", error: "boom" })).toBe("failed: boom")
+		expect(formatMonitorUpdateExit({ status: "exited", code: 1 })).toBe("ended with exit code 1")
+		expect(formatMonitorUpdateExit({ status: "exited" })).toBe("ended")
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/monitor-update.ts
+++ b/apps/vscode/webview-ui/src/components/chat/monitor-update.ts
@@ -15,6 +15,10 @@ export function parseMonitorUpdate(text: string | undefined): MonitorUpdatePaylo
 			description: typeof parsed.description === "string" ? parsed.description : "",
 			lines: parsed.lines.filter((line): line is string => typeof line === "string"),
 			droppedLines: typeof parsed.droppedLines === "number" ? parsed.droppedLines : undefined,
+			omittedEarlierUpdates:
+				typeof parsed.omittedEarlierUpdates === "number" && parsed.omittedEarlierUpdates > 0
+					? parsed.omittedEarlierUpdates
+					: undefined,
 			exit: parsed.exit,
 		}
 	} catch {
@@ -30,6 +34,9 @@ export function formatMonitorUpdateExit(exit: NonNullable<MonitorUpdatePayload["
 		case "failed":
 			return exit.error ? `failed: ${exit.error}` : "failed"
 		default:
-			return exit.code !== undefined && exit.code !== null ? `ended with exit code ${exit.code}` : "ended"
+			if (exit.code !== undefined && exit.code !== null) {
+				return `ended with exit code ${exit.code}`
+			}
+			return exit.signal ? `ended on signal ${exit.signal}` : "ended"
 	}
 }

--- a/apps/vscode/webview-ui/src/components/chat/monitor-update.ts
+++ b/apps/vscode/webview-ui/src/components/chat/monitor-update.ts
@@ -1,0 +1,35 @@
+import type { MonitorUpdatePayload } from "@shared/ExtensionMessage"
+
+/** Parses a `say: "monitor_update"` message's JSON text; undefined when malformed. */
+export function parseMonitorUpdate(text: string | undefined): MonitorUpdatePayload | undefined {
+	if (!text) {
+		return undefined
+	}
+	try {
+		const parsed = JSON.parse(text) as Partial<MonitorUpdatePayload>
+		if (typeof parsed.name !== "string" || !Array.isArray(parsed.lines)) {
+			return undefined
+		}
+		return {
+			name: parsed.name,
+			description: typeof parsed.description === "string" ? parsed.description : "",
+			lines: parsed.lines.filter((line): line is string => typeof line === "string"),
+			droppedLines: typeof parsed.droppedLines === "number" ? parsed.droppedLines : undefined,
+			exit: parsed.exit,
+		}
+	} catch {
+		return undefined
+	}
+}
+
+/** Terminal line for a monitor card; mirrors the CLI wording. */
+export function formatMonitorUpdateExit(exit: NonNullable<MonitorUpdatePayload["exit"]>): string {
+	switch (exit.status) {
+		case "stopped":
+			return exit.stoppedBy === "user" ? "stopped by you" : "stopped"
+		case "failed":
+			return exit.error ? `failed: ${exit.error}` : "failed"
+		default:
+			return exit.code !== undefined && exit.code !== null ? `ended with exit code ${exit.code}` : "ended"
+	}
+}

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1535,11 +1535,20 @@ export class AgentRuntime {
 		if (!consumePendingUserMessage) {
 			return undefined;
 		}
-		const pending = (await consumePendingUserMessage())?.trim();
+		const consumed = await consumePendingUserMessage();
+		const pending = (
+			typeof consumed === "string" ? consumed : consumed?.text
+		)?.trim();
 		if (!pending) {
 			return undefined;
 		}
+		// The object form carries display metadata (e.g. monitor provenance)
+		// that must survive on the persisted message; the model-facing text is
+		// unchanged either way.
+		const extraMetadata =
+			typeof consumed === "object" ? consumed.metadata : undefined;
 		const message = createMessage("user", [{ type: "text", text: pending }], {
+			...extraMetadata,
 			userRunSpan: 0,
 		});
 		this.state.messages.push(message);

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -1988,6 +1988,7 @@ export class HubRuntimeHost implements RuntimeHost {
 						attachmentCount: prompt.attachmentCount,
 						userImages: prompt.userImages,
 						userFiles: prompt.userFiles,
+						origin: prompt.origin,
 					},
 				});
 				return;

--- a/sdk/packages/core/src/hub/server/handlers/session-event-projector.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-event-projector.ts
@@ -96,6 +96,7 @@ export async function projectSessionEvent(
 				attachmentCount: event.payload.attachmentCount,
 				userImages: event.payload.userImages,
 				userFiles: event.payload.userFiles,
+				origin: event.payload.origin,
 			};
 			ctx.publish(
 				ctx.buildEvent(

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -1059,6 +1059,9 @@ export type {
 } from "./types/config";
 export type {
 	CoreSessionEvent,
+	MonitorPromptOrigin,
+	MonitorPromptUpdate,
+	PendingPromptOrigin,
 	SessionChunkEvent,
 	SessionEndedEvent,
 	SessionMonitorStateEvent,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -836,12 +836,19 @@ export class LocalRuntimeHost implements RuntimeHost {
 			completionPolicy: runtime.completionPolicy,
 			consumePendingUserMessage: () => {
 				const entry = this.pendingPromptsController.consumeSteer(sessionId);
-				return entry
-					? formatModePrompt(
-							entry.prompt,
-							entry.mode ?? configWithProvider.mode,
-						)
-					: undefined;
+				if (!entry) {
+					return undefined;
+				}
+				const text = formatModePrompt(
+					entry.prompt,
+					entry.mode ?? configWithProvider.mode,
+				);
+				// Monitor provenance rides along as display metadata so resumed
+				// transcripts can render cards instead of the fenced text. The
+				// model-facing prompt is exactly `text` either way.
+				return entry.origin?.kind === "monitor"
+					? { text, metadata: { monitorOrigin: entry.origin } }
+					: text;
 			},
 			logger: runtime.logger ?? configWithProvider.logger,
 			extensionContext: configWithProvider.extensionContext,
@@ -1121,6 +1128,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 				delivery,
 				userImages: input.userImages,
 				userFiles: input.userFiles,
+				origin: input.origin,
 			});
 			return undefined;
 		}
@@ -1130,6 +1138,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 				mode: input.mode,
 				userImages: input.userImages,
 				userFiles: input.userFiles,
+				origin: input.origin,
 			});
 			if (!session.interactive) {
 				await this.finalizeSingleRun(session, result.finishReason);
@@ -1749,6 +1758,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 			mode?: SendSessionInput["mode"];
 			userImages?: string[];
 			userFiles?: string[];
+			origin?: SendSessionInput["origin"];
 		},
 	): Promise<AgentResult> {
 		const preparedInput = await this.prepareTurnInput(session, input);
@@ -1791,6 +1801,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 				prompt,
 				preparedInput.userImages,
 				preparedInput.userFiles,
+				input.origin,
 			);
 
 			while (shouldAutoContinueTeamRuns(session, result.finishReason)) {
@@ -1921,6 +1932,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		prompt: string,
 		userImages?: string[],
 		userFiles?: string[],
+		origin?: SendSessionInput["origin"],
 	): Promise<AgentResult> {
 		const shouldContinue =
 			session.started || session.agent.getMessages().length > 0;
@@ -1951,9 +1963,16 @@ export class LocalRuntimeHost implements RuntimeHost {
 		});
 
 		try {
+			// Monitor provenance persists as display metadata on the user turn
+			// so resumed transcripts can render cards instead of the fence.
+			const turnOptions =
+				origin?.kind === "monitor"
+					? { userMetadata: { monitorOrigin: origin } }
+					: undefined;
 			const runFn = shouldContinue
-				? () => session.agent.continue(prompt, userImages, userFiles)
-				: () => session.agent.run(prompt, userImages, userFiles);
+				? () =>
+						session.agent.continue(prompt, userImages, userFiles, turnOptions)
+				: () => session.agent.run(prompt, userImages, userFiles, turnOptions);
 			const result = await this.runWithAuthRetry(
 				session,
 				runFn,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1965,14 +1965,20 @@ export class LocalRuntimeHost implements RuntimeHost {
 		try {
 			// Monitor provenance persists as display metadata on the user turn
 			// so resumed transcripts can render cards instead of the fence.
-			const turnOptions =
+			// The options argument is only supplied when present, keeping the
+			// call shape unchanged for ordinary turns.
+			const turnArgs =
 				origin?.kind === "monitor"
-					? { userMetadata: { monitorOrigin: origin } }
-					: undefined;
+					? ([
+							prompt,
+							userImages,
+							userFiles,
+							{ userMetadata: { monitorOrigin: origin } },
+						] as const)
+					: ([prompt, userImages, userFiles] as const);
 			const runFn = shouldContinue
-				? () =>
-						session.agent.continue(prompt, userImages, userFiles, turnOptions)
-				: () => session.agent.run(prompt, userImages, userFiles, turnOptions);
+				? () => session.agent.continue(...turnArgs)
+				: () => session.agent.run(...turnArgs);
 			const result = await this.runWithAuthRetry(
 				session,
 				runFn,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1967,18 +1967,19 @@ export class LocalRuntimeHost implements RuntimeHost {
 			// so resumed transcripts can render cards instead of the fence.
 			// The options argument is only supplied when present, keeping the
 			// call shape unchanged for ordinary turns.
-			const turnArgs =
+			const turnOptions =
 				origin?.kind === "monitor"
-					? ([
-							prompt,
-							userImages,
-							userFiles,
-							{ userMetadata: { monitorOrigin: origin } },
-						] as const)
-					: ([prompt, userImages, userFiles] as const);
+					? { userMetadata: { monitorOrigin: origin } }
+					: undefined;
 			const runFn = shouldContinue
-				? () => session.agent.continue(...turnArgs)
-				: () => session.agent.run(...turnArgs);
+				? () =>
+						turnOptions
+							? session.agent.continue(prompt, userImages, userFiles, turnOptions)
+							: session.agent.continue(prompt, userImages, userFiles)
+				: () =>
+						turnOptions
+							? session.agent.run(prompt, userImages, userFiles, turnOptions)
+							: session.agent.run(prompt, userImages, userFiles);
 			const result = await this.runWithAuthRetry(
 				session,
 				runFn,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -594,9 +594,28 @@ export class LocalRuntimeHost implements RuntimeHost {
 			// and pacing a chatty log would grow the queue without bound and
 			// start a paid turn per report.
 			monitorNotifier: (notification) => {
+				// The formatted text is what the model receives (fully fenced for
+				// injection defense); the structured update lets UIs render a
+				// clean card instead of showing the fence to the user.
 				this.monitorSteerQueue.deliver(
 					sessionId,
 					formatMonitorNotification(notification),
+					{
+						monitorId: notification.monitorId,
+						name: notification.name,
+						description: notification.description,
+						lines: notification.lines,
+						droppedLines: notification.droppedLines,
+						exit: notification.exit
+							? {
+									status: notification.exit.status,
+									stoppedBy: notification.exit.stoppedBy,
+									code: notification.exit.code,
+									signal: notification.exit.signal,
+									error: notification.exit.error,
+								}
+							: undefined,
+					},
 				);
 			},
 			// Host-facing roster state for UIs, separate from the agent-facing

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -288,6 +288,12 @@ export interface PendingPromptsUpdateInput {
 	prompt?: string;
 	mode?: AgentMode;
 	delivery?: "queue" | "steer";
+	/**
+	 * Structured provenance for runtime-generated prompts. Only runtime
+	 * updaters (the monitor steer queue) supply this; a user edit that
+	 * rewrites the prompt text clears the stale origin instead.
+	 */
+	origin?: import("../../types/events").PendingPromptOrigin;
 }
 
 export interface PendingPromptsDeleteInput {

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../types/config";
 import type {
 	CoreSessionEvent,
+	PendingPromptOrigin,
 	SessionPendingPrompt,
 } from "../../types/events";
 import type { SessionRecord } from "../../types/sessions";
@@ -255,6 +256,12 @@ export interface SendSessionInput {
 	userFiles?: string[];
 	delivery?: "queue" | "steer";
 	timeoutMs?: number;
+	/**
+	 * Structured provenance for runtime-generated prompts (monitor reports).
+	 * Persisted as display metadata on the resulting user message so UIs can
+	 * render cards after a resume; never sent to the model.
+	 */
+	origin?: PendingPromptOrigin;
 }
 
 export interface SessionAccumulatedUsage {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -292,6 +292,15 @@ export interface SessionRuntimeOrchestratorDeps {
 /** Connection overrides applied via `updateConnection`. */
 export type ConnectionOverrides = ConnectionUpdate;
 
+/** Optional per-turn extras for `run` / `continue`. */
+export interface SessionRunTurnOptions {
+	/**
+	 * Display metadata persisted on the appended user message (e.g. structured
+	 * monitor provenance). Never alters the model-facing content.
+	 */
+	userMetadata?: Record<string, unknown>;
+}
+
 // =============================================================================
 // SessionRuntime orchestrator
 // =============================================================================
@@ -672,6 +681,7 @@ export class SessionRuntime {
 		userMessage: string,
 		userImages?: string[],
 		userFiles?: string[],
+		options?: SessionRunTurnOptions,
 	): Promise<AgentResult> {
 		this.conversation.resetForRun();
 		this.resetConversationBoundaryTrackers();
@@ -679,6 +689,7 @@ export class SessionRuntime {
 			userMessage,
 			userImages,
 			userFiles,
+			userMetadata: options?.userMetadata,
 			isContinue: false,
 		});
 	}
@@ -687,11 +698,13 @@ export class SessionRuntime {
 		userMessage?: string,
 		userImages?: string[],
 		userFiles?: string[],
+		options?: SessionRunTurnOptions,
 	): Promise<AgentResult> {
 		return this.executeRun({
 			userMessage,
 			userImages,
 			userFiles,
+			userMetadata: options?.userMetadata,
 			isContinue: true,
 		});
 	}
@@ -715,6 +728,7 @@ export class SessionRuntime {
 		userMessage?: string;
 		userImages?: string[];
 		userFiles?: string[];
+		userMetadata?: Record<string, unknown>;
 		isContinue: boolean;
 	}): Promise<AgentResult> {
 		let activePromise!: Promise<AgentResult>;
@@ -737,6 +751,7 @@ export class SessionRuntime {
 		userMessage?: string;
 		userImages?: string[];
 		userFiles?: string[];
+		userMetadata?: Record<string, unknown>;
 		isContinue: boolean;
 	}): Promise<AgentResult> {
 		const result = await this.executeRunInternal(input);
@@ -762,6 +777,7 @@ export class SessionRuntime {
 		userMessage?: string;
 		userImages?: string[];
 		userFiles?: string[];
+		userMetadata?: Record<string, unknown>;
 		isContinue: boolean;
 	}): Promise<AgentResult> {
 		if (this.shutdownCalled) {
@@ -811,7 +827,13 @@ export class SessionRuntime {
 				input.userFiles,
 				this.config.userFileContentLoader,
 			);
-			this.conversation.appendMessage({ role: "user", content });
+			this.conversation.appendMessage({
+				role: "user",
+				content,
+				// Display provenance (e.g. structured monitor origin) persists
+				// with the message; the model-facing content is untouched.
+				...(input.userMetadata ? { metadata: input.userMetadata } : {}),
+			});
 		}
 
 		// Build the AgentRuntime for this turn.

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
@@ -16,18 +16,33 @@ function createQueue(options?: {
 	let prompts: SessionPendingPrompt[] = [];
 	let nextId = 1;
 	let clock = 1_000_000;
-	const enqueue = vi.fn((_sessionId: string, entry: { prompt: string }) => {
-		prompts.push({
-			id: `p${nextId++}`,
-			prompt: entry.prompt,
-			delivery: "steer",
-			attachmentCount: 0,
-		});
-	});
-	const update = vi.fn((input: { promptId: string; prompt: string }) => {
-		const found = prompts.find((prompt) => prompt.id === input.promptId);
-		if (found) found.prompt = input.prompt;
-	});
+	const enqueue = vi.fn(
+		(
+			_sessionId: string,
+			entry: { prompt: string; origin?: SessionPendingPrompt["origin"] },
+		) => {
+			prompts.push({
+				id: `p${nextId++}`,
+				prompt: entry.prompt,
+				delivery: "steer",
+				attachmentCount: 0,
+				origin: entry.origin,
+			});
+		},
+	);
+	const update = vi.fn(
+		(input: {
+			promptId: string;
+			prompt: string;
+			origin?: SessionPendingPrompt["origin"];
+		}) => {
+			const found = prompts.find((prompt) => prompt.id === input.promptId);
+			if (found) {
+				found.prompt = input.prompt;
+				found.origin = input.origin;
+			}
+		},
+	);
 	const queue = new MonitorSteerQueue(
 		{
 			list: () => prompts,
@@ -182,5 +197,65 @@ describe("MonitorSteerQueue", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("carries structured origin metadata alongside the fenced text", () => {
+		const harness = createQueue();
+		harness.queue.deliver("s1", "fenced text", {
+			monitorId: "mon_1",
+			name: "ci",
+			description: "CI status",
+			lines: ["build failed"],
+		});
+
+		expect(harness.prompts[0]?.origin).toEqual({
+			kind: "monitor",
+			updates: [
+				expect.objectContaining({
+					monitorId: "mon_1",
+					lines: ["build failed"],
+				}),
+			],
+		});
+	});
+
+	it("merges origin updates into the outstanding prompt", () => {
+		const harness = createQueue();
+		harness.queue.deliver("s1", "first", {
+			monitorId: "mon_1",
+			name: "ci",
+			description: "CI status",
+			lines: ["one"],
+		});
+		harness.queue.deliver("s1", "second", {
+			monitorId: "mon_1",
+			name: "ci",
+			description: "CI status",
+			lines: ["two"],
+		});
+
+		expect(harness.prompts).toHaveLength(1);
+		const origin = harness.prompts[0]?.origin;
+		expect(origin?.kind).toBe("monitor");
+		expect(origin?.updates.map((update) => update.lines[0])).toEqual([
+			"one",
+			"two",
+		]);
+	});
+
+	it("keeps only the newest origin updates when merged past the cap", () => {
+		const harness = createQueue();
+		for (let index = 0; index < 25; index += 1) {
+			harness.queue.deliver("s1", `report ${index}`, {
+				monitorId: "mon_1",
+				name: "ci",
+				description: "CI status",
+				lines: [`line ${index}`],
+			});
+		}
+
+		const origin = harness.prompts[0]?.origin;
+		expect(origin?.updates).toHaveLength(20);
+		expect(origin?.updates.at(-1)?.lines).toEqual(["line 24"]);
 	});
 });

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
@@ -258,4 +258,97 @@ describe("MonitorSteerQueue", () => {
 		expect(origin?.updates).toHaveLength(20);
 		expect(origin?.updates.at(-1)?.lines).toEqual(["line 24"]);
 	});
+
+	it("counts the origin updates dropped past the cap", () => {
+		// The prompt text is bounded by characters, the card set by count, so
+		// the cards can shrink before the text does. The dropped count is what
+		// lets UIs say so instead of silently showing less than the model saw.
+		const harness = createQueue();
+		for (let index = 0; index < 25; index += 1) {
+			harness.queue.deliver("s1", `report ${index}`, {
+				monitorId: "mon_1",
+				name: "ci",
+				description: "CI status",
+				lines: [`line ${index}`],
+			});
+		}
+
+		const origin = harness.prompts[0]?.origin;
+		expect(origin?.droppedUpdates).toBe(5);
+		expect(origin?.updates[0]?.lines).toEqual(["line 5"]);
+	});
+
+	it("counts updates dropped while buffering through the cooldown", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = createQueue({ cooldownMs: 100 });
+			harness.queue.deliver("s1", "first", {
+				monitorId: "mon_1",
+				name: "ci",
+				description: "CI status",
+				lines: ["first"],
+			});
+			harness.consumeAll();
+			for (let index = 0; index < 25; index += 1) {
+				harness.queue.deliver("s1", `buffered ${index}`, {
+					monitorId: "mon_1",
+					name: "ci",
+					description: "CI status",
+					lines: [`buffered ${index}`],
+				});
+			}
+			harness.advance(100);
+			await vi.advanceTimersByTimeAsync(100);
+
+			const origin = harness.prompts[0]?.origin;
+			expect(origin?.updates).toHaveLength(20);
+			expect(origin?.droppedUpdates).toBe(5);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not merge into a prompt the user has edited", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = createQueue({ cooldownMs: 100 });
+			harness.queue.deliver("s1", "monitor text", {
+				monitorId: "mon_1",
+				name: "ci",
+				description: "CI status",
+				lines: ["one"],
+			});
+
+			// A user edit rewrites the prompt and clears its origin: it is
+			// their prompt now. Later reports must not splice monitor output
+			// into it or re-stamp it as monitor-originated (which would hide
+			// the user's words behind a card).
+			const edited = harness.prompts[0];
+			expect(edited).toBeDefined();
+			if (edited) {
+				edited.prompt = "USER EDIT";
+				edited.origin = undefined;
+			}
+
+			harness.queue.deliver("s1", "later monitor text", {
+				monitorId: "mon_1",
+				name: "ci",
+				description: "CI status",
+				lines: ["two"],
+			});
+			// The disowned report waits out the normal cooldown before
+			// enqueueing fresh; it must never touch the edited prompt.
+			harness.advance(100);
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(harness.prompts).toHaveLength(2);
+			expect(harness.prompts[0]?.prompt).toBe("USER EDIT");
+			expect(harness.prompts[0]?.origin).toBeUndefined();
+			expect(harness.prompts[1]?.prompt).toBe("later monitor text");
+			expect(harness.prompts[1]?.origin?.kind).toBe("monitor");
+			expect(harness.prompts[1]?.origin?.updates[0]?.lines).toEqual(["two"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.test.ts
@@ -12,6 +12,8 @@ import { MonitorSteerQueue } from "./monitor-steer-queue";
 function createQueue(options?: {
 	cooldownMs?: number;
 	maxMergedChars?: number;
+	/** Mimics PendingPromptService.update normalizing prompts on write. */
+	normalize?: (prompt: string) => string;
 }) {
 	let prompts: SessionPendingPrompt[] = [];
 	let nextId = 1;
@@ -38,9 +40,13 @@ function createQueue(options?: {
 		}) => {
 			const found = prompts.find((prompt) => prompt.id === input.promptId);
 			if (found) {
-				found.prompt = input.prompt;
+				found.prompt = options?.normalize
+					? options.normalize(input.prompt)
+					: input.prompt;
 				found.origin = input.origin;
 			}
+			// Mirrors PendingPromptMutationResult: the stored snapshot.
+			return { prompt: found };
 		},
 	);
 	const queue = new MonitorSteerQueue(
@@ -306,6 +312,29 @@ describe("MonitorSteerQueue", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("keeps merging when the service normalizes stored prompts", () => {
+		// PendingPromptService.update stores normalizeUserInput(prompt), so
+		// tag-shaped monitor output (a watched process printing a literal
+		// "<user_input …>", e.g. when tailing an LLM app's own logs) is
+		// stripped on write. The queue must track the text the service stored:
+		// tracking its own pre-normalization copy would misread the difference
+		// as a user edit, permanently disown the entry, and stack one fresh
+		// steer prompt per cooldown — each able to start a paid turn.
+		const harness = createQueue({
+			normalize: (prompt) => prompt.replace(/<user_input[^>]*>/g, ""),
+		});
+		harness.queue.deliver("s1", "first report");
+		harness.queue.deliver("s1", 'log line: <user_input mode="act"> seen');
+		harness.queue.deliver("s1", "third report");
+
+		// All three reports live in the same outstanding prompt; the
+		// normalization was not mistaken for a user edit.
+		expect(harness.enqueue).toHaveBeenCalledTimes(1);
+		expect(harness.prompts).toHaveLength(1);
+		expect(harness.prompts[0]?.prompt).toContain("third report");
+		expect(harness.prompts[0]?.prompt).not.toContain("<user_input");
 	});
 
 	it("does not merge into a prompt the user has edited", async () => {

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
@@ -18,6 +18,10 @@
  *   during the cooldown accumulates and is delivered as a single prompt when it
  *   expires, so turn starts are paced by wall-clock rather than by how fast the
  *   watched process writes.
+ *
+ * Alongside the model-facing text (which stays fully fenced for injection
+ * defense), each prompt carries a structured {@link MonitorPromptOrigin} so
+ * UIs can render a clean update card instead of the fence.
  */
 
 import {
@@ -25,18 +29,27 @@ import {
 	MONITOR_OUTPUT_OPEN_TAG,
 	MONITOR_UNTRUSTED_GUIDANCE,
 } from "../../extensions/tools/executors/monitor";
-import type { SessionPendingPrompt } from "../../types/events";
+import type {
+	MonitorPromptOrigin,
+	MonitorPromptUpdate,
+	SessionPendingPrompt,
+} from "../../types/events";
 
 export interface MonitorSteerQueueDeps {
 	list(sessionId: string): SessionPendingPrompt[];
 	enqueue(
 		sessionId: string,
-		entry: { prompt: string; delivery: "steer" },
+		entry: {
+			prompt: string;
+			delivery: "steer";
+			origin?: MonitorPromptOrigin;
+		},
 	): void;
 	update(input: {
 		sessionId: string;
 		promptId: string;
 		prompt: string;
+		origin?: MonitorPromptOrigin;
 	}): unknown;
 	/** Injectable for tests. */
 	now?: () => number;
@@ -54,17 +67,25 @@ export interface MonitorSteerQueueOptions {
 	 * @default 16000
 	 */
 	maxMergedChars?: number;
+	/**
+	 * Cap on structured updates carried per prompt for UI rendering. Older
+	 * updates are dropped first, mirroring the text cap.
+	 * @default 20
+	 */
+	maxMergedUpdates?: number;
 }
 
 interface SessionState {
 	outstandingId?: string;
 	lastEnqueuedAt: number;
 	buffered?: string;
+	bufferedUpdates: MonitorPromptUpdate[];
 	timer?: NodeJS.Timeout;
 }
 
 const DEFAULT_COOLDOWN_MS = 5_000;
 const DEFAULT_MAX_MERGED_CHARS = 16_000;
+const DEFAULT_MAX_MERGED_UPDATES = 20;
 const DROPPED_PREFIX = "[older monitor output dropped to bound this update]";
 
 export class MonitorSteerQueue {
@@ -83,16 +104,22 @@ export class MonitorSteerQueue {
 		return this.options.maxMergedChars ?? DEFAULT_MAX_MERGED_CHARS;
 	}
 
+	private get maxMergedUpdates(): number {
+		return this.options.maxMergedUpdates ?? DEFAULT_MAX_MERGED_UPDATES;
+	}
+
 	private now(): number {
 		return this.deps.now?.() ?? Date.now();
 	}
 
 	/** Delivers one formatted monitor notification, merging or pacing as needed. */
-	deliver(sessionId: string, text: string): void {
+	deliver(sessionId: string, text: string, update?: MonitorPromptUpdate): void {
 		const state = this.sessions.get(sessionId) ?? {
 			lastEnqueuedAt: Number.NEGATIVE_INFINITY,
+			bufferedUpdates: [],
 		};
 		this.sessions.set(sessionId, state);
+		const updates = update ? [update] : [];
 
 		// An unconsumed monitor prompt is still sitting in the queue: fold this
 		// report into it rather than adding a second one.
@@ -102,6 +129,7 @@ export class MonitorSteerQueue {
 				sessionId,
 				promptId: outstanding.id,
 				prompt: this.merge(outstanding.prompt, text),
+				origin: this.mergeOrigin(originUpdates(outstanding.origin), updates),
 			});
 			return;
 		}
@@ -109,6 +137,10 @@ export class MonitorSteerQueue {
 		const elapsed = this.now() - state.lastEnqueuedAt;
 		if (elapsed < this.cooldownMs) {
 			state.buffered = state.buffered ? this.merge(state.buffered, text) : text;
+			state.bufferedUpdates = this.cappedUpdates([
+				...state.bufferedUpdates,
+				...updates,
+			]);
 			if (!state.timer) {
 				state.timer = setTimeout(() => {
 					state.timer = undefined;
@@ -119,7 +151,7 @@ export class MonitorSteerQueue {
 			return;
 		}
 
-		this.enqueue(sessionId, state, text);
+		this.enqueue(sessionId, state, text, this.mergeOrigin([], updates));
 	}
 
 	/** Drops all state for a session. Call on teardown so timers cannot leak. */
@@ -138,7 +170,9 @@ export class MonitorSteerQueue {
 		const state = this.sessions.get(sessionId);
 		if (!state?.buffered) return;
 		const text = state.buffered;
+		const updates = state.bufferedUpdates;
 		state.buffered = undefined;
+		state.bufferedUpdates = [];
 
 		// The agent may have gone quiet and left an earlier prompt queued while
 		// this was buffering; merge rather than stacking a second one.
@@ -148,14 +182,20 @@ export class MonitorSteerQueue {
 				sessionId,
 				promptId: outstanding.id,
 				prompt: this.merge(outstanding.prompt, text),
+				origin: this.mergeOrigin(originUpdates(outstanding.origin), updates),
 			});
 			return;
 		}
-		this.enqueue(sessionId, state, text);
+		this.enqueue(sessionId, state, text, this.mergeOrigin([], updates));
 	}
 
-	private enqueue(sessionId: string, state: SessionState, text: string): void {
-		this.deps.enqueue(sessionId, { prompt: text, delivery: "steer" });
+	private enqueue(
+		sessionId: string,
+		state: SessionState,
+		text: string,
+		origin: MonitorPromptOrigin | undefined,
+	): void {
+		this.deps.enqueue(sessionId, { prompt: text, delivery: "steer", origin });
 		state.lastEnqueuedAt = this.now();
 		// enqueue() does not hand back an id, so recover it by matching the text
 		// we just submitted. A miss simply means the prompt was consumed before
@@ -175,6 +215,23 @@ export class MonitorSteerQueue {
 			.find((prompt) => prompt.id === state.outstandingId);
 		if (!found) state.outstandingId = undefined;
 		return found;
+	}
+
+	private mergeOrigin(
+		existing: readonly MonitorPromptUpdate[],
+		additions: readonly MonitorPromptUpdate[],
+	): MonitorPromptOrigin | undefined {
+		const updates = this.cappedUpdates([...existing, ...additions]);
+		if (updates.length === 0) return undefined;
+		return { kind: "monitor", updates };
+	}
+
+	private cappedUpdates(
+		updates: readonly MonitorPromptUpdate[],
+	): MonitorPromptUpdate[] {
+		// Keep the newest updates, mirroring the text cap: the agent and the
+		// user both care about current state over history.
+		return updates.slice(Math.max(0, updates.length - this.maxMergedUpdates));
 	}
 
 	private merge(existing: string, addition: string): string {
@@ -202,4 +259,10 @@ export class MonitorSteerQueue {
 			kept,
 		].join("\n");
 	}
+}
+
+function originUpdates(
+	origin: SessionPendingPrompt["origin"],
+): readonly MonitorPromptUpdate[] {
+	return origin?.kind === "monitor" ? origin.updates : [];
 }

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
@@ -45,12 +45,18 @@ export interface MonitorSteerQueueDeps {
 			origin?: MonitorPromptOrigin;
 		},
 	): void;
+	/**
+	 * Returns the mutation result so the queue can record the prompt text the
+	 * service actually stored; the service normalizes on write (e.g. stripping
+	 * user_input/user_command tags), so the submitted text is not reliable for
+	 * the later user-edit comparison.
+	 */
 	update(input: {
 		sessionId: string;
 		promptId: string;
 		prompt: string;
 		origin?: MonitorPromptOrigin;
-	}): unknown;
+	}): { prompt?: { prompt: string } } | undefined | void;
 	/** Injectable for tests. */
 	now?: () => number;
 }
@@ -135,13 +141,18 @@ export class MonitorSteerQueue {
 		const outstanding = this.findOutstanding(sessionId, state);
 		if (outstanding) {
 			const merged = this.merge(outstanding.prompt, text);
-			this.deps.update({
+			const result = this.deps.update({
 				sessionId,
 				promptId: outstanding.id,
 				prompt: merged,
 				origin: this.mergeOrigin(monitorOrigin(outstanding.origin), updates),
 			});
-			state.outstandingText = merged;
+			// Record what was stored, not what was submitted: monitor output can
+			// legitimately contain text the service's normalization strips, and
+			// tracking the pre-normalization copy would misread that difference
+			// as a user edit on the next report, permanently disowning the entry
+			// and stacking a fresh prompt per cooldown.
+			state.outstandingText = result?.prompt?.prompt ?? merged;
 			return;
 		}
 
@@ -191,7 +202,7 @@ export class MonitorSteerQueue {
 		const outstanding = this.findOutstanding(sessionId, state);
 		if (outstanding) {
 			const merged = this.merge(outstanding.prompt, text);
-			this.deps.update({
+			const result = this.deps.update({
 				sessionId,
 				promptId: outstanding.id,
 				prompt: merged,
@@ -201,7 +212,8 @@ export class MonitorSteerQueue {
 					dropped,
 				),
 			});
-			state.outstandingText = merged;
+			// See deliver(): track the stored text, not the submitted text.
+			state.outstandingText = result?.prompt?.prompt ?? merged;
 			return;
 		}
 		this.enqueue(

--- a/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/monitor-steer-queue.ts
@@ -77,9 +77,17 @@ export interface MonitorSteerQueueOptions {
 
 interface SessionState {
 	outstandingId?: string;
+	/**
+	 * The prompt text this queue last wrote to the outstanding entry. A
+	 * mismatch on the next report means the user edited the prompt, which
+	 * makes it theirs: reports must stop merging into it.
+	 */
+	outstandingText?: string;
 	lastEnqueuedAt: number;
 	buffered?: string;
 	bufferedUpdates: MonitorPromptUpdate[];
+	/** Updates dropped from bufferedUpdates while waiting out the cooldown. */
+	bufferedDropped: number;
 	timer?: NodeJS.Timeout;
 }
 
@@ -117,6 +125,7 @@ export class MonitorSteerQueue {
 		const state = this.sessions.get(sessionId) ?? {
 			lastEnqueuedAt: Number.NEGATIVE_INFINITY,
 			bufferedUpdates: [],
+			bufferedDropped: 0,
 		};
 		this.sessions.set(sessionId, state);
 		const updates = update ? [update] : [];
@@ -125,22 +134,23 @@ export class MonitorSteerQueue {
 		// report into it rather than adding a second one.
 		const outstanding = this.findOutstanding(sessionId, state);
 		if (outstanding) {
+			const merged = this.merge(outstanding.prompt, text);
 			this.deps.update({
 				sessionId,
 				promptId: outstanding.id,
-				prompt: this.merge(outstanding.prompt, text),
-				origin: this.mergeOrigin(originUpdates(outstanding.origin), updates),
+				prompt: merged,
+				origin: this.mergeOrigin(monitorOrigin(outstanding.origin), updates),
 			});
+			state.outstandingText = merged;
 			return;
 		}
 
 		const elapsed = this.now() - state.lastEnqueuedAt;
 		if (elapsed < this.cooldownMs) {
 			state.buffered = state.buffered ? this.merge(state.buffered, text) : text;
-			state.bufferedUpdates = this.cappedUpdates([
-				...state.bufferedUpdates,
-				...updates,
-			]);
+			const combined = [...state.bufferedUpdates, ...updates];
+			state.bufferedUpdates = this.cappedUpdates(combined);
+			state.bufferedDropped += combined.length - state.bufferedUpdates.length;
 			if (!state.timer) {
 				state.timer = setTimeout(() => {
 					state.timer = undefined;
@@ -151,7 +161,7 @@ export class MonitorSteerQueue {
 			return;
 		}
 
-		this.enqueue(sessionId, state, text, this.mergeOrigin([], updates));
+		this.enqueue(sessionId, state, text, this.mergeOrigin(undefined, updates));
 	}
 
 	/** Drops all state for a session. Call on teardown so timers cannot leak. */
@@ -171,22 +181,35 @@ export class MonitorSteerQueue {
 		if (!state?.buffered) return;
 		const text = state.buffered;
 		const updates = state.bufferedUpdates;
+		const dropped = state.bufferedDropped;
 		state.buffered = undefined;
 		state.bufferedUpdates = [];
+		state.bufferedDropped = 0;
 
 		// The agent may have gone quiet and left an earlier prompt queued while
 		// this was buffering; merge rather than stacking a second one.
 		const outstanding = this.findOutstanding(sessionId, state);
 		if (outstanding) {
+			const merged = this.merge(outstanding.prompt, text);
 			this.deps.update({
 				sessionId,
 				promptId: outstanding.id,
-				prompt: this.merge(outstanding.prompt, text),
-				origin: this.mergeOrigin(originUpdates(outstanding.origin), updates),
+				prompt: merged,
+				origin: this.mergeOrigin(
+					monitorOrigin(outstanding.origin),
+					updates,
+					dropped,
+				),
 			});
+			state.outstandingText = merged;
 			return;
 		}
-		this.enqueue(sessionId, state, text, this.mergeOrigin([], updates));
+		this.enqueue(
+			sessionId,
+			state,
+			text,
+			this.mergeOrigin(undefined, updates, dropped),
+		);
 	}
 
 	private enqueue(
@@ -203,6 +226,7 @@ export class MonitorSteerQueue {
 		state.outstandingId = this.deps
 			.list(sessionId)
 			.find((prompt) => prompt.prompt === text)?.id;
+		state.outstandingText = state.outstandingId ? text : undefined;
 	}
 
 	private findOutstanding(
@@ -213,17 +237,41 @@ export class MonitorSteerQueue {
 		const found = this.deps
 			.list(sessionId)
 			.find((prompt) => prompt.id === state.outstandingId);
-		if (!found) state.outstandingId = undefined;
+		if (!found) {
+			state.outstandingId = undefined;
+			state.outstandingText = undefined;
+			return undefined;
+		}
+		// A user edit rewrote the prompt (and cleared its monitor origin): it
+		// is their prompt now. Merging into it would splice fenced monitor
+		// text into what the user wrote and re-stamp the whole thing as
+		// monitor-originated, so UIs would render cards and hide the user's
+		// words. Disown it and let later reports enqueue a fresh prompt.
+		if (found.prompt !== state.outstandingText) {
+			state.outstandingId = undefined;
+			state.outstandingText = undefined;
+			return undefined;
+		}
 		return found;
 	}
 
 	private mergeOrigin(
-		existing: readonly MonitorPromptUpdate[],
+		existing: MonitorPromptOrigin | undefined,
 		additions: readonly MonitorPromptUpdate[],
+		alreadyDropped = 0,
 	): MonitorPromptOrigin | undefined {
-		const updates = this.cappedUpdates([...existing, ...additions]);
+		const combined = [...(existing?.updates ?? []), ...additions];
+		const updates = this.cappedUpdates(combined);
 		if (updates.length === 0) return undefined;
-		return { kind: "monitor", updates };
+		const droppedUpdates =
+			(existing?.droppedUpdates ?? 0) +
+			alreadyDropped +
+			(combined.length - updates.length);
+		return {
+			kind: "monitor",
+			updates,
+			...(droppedUpdates > 0 ? { droppedUpdates } : {}),
+		};
 	}
 
 	private cappedUpdates(
@@ -261,8 +309,8 @@ export class MonitorSteerQueue {
 	}
 }
 
-function originUpdates(
+function monitorOrigin(
 	origin: SessionPendingPrompt["origin"],
-): readonly MonitorPromptUpdate[] {
-	return origin?.kind === "monitor" ? origin.updates : [];
+): MonitorPromptOrigin | undefined {
+	return origin?.kind === "monitor" ? origin : undefined;
 }

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -336,6 +336,9 @@ export class PendingPromptsController {
 				...(next.mode ? { mode: next.mode } : {}),
 				userImages: next.userImages,
 				userFiles: next.userFiles,
+				// Provenance rides along so the executed turn persists it as
+				// display metadata on the user message.
+				...(next.origin ? { origin: next.origin } : {}),
 			});
 			// A turn that resolves with an error finish ran (the prompt is in
 			// the conversation and the error is surfaced), so the entry is not

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -2,6 +2,7 @@ import { type AgentMode, normalizeUserInput } from "@cline/shared";
 import { nanoid } from "nanoid";
 import type {
 	CoreSessionEvent,
+	PendingPromptOrigin,
 	SessionPendingPrompt,
 } from "../../types/events";
 import type { ActiveSession, PendingPrompt } from "../../types/session";
@@ -20,6 +21,7 @@ export interface PendingPromptEntry {
 	delivery: PendingPromptDelivery;
 	userImages?: string[];
 	userFiles?: string[];
+	origin?: PendingPromptOrigin;
 }
 
 export interface PendingPromptQueueState {
@@ -44,6 +46,7 @@ export interface PendingPromptEnqueueInput {
 	delivery: PendingPromptDelivery;
 	userImages?: string[];
 	userFiles?: string[];
+	origin?: PendingPromptOrigin;
 }
 
 export interface PendingPromptConsumeResult {
@@ -96,6 +99,11 @@ export class PendingPromptService {
 			prompt,
 			mode: input.mode ?? existing.mode,
 			delivery,
+			// A user edit to a runtime-generated prompt invalidates its
+			// structured provenance unless the updater re-supplies it.
+			origin:
+				input.origin ??
+				(input.prompt === undefined ? existing.origin : undefined),
 		};
 		state.pendingPrompts.splice(index, 1);
 		insertUpdatedPrompt(state, next, index, existing.delivery);
@@ -138,7 +146,7 @@ export class PendingPromptService {
 		state: PendingPromptQueueState,
 		input: PendingPromptEnqueueInput,
 	): SessionPendingPrompt[] {
-		const { prompt, mode, delivery, userImages, userFiles } = input;
+		const { prompt, mode, delivery, userImages, userFiles, origin } = input;
 		const existingIndex = state.pendingPrompts.findIndex(
 			(queued) => queued.prompt === prompt,
 		);
@@ -150,6 +158,7 @@ export class PendingPromptService {
 				mode: mode ?? existing.mode,
 				userImages: userImages ?? existing.userImages,
 				userFiles: userFiles ?? existing.userFiles,
+				origin: origin ?? existing.origin,
 			};
 			if (delivery === "steer" || existing.delivery === "steer") {
 				state.pendingPrompts.unshift({ ...next, delivery: "steer" });
@@ -164,6 +173,7 @@ export class PendingPromptService {
 				delivery,
 				userImages,
 				userFiles,
+				origin,
 			};
 			if (delivery === "steer") {
 				state.pendingPrompts.unshift(newEntry);
@@ -243,6 +253,7 @@ export class PendingPromptsController {
 			delivery: "queue" | "steer";
 			userImages?: string[];
 			userFiles?: string[];
+			origin?: PendingPromptOrigin;
 		},
 	): void {
 		const session = this.deps.getSession(sessionId);
@@ -365,6 +376,7 @@ export class PendingPromptsController {
 				attachmentCount: prompt.attachmentCount,
 				userImages: prompt.userImages,
 				userFiles: prompt.userFiles,
+				origin: prompt.origin,
 			},
 		});
 	}
@@ -388,6 +400,7 @@ function snapshotPrompt(entry: PendingPromptEntry): SessionPendingPrompt {
 			(entry.userImages?.length ?? 0) + (entry.userFiles?.length ?? 0),
 		userImages: entry.userImages,
 		userFiles: entry.userFiles,
+		origin: entry.origin,
 	};
 }
 

--- a/sdk/packages/core/src/types/events.ts
+++ b/sdk/packages/core/src/types/events.ts
@@ -63,6 +63,14 @@ export interface MonitorPromptOrigin {
 	kind: "monitor";
 	/** In delivery order; the steer queue appends as it merges reports. */
 	updates: MonitorPromptUpdate[];
+	/**
+	 * Updates dropped from the front of `updates` to bound the origin. The
+	 * model-facing text has its own (character) bound, so the card set can
+	 * shrink before the text does; a nonzero count tells UIs to say that
+	 * earlier updates were omitted instead of silently underreporting what
+	 * the model saw.
+	 */
+	droppedUpdates?: number;
 }
 
 /**

--- a/sdk/packages/core/src/types/events.ts
+++ b/sdk/packages/core/src/types/events.ts
@@ -39,6 +39,39 @@ export interface SessionTeamProgressEvent {
 	summary: import("@cline/shared").TeamProgressSummary;
 }
 
+/**
+ * One monitor notification folded into a pending prompt. Mirrors the
+ * agent-facing text (which stays fully fenced for injection defense) with
+ * structured fields so UIs can render a clean card instead of the fence.
+ */
+export interface MonitorPromptUpdate {
+	monitorId: string;
+	name: string;
+	description: string;
+	lines: string[];
+	droppedLines?: number;
+	exit?: {
+		status: "exited" | "stopped" | "failed";
+		stoppedBy?: "user";
+		code?: number | null;
+		signal?: string | null;
+		error?: string;
+	};
+}
+
+export interface MonitorPromptOrigin {
+	kind: "monitor";
+	/** In delivery order; the steer queue appends as it merges reports. */
+	updates: MonitorPromptUpdate[];
+}
+
+/**
+ * Structured provenance for a runtime-generated pending prompt. The prompt
+ * text is what the model receives; UIs that recognize the origin render from
+ * it instead of showing the model-facing framing to the user.
+ */
+export type PendingPromptOrigin = MonitorPromptOrigin;
+
 export interface SessionPendingPrompt {
 	id: string;
 	prompt: string;
@@ -46,6 +79,7 @@ export interface SessionPendingPrompt {
 	attachmentCount: number;
 	userImages?: string[];
 	userFiles?: string[];
+	origin?: PendingPromptOrigin;
 }
 
 export interface SessionPendingPromptsEvent {
@@ -61,6 +95,7 @@ export interface SessionPendingPromptSubmittedEvent {
 	attachmentCount: number;
 	userImages?: string[];
 	userFiles?: string[];
+	origin?: PendingPromptOrigin;
 }
 
 export interface SessionSnapshotEvent {

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -255,6 +255,16 @@ export interface AgentRuntimePrepareTurnResult {
 	systemPrompt?: string;
 }
 
+/**
+ * Object form of a consumed pending steer message: the model-facing text plus
+ * metadata to persist on the injected user message (display provenance only;
+ * the text the model receives is exactly `text`).
+ */
+export interface PendingUserSteerMessage {
+	text: string;
+	metadata?: Record<string, unknown>;
+}
+
 export type AgentModelFinishReason =
 	| "stop"
 	| "tool-calls"
@@ -517,11 +527,14 @@ export interface AgentRuntimeConfig {
 		| undefined;
 	// Optional host callback used by interactive sessions to inject a queued
 	// user steering message between agent loop iterations, before the next
-	// model request.
+	// model request. The object form carries display metadata (e.g. structured
+	// monitor provenance) that is persisted on the injected message without
+	// altering the model-facing text.
 	consumePendingUserMessage?: () =>
 		| string
+		| PendingUserSteerMessage
 		| undefined
-		| Promise<string | undefined>;
+		| Promise<string | PendingUserSteerMessage | undefined>;
 }
 
 // =============================================================================

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -893,12 +893,17 @@ export interface AgentConfig {
 
 	/**
 	 * Optional callback invoked at the top of each agent loop iteration
-	 * (after the first). If it returns a non-empty string, that string is
-	 * injected as a user message into the conversation before the next API
-	 * call. This allows the host to feed user input into a running loop
-	 * without waiting for the current run to finish.
+	 * (after the first). If it returns a non-empty string (or object form
+	 * with `text`), that text is injected as a user message into the
+	 * conversation before the next API call. This allows the host to feed
+	 * user input into a running loop without waiting for the current run to
+	 * finish. The object form additionally carries display metadata persisted
+	 * on the injected message (e.g. structured monitor provenance).
 	 */
-	consumePendingUserMessage?: () => string | undefined;
+	consumePendingUserMessage?: () =>
+		| string
+		| { text: string; metadata?: Record<string, unknown> }
+		| undefined;
 
 	// -------------------------------------------------------------------------
 	// Cancellation


### PR DESCRIPTION
### Related Issue

None linked. Follow-up to #13261, #13386, and #13387: replaces the raw fenced monitor-notification text in user-facing transcripts with clean cards on both the CLI and the VS Code extension. Stacked on #13387.

### Description

Monitor notifications reach the agent as user-role steer prompts wrapped in `<monitor-output>` fencing plus untrusted-content guidance, which is load-bearing prompt-injection defense (a watched process must never speak with the user's authority). Both the CLI and the extension previously rendered that model-facing payload verbatim to the human: three lines of security boilerplate around every update.

This PR separates the model-facing payload from the user-facing display:

- Pending prompts now carry structured `origin` metadata. The monitor steer queue attaches `{kind: "monitor", updates: [{name, description, lines, exit}]}` to each prompt it enqueues, merges metadata the same way it merges text (capped, newest kept), and the origin flows through the pending-prompt service, hub projection, and `pending_prompt_submitted` events. The fenced text the model receives is byte-for-byte unchanged. A user edit to a runtime-generated prompt clears its stale origin.
- CLI: monitor steer messages render as compact cards (name, description, output lines, and exit lines like "stopped by you") instead of the fence. Queued monitor prompts show "Monitor update from applog (3 lines)" instead of truncated fence text.
- Extension: monitor-origin prompts translate to a new `monitor_update` say type (proto enum and conversions included) carrying a JSON payload, rendered in ChatRow as a card with a pulse icon, bold name, description, monospace output, and exit outcome. The queued strip shows the same compact label.

### Test Procedure

- Full SDK typecheck, `@cline/cli` typecheck, and extension `check-types` (with proto regen) pass.
- SDK turn-queue and hub boundary suites pass, with new tests for origin metadata attach/merge/cap in the steer queue.
- CLI suites pass with new tests for queued-prompt labels and card exit-line formatting.
- Extension unit suite passes with a new translator test (monitor-origin prompt becomes a `monitor_update` card, not a user bubble); webview tests cover the card payload parser and exit formatting.
- Manually verified on both surfaces with real agent turns: monitor output and user-attributed stops render as clean cards, and no `<monitor-output>` tags or untrusted-content guidance are visible anywhere in either UI. Verified the injection defense unchanged: the model-bound prompt text still carries the full fencing.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


**CLI transcript, including the user-attributed stop card ("stopped by you"):**

![CLI monitor cards](https://raw.githubusercontent.com/cline/cline/saoudrizwan/monitor-ui-screenshots-d8cc/screenshots/cli_monitor_card_rendering.png)

**Extension chat card plus the roster strip, no fence text anywhere:**

![Extension monitor card](https://raw.githubusercontent.com/cline/cline/saoudrizwan/monitor-ui-screenshots-d8cc/screenshots/extension_monitor_card_rendering.png)


### Additional Notes

Hydrated transcripts (resumed sessions) still show the raw prompt text for monitor messages, since persisted messages do not yet carry the origin metadata; live sessions render cards everywhere. Carrying origin into message persistence is a possible follow-up.