### PR TITLE
fix(task): stop logging every assistant presentation delta

### DIFF
--- a/apps/vscode/src/core/task/__tests__/latency.test.ts
+++ b/apps/vscode/src/core/task/__tests__/latency.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha"
 import "should"
 
-import { isRemoteWorkspaceEnvironment } from "../latency"
+import { isRemoteWorkspaceEnvironment, shouldLogAssistantPresentationSchedule } from "../latency"
 
 describe("latency", () => {
 	it("detects remote workspaces from explicit remoteName metadata", () => {
@@ -48,5 +48,10 @@ describe("latency", () => {
 
 	it("does not classify hosts as remote when no fields are provided", () => {
 		isRemoteWorkspaceEnvironment({}).should.equal(false)
+	})
+
+	it("logs presentation schedules only at immediate semantic boundaries", () => {
+		shouldLogAssistantPresentationSchedule("immediate").should.equal(true)
+		shouldLogAssistantPresentationSchedule("normal").should.equal(false)
 	})
 })

--- a/apps/vscode/src/core/task/index.ts
+++ b/apps/vscode/src/core/task/index.ts
@@ -144,6 +144,7 @@ import {
 	getPresentationCadenceMs,
 	isPresentationSchedulingDisabled,
 	isRemoteWorkspaceEnvironment,
+	shouldLogAssistantPresentationSchedule,
 	type TaskLatencyTrigger,
 } from "./latency";
 import { MessageStateHandler } from "./message-state";
@@ -757,10 +758,13 @@ export class Task {
 			return;
 		}
 
-		// Immediate semantic boundaries: first visible token, tool transitions, finalization, and cleanup drains.
-		Logger.debug(
-			`[Task ${this.taskId}] schedule assistant presentation (${trigger}, ${priority})`,
-		);
+		// Do not log coalesced (text, normal) deltas — that line ran once per
+		// stream chunk and froze the extension host (#13339).
+		if (shouldLogAssistantPresentationSchedule(priority)) {
+			Logger.debug(
+				`[Task ${this.taskId}] schedule assistant presentation (${trigger}, ${priority})`,
+			);
+		}
 		this.presentationScheduler.requestFlush(priority);
 	}
 
@@ -3551,6 +3555,9 @@ export class Task {
 							}
 							if (chunk.id) {
 								assistantMessageId = chunk.id;
+							}
+							if (!chunk.text) {
+								break;
 							}
 							assistantMessage += chunk.text;
 							assistantTextOnly += chunk.text; // Accumulate text separately

--- a/apps/vscode/src/core/task/latency.ts
+++ b/apps/vscode/src/core/task/latency.ts
@@ -50,6 +50,11 @@ export function isPresentationSchedulingDisabled(): boolean {
 	return schedulingDisabled
 }
 
+/** True only for first-token / tool / finalize flushes. Logging every delta froze the host (#13339). */
+export function shouldLogAssistantPresentationSchedule(priority: PresentationPriority): boolean {
+	return priority === "immediate"
+}
+
 export function getPresentationCadenceMs(isRemoteWorkspace: boolean, priority: PresentationPriority): number {
 	if (priority === "immediate") {
 		return 0


### PR DESCRIPTION
### Related Issue

**Issue:** #13339

### Description

On the legacy VS Code bundle, every streamed assistant text delta called `Logger.debug` with `schedule assistant presentation (text, normal)`. That is the coalesced hot path, not a semantic boundary.

In #13339 that line was written 9,133 times in ~3 minutes (96% of the Cline log) and the extension host UI froze until VS Code was restarted. The comment above the log already described first-token / tool / finalize flushes; the code logged every chunk anyway.

This PR:

- Logs presentation schedules only when priority is `immediate`
- Skips empty text deltas so they do not parse or schedule a flush
- Adds a unit test for the log gate

Presentation cadence / coalescing is unchanged. New sessions on the SDK ("Next") bundle do not contain this log line; this targets `legacy-extension`, which is still shipped in the marketplace VSIX.

### Test Procedure

- `mocha` on `src/core/task/__tests__/latency.test.ts` and `TaskPresentationScheduler.test.ts` — 16 passing
- Confirmed coalescing tests still pass (multiple `normal` requests remain a single timer)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend logging / stream hot path.

### Additional Notes

Maintainer asked the reporter to try the Next bundle. This fix is for users still on legacy in the combined 4.1.x VSIX.