### PR TITLE
fix: migrating legacy tasks would use entire conversation history without truncations

### DIFF
--- a/apps/vscode/src/sdk/legacy-task-handling.test.ts
+++ b/apps/vscode/src/sdk/legacy-task-handling.test.ts
@@ -1,0 +1,115 @@
+import type { HistoryItem } from "@shared/HistoryItem"
+import { describe, expect, it } from "vitest"
+import { legacyApiHistoryToSdkMessages } from "./legacy-task-handling"
+
+const baseHistoryItem = { id: "task-1" } as HistoryItem
+
+function textMessage(role: "user" | "assistant", text: string) {
+	return { role, content: [{ type: "text", text }] }
+}
+
+describe("legacyApiHistoryToSdkMessages", () => {
+	it("converts the full history when no deleted range is recorded", () => {
+		const messages = legacyApiHistoryToSdkMessages(
+			[
+				textMessage("user", "first task"),
+				textMessage("assistant", "first answer"),
+				textMessage("user", "middle request"),
+				textMessage("assistant", "middle answer"),
+			],
+			baseHistoryItem,
+		)
+
+		const serialized = JSON.stringify(messages)
+		expect(serialized).toContain("first task")
+		expect(serialized).toContain("middle request")
+		expect(serialized).toContain("middle answer")
+	})
+
+	it("replays the classic truncation range instead of resurrecting the full history", () => {
+		// Classic Cline sent [first user-assistant pair, ...messages after the
+		// range end] to the API while keeping the full history on disk.
+		// Migration must produce the same working context, or a long task
+		// resumes with millions of tokens the classic extension had already
+		// truncated away (cline/cline#12996).
+		const apiHistory = [
+			textMessage("user", "first task"),
+			textMessage("assistant", "first answer"),
+			textMessage("user", "truncated request 1"),
+			textMessage("assistant", "truncated answer 1"),
+			textMessage("user", "truncated request 2"),
+			textMessage("assistant", "truncated answer 2"),
+			textMessage("user", "kept request"),
+			textMessage("assistant", "kept answer"),
+		]
+
+		const messages = legacyApiHistoryToSdkMessages(apiHistory, {
+			...baseHistoryItem,
+			conversationHistoryDeletedRange: [2, 5],
+		})
+
+		const serialized = JSON.stringify(messages)
+		expect(serialized).toContain("first task")
+		expect(serialized).toContain("first answer")
+		expect(serialized).toContain("kept request")
+		expect(serialized).toContain("kept answer")
+		expect(serialized).not.toContain("truncated request 1")
+		expect(serialized).not.toContain("truncated answer 2")
+	})
+
+	it("strips orphaned tool_results from the first message after the cut", () => {
+		// The message right after the cut can carry tool_results whose
+		// tool_use was truncated away; classic filtered them out and so must
+		// the migration, or providers reject the resumed conversation.
+		const apiHistory = [
+			textMessage("user", "first task"),
+			textMessage("assistant", "first answer"),
+			textMessage("user", "truncated request"),
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "tool-gone", name: "read_file", input: {} }],
+			},
+			{
+				role: "user",
+				content: [
+					{ type: "tool_result", tool_use_id: "tool-gone", content: "orphaned result" },
+					{ type: "text", text: "environment details" },
+				],
+			},
+			textMessage("assistant", "kept answer"),
+		]
+
+		const messages = legacyApiHistoryToSdkMessages(apiHistory, {
+			...baseHistoryItem,
+			conversationHistoryDeletedRange: [2, 3],
+		})
+
+		const serialized = JSON.stringify(messages)
+		expect(serialized).not.toContain("orphaned result")
+		expect(serialized).not.toContain("tool-gone")
+		expect(serialized).toContain("environment details")
+		expect(serialized).toContain("kept answer")
+	})
+
+	it("ignores a malformed deleted range", () => {
+		const apiHistory = [
+			textMessage("user", "first task"),
+			textMessage("assistant", "first answer"),
+			textMessage("user", "latest request"),
+		]
+
+		for (const range of [
+			[2, 99],
+			[2, 2],
+			[0, 1],
+			[2, 1.5],
+		] as Array<[number, number]>) {
+			const messages = legacyApiHistoryToSdkMessages(apiHistory, {
+				...baseHistoryItem,
+				conversationHistoryDeletedRange: range,
+			})
+			expect(JSON.stringify(messages)).toContain("latest request")
+			expect(JSON.stringify(messages)).toContain("first answer")
+		}
+	})
+})

--- a/apps/vscode/src/sdk/legacy-task-handling.ts
+++ b/apps/vscode/src/sdk/legacy-task-handling.ts
@@ -79,8 +79,49 @@ export function appendLegacyResumeWarning<T extends { role: string; content: unk
 	]
 }
 
+/**
+ * Classic Cline truncated long conversations by omitting an index range of
+ * api_conversation_history from every API request: it kept the first
+ * user-assistant pair, dropped everything up to and including the range end,
+ * and stripped orphaned tool_results from the first kept message
+ * (ContextManager.getTruncatedMessages — see origin/main). The range was
+ * persisted on the history item while the full history stayed on disk.
+ *
+ * Migration must replay that truncation: converting the full file hands the
+ * resumed SDK session an untruncated working context that can exceed the
+ * model's context window by millions of tokens, wedging the session with
+ * "prompt is too long" on every request (cline/cline#12996).
+ */
+function applyLegacyDeletedRange(apiHistory: unknown[], historyItem: HistoryItem): unknown[] {
+	const deletedRangeEnd = historyItem.conversationHistoryDeletedRange?.[1]
+	if (
+		deletedRangeEnd === undefined ||
+		!Number.isInteger(deletedRangeEnd) ||
+		deletedRangeEnd < 2 ||
+		deletedRangeEnd >= apiHistory.length - 1
+	) {
+		return apiHistory
+	}
+	const truncated = [...apiHistory.slice(0, 2), ...apiHistory.slice(deletedRangeEnd + 1)]
+	// Classic's orphan cleanup: the first message after the cut may carry
+	// tool_results whose tool_use was truncated away, which providers reject.
+	const firstAfterCut = truncated[2]
+	if (firstAfterCut && typeof firstAfterCut === "object") {
+		const record = firstAfterCut as Record<string, unknown>
+		if (record.role === "user" && Array.isArray(record.content)) {
+			const content = record.content.filter(
+				(block) => !(block && typeof block === "object" && (block as { type?: unknown }).type === "tool_result"),
+			)
+			if (content.length !== record.content.length) {
+				truncated[2] = { ...record, content }
+			}
+		}
+	}
+	return truncated
+}
+
 export function legacyApiHistoryToSdkMessages(apiHistory: unknown[], historyItem: HistoryItem): MessageWithMetadata[] {
-	const messages = apiHistory.flatMap((raw): MessageWithMetadata[] => {
+	const messages = applyLegacyDeletedRange(apiHistory, historyItem).flatMap((raw): MessageWithMetadata[] => {
 		if (!raw || typeof raw !== "object") {
 			return []
 		}


### PR DESCRIPTION
### Related Issue

**Issue:** #12996

### Description

The reporter confirmed the affected session was a task migrated from the classic (pre-SDK) extension: it worked for a few messages after migration, broke after a restart, and from then on every request failed with `prompt is too long: 1096513 tokens > 1000000 maximum` while every compaction restarted from ~3M tokens. Their guess that "it may be treating the entire history as context" is exactly what happens.

Classic Cline handled long conversations by keeping the full `api_conversation_history.json` on disk while omitting a truncated index range from every API request: keep the first user-assistant pair, drop everything through the range end, and strip orphaned `tool_result` blocks from the first kept message (`ContextManager.getTruncatedMessages` on origin/main). The range is persisted as `conversationHistoryDeletedRange` on the history item.

`legacyApiHistoryToSdkMessages` ignored that field and converted the entire file, and the migration creates no compaction sidecar, so a resumed long task handed the SDK an untruncated working context. In this case that was over a million real tokens on a 1M-window model. The overflow then cascaded through the compaction pipeline (that unrecoverable cascade is fixed separately on the overflow-recovery branch); this PR fixes the entry path so migrated tasks never send history the classic extension had already truncated away.

The migration now replays exactly what classic sent to the API: slice out `[2, rangeEnd]`, keep the first pair, and drop orphaned tool_results from the first message after the cut. Malformed or missing ranges fall back to converting the full history, which is the previous behavior. One function in `apps/vscode/src/sdk/legacy-task-handling.ts`; no changes anywhere else.

### Test Procedure

New `legacy-task-handling.test.ts` covering: full conversion when no range is recorded, the range being replayed (first pair and post-range tail kept, middle omitted), orphaned tool_results stripped from the first kept message while its other content survives, and malformed ranges (out of bounds, non-integer, degenerate) falling back to the full history.

Suites: VS Code `test:unit` 1069 passed, `test:vitest` 1148 passed (includes the 4 new tests), lint clean, `@cline/vscode` typecheck clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change; behavior is covered by the unit tests above.

### Additional Notes

Nothing is deleted from disk: the full legacy history file is untouched, and the truncation only affects what the resumed session sends to the model, which is the same working context the classic extension was already using. Tasks migrated before this fix keep their oversized canonical transcript; the overflow-recovery branch handles those at request time.