### PR TITLE
Treat an empty preserved capability list as unspecified when seeding tools

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -908,6 +908,31 @@ describe("buildSessionConfig", () => {
 		expect(knownModel.modalities).toEqual({ input: ["text", "image"], output: ["text", "image"] })
 	})
 
+	it("defaults tool-calling on when the preserved capability list is defined but empty", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openrouter",
+			actModeOpenRouterModelId: "mock/empty-capabilities-model",
+			openRouterApiKey: "openrouter-key",
+			// A capabilities field that round-tripped through a boundary
+			// defaulting the missing array to [] — same "no signal" state as
+			// an absent one (modelHasCapability treats both as unspecified).
+			// Before the fix, the strict `=== undefined` guard skipped the
+			// tools seeding, supportsReasoning populated the array, and the
+			// runtime gate silently dropped every tool definition (#13463).
+			actModeOpenRouterModelInfo: {
+				name: "Empty Capabilities Model",
+				contextWindow: 16_000,
+				supportsReasoning: true,
+				capabilities: [],
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["mock/empty-capabilities-model"]
+
+		expect(knownModel.capabilities).toEqual(expect.arrayContaining(["reasoning", "tools"]))
+	})
+
 	it("keeps legacy supportsTools=false authoritative for dynamic-list models", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openrouter",

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -922,6 +922,10 @@ describe("buildSessionConfig", () => {
 			actModeOpenRouterModelInfo: {
 				name: "Empty Capabilities Model",
 				contextWindow: 16_000,
+				// Required by the store's isModelInfo gate: without a boolean
+				// supportsPromptCache the state snapshot is rejected and the
+				// model never reaches knownModels at all.
+				supportsPromptCache: false,
 				supportsReasoning: true,
 				capabilities: [],
 			},

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -258,13 +258,21 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 	setCapability("prompt-cache", modelInfo.supportsPromptCache)
 	if (modelInfo.supportsReasoning !== undefined) setCapability("reasoning", modelInfo.supportsReasoning)
 	if (selection.overrides?.supportsAttachments !== undefined) setCapability("files", selection.overrides.supportsAttachments)
-	if (preservedCapabilities === undefined) {
+	if (preservedCapabilities === undefined || preservedCapabilities.length === 0) {
 		// No authoritative SDK list survived to here (dynamic-list snapshot,
 		// fallback metadata, or a custom model). The array we are rebuilding
 		// from booleans must still carry a definitive tool-calling signal,
 		// because a non-empty capabilities array without "tools" reads as
 		// "cannot call tools" to the SDK runtime. Legacy metadata only models
 		// tool support for OpenAI-compatible entries via `supportsTools`.
+		//
+		// An EMPTY array is the same "no signal" state as an absent one —
+		// modelHasCapability treats both as unspecified — and configs carried
+		// over from before the field existed (or round-tripped through a
+		// boundary that defaults it to []) land exactly here. Guarding only
+		// `undefined` let those custom models keep a non-empty, tool-less
+		// array once any boolean projection (e.g. reasoning) populated it,
+		// silently disabling tool calling at the runtime gate (#13463).
 		const supportsTools = (modelInfo as { supportsTools?: boolean }).supportsTools
 		setCapability("tools", supportsTools !== false)
 	}


### PR DESCRIPTION
Fixes #13463.

## Root cause

Exactly the mismatch the issue traces: `toSdkModelInfo` guards the `tools` seeding with `preservedCapabilities === undefined` (strict), while `modelHasCapability` — the runtime's own reader (`modelSupportsToolCalling`) — treats **`undefined` and `length === 0` as the same "unspecified" state**, failing open for both.

So a custom OpenAI-Compatible model whose stored `capabilities` is a defined-but-empty `[]` (a config carried over from before the field existed in 4.1.10, or one round-tripped through a boundary that defaults the missing array to `[]`) skipped the seeding. The very next line — `if (modelInfo.supportsReasoning !== undefined) setCapability("reasoning", ...)` — populated the array, and the runtime gate then read that non-empty, tool-less list as authoritative: no `tools` in the request body, and the model free-form hallucinates tool-call syntax as plain text.

## Fix

One guard: `preservedCapabilities === undefined || preservedCapabilities.length === 0` — the seeding now runs for the empty array too, with a comment pinning why the two states are the same.

## Test

`defaults tool-calling on when the preserved capability list is defined but empty` in `cline-session-factory.test.ts`, mirroring the shape of its three green siblings: `capabilities: []` + `supportsReasoning: true` must reconstruct an array containing both `"reasoning"` and `"tools"`. On the unfixed guard, `"tools"` is absent — the exact #13463 signature.

Note on local verification: this machine has no bun/the workspace's node_modules, so the committed test runs in CI (differential against the guard is mechanical — the sibling test `defaults tool-calling on for dynamic-list models without preserved SDK capabilities` already proves the `undefined` branch, and this PR only widens that branch's condition).
