### PR TITLE
fix(desktop): don't show "No sessions found" while session history is still loading

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -54,12 +54,13 @@ function makeSessionHistory(
 	options: {
 		loadOlderSessions?: ReturnType<typeof vi.fn>;
 		mayHaveMoreSessions?: boolean;
+		hasLoadedHistory?: boolean;
 	} = {},
 ): UseSessionHistoryResult {
 	return {
 		deleteThread: vi.fn(),
 		forkThread: vi.fn(),
-		isLoadingHistory: false,
+		hasLoadedHistory: options.hasLoadedHistory ?? true,
 		isLoadingMore: false,
 		loadOlderSessions: options.loadOlderSessions ?? vi.fn(),
 		loadMoreSessions,
@@ -517,6 +518,56 @@ describe("AgentSidebar session organization", () => {
 
 		expect(sessionIsVisible("desktop session 1")).toBe(false);
 		expect(sessionIsVisible("cli session 1")).toBe(true);
+	});
+
+	it("keeps the loading state until the first history response arrives", async () => {
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onNewThread={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory([], vi.fn(), {
+							hasLoadedHistory: false,
+						})}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		// Before the backend has answered, an empty list means "still loading",
+		// never "no sessions": the definitive copy would read as lost history.
+		expect(container.textContent).toContain("Loading session history...");
+		expect(container.textContent).not.toContain("No sessions found in history");
+	});
+
+	it("shows the empty state only after the backend answered with zero sessions", async () => {
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onNewThread={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory([], vi.fn(), {
+							hasLoadedHistory: true,
+						})}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		expect(container.textContent).toContain("No sessions found in history");
+		expect(container.textContent).not.toContain("Loading session history...");
 	});
 
 	it("builds the hover overview with branch and secondary metadata last", () => {

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -279,7 +279,7 @@ export function AgentSidebar({
 	const {
 		deleteThread: deleteHistoryThread,
 		forkThread: forkHistoryThread,
-		isLoadingHistory,
+		hasLoadedHistory,
 		isLoadingMore,
 		loadOlderSessions,
 		loadMoreSessions,
@@ -942,7 +942,11 @@ export function AgentSidebar({
 						<div className="mt-1 min-h-0 w-full flex-1">
 							<ScrollArea className="h-full min-h-0 w-full min-w-0">
 								<div className="flex min-w-0 flex-col gap-0.5 pb-3 px-2">
-									{isLoadingHistory && threads.length === 0 ? (
+									{/* Empty-state copy is reserved for a definitive zero-
+									    session answer from the backend: before the first
+									    response (or while a failed fetch is being retried)
+									    "No sessions found" would read as lost history. */}
+									{!hasLoadedHistory && threads.length === 0 ? (
 										<div className="p-4 text-xs text-muted-foreground">
 											Loading session history...
 										</div>

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.test.tsx
@@ -45,17 +45,19 @@ function renderView({
 	loadOlderSessions = vi.fn(),
 	mayHaveMoreSessions = false,
 	threads = [thread],
+	hasLoadedHistory = true,
 }: {
 	openThread?: ReturnType<typeof vi.fn>;
 	loadAllSessions?: ReturnType<typeof vi.fn>;
 	loadOlderSessions?: ReturnType<typeof vi.fn>;
 	mayHaveMoreSessions?: boolean;
 	threads?: SessionThread[];
+	hasLoadedHistory?: boolean;
 } = {}) {
 	const history = {
 		deleteThread: vi.fn(),
 		forkThread: vi.fn(),
-		isLoadingHistory: false,
+		hasLoadedHistory,
 		isLoadingMore: false,
 		loadAllSessions,
 		loadOlderSessions,
@@ -187,6 +189,21 @@ describe("SessionsView table", () => {
 			row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
 		expect(view.openThread).toHaveBeenCalledWith(thread.id);
+	});
+
+	it("keeps loading until the first response and only then shows the empty state", async () => {
+		const loading = renderView({ threads: [], hasLoadedHistory: false });
+		await loading.render();
+		expect(container.textContent).toContain("Loading session history...");
+		expect(container.textContent).not.toContain("No sessions yet.");
+
+		await act(async () => root.unmount());
+		root = createRoot(container);
+
+		const empty = renderView({ threads: [], hasLoadedHistory: true });
+		await empty.render();
+		expect(container.textContent).toContain("No sessions yet.");
+		expect(container.textContent).not.toContain("Loading session history...");
 	});
 
 	it("loads complete history before treating search results as exhaustive", async () => {

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
@@ -426,13 +426,16 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 						<span className="sr-only">Actions</span>
 					</div>
 					<div>
-						{history.isLoadingHistory && history.threads.length === 0 ? (
+						{/* Keep the loader up until the backend's first response: the
+						    empty-state copy must only describe an actual zero-session
+						    answer, not a fetch that is still in flight or retrying. */}
+						{!history.hasLoadedHistory && history.threads.length === 0 ? (
 							<div className="flex items-center gap-2 border-t px-4 py-8 text-sm text-muted-foreground">
 								<Loader2 className="size-4 animate-spin" />
 								Loading session history...
 							</div>
 						) : null}
-						{!history.isLoadingHistory && filteredThreads.length === 0 ? (
+						{history.hasLoadedHistory && filteredThreads.length === 0 ? (
 							<div className="border-t px-4 py-8 text-sm text-muted-foreground">
 								{history.threads.length === 0
 									? "No sessions yet."

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -167,6 +167,28 @@ describe("useSessionHistory initial load", () => {
 		expect(current.threads).toHaveLength(1);
 	});
 
+	it("stops fast retries when the hook unmounts mid-request", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+		expect(pendingLists).toHaveLength(1);
+
+		// Unmount while the initial request is still in flight, then fail it:
+		// the retry continuation must not re-arm the cleared refresh timer.
+		await act(async () => root.unmount());
+		await act(async () => {
+			pendingLists[0].reject(new Error("transport closed"));
+			await Promise.resolve();
+		});
+
+		await flush(3_000);
+		expect(pendingLists).toHaveLength(1);
+
+		// Fresh root so the shared afterEach unmount stays valid.
+		root = createRoot(container);
+	});
+
 	it("does not schedule fast retries once history has loaded", async () => {
 		await act(async () => {
 			root.render(<HookHarness />);

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -120,6 +120,76 @@ describe("useSessionHistory session mapping", () => {
 	});
 });
 
+describe("useSessionHistory initial load", () => {
+	it("reports history as loaded only after the backend has answered", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+		expect(pendingLists).toHaveLength(1);
+		expect(current.hasLoadedHistory).toBe(false);
+
+		await act(async () => {
+			pendingLists[0].resolve([]);
+			await Promise.resolve();
+		});
+
+		// A zero-session answer is a definitive result, not a loading state.
+		expect(current.hasLoadedHistory).toBe(true);
+		expect(current.threads).toHaveLength(0);
+	});
+
+	it("retries a failed initial fetch quickly instead of waiting for the poll", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+		expect(pendingLists).toHaveLength(1);
+
+		await act(async () => {
+			pendingLists[0].reject(new Error("transport closed"));
+			await Promise.resolve();
+		});
+
+		// The rejected request must not read as an empty history.
+		expect(current.hasLoadedHistory).toBe(false);
+
+		// The retry fires on the short event cadence (2s), well before the
+		// 12s periodic poll.
+		await flush(2_000);
+		expect(pendingLists).toHaveLength(2);
+
+		await act(async () => {
+			pendingLists[1].resolve([sessionRow("recovered-session")]);
+			await Promise.resolve();
+		});
+		expect(current.hasLoadedHistory).toBe(true);
+		expect(current.threads).toHaveLength(1);
+	});
+
+	it("does not schedule fast retries once history has loaded", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+		await act(async () => {
+			pendingLists[0].resolve([sessionRow("session-1")]);
+			await Promise.resolve();
+		});
+		expect(current.hasLoadedHistory).toBe(true);
+
+		// Advance to the periodic poll and fail it: no 2s retry may follow.
+		await flush(12_000);
+		expect(pendingLists).toHaveLength(2);
+		await act(async () => {
+			pendingLists[1].reject(new Error("transport closed"));
+			await Promise.resolve();
+		});
+		await flush(3_000);
+		expect(pendingLists).toHaveLength(2);
+	});
+});
+
 describe("useSessionHistory refresh coalescing", () => {
 	it("reuses an in-flight refresh that already covers the requested limit", async () => {
 		await act(async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -526,6 +526,10 @@ export function useSessionHistory({
 	const refreshLimitRef = useRef(0);
 	const loadAllPromiseRef = useRef<Promise<boolean> | null>(null);
 	const lastRefreshStartedAtRef = useRef(0);
+	// Guards scheduleRefresh against continuations that settle after unmount
+	// (e.g. the fast retry of a failed initial fetch), which would otherwise
+	// re-arm a timer the cleanup has already cleared and poll forever.
+	const disposedRef = useRef(false);
 
 	useEffect(() => {
 		sessionsRef.current = sessions;
@@ -675,6 +679,9 @@ export function useSessionHistory({
 
 	const scheduleRefresh = useCallback(
 		(delayMs = 0, options: { force?: boolean } = {}) => {
+			if (disposedRef.current) {
+				return;
+			}
 			const now = Date.now();
 			const minTarget = options.force
 				? now
@@ -715,6 +722,7 @@ export function useSessionHistory({
 
 	useEffect(() => {
 		let disposed = false;
+		disposedRef.current = false;
 
 		const runRefresh = () => {
 			if (!disposed) {
@@ -732,6 +740,7 @@ export function useSessionHistory({
 
 		return () => {
 			disposed = true;
+			disposedRef.current = true;
 			window.clearInterval(interval);
 			if (refreshTimeoutRef.current !== null) {
 				window.clearTimeout(refreshTimeoutRef.current);

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -492,7 +492,11 @@ export function useSessionHistory({
 }: UseSessionHistoryOptions) {
 	const [sessions, setSessions] = useState<SessionHistoryItem[]>([]);
 	const [threads, setThreads] = useState<SessionThread[]>([]);
-	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+	// False until the backend has answered a history request at least once.
+	// Consumers use this to tell "still loading" apart from "loaded, zero
+	// sessions": an empty-state copy shown before the first response reads as
+	// lost history whenever fetching takes more than an instant.
+	const [hasLoadedHistory, setHasLoadedHistory] = useState(false);
 	const [isLoadingMore, setIsLoadingMore] = useState(false);
 	const [mayHaveMoreSessions, setMayHaveMoreSessions] = useState(false);
 	const [pendingAction, setPendingAction] =
@@ -562,12 +566,6 @@ export function useSessionHistory({
 			lastRefreshStartedAtRef.current = Date.now();
 			const limit = fetchLimitRef.current;
 			refreshLimitRef.current = limit;
-			// Only surface the loading state before anything has been fetched:
-			// consumers only render it for an empty list, and toggling it on
-			// every background poll re-rendered the whole app twice per refresh.
-			if (sessionsRef.current.length === 0) {
-				setIsLoadingHistory(true);
-			}
 			try {
 				const discovered = await desktopClient
 					.invoke<CliDiscoveredSession[]>("list_discovered_sessions", { limit })
@@ -655,12 +653,11 @@ export function useSessionHistory({
 					return areThreadsEquivalent(current, next) ? current : next;
 				});
 				loadedLimitRef.current = Math.max(loadedLimitRef.current, limit);
+				setHasLoadedHistory(true);
 				return true;
 			} catch {
 				// Ignore in browser mode or when tauri command is unavailable.
 				return false;
-			} finally {
-				setIsLoadingHistory(false);
 			}
 		})();
 
@@ -699,7 +696,16 @@ export function useSessionHistory({
 				() => {
 					refreshTimeoutRef.current = null;
 					scheduledRefreshAtRef.current = null;
-					void refreshSessions();
+					void refreshSessions().then((loaded) => {
+						// Until something has loaded the UI has nothing but a
+						// loading state to show, so a failed fetch (e.g. the
+						// websocket losing the race with a webview reload) retries
+						// on the short event cadence instead of stranding the
+						// sidebar until the periodic poll fires.
+						if (!loaded && loadedLimitRef.current === 0) {
+							scheduleRefresh(MIN_EVENT_HISTORY_REFRESH_INTERVAL_MS);
+						}
+					});
 				},
 				Math.max(0, target - now),
 			);
@@ -1416,7 +1422,7 @@ export function useSessionHistory({
 
 	return {
 		getSessionByThreadId,
-		isLoadingHistory,
+		hasLoadedHistory,
 		isLoadingMore,
 		loadAllSessions,
 		loadOlderSessions,


### PR DESCRIPTION
### Related Issue

Found during a regression pass on desktop-v0.0.14: after a webview reload (F5), the Sessions sidebar showed "No sessions found in history" for roughly 10 seconds before the real session list populated, which reads as lost history even though the data on disk was intact.

### Description

Two things were wrong:

1. The sidebar (and the Sessions view) fell through to the definitive empty-state copy whenever the list was empty and no fetch was flagged as in flight. The old `isLoadingHistory` flag was false on first render and was also cleared when a fetch failed, so any gap before the first successful response rendered "No sessions found in history".
2. When the first `list_discovered_sessions` request failed (for example the websocket losing the race with the page reload, or the sidecar restarting), nothing retried until the 12 second periodic poll. That poll interval is what stretched the misleading copy to the observed ~10 seconds.

The fix replaces `isLoadingHistory` in `useSessionHistory` with `hasLoadedHistory`, which flips to true only once the backend has actually answered a history request. Both consumers now keep their loading state ("Loading session history...") until that first definitive response, and show the empty-state copy only when the backend has answered with zero sessions. Additionally, a failed fetch while nothing has ever loaded now retries on the existing 2 second event cadence instead of waiting out the 12 second poll, so the recovery is fast too.

On the perf question from the report: the sidecar itself is not slow. `list_discovered_sessions` goes through `ClineCore.list(max, { hydrate: false })`, which skips per-session message parsing, and measured at 24ms cold / 2ms warm over the websocket with sessions on disk. The ~10 seconds was the failed-first-fetch plus poll-interval window, not a scan cost, so no sidecar changes were needed.

### Test Procedure

- Reproduced the bug on main in dev mode (`bun run dev:sidecar` + `bun run dev:web`, sessions on disk): reloading the webview while the sidecar was briefly down showed "No sessions found in history" until the periodic poll recovered (~15s). See before screenshots.
- Verified the fix in the same scenario: the sidebar shows "Loading session history..." for the whole outage and populates within ~2 seconds of the sidecar coming back, without user interaction. See after screenshots.
- `bunx vitest run webview --config vitest.config.ts`: 51 files, 533 tests passed, including new tests for the loading-vs-empty distinction in the sidebar and Sessions view, plus hook tests covering `hasLoadedHistory` transitions, the fast retry after a failed initial fetch, and that no fast retry fires once history has loaded.
- `bun -F @cline/code typecheck` passes; changed files pass `bun biome check`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (main): reload while the backend is briefly unavailable shows the misleading empty state, with 6 sessions on disk:

![Before: sidebar shows No sessions found in history right after reload](https://cursor.com/artifacts/c/art-79b0b1b5-e424-4e06-85b3-4bbea22d60ff)

Before (main): the sessions only appear once the 12s poll recovers (~15s later):

![Before: sessions populate only after the periodic poll](https://cursor.com/artifacts/c/art-a9aefbac-b0ca-47dc-a9f1-2311a2e7dd3d)

After (this PR): the same reload shows the loading state instead, for as long as the backend has not answered:

![After: sidebar shows Loading session history while the backend is down](https://cursor.com/artifacts/c/art-ced587c2-a9be-4723-825c-9fc853d1a01d)

After (this PR): sessions populate within ~2 seconds of the backend returning, via the fast retry:

![After: sessions populated shortly after the backend returned](https://cursor.com/artifacts/c/art-0053d0e1-6970-469d-bdae-b05147b2c1a8)

### Additional Notes

`isLoadingHistory` was only ever consumed by these two loading/empty branches, so it was removed from the hook's return value rather than kept alongside the new flag.