### PR TITLE
fix(vscode): treat empty preserved capability list as unspecified for tool-calling

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -949,6 +949,30 @@ describe("buildSessionConfig", () => {
 		expect(knownModel.capabilities).not.toContain("tools")
 	})
 
+	it("treats an empty preserved capability list as unspecified and keeps tool-calling on", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openrouter",
+			actModeOpenRouterModelId: "mock/empty-capabilities-reasoner",
+			openRouterApiKey: "openrouter-key",
+			// A defined-but-empty capabilities array carries no signal (same
+			// fail-open rule as `modelHasCapability`). With supportsReasoning
+			// set, the rebuilt array becomes populated — it must still include
+			// "tools", or the SDK silently drops every tool (issue #13463).
+			actModeOpenRouterModelInfo: {
+				name: "Empty Capabilities Reasoner",
+				supportsPromptCache: false,
+				supportsReasoning: true,
+				capabilities: [],
+			},
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+		const knownModel = (config.providerConfig as any).knownModels["mock/empty-capabilities-reasoner"]
+
+		expect(knownModel.capabilities).toContain("reasoning")
+		expect(knownModel.capabilities).toContain("tools")
+	})
+
 	it("keeps -1 OpenAI Compatible values out of request settings and fallback knownModels", async () => {
 		mocks.stateManager.getApiConfiguration.mockReturnValue({
 			actModeApiProvider: "openai",

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -258,13 +258,14 @@ function toSdkModelInfo(selection: ResolvedModelSelection): SdkModelInfo {
 	setCapability("prompt-cache", modelInfo.supportsPromptCache)
 	if (modelInfo.supportsReasoning !== undefined) setCapability("reasoning", modelInfo.supportsReasoning)
 	if (selection.overrides?.supportsAttachments !== undefined) setCapability("files", selection.overrides.supportsAttachments)
-	if (preservedCapabilities === undefined) {
+	if (preservedCapabilities === undefined || preservedCapabilities.length === 0) {
 		// No authoritative SDK list survived to here (dynamic-list snapshot,
-		// fallback metadata, or a custom model). The array we are rebuilding
-		// from booleans must still carry a definitive tool-calling signal,
-		// because a non-empty capabilities array without "tools" reads as
-		// "cannot call tools" to the SDK runtime. Legacy metadata only models
-		// tool support for OpenAI-compatible entries via `supportsTools`.
+		// fallback metadata, or a custom model). An empty list carries no
+		// signal either — same fail-open rule as `modelHasCapability` — and
+		// booleans like `supportsReasoning` can populate the rebuilt array, so
+		// without this it would read as "cannot call tools" to the SDK runtime
+		// (issue #13463). Legacy metadata only models tool support for
+		// OpenAI-compatible entries via `supportsTools`.
 		const supportsTools = (modelInfo as { supportsTools?: boolean }).supportsTools
 		setCapability("tools", supportsTools !== false)
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #13463

### Description

Custom OpenAI-Compatible (and other dynamic-list) models could silently lose tool-calling in 4.1.11's `next` bundle. The SDK's fail-open rule (`modelHasCapability` in `sdk/packages/shared/src/llms/model-info.ts`) treats a capabilities list that is `undefined` **or empty** as "unspecified", but the guard in `toSdkModelInfo()` (`apps/vscode/src/sdk/cline-session-factory.ts`) that injects the definitive `"tools"` signal only ran when the preserved list was strictly `undefined`.

A defined-but-empty `capabilities: []` can survive to that point (e.g. a live provider catalog listing preserved verbatim by `adaptSdkModelInfo`, or an older state snapshot). When a boolean projection like `supportsReasoning: true` then populates the rebuilt array, the SDK reads it as an authoritative list that omits `"tools"` and stops attaching tool definitions to requests entirely, so the model hallucinates free-form tool-call text instead.

The fix makes the guard consistent with `modelHasCapability`'s own unspecified-list semantics: `preservedCapabilities === undefined || preservedCapabilities.length === 0`. Legacy `supportsTools: false` remains authoritative and still disables tool-calling.

This matches the fix suggested in the issue. The related UI note in the issue (the removed "Supports Reasoning" checkbox in `OpenAICompatible.tsx`) is a separate concern; with this fix a stale `supportsReasoning: true` flag no longer breaks tool-calling.

### Test Procedure

- Added a regression test in `cline-session-factory.test.ts` reproducing the reported shape: a dynamic-list model whose state snapshot carries `capabilities: []` plus `supportsReasoning: true`. Verified it fails without the fix (`capabilities` ends up `["reasoning"]` with no `"tools"`, so `knownModel` never gets the tools signal) and passes with it.
- Full `bun run test:unit` in `apps/vscode`: 1069 pass, 0 fail.
- `bun run test:bun` shows the same 36 failures with and without this change (verified against clean main), all in unrelated suites (e.g. SdkDiffEditCoordinator), so they are pre-existing.
- `bunx tsc --noEmit` passes; biome reports no error-level diagnostics on the changed files.
- Existing tests covering the adjacent semantics still pass: `supportsTools: false` stays authoritative, and a populated preserved capability list without `"tools"` still disables tool-calling.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable, non-UI change; evidence is the regression test and suite results above.

### Additional Notes

The failing-then-passing regression test exercises the exact guard the issue traced. The reporter's workaround (staying on the `legacy` bundle) is unaffected.