### PR TITLE
fix(ui): stack code block lines when streamdown lineNumbers is off

### DIFF
--- a/apps/examples/desktop-app/webview/components/ui/markdown.interactions.test.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/markdown.interactions.test.tsx
@@ -238,6 +238,34 @@ describe("MemoizedMarkdown interactions", () => {
 		});
 	});
 
+	// With lineNumbers off, Streamdown emits one bare inline <span> per Shiki
+	// token line with no newline text between non-empty lines; the shared
+	// @cline/ui markdown.css turns those direct line spans into blocks. This
+	// asserts the one-span-per-line structure that CSS contract depends on,
+	// after the async Shiki highlight replaces the raw fallback render (the
+	// SSR tests never exercise that client-side path).
+	test("keeps highlighted code lines as separate line spans", async () => {
+		await renderMarkdown({
+			content: "```typescript\nconst a = 1;\nconst b = 2;\nconst c = 3;\n```",
+		});
+
+		const code = await vi.waitFor(() => {
+			const rendered = container.querySelector<HTMLElement>(
+				'[data-streamdown="code-block-body"] code',
+			);
+			expect(rendered).not.toBeNull();
+			// Styled token spans only appear once the highlighter callback lands.
+			expect(rendered?.querySelector("span > span[style]")).not.toBeNull();
+			return rendered as HTMLElement;
+		});
+
+		expect([...code.children].map((line) => line.textContent)).toEqual([
+			"const a = 1;",
+			"const b = 2;",
+			"const c = 3;",
+		]);
+	});
+
 	test("rerenders incomplete streaming Markdown as completed static Markdown", async () => {
 		await renderMarkdown({
 			content: "```text\nconst answer =",

--- a/sdk/packages/ui/components/markdown.css
+++ b/sdk/packages/ui/components/markdown.css
@@ -145,6 +145,21 @@
 	background: transparent;
 }
 
+/* Streamdown renders each code line as a <span> whose contents hold no
+ * newline characters (Shiki line convention), and it only applies its own
+ * block line class when lineNumbers is on. With lineNumbers off the line
+ * spans are bare inline elements with no separator, so every multi-line
+ * block collapses into one run-on line. Stack the lines ourselves; the rule
+ * is a no-op in the lineNumbers path, and empty lines keep their height
+ * because Streamdown renders them as a lone "\n" child that white-space:
+ * pre turns into a line box. */
+:is(.markdown, .cline-markdown)
+	[data-streamdown="code-block-body"]
+	code
+	> span {
+	display: block;
+}
+
 /* The actions overlay's -mt-10 was sized to cover the (now hidden) header
  * row; re-anchor it over the top-right of the code body and reveal on
  * hover/focus so it stops competing with the code. Stickiness is kept so the

--- a/sdk/packages/ui/tests/markdown-code-block.test.tsx
+++ b/sdk/packages/ui/tests/markdown-code-block.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Streamdown } from "streamdown";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	agentMarkdownControls,
+	markdownCodeHighlighter,
+} from "../components/markdown";
+
+// Vitest rewrites import.meta.url under jsdom, so resolve from the package
+// root (the vitest config pins `root` to this package).
+const markdownCss = readFileSync(
+	join(process.cwd(), "components/markdown.css"),
+	"utf8",
+);
+
+let container: HTMLDivElement;
+let root: Root;
+let style: HTMLStyleElement;
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	style = document.createElement("style");
+	style.textContent = markdownCss;
+	document.head.appendChild(style);
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+	style.remove();
+	vi.restoreAllMocks();
+});
+
+async function renderFence(content: string): Promise<HTMLElement> {
+	await act(async () =>
+		root.render(
+			<Streamdown
+				className="cline-markdown"
+				controls={agentMarkdownControls}
+				lineNumbers={false}
+				mode="static"
+				plugins={{ code: markdownCodeHighlighter }}
+			>
+				{content}
+			</Streamdown>,
+		),
+	);
+	return vi.waitFor(() => {
+		const code = container.querySelector<HTMLElement>(
+			'[data-streamdown="code-block-body"] code',
+		);
+		expect(code).not.toBeNull();
+		return code as HTMLElement;
+	});
+}
+
+/**
+ * Streamdown emits one <span> per Shiki token line with no newline text
+ * between non-empty lines, and only applies its own block line class when
+ * lineNumbers is on. With lineNumbers off, line separation exists only
+ * because markdown.css makes the line spans display: block — without it
+ * every multi-line fence collapses into one run-on line (white-space: pre
+ * has no newline characters to preserve).
+ */
+describe("fenced code block line separation", () => {
+	test("stacks highlighted lines as blocks once Shiki tokens apply", async () => {
+		const code = await renderFence(
+			"```typescript\nconst a = 1;\nconst b = 2;\nconst c = 3;\n```",
+		);
+
+		// The shared highlighter resolves asynchronously; wait until the themed
+		// tokens (styled child spans) replace Streamdown's raw fallback render.
+		await vi.waitFor(() => {
+			expect(
+				code.querySelector<HTMLElement>("span > span[style]"),
+			).not.toBeNull();
+		});
+
+		const lines = [...code.children].filter(
+			(child): child is HTMLElement => child instanceof HTMLElement,
+		);
+		expect(lines.map((line) => line.textContent)).toEqual([
+			"const a = 1;",
+			"const b = 2;",
+			"const c = 3;",
+		]);
+		for (const line of lines) {
+			expect(getComputedStyle(line).display).toBe("block");
+		}
+	});
+
+	test("keeps unhighlighted fences and empty lines separated", async () => {
+		const code = await renderFence("```\ntick 1\n\ntick 3\n```");
+
+		const lines = [...code.children].filter(
+			(child): child is HTMLElement => child instanceof HTMLElement,
+		);
+		expect(lines.map((line) => line.textContent)).toEqual([
+			"tick 1",
+			"\n",
+			"tick 3",
+		]);
+		for (const line of lines) {
+			expect(getComputedStyle(line).display).toBe("block");
+		}
+	});
+});


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (diagnosed during the desktop-v0.0.14 regression pass; pre-existing since at least v0.0.13)

### Description

Every multi-line fenced code block in the desktop app chat rendered as a single run-on line with all newlines missing, e.g. a block containing "tick 1 / tick 2 / tick 3" rendered as `tick 1tick 2tick 3` in one horizontally clipped row. This affected all languages and plain fences.

Root cause: streamdown 2.5.0 (the latest release) renders each Shiki token line as a `<span>` whose contents contain no newline characters (Shiki's line convention). It only emits a literal `"\n"` child for empty lines and only applies its `block` line class when `lineNumbers` is true. The desktop app renders `<Streamdown lineNumbers={false}>`, so non-empty lines become bare inline spans with no separator; `white-space: pre` was correctly applied but there were no newline characters to preserve.

Fix: a rule in the shared `sdk/packages/ui/components/markdown.css` making the direct line spans under `[data-streamdown="code-block-body"] code` `display: block`. This lives in the shared package because the markdown pipeline is shared across products. The CSS approach was chosen over patching the highlighter output because it also fixes streamdown's internal raw-token render (shown before the async Shiki highlight resolves), it is a no-op in the `lineNumbers` path (streamdown already applies `block` there), and empty lines keep their height because their lone `"\n"` child still forces one line box under `white-space: pre`. The copy button is unaffected since it copies the raw code from context, and selecting rendered code still copies with line breaks because browsers insert newlines at block boundaries.

### Test Procedure

- New jsdom test in `sdk/packages/ui/tests/markdown-code-block.test.tsx`: renders Streamdown with the shared highlighter and the actual `markdown.css` injected, waits for the async Shiki highlight to apply, and asserts each line span computes `display: block` with the expected per-line text, for both highlighted and unhighlighted fences (including an empty line). Both tests fail without the CSS fix and pass with it.
- New test in the desktop app's `markdown.interactions.test.tsx` asserting the one-span-per-line structure the CSS contract depends on, after the async client-side highlight path (which the existing SSR tests never exercised).
- Full suites pass: `@cline/ui` 129 tests, desktop `bunx vitest run webview` 528 tests, `bun -F @cline/code typecheck` clean.
- Manual verification: ran `dev:sidecar` + `dev:web`, sent a live agent prompt producing multi-line `text` and `typescript` fenced blocks, and captured before/after screenshots of the same session with the CSS reverted vs applied (below).
- Verified other consumers: the cline-hub and vscode webviews use their own Streamdown wrappers (default `lineNumbers`), so only consumers of the shared markdown CSS are affected, and the rule is a no-op when line numbers are on.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (CSS rule reverted, same chat session): code block lines run together and clip.

![Before: code block lines run together](https://cursor.com/artifacts/c/art-2d404ff8-d677-4a09-8624-b1be0675f6a3)

After (this fix): lines stack correctly, including the preserved blank line inside the typescript block.

![After: code block lines separated](https://cursor.com/artifacts/c/art-71505c8c-cf88-47e4-a81f-fb6e7481d47e)

### Additional Notes

The bug also reproduces on current main; this is not a v0.0.14 regression.