### PR TITLE
fix(cli): register a workspace client for remote schedule commands

### DIFF
--- a/apps/cli/src/commands/schedule.test.ts
+++ b/apps/cli/src/commands/schedule.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createScheduleCommand } from "./schedule";
 
-const mockSendHubCommand = vi.hoisted(() => vi.fn());
+const mockHubClientCommand = vi.hoisted(() => vi.fn());
+const mockNodeHubClientCtor = vi.hoisted(() => vi.fn());
 const mockEnsureCliHubServer = vi.hoisted(() => vi.fn());
 const mockProviderSettings = vi.hoisted(() => ({
 	lastUsed: undefined as { provider?: string; model?: string } | undefined,
@@ -16,7 +17,17 @@ vi.mock("@cline/core", async () => {
 		await vi.importActual<typeof import("@cline/core")>("@cline/core");
 	return {
 		...actual,
-		sendHubCommand: mockSendHubCommand,
+		NodeHubClient: class {
+			command = mockHubClientCommand;
+
+			constructor(options: Record<string, unknown>) {
+				mockNodeHubClientCtor(options);
+			}
+
+			async connect(): Promise<void> {}
+
+			close(): void {}
+		},
 		ProviderSettingsManager: class {
 			getLastUsedProviderSettings() {
 				return mockProviderSettings.lastUsed;
@@ -74,7 +85,7 @@ describe("runScheduleCommand list output", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedules: [] },
 		});
@@ -96,18 +107,21 @@ describe("runScheduleCommand list output", () => {
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
 		expect(output).toEqual(["No schedules found."]);
-		expect(mockSendHubCommand).toHaveBeenCalledWith(
-			{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
-			{
-				clientId: "cline-schedule",
-				command: "schedule.list",
-				payload: {
-					limit: 100,
-					enabled: undefined,
-					tags: undefined,
-				},
-			},
+		// Schedule commands are workspace-scoped: the hub client must register
+		// with a workspace context (and the hub auth token) before commanding.
+		expect(mockNodeHubClientCtor).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "ws://127.0.0.1:25463/hub",
+				workspaceRoot: process.cwd(),
+				cwd: process.cwd(),
+				authToken: "test-token",
+			}),
 		);
+		expect(mockHubClientCommand).toHaveBeenCalledWith("schedule.list", {
+			limit: 100,
+			enabled: undefined,
+			tags: undefined,
+		});
 	});
 
 	it("keeps JSON list output unchanged when --json is provided", async () => {
@@ -115,7 +129,7 @@ describe("runScheduleCommand list output", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedules: [] },
 		});
@@ -137,7 +151,7 @@ describe("runScheduleCommand list output", () => {
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
 		expect(output).toEqual(["[]"]);
-		expect(mockSendHubCommand).toHaveBeenCalled();
+		expect(mockHubClientCommand).toHaveBeenCalled();
 	});
 });
 
@@ -157,7 +171,7 @@ describe("runScheduleCommand create", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: { scheduleId: "sched_123" } },
 		});
@@ -189,15 +203,19 @@ describe("runScheduleCommand create", () => {
 
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
-		expect(mockSendHubCommand).toHaveBeenCalledWith(
-			{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
+		expect(mockNodeHubClientCtor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				clientId: "cline-schedule",
-				command: "schedule.create",
-				payload: expect.objectContaining({
-					provider: "anthropic",
-					model: "claude-sonnet-4-6",
-				}),
+				url: "ws://127.0.0.1:25463/hub",
+				workspaceRoot: "/tmp/workspace",
+				cwd: "/tmp/workspace",
+				authToken: "test-token",
+			}),
+		);
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.create",
+			expect.objectContaining({
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
 			}),
 		);
 	});
@@ -215,7 +233,7 @@ describe("runScheduleCommand create", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: { scheduleId: "sched_123" } },
 		});
@@ -246,14 +264,11 @@ describe("runScheduleCommand create", () => {
 
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
-		expect(mockSendHubCommand).toHaveBeenCalledWith(
-			{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.create",
 			expect.objectContaining({
-				command: "schedule.create",
-				payload: expect.objectContaining({
-					provider: "anthropic",
-					model: "claude-sonnet-4-6",
-				}),
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
 			}),
 		);
 	});
@@ -292,7 +307,7 @@ describe("runScheduleCommand create", () => {
 		expect(errors).toEqual([
 			'No model is configured for provider "anthropic". Pass --model or save a model for that provider before creating the schedule.',
 		]);
-		expect(mockSendHubCommand).not.toHaveBeenCalled();
+		expect(mockHubClientCommand).not.toHaveBeenCalled();
 	});
 
 	it("maps --delivery-bot to delivery.userName", async () => {
@@ -300,7 +315,7 @@ describe("runScheduleCommand create", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: { scheduleId: "sched_delivery" } },
 		});
@@ -339,21 +354,17 @@ describe("runScheduleCommand create", () => {
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
 		expect(output).toEqual(['{\n  "scheduleId": "sched_delivery"\n}']);
-		expect(mockSendHubCommand).toHaveBeenCalledWith(
-			{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
-			{
-				clientId: "cline-schedule",
-				command: "schedule.create",
-				payload: expect.objectContaining({
-					metadata: {
-						delivery: {
-							adapter: "telegram",
-							threadId: "telegram:123456789",
-							userName: "my_bot",
-						},
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.create",
+			expect.objectContaining({
+				metadata: {
+					delivery: {
+						adapter: "telegram",
+						threadId: "telegram:123456789",
+						userName: "my_bot",
 					},
-				}),
-			},
+				},
+			}),
 		);
 	});
 });
@@ -370,7 +381,7 @@ describe("runScheduleCommand import", () => {
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: { scheduleId: "sched_123" } },
 		});
@@ -411,16 +422,12 @@ describe("runScheduleCommand import", () => {
 		expect(code).toBe(0);
 		expect(errors).toEqual([]);
 		expect(output).toEqual(['{\n  "scheduleId": "sched_123"\n}']);
-		expect(mockSendHubCommand).toHaveBeenCalledWith(
-			{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
-			{
-				clientId: "cline-schedule",
-				command: "schedule.create",
-				payload: expect.objectContaining({
-					provider: "anthropic",
-					model: "claude-sonnet-4-6",
-				}),
-			},
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.create",
+			expect.objectContaining({
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
+			}),
 		);
 	});
 });
@@ -444,7 +451,7 @@ describe("runScheduleCommand export", () => {
 			prompt: "review status",
 			workspaceRoot: "/tmp/workspace",
 		};
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: scheduleRecord },
 		});
@@ -484,14 +491,9 @@ describe("runScheduleCommand export", () => {
 
 			const written = await readFile(targetPath, "utf8");
 			expect(written).toBe(JSON.stringify(scheduleRecord, null, 2));
-			expect(mockSendHubCommand).toHaveBeenCalledWith(
-				{ host: "127.0.0.1", port: 25463, pathname: "/hub" },
-				{
-					clientId: "cline-schedule",
-					command: "schedule.get",
-					payload: { scheduleId: "sched_abc" },
-				},
-			);
+			expect(mockHubClientCommand).toHaveBeenCalledWith("schedule.get", {
+				scheduleId: "sched_abc",
+			});
 		} finally {
 			await rm(targetPath, { force: true });
 		}
@@ -507,7 +509,7 @@ describe("runScheduleCommand export", () => {
 			name: "Weekly Sync",
 			cronPattern: "0 9 * * 1",
 		};
-		mockSendHubCommand.mockResolvedValue({
+		mockHubClientCommand.mockResolvedValue({
 			ok: true,
 			payload: { schedule: scheduleRecord },
 		});

--- a/apps/cli/src/commands/schedule/client.ts
+++ b/apps/cli/src/commands/schedule/client.ts
@@ -2,7 +2,7 @@ import {
 	createLocalHubScheduleRuntimeHandlers,
 	HubScheduleCommandService,
 	HubScheduleService,
-	sendHubCommand,
+	NodeHubClient,
 } from "@cline/core";
 import {
 	ensureCliHubServer,
@@ -11,28 +11,51 @@ import {
 import type { CommandIo } from "./types";
 
 export class HubScheduleClient {
+	private hub: Promise<NodeHubClient> | undefined;
+
 	constructor(
-		private readonly endpoint: {
-			host?: string;
-			port?: number;
-			pathname?: string;
-		},
+		private readonly url: string,
+		private readonly workspaceRoot: string,
+		private readonly authToken?: string,
 	) {}
 
-	close(): void {}
+	close(): void {
+		const hub = this.hub;
+		this.hub = undefined;
+		void hub?.then((client) => client.close()).catch(() => undefined);
+	}
+
+	// Schedule commands are authorized against the workspace bound to the
+	// connection's client registration, so all commands must share one
+	// registered connection instead of fire-and-forget envelopes.
+	private connectedHub(): Promise<NodeHubClient> {
+		this.hub ??= (async () => {
+			const client = new NodeHubClient({
+				url: this.url,
+				clientType: "cli-schedule",
+				displayName: "Cline CLI scheduler",
+				workspaceRoot: this.workspaceRoot,
+				cwd: this.workspaceRoot,
+				authToken: this.authToken,
+			});
+			try {
+				await client.connect();
+			} catch (error) {
+				client.close();
+				this.hub = undefined;
+				throw error;
+			}
+			return client;
+		})();
+		return this.hub;
+	}
 
 	private async command(
 		command: string,
 		payload?: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
-		const reply = await sendHubCommand(this.endpoint, {
-			clientId: "cline-schedule",
-			command: command as never,
-			payload,
-		});
-		if (!reply.ok) {
-			throw new Error(reply.error?.message ?? `hub command failed: ${command}`);
-		}
+		const client = await this.connectedHub();
+		const reply = await client.command(command as never, payload);
 		return (reply.payload ?? {}) as Record<string, unknown>;
 	}
 
@@ -202,14 +225,13 @@ export async function ensureSchedulerHub(
 	}
 	try {
 		const requestedEndpoint = parseHubEndpointOverride(address);
-		const { url: hubUrl } = await ensureCliHubServer(
+		const { url: hubUrl, authToken } = await ensureCliHubServer(
 			workspaceRoot,
 			requestedEndpoint,
 		);
-		const endpoint = parseHubEndpointOverride(hubUrl);
 		return {
 			ok: true,
-			client: new HubScheduleClient(endpoint),
+			client: new HubScheduleClient(hubUrl, workspaceRoot, authToken),
 		};
 	} catch (_error) {
 		return {


### PR DESCRIPTION
### Related Issue

Fixes a regression found while reviewing #13331 (targets `bee/schedule-tool` so it lands with that PR).

### Description

#13331 makes hub schedule commands require a registered workspace client: `HubScheduleCommandService.resolveScope` rejects any connection without registered workspace authority, and the websocket adapter passes `authority = null` until a connection sends `client.register`. The PR updated the CLI's in-process `LocalScheduleClient` to pass authority, but the remote `HubScheduleClient` (used by every `cline schedule <cmd> --address <host:port>` invocation, including `schedule import`/`export`) still sent one-shot envelopes through `sendHubCommand`, which opens a raw websocket and never registers.

Result on `bee/schedule-tool`:

```
$ cline schedule list --address 127.0.0.1:26837
error: schedule commands require a registered workspace client
```

The same command on `main` succeeds.

This change rewires `HubScheduleClient` on top of `NodeHubClient`, which registers with the hub auth token and a `workspaceContext` on connect, so all schedule commands share one authorized connection:

- `ensureSchedulerHub` now passes the resolved hub URL, the workspace root, and the `authToken` returned by `ensureCliHubServer` instead of a re-parsed endpoint.
- `HubScheduleClient` lazily connects (and registers) once per client and reuses the connection for subsequent commands; `close()` tears it down.
- Error surfacing is preserved: `NodeHubClient.command` throws `HubCommandError` carrying the server's error message, matching the previous `reply.error?.message` behavior.

### Test Procedure

- Updated `apps/cli/src/commands/schedule.test.ts` to mock `NodeHubClient` instead of `sendHubCommand`, including an assertion that the client registers with the workspace context and hub auth token before commanding (the gap that let this regress silently).
- `bun -F @cline/cli test:unit`: 137 files, 1158 tests, all pass.
- `bun run typecheck` in `apps/cli` and Biome on the changed files: clean.
- Live end-to-end against a hub daemon spawned from this branch: `schedule create/list/get/delete --address 127.0.0.1:26837` all succeed from the owning workspace, and workspace scoping from #13331 is preserved (a `schedule get` for the same id from a different workspace still fails with `schedule does not exist in this workspace`).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The `--address`-less path (`LocalScheduleClient`) is untouched. No changes to SDK packages.