### PR TITLE
ci(vscode): upload E2E failure recordings from the right path

### DIFF
--- a/.github/workflows/ext-vscode-test-e2e.yml
+++ b/.github/workflows/ext-vscode-test-e2e.yml
@@ -169,9 +169,12 @@ jobs:
               if: matrix.runner != 'ubuntu'
               run: bun run test:e2e:optimal
 
+            # Repo-root relative: the job's `working-directory` default applies to `run`
+            # steps only, so an apps/vscode-relative path here silently matches nothing
+            # and every failing run uploads no recordings at all.
             - uses: actions/upload-artifact@v4
               if: ${{ failure() }}
               with:
                   name: playwright-recordings-${{ matrix.runner }}
                   path: |
-                      test-results/playwright/
+                      apps/vscode/test-results/


### PR DESCRIPTION
## What

Fixes the E2E failure-artifact upload, which has been silently uploading nothing.

## Why

The `e2e` job sets `defaults.run.working-directory: apps/vscode`, but that default applies to `run` steps only — **not** to `uses:` steps. The `actions/upload-artifact` path therefore resolves against the repo root:

```
path: test-results/playwright/     # repo root — does not exist
```

while Playwright writes its recordings to `apps/vscode/test-results/playwright/` (the fixture's results dir is rooted at `CODEBASE_ROOT_DIR`, i.e. `apps/vscode`).

This regressed in #10961, which moved the extension under `apps/` and introduced the `working-directory` default; the artifact path stayed repo-root-relative. Every failing run since has logged:

```
##[warning]No files were found with the provided path: test-results/playwright/. No artifacts will be uploaded.
```

Beatrix raised this in Slack on Aug 13 ("it looks like we are no longer uploading video recording as artifacts when the E2E tests failed?") and it hadn't been picked up.

The path is also widened from `test-results/playwright/` to `test-results/` so Playwright's `error-context.md` ARIA snapshots ship alongside the videos — they sit in a sibling directory and are often the fastest way to read a failure.

## Verification

Confirmed end-to-end on a scratch branch that failed deliberately: the run uploaded `playwright-recordings-{ubuntu,macos,windows}`, each containing the `.webm` recordings and the `error-context.md` snapshots.

This mattered concretely this week: the VS Code 1.134 code-action breakage (fixed in #13402) was diagnosed only after pulling a recording, and the missing artifacts were why the red runs were opaque in the first place.

## Note

The artifact step only runs `if: failure()`, so a green run on this PR won't exercise it — the verification above is the evidence.
