### PR TITLE
ci: tidy workflow cache config and job permissions

### DIFF
--- a/.github/workflows/ext-vscode-ab-package.yml
+++ b/.github/workflows/ext-vscode-ab-package.yml
@@ -150,14 +150,12 @@ jobs:
               id: rev
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+            # Deliberately no dependency cache here: publish workflows do clean
+            # installs and should not restore actions caches.
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: 22
-                  cache: "npm"
-                  cache-dependency-path: |
-                      apps/vscode/package-lock.json
-                      apps/vscode/webview-ui/package-lock.json
 
             - name: Install extension dependencies
               working-directory: ${{ github.workspace }}

--- a/.github/workflows/ext-vscode-publish-legacy.yml
+++ b/.github/workflows/ext-vscode-publish-legacy.yml
@@ -58,14 +58,12 @@ jobs:
               with:
                   ref: legacy-extension
 
+            # Deliberately no dependency cache here: publish workflows do clean
+            # installs and should not restore actions caches.
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: 22
-                  cache: 'npm'
-                  cache-dependency-path: |
-                      apps/vscode/package-lock.json
-                      apps/vscode/webview-ui/package-lock.json
 
             - name: Install extension dependencies
               working-directory: ${{ github.workspace }}

--- a/.github/workflows/ext-vscode-test-e2e.yml
+++ b/.github/workflows/ext-vscode-test-e2e.yml
@@ -80,8 +80,9 @@ jobs:
                 include: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
         runs-on: ${{ matrix.runner }}-latest
         timeout-minutes: 20
+        # Nothing in this job uses OIDC, so it does not need an id-token
+        # permission.
         permissions:
-            id-token: write
             contents: read
         defaults:
             run:
@@ -93,6 +94,9 @@ jobs:
               with:
                   bun-version: 1.3.14
 
+            # Cache keys below are exact-match only (no restore-keys prefix
+            # fallbacks); a miss just means a cold install, which is acceptable.
+
             # Cache Bun's global install cache - keyed on the authoritative root bun.lock.
             - name: Cache Bun install cache
               uses: actions/cache@v4
@@ -100,8 +104,6 @@ jobs:
               with:
                   path: ~/.bun/install/cache
                   key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-bun-
 
             # Cache VS Code installation
             - name: Cache VS Code
@@ -110,8 +112,6 @@ jobs:
               with:
                   path: apps/vscode/.vscode-test
                   key: vscode-${{ runner.os }}-stable-${{ hashFiles('apps/vscode/.vscode-test.mjs', 'apps/vscode/package.json') }}
-                  restore-keys: |
-                      vscode-${{ runner.os }}-stable-
 
             # Cache Playwright browsers
             - name: Cache Playwright browsers
@@ -123,8 +123,6 @@ jobs:
                       ~/Library/Caches/ms-playwright
                       ~/AppData/Local/ms-playwright
                   key: playwright-browsers-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-                  restore-keys: |
-                      playwright-browsers-${{ runner.os }}-
 
             # Single root install resolves the entire bun workspace at once (replaces
             # the per-package `npm ci` steps for apps/vscode + webview-ui).


### PR DESCRIPTION
Small cleanup of how our workflows use caches and permissions:

Publish workflows now always do clean npm installs (dropped the dependency cache from their test gates)
The e2e workflow's caches use exact keys instead of prefix fallbacks
Removed an unused id-token permission from the e2e job
Worst case is a slightly colder install in a couple of rarely-run jobs; no build or test behavior changes.

Test Procedure

Workflow YAML validated; no build or test commands are touched. The e2e workflow runs on this PR itself.