### PR TITLE
feat(vscode): add Eden AI presentation override and docs entry

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -126,6 +126,24 @@ describe("providerSettingsRegistry", () => {
 		})
 	})
 
+	it("builds Eden AI settings through the generic registry", () => {
+		expect(
+			getGenericProviderSettings(
+				"edenai",
+				listing({ id: "edenai", name: "Eden AI", protocol: "openai-chat", allowsCustomModelIds: false }),
+			),
+		).toEqual({
+			allowsCustomIds: false,
+			baseUrlField: {
+				label: "Base URL",
+				placeholder: "https://api.edenai.run/v3",
+			},
+			providerId: "edenai",
+			providerName: "Eden AI",
+			signupUrl: "https://app.edenai.run/settings/api-keys",
+		})
+	})
+
 	it("allows future simple SDK providers to use the generic fallback", () => {
 		const futureProvider = listing({
 			allowsCustomModelIds: true,

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -45,6 +45,13 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	doubao: {
 		signupUrl: "https://console.volcengine.com/home",
 	},
+	edenai: {
+		signupUrl: "https://app.edenai.run/settings/api-keys",
+		baseUrlField: {
+			label: "Base URL",
+			placeholder: "https://api.edenai.run/v3",
+		},
+	},
 	fireworks: {
 		signupUrl: "https://app.fireworks.ai/settings/users/api-keys",
 	},

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -15,6 +15,7 @@ Use this page for providers that follow the same setup pattern.
   - [Cerebras](#cerebras)
   - [Dify.ai](#difyai)
   - [Doubao](#doubao)
+  - [Eden AI](#eden-ai)
   - [Fireworks AI](#fireworks-ai)
   - [GCP Vertex AI](#gcp-vertex-ai)
   - [Groq](#groq)
@@ -111,6 +112,17 @@ Doubao is ByteDance’s model family, typically accessed through Volcengine serv
 1. Sign in to Volcengine and enable model access.
 2. Generate API credentials for Doubao endpoints.
 3. In Cline, select **Doubao** and paste credentials.
+
+### Eden AI
+Eden AI is a European gateway that routes to many model vendors behind one API key.
+
+**Website:** [https://www.edenai.co/](https://www.edenai.co/)
+
+#### Basic Setup
+
+1. Create/sign in to your Eden AI account.
+2. Generate an API key from your account settings.
+3. In Cline, select **Eden AI** and paste the key. To keep requests on Eden AI’s EU endpoint, set **Base URL** to `https://api.eu.edenai.run/v3`, which serves the subset of the catalog available in the EU.
 
 ### Fireworks AI
 Fireworks AI provides hosted inference for open models and performance-focused deployment.


### PR DESCRIPTION
### Related Issue

**Discussion:** https://github.com/cline/cline/discussions/13454

Blank issues are disabled and this is not a bug, so I opened a discussion in Feature Requests instead, as the template suggests. Happy to move it if you would rather have an issue.

### Description

Eden AI is already a Cline provider. It comes from the generated models.dev catalog (anomalyco/models.dev#4506, merged on 12 August), so the entry is in `providers.generated.ts`, it shows up under API Provider, and the generic settings form renders for it because `inferProtocol` maps an `openai-compatible` family to `openai-chat`, which `GENERIC_PROVIDER_PROTOCOLS` accepts.

What was missing is the hand maintained presentation data around it:

- No `edenai` entry in `GENERIC_PROVIDER_PRESENTATION_OVERRIDES`, so the settings panel showed no Get API Key link, and there was no base URL field. Eden AI runs a separate EU endpoint on a different host, `https://api.eu.edenai.run/v3`, rather than behind a flag, so that field is what makes it reachable for teams that need requests to stay in the EU.
- Eden AI was absent from the Other 30+ Providers page, even though it is selectable in the dropdown.

So this PR adds three things: the presentation override, a test case for it, and the docs section. No handwritten provider registration, the spec still comes from the generated catalog, which is the path #12087 pointed at.

Two smaller calls worth flagging. The signup URL points at the API key page rather than our marketing page, following #13337. And on the docs page, I checked it was the right place first: #12397 established that page is for providers available in the API Provider dropdown, which is the case here.

### Test Procedure

- `apps/vscode/webview-ui`: `vitest run`, 56 files and 443 tests pass, including the new case. On a fresh clone 29 files fail to collect with `Failed to resolve import "@shared/proto/cline/common"` until you run `bun run protos`, which is in CONTRIBUTING, so that is worth knowing rather than a regression here.
- `bunx tsc` in `webview-ui` is clean, and `bun run check-types` in `apps/vscode` exits 0 with no TS errors, after `bun run build:sdk`.
- `bun run lint` in `apps/vscode`, and `biome lint --changed` in `webview-ui` on the two touched files, no findings.
- `mintlify broken-links` in `docs` reports no broken links, and both URLs I added return 200.
- The EU endpoint claim in the docs is tested, not assumed. A model that works on the global host can return `451 region_not_allowed` on the EU host, so the wording says that endpoint serves the subset of the catalog available in the EU rather than promising parity.

What could break: only the settings panel for this one provider, and the docs page rendering. Both are covered above. The change is additive, 37 lines, no existing entry touched.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshot, and I would rather say so than pass off a mockup. The change adds no UI of its own, it fills two fields that `GenericProviderSettings` already renders for every other provider in that map, so it looks exactly like the Fireworks or Together panel. Glad to add a capture if that is useful.

### Additional Notes

One open question. I considered `allowsCustomIds: true`, the way the `together` entry does, since our catalog is refreshed upstream more often than a committed snapshot can follow. I left it out because `CUSTOM_MODEL_ID_PROVIDER_IDS` does not include us, and I could not convince myself that a user supplied model id survives resolution rather than being coerced to the catalog default. I did not want to promise a field in the UI that the backend might ignore. Happy to add it if you tell me it is safe.

I do work at Eden AI.
