### PR TITLE
fix(desktop): treat ClinePass as OAuth-managed in the chat credential gate

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
@@ -83,8 +83,8 @@ function isApiKeyOnlyProvider(provider: Provider): boolean {
 
 /**
  * Orders the provider catalog for the API-key setup step: OAuth-managed
- * providers (Cline itself, ChatGPT, OCA) are excluded because they have
- * dedicated sign-in paths, providers needing more than an API key are
+ * providers (Cline itself, ClinePass, ChatGPT, OCA) are excluded because they
+ * have dedicated sign-in paths, providers needing more than an API key are
  * excluded because this form only collects one, popular API-key providers
  * come first, and the rest follow alphabetically.
  */

--- a/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
@@ -13,6 +13,9 @@ export const CHAT_WS_RECONNECT_MAX_DELAY_MS = 3000;
 export const CHAT_WS_REQUEST_TIMEOUT_MS = 120000;
 export const OAUTH_MANAGED_PROVIDERS = new Set([
 	"cline",
+	// ClinePass shares the Cline account OAuth credentials (its auth handler
+	// stores under the "cline" provider), so it never has its own API key.
+	"cline-pass",
 	"oca",
 	"openai-codex",
 ]);

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { ChatSessionConfig } from "@/lib/chat-schema";
+import { resolveCredentialError } from "./helpers";
+
+function makeConfig(overrides: Partial<ChatSessionConfig>): ChatSessionConfig {
+	return {
+		workspaceRoot: "/tmp/project",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		mode: "act",
+		apiKey: "",
+		enableTools: true,
+		...overrides,
+	};
+}
+
+describe("resolveCredentialError", () => {
+	it("requires a provider", () => {
+		expect(resolveCredentialError(makeConfig({ provider: "  " }))).toMatch(
+			/Provider is required/,
+		);
+	});
+
+	it("blocks API-key providers without a key", () => {
+		expect(resolveCredentialError(makeConfig({ provider: "anthropic" }))).toMatch(
+			/Missing API key/,
+		);
+	});
+
+	it("allows API-key providers with a key", () => {
+		expect(
+			resolveCredentialError(
+				makeConfig({ provider: "anthropic", apiKey: "sk-123" }),
+			),
+		).toBeNull();
+	});
+
+	it.each(["cline", "cline-pass", "oca", "openai-codex"])(
+		"allows OAuth-managed provider %s without a visible API key",
+		(provider) => {
+			// OAuth credentials live in the backend provider settings store
+			// (ClinePass shares the Cline account login), never in the webview
+			// config, so the pre-flight gate must not demand an API key.
+			expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
+		},
+	);
+
+	it("treats provider ids case-insensitively", () => {
+		expect(
+			resolveCredentialError(makeConfig({ provider: "Cline-Pass" })),
+		).toBeNull();
+	});
+});

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -22,9 +22,9 @@ describe("resolveCredentialError", () => {
 	});
 
 	it("blocks API-key providers without a key", () => {
-		expect(resolveCredentialError(makeConfig({ provider: "anthropic" }))).toMatch(
-			/Missing API key/,
-		);
+		expect(
+			resolveCredentialError(makeConfig({ provider: "anthropic" })),
+		).toMatch(/Missing API key/);
 	});
 
 	it("allows API-key providers with a key", () => {
@@ -35,15 +35,17 @@ describe("resolveCredentialError", () => {
 		).toBeNull();
 	});
 
-	it.each(["cline", "cline-pass", "oca", "openai-codex"])(
-		"allows OAuth-managed provider %s without a visible API key",
-		(provider) => {
-			// OAuth credentials live in the backend provider settings store
-			// (ClinePass shares the Cline account login), never in the webview
-			// config, so the pre-flight gate must not demand an API key.
-			expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
-		},
-	);
+	it.each([
+		"cline",
+		"cline-pass",
+		"oca",
+		"openai-codex",
+	])("allows OAuth-managed provider %s without a visible API key", (provider) => {
+		// OAuth credentials live in the backend provider settings store
+		// (ClinePass shares the Cline account login), never in the webview
+		// config, so the pre-flight gate must not demand an API key.
+		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
+	});
 
 	it("treats provider ids case-insensitively", () => {
 		expect(


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (reported directly: switching the desktop app to ClinePass showed "Missing API key for provider cline-pass" while the same account worked fine in the CLI)

### Description

The desktop webview runs a pre-flight credential check (`resolveCredentialError`) before starting a chat session, and exempts OAuth-managed providers via the hard-coded `OAUTH_MANAGED_PROVIDERS` set. That set only contained `cline`, `oca`, and `openai-codex`.

ClinePass (`cline-pass`) is registered in the SDK auth registry as an OAuth provider that shares the Cline account credentials (`storageProviderId: "cline"`), so a user signed in via OAuth never has a plain API key the catalog can expose for it (`resolveVisibleApiKey` intentionally only surfaces plain keys, not OAuth access tokens). The gate therefore blocked the send client-side with the "Missing API key" error before the request ever reached the sidecar.

The backend path was already correct: the sidecar and `@cline/core` resolve `cline-pass` credentials from the stored `cline` OAuth access token (`resolveProviderSettings` storage mapping plus the auth handler's `getApiKey`), which is exactly why the CLI worked for the same account. The fix adds `cline-pass` to the webview's OAuth-managed set so the desktop follows the same path.

Note the bug only reproduces with an OAuth sign-in. If the Cline provider is configured with a plain API key, the catalog exposes that key for ClinePass too and the gate passes, which is why this slipped through.

### Test Procedure

- Added unit tests for `resolveCredentialError` (`helpers.test.ts`, 8 tests) covering the OAuth-managed exemptions (including `cline-pass`, case-insensitive) and the still-blocked plain API-key providers. Also ran the existing `provider-connection` and `onboarding-view` webview tests: 25 passed.
- Manual end-to-end test of the desktop app (headless: `dev:sidecar` + `dev:web`), replicating the reported state: `providers.json` with the Cline provider holding only OAuth credentials (`auth.accessToken`, no plain `apiKey`) and ClinePass enabled.
  - Before the fix: selecting provider `cline-pass` / model `cline-pass/glm-5.2` and sending a message immediately shows the reported error, and the request never reaches the sidecar.
  - After the fix: the same flow starts the session, the sidecar resolves the stored Cline OAuth token for `cline-pass`, and the turn completes with the model's reply.
- Since a real WorkOS OAuth login is not possible in the headless test environment, the stored access token was simulated and a small local proxy swapped the resulting `Bearer workos:...` header for a real Cline API key at the HTTP boundary before forwarding to `api.cline.bot`. The entire desktop stack (webview gate, sidecar, `@cline/core` credential resolution, request header construction) ran unmodified; proxy logs confirm the app sent the OAuth-derived token and the completion returned 200.
- Lint/format: `biome check` clean on changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (OAuth-signed-in account, ClinePass selected, send blocked client-side):

![Before: Missing API key error for cline-pass](https://cursor.com/artifacts/c/art-217b03f2-6835-478e-82bd-20a2de0b84ce)

After (same state, turn completes on cline-pass/glm-5.2):

![After: ClinePass turn completes with HELLO reply](https://cursor.com/artifacts/c/art-c6e91f0d-1e81-4dde-a7e2-e4a5e0c3f44c)

### Additional Notes

The onboarding API-key setup step's comment was updated to mention ClinePass in the OAuth-managed list; its behavior there was already correct because the provider config fields for OAuth providers contain no `apiKey` field.