### PR TITLE
Pull request: add 'Filter' tooltip to sessions filter icon

### DIFF
--- a/apps/cline-hub/src/webview/src/App.tsx
+++ b/apps/cline-hub/src/webview/src/App.tsx
@@ -52,6 +52,11 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type {
 	WebviewActiveConnector,
 	WebviewConnectedClient,
@@ -843,54 +848,62 @@ function SessionsView({
 								</DropdownMenuItem>
 							</DropdownMenuContent>
 						</DropdownMenu>
-						<DropdownMenu>
-							<DropdownMenuTrigger
-								render={
-									<Button
-										title="Filter sessions"
-										aria-label="Filter sessions"
-										size="icon-sm"
-										type="button"
-										variant={
-											sessionFilters.length > 0 ? "default" : "secondary"
-										}
-										className="size-8 rounded-md"
-									/>
-								}
-							>
-								<FunnelIcon className="size-4" />
-							</DropdownMenuTrigger>
-							<DropdownMenuContent align="end" className="max-h-72 w-72">
-								<DropdownMenuGroup>
-									<DropdownMenuLabel>Filter sessions</DropdownMenuLabel>
-									{sessionFilters.length > 0 ? (
-										<>
-											<DropdownMenuItem onClick={() => setSessionFilters([])}>
-												Clear filters
+						<Tooltip>
+							<DropdownMenu>
+								<TooltipTrigger
+									render={
+										<DropdownMenuTrigger
+											render={
+												<Button
+													aria-label="Filter sessions"
+													size="icon-sm"
+													type="button"
+													variant={
+														sessionFilters.length > 0 ? "default" : "secondary"
+													}
+													className="size-8 rounded-md"
+												/>
+											}
+										>
+											<FunnelIcon className="size-4" />
+										</DropdownMenuTrigger>
+									}
+								/>
+								<DropdownMenuContent align="end" className="max-h-72 w-72">
+									<DropdownMenuGroup>
+										<DropdownMenuLabel>Filter sessions</DropdownMenuLabel>
+										{sessionFilters.length > 0 ? (
+											<>
+												<DropdownMenuItem onClick={() => setSessionFilters([])}>
+													Clear filters
+												</DropdownMenuItem>
+												<DropdownMenuSeparator />
+											</>
+										) : null}
+										{runDetailFilterOptions.length === 0 ? (
+											<DropdownMenuItem disabled>
+												No run details
 											</DropdownMenuItem>
-											<DropdownMenuSeparator />
-										</>
-									) : null}
-									{runDetailFilterOptions.length === 0 ? (
-										<DropdownMenuItem disabled>No run details</DropdownMenuItem>
-									) : (
-										runDetailFilterOptions.map((detail) => (
-											<DropdownMenuCheckboxItem
-												checked={sessionFilters.includes(detail)}
-												key={detail}
-												onCheckedChange={(checked: boolean) =>
-													toggleSessionFilter(detail, checked)
-												}
-											>
-												<span className="truncate" title={detail}>
-													{detail}
-												</span>
-											</DropdownMenuCheckboxItem>
-										))
-									)}
-								</DropdownMenuGroup>
-							</DropdownMenuContent>
-						</DropdownMenu>
+										) : (
+											runDetailFilterOptions.map((detail) => (
+												<DropdownMenuCheckboxItem
+													checked={sessionFilters.includes(detail)}
+													key={detail}
+													onCheckedChange={(checked: boolean) =>
+														toggleSessionFilter(detail, checked)
+													}
+												>
+													<span className="truncate" title={detail}>
+														{detail}
+													</span>
+												</DropdownMenuCheckboxItem>
+											))
+										)}
+									</DropdownMenuGroup>
+								</DropdownMenuContent>
+							</DropdownMenu>
+							<TooltipContent>Filter</TooltipContent>
+						</Tooltip>
 					</>
 				}
 			/>


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The sessions filter icon button in the Cline Hub had no visible label, so its
purpose wasn't discoverable at a glance — you had to click it to find out what
it did.

This wraps the filter dropdown trigger in the app's existing `Tooltip` primitive
so hovering the funnel icon shows a "Filter" label, matching the tooltip pattern
already used elsewhere in the webview.

Also removes the button's redundant native `title="Filter sessions"` attribute.
Left in place, the browser would render its own tooltip on top of the styled
one, producing two overlapping labels on hover. `aria-label` is retained so
screen reader behaviour is unchanged.

### Test Procedure

Verified with the repo's own tooling in `apps/cline-hub`:

- `biome check` — passes (lint + formatting)
- `typecheck` — passes
- `bun test` — 8 files, 106 tests passing
- `build:webview` — production build succeeds

Notes on scope and risk:
- The change is presentational and adds no state or handlers, so the existing
  dropdown behaviour (filtering, "Clear filters", checkbox items) is untouched.
- The main thing that could regress is accessibility, since I removed `title`.
  `aria-label="Filter sessions"` remains on the button, so the accessible name
  is unchanged.
- Tooltip rendering relies on `TooltipProvider`, which already wraps the app in
  `main.tsx`, so no provider changes were needed.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- Drag your before/after screenshots here -->

### Additional Notes

Scoped to the filter icon only. The adjacent sort icon has the same missing-label
issue — happy to include it here or in a follow-up if maintainers prefer.
