### PR TITLE
fix(desktop): work summary undercounts wall time when pre-tool thinking attaches to the answer

### DIFF
--- a/apps/examples/desktop-app/sidecar/session-data/messages.test.ts
+++ b/apps/examples/desktop-app/sidecar/session-data/messages.test.ts
@@ -160,7 +160,7 @@ describe("readSessionMessages", () => {
 				createdAt: userTimestamp,
 			}),
 			expect.objectContaining({
-				id: "assistant-tool_reasoning",
+				id: "assistant-tool_reasoning_0",
 				role: "assistant",
 				reasoning: "Planning the command",
 				createdAt: assistantTimestamp,
@@ -179,6 +179,71 @@ describe("readSessionMessages", () => {
 				role: "assistant",
 				content: "The command finished.",
 				createdAt: answerTimestamp,
+			}),
+		]);
+	});
+
+	it("keeps interleaved thinking between the tool calls it separates", async () => {
+		// Interleaved thinking can produce [thinking, tool_use, thinking,
+		// tool_use] in a single assistant message. Each thinking segment must
+		// project at its own position — merging the second segment into the
+		// first row would display it before a tool call it actually followed.
+		const sessionId = `interleaved-thinking-projection-${Date.now()}`;
+		const assistantTimestamp = 1_781_041_621_000;
+		const liveSessions = new Map([
+			[
+				sessionId,
+				{
+					messages: [
+						{
+							id: "assistant-tools",
+							role: "assistant",
+							content: [
+								{ type: "thinking", thinking: "First I need the date" },
+								{
+									type: "tool_use",
+									id: "tool-a",
+									name: "run_commands",
+									input: { commands: ["date"] },
+								},
+								{ type: "thinking", thinking: "Now check the files" },
+								{
+									type: "tool_use",
+									id: "tool-b",
+									name: "read_files",
+									input: { paths: ["a.ts"] },
+								},
+							],
+							ts: assistantTimestamp,
+						},
+					],
+				},
+			],
+		]);
+
+		await expect(
+			readSessionMessages(
+				{ liveSessions } as Parameters<typeof readSessionMessages>[0],
+				sessionId,
+			),
+		).resolves.toEqual([
+			expect.objectContaining({
+				id: "assistant-tools_reasoning_0",
+				role: "assistant",
+				reasoning: "First I need the date",
+			}),
+			expect.objectContaining({
+				id: "assistant-tools_tool_use_1",
+				role: "tool",
+			}),
+			expect.objectContaining({
+				id: "assistant-tools_reasoning_1",
+				role: "assistant",
+				reasoning: "Now check the files",
+			}),
+			expect.objectContaining({
+				id: "assistant-tools_tool_use_3",
+				role: "tool",
 			}),
 		]);
 	});

--- a/apps/examples/desktop-app/sidecar/session-data/messages.test.ts
+++ b/apps/examples/desktop-app/sidecar/session-data/messages.test.ts
@@ -88,6 +88,101 @@ describe("readSessionMessages", () => {
 		]);
 	});
 
+	it("projects pre-tool thinking before the tool row it preceded", async () => {
+		// A thinking model can issue a tool call without narration text:
+		// content = [thinking, tool_use]. The thinking happened before the
+		// tool executed, so it must project before the tool row — matching the
+		// live-stream order and keeping the reasoning from attaching to the
+		// next turn-ending answer (which would corrupt the work summary's
+		// duration anchor in the webview).
+		const sessionId = `thinking-tool-projection-${Date.now()}`;
+		const userTimestamp = 1_781_041_621_000;
+		const assistantTimestamp = userTimestamp + 5_000;
+		const resultTimestamp = userTimestamp + 13_000;
+		const answerTimestamp = userTimestamp + 13_500;
+		const liveSessions = new Map([
+			[
+				sessionId,
+				{
+					messages: [
+						{
+							id: "user-message",
+							role: "user",
+							content: [{ type: "text", text: "Run the command" }],
+							ts: userTimestamp,
+						},
+						{
+							id: "assistant-tool",
+							role: "assistant",
+							content: [
+								{ type: "thinking", thinking: "Planning the command" },
+								{
+									type: "tool_use",
+									id: "tool-use",
+									name: "run_commands",
+									input: { commands: ["sleep 8"] },
+								},
+							],
+							ts: assistantTimestamp,
+						},
+						{
+							id: "tool-result-message",
+							role: "user",
+							content: [
+								{
+									type: "tool_result",
+									tool_use_id: "tool-use",
+									content: "done",
+								},
+							],
+							ts: resultTimestamp,
+						},
+						{
+							id: "assistant-answer",
+							role: "assistant",
+							content: [{ type: "text", text: "The command finished." }],
+							ts: answerTimestamp,
+						},
+					],
+				},
+			],
+		]);
+
+		await expect(
+			readSessionMessages(
+				{ liveSessions } as Parameters<typeof readSessionMessages>[0],
+				sessionId,
+			),
+		).resolves.toEqual([
+			expect.objectContaining({
+				id: "user-message_text_0",
+				role: "user",
+				createdAt: userTimestamp,
+			}),
+			expect.objectContaining({
+				id: "assistant-tool_reasoning",
+				role: "assistant",
+				reasoning: "Planning the command",
+				createdAt: assistantTimestamp,
+			}),
+			expect.objectContaining({
+				id: "assistant-tool_tool_use_1",
+				role: "tool",
+				createdAt: assistantTimestamp + 1,
+				meta: expect.objectContaining({
+					toolCallId: "tool-use",
+					hookEventName: "history_tool_result",
+				}),
+			}),
+			expect.objectContaining({
+				id: "assistant-answer_text_0",
+				role: "assistant",
+				content: "The command finished.",
+				createdAt: answerTimestamp,
+			}),
+		]);
+	});
+
 	it("projects image content blocks without replacing them with placeholder text", async () => {
 		const sessionId = `image-projection-${Date.now()}`;
 		const liveSessions = new Map([

--- a/apps/examples/desktop-app/sidecar/session-data/messages.ts
+++ b/apps/examples/desktop-app/sidecar/session-data/messages.ts
@@ -465,6 +465,11 @@ export async function readSessionMessages(
 		const reasoningParts: string[] = [];
 		let reasoningRedacted = false;
 		let textSegmentIndex = 0;
+		let reasoningSegmentIndex = 0;
+		// The text row pushed since the last reasoning flush. Reasoning that
+		// streamed alongside it (the classic [thinking, text] shape) attaches
+		// there instead of becoming a separate row.
+		let reasoningTextTarget: JsonRecord | undefined;
 		const outStartIndex = out.length;
 		const flushTextParts = () => {
 			if (textParts.length === 0) {
@@ -475,7 +480,7 @@ export async function readSessionMessages(
 			if (!joined.trim()) {
 				return;
 			}
-			out.push({
+			const textRow: JsonRecord = {
 				id: `${messageIdBase}_text_${textSegmentIndex}`,
 				sessionId,
 				role,
@@ -486,7 +491,9 @@ export async function readSessionMessages(
 				// the run; later segments must not acquire a fallback ordinal in
 				// the webview.
 				meta: textMeta ?? (role === "user" ? { userRunSpan: 0 } : undefined),
-			});
+			};
+			out.push(textRow);
+			reasoningTextTarget = textRow;
 			textSegmentIndex += 1;
 			textMeta = undefined;
 		};
@@ -495,12 +502,13 @@ export async function readSessionMessages(
 			const redacted = reasoningRedacted;
 			reasoningParts.length = 0;
 			reasoningRedacted = false;
+			// Consumed per flush: reasoning must only attach to a text row from
+			// its own segment, never to one emitted before an earlier tool call.
+			const target = reasoningTextTarget;
+			reasoningTextTarget = undefined;
 			if (!reasoning && !redacted) {
 				return;
 			}
-			const target = out
-				.slice(outStartIndex)
-				.find((item) => item.role === role);
 			if (target) {
 				if (reasoning) {
 					const existing =
@@ -515,7 +523,7 @@ export async function readSessionMessages(
 				return;
 			}
 			out.push({
-				id: `${messageIdBase}_reasoning`,
+				id: `${messageIdBase}_reasoning_${reasoningSegmentIndex}`,
 				sessionId,
 				role,
 				content: "",
@@ -524,6 +532,7 @@ export async function readSessionMessages(
 				createdAt: nextPartCreatedAt(),
 				meta: textMeta,
 			});
+			reasoningSegmentIndex += 1;
 			textMeta = undefined;
 		};
 

--- a/apps/examples/desktop-app/sidecar/session-data/messages.ts
+++ b/apps/examples/desktop-app/sidecar/session-data/messages.ts
@@ -490,6 +490,42 @@ export async function readSessionMessages(
 			textSegmentIndex += 1;
 			textMeta = undefined;
 		};
+		const flushReasoningParts = () => {
+			const reasoning = reasoningParts.join("\n").trim();
+			const redacted = reasoningRedacted;
+			reasoningParts.length = 0;
+			reasoningRedacted = false;
+			if (!reasoning && !redacted) {
+				return;
+			}
+			const target = out
+				.slice(outStartIndex)
+				.find((item) => item.role === role);
+			if (target) {
+				if (reasoning) {
+					const existing =
+						typeof target.reasoning === "string" && target.reasoning
+							? `${target.reasoning}\n`
+							: "";
+					target.reasoning = `${existing}${reasoning}`;
+				}
+				if (redacted) {
+					target.reasoningRedacted = true;
+				}
+				return;
+			}
+			out.push({
+				id: `${messageIdBase}_reasoning`,
+				sessionId,
+				role,
+				content: "",
+				reasoning: reasoning || undefined,
+				reasoningRedacted: redacted || undefined,
+				createdAt: nextPartCreatedAt(),
+				meta: textMeta,
+			});
+			textMeta = undefined;
+		};
 
 		for (let blockIdx = 0; blockIdx < contentBlocks.length; blockIdx += 1) {
 			const block = contentBlocks[blockIdx];
@@ -504,6 +540,13 @@ export async function readSessionMessages(
 			const blockType = typeof record.type === "string" ? record.type : "";
 			if (blockType === "tool_use") {
 				flushTextParts();
+				// Everything the model emitted in this message — thinking
+				// included — happened before the tool executed. Flushing the
+				// reasoning here keeps the thinking row ahead of the tool row
+				// (matching the live-stream order) so the webview never attaches
+				// pre-tool reasoning to a later answer, which would drag the
+				// work summary's duration anchor back before the tool ran.
+				flushReasoningParts();
 				const toolName =
 					typeof record.name === "string" ? record.name : "tool_call";
 				const toolUseId = typeof record.id === "string" ? record.id : "";
@@ -631,32 +674,7 @@ export async function readSessionMessages(
 				textMeta = undefined;
 			}
 		}
-		if (reasoningParts.length > 0 || reasoningRedacted) {
-			const reasoning = reasoningParts.join("\n").trim();
-			const target = out
-				.slice(outStartIndex)
-				.find((item) => item.role === role);
-			if (target) {
-				if (reasoning) {
-					target.reasoning = reasoning;
-				}
-				if (reasoningRedacted) {
-					target.reasoningRedacted = true;
-				}
-			} else {
-				out.push({
-					id: `${messageIdBase}_reasoning`,
-					sessionId,
-					role,
-					content: "",
-					reasoning: reasoning || undefined,
-					reasoningRedacted: reasoningRedacted || undefined,
-					createdAt: nextPartCreatedAt(),
-					meta: textMeta,
-				});
-				textMeta = undefined;
-			}
-		}
+		flushReasoningParts();
 		if (textMeta && out[outStartIndex]) {
 			out[outStartIndex].meta = {
 				...(typeof out[outStartIndex].meta === "object"

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
@@ -365,6 +365,61 @@ describe("collapseCompletedWork", () => {
 		]);
 	});
 
+	it("counts tool execution time when pre-tool thinking attaches to the answer", () => {
+		// Canonical projection of a thinking-only assistant message that issued
+		// a tool call: the tool row and the reasoning-only row are both stamped
+		// with pre-execution timestamps, and the reasoning row attaches to the
+		// run's final answer in groupChatMessages. The duration must span to
+		// the answer itself (14_500), not to the pre-tool thinking (6_001) —
+		// that would exclude the entire tool execution from "Worked for".
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "run it",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 6_000),
+				makeMessage({
+					id: "r1",
+					reasoning: "planning the command",
+					createdAt: 6_001,
+				}),
+				makeMessage({ id: "a1", content: "Done.", createdAt: 14_500 }),
+			],
+			true,
+		);
+
+		const work = items.find((item) => item.type === "work");
+		if (work?.type !== "work") throw new Error("expected work item");
+		expect(work.toolCallCount).toBe(1);
+		expect(work.durationMilliseconds).toBe(13_500);
+	});
+
+	it("clamps the duration to the collapsed rows when the answer's timestamp is earlier", () => {
+		// A fallback answer bubble can be minted with a synthetic timestamp
+		// near the send time (RPC completion path); it must not shrink the
+		// duration below the work the run demonstrably performed.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 5_000),
+				makeMessage({ id: "a1", content: "Done.", createdAt: 1_001 }),
+			],
+			true,
+		);
+
+		const work = items.find((item) => item.type === "work");
+		if (work?.type !== "work") throw new Error("expected work item");
+		expect(work.durationMilliseconds).toBe(4_000);
+	});
+
 	it("measures duration from the first working row when no user message precedes it", () => {
 		const items = collapse(
 			[

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
@@ -141,6 +141,19 @@ function lastTimestamp(item: ChatRenderItem): number | undefined {
 	return undefined;
 }
 
+function maxFiniteTimestamp(
+	...values: Array<number | undefined>
+): number | undefined {
+	let max: number | undefined;
+	for (const value of values) {
+		if (value === undefined || !Number.isFinite(value)) continue;
+		if (max === undefined || value > max) {
+			max = value;
+		}
+	}
+	return max;
+}
+
 function firstMessageId(item: ChatRenderItem): string | undefined {
 	if (item.type === "tools") return item.messages[0]?.id;
 	if (item.type === "message") {
@@ -223,9 +236,19 @@ export function collapseCompletedWork(
 			const startTimestamp =
 				runStartTimestamp ?? firstTimestamp(firstCollapsed);
 			const lastCollapsed = collapsed[collapsed.length - 1];
-			const endTimestamp = answer
-				? firstTimestamp(answer)
-				: lastTimestamp(lastCollapsed);
+			// The work span ends where the run's answer begins — anchored on the
+			// answer row's own timestamp, not its earliest attached reasoning
+			// row: canonical history projects a thinking-only message that
+			// issued a tool call as a reasoning row stamped before the tool
+			// executed, and that row rides on the answer's reasoningMessages,
+			// which would exclude the entire tool execution from "Worked for".
+			// Clamping to the last collapsed row keeps a fallback answer bubble
+			// minted with an early synthetic timestamp from shrinking the
+			// duration below the work the run demonstrably performed.
+			const endTimestamp = maxFiniteTimestamp(
+				answer ? lastTimestamp(answer) : undefined,
+				lastTimestamp(lastCollapsed),
+			);
 			const durationMilliseconds =
 				startTimestamp !== undefined &&
 				endTimestamp !== undefined &&


### PR DESCRIPTION
### Description

The collapsed work summary row from #13315 ("Worked for Xs and made N tool calls") sometimes undercounted wall time when a turn contained a long-running command, e.g. showing "Worked for 5s and made 1 tool call" for a turn whose shell command verifiably ran 8 seconds.

Root cause (deterministic, but dependent on model output shape, which is why it looked intermittent):

1. When a thinking model issues a tool call without narration text, the persisted assistant message is `[thinking, tool_use]`. The sidecar's canonical projection (`readSessionMessages`) only flushed reasoning at end-of-message, so it emitted the tool row first and the reasoning-only row after it, both stamped with pre-execution timestamps (`ts`, `ts+1`).
2. In the webview, `groupChatMessages` attaches a trailing reasoning-only row to the next assistant message with content, which is the run's final answer.
3. `collapseCompletedWork` anchored the work span's end on `firstTimestamp(answer)`, which reads the answer's earliest attached reasoning row, so the duration became user message to pre-tool thinking, excluding the entire tool execution and second model response.

When the model narrates text before the tool call, the reasoning attaches to that text row instead and the duration is correct, which explains why a later 20-second turn showed the right value.

### Changes

- `webview/.../messages/group-messages.ts`: end the work span at the answer row's own timestamp instead of its earliest attached reasoning row, clamped to the last collapsed row so a fallback answer bubble minted with a synthetic early timestamp cannot shrink the duration either.
- `sidecar/session-data/messages.ts`: flush pending thinking before a `tool_use` row so rehydrated transcripts keep the live-stream order (thinking renders before the tool call it preceded) and pre-tool reasoning no longer rides on the next answer's reasoning trace.

### Test plan

- New unit tests in `group-messages.test.ts` reproduce the exact symptom (computed 5001ms for a 13.5s turn with an 8s tool run before the fix) and cover the clamp; new test in `sidecar/session-data/messages.test.ts` locks in the projection order. `bunx vitest run webview sidecar --config vitest.config.ts`: 711 passed, 2 pre-existing failures in `sidecar/context.test.ts` that also fail on the base commit.
- `bun -F @cline/code typecheck` passes.
- Manual verification with the live app (dev:sidecar + dev:web) against ground-truth timestamps in the persisted session messages file.