### PR TITLE
chore(desktop): cut 0.0.16-beta.1

### DIFF
--- a/apps/examples/desktop-app/CHANGELOG.md
+++ b/apps/examples/desktop-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Cline Desktop Changelog
 
+## 0.0.16-beta.1
+
+- Beta: your typed prompt is no longer lost when a cloud handoff starts — the live draft carries into the handoff and is restored if it fails.
+- Beta: fixed a closed model popover blocking clicks in the composer.
+- Beta: cleaned up visual regressions in provider settings, notifications, and the avatar overlay from the previous sync.
+- Includes the 0.0.16-track main updates: the redesigned first-run onboarding with an interactive welcome graphic, centralized tool availability, hook fixes (PostToolUse output and context changes now reach the model), and the fix for checkpoint restore staying locked after queued turns.
+
 ## 0.0.15
 
 - The app is now called Cline, renamed from Cline Code. Your settings, sessions, and credentials carry over untouched — only the name and icon change

--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cline/code",
-	"version": "0.0.15-beta.1",
+	"version": "0.0.16-beta.1",
 	"private": true,
 	"scripts": {
 		"build:ui": "bun -F @cline/ui build",

--- a/apps/examples/desktop-app/src-tauri/tauri.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Cline",
-	"version": "0.0.15-beta.1",
+	"version": "0.0.16-beta.1",
 	"identifier": "bot.cline.app",
 	"build": {
 		"beforeDevCommand": "bun run build:sidecar:bin && bun run dev:web",

--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
     },
     "apps/examples/desktop-app": {
       "name": "@cline/code",
-      "version": "0.0.15-beta.1",
+      "version": "0.0.16-beta.1",
       "dependencies": {
         "@ai-sdk/gateway": "4.0.31",
         "@ai-sdk/google": "4.0.44",


### PR DESCRIPTION
## Summary

Stacked on #13461 (merge that first). Version-only PR:

- bump `0.0.15-beta.1` → `0.0.16-beta.1` in `package.json`, `src-tauri/tauri.conf.json`, and the bun.lock workspace entry — the 0.0.15 base is burned by shipped stable `desktop-v0.0.15`
- prepend the `## 0.0.16-beta.1` changelog section (handoff prompt preservation #13434, popover fix #13431, UI cleanup #13450, plus the synced main items)

## After #13461 merges

Rebase this onto the updated `desktop-experimental` (it retargets automatically; the rebase is one trivial commit), merge, then per the publish-desktop skill: annotated tag `desktop-v0.0.16-beta.1` on the release commit, dispatch `desktop-publish.yml` from `main` with `channel=beta`, approve the PublishDesktop gate, verify both feeds (`desktop-beta` serves 0.0.16-beta.1; `desktop-latest` still 0.0.15).