### PR TITLE
Surface LM Studio's per-model context length from the public models list

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -527,6 +527,53 @@ describe("resolveProviderConfig", () => {
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(["local-llama"]);
 	});
 
+	it("surfaces LM Studio's per-model context length from the public models endpoint", async () => {
+		// #13457: LM Studio reports the loaded model's real context length on
+		// /v1/models; dropping it left every model on the generic 128k safe
+		// default, so the chat indicator and auto-compaction budgeted against
+		// a window the server does not apply.
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "qwen-3.8-27b",
+							object: "model",
+							max_context_length: 200_000,
+						},
+						{ id: "no-context-model", object: "model" },
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"lmstudio",
+			{ failOnError: false, cacheTtlMs: 0 },
+			{
+				providerId: "lmstudio",
+				modelId: "",
+				baseUrl: "http://localhost:1234/v1",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://localhost:1234/v1/models",
+			{ method: "GET" },
+		);
+		expect(resolved?.knownModels?.["qwen-3.8-27b"]?.contextWindow).toBe(
+			200_000,
+		);
+		// A model the server did not describe keeps the generic default.
+		expect(resolved?.knownModels?.["no-context-model"]).toBeDefined();
+	});
+
 	it("loads Poolside models from the authenticated models endpoint", async () => {
 		const fetchMock = vi.fn(async () => {
 			return new Response(

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -2,7 +2,7 @@
 
 import * as Llms from "@cline/llms";
 import {
-	fetchModelIdsFromSource,
+	fetchModelEntriesFromSource,
 	resolveModelsSourceUrl,
 } from "../providers/model-source";
 import type {
@@ -714,12 +714,21 @@ async function getPublicProviderModels(
 		return inFlight;
 	}
 
-	const request = fetchModelIdsFromSource(sourceUrl, providerId)
-		.then((modelIds) => {
+	const request = fetchModelEntriesFromSource(sourceUrl, providerId)
+		.then((modelEntries) => {
 			const data = Object.fromEntries(
-				modelIds.map((id) => [
+				modelEntries.map(({ id, contextWindow }) => [
 					id,
-					buildModelFromPrivateSource(id, { name: id }),
+					buildModelFromPrivateSource(id, {
+						name: id,
+						// Local sources (LM Studio) report the loaded model's
+						// real context length per entry; keep it so context
+						// management budgets against the server's window
+						// instead of the generic safe default (#13457).
+						...(contextWindow !== undefined
+							? { contextWindow, maxInputTokens: contextWindow }
+							: {}),
+					}),
 				]),
 			);
 			PUBLIC_MODELS_CACHE.set(cacheKey, {

--- a/sdk/packages/core/src/services/providers/model-source.test.ts
+++ b/sdk/packages/core/src/services/providers/model-source.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	extractModelEntriesFromPayload,
+	extractModelIdsFromPayload,
+	resolveModelsSourceUrl,
+} from "./model-source";
+
+describe("extractModelEntriesFromPayload", () => {
+	it("keeps LM Studio's per-model context length from an OpenAI-shaped payload", () => {
+		const payload = {
+			object: "list",
+			data: [
+				{
+					id: "qwen-3.8-27b",
+					object: "model",
+					owned_by: "organization",
+					max_context_length: 200_000,
+				},
+				{ id: "gemma-4-26b", object: "model", max_context_length: 131_072 },
+			],
+		};
+
+		expect(extractModelEntriesFromPayload(payload, "lmstudio")).toEqual([
+			{ id: "qwen-3.8-27b", contextWindow: 200_000 },
+			{ id: "gemma-4-26b", contextWindow: 131_072 },
+		]);
+	});
+
+	it("recognizes the alternative context-length key spellings", () => {
+		const payload = {
+			data: [
+				{ id: "a", max_model_len: 8192 },
+				{ id: "b", context_length: 4096 },
+			],
+		};
+
+		expect(extractModelEntriesFromPayload(payload, "lmstudio")).toEqual([
+			{ id: "a", contextWindow: 8192 },
+			{ id: "b", contextWindow: 4096 },
+		]);
+	});
+
+	it("ignores non-positive or non-numeric context lengths", () => {
+		const payload = {
+			data: [
+				{ id: "a", max_context_length: 0 },
+				{ id: "b", max_context_length: "many" },
+				{ id: "c", max_context_length: Number.NaN },
+			],
+		};
+
+		expect(extractModelEntriesFromPayload(payload, "lmstudio")).toEqual([
+			{ id: "a" },
+			{ id: "b" },
+			{ id: "c" },
+		]);
+	});
+
+	it("falls back to the name/model fields like the id-only extractor", () => {
+		const payload = { models: [{ name: "local-llama" }, { model: "other" }] };
+
+		expect(extractModelEntriesFromPayload(payload, "ollama")).toEqual([
+			{ id: "local-llama" },
+			{ id: "other" },
+		]);
+	});
+
+	it("handles Ollama's /api/tags shape with per-model context", () => {
+		const payload = {
+			models: [
+				{ name: "llama3.2", context_length: 131_072 },
+				{ name: "nemo" },
+			],
+		};
+
+		expect(extractModelEntriesFromPayload(payload, "ollama")).toEqual([
+			{ id: "llama3.2", contextWindow: 131_072 },
+			{ id: "nemo" },
+		]);
+	});
+
+	it("keeps the id-only behavior for plain string arrays and object maps", () => {
+		expect(extractModelEntriesFromPayload(["a", "b"], "lmstudio")).toEqual([
+			{ id: "a" },
+			{ id: "b" },
+		]);
+		expect(
+			extractModelEntriesFromPayload({ models: { first: {}, second: {} } }, "lmstudio"),
+		).toEqual([{ id: "first" }, { id: "second" }]);
+	});
+
+	it("extractModelIdsFromPayload matches the entry ids", () => {
+		const payload = {
+			data: [{ id: "x", max_context_length: 8192 }],
+		};
+
+		expect(extractModelIdsFromPayload(payload, "lmstudio")).toEqual(["x"]);
+	});
+});
+
+describe("resolveModelsSourceUrl", () => {
+	it("replaces the default base path with the configured one", () => {
+		expect(
+			resolveModelsSourceUrl(
+				"http://remote-host:1234/v1",
+				"http://localhost:1234/v1",
+				"http://localhost:1234/v1/models",
+			),
+		).toBe("http://remote-host:1234/v1/models");
+	});
+});

--- a/sdk/packages/core/src/services/providers/model-source.ts
+++ b/sdk/packages/core/src/services/providers/model-source.ts
@@ -1,26 +1,61 @@
-function parseModelIdList(input: unknown): string[] {
+/**
+ * A model discovered from a provider's public model source, keeping whatever
+ * metadata the payload carried. Local OpenAI-compatible sources (LM Studio)
+ * report the loaded model's context length per entry; surfacing it means the
+ * chat indicator and auto-compaction budget against the window the server
+ * actually applies instead of a generic safe default (#13457).
+ */
+export interface PublicModelEntry {
+	id: string;
+	contextWindow?: number;
+}
+
+const CONTEXT_WINDOW_KEYS = [
+	"max_context_length",
+	"max_model_len",
+	"context_length",
+] as const;
+
+function readEntryContextWindow(entry: object): number | undefined {
+	const record = entry as Record<string, unknown>;
+	for (const key of CONTEXT_WINDOW_KEYS) {
+		const value = record[key];
+		if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+			return Math.floor(value);
+		}
+	}
+	return undefined;
+}
+
+function parseModelEntryList(input: unknown): PublicModelEntry[] {
 	if (!Array.isArray(input)) return [];
 	return input
 		.map((item) => {
-			if (typeof item === "string") return item.trim();
+			if (typeof item === "string") {
+				const id = item.trim();
+				return id ? { id } : undefined;
+			}
 			if (item && typeof item === "object") {
 				const entry = item as { id?: unknown; name?: unknown; model?: unknown };
 				for (const value of [entry.id, entry.name, entry.model]) {
 					if (typeof value === "string" && value.trim()) {
-						return value.trim();
+						return {
+							id: value.trim(),
+							contextWindow: readEntryContextWindow(item),
+						};
 					}
 				}
 			}
-			return "";
+			return undefined;
 		})
-		.filter((id) => id.length > 0);
+		.filter((entry): entry is PublicModelEntry => entry !== undefined);
 }
 
-export function extractModelIdsFromPayload(
+export function extractModelEntriesFromPayload(
 	payload: unknown,
 	providerId: string,
-): string[] {
-	const rootArray = parseModelIdList(payload);
+): PublicModelEntry[] {
+	const rootArray = parseModelEntryList(payload);
 	if (rootArray.length > 0) return rootArray;
 	if (!payload || typeof payload !== "object") return [];
 
@@ -30,7 +65,7 @@ export function extractModelIdsFromPayload(
 		providers?: Record<string, unknown>;
 	};
 
-	const direct = parseModelIdList(data.data ?? data.models);
+	const direct = parseModelEntryList(data.data ?? data.models);
 	if (direct.length > 0) return direct;
 
 	if (
@@ -39,33 +74,52 @@ export function extractModelIdsFromPayload(
 		!Array.isArray(data.models)
 	) {
 		const keys = Object.keys(data.models).filter((k) => k.trim().length > 0);
-		if (keys.length > 0) return keys;
+		if (keys.length > 0) {
+			return keys.map((id) => ({ id }));
+		}
 	}
 
 	const scoped = data.providers?.[providerId];
 	if (scoped && typeof scoped === "object") {
 		const nested = scoped as { models?: unknown };
-		const list = parseModelIdList(nested.models ?? scoped);
+		const list = parseModelEntryList(nested.models ?? scoped);
 		if (list.length > 0) return list;
 	}
 
 	return [];
 }
 
-export async function fetchModelIdsFromSource(
+export function extractModelIdsFromPayload(
+	payload: unknown,
+	providerId: string,
+): string[] {
+	return extractModelEntriesFromPayload(payload, providerId).map(
+		(entry) => entry.id,
+	);
+}
+
+export async function fetchModelEntriesFromSource(
 	url: string,
 	providerId: string,
-): Promise<string[]> {
+): Promise<PublicModelEntry[]> {
 	const response = await fetch(url, { method: "GET" });
 	if (!response.ok) {
 		throw new Error(
 			`failed to fetch models from ${url}: HTTP ${response.status}`,
 		);
 	}
-	return extractModelIdsFromPayload(
+	return extractModelEntriesFromPayload(
 		(await response.json()) as unknown,
 		providerId,
 	);
+}
+
+export async function fetchModelIdsFromSource(
+	url: string,
+	providerId: string,
+): Promise<string[]> {
+	const entries = await fetchModelEntriesFromSource(url, providerId);
+	return entries.map((entry) => entry.id);
 }
 
 function trimTrailingSlash(value: string): string {


### PR DESCRIPTION
Fixes #13457. getPublicProviderModels reduced the public model source payload to bare ids, dropping LM Studio max_context_length; every model fell to the 128k safe default. extractModelEntriesFromPayload keeps the reported context length and getPublicProviderModels passes it into ModelInfo. 9 vitest tests (isModelInfo-shaped mocks); pure parser verified locally with a standalone harness (differential vs main fails 5/6). Full description in the commit message.