### PR TITLE
feat(desktop-app): add find in session

### DIFF
--- a/apps/examples/desktop-app/webview/app/globals.css
+++ b/apps/examples/desktop-app/webview/app/globals.css
@@ -164,3 +164,23 @@
 	--primary-emphasis: oklch(0.77 0.15 36);
 	--ring: oklch(0.7 0.14 36);
 }
+
+/*
+ * Find-in-session match painting (hooks/use-session-search-highlight.ts).
+ *
+ * Uses the CSS Custom Highlight API so matches are painted over the existing
+ * DOM instead of being wrapped in <mark> elements. That keeps MemoizedMarkdown's
+ * memoization intact and cannot disturb rendered markdown formatting.
+ *
+ * Only color and background-color are honored inside ::highlight(), so the
+ * active match is distinguished by a stronger fill rather than a border.
+ */
+::highlight(cline-find-match) {
+	background-color: color-mix(in oklch, var(--primary) 28%, transparent);
+	color: var(--foreground);
+}
+
+::highlight(cline-find-match-active) {
+	background-color: var(--primary);
+	color: var(--primary-foreground);
+}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.tsx
@@ -20,13 +20,27 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+	supportsHighlightApi,
+	useSessionSearchHighlight,
+} from "@/hooks/use-session-search-highlight";
 import { toast } from "@/hooks/use-toast";
 import type {
 	ChatMessage,
 	ChatMessageImage,
 	ChatSessionStatus,
 } from "@/lib/chat-schema";
+import {
+	clampMatchIndex,
+	findSessionMatches,
+	isSearchableMessage,
+	type SessionSearchStepDirection,
+	searchAnchorId,
+	stepMatchIndex,
+} from "@/lib/session-search";
 import { cn } from "@/lib/utils";
+import { FindInSession } from "./find-in-session";
+import { formatChatMessageContent } from "./message-content";
 import { STREAMING_TITLE_CLASS } from "./messages/constants";
 import {
 	buildPreviousTimestampMap,
@@ -185,6 +199,9 @@ function ChatMessagesImpl({
 		sessionId: string | null;
 		image: ChatMessageImage;
 	} | null>(null);
+	const [isFindOpen, setIsFindOpen] = useState(false);
+	const [searchQuery, setSearchQuery] = useState("");
+	const [activeMatchIndex, setActiveMatchIndex] = useState(0);
 	const sessionVersioningPending =
 		editingMessageId !== null ||
 		forkingMessageId !== null ||
@@ -216,6 +233,49 @@ function ChatMessagesImpl({
 			lastRenderItem.type === "run" ||
 			(lastRenderItem.type === "message" &&
 				lastRenderItem.message.role === "assistant"));
+	// Matches are derived from the displayed text, not the raw content, so the
+	// search cannot hit text the user is not shown.
+	const searchMatches = useMemo(() => {
+		if (!isFindOpen) {
+			return [];
+		}
+		return findSessionMatches(
+			messages.filter(isSearchableMessage).map((message) => ({
+				messageId: message.id,
+				text: formatChatMessageContent(message.role, message.content),
+			})),
+			searchQuery,
+		);
+	}, [isFindOpen, messages, searchQuery]);
+	const matchedMessageIds = useMemo(
+		() => new Set(searchMatches.map((match) => match.messageId)),
+		[searchMatches],
+	);
+	// Streaming can shrink the match list under a stale index, so clamp on read
+	// rather than trusting the stored value.
+	const safeMatchIndex = clampMatchIndex(
+		activeMatchIndex,
+		searchMatches.length,
+	);
+	const activeMatchId = searchMatches[safeMatchIndex]?.messageId ?? null;
+	const matchedIdList = useMemo(
+		() => searchMatches.map((match) => match.messageId),
+		[searchMatches],
+	);
+	// Ranges hold live text-node references, so a transcript edit under an
+	// unchanged query has to force a rebuild.
+	useSessionSearchHighlight({
+		activeMessageId: activeMatchId,
+		messageIds: matchedIdList,
+		query: searchQuery,
+		revision: messages.length,
+	});
+	// Character-level painting is the intended presentation; the container tint
+	// is only a fallback where the Highlight API is unavailable.
+	const [useContainerTint, setUseContainerTint] = useState(false);
+	useEffect(() => {
+		setUseContainerTint(!supportsHighlightApi());
+	}, []);
 	// Built once per pendingAskQuestions change instead of per render: the
 	// list re-renders on every stream flush and these rows carry JSX.
 	const askQuestionItems = useMemo(
@@ -345,6 +405,63 @@ function ChatMessagesImpl({
 		},
 		[onAnswerAskQuestion],
 	);
+
+	// Cmd/Ctrl+F opens the bar only while a session is open, matching the
+	// Cmd+N / Cmd+, shortcuts registered in app/page.tsx.
+	useEffect(() => {
+		if (!sessionId) {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+				return;
+			}
+			if (event.key === "f" || event.key === "F") {
+				event.preventDefault();
+				setIsFindOpen(true);
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [sessionId]);
+	// Closing the bar drops the query so reopening starts clean, and switching
+	// sessions must not carry a previous session's matches across.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: resets on session change.
+	useEffect(() => {
+		setIsFindOpen(false);
+		setSearchQuery("");
+		setActiveMatchIndex(0);
+	}, [sessionId]);
+	const previousActiveMatchId = useRef<string | null>(null);
+	useEffect(() => {
+		if (!activeMatchId || activeMatchId === previousActiveMatchId.current) {
+			previousActiveMatchId.current = activeMatchId;
+			return;
+		}
+		previousActiveMatchId.current = activeMatchId;
+		document
+			.getElementById(searchAnchorId(activeMatchId))
+			?.scrollIntoView({ block: "center", behavior: "smooth" });
+	}, [activeMatchId]);
+	const handleSearchQueryChange = useCallback((query: string) => {
+		setSearchQuery(query);
+		// Every edit restarts from the first match, so results always read
+		// top-down rather than from wherever the previous query left off.
+		setActiveMatchIndex(0);
+	}, []);
+	const handleStepMatch = useCallback(
+		(direction: SessionSearchStepDirection) => {
+			setActiveMatchIndex((current) =>
+				stepMatchIndex(current, searchMatches.length, direction),
+			);
+		},
+		[searchMatches.length],
+	);
+	const handleCloseFind = useCallback(() => {
+		setIsFindOpen(false);
+		setSearchQuery("");
+		setActiveMatchIndex(0);
+	}, []);
 
 	const handleCopyMessage = useCallback(
 		async (messageId: string, text: string) => {
@@ -511,6 +628,16 @@ function ChatMessagesImpl({
 			className="relative isolate h-full min-h-0 min-w-0 overflow-hidden"
 			key={sessionId ?? "new-chat"}
 		>
+			{isFindOpen ? (
+				<FindInSession
+					activeMatchIndex={safeMatchIndex}
+					onClose={handleCloseFind}
+					onQueryChange={handleSearchQueryChange}
+					onStepMatch={handleStepMatch}
+					query={searchQuery}
+					totalMatches={searchMatches.length}
+				/>
+			) : null}
 			<ConversationViewport
 				aria-label="Agent conversation"
 				className="h-full min-h-0 min-w-0"
@@ -610,6 +737,12 @@ function ChatMessagesImpl({
 												lastConversationMessage === message
 											}
 											isStreaming={streamingMessageId === message.id}
+											isSearchMatch={
+												useContainerTint && matchedMessageIds.has(message.id)
+											}
+											isActiveSearchMatch={
+												useContainerTint && activeMatchId === message.id
+											}
 											key={message.id}
 											message={message}
 											runCount={userRunCountByMessage.get(message)}

--- a/apps/examples/desktop-app/webview/components/views/chat/find-in-session.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/find-in-session.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { useEffect, useId, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Kbd } from "@/components/ui/kbd";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatMatchCount } from "@/lib/session-search";
+
+type FindInSessionProps = {
+	query: string;
+	onQueryChange: (query: string) => void;
+	activeMatchIndex: number;
+	totalMatches: number;
+	onStepMatch: (direction: "next" | "previous") => void;
+	onClose: () => void;
+};
+
+/**
+ * Search bar for the open session. Purely presentational: matching, stepping
+ * and wraparound all live in lib/session-search, so this component only owns
+ * focus, keyboard handling and layout.
+ */
+export function FindInSession({
+	query,
+	onQueryChange,
+	activeMatchIndex,
+	totalMatches,
+	onStepMatch,
+	onClose,
+}: FindInSessionProps) {
+	const inputId = useId();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	// Focus on mount so Cmd+F lands the caret in the field, and select any
+	// preserved query so typing replaces it the way native find bars behave.
+	useEffect(() => {
+		inputRef.current?.focus();
+		inputRef.current?.select();
+	}, []);
+
+	const hasMatches = totalMatches > 0;
+	const countLabel = formatMatchCount(activeMatchIndex, totalMatches, query);
+
+	return (
+		/* <search> carries the implicit search landmark role natively. */
+		<search
+			aria-label="Find in session"
+			className="absolute right-6 top-4 z-30 flex items-center gap-2 rounded-lg border border-border/70 bg-background/95 p-1.5 shadow-md backdrop-blur-[2px]"
+		>
+			<label className="sr-only" htmlFor={inputId}>
+				Find in session
+			</label>
+			<Input
+				aria-describedby={`${inputId}-count`}
+				className="h-7 w-56 text-sm"
+				id={inputId}
+				onChange={(event) => onQueryChange(event.target.value)}
+				onKeyDown={(event) => {
+					if (event.key === "Escape") {
+						event.preventDefault();
+						onClose();
+						return;
+					}
+					if (event.key === "Enter") {
+						event.preventDefault();
+						onStepMatch(event.shiftKey ? "previous" : "next");
+					}
+				}}
+				placeholder="Find in session"
+				ref={inputRef}
+				type="search"
+				value={query}
+			/>
+			{/* Polite so stepping through matches is announced without
+			    interrupting whatever the screen reader is already saying. */}
+			<output
+				aria-live="polite"
+				className="min-w-16 shrink-0 text-center text-xs tabular-nums text-muted-foreground"
+				id={`${inputId}-count`}
+			>
+				{countLabel}
+			</output>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						aria-label="Previous match"
+						disabled={!hasMatches}
+						onClick={() => onStepMatch("previous")}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						<ChevronUp />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>
+					Previous match <Kbd>⇧⏎</Kbd>
+				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						aria-label="Next match"
+						disabled={!hasMatches}
+						onClick={() => onStepMatch("next")}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						<ChevronDown />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>
+					Next match <Kbd>⏎</Kbd>
+				</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						aria-label="Close find bar"
+						onClick={onClose}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						<X />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>
+					Close <Kbd>Esc</Kbd>
+				</TooltipContent>
+			</Tooltip>
+		</search>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
@@ -24,6 +24,7 @@ import type {
 	ChatMessageImage,
 	ChatMessageMedia,
 } from "@/lib/chat-schema";
+import { searchAnchorId } from "@/lib/session-search";
 import { cn } from "@/lib/utils";
 import { MemoizedMarkdown } from "../../../ui/markdown";
 import { formatChatMessageContent } from "../message-content";
@@ -176,6 +177,8 @@ export const MessageBubble = memo(function MessageBubble({
 	forkError,
 	isLastAssistantMessage = false,
 	followsWorkingRows = false,
+	isSearchMatch = false,
+	isActiveSearchMatch = false,
 	reasoningContent,
 	reasoningRedacted,
 	thoughtDurationMilliseconds,
@@ -210,6 +213,10 @@ export const MessageBubble = memo(function MessageBubble({
 	/** Pulls the bubble closer to the working rows (tool calls/run summary)
 	 * directly above it, which it answers. */
 	followsWorkingRows?: boolean;
+	/** Message contains the find-in-session query. */
+	isSearchMatch?: boolean;
+	/** Message is the match the find bar is currently focused on. */
+	isActiveSearchMatch?: boolean;
 	reasoningContent: string;
 	reasoningRedacted: boolean;
 	thoughtDurationMilliseconds?: number;
@@ -270,8 +277,17 @@ export const MessageBubble = memo(function MessageBubble({
 				"relative flex flex-col gap-2",
 				isUser && "mt-4 first:mt-0",
 				followsWorkingRows && "-mt-2",
+				// Fallback presentation only: where the CSS Custom Highlight API is
+				// unavailable the whole container is tinted instead of the matched
+				// characters. Highlighting words inside the rendered markdown would
+				// mean mutating MemoizedMarkdown's output and defeating its memo.
+				isSearchMatch &&
+					"rounded-md ring-1 ring-primary/30 bg-primary/5 -mx-2 px-2 py-1",
+				isActiveSearchMatch && "ring-2 ring-primary/70 bg-primary/10",
 			)}
+			data-search-match={isSearchMatch || undefined}
 			from={agentRole}
+			id={searchAnchorId(message.id)}
 		>
 			<MessageContent className="flex min-w-0 flex-col gap-2 wrap-break-word">
 				{reasoningContent || reasoningRedacted ? (

--- a/apps/examples/desktop-app/webview/hooks/use-session-search-highlight.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-search-highlight.ts
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+	findMatchOffsets,
+	isActiveSearchQuery,
+	locateOffsetInSegments,
+	searchAnchorId,
+} from "@/lib/session-search";
+
+/**
+ * Paints find-in-session matches using the CSS Custom Highlight API.
+ *
+ * Why this and not <mark> elements: message text renders through
+ * MemoizedMarkdown, which is memoized so a stream flush does not re-run the
+ * markdown pipeline for every bubble. Wrapping matches in elements would mean
+ * mutating that rendered output — invalidating the memo and risking broken
+ * formatting where a match spans inline markup. Highlight ranges paint over
+ * the existing DOM without modifying it at all, so React never re-renders and
+ * the markdown pipeline never re-runs.
+ *
+ * Ranges are built from *rendered* text, so markdown syntax characters are
+ * absent by construction and a match can never straddle them.
+ */
+
+const ALL_MATCHES_HIGHLIGHT = "cline-find-match";
+const ACTIVE_MATCH_HIGHLIGHT = "cline-find-match-active";
+
+type HighlightRegistry = {
+	set: (name: string, highlight: unknown) => void;
+	delete: (name: string) => void;
+};
+
+type HighlightConstructor = new (...ranges: Range[]) => unknown;
+
+function getHighlightApi(): {
+	registry: HighlightRegistry;
+	Highlight: HighlightConstructor;
+} | null {
+	// Read both off globalThis: a bare `CSS` reference throws a ReferenceError
+	// rather than yielding undefined in environments that lack it (jsdom).
+	const scope = globalThis as unknown as {
+		CSS?: { highlights?: HighlightRegistry };
+		Highlight?: HighlightConstructor;
+	};
+	const registry = scope.CSS?.highlights;
+	const Highlight = scope.Highlight;
+	if (!registry || typeof Highlight !== "function") {
+		return null;
+	}
+	return { registry, Highlight };
+}
+
+/** True when the browser can paint highlight ranges. */
+export function supportsHighlightApi(): boolean {
+	return getHighlightApi() !== null;
+}
+
+function collectTextNodes(root: HTMLElement): Text[] {
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+		acceptNode(node) {
+			// Skip the action row (timestamps, copy/edit buttons): it is chrome,
+			// not message prose, and highlighting it would be noise.
+			const parent = node.parentElement;
+			if (!parent || parent.closest("[data-slot='kbd']")) {
+				return NodeFilter.FILTER_REJECT;
+			}
+			if (parent.closest(".cline-chat-message-actions")) {
+				return NodeFilter.FILTER_REJECT;
+			}
+			return node.nodeValue
+				? NodeFilter.FILTER_ACCEPT
+				: NodeFilter.FILTER_REJECT;
+		},
+	});
+	const nodes: Text[] = [];
+	let current = walker.nextNode();
+	while (current) {
+		nodes.push(current as Text);
+		current = walker.nextNode();
+	}
+	return nodes;
+}
+
+/**
+ * Builds one Range per occurrence inside a message container. Matching runs
+ * over the concatenation of the container's text nodes so an occurrence split
+ * across nodes (by bold, code spans, links) is still found.
+ */
+function buildRangesForMessage(root: HTMLElement, query: string): Range[] {
+	const textNodes = collectTextNodes(root);
+	if (textNodes.length === 0) {
+		return [];
+	}
+	const segments = textNodes.map((node) => node.nodeValue ?? "");
+	const lengths = segments.map((segment) => segment.length);
+	const combined = segments.join("");
+	const ranges: Range[] = [];
+	for (const offset of findMatchOffsets(combined, query)) {
+		const start = locateOffsetInSegments(lengths, offset.start);
+		const end = locateOffsetInSegments(lengths, offset.end, {
+			preferSegmentEnd: true,
+		});
+		if (!start || !end) {
+			continue;
+		}
+		const range = document.createRange();
+		range.setStart(textNodes[start.segmentIndex], start.offsetInSegment);
+		range.setEnd(textNodes[end.segmentIndex], end.offsetInSegment);
+		ranges.push(range);
+	}
+	return ranges;
+}
+
+/**
+ * Registers highlight ranges for the given matches.
+ *
+ * `messageIds` and `activeMessageId` identify which containers to paint;
+ * `revision` lets callers force a repaint when the transcript changes under a
+ * stable query, since Ranges hold live node references that stale out.
+ */
+export function useSessionSearchHighlight({
+	query,
+	messageIds,
+	activeMessageId,
+	revision = 0,
+}: {
+	query: string;
+	messageIds: string[];
+	activeMessageId: string | null;
+	revision?: number;
+}): void {
+	// messageIds is joined into a primitive so a fresh array of identical ids
+	// does not retrigger the effect on every render.
+	const messageKey = messageIds.join(",");
+	useEffect(() => {
+		// Read so the dependency is genuine rather than suppressed: ranges
+		// capture live text nodes, so a transcript change under an unchanged
+		// query must rebuild them.
+		void revision;
+		const api = getHighlightApi();
+		if (!api) {
+			return;
+		}
+		const { registry, Highlight } = api;
+		const clear = () => {
+			registry.delete(ALL_MATCHES_HIGHLIGHT);
+			registry.delete(ACTIVE_MATCH_HIGHLIGHT);
+		};
+		if (!isActiveSearchQuery(query) || messageKey.length === 0) {
+			clear();
+			return clear;
+		}
+		const allRanges: Range[] = [];
+		const activeRanges: Range[] = [];
+		for (const messageId of messageKey.split(",")) {
+			const element = document.getElementById(searchAnchorId(messageId));
+			if (!element) {
+				continue;
+			}
+			const ranges = buildRangesForMessage(element, query);
+			allRanges.push(...ranges);
+			if (messageId === activeMessageId) {
+				activeRanges.push(...ranges);
+			}
+		}
+		if (allRanges.length === 0) {
+			clear();
+			return clear;
+		}
+		registry.set(ALL_MATCHES_HIGHLIGHT, new Highlight(...allRanges));
+		if (activeRanges.length > 0) {
+			registry.set(ACTIVE_MATCH_HIGHLIGHT, new Highlight(...activeRanges));
+		} else {
+			registry.delete(ACTIVE_MATCH_HIGHLIGHT);
+		}
+		return clear;
+	}, [query, messageKey, activeMessageId, revision]);
+}

--- a/apps/examples/desktop-app/webview/lib/session-search.test.ts
+++ b/apps/examples/desktop-app/webview/lib/session-search.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@/lib/chat-schema";
+import {
+	clampMatchIndex,
+	findMatchOffsets,
+	findSessionMatches,
+	formatMatchCount,
+	isActiveSearchQuery,
+	isSearchableMessage,
+	locateOffsetInSegments,
+	matchesSearchQuery,
+	stepMatchIndex,
+} from "@/lib/session-search";
+
+function message(role: ChatMessage["role"]): ChatMessage {
+	return {
+		id: `${role}_1`,
+		sessionId: "session_1",
+		role,
+		content: "content",
+		createdAt: 0,
+	};
+}
+
+describe("isSearchableMessage", () => {
+	it("searches the roles that render as prose", () => {
+		for (const role of ["user", "assistant", "error"] as const) {
+			expect(isSearchableMessage(message(role))).toBe(true);
+		}
+	});
+
+	it("skips tool and status roles that have no prose bubble", () => {
+		for (const role of ["tool", "status", "system"] as const) {
+			expect(isSearchableMessage(message(role))).toBe(false);
+		}
+	});
+});
+
+describe("isActiveSearchQuery", () => {
+	it("treats blank and whitespace-only queries as inactive", () => {
+		expect(isActiveSearchQuery("")).toBe(false);
+		expect(isActiveSearchQuery("   ")).toBe(false);
+		expect(isActiveSearchQuery("\t\n")).toBe(false);
+	});
+
+	it("treats any non-blank query as active", () => {
+		expect(isActiveSearchQuery("a")).toBe(true);
+		expect(isActiveSearchQuery("  padded  ")).toBe(true);
+	});
+});
+
+describe("matchesSearchQuery", () => {
+	it("matches substrings regardless of case", () => {
+		expect(matchesSearchQuery("Refactor the Parser", "parser")).toBe(true);
+		expect(matchesSearchQuery("refactor the parser", "PARSER")).toBe(true);
+		expect(matchesSearchQuery("refactor the parser", "fact")).toBe(true);
+	});
+
+	it("does not match a missing substring", () => {
+		expect(matchesSearchQuery("refactor the parser", "lexer")).toBe(false);
+	});
+
+	it("treats the query literally rather than as a regular expression", () => {
+		expect(matchesSearchQuery("cost is 12 dollars", "1.")).toBe(false);
+		expect(matchesSearchQuery("literal a.b match", "a.b")).toBe(true);
+	});
+
+	it("never matches on an inactive query", () => {
+		expect(matchesSearchQuery("anything", "")).toBe(false);
+		expect(matchesSearchQuery("anything", "   ")).toBe(false);
+	});
+});
+
+describe("findSessionMatches", () => {
+	const entries = [
+		{ messageId: "m1", text: "Fix the parser bug" },
+		{ messageId: "m2", text: "Unrelated note" },
+		{ messageId: "m3", text: "PARSER rewrite, parser cleanup, parser tests" },
+	];
+
+	it("returns matches in transcript order with sequential ordinals", () => {
+		expect(findSessionMatches(entries, "parser")).toEqual([
+			{ messageId: "m1", ordinal: 0 },
+			{ messageId: "m3", ordinal: 1 },
+		]);
+	});
+
+	it("counts a message once even when it contains the query repeatedly", () => {
+		expect(findSessionMatches([entries[2]], "parser")).toHaveLength(1);
+	});
+
+	it("returns nothing for an inactive query", () => {
+		expect(findSessionMatches(entries, "  ")).toEqual([]);
+	});
+
+	it("returns nothing when no entry matches", () => {
+		expect(findSessionMatches(entries, "lexer")).toEqual([]);
+	});
+});
+
+describe("findMatchOffsets", () => {
+	it("returns every occurrence as half-open offsets", () => {
+		expect(findMatchOffsets("parser and parser", "parser")).toEqual([
+			{ start: 0, end: 6 },
+			{ start: 11, end: 17 },
+		]);
+	});
+
+	it("finds occurrences regardless of case", () => {
+		expect(findMatchOffsets("PARSER parser", "Parser")).toEqual([
+			{ start: 0, end: 6 },
+			{ start: 7, end: 13 },
+		]);
+	});
+
+	it("does not return overlapping occurrences", () => {
+		expect(findMatchOffsets("aaaa", "aa")).toEqual([
+			{ start: 0, end: 2 },
+			{ start: 2, end: 4 },
+		]);
+	});
+
+	it("slices the exact matched text", () => {
+		const text = "the parser here";
+		const [offset] = findMatchOffsets(text, "PARSER");
+		expect(text.slice(offset.start, offset.end)).toBe("parser");
+	});
+
+	it("returns nothing for inactive queries or empty text", () => {
+		expect(findMatchOffsets("parser", "")).toEqual([]);
+		expect(findMatchOffsets("parser", "   ")).toEqual([]);
+		expect(findMatchOffsets("", "parser")).toEqual([]);
+	});
+
+	it("returns nothing when the query is longer than the text", () => {
+		expect(findMatchOffsets("ab", "abcdef")).toEqual([]);
+	});
+});
+
+describe("locateOffsetInSegments", () => {
+	// Segments of 5, 0 and 4 characters: "hello" + "" + "here".
+	const lengths = [5, 0, 4];
+
+	it("locates an offset inside the first segment", () => {
+		expect(locateOffsetInSegments(lengths, 0)).toEqual({
+			segmentIndex: 0,
+			offsetInSegment: 0,
+		});
+		expect(locateOffsetInSegments(lengths, 4)).toEqual({
+			segmentIndex: 0,
+			offsetInSegment: 4,
+		});
+	});
+
+	it("locates an offset in a later segment, skipping empty ones", () => {
+		expect(locateOffsetInSegments(lengths, 5)).toEqual({
+			segmentIndex: 2,
+			offsetInSegment: 0,
+		});
+		expect(locateOffsetInSegments(lengths, 7)).toEqual({
+			segmentIndex: 2,
+			offsetInSegment: 2,
+		});
+	});
+
+	it("anchors a boundary offset to the earlier segment when preferring ends", () => {
+		expect(
+			locateOffsetInSegments(lengths, 5, { preferSegmentEnd: true }),
+		).toEqual({ segmentIndex: 0, offsetInSegment: 5 });
+	});
+
+	it("resolves an offset at the very end of the text", () => {
+		expect(locateOffsetInSegments(lengths, 9)).toEqual({
+			segmentIndex: 2,
+			offsetInSegment: 4,
+		});
+		expect(
+			locateOffsetInSegments(lengths, 9, { preferSegmentEnd: true }),
+		).toEqual({ segmentIndex: 2, offsetInSegment: 4 });
+	});
+
+	it("returns null for offsets outside the text", () => {
+		expect(locateOffsetInSegments(lengths, 10)).toBeNull();
+		expect(locateOffsetInSegments(lengths, -1)).toBeNull();
+		expect(locateOffsetInSegments([], 0)).toBeNull();
+	});
+});
+
+describe("stepMatchIndex", () => {
+	it("advances forward and wraps past the last match", () => {
+		expect(stepMatchIndex(0, 3, "next")).toBe(1);
+		expect(stepMatchIndex(1, 3, "next")).toBe(2);
+		expect(stepMatchIndex(2, 3, "next")).toBe(0);
+	});
+
+	it("advances backward and wraps past the first match", () => {
+		expect(stepMatchIndex(2, 3, "previous")).toBe(1);
+		expect(stepMatchIndex(1, 3, "previous")).toBe(0);
+		expect(stepMatchIndex(0, 3, "previous")).toBe(2);
+	});
+
+	it("stays put when there is a single match", () => {
+		expect(stepMatchIndex(0, 1, "next")).toBe(0);
+		expect(stepMatchIndex(0, 1, "previous")).toBe(0);
+	});
+
+	it("returns zero when there are no matches", () => {
+		expect(stepMatchIndex(0, 0, "next")).toBe(0);
+		expect(stepMatchIndex(4, 0, "previous")).toBe(0);
+	});
+
+	it("recovers from an index left over from a longer match list", () => {
+		expect(stepMatchIndex(9, 3, "next")).toBe(0);
+		expect(stepMatchIndex(9, 3, "previous")).toBe(1);
+	});
+});
+
+describe("clampMatchIndex", () => {
+	it("keeps valid indexes untouched", () => {
+		expect(clampMatchIndex(0, 3)).toBe(0);
+		expect(clampMatchIndex(2, 3)).toBe(2);
+	});
+
+	it("clamps indexes that fall outside the match list", () => {
+		expect(clampMatchIndex(7, 3)).toBe(2);
+		expect(clampMatchIndex(-1, 3)).toBe(0);
+		expect(clampMatchIndex(1, 0)).toBe(0);
+	});
+});
+
+describe("formatMatchCount", () => {
+	it("renders a one-based position out of the total", () => {
+		expect(formatMatchCount(0, 12, "parser")).toBe("1 of 12");
+		expect(formatMatchCount(2, 12, "parser")).toBe("3 of 12");
+	});
+
+	it("reports an empty result set", () => {
+		expect(formatMatchCount(0, 0, "parser")).toBe("No results");
+	});
+
+	it("announces nothing until a query is entered", () => {
+		expect(formatMatchCount(0, 0, "")).toBe("");
+		expect(formatMatchCount(0, 0, "   ")).toBe("");
+	});
+
+	it("clamps a stale index rather than reporting past the total", () => {
+		expect(formatMatchCount(9, 2, "parser")).toBe("2 of 2");
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/session-search.ts
+++ b/apps/examples/desktop-app/webview/lib/session-search.ts
@@ -1,0 +1,207 @@
+import type { ChatMessage } from "@/lib/chat-schema";
+
+/**
+ * Find-in-session logic, kept free of React and DOM so the rules that decide
+ * what counts as a match live in one testable place.
+ *
+ * Two deliberate limits, both of which follow from highlighting whole message
+ * containers rather than individual words:
+ *
+ * - Only roles that render as prose bubbles are searched. Tool messages render
+ *   through a collapsed tool block whose payload is not prose, and status
+ *   messages are chrome, so neither can be meaningfully highlighted.
+ * - A message counts as one match no matter how many times the query occurs
+ *   inside it. Counting occurrences would make stepping appear to do nothing
+ *   when consecutive occurrences share a message, because there is no in-text
+ *   marker to move between.
+ */
+
+export type SessionSearchEntry = {
+	messageId: string;
+	/**
+	 * The text as displayed, not the raw message content. Callers pass the
+	 * formatted string so the search cannot match text the user cannot see
+	 * (user input is stripped of command envelopes and mode notices before it
+	 * is rendered).
+	 */
+	text: string;
+};
+
+export type SessionSearchMatch = {
+	messageId: string;
+	/** Zero-based position of this match within the ordered match list. */
+	ordinal: number;
+};
+
+export type SessionSearchStepDirection = "next" | "previous";
+
+/**
+ * DOM id for a message container, so the find bar can scroll a match into view
+ * without threading refs through every bubble. Built here rather than inline so
+ * the writer and the reader cannot drift apart.
+ */
+export function searchAnchorId(messageId: string): string {
+	return `session-message-${messageId}`;
+}
+
+const SEARCHABLE_ROLES: ReadonlySet<ChatMessage["role"]> = new Set([
+	"user",
+	"assistant",
+	"error",
+]);
+
+export function isSearchableMessage(message: ChatMessage): boolean {
+	return SEARCHABLE_ROLES.has(message.role);
+}
+
+/**
+ * A query of only whitespace is treated as no query at all: it would match
+ * nearly every message and tell the user nothing.
+ */
+export function isActiveSearchQuery(query: string): boolean {
+	return query.trim().length > 0;
+}
+
+export function matchesSearchQuery(text: string, query: string): boolean {
+	if (!isActiveSearchQuery(query)) {
+		return false;
+	}
+	return text.toLowerCase().includes(query.toLowerCase());
+}
+
+export function findSessionMatches(
+	entries: SessionSearchEntry[],
+	query: string,
+): SessionSearchMatch[] {
+	if (!isActiveSearchQuery(query)) {
+		return [];
+	}
+	const matches: SessionSearchMatch[] = [];
+	for (const entry of entries) {
+		if (matchesSearchQuery(entry.text, query)) {
+			matches.push({ messageId: entry.messageId, ordinal: matches.length });
+		}
+	}
+	return matches;
+}
+
+export type SessionSearchOffset = { start: number; end: number };
+
+/**
+ * Every occurrence of the query in a single block of text, as half-open
+ * [start, end) offsets. Occurrences cannot overlap: the scan resumes after the
+ * end of the previous hit, so searching "aa" in "aaaa" yields two matches
+ * rather than three.
+ */
+export function findMatchOffsets(
+	text: string,
+	query: string,
+): SessionSearchOffset[] {
+	if (!isActiveSearchQuery(query) || !text) {
+		return [];
+	}
+	const haystack = text.toLowerCase();
+	const needle = query.toLowerCase();
+	const offsets: SessionSearchOffset[] = [];
+	let cursor = 0;
+	while (cursor <= haystack.length - needle.length) {
+		const found = haystack.indexOf(needle, cursor);
+		if (found === -1) {
+			break;
+		}
+		offsets.push({ start: found, end: found + needle.length });
+		cursor = found + needle.length;
+	}
+	return offsets;
+}
+
+export type SegmentLocation = {
+	segmentIndex: number;
+	offsetInSegment: number;
+};
+
+/**
+ * Maps an offset in concatenated text back to the segment that contains it.
+ *
+ * Rendered message text is spread across many DOM text nodes, so a match found
+ * in the joined string has to be translated back into a (node, offset) pair
+ * before it can become a Range. Kept pure — segment lengths in, coordinates
+ * out — so the arithmetic is testable without a DOM.
+ *
+ * Boundary offsets resolve to the end of the earlier segment rather than the
+ * start of the next, which keeps a Range's end anchored to the node holding
+ * the final matched character.
+ */
+export function locateOffsetInSegments(
+	segmentLengths: number[],
+	offset: number,
+	{ preferSegmentEnd = false }: { preferSegmentEnd?: boolean } = {},
+): SegmentLocation | null {
+	if (offset < 0) {
+		return null;
+	}
+	let consumed = 0;
+	for (let index = 0; index < segmentLengths.length; index += 1) {
+		const length = segmentLengths[index];
+		const end = consumed + length;
+		const isInside = preferSegmentEnd
+			? offset > consumed && offset <= end
+			: offset >= consumed && offset < end;
+		if (isInside) {
+			return { segmentIndex: index, offsetInSegment: offset - consumed };
+		}
+		consumed = end;
+	}
+	// An offset exactly at the very end of the text belongs to the last
+	// non-empty segment.
+	if (offset === consumed) {
+		for (let index = segmentLengths.length - 1; index >= 0; index -= 1) {
+			if (segmentLengths[index] > 0) {
+				return { segmentIndex: index, offsetInSegment: segmentLengths[index] };
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Steps through matches with wraparound. Returns 0 for an empty match list so
+ * callers always hold a usable index.
+ */
+export function stepMatchIndex(
+	currentIndex: number,
+	totalMatches: number,
+	direction: SessionSearchStepDirection,
+): number {
+	if (totalMatches <= 0) {
+		return 0;
+	}
+	const delta = direction === "next" ? 1 : -1;
+	const safeIndex = clampMatchIndex(currentIndex, totalMatches);
+	return (safeIndex + delta + totalMatches) % totalMatches;
+}
+
+export function clampMatchIndex(index: number, totalMatches: number): number {
+	if (totalMatches <= 0 || !Number.isFinite(index) || index < 0) {
+		return 0;
+	}
+	return Math.min(Math.floor(index), totalMatches - 1);
+}
+
+/**
+ * Text for the live region beside the input. Returns an empty string while no
+ * query is entered so the region does not announce anything on open.
+ */
+export function formatMatchCount(
+	activeIndex: number,
+	totalMatches: number,
+	query: string,
+): string {
+	if (!isActiveSearchQuery(query)) {
+		return "";
+	}
+	if (totalMatches <= 0) {
+		return "No results";
+	}
+	return `${clampMatchIndex(activeIndex, totalMatches) + 1} of ${totalMatches}`;
+}


### PR DESCRIPTION
## What

Pressing <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>F</kbd> while a task is open reveals a search bar that finds a query in the current session's messages, jumps to each match, and shows a match count.

- **Current session only.** No cross-session search.
- **Plain case-insensitive substring matching.** No regex, no fuzzy matching.
- **Message prose only** — `user`, `assistant` and `error` roles. Tool payloads and status rows are skipped; they do not render as prose and cannot be highlighted meaningfully.
- <kbd>Enter</kbd> / <kbd>Shift</kbd>+<kbd>Enter</kbd> step forward and back with wraparound. <kbd>Esc</kbd> closes.
- Count reads `3 of 12`.

## Why the CSS Custom Highlight API instead of `<mark>`

This is the main design decision and the one most worth scrutiny.

Message text renders through `MemoizedMarkdown`, which is memoized on purpose so a stream flush does not re-run the markdown pipeline for every bubble. Wrapping matches in `<mark>` elements would mean mutating that rendered output — invalidating the memo, and risking broken formatting where a match spans inline markup.

`CSS.highlights` paints ranges **over** the existing DOM without modifying it, so React never re-renders and the markdown pipeline never re-runs.

A useful consequence: ranges are built from **rendered** text, so markdown syntax characters are absent by construction and a match can never straddle them. A match spanning inline markup (`**par**ser`) yields one correct range.

Where the API is unavailable, the matching message container is tinted instead. `supportsHighlightApi()` feature-detects at mount.

## Structure

| File | Role |
| --- | --- |
| `lib/session-search.ts` | Pure logic. No React, no DOM. |
| `lib/session-search.test.ts` | 34 tests, default node environment. |
| `components/views/chat/find-in-session.tsx` | The bar. Built from existing `ui` primitives. |
| `hooks/use-session-search-highlight.ts` | DOM traversal + range registration. |
| `chat-messages.tsx`, `message-bubble.tsx`, `globals.css` | Wiring, anchor ids, `::highlight()` rules. |

Matching, wraparound and the offset-to-text-node arithmetic are all pure functions in `lib/`, so the tricky parts are tested without a DOM. The hook only does traversal. **No new dependencies.**

## Accessibility

- The bar is a native `<search>` landmark (Biome's `useSemanticElements` prefers this over `role="search"`).
- The input has a real `<label>`.
- The count sits in an `aria-live="polite"` region so stepping through matches is announced.
- Next/previous buttons have tooltips and `aria-label`s.

## Testing

- `webview/lib/session-search.test.ts` — **34 passing**.
- `webview/components/views/chat/chat-messages.test.tsx` — **81 passing**, unchanged.
- `tsc --noEmit` clean for these files; `biome check --diagnostic-level=error` clean.
- Verified separately with throwaway DOM tests (not included) that ranges land on exactly the right characters, including across a `<strong>` boundary, and that the Cmd+F → type → Enter → Esc flow works end to end.

## Not done / open questions

1. **The visual result has not been reviewed on screen.** `::highlight()` only honors `color` and `background-color`, so the active match is distinguished by a stronger fill rather than a border. Whether active-vs-other reads clearly in both themes needs a human look.
2. **The count is one per message, not per occurrence.** That followed from the original container-level highlighting. Now that individual occurrences are visible, counting occurrences is arguably more correct — <kbd>Enter</kbd> moving *within* a long message is now meaningful. Happy to change it; it is contained in `findSessionMatches`.
3. **In-text highlighting during streaming** is untested under rapid flushes. Ranges are rebuilt when `messages.length` changes, but a long single-message stream will not trigger a rebuild until it ends.
