### PR TITLE
fix(desktop): distinguish unconfirmed handoff delivery

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2595,6 +2595,7 @@ async function handleHandoffOnce(
 	);
 
 	let warning: string | undefined;
+	let followUpDelivery: "queued" | "unknown" | "failed" | undefined;
 	if (nextCommand) {
 		try {
 			await cloud.send(
@@ -2604,8 +2605,12 @@ async function handleHandoffOnce(
 				prepared.modelId,
 				request.attachments?.userImages,
 			);
+			followUpDelivery = "queued";
 		} catch (error) {
-			warning = `The handoff completed, but the follow-up command was not queued: ${error instanceof Error ? error.message : String(error)}`;
+			const deliveryUnknown =
+				error instanceof CloudSessionError && error.promptDeliveryUnknown;
+			followUpDelivery = deliveryUnknown ? "unknown" : "failed";
+			warning = `The handoff completed, but the follow-up command ${deliveryUnknown ? "could not be confirmed" : "was not queued"}: ${error instanceof Error ? error.message : String(error)}`;
 		}
 	}
 	const destination = "in_app" as const;
@@ -2623,6 +2628,7 @@ async function handleHandoffOnce(
 		innerSessionId,
 		dashboardUrl,
 		destination,
+		...(followUpDelivery ? { followUpDelivery } : {}),
 		...(warning ? { warning } : {}),
 	};
 }

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -2951,7 +2951,12 @@ describe("CloudSessionManager", () => {
 
 		await expect(
 			manager.send("ses-outer", "Possibly queued", "queue"),
-		).rejects.toThrow(/check the cloud session before resending/i);
+		).rejects.toMatchObject({
+			promptDeliveryUnknown: true,
+			message: expect.stringMatching(
+				/check the cloud session before resending/i,
+			),
+		});
 	});
 
 	it("disposes the Hub connection before deleting the outer session", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -2782,7 +2782,7 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
-	it("does not confirm a lost duplicate prompt against an earlier delivery", async () => {
+	it("does not confirm a duplicate queued prompt against an earlier delivery", async () => {
 		// Baseline must advance on delivered sends: without it, the first
 		// delivery's occurrence falsely confirms a second, genuinely lost send.
 		const { ctx } = createContext();
@@ -2805,9 +2805,9 @@ describe("CloudSessionManager", () => {
 		hub.failNextSend = true;
 		hub.onFailedSend = () => {};
 
-		await expect(manager.send("ses-outer", "yes")).rejects.toThrow(
-			/please send it again/,
-		);
+		await expect(manager.send("ses-outer", "yes")).rejects.toMatchObject({
+			promptDeliveryUnknown: true,
+		});
 	});
 
 	it("reattaches after a transport failure without retrying the prompt", async () => {

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -147,6 +147,8 @@ export class CloudSessionError extends Error {
 		readonly connectUrl?: string,
 		/** HTTP status of the failed request, when one was received. */
 		readonly status?: number,
+		/** A queue send may have reached the runtime even though confirmation failed. */
+		readonly promptDeliveryUnknown = false,
 	) {
 		super(
 			`${CLOUD_ERROR_PREFIX}${JSON.stringify({ code, message: detail, connectUrl })}`,
@@ -2000,7 +2002,16 @@ export class CloudSessionManager {
 						live.busy = false;
 						live.status = "error";
 					}
-					throw recoveryError;
+					if (delivery !== "queue") {
+						throw recoveryError;
+					}
+					throw new CloudSessionError(
+						"request_failed",
+						"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
+						undefined,
+						undefined,
+						true,
+					);
 				}
 				const promptOccurrencesAfterRecovery = countPromptOccurrences(
 					snapshot.messages,
@@ -2012,6 +2023,9 @@ export class CloudSessionManager {
 						throw new CloudSessionError(
 							"request_failed",
 							"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
+							undefined,
+							undefined,
+							true,
 						);
 					}
 					throw new CloudSessionError(

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -2019,7 +2019,7 @@ export class CloudSessionManager {
 					prompt,
 				);
 				if (promptOccurrencesAfterRecovery <= promptOccurrencesBeforeSend) {
-					if (delivery === "queue" && snapshot.prompts === undefined) {
+					if (delivery === "queue") {
 						throw new CloudSessionError(
 							"request_failed",
 							"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1883,7 +1883,10 @@ function ChatThreadPane({
 				}
 				if (result.warning) {
 					toast({
-						title: "Handoff completed with a warning",
+						title:
+							result.followUpDelivery === "unknown"
+								? "Follow-up delivery is unconfirmed"
+								: "Handoff completed with a warning",
 						description: result.warning,
 					});
 				}

--- a/sdk/packages/core/src/services/cloud-handoff/types.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/types.ts
@@ -43,5 +43,6 @@ export type CloudHandoffResult = {
 	innerSessionId: string;
 	dashboardUrl: string;
 	destination: CloudHandoffDestination;
+	followUpDelivery?: "queued" | "unknown" | "failed";
 	warning?: string;
 };


### PR DESCRIPTION
## Summary

- distinguish a definitely failed handoff follow-up from delivery that became unconfirmable after a transport interruption
- treat a missing recovery snapshot occurrence as unconfirmed for queued sends, because an accepted queue entry may already have started before persistence catches up
- return a machine-readable `followUpDelivery` outcome and use accurate warning copy in the desktop UI
- preserve existing behavior for non-queued cloud sends

This is intentionally separate from #13434 so the live handoff-prompt UI fix does not absorb a pre-existing sidecar delivery-contract issue.

## Verification

- `mise exec -- bunx vitest run sidecar/cloud-sessions.test.ts sidecar/chat-session.test.ts --config vitest.config.ts` — 191 passed
- `mise exec -- bun run typecheck`
- `git diff --check`
