### PR TITLE
fix(core): merge partial thinking updates and adopt restored checkpoint metadata

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -792,6 +792,88 @@ describe("LocalRuntimeHost", () => {
 		});
 	});
 
+	it("keeps provider-inherited reasoning on partial thinking updates", async () => {
+		const sessionId = "sess-thinking-inherited";
+		const manifest = createManifest(sessionId);
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+			createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+				manifestPath: "/tmp/manifest-thinking-inherited.json",
+				messagesPath: "/tmp/messages-thinking-inherited.json",
+				manifest,
+			}),
+			persistSessionMessages: vi.fn(),
+			updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+			updateSession: vi.fn().mockResolvedValue({ updated: true }),
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({ tools: [], shutdown: vi.fn() }),
+		};
+		const agent = {
+			run: vi.fn().mockResolvedValue(createResult()),
+			continue: vi.fn().mockResolvedValue(createResult()),
+			getMessages: vi.fn().mockReturnValue([]),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			updateConnection: vi.fn(),
+			canStartRun: vi.fn().mockReturnValue(true),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+		};
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: runtimeBuilder as never,
+			createAgent: () => agent as never,
+			// The session config makes no reasoning choice; the effective level
+			// comes from persisted provider settings.
+			providerSettingsManager: {
+				getProviderSettings: vi.fn().mockReturnValue({
+					reasoning: { effort: "high" },
+				}),
+			} as never,
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				prompt: "hello",
+				interactive: true,
+			}),
+		);
+
+		expect(sessionService.createRootSessionWithArtifacts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId,
+				metadata: expect.objectContaining({
+					thinking: { enabled: true, level: "high" },
+				}),
+			}),
+		);
+
+		// A partial update must merge into the tracked state like the live
+		// agent's `updateConnection` does; re-deriving from `session.config`
+		// (which never carried the inherited level) would drop it.
+		await manager.updateSessionConnection(sessionId, {
+			thinkingBudgetTokens: 2048,
+		});
+
+		expect(agent.updateConnection).toHaveBeenLastCalledWith({
+			thinking: true,
+			thinkingBudgetTokens: 2048,
+		});
+		expect(sessionService.updateSession).toHaveBeenLastCalledWith({
+			sessionId,
+			metadata: expect.objectContaining({
+				thinking: { enabled: true, level: "high", budgetTokens: 2048 },
+			}),
+		});
+	});
+
 	it("serializes thinking and turn-usage metadata updates", async () => {
 		const sessionId = "sess-thinking-metadata-race";
 		let storedManifest: SessionManifest = {
@@ -4655,6 +4737,114 @@ describe("LocalRuntimeHost", () => {
 			cacheWriteTokens: 3,
 			totalCost: 0.47,
 		});
+	});
+
+	it("persists newly trimmed checkpoint metadata on a same-id restore resume", async () => {
+		const sessionId = "sess-resume-checkpoint-trim";
+		const sessionsDir = join(isolatedHomeDir, "sessions");
+		const sessionDir = join(sessionsDir, sessionId);
+		const messagesPath = join(sessionDir, `${sessionId}.messages.json`);
+		mkdirSync(sessionDir, { recursive: true });
+		const staleCheckpoint = {
+			latest: { ref: "checkpoint-2", createdAt: 2, runCount: 2 },
+			history: [
+				{ ref: "checkpoint-1", createdAt: 1, runCount: 1 },
+				{ ref: "checkpoint-2", createdAt: 2, runCount: 2 },
+			],
+		};
+		const trimmedCheckpoint = {
+			latest: { ref: "checkpoint-1", createdAt: 1, runCount: 1 },
+			history: [{ ref: "checkpoint-1", createdAt: 1, runCount: 1 }],
+		};
+		const manifest = {
+			...createManifest(sessionId),
+			status: "completed" as const,
+			ended_at: "2026-01-01T00:03:00.000Z",
+			metadata: {
+				title: "saved title",
+				checkpoint: staleCheckpoint,
+			},
+			messages_path: messagesPath,
+		};
+		const initialMessages: MessageWithMetadata[] = [
+			{ role: "user", content: "first prompt" },
+			{ role: "assistant", content: "first answer" },
+		];
+		const persistSessionMessages = vi.fn();
+		const updateSession = vi.fn().mockResolvedValue({ updated: true });
+		const sessionService = {
+			ensureSessionsDir: vi.fn().mockReturnValue(sessionsDir),
+			readSessionManifest: vi.fn().mockReturnValue(manifest),
+			createRootSessionWithArtifacts: vi.fn(),
+			persistSessionMessages,
+			updateSessionStatus: vi
+				.fn()
+				.mockResolvedValue({ updated: true, endedAt: null }),
+			updateSession,
+			writeSessionManifest: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue([]),
+			deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+		};
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: sessionService as never,
+			runtimeBuilder: {
+				build: vi.fn().mockReturnValue({
+					tools: [],
+					registerLeadAgent: vi.fn(),
+					shutdown: vi.fn(),
+				}),
+			},
+			createAgent: () =>
+				({
+					run: vi.fn(),
+					continue: vi.fn().mockResolvedValue(createResult()),
+					abort: vi.fn(),
+					subscribeEvents: vi.fn().mockReturnValue(() => {}),
+					canStartRun: vi.fn().mockReturnValue(true),
+					getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+					getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+					shutdown: vi.fn().mockResolvedValue(undefined),
+					getMessages: vi.fn().mockReturnValue(initialMessages),
+					messages: initialMessages,
+				}) as never,
+		});
+
+		// A same-id checkpoint restore looks like a read-only resume (requested
+		// session id, seeded messages, no prompt) but supplies the trimmed
+		// checkpoint record in its start metadata.
+		await manager.startSession({
+			config: { ...createConfig({ sessionId }), cwd: undefined },
+			interactive: true,
+			initialMessages,
+			sessionMetadata: {
+				restoredFromSessionId: sessionId,
+				restoredCheckpointRunCount: 1,
+				checkpoint: trimmedCheckpoint,
+			},
+		});
+
+		// The trimmed record replaces the stale one on disk without rewriting
+		// the rest of the saved metadata, and the seeded messages stay
+		// memory-only like any other resume.
+		expect(
+			sessionService.createRootSessionWithArtifacts,
+		).not.toHaveBeenCalled();
+		expect(persistSessionMessages).not.toHaveBeenCalled();
+		expect(updateSession).toHaveBeenCalledTimes(1);
+		expect(updateSession).toHaveBeenCalledWith({
+			sessionId,
+			metadata: {
+				title: "saved title",
+				checkpoint: trimmedCheckpoint,
+			},
+		});
+		expect((await manager.getSession(sessionId))?.metadata).toEqual(
+			expect.objectContaining({
+				restoredFromSessionId: sessionId,
+				checkpoint: trimmedCheckpoint,
+			}),
+		);
 	});
 
 	it("restores full persisted aggregate usage when child message artifacts are missing", async () => {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -36,6 +36,7 @@ import {
 	emitSessionCreationTelemetry,
 } from "../../services/session-telemetry";
 import {
+	applySessionThinkingConnectionUpdate,
 	resolveSessionThinkingMetadata,
 	withSessionThinkingMetadata,
 } from "../../services/session-thinking";
@@ -885,6 +886,10 @@ export class LocalRuntimeHost implements RuntimeHost {
 		this.sessions.set(sessionId, active);
 		if (resumedArtifacts) {
 			await this.refreshActiveSessionGitMetadata(active, bootstrap.gitState);
+			await this.adoptSuppliedCheckpointMetadata(
+				active,
+				startInput.sessionMetadata,
+			);
 		}
 		// Sessions seeded with history (mode-switch restarts, forks, missing-
 		// session recovery) must be durable immediately. Lazy persistence
@@ -1566,13 +1571,19 @@ export class LocalRuntimeHost implements RuntimeHost {
 		// Only when the update actually carries a reasoning field: a plain model
 		// switch leaves `session.config` without the effective level resolved from
 		// provider settings, and re-deriving it here would clobber what start
-		// recorded.
+		// recorded. Merge the partial update into the tracked state — exactly what
+		// `agent.updateConnection` did above — so a partial update (e.g. a budget
+		// with no level) keeps the reasoning the session inherited from provider
+		// settings and the saved metadata matches the live agent.
 		if (
 			Object.hasOwn(updates, "reasoningEffort") ||
 			Object.hasOwn(updates, "thinking") ||
 			Object.hasOwn(updates, "thinkingBudgetTokens")
 		) {
-			session.thinking = resolveSessionThinkingMetadata(session.config);
+			session.thinking = applySessionThinkingConnectionUpdate(
+				session.thinking,
+				updates,
+			);
 			await this.refreshActiveSessionThinkingMetadata(session);
 		}
 	}
@@ -2098,6 +2109,42 @@ export class LocalRuntimeHost implements RuntimeHost {
 				error,
 			});
 		}
+	}
+
+	/**
+	 * A same-id checkpoint restore resumes the existing session artifacts but
+	 * supplies newly trimmed checkpoint metadata in its start input; by the time
+	 * the session starts, the restore has already deleted the refs of the
+	 * checkpoints it dropped. The supplied record is authoritative, so replace
+	 * the stored checkpoint state instead of retaining stale future checkpoints.
+	 * A plain read-only resume supplies no `checkpoint` key and keeps stored
+	 * metadata untouched. Failures are logged and swallowed: throwing here would
+	 * make the restore's cleanup path delete the original session.
+	 */
+	private async adoptSuppliedCheckpointMetadata(
+		session: ActiveSession,
+		suppliedMetadata: Record<string, unknown> | undefined,
+	): Promise<void> {
+		if (!suppliedMetadata || !Object.hasOwn(suppliedMetadata, "checkpoint")) {
+			return;
+		}
+		const checkpoint = suppliedMetadata.checkpoint;
+		// persistSessionMetadata swaps the in-memory metadata for the persisted
+		// snapshot; keep the richer resume-time view (it already carries the
+		// supplied checkpoint) so start callers still see every supplied key.
+		const inMemoryMetadata = session.sessionMetadata;
+		try {
+			await this.persistSessionMetadata(session.sessionId, (current) => ({
+				...(current ?? {}),
+				checkpoint,
+			}));
+		} catch (error) {
+			session.config.logger?.debug?.(
+				"Failed to persist restored checkpoint metadata",
+				{ sessionId: session.sessionId, error },
+			);
+		}
+		session.sessionMetadata = inMemoryMetadata;
 	}
 
 	/**

--- a/sdk/packages/core/src/services/session-thinking.test.ts
+++ b/sdk/packages/core/src/services/session-thinking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	applySessionThinkingConnectionUpdate,
 	hasCurrentSessionThinkingMetadata,
 	readSessionThinkingMetadata,
 	resolveSessionThinkingMetadata,
@@ -58,6 +59,77 @@ describe("resolveSessionThinkingMetadata", () => {
 				thinkingBudgetTokens: 0,
 			}),
 		).toEqual({ enabled: false });
+	});
+});
+
+describe("applySessionThinkingConnectionUpdate", () => {
+	it("keeps inherited reasoning on a partial budget update", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, level: "high" },
+				{ thinkingBudgetTokens: 2048 },
+			),
+		).toEqual({ enabled: true, level: "high", budgetTokens: 2048 });
+	});
+
+	it("keeps an existing budget on a level-only update", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, budgetTokens: 4096 },
+				{ reasoningEffort: "low" },
+			),
+		).toEqual({ enabled: true, level: "low", budgetTokens: 4096 });
+	});
+
+	it("keeps the current level when only the boolean is toggled on", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, level: "medium" },
+				{ thinking: true },
+			),
+		).toEqual({ enabled: true, level: "medium" });
+	});
+
+	it("clears level and budget when thinking is disabled", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, level: "high", budgetTokens: 8192 },
+				{ thinking: false },
+			),
+		).toEqual({ enabled: false });
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, level: "high" },
+				{ thinking: null, reasoningEffort: null, thinkingBudgetTokens: null },
+			),
+		).toEqual({ enabled: false });
+	});
+
+	it("disables the level-only state when its effort is cleared", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true, level: "high" },
+				{ reasoningEffort: "none" },
+			),
+		).toEqual({ enabled: false });
+	});
+
+	it("stays enabled without a level when the boolean was explicit", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: true },
+				{ thinkingBudgetTokens: null },
+			),
+		).toEqual({ enabled: true });
+	});
+
+	it("enables thinking from a disabled state via an effort", () => {
+		expect(
+			applySessionThinkingConnectionUpdate(
+				{ enabled: false },
+				{ reasoningEffort: "medium" },
+			),
+		).toEqual({ enabled: true, level: "medium" });
 	});
 });
 

--- a/sdk/packages/core/src/services/session-thinking.ts
+++ b/sdk/packages/core/src/services/session-thinking.ts
@@ -62,6 +62,57 @@ export function resolveSessionThinkingMetadata(config: {
 	return buildThinkingMetadata(enabled, level, budgetTokens);
 }
 
+/**
+ * Merge a partial connection update into the current thinking metadata,
+ * mirroring how the live agent's `updateConnection` folds partial reasoning
+ * fields into its existing config. Recomputing from the session config
+ * instead would drop reasoning the session inherited from persisted provider
+ * settings, which only the effective bootstrap config ever carried.
+ */
+export function applySessionThinkingConnectionUpdate(
+	current: SessionThinkingMetadata | undefined,
+	updates: {
+		thinking?: boolean | null;
+		reasoningEffort?: string | null;
+		thinkingBudgetTokens?: number | null;
+	},
+): SessionThinkingMetadata {
+	// Reconstruct the config-field view of the current state. `enabled` with a
+	// level or budget may or may not have had the boolean set; `enabled` with
+	// neither can only have come from an explicit `thinking: true`.
+	let level = current?.enabled === true ? current.level : undefined;
+	let budgetTokens =
+		current?.enabled === true ? current.budgetTokens : undefined;
+	let thinking: boolean | undefined =
+		current?.enabled === true &&
+		level === undefined &&
+		budgetTokens === undefined
+			? true
+			: undefined;
+	// Mirror the agent's `updateConnection`: only fields present in the update
+	// replace the current value, and disabling thinking clears effort/budget.
+	if (Object.hasOwn(updates, "reasoningEffort")) {
+		level = normalizeThinkingLevel(updates.reasoningEffort ?? undefined);
+	}
+	if (Object.hasOwn(updates, "thinkingBudgetTokens")) {
+		budgetTokens = normalizeBudgetTokens(
+			updates.thinkingBudgetTokens ?? undefined,
+		);
+	}
+	if (Object.hasOwn(updates, "thinking")) {
+		thinking = updates.thinking ?? undefined;
+		if (updates.thinking === false || updates.thinking === null) {
+			level = undefined;
+			budgetTokens = undefined;
+		}
+	}
+	return buildThinkingMetadata(
+		thinking === true || level !== undefined || budgetTokens !== undefined,
+		level,
+		budgetTokens,
+	);
+}
+
 /** Read back what was persisted, ignoring malformed values. */
 export function readSessionThinkingMetadata(
 	metadata: Record<string, unknown> | undefined,


### PR DESCRIPTION
### Related Issue

Addresses the two unresolved review comments from @johnwschoi on #12692 (2026-07-29): [comment on the connection-update path](https://github.com/cline/cline/pull/12692#discussion_r3678315429) and [comment on the resume path](https://github.com/cline/cline/pull/12692#discussion_r3678318903).

### Description

**1. Partial thinking updates persisted state different from the live agent** (`local-runtime-host.ts` ~1575)

`updateSessionConnection` recomputed `session.thinking` from `session.config`. When the session's reasoning level was inherited from persisted provider settings, it only ever lived in `bootstrap.providerConfig` — `session.config` never carried it. A partial update (e.g. `{ thinkingBudgetTokens: 2048 }` with no level) therefore persisted `{ enabled: true, budgetTokens: 2048 }` while the live agent — whose `updateConnection` merges partial fields into its existing effective config — kept reasoning at the inherited level.

Fix: new `applySessionThinkingConnectionUpdate` in `services/session-thinking.ts` merges the update into `session.thinking` with the same field semantics as the agent's `updateConnection` (only fields present in the update replace current values; disabling thinking clears level and budget), so saved metadata matches the live agent.

**2. Same-ID restore ignored newly trimmed checkpoint metadata** (`local-runtime-host.ts` ~584)

A same-ID checkpoint restore reaches `startSession` looking like a read-only resume (requested session id, seeded messages, no prompt), but its start input carries newly trimmed checkpoint metadata — and by that point the restore has already deleted the dropped checkpoints' git refs (`retainCheckpointRefs`). The resume path never persisted supplied metadata, so the stored `metadata.checkpoint` kept referencing stale future checkpoints forever (the per-turn metadata write merges over disk state and never touches the checkpoint key).

Fix: new `adoptSuppliedCheckpointMetadata` persists the supplied `checkpoint` record over the stored one on resume. The rest of the read-only resume invariant is intact: a plain resume supplies no `checkpoint` key and still never rewrites saved metadata (the pre-existing invariant test covering that is unchanged and passing).

### Test Procedure

- New unit tests for `applySessionThinkingConnectionUpdate` covering partial budget/level/boolean updates, disable-clears-all, and enable-from-disabled (`session-thinking.test.ts`).
- New host test "keeps provider-inherited reasoning on partial thinking updates": provider settings supply `reasoning.effort: "high"`, session config makes no choice, a budget-only connection update must persist `{ enabled: true, level: "high", budgetTokens: 2048 }`. Fails on the old recompute-from-config code.
- New host test "persists newly trimmed checkpoint metadata on a same-id restore resume": a resume start supplying a trimmed `checkpoint` record replaces the stale one on disk without rewriting other saved keys or persisting seeded messages.
- `bun -F @cline/core test:unit` for the two touched test files: 98/98 pass. Full core suite: 1903 pass; the 2 failures are the documented cloud-VM git `insteadOf` artifact (`workspace-manifest.test.ts`) and a load-dependent `checkpoint-diff.test.ts` flake that passes in isolation — both pre-existing and unrelated.
- `bun run types` passes across all SDK packages; changed files are biome-clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

One deliberate semantic choice in the merge helper: normalized metadata cannot distinguish "enabled via explicit `thinking: true`" from "enabled via an effort level alone". When an update clears the effort of a level-carrying state without touching the boolean, the helper treats the state as effort-derived and disables — matching how the CLI/desktop actually set levels (`reasoningEffort` without the boolean).