### PR TITLE
feat(llms, vscode): add GMI Cloud as a first-class provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -57,6 +57,7 @@ describe("parseProviderId", () => {
 		parseProviderId("xiaomi")
 		parseProviderId("tencent-tokenhub")
 		parseProviderId("chutes")
+		parseProviderId("gmicloud")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -74,6 +75,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("chutes"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("gmicloud"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -59,6 +59,7 @@ const KNOWN_API_PROVIDERS = {
 	xiaomi: true,
 	"tencent-tokenhub": true,
 	chutes: true,
+	gmicloud: true,
 	"cline-pass": true,
 } satisfies Record<ApiProvider, true>
 

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -52,6 +52,7 @@ export type ApiProvider =
 	| "xiaomi"
 	| "tencent-tokenhub"
 	| "chutes"
+	| "gmicloud"
 
 export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
 

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -4,7 +4,7 @@ import { convertApiConfigurationToProto, convertProtoToApiConfiguration } from "
 
 describe("api configuration provider conversion", () => {
 	it("round-trips SDK provider ids added after the legacy enum list", () => {
-		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "chutes", "zai-coding-plan"]
+		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "chutes", "zai-coding-plan", "gmicloud"]
 
 		for (const provider of providers) {
 			const proto = convertApiConfigurationToProto({

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -93,6 +93,19 @@ describe("providerSettingsRegistry", () => {
 		}
 	})
 
+	it("lets GMI Cloud accept model ids missing from the catalog", () => {
+		expect(getGenericProviderSettings("gmicloud", listing({ id: "gmicloud", name: "GMI Cloud" }))).toEqual({
+			allowsCustomIds: true,
+			baseUrlField: {
+				label: "Base URL",
+				placeholder: "https://api.gmi-serving.com/v1",
+			},
+			providerId: "gmicloud",
+			providerName: "GMI Cloud",
+			signupUrl: "https://console.gmicloud.ai/user-setting/ie/api-keys",
+		})
+	})
+
 	it("builds MiniMax and Together settings through the generic registry", () => {
 		expect(
 			getGenericProviderSettings(

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -107,6 +107,16 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	chutes: {
 		signupUrl: "https://chutes.ai/app/api",
 	},
+	gmicloud: {
+		// GMI serves far more models than models.dev lists for it, so the picker
+		// must accept ids the catalog does not carry.
+		allowsCustomIds: true,
+		signupUrl: "https://console.gmicloud.ai/user-setting/ie/api-keys",
+		baseUrlField: {
+			label: "Base URL",
+			placeholder: "https://api.gmi-serving.com/v1",
+		},
+	},
 	"zai-coding-plan": {},
 }
 
@@ -169,6 +179,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	xiaomi: "Xiaomi",
 	"tencent-tokenhub": "Tencent TokenHub",
 	chutes: "Chutes",
+	gmicloud: "GMI Cloud",
 	"zai-coding-plan": "Z.AI Coding Plan",
 } as const
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1036,6 +1036,10 @@
 			"destination": "/provider-config/other-30-plus-providers#gcp-vertex-ai"
 		},
 		{
+			"source": "/provider-config/gmicloud",
+			"destination": "/provider-config/other-30-plus-providers#gmi-cloud"
+		},
+		{
 			"source": "/provider-config/groq",
 			"destination": "/provider-config/other-30-plus-providers#groq"
 		},

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -17,6 +17,7 @@ Use this page for providers that follow the same setup pattern.
   - [Doubao](#doubao)
   - [Fireworks AI](#fireworks-ai)
   - [GCP Vertex AI](#gcp-vertex-ai)
+  - [GMI Cloud](#gmi-cloud)
   - [Groq](#groq)
   - [Hicap](#hicap)
   - [Huawei Cloud MaaS](#huawei-cloud-maas)
@@ -133,6 +134,17 @@ Vertex AI is Google Cloud’s enterprise model platform with IAM and project-lev
 1. Set up a GCP project with Vertex AI enabled.
 2. Configure authentication (service account or application default credentials).
 3. In Cline, select **GCP Vertex AI** and provide required config values.
+
+### GMI Cloud
+GMI Cloud is a GPU cloud whose inference engine exposes an OpenAI-compatible gateway over open-weight and frontier models.
+
+**Website:** [https://www.gmicloud.ai/](https://www.gmicloud.ai/)
+
+#### Basic Setup
+
+1. Create/sign in to your GMI Cloud account.
+2. Generate an API key in the console.
+3. In Cline, select **GMI Cloud** and paste the key.
 
 ### Groq
 Groq is a low-latency inference provider for supported model families.

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -385,6 +385,22 @@ describe("built-in provider metadata", () => {
 		});
 	});
 
+	it("re-keys the GMI Cloud default model to the id GMI serves", async () => {
+		const provider = await getProvider("gmicloud");
+		const models = await getModelsForProvider("gmicloud");
+		const defaultModel = models[provider.defaultModelId ?? ""];
+
+		expect(provider.defaultModelId).toBe("deepseek-ai/DeepSeek-V4-Flash-0731");
+		// Carries the upstream record rather than the 128k stub fallbackModelInfo
+		// synthesizes for a default missing from the catalog. Bounds instead of
+		// exact values: the numbers rotate with models.dev.
+		expect(defaultModel.contextWindow).toBeGreaterThan(128_000);
+		expect(defaultModel.maxTokens).toBeGreaterThan(0);
+		expect(defaultModel.pricing).toBeDefined();
+		// Added alongside the rolling id GMI also serves, not replacing it.
+		expect(models["deepseek-ai/DeepSeek-V4-Flash"]).toBeDefined();
+	});
+
 	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const chatGptModels = await getModelsForProvider("openai-codex");
 		const openAiModels = await getModelsForProvider("openai-native");

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -525,6 +525,30 @@ function buildVertexModels(): Record<string, ModelInfo> {
 	};
 }
 
+const GMICLOUD_DEFAULT_MODEL_ID = "deepseek-ai/DeepSeek-V4-Flash-0731";
+
+function buildGmiCloudModels(): Record<string, ModelInfo> {
+	const gmiCloudModels = generatedModels("gmicloud");
+
+	// GMI serves both the rolling DeepSeek V4 Flash id and its dated snapshot;
+	// models.dev only carries the rolling one. Add the snapshot with the
+	// rolling record's facts so the default model gets its real context window
+	// and pricing instead of the 128k stub fallbackModelInfo synthesizes.
+	// Drop once models.dev carries the dated id.
+	const rolling = gmiCloudModels["deepseek-ai/DeepSeek-V4-Flash"];
+	if (!rolling || gmiCloudModels[GMICLOUD_DEFAULT_MODEL_ID]) {
+		return gmiCloudModels;
+	}
+	return {
+		[GMICLOUD_DEFAULT_MODEL_ID]: {
+			...rolling,
+			id: GMICLOUD_DEFAULT_MODEL_ID,
+			name: "DeepSeek V4 Flash 0731",
+		},
+		...gmiCloudModels,
+	};
+}
+
 function fallbackModelInfo(id: string, spec?: BuiltinSpec): ModelInfo {
 	const info: ModelInfo = {
 		id,
@@ -828,6 +852,16 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		apiKeyEnv: ["SAMBANOVA_API_KEY"],
 		modelsProviderId: "sambanova",
 		defaults: { baseUrl: "https://api.sambanova.ai/v1" },
+	},
+	{
+		// models.dev covers the rest. Cline-specific: the product description,
+		// the coding default model, and the Anthropic wire shapes its resold
+		// Claude ids need.
+		id: "gmicloud",
+		description: "GPU cloud with an OpenAI-compatible inference gateway",
+		defaultModelId: GMICLOUD_DEFAULT_MODEL_ID,
+		modelsFactory: buildGmiCloudModels,
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "litellm",

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -949,6 +949,7 @@ describe("sdk-gateway", () => {
 			"anthropic",
 			"cline",
 			"cline-pass",
+			"gmicloud",
 			"minimax",
 			"oca",
 			"openrouter",

--- a/sdk/packages/llms/src/providers/provider-keys.ts
+++ b/sdk/packages/llms/src/providers/provider-keys.ts
@@ -121,6 +121,11 @@ const PROVIDER_IDS_MAP: ReadonlyArray<{
 		generatedProviderId: "aihubmix",
 		runtimeProviderId: "aihubmix",
 	},
+	{
+		modelsDevKey: "gmicloud",
+		generatedProviderId: "gmicloud",
+		runtimeProviderId: "gmicloud",
+	},
 	{ modelsDevKey: "hicap", runtimeProviderId: "hicap" },
 	{ modelsDevKey: "nous-research", runtimeProviderId: "nousResearch" },
 	{ modelsDevKey: "huawei-cloud-maas", runtimeProviderId: "huawei-cloud-maas" },

--- a/sdk/packages/llms/src/tests/live-providers.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.example.json
@@ -249,6 +249,26 @@
 				"requireUsage": true,
 				"requireCacheReadTokens": true
 			}
+		},
+		"gmicloud": {
+			"settings": {
+				"provider": "gmicloud",
+				"model": "deepseek-ai/DeepSeek-V4-Flash-0731"
+			},
+			"expectations": {
+				"requireUsage": true
+			}
+		},
+		"gmicloud-anthropic": {
+			"settings": {
+				"provider": "gmicloud",
+				"model": "anthropic/claude-sonnet-4.6"
+			},
+			"runs": 3,
+			"expectations": {
+				"requireUsage": true,
+				"requireCacheReadTokens": true
+			}
 		}
 	}
 }

--- a/sdk/packages/llms/src/tests/live-providers.reasoning.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.reasoning.example.json
@@ -344,6 +344,20 @@
 				"requireUsage": true,
 				"requireReasoningChunk": true
 			}
+		},
+		"gmicloud-reasoning": {
+			"settings": {
+				"provider": "gmicloud",
+				"model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+				"reasoning": {
+					"enabled": true
+				}
+			},
+			"prompt": "Solve this multi-step problem briefly: A shop has 17 boxes with 23 bolts each, sells 128 bolts, then receives 4 boxes with 19 bolts each. How many bolts are left? Give only the final arithmetic result and one short explanation.",
+			"expectations": {
+				"requireUsage": true,
+				"requireReasoningSignal": true
+			}
 		}
 	}
 }

--- a/sdk/packages/llms/src/tests/live-providers.tools.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.tools.example.json
@@ -194,6 +194,26 @@
 				"requireUsage": true,
 				"requireToolCall": true
 			}
+		},
+		"gmicloud-tools": {
+			"settings": {
+				"provider": "gmicloud",
+				"model": "deepseek-ai/DeepSeek-V4-Flash-0731"
+			},
+			"expectations": {
+				"requireUsage": true,
+				"requireToolCall": true
+			}
+		},
+		"gmicloud-anthropic-tools": {
+			"settings": {
+				"provider": "gmicloud",
+				"model": "anthropic/claude-sonnet-4.6"
+			},
+			"expectations": {
+				"requireUsage": true,
+				"requireToolCall": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Related Issue

**Discussion:** #13579

### Description

Adds GMI Cloud as a built-in provider.

`gmicloud` is already generated from models.dev, so base URL, API key env,
capabilities, and the model catalog come from the generated spec. This PR adds
the extension-side wiring and the provider policy models.dev doesn't express.

**VS Code**
- `"gmicloud"` in the `ApiProvider` union and `KNOWN_API_PROVIDERS`, so it
  appears in the settings dropdown.
- Presentation override in the generic settings registry: display name, signup
  URL, Base URL field, and `allowsCustomIds` (GMI serves 85 models, models.dev
  lists 13). No custom UI or transport.

**SDK (`@cline/llms`)**
- Partial override of the generated spec: coding-oriented default model plus
  `ANTHROPIC_ROUTING_METADATA`, since part of GMI's catalog uses
  Anthropic-compatible wire formats and needs the `cache_control` / thinking
  shapes rather than the generic ones.
- `buildGmiCloudModels()` adds the dated DeepSeek V4 Flash snapshot GMI serves
  (`deepseek-ai/DeepSeek-V4-Flash-0731`) alongside the rolling id, carrying the
  upstream record so the default keeps its real context window and pricing.
  Removable once models.dev carries the dated id.
- Pins the `gmicloud` models.dev key mapping in `provider-keys.ts`.

**Docs** — GMI Cloud section in
`docs/provider-config/other-30-plus-providers.mdx`, following the format of the
neighbouring entries (website link plus three setup steps), and a
`/provider-config/gmicloud` → `#gmi-cloud` redirect in `docs/docs.json`.

### Test Procedure

**How it was tested.** Live, against the real endpoint through the existing
live-test harness (entries added to the three `live-providers.*.example.json`
files): streaming, usage, tool calling, and reasoning all pass on both
`deepseek-ai/DeepSeek-V4-Flash-0731` and `anthropic/claude-sonnet-4.6`, and
prompt caching engages (`cacheRead` reaching 4221 tokens on repeat calls, cost
$0.012732 → $0.0013353). A catalog-external model id resolves instead of
coercing to the default, which is what makes `allowsCustomIds` meaningful.
Offline: full monorepo suite, `@cline/llms` typecheck, `apps/vscode`
check-types (0 errors), webview-ui suite, and Biome all pass.

**What could break, and what I checked.**

- `ANTHROPIC_ROUTING_METADATA` widens the set of providers using Anthropic
  cache-control routing, so the explicit provider-set assertion in
  `gateway.test.ts` needed updating. That's the one intentional edit to an
  existing test, and it's the assertion that would catch an accidental
  widening.
- `buildGmiCloudModels()` only augments the `gmicloud` catalog and no-ops once
  models.dev carries the dated id. A test asserts the rolling id is still
  listed, so the re-key adds rather than replaces.
- The `ApiProvider` union addition is compiler-enforced by
  `satisfies Record<ApiProvider, true>`, so a missed registration fails
  typecheck instead of silently dropping the provider.

**What else is affected.** The provider dropdown isn't sorted, so registering an
override moves `gmicloud` from index 87 to 23 in that list. The relative order
of every other provider is unchanged, and no other provider's catalog or
configuration is touched.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes