### PR TITLE
fix: propagate Langfuse session telemetry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -698,6 +698,7 @@
         "@aws-sdk/credential-providers": "^3.922.0",
         "@cline/shared": "workspace:*",
         "@jerome-benoit/sap-ai-provider": "4.8.0",
+        "@langfuse/core": "5.10.1",
         "@langfuse/otel": "5.10.1",
         "@langfuse/vercel-ai-sdk": "5.9.1",
         "@openrouter/ai-sdk-provider": "^3",

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1026,6 +1026,9 @@ export class AgentRuntime {
 		const usageBeforeModel = cloneUsage(this.state.usage);
 		const modelRequestMetadata = omitUndefinedValues({
 			distinctId: trimNonEmpty(this.config.distinctId),
+			clientName: trimNonEmpty(this.config.clientName),
+			clientVersion: trimNonEmpty(this.config.clientVersion),
+			clineCoreVersion: trimNonEmpty(this.config.clineCoreVersion),
 			sessionId: trimNonEmpty(this.config.sessionId),
 			agentId: this.state.agentId,
 			conversationId: trimNonEmpty(this.config.conversationId),

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildDelegatedAgentConfig,
+	createDelegatedAgentConfigProvider,
+} from "./delegated-agent";
+
+describe("buildDelegatedAgentConfig", () => {
+	it("inherits the parent distinctId and sessionId for telemetry grouping", () => {
+		const configProvider = createDelegatedAgentConfigProvider({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-5",
+			distinctId: "user-123",
+			sessionId: "sess-parent",
+		});
+
+		const config = buildDelegatedAgentConfig({
+			kind: "subagent",
+			prompt: "review the diff",
+			tools: [],
+			configProvider,
+			parentAgentId: "agent-lead",
+		});
+
+		expect(config.distinctId).toBe("user-123");
+		expect(config.sessionId).toBe("sess-parent");
+		expect(config.parentAgentId).toBe("agent-lead");
+	});
+
+	it("leaves identity fields undefined when the parent has none", () => {
+		const configProvider = createDelegatedAgentConfigProvider({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-5",
+		});
+
+		const config = buildDelegatedAgentConfig({
+			kind: "subagent",
+			prompt: "review the diff",
+			tools: [],
+			configProvider,
+		});
+
+		expect(config.distinctId).toBeUndefined();
+		expect(config.sessionId).toBeUndefined();
+	});
+});

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -46,6 +46,16 @@ export interface DelegatedAgentRuntimeConfig
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
 	workspaceMetadata?: string;
+	/**
+	 * Stable end-user identity inherited from the parent session so
+	 * delegated-agent telemetry (Langfuse `userId`) groups with the user.
+	 */
+	distinctId?: string;
+	/**
+	 * Root core session id inherited from the parent session so
+	 * delegated-agent telemetry (Langfuse `sessionId`) groups with it.
+	 */
+	sessionId?: string;
 }
 
 export interface DelegatedAgentConfigProvider {
@@ -118,6 +128,8 @@ export function buildDelegatedAgentConfig(
 
 	return {
 		...options.configProvider.getConnectionConfig(),
+		distinctId: runtimeConfig.distinctId,
+		sessionId: runtimeConfig.sessionId,
 		systemPrompt,
 		tools: options.tools,
 		maxIterations: options.maxIterations ?? runtimeConfig.maxIterations,

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
@@ -13,6 +13,7 @@ import type {
 	ITelemetryService,
 } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
+import { version as clineCoreVersion } from "../../../package.json";
 import {
 	buildMessageModelInfo,
 	buildModelOptions,
@@ -190,6 +191,32 @@ describe("createAgentRuntimeConfig", () => {
 		expect(runtimeConfig.consumePendingUserMessage).toBe(
 			agentConfig.consumePendingUserMessage,
 		);
+	});
+
+	it("maps telemetry identity fields from AgentConfig", () => {
+		const runtimeConfig = createAgentRuntimeConfig({
+			agentConfig: makeAgentConfig({
+				distinctId: "user-123",
+				extensionContext: {
+					client: { name: "cline-cli", version: "3.0.38" },
+				},
+			}),
+			agentId: "a",
+			model: nullModel,
+		});
+		expect(runtimeConfig.distinctId).toBe("user-123");
+		expect(runtimeConfig.clientName).toBe("cline-cli");
+		expect(runtimeConfig.clientVersion).toBe("3.0.38");
+		expect(runtimeConfig.clineCoreVersion).toBe(clineCoreVersion);
+	});
+
+	it("falls back to AgentConfig.sessionId when the input has none", () => {
+		const runtimeConfig = createAgentRuntimeConfig({
+			agentConfig: makeAgentConfig({ sessionId: "sess-parent" }),
+			agentId: "a",
+			model: nullModel,
+		});
+		expect(runtimeConfig.sessionId).toBe("sess-parent");
 	});
 
 	it("uses the override systemPrompt when provided", () => {

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
@@ -25,6 +25,7 @@ import type {
 	BasicLogger,
 	ITelemetryService,
 } from "@cline/shared";
+import { version as clineCoreVersion } from "../../../package.json";
 
 /**
  * Inputs required to assemble an `AgentRuntimeConfig`. Distinct from
@@ -97,6 +98,9 @@ export function createAgentRuntimeConfig(
 
 	const config: AgentRuntimeConfig = {
 		distinctId: agentConfig.distinctId,
+		clientName: agentConfig.extensionContext?.client?.name,
+		clientVersion: agentConfig.extensionContext?.client?.version,
+		clineCoreVersion,
 		sessionId: input.sessionId ?? agentConfig.sessionId,
 		agentId: input.agentId,
 		conversationId: input.conversationId,

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
@@ -96,6 +96,7 @@ export function createAgentRuntimeConfig(
 	const toolExecution = resolveToolExecution(agentConfig.maxParallelToolCalls);
 
 	const config: AgentRuntimeConfig = {
+		distinctId: agentConfig.distinctId,
 		sessionId: input.sessionId ?? agentConfig.sessionId,
 		agentId: input.agentId,
 		conversationId: input.conversationId,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -614,6 +614,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		if (!resumedArtifacts) manifest.metadata = initialSessionMetadata;
 		const runtime = await this.runtimeBuilder.build({
 			...bootstrap.runtimeBuilderInput,
+			distinctId: this.distinctId,
 			runCommandExecutionController: this.runCommandExecutionController,
 		});
 		const configWithProvider = bootstrap.config;

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -264,6 +264,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 	private readonly providerSettingsManager: ProviderSettingsManager;
 	private readonly oauthTokenManager: RuntimeOAuthTokenManager;
 	private readonly defaultTelemetry?: ITelemetryService;
+	private readonly distinctId: string;
 	private readonly defaultLogger?: BasicLogger;
 	private readonly defaultFetch?: typeof fetch;
 	private readonly events = new RuntimeHostEventBus();
@@ -286,6 +287,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		const homeDir = homedir();
 		if (homeDir) setHomeDirIfUnset(homeDir);
 		const distinctId = resolveCoreDistinctId(options.distinctId);
+		this.distinctId = distinctId;
 		this.sessionService = options.sessionService;
 		this.runtimeBuilder = options.runtimeBuilder ?? new DefaultRuntimeBuilder();
 		this.createAgentInstance =
@@ -712,6 +714,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		});
 
 		const agentConfig = {
+			distinctId: this.distinctId,
 			sessionId,
 			providerId: providerConfig.providerId,
 			modelId: providerConfig.modelId,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -539,6 +539,8 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 		const delegatedAgentConfigProvider = createDelegatedAgentConfigProvider({
 			providerId: config.providerId,
 			modelId: config.modelId,
+			distinctId: input.distinctId,
+			sessionId: config.sessionId,
 			cwd: config.cwd,
 			apiKey: config.apiKey ?? "",
 			baseUrl: config.baseUrl,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
@@ -56,6 +56,11 @@ export interface BuiltRuntime {
 
 export interface RuntimeBuilderInput {
 	config: CoreSessionConfig;
+	/**
+	 * Host-resolved stable end-user identity, forwarded so delegated agents
+	 * (sub-agents / teammates) emit the same telemetry `userId` as the lead.
+	 */
+	distinctId?: string;
 	hooks?: AgentHooks;
 	extensions?: AgentConfig["extensions"];
 	onTeamEvent?: (event: TeamEvent) => void;

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -474,6 +474,82 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 	});
 
+	it("rebuilds extensionContext.client from hub-baked request headers", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+		};
+		config.headers = {
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "3.0.38",
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			sessionId: "sess-hub-client",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.config.extensionContext?.client).toEqual({
+			name: "cline-cli",
+			version: "3.0.38",
+		});
+		expect(bootstrap.providerConfig.headers).toMatchObject({
+			"User-Agent": "Cline/3.0.38",
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "3.0.38",
+		});
+	});
+
+	it("prefers configured extensionContext.client over header-derived identity", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+		};
+		config.headers = {
+			"X-CLIENT-TYPE": "header-client",
+			"X-CLIENT-VERSION": "0.0.1",
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			localRuntime: {
+				extensionContext: {
+					client: { name: "cline-vscode", version: "9.9.9" },
+				},
+			},
+			sessionId: "sess-local-client",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.config.extensionContext?.client).toEqual({
+			name: "cline-vscode",
+			version: "9.9.9",
+		});
+	});
+
 	it("uses host request headers for Cline providers on core sessions", async () => {
 		const { prepareLocalRuntimeBootstrap } = await import(
 			"./local-runtime-bootstrap"

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -5,6 +5,7 @@ import type {
 	AgentHooks,
 	AgentTool,
 	BasicLogger,
+	ClientContext,
 	ExtensionContext,
 	ITelemetryService,
 	RuntimeConfigExtensionKind,
@@ -91,6 +92,25 @@ function logPluginDiagnostics(
 			},
 		);
 	}
+}
+
+/**
+ * Recover client identity from the Cline request headers baked into the
+ * session config. Hub-backed sessions do not transport `extensionContext`
+ * (it is local-only), but the hub client resolves `X-CLIENT-TYPE` /
+ * `X-CLIENT-VERSION` headers before `session.create`, so the daemon can
+ * rebuild `extensionContext.client` from them and keep trace metadata
+ * (Langfuse `clientName` / `clientVersion`) consistent with local runtimes.
+ */
+function resolveClientContextFromHeaders(
+	headers: Record<string, string> | undefined,
+): ClientContext | undefined {
+	const name = headers?.["X-CLIENT-TYPE"]?.trim();
+	if (!name) {
+		return undefined;
+	}
+	const version = headers?.["X-CLIENT-VERSION"]?.trim();
+	return { name, ...(version ? { version } : {}) };
 }
 
 function resolveReasoningSettings(
@@ -287,8 +307,12 @@ export async function prepareLocalRuntimeBootstrap(
 		initError,
 	} = await buildWorkspaceMetadataWithInfo(workspacePath);
 	const configuredExtensionContext = localConfig?.extensionContext;
+	const headerClientContext = configuredExtensionContext?.client
+		? undefined
+		: resolveClientContextFromHeaders(input.config.headers);
 	const extensionContext: ExtensionContext = {
 		...(configuredExtensionContext ?? {}),
+		...(headerClientContext ? { client: headerClientContext } : {}),
 		workspace: {
 			...workspaceInfo,
 			...(configuredExtensionContext?.workspace ?? {}),

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -64,6 +64,7 @@
 		"@aws-sdk/credential-providers": "^3.922.0",
 		"@cline/shared": "workspace:*",
 		"@jerome-benoit/sap-ai-provider": "4.8.0",
+		"@langfuse/core": "5.10.1",
 		"@langfuse/otel": "5.10.1",
 		"@langfuse/vercel-ai-sdk": "5.9.1",
 		"@openrouter/ai-sdk-provider": "^3",

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -669,6 +669,15 @@ function buildAiSdkRuntimeContext(
 		...(typeof metadata.sessionId === "string"
 			? { sessionId: metadata.sessionId }
 			: {}),
+		...(typeof metadata.clientName === "string"
+			? { clientName: metadata.clientName }
+			: {}),
+		...(typeof metadata.clientVersion === "string"
+			? { clientVersion: metadata.clientVersion }
+			: {}),
+		...(typeof metadata.clineCoreVersion === "string"
+			? { clineCoreVersion: metadata.clineCoreVersion }
+			: {}),
 		...(tags && tags.length > 0 ? { tags } : {}),
 		// Keep Cline correlation fields available even when the integration
 		// does not promote them to first-class Langfuse fields.
@@ -2218,6 +2227,9 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 									distinctId: true,
 									userId: true,
 									sessionId: true,
+									clientName: true,
+									clientVersion: true,
+									clineCoreVersion: true,
 									tags: true,
 									conversationId: true,
 									runId: true,

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -599,6 +599,50 @@ async function ensureGatewayLangfuseTelemetry(
 	}
 }
 
+async function withAiSdkLangfuseTraceContext<T>(
+	enabled: boolean,
+	request: GatewayStreamRequest,
+	callback: () => T | Promise<T>,
+): Promise<T> {
+	const metadata =
+		request.metadata && typeof request.metadata === "object"
+			? request.metadata
+			: {};
+	const tags = Array.isArray(metadata.tags)
+		? metadata.tags.filter(
+				(value): value is string =>
+					typeof value === "string" && value.trim().length > 0,
+			)
+		: undefined;
+	const distinctId =
+		typeof metadata.distinctId === "string" ? metadata.distinctId : undefined;
+	const sessionId =
+		typeof metadata.sessionId === "string" ? metadata.sessionId : undefined;
+
+	if (!enabled || (!distinctId && !sessionId && !tags?.length)) {
+		return await callback();
+	}
+
+	const runtime = await import("../services/langfuse-telemetry");
+	return await runtime.withLangfuseTraceAttributes(
+		true,
+		{
+			...(distinctId ? { userId: distinctId } : {}),
+			...(sessionId ? { sessionId } : {}),
+			...(tags?.length ? { tags } : {}),
+			metadata: {
+				...(typeof metadata.conversationId === "string"
+					? { conversationId: metadata.conversationId }
+					: {}),
+				...(typeof metadata.runId === "string"
+					? { runId: metadata.runId }
+					: {}),
+			},
+		},
+		callback,
+	);
+}
+
 function buildAiSdkRuntimeContext(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
@@ -2152,71 +2196,76 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 						...(portableReasoning ? { reasoning: portableReasoning } : {}),
 					},
 				});
-				stream = streamText({
-					model: withEmptyResponseRetry(
-						provider.operations.language(context.model.id),
-						provider.retryEmptyResponses,
-						context.logger,
-					) as never,
-					messages: messages as never,
-					...(useSystemOption ? { system: systemPrompt } : {}),
-					...(tools ? { tools } : {}),
-					abortSignal: request.signal,
-					experimental_repairToolCall: repairMalformedToolCall as never,
-						experimental_telemetry: {
-						isEnabled: langfuse,
-						functionId: "cline-agent-turn",
-						includeRuntimeContext: {
-							distinctId: true,
-							userId: true,
-							sessionId: true,
-							tags: true,
-							conversationId: true,
-							runId: true,
-							iteration: true,
-							providerId: true,
-							modelId: true,
-							resolvedModelId: true,
-						},
-					},
-					runtimeContext: buildAiSdkRuntimeContext(request, context),
-					providerOptions: providerOptions as never,
-					...(provider.executesModelTools && activeModelTools.length
-						? { stopWhen: stepCountIs(8) }
-						: {}),
-					...requestConfig,
-					...(portableReasoning ? { reasoning: portableReasoning } : {}),
-					onError: ({ error: streamError }) => {
-						const captured = captureStreamError(streamError);
-						const msg = captured.message;
-						capturedError.current = captured;
-						if (log?.error) {
-							log.error("[ai-sdk] stream error", {
-								providerId: request.providerId,
-								error: streamError,
-								severity: "error",
-							});
-						} else if (log) {
-							log.log(`[ai-sdk] stream error: ${msg}`, {
-								providerId: request.providerId,
-								severity: "error",
-							});
-						}
-						captured.reported = captureSdkError(context.telemetry, {
-							component: "llms",
-							operation: "provider.stream",
-							error: streamError,
-							errorMessage: msg,
-							severity: "error",
-							handled: true,
-							context: {
-								providerId: request.providerId,
-								modelId: request.modelId,
-								providerKind: kind,
+				stream = await withAiSdkLangfuseTraceContext(
+					langfuse,
+					request,
+					() =>
+						streamText({
+							model: withEmptyResponseRetry(
+								provider.operations.language(context.model.id),
+								provider.retryEmptyResponses,
+								context.logger,
+							) as never,
+							messages: messages as never,
+							...(useSystemOption ? { system: systemPrompt } : {}),
+							...(tools ? { tools } : {}),
+							abortSignal: request.signal,
+							experimental_repairToolCall: repairMalformedToolCall as never,
+							experimental_telemetry: {
+								isEnabled: langfuse,
+								functionId: "cline-agent-turn",
+								includeRuntimeContext: {
+									distinctId: true,
+									userId: true,
+									sessionId: true,
+									tags: true,
+									conversationId: true,
+									runId: true,
+									iteration: true,
+									providerId: true,
+									modelId: true,
+									resolvedModelId: true,
+								},
 							},
-						});
-					},
-				}) as unknown as AiSdkStreamResult;
+							runtimeContext: buildAiSdkRuntimeContext(request, context),
+							providerOptions: providerOptions as never,
+							...(provider.executesModelTools && activeModelTools.length
+								? { stopWhen: stepCountIs(8) }
+								: {}),
+							...requestConfig,
+							...(portableReasoning ? { reasoning: portableReasoning } : {}),
+							onError: ({ error: streamError }) => {
+								const captured = captureStreamError(streamError);
+								const msg = captured.message;
+								capturedError.current = captured;
+								if (log?.error) {
+									log.error("[ai-sdk] stream error", {
+										providerId: request.providerId,
+										error: streamError,
+										severity: "error",
+									});
+								} else if (log) {
+									log.log(`[ai-sdk] stream error: ${msg}`, {
+										providerId: request.providerId,
+										severity: "error",
+									});
+								}
+								captured.reported = captureSdkError(context.telemetry, {
+									component: "llms",
+									operation: "provider.stream",
+									error: streamError,
+									errorMessage: msg,
+									severity: "error",
+									handled: true,
+									context: {
+										providerId: request.providerId,
+										modelId: request.modelId,
+										providerKind: kind,
+									},
+								});
+							},
+						}) as unknown as AiSdkStreamResult,
+				);
 
 				// Suppress dangling promise rejections (finishReason, totalUsage, steps, etc.)
 				// BEFORE iterating. The AI SDK rejects these DelayedPromises inside the stream's

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -11,6 +11,32 @@ type LangfuseTelemetryConfig = {
 	secretKey: string;
 };
 
+export type LangfuseTraceAttributes = {
+	userId?: string;
+	sessionId?: string;
+	tags?: string[];
+	metadata?: Record<string, string>;
+	traceName?: string;
+};
+
+/**
+ * Set Langfuse trace-level attributes for the duration of an SDK operation.
+ * Runtime context is useful observation metadata, but Langfuse's Sessions and
+ * Users views are indexed from propagated trace attributes instead.
+ */
+export async function withLangfuseTraceAttributes<T>(
+	enabled: boolean,
+	attributes: LangfuseTraceAttributes,
+	callback: () => T | Promise<T>,
+): Promise<T> {
+	if (!enabled) {
+		return await callback();
+	}
+
+	const { propagateAttributes } = await import("@langfuse/core");
+	return await propagateAttributes(attributes, callback);
+}
+
 const LANGFUSE_DEBUG_ENV = "CLINE_DEBUG_LANGFUSE";
 
 let langfuseTelemetryReady: boolean | undefined;

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -481,6 +481,12 @@ export interface AgentRuntimeConfig {
 	 * This is intentionally separate from the host-owned session id.
 	 */
 	distinctId?: string;
+	/** Calling client surface, for example `cline-vscode` or `cline-sdk`. */
+	clientName?: string;
+	/** Calling client version, such as the VS Code extension version. */
+	clientVersion?: string;
+	/** Version of the Cline Core SDK executing the runtime. */
+	clineCoreVersion?: string;
 	/**
 	 * Core/hub runtime session identifier.
 	 *

--- a/sdk/packages/shared/src/agents/types.ts
+++ b/sdk/packages/shared/src/agents/types.ts
@@ -684,6 +684,8 @@ export const AgentResultSchema = z.object({
  * Configuration for creating an Agent
  */
 export interface AgentConfig {
+	/** Stable end-user identity used for provider and observability metadata. */
+	distinctId?: string;
 	/**
 	 * Core/hub runtime session identifier.
 	 *
@@ -911,6 +913,7 @@ export interface AgentConfig {
 }
 
 export const AgentConfigSchema = z.object({
+	distinctId: z.string().optional(),
 	sessionId: z.string().optional(),
 	// Provider Settings
 	providerId: z.string(),


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Langfuse was receiving `sessionId` and user identity as ordinary AI SDK observation metadata, so the Langfuse Sessions and Users views could not reliably associate traces.

This change:

- Propagates Langfuse trace-level `sessionId`, `userId`, tags, and metadata around AI SDK calls.
- Carries the resolved Cline `distinctId` from `LocalRuntimeHost` through `AgentConfig` into `AgentRuntimeConfig`.
- Adds the direct Langfuse core dependency required for trace attribute propagation.

### Test Procedure

- `bun run build:sdk` passed before moving the changes into the main-based worktree.
- Langfuse telemetry tests passed: 3/3.
- Runtime config tests passed: 14/14.
- `git diff --check` and Biome checks passed.
- The new worktree’s full dependency install could not resolve the existing `ollama-ai-provider-v2` package link, so the full build was not repeatable there.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is an SDK telemetry change.

### Additional Notes

New traces must be generated after deployment for Langfuse to populate Sessions and Users. Existing traces are not retroactively updated.
