### PR TITLE
fix(vscode): show the diff edit view for multi-line edits in CRLF files

### DIFF
--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.test.ts
@@ -67,6 +67,25 @@ describe("computeNewEditorContent", () => {
 		expect(computeNewEditorContent("a\nb", input, filePath, "modify")).toBe("a\nb\nx")
 	})
 
+	// Reads strip "\r", so models emit LF-only old_text even for CRLF files. The SDK
+	// executor normalizes to the file's EOL before matching (#12305); the preview must
+	// too, or every multi-line edit in a CRLF file silently skips its diff view while
+	// the executor still applies it (github.com/cline/cline/issues/13296).
+	it("matches LF-only multi-line old_text in a CRLF file and keeps CRLF endings", () => {
+		const input: EditFileInput = { path: filePath, old_text: "b\nc", new_text: "B\nC\nX" }
+		expect(computeNewEditorContent("a\r\nb\r\nc\r\nd", input, filePath, "modify")).toBe("a\r\nB\r\nC\r\nX\r\nd")
+	})
+
+	it("inserts with the file's CRLF endings", () => {
+		const input: EditFileInput = { path: filePath, new_text: "first\nsecond", insert_line: 2 }
+		expect(computeNewEditorContent("one\r\ntwo", input, filePath, "modify")).toBe("one\r\nfirst\r\nsecond\r\ntwo")
+	})
+
+	it("inserts $-sequences in new_text literally, like the executor", () => {
+		const input: EditFileInput = { path: filePath, old_text: "b", new_text: "match=$& pid=$$" }
+		expect(computeNewEditorContent("a\nb\nc", input, filePath, "modify")).toBe("a\nmatch=$& pid=$$\nc")
+	})
+
 	// Mirrors the SDK executor's semantics (editor.ts) so the preview shows exactly what
 	// the executor will write, and inputs the SDK would reject skip the preview.
 	it("throws for text not found", () => {
@@ -281,6 +300,21 @@ describe("SdkDiffEditCoordinator", () => {
 			leftContent: "line1\nline2\n",
 			rightContent: "changed\nline2\n",
 			title: "a.ts: Original ↔ Cline's Changes (Preview)",
+		})
+	})
+
+	it("opens a preview for a multi-line edit in a CRLF file (issue #13296)", async () => {
+		await writeFile("crlf.ts", "line1\r\nline2\r\nline3")
+		await coordinator.openForApproval("tc1", "editor", {
+			path: "crlf.ts",
+			old_text: "line1\nline2",
+			new_text: "changed1\nchanged2",
+		})
+
+		expect(previews).toHaveLength(1)
+		expect(previews[0].opened).toMatchObject({
+			leftContent: "line1\r\nline2\r\nline3",
+			rightContent: "changed1\r\nchanged2\r\nline3",
 		})
 	})
 

--- a/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-diff-edit-coordinator.ts
@@ -367,11 +367,26 @@ export class SdkDiffEditCoordinator {
 	}
 }
 
+/** Mirrors the SDK executor's detectLineEnding: "\r\n" if it appears anywhere, else "\n". */
+function detectLineEnding(content: string): "\r\n" | "\n" {
+	return content.includes("\r\n") ? "\r\n" : "\n"
+}
+
+function normalizeLineEndings(text: string, eol: "\r\n" | "\n"): string {
+	return text.split(/\r\n|\n/).join(eol)
+}
+
 /**
  * Computes the full proposed file content for an `editor` tool input, mirroring the
  * SDK executor's semantics (sdk/packages/core/src/extensions/tools/executors/editor.ts)
  * so the preview shows exactly what the executor will write. Inputs the SDK would
  * reject throw here too, and the preview is simply skipped.
+ *
+ * Like the executor, old/new text are normalized to the file's own line endings
+ * before matching: reads strip "\r", so models emit LF-only text even for CRLF
+ * files, and an exact match would fail on every multi-line old_text in a CRLF
+ * file — silently skipping the preview while the executor applies the edit
+ * (github.com/cline/cline/issues/13296).
  */
 export function computeNewEditorContent(
 	originalContent: string,
@@ -380,15 +395,16 @@ export function computeNewEditorContent(
 	editType: "create" | "modify",
 ): string {
 	if (input.insert_line != null) {
-		const lines = originalContent.split("\n")
+		const eol = detectLineEnding(originalContent)
+		const lines = originalContent.split(/\r\n|\n/)
 		const maxBoundaryLine = lines.length + 1
 		if (input.insert_line < 1 || input.insert_line > maxBoundaryLine) {
 			throw new Error(
 				`Invalid insert_line: ${input.insert_line}. insert_line must be a positive one-based boundary line in the range 1-${maxBoundaryLine}. Use ${maxBoundaryLine} to append at EOF.`,
 			)
 		}
-		lines.splice(input.insert_line - 1, 0, ...input.new_text.split("\n"))
-		return lines.join("\n")
+		lines.splice(input.insert_line - 1, 0, ...input.new_text.split(/\r\n|\n/))
+		return lines.join(eol)
 	}
 
 	if (editType === "create") {
@@ -399,14 +415,18 @@ export function computeNewEditorContent(
 		throw new Error("Parameter `old_text` is required when editing an existing file without `insert_line`")
 	}
 
-	const occurrences = input.old_text.length === 0 ? 0 : originalContent.split(input.old_text).length - 1
+	const eol = detectLineEnding(originalContent)
+	const normalizedOldText = normalizeLineEndings(input.old_text, eol)
+	const normalizedNewText = normalizeLineEndings(input.new_text ?? "", eol)
+	const occurrences = normalizedOldText.length === 0 ? 0 : originalContent.split(normalizedOldText).length - 1
 	if (occurrences === 0) {
 		throw new Error(`No replacement performed: text not found in ${filePath}.`)
 	}
 	if (occurrences > 1) {
 		throw new Error(`No replacement performed: multiple occurrences of text found in ${filePath}.`)
 	}
-	return originalContent.replace(input.old_text, input.new_text ?? "")
+	// Replacer function so "$"-sequences in new_text are inserted literally, as the executor does.
+	return originalContent.replace(normalizedOldText, () => normalizedNewText)
 }
 
 /** Mirrors the SDK executor's resolveFilePath (restrictToCwd=true): absolute paths pass through. */


### PR DESCRIPTION
The edit preview computed proposed content with an exact old_text match, but the SDK executor normalizes old/new text to the file's own line endings before matching (#12305) - reads strip CR, so models emit LF-only text even for CRLF files. Any multi-line old_text in a CRLF file therefore failed the preview's match: the diff edit view silently never opened while the executor applied the edit. Single-line edits (no line break in old_text) were unaffected, which is why the diff view appeared to trigger inconsistently.

Mirror the executor's EOL normalization (and its literal $-sequence insertion) in the preview computation.

Fixes #13296

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
