### PR TITLE
fix(desktop): keep closed model popover from blocking composer input

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -978,6 +978,7 @@ describe("ChatInputBar", () => {
 			expect(content?.getAttribute("data-state")).toBe("closed");
 			return content as HTMLElement;
 		});
+		expect(modelSettingsContent.hidden).toBe(true);
 		expect(modelSettingsContent.getAttribute("inert")).toBe("");
 
 		const modelSettingsTrigger = container.querySelector<HTMLButtonElement>(
@@ -986,6 +987,7 @@ describe("ChatInputBar", () => {
 		await act(async () => modelSettingsTrigger?.click());
 
 		expect(modelSettingsContent.getAttribute("data-state")).toBe("open");
+		expect(modelSettingsContent.hidden).toBe(false);
 		expect(modelSettingsContent.hasAttribute("inert")).toBe(false);
 	});
 

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -965,6 +965,30 @@ describe("ChatInputBar", () => {
 		expect(textarea?.value).toBe("draft one");
 	});
 
+	it("keeps the force-mounted model settings inert while closed", async () => {
+		await renderVoiceComposer();
+
+		const modelSettingsContent = await vi.waitFor(() => {
+			const effortSlider = document.querySelector<HTMLInputElement>(
+				'[aria-label="Effort"]',
+			);
+			const content = effortSlider?.closest<HTMLElement>(
+				'[data-slot="popover-content"]',
+			);
+			expect(content?.getAttribute("data-state")).toBe("closed");
+			return content as HTMLElement;
+		});
+		expect(modelSettingsContent.getAttribute("inert")).toBe("");
+
+		const modelSettingsTrigger = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Model settings"]',
+		);
+		await act(async () => modelSettingsTrigger?.click());
+
+		expect(modelSettingsContent.getAttribute("data-state")).toBe("open");
+		expect(modelSettingsContent.hasAttribute("inert")).toBe(false);
+	});
+
 	it("preserves an explicit High selection across capability and status updates", async () => {
 		const onReasoningChange = vi.fn();
 		const onOpenVoiceInputSettings = vi.fn();

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1630,6 +1630,7 @@ function ChatInputBarImpl({
 										align="end"
 										className="w-72 space-y-1 p-2"
 										forceMount
+										hidden={!modelSettingsOpen}
 										inert={!modelSettingsOpen ? true : undefined}
 										onOpenAutoFocus={(event) => {
 											event.preventDefault();

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1630,6 +1630,7 @@ function ChatInputBarImpl({
 										align="end"
 										className="w-72 space-y-1 p-2"
 										forceMount
+										inert={!modelSettingsOpen ? true : undefined}
 										onOpenAutoFocus={(event) => {
 											event.preventDefault();
 											requestAnimationFrame(() =>


### PR DESCRIPTION
## Summary
- keep the force-mounted model settings popover warm, but collapse it while closed so its Radix positioning wrapper cannot intercept composer clicks
- mark the closed content inert so its controls also leave focus and accessibility navigation
- restore layout and interactivity when the popover opens
- add regression coverage for both states

## Why
`forceMount` keeps the closed popover in the DOM so model capability state stays warm. Its exit animation leaves the panel transparent, but the Radix positioning wrapper remains hit-testable and covers part of the composer, preventing mouse clicks from focusing the input.

## Validation
- native Tauri E2E against an isolated branch-matched Hub: center click/type, right-side click/type, open/close model settings, then right-side click/type again; all markers reached the composer and were cleared without submission
- `bun x vitest run webview/components/views/chat/chat-input-bar.test.tsx --config vitest.config.ts` (31 tests)
- `bun -F @cline/code typecheck`
- `bun x biome check apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx`
- `git diff --check`