### PR TITLE
fix(cerebras): preserve output and reasoning options

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
@@ -75,4 +75,16 @@ describe("resolvePortableReasoning", () => {
 			buildAiSdkStreamConfig(ollamaRequest, undefined as never),
 		).toHaveProperty("reasoning", "high");
 	});
+
+	it("uses Cerebras top-level reasoning to disable reasoning", () => {
+		const cerebrasRequest = {
+			...request({ enabled: false }),
+			providerId: "cerebras",
+			modelId: "gemma-4-31b",
+		};
+		expect(resolvePortableReasoning(cerebrasRequest)).toBe("none");
+		expect(
+			buildAiSdkStreamConfig(cerebrasRequest, undefined as never),
+		).toHaveProperty("reasoning", "none");
+	});
 });

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -6,6 +6,7 @@ export type AiSdkReasoning = NonNullable<CallSettings["reasoning"]>;
 const PORTABLE_REASONING_PROVIDERS = new Set([
 	"anthropic",
 	"bedrock",
+	"cerebras",
 	"deepseek",
 	"fireworks",
 	"gemini",

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.test.ts
@@ -113,6 +113,21 @@ describe("withMaxCompletionTokensForReasoningModels", () => {
 		});
 	});
 
+	it("uses max_completion_tokens for Cerebras model ids", () => {
+		const body = withMaxCompletionTokensForReasoningModels(
+			{
+				model: "gemma-4-31b",
+				max_tokens: 8_192,
+			},
+			true,
+		);
+
+		expect(body).toEqual({
+			model: "gemma-4-31b",
+			max_completion_tokens: 8_192,
+		});
+	});
+
 	it("leaves bodies without a string model id untouched", () => {
 		const body = { max_tokens: 8_192 };
 

--- a/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
+++ b/sdk/packages/llms/src/providers/vendors/openai-compatible.ts
@@ -10,7 +10,10 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { wrapLanguageModel } from "ai";
 import { ensureFetch, resolveApiKey } from "../http";
 import { splitToolImagesMiddleware } from "../middleware/split-tool-images";
-import { isOpenAIReasoningEraModelId } from "../model-facts";
+import {
+	isCerebrasProvider,
+	isOpenAIReasoningEraModelId,
+} from "../model-facts";
 import type { ProviderFactoryResult } from "./types";
 
 type FetchInput = Parameters<typeof fetch>[0];
@@ -149,12 +152,13 @@ function createResponseErrorFetch(input: {
  */
 export function withMaxCompletionTokensForReasoningModels(
 	body: Record<string, unknown>,
+	useCanonicalOutputLimit = false,
 ): Record<string, unknown> {
 	const { max_tokens: maxTokens, ...rest } = body;
 	if (
 		maxTokens == null ||
 		typeof body.model !== "string" ||
-		!isOpenAIReasoningEraModelId(body.model)
+		(!useCanonicalOutputLimit && !isOpenAIReasoningEraModelId(body.model))
 	) {
 		return body;
 	}
@@ -240,6 +244,10 @@ export async function createOpenAICompatibleProviderModule(
 				onResponseError,
 			})
 		: fetch;
+	const useCanonicalOutputLimit = isCerebrasProvider(
+		{ providerId: context.provider.id },
+		context,
+	);
 	const provider = createOpenAICompatible({
 		name: context.provider.id,
 		apiKey,
@@ -247,7 +255,8 @@ export async function createOpenAICompatibleProviderModule(
 		...(config.headers ? { headers: config.headers } : {}),
 		...(providerFetch ? { fetch: providerFetch } : {}),
 		includeUsage: true,
-		transformRequestBody: withMaxCompletionTokensForReasoningModels,
+		transformRequestBody: (body: Record<string, unknown>) =>
+			withMaxCompletionTokensForReasoningModels(body, useCanonicalOutputLimit),
 	} as never);
 	const useOpenRouterImageTransport =
 		context.provider.metadata?.imageTransport === "openrouter" &&


### PR DESCRIPTION
## Summary

- serialize the canonical max_completion_tokens field for Cerebras instead of max_tokens
- map disabled reasoning to reasoning_effort none for Cerebras
- cover both transformations with focused tests

## Validation

- 28 focused tests passed
- package typecheck passed
- Biome check passed

Closes #13435