### PR TITLE
fix(vscode): prevent hook spawn failures from crashing the core process

### DIFF
--- a/apps/vscode/src/core/hooks/HookProcess.ts
+++ b/apps/vscode/src/core/hooks/HookProcess.ts
@@ -108,9 +108,6 @@ export class HookProcess extends EventEmitter {
 	// Track registration state to prevent leaks and ensure cleanup
 	private isRegistered = false
 
-	// The working directory actually passed to spawn (after existence validation)
-	private spawnCwd: string | undefined
-
 	constructor(
 		private readonly scriptPath: string,
 		private readonly timeoutMs: number = 30000,
@@ -180,20 +177,20 @@ export class HookProcess extends EventEmitter {
 
 						// A cwd that doesn't exist makes spawn fail with a misleading
 						// ENOENT against the launcher binary (e.g. "spawn /bin/sh ENOENT").
-						// Run the hook without an explicit cwd instead of failing.
-						let cwd = this.cwd
-						if (cwd && !existsSync(cwd)) {
-							Logger.warn(
-								`[HookProcess] Working directory '${cwd}' does not exist; running hook '${this.scriptPath}' without an explicit working directory`,
+						// Fail the hook with an error naming the real culprit instead.
+						// Running the hook anyway (with no explicit cwd) is not safe: its
+						// relative paths would resolve against the host process's own
+						// working directory, not the workspace it was written for.
+						if (this.cwd && !existsSync(this.cwd)) {
+							throw new Error(
+								`Hook working directory '${this.cwd}' does not exist; not running hook '${this.scriptPath}'`,
 							)
-							cwd = undefined
 						}
-						this.spawnCwd = cwd
 						this.childProcess = spawn(launchConfig.command, launchConfig.args, {
 							stdio: ["pipe", "pipe", "pipe"],
 							shell: launchConfig.shell,
 							detached: launchConfig.detached,
-							cwd, // Execute from the determined workspace root (validated above)
+							cwd: this.cwd, // Execute from the determined workspace root (validated above)
 							windowsHide: true,
 						})
 
@@ -317,8 +314,8 @@ export class HookProcess extends EventEmitter {
 	 */
 	private describeSpawnError(error: Error): Error {
 		const code = (error as NodeJS.ErrnoException).code
-		if (code === "ENOENT" && this.spawnCwd && !existsSync(this.spawnCwd)) {
-			return new Error(`Hook working directory '${this.spawnCwd}' does not exist (reported by spawn as: ${error.message})`)
+		if (code === "ENOENT" && this.cwd && !existsSync(this.cwd)) {
+			return new Error(`Hook working directory '${this.cwd}' does not exist (reported by spawn as: ${error.message})`)
 		}
 		return error
 	}

--- a/apps/vscode/src/core/hooks/HookProcess.ts
+++ b/apps/vscode/src/core/hooks/HookProcess.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, spawn } from "child_process"
 import { EventEmitter } from "events"
+import { existsSync } from "fs"
 import { Logger } from "@/shared/services/Logger"
 import { resolveWindowsPowerShellExecutable } from "@/utils/powershell"
 import { HookProcessRegistry } from "./HookProcessRegistry"
@@ -107,6 +108,9 @@ export class HookProcess extends EventEmitter {
 	// Track registration state to prevent leaks and ensure cleanup
 	private isRegistered = false
 
+	// The working directory actually passed to spawn (after existence validation)
+	private spawnCwd: string | undefined
+
 	constructor(
 		private readonly scriptPath: string,
 		private readonly timeoutMs: number = 30000,
@@ -173,11 +177,23 @@ export class HookProcess extends EventEmitter {
 				void (async () => {
 					try {
 						const launchConfig = await getHookLaunchConfig(this.scriptPath)
+
+						// A cwd that doesn't exist makes spawn fail with a misleading
+						// ENOENT against the launcher binary (e.g. "spawn /bin/sh ENOENT").
+						// Run the hook without an explicit cwd instead of failing.
+						let cwd = this.cwd
+						if (cwd && !existsSync(cwd)) {
+							Logger.warn(
+								`[HookProcess] Working directory '${cwd}' does not exist; running hook '${this.scriptPath}' without an explicit working directory`,
+							)
+							cwd = undefined
+						}
+						this.spawnCwd = cwd
 						this.childProcess = spawn(launchConfig.command, launchConfig.args, {
 							stdio: ["pipe", "pipe", "pipe"],
 							shell: launchConfig.shell,
 							detached: launchConfig.detached,
-							cwd: this.cwd, // Execute from the determined workspace root
+							cwd, // Execute from the determined workspace root (validated above)
 							windowsHide: true,
 						})
 
@@ -259,8 +275,15 @@ export class HookProcess extends EventEmitter {
 							if (this.abortSignal) {
 								this.abortSignal.removeEventListener("abort", abortHandler)
 							}
-							this.emit("error", error)
-							reject(error)
+							const spawnError = this.describeSpawnError(error)
+							// Emitting "error" with no listener registered makes EventEmitter
+							// throw, which would escape this callback as an uncaught exception
+							// and kill the whole host process. Hook failures must fail open,
+							// so only forward the event when someone is actually listening.
+							if (this.listenerCount("error") > 0) {
+								this.emit("error", spawnError)
+							}
+							reject(spawnError)
 						})
 
 						// Send input to the process
@@ -283,6 +306,21 @@ export class HookProcess extends EventEmitter {
 			// Guaranteed cleanup even if process setup fails or throws
 			this.safeUnregister()
 		}
+	}
+
+	/**
+	 * Translates a child-process spawn failure into an actionable error.
+	 *
+	 * Node reports a working directory that vanished between validation and
+	 * spawn as an ENOENT on the launcher binary (e.g. "spawn /bin/sh ENOENT"),
+	 * so name the real culprit when that is what happened.
+	 */
+	private describeSpawnError(error: Error): Error {
+		const code = (error as NodeJS.ErrnoException).code
+		if (code === "ENOENT" && this.spawnCwd && !existsSync(this.spawnCwd)) {
+			return new Error(`Hook working directory '${this.spawnCwd}' does not exist (reported by spawn as: ${error.message})`)
+		}
+		return error
 	}
 
 	/**

--- a/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
@@ -96,13 +96,12 @@ console.log(JSON.stringify({
 		)
 
 		it(
-			"should execute hooks even when the configured workspace root no longer exists",
+			"should fail open without crashing when the workspace root no longer exists",
 			async () => {
 				const hookPath = path.join(tempDir, ".clinerules", "hooks", "PreToolUse")
 				const hookScript = `#!/usr/bin/env node
 console.log(JSON.stringify({
-  cancel: false,
-  contextModification: "CWD: " + process.cwd()
+  cancel: false
 }))`
 
 				await writeHookScript(hookPath, hookScript)
@@ -118,18 +117,22 @@ console.log(JSON.stringify({
 				const factory = new HookFactory()
 				const runner = await factory.create("PreToolUse")
 
-				const result = await runner.run({
-					taskId: "test-task",
-					preToolUse: {
-						toolName: "test_tool",
-						parameters: {},
-					},
-				})
-
-				// The hook must still run (from the process default cwd) instead
-				// of crashing or failing on the stale root.
-				result.cancel.should.be.false()
-				result.contextModification?.should.startWith("CWD: ")
+				try {
+					await runner.run({
+						taskId: "test-task",
+						preToolUse: {
+							toolName: "test_tool",
+							parameters: {},
+						},
+					})
+					throw new Error("Expected hook run to fail")
+				} catch (error: any) {
+					// The failure must be a catchable hook error that names the
+					// missing directory - not an uncaught exception killing the
+					// process, and not a run from an unrelated working directory.
+					error.message.should.not.equal("Expected hook run to fail")
+					String(error.errorInfo?.stderr ?? "").should.containEql("deleted-workspace-root")
+				}
 			},
 			WINDOWS_HOOK_TEST_TIMEOUT_MS,
 		)

--- a/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import path from "path"
 import sinon from "sinon"
 import { setDistinctId } from "@/services/logging/distinctId"
+import { stubWorkspacePaths } from "../../../test/host-provider-test-utils"
 import { HookFactory, isPathWithin } from "../hook-factory"
 import { createHookTestEnv, HookTestEnv, stubHookDirs, withPlatform, writeHookScriptForPlatform } from "./test-utils"
 
@@ -90,6 +91,45 @@ console.log(JSON.stringify({
 				const normalizedCwd = await fs.realpath(cwdFromHook)
 				const normalizedTempDir = await fs.realpath(tempDir)
 				normalizedCwd.should.equal(normalizedTempDir)
+			},
+			WINDOWS_HOOK_TEST_TIMEOUT_MS,
+		)
+
+		it(
+			"should execute hooks even when the configured workspace root no longer exists",
+			async () => {
+				const hookPath = path.join(tempDir, ".clinerules", "hooks", "PreToolUse")
+				const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "CWD: " + process.cwd()
+}))`
+
+				await writeHookScript(hookPath, hookScript)
+
+				// Point the host-reported workspace roots at a directory that no
+				// longer exists on disk (deleted, renamed, or unmounted since the
+				// host resolved it). Spawning with that path as cwd used to fail
+				// with a misleading "spawn /bin/sh ENOENT" whose unlistened
+				// "error" emit crashed the whole host process.
+				sandbox.restore()
+				stubWorkspacePaths(sandbox, [path.join(tempDir, "deleted-workspace-root")])
+
+				const factory = new HookFactory()
+				const runner = await factory.create("PreToolUse")
+
+				const result = await runner.run({
+					taskId: "test-task",
+					preToolUse: {
+						toolName: "test_tool",
+						parameters: {},
+					},
+				})
+
+				// The hook must still run (from the process default cwd) instead
+				// of crashing or failing on the stale root.
+				result.cancel.should.be.false()
+				result.contextModification?.should.startWith("CWD: ")
 			},
 			WINDOWS_HOOK_TEST_TIMEOUT_MS,
 		)

--- a/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from "bun:test"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
-import should from "should"
+import "should"
 import { getHookLaunchConfig, HookProcess, resetHookLaunchConfigCacheForTesting } from "../HookProcess"
 import { withPlatform, writeHookScriptForPlatform } from "./test-utils"
 
@@ -196,15 +196,22 @@ describe("HookProcess spawn failures", () => {
 		return process.platform === "win32" ? `${hookBasePath}.ps1` : hookBasePath
 	}
 
-	it("runs the hook without an explicit cwd when the requested cwd does not exist", async () => {
+	it("fails the hook run with an error naming the cwd when it does not exist", async () => {
 		const scriptPath = await writeTestHook()
 		const missingCwd = path.join(tempDir, "deleted-workspace-root")
 
+		// A hook assigned a working directory that no longer exists must fail
+		// (open, catchably) rather than run with its relative paths resolving
+		// against the host process's own working directory.
 		const hookProcess = new HookProcess(scriptPath, 30000, undefined, missingCwd)
-		await hookProcess.run("{}")
 
-		should(hookProcess.getExitCode()).equal(0)
-		hookProcess.getStdout().should.containEql('"cancel":false')
+		try {
+			await hookProcess.run("{}")
+			throw new Error("Expected hook run to fail")
+		} catch (error: any) {
+			error.message.should.containEql(missingCwd)
+			error.message.should.containEql("does not exist")
+		}
 	}, 15000)
 
 	it.skipIf(process.platform === "win32")(

--- a/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, it } from "bun:test"
-import "should"
-import { getHookLaunchConfig, resetHookLaunchConfigCacheForTesting } from "../HookProcess"
-import { withPlatform } from "./test-utils"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import should from "should"
+import { getHookLaunchConfig, HookProcess, resetHookLaunchConfigCacheForTesting } from "../HookProcess"
+import { withPlatform, writeHookScriptForPlatform } from "./test-utils"
 
 function createDeferred<T>() {
 	let resolve!: (value: T | PromiseLike<T>) => void
@@ -174,4 +177,57 @@ describe("HookProcess", () => {
 			}
 		})
 	})
+})
+
+describe("HookProcess spawn failures", () => {
+	let tempDir: string
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hookprocess-test-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	async function writeTestHook(): Promise<string> {
+		const hookBasePath = path.join(tempDir, "TaskStart")
+		await writeHookScriptForPlatform(hookBasePath, `#!/usr/bin/env node\nconsole.log(JSON.stringify({ cancel: false }))\n`)
+		return process.platform === "win32" ? `${hookBasePath}.ps1` : hookBasePath
+	}
+
+	it("runs the hook without an explicit cwd when the requested cwd does not exist", async () => {
+		const scriptPath = await writeTestHook()
+		const missingCwd = path.join(tempDir, "deleted-workspace-root")
+
+		const hookProcess = new HookProcess(scriptPath, 30000, undefined, missingCwd)
+		await hookProcess.run("{}")
+
+		should(hookProcess.getExitCode()).equal(0)
+		hookProcess.getStdout().should.containEql('"cancel":false')
+	}, 15000)
+
+	it.skipIf(process.platform === "win32")(
+		"rejects instead of crashing when spawn fails with no error listener registered",
+		async () => {
+			const scriptPath = await writeTestHook()
+
+			// A regular file passes the pre-spawn cwd existence check but makes
+			// spawn fail with an "error" event (ENOTDIR). No "error" listener is
+			// registered here, matching StdioHookRunner: an unguarded emit would
+			// escape the child's error callback as an uncaught exception and kill
+			// the whole process instead of failing this one hook.
+			const fileAsCwd = path.join(tempDir, "not-a-directory")
+			await fs.writeFile(fileAsCwd, "")
+
+			const hookProcess = new HookProcess(scriptPath, 5000, undefined, fileAsCwd)
+
+			try {
+				await hookProcess.run("{}")
+				throw new Error("Expected hook run to fail")
+			} catch (error: any) {
+				error.message.should.not.equal("Expected hook run to fail")
+			}
+		},
+	)
 })

--- a/apps/vscode/src/core/hooks/hook-factory.ts
+++ b/apps/vscode/src/core/hooks/hook-factory.ts
@@ -642,7 +642,11 @@ class StdioHookRunner<Name extends HookName> extends HookRunner<Name> {
 					"HookFactory.exec.catch.execution",
 				)
 			}
-			throw HookExecutionError.execution(this.scriptPath, exitCode ?? 1, stderr, this.hookName)
+			// A failure before the process produced any stderr (e.g. spawn never
+			// happened) would otherwise surface as a bare "exited with code 1";
+			// carry the underlying error message so the user sees the cause.
+			const details = stderr || (error instanceof Error ? error.message : String(error))
+			throw HookExecutionError.execution(this.scriptPath, exitCode ?? 1, details, this.hookName)
 		}
 	}
 }


### PR DESCRIPTION
Fixes [CLINE-3026](https://linear.app/cline-bot/issue/CLINE-3026/cline-cline-core-error-occurred-while-creating-a-task-with-hooks) / [cline/intellij-plugin#1120](https://github.com/cline/intellij-plugin/issues/1120).

## Problem

On a JetBrains nightly (which runs the vscode host code), creating any task with hooks enabled killed the cline-core process with exit code 1:

```
Error: spawn /bin/sh ENOENT
```

Two things combined here:

1. **Crash mechanism** — in `HookProcess`, the child process `error` handler called `this.emit("error", error)` before `reject(error)`. `HookProcess` extends `EventEmitter`, and no caller registers an `"error"` listener (`StdioHookRunner` only listens for `"line"`). Node turns an unlistened `"error"` emit into an uncaught exception, so any hook spawn failure killed the whole core process instead of failing that one hook open. The `reject` alone propagates gracefully — `StdioHookRunner` already catches and wraps hook errors.

2. **Environmental trigger** — the workspace root passed to spawn as `cwd` can name a directory that no longer exists on disk (deleted, renamed, or unmounted). Node reports a bad cwd as an ENOENT on the launcher binary — the misleading `spawn /bin/sh ENOENT`.

This crash does not depend on #13297: before that PR hooks also ran through the SDK's own (fail-open) runner, but the adapter's uncaught exception killed the process regardless — a `main` build from before #13297 reproduces the exit-1 crash exactly as one from after it does. #13297 is only relevant in that the adapter is now the sole hook execution path, so there is no longer any redundant path at all. Either way: hooks enabled + any spawn failure = dead core.

## Fix

- In `HookProcess`, guard the `"error"` emit behind `listenerCount("error") > 0` so rejection is the only propagation path when nobody listens; hook failures fail open per the hook error contract.
- In `HookProcess`, validate cwd existence immediately before spawning. A hook whose assigned working directory no longer exists **fails with an error naming that directory** — it is not run from some other location, because its relative paths would then resolve against the host process's own cwd (e.g. the IDE install dir). The runner reports the hook as failed and the task continues. (Hooks created with no cwd at all — the no-workspace case — keep their long-standing behavior.)
- When a spawn still fails ENOENT because the cwd vanished between validation and spawn, the error names the missing directory instead of blaming `/bin/sh`.
- In `StdioHookRunner`, pre-spawn failures (which produce no stderr) now carry the underlying error message into `HookExecutionError` details instead of surfacing as a bare "exited with code 1".

## Tests

- `HookProcess` fails the run with an error naming the missing cwd, catchably, when the requested cwd does not exist.
- `HookProcess` rejects catchably — no uncaught exception — when spawn fails with no `"error"` listener registered (a regular file as cwd, which passes the existence check but fails spawn with ENOTDIR).
- Factory-level: when the host reports a workspace root that no longer exists, the hook run fails open with a hook error naming the directory — no crash, no execution from an unrelated cwd.

Verified end-to-end against the standalone core (the JetBrains deployment) with the hostbridge reporting a nonexistent workspace root and a global TaskStart hook present: a `main` build dies with the exact `Uncaught exception: spawn /bin/sh ENOENT` / exit 1 from the bug report on every `newTask`; this branch's build stays alive, reports the hook as failed (`[HooksAdapter] beforeRun (TaskStart) hook failed`), does not execute the hook anywhere, and the task proceeds.
