### PR TITLE
fix(core): address Langfuse review feedback — hub client identity + delegated agent session grouping

### DIFF
--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildDelegatedAgentConfig,
+	createDelegatedAgentConfigProvider,
+} from "./delegated-agent";
+
+describe("buildDelegatedAgentConfig", () => {
+	it("inherits the parent distinctId and sessionId for telemetry grouping", () => {
+		const configProvider = createDelegatedAgentConfigProvider({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-5",
+			distinctId: "user-123",
+			sessionId: "sess-parent",
+		});
+
+		const config = buildDelegatedAgentConfig({
+			kind: "subagent",
+			prompt: "review the diff",
+			tools: [],
+			configProvider,
+			parentAgentId: "agent-lead",
+		});
+
+		expect(config.distinctId).toBe("user-123");
+		expect(config.sessionId).toBe("sess-parent");
+		expect(config.parentAgentId).toBe("agent-lead");
+	});
+
+	it("leaves identity fields undefined when the parent has none", () => {
+		const configProvider = createDelegatedAgentConfigProvider({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-5",
+		});
+
+		const config = buildDelegatedAgentConfig({
+			kind: "subagent",
+			prompt: "review the diff",
+			tools: [],
+			configProvider,
+		});
+
+		expect(config.distinctId).toBeUndefined();
+		expect(config.sessionId).toBeUndefined();
+	});
+});

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -46,6 +46,16 @@ export interface DelegatedAgentRuntimeConfig
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
 	workspaceMetadata?: string;
+	/**
+	 * Stable end-user identity inherited from the parent session so
+	 * delegated-agent telemetry (Langfuse `userId`) groups with the user.
+	 */
+	distinctId?: string;
+	/**
+	 * Root core session id inherited from the parent session so
+	 * delegated-agent telemetry (Langfuse `sessionId`) groups with it.
+	 */
+	sessionId?: string;
 }
 
 export interface DelegatedAgentConfigProvider {
@@ -118,6 +128,8 @@ export function buildDelegatedAgentConfig(
 
 	return {
 		...options.configProvider.getConnectionConfig(),
+		distinctId: runtimeConfig.distinctId,
+		sessionId: runtimeConfig.sessionId,
 		systemPrompt,
 		tools: options.tools,
 		maxIterations: options.maxIterations ?? runtimeConfig.maxIterations,

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
@@ -13,6 +13,7 @@ import type {
 	ITelemetryService,
 } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
+import { version as clineCoreVersion } from "../../../package.json";
 import {
 	buildMessageModelInfo,
 	buildModelOptions,
@@ -190,6 +191,32 @@ describe("createAgentRuntimeConfig", () => {
 		expect(runtimeConfig.consumePendingUserMessage).toBe(
 			agentConfig.consumePendingUserMessage,
 		);
+	});
+
+	it("maps telemetry identity fields from AgentConfig", () => {
+		const runtimeConfig = createAgentRuntimeConfig({
+			agentConfig: makeAgentConfig({
+				distinctId: "user-123",
+				extensionContext: {
+					client: { name: "cline-cli", version: "3.0.38" },
+				},
+			}),
+			agentId: "a",
+			model: nullModel,
+		});
+		expect(runtimeConfig.distinctId).toBe("user-123");
+		expect(runtimeConfig.clientName).toBe("cline-cli");
+		expect(runtimeConfig.clientVersion).toBe("3.0.38");
+		expect(runtimeConfig.clineCoreVersion).toBe(clineCoreVersion);
+	});
+
+	it("falls back to AgentConfig.sessionId when the input has none", () => {
+		const runtimeConfig = createAgentRuntimeConfig({
+			agentConfig: makeAgentConfig({ sessionId: "sess-parent" }),
+			agentId: "a",
+			model: nullModel,
+		});
+		expect(runtimeConfig.sessionId).toBe("sess-parent");
 	});
 
 	it("uses the override systemPrompt when provided", () => {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -614,6 +614,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		if (!resumedArtifacts) manifest.metadata = initialSessionMetadata;
 		const runtime = await this.runtimeBuilder.build({
 			...bootstrap.runtimeBuilderInput,
+			distinctId: this.distinctId,
 			runCommandExecutionController: this.runCommandExecutionController,
 		});
 		const configWithProvider = bootstrap.config;

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -539,6 +539,8 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 		const delegatedAgentConfigProvider = createDelegatedAgentConfigProvider({
 			providerId: config.providerId,
 			modelId: config.modelId,
+			distinctId: input.distinctId,
+			sessionId: config.sessionId,
 			cwd: config.cwd,
 			apiKey: config.apiKey ?? "",
 			baseUrl: config.baseUrl,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime.ts
@@ -56,6 +56,11 @@ export interface BuiltRuntime {
 
 export interface RuntimeBuilderInput {
 	config: CoreSessionConfig;
+	/**
+	 * Host-resolved stable end-user identity, forwarded so delegated agents
+	 * (sub-agents / teammates) emit the same telemetry `userId` as the lead.
+	 */
+	distinctId?: string;
 	hooks?: AgentHooks;
 	extensions?: AgentConfig["extensions"];
 	onTeamEvent?: (event: TeamEvent) => void;

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -474,6 +474,82 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 	});
 
+	it("rebuilds extensionContext.client from hub-baked request headers", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+		};
+		config.headers = {
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "3.0.38",
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			sessionId: "sess-hub-client",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.config.extensionContext?.client).toEqual({
+			name: "cline-cli",
+			version: "3.0.38",
+		});
+		expect(bootstrap.providerConfig.headers).toMatchObject({
+			"User-Agent": "Cline/3.0.38",
+			"X-CLIENT-TYPE": "cline-cli",
+			"X-CLIENT-VERSION": "3.0.38",
+		});
+	});
+
+	it("prefers configured extensionContext.client over header-derived identity", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+
+		const input = createStartInput();
+		const config = input.config as typeof input.config & {
+			headers: Record<string, string>;
+		};
+		config.headers = {
+			"X-CLIENT-TYPE": "header-client",
+			"X-CLIENT-VERSION": "0.0.1",
+		};
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			localRuntime: {
+				extensionContext: {
+					client: { name: "cline-vscode", version: "9.9.9" },
+				},
+			},
+			sessionId: "sess-local-client",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.config.extensionContext?.client).toEqual({
+			name: "cline-vscode",
+			version: "9.9.9",
+		});
+	});
+
 	it("uses host request headers for Cline providers on core sessions", async () => {
 		const { prepareLocalRuntimeBootstrap } = await import(
 			"./local-runtime-bootstrap"

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -5,6 +5,7 @@ import type {
 	AgentHooks,
 	AgentTool,
 	BasicLogger,
+	ClientContext,
 	ExtensionContext,
 	ITelemetryService,
 	RuntimeConfigExtensionKind,
@@ -91,6 +92,25 @@ function logPluginDiagnostics(
 			},
 		);
 	}
+}
+
+/**
+ * Recover client identity from the Cline request headers baked into the
+ * session config. Hub-backed sessions do not transport `extensionContext`
+ * (it is local-only), but the hub client resolves `X-CLIENT-TYPE` /
+ * `X-CLIENT-VERSION` headers before `session.create`, so the daemon can
+ * rebuild `extensionContext.client` from them and keep trace metadata
+ * (Langfuse `clientName` / `clientVersion`) consistent with local runtimes.
+ */
+function resolveClientContextFromHeaders(
+	headers: Record<string, string> | undefined,
+): ClientContext | undefined {
+	const name = headers?.["X-CLIENT-TYPE"]?.trim();
+	if (!name) {
+		return undefined;
+	}
+	const version = headers?.["X-CLIENT-VERSION"]?.trim();
+	return { name, ...(version ? { version } : {}) };
 }
 
 function resolveReasoningSettings(
@@ -287,8 +307,12 @@ export async function prepareLocalRuntimeBootstrap(
 		initError,
 	} = await buildWorkspaceMetadataWithInfo(workspacePath);
 	const configuredExtensionContext = localConfig?.extensionContext;
+	const headerClientContext = configuredExtensionContext?.client
+		? undefined
+		: resolveClientContextFromHeaders(input.config.headers);
 	const extensionContext: ExtensionContext = {
 		...(configuredExtensionContext ?? {}),
+		...(headerClientContext ? { client: headerClientContext } : {}),
 		workspace: {
 			...workspaceInfo,
 			...(configuredExtensionContext?.workspace ?? {}),


### PR DESCRIPTION
### Related Issue

Addresses johnwschoi's two unresolved review comments on #13473 (`sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts` lines 100–101).

### Description

**1. Hub-backed traces omitted `clientName` / `clientVersion` ([comment](https://github.com/cline/cline/pull/13473#discussion_r3834045819))**

`extensionContext` is a local-only session config key, so it is stripped before `session.create` reaches the hub daemon. The daemon's `LocalRuntimeHost` then built the lead `AgentConfig` with no `extensionContext.client`, and `createAgentRuntimeConfig` produced traces without `clientName` / `clientVersion` — even though `HubRuntimeHost.buildCommandSessionConfig` bakes the client identity into the session's `X-CLIENT-TYPE` / `X-CLIENT-VERSION` provider headers.

Fix: `prepareLocalRuntimeBootstrap` now reconstructs `extensionContext.client` from those baked headers when the host did not supply one (`resolveClientContextFromHeaders`). This threads `clientName` / `clientVersion` into hub-backed traces through the exact same `extensionContext.client` path local runtimes use, and — as a side effect of the same gap — stops the daemon's header re-resolution from clobbering the original `X-CLIENT-TYPE` with a generic `cline-<source>` (mirroring the existing `versionHeaderFallback` semantics for `X-CLIENT-VERSION`).

**2. Delegated-agent traces lacked Langfuse `userId` / `sessionId` ([comment](https://github.com/cline/cline/pull/13473#discussion_r3834045820))**

`buildDelegatedAgentConfig` never set `distinctId` or `sessionId`, so sub-agents, configured agents, and teammates produced traces that did not group with the parent user or session.

Fix: the host-resolved `distinctId` is threaded through a new `RuntimeBuilderInput.distinctId`, the root `sessionId` comes from `CoreSessionConfig`, both are stored on `DelegatedAgentRuntimeConfig`, and `buildDelegatedAgentConfig` copies them onto the delegated `AgentConfig`. From there the existing `createAgentRuntimeConfig` fallback (`input.sessionId ?? agentConfig.sessionId`) and `distinctId` mapping put them on the runtime config, so `AgentRuntime` stamps them into model-request metadata and `withAiSdkLangfuseTraceContext` propagates them as Langfuse `userId` / `sessionId`. Configured-agent providers spread the base runtime config, so they inherit both fields.

### Test Procedure

- New tests: `local-runtime-bootstrap.test.ts` (client identity rebuilt from hub-baked headers; configured `extensionContext.client` still wins), `delegated-agent.test.ts` (delegated config inherits parent `distinctId`/`sessionId`; stays undefined when absent), `agent-runtime-config-builder.test.ts` (telemetry identity field mapping incl. `clineCoreVersion`; `AgentConfig.sessionId` fallback).
- Full `@cline/core` unit suite: 2026 passed, 14 skipped, 1 failed — the failure is the documented cloud-VM git `insteadOf` environment artifact in `workspace-manifest.test.ts`, unrelated to this change.
- `bun run types` passes for all SDK packages; changed files are Biome-clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Behavior note: for local (non-hub) sessions on Cline billing providers, an explicitly configured `X-CLIENT-TYPE` header now also survives header re-resolution instead of being overwritten by the generic `cline-<source>` fallback — consistent with how a configured `X-CLIENT-VERSION` already behaved.