### PR TITLE
fix(search): honor .gitignore/.clineignore/.agentignore in codebase search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -661,6 +661,7 @@
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ignore": "^7.0.3",
         "jiti": "^2.7.0",
         "nanoid": "^5.1.7",
         "node-machine-id": "^1.1.12",

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -64,6 +64,7 @@
 		"@opentelemetry/sdk-trace-base": "^2.6.1",
 		"@opentelemetry/sdk-trace-node": "^2.6.1",
 		"@opentelemetry/semantic-conventions": "^1.40.0",
+		"ignore": "^7.0.3",
 		"jiti": "^2.7.0",
 		"node-machine-id": "^1.1.12",
 		"nanoid": "^5.1.7",

--- a/sdk/packages/core/src/extensions/tools/executors/search.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.test.ts
@@ -36,4 +36,46 @@ describe("createSearchExecutor", () => {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("excludes matches from directories ignored by .gitignore / .clineignore", async () => {
+		const dir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "agents-search-ignore-"),
+		);
+		// Use directory names that are NOT in the hard-coded exclude list so the
+		// assertion isolates ignore-file handling from the built-in dir skips.
+		await fs.writeFile(path.join(dir, ".gitignore"), "generated/\n", "utf-8");
+		await fs.writeFile(path.join(dir, ".clineignore"), "secret/\n", "utf-8");
+
+		await fs.mkdir(path.join(dir, "src"), { recursive: true });
+		await fs.mkdir(path.join(dir, "generated"), { recursive: true });
+		await fs.mkdir(path.join(dir, "secret"), { recursive: true });
+
+		const marker = "ZZ_IGNORE_MARKER_ZZ";
+		await fs.writeFile(
+			path.join(dir, "src", "keep.ts"),
+			`const a = "${marker}";\n`,
+			"utf-8",
+		);
+		await fs.writeFile(
+			path.join(dir, "generated", "gen.ts"),
+			`const b = "${marker}";\n`,
+			"utf-8",
+		);
+		await fs.writeFile(
+			path.join(dir, "secret", "leak.ts"),
+			`const c = "${marker}";\n`,
+			"utf-8",
+		);
+
+		try {
+			const search = createSearchExecutor({ contextLines: 0 });
+			const result = await search(marker, dir, ctx);
+
+			expect(result).toContain("src/keep.ts");
+			expect(result).not.toContain("generated/gen.ts");
+			expect(result).not.toContain("secret/leak.ts");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -8,6 +8,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolContext } from "@cline/shared";
+import ignore, { type Ignore } from "ignore";
 import { getFileIndex } from "../../../services/workspace";
 import type { SearchExecutor } from "../types";
 import { MAX_SEARCH_OUTPUT_CHARS } from "./output-limits";
@@ -120,6 +121,54 @@ interface SearchMatch {
 	context: string[];
 }
 
+/**
+ * Workspace ignore files consulted when filtering search results, in ascending
+ * precedence. `.gitignore` is honored by ripgrep itself, but Cline's own
+ * `.clineignore` / `.agentignore` files are not known to ripgrep and are never
+ * honored in the JS fallback, so we load all three and filter both code paths.
+ */
+const WORKSPACE_IGNORE_FILES = [".gitignore", ".clineignore", ".agentignore"];
+
+/**
+ * Build an ignore matcher from the workspace-root ignore files.
+ *
+ * Uses the `ignore` library (the same matcher backing ClineIgnoreController) so
+ * both search paths drop results the user has explicitly excluded, with
+ * gitignore semantics (root-anchored and trailing-slash patterns, `!` negation,
+ * character classes). Returns null when no ignore files are present so callers
+ * can skip filtering entirely.
+ */
+async function loadWorkspaceIgnoreFilter(cwd: string): Promise<Ignore | null> {
+	const patterns: string[] = [];
+	for (const fileName of WORKSPACE_IGNORE_FILES) {
+		try {
+			patterns.push(await fs.readFile(path.join(cwd, fileName), "utf-8"));
+		} catch {
+			// Missing or unreadable ignore file: nothing to load from it.
+		}
+	}
+	if (patterns.length === 0) {
+		return null;
+	}
+	return ignore().add(patterns.join("\n"));
+}
+
+/**
+ * Test a workspace-relative path against the ignore matcher. Paths are
+ * normalized to posix and stripped of any leading "./" because the `ignore`
+ * library rejects absolute paths and leading-slash inputs.
+ */
+function isIgnoredPath(matcher: Ignore | null, relativePath: string): boolean {
+	if (!matcher) {
+		return false;
+	}
+	const normalized = relativePath.replace(/\\/g, "/").replace(/^\.\//, "");
+	if (!normalized || normalized === "." || normalized.startsWith("../")) {
+		return false;
+	}
+	return matcher.ignores(normalized);
+}
+
 let rgAvailable: boolean | null = null;
 
 function checkRipgrepAvailable(): Promise<boolean> {
@@ -167,7 +216,16 @@ function searchWithRipgrep(
 	return new Promise((resolve) => {
 		const child = spawn(
 			"rg",
-			["--json", `--context=${contextLines}`, "--max-count=1", "-i", query],
+			[
+				"--json",
+				// Honor .gitignore even outside a git working tree; ripgrep only
+				// applies gitignore rules inside a git repo by default.
+				"--no-require-git",
+				`--context=${contextLines}`,
+				"--max-count=1",
+				"-i",
+				query,
+			],
 			{
 				cwd,
 				stdio: ["ignore", "pipe", "pipe"],
@@ -332,6 +390,10 @@ export function createSearchExecutor(
 			throw new Error("Search operation aborted");
 		}
 
+		// Load the workspace ignore rules once and apply them to whichever code
+		// path runs, so results from ignored directories never leak through.
+		const ignoreFilter = await loadWorkspaceIgnoreFilter(cwd);
+
 		// Try ripgrep first if available
 		const isRgAvailable = await checkRipgrepAvailable();
 		let rgMatches: SearchMatch[] | null = null;
@@ -347,18 +409,21 @@ export function createSearchExecutor(
 		}
 
 		if (rgMatches) {
+			const visibleMatches = rgMatches.filter(
+				(match) => !isIgnoredPath(ignoreFilter, match.file),
+			);
 			const resultLines: string[] = [
-				`Found ${rgMatches.length} result${rgMatches.length === 1 ? "" : "s"} for pattern: ${query}`,
+				`Found ${visibleMatches.length} result${visibleMatches.length === 1 ? "" : "s"} for pattern: ${query}`,
 				"",
 			];
 
-			for (const match of rgMatches) {
+			for (const match of visibleMatches) {
 				resultLines.push(`${match.file}:${match.line}:${match.column}`);
 				resultLines.push(...match.context);
 				resultLines.push("");
 			}
 
-			if (rgMatches.length >= maxResults) {
+			if (visibleMatches.length >= maxResults) {
 				resultLines.push(
 					`(Showing first ${maxResults} results. Refine your search for more specific results.)`,
 				);
@@ -397,6 +462,10 @@ export function createSearchExecutor(
 					maxDepth,
 				)
 			) {
+				continue;
+			}
+
+			if (isIgnoredPath(ignoreFilter, relativePath)) {
 				continue;
 			}
 


### PR DESCRIPTION
### Related Issue
Closes #13384

### Description
`search_codebase` returned matches from directories the user had already excluded via ignore files. ripgrep only applies `.gitignore` inside a git working tree and never reads Cline's own `.clineignore` / `.agentignore`, and the JS fallback walker filtered on a hard-coded directory list only, so ignored/generated content still showed up in results and context.

This loads the workspace-root ignore files (`.gitignore`, `.clineignore`, `.agentignore`) into a single `ignore` matcher — the same library backing `ClineIgnoreController` — and applies it to both search paths: the ripgrep results are filtered, and the fallback walker skips ignored files. It also passes `--no-require-git` so ripgrep honors `.gitignore` even outside a git repo. Added a unit test that seeds an ignored directory and asserts it stays out of the results.

Custom ignore files are read at the workspace root, matching how `ClineIgnoreController` already loads `.clineignore`; nested `.gitignore` files keep working through ripgrep.

### Testing
- New unit test in `search.test.ts`: fails without the fix (ignored `generated/` and `secret/` files leak into results), passes with it.
- Surrounding suite `src/extensions/tools/` + `src/services/workspace/`: 339 passed / 12 skipped / 0 failed. `tsc --noEmit` clean; `biome check` clean.

Assisted by Claude (claude-opus-4-8); code reviewed and verified by me.