### PR TITLE
fix(core): thread client identity to hub sessions on all providers and delegated agents

### DIFF
--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.test.ts
@@ -26,6 +26,28 @@ describe("buildDelegatedAgentConfig", () => {
 		expect(config.parentAgentId).toBe("agent-lead");
 	});
 
+	it("preserves the parent client context for trace metadata", () => {
+		const configProvider = createDelegatedAgentConfigProvider({
+			providerId: "anthropic",
+			modelId: "claude-sonnet-4-5",
+			extensionContext: {
+				client: { name: "cline-cli", version: "3.0.38" },
+			},
+		});
+
+		const config = buildDelegatedAgentConfig({
+			kind: "teammate",
+			prompt: "review the diff",
+			tools: [],
+			configProvider,
+		});
+
+		expect(config.extensionContext?.client).toEqual({
+			name: "cline-cli",
+			version: "3.0.38",
+		});
+	});
+
 	it("leaves identity fields undefined when the parent has none", () => {
 		const configProvider = createDelegatedAgentConfigProvider({
 			providerId: "anthropic",

--- a/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
+++ b/sdk/packages/core/src/extensions/tools/team/delegated-agent.ts
@@ -56,6 +56,11 @@ export interface DelegatedAgentRuntimeConfig
 	 * delegated-agent telemetry (Langfuse `sessionId`) groups with it.
 	 */
 	sessionId?: string;
+	/**
+	 * Parent client identity (`extensionContext.client`) so delegated-agent
+	 * traces keep the `clientName` / `clientVersion` metadata.
+	 */
+	extensionContext?: AgentConfig["extensionContext"];
 }
 
 export interface DelegatedAgentConfigProvider {
@@ -130,6 +135,7 @@ export function buildDelegatedAgentConfig(
 		...options.configProvider.getConnectionConfig(),
 		distinctId: runtimeConfig.distinctId,
 		sessionId: runtimeConfig.sessionId,
+		extensionContext: runtimeConfig.extensionContext,
 		systemPrompt,
 		tools: options.tools,
 		maxIterations: options.maxIterations ?? runtimeConfig.maxIterations,

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
@@ -151,7 +151,9 @@ describe("HubRuntimeHost", () => {
 					version: "3.0.38",
 				},
 			}),
-			runtimeOptions: {},
+			runtimeOptions: {
+				client: { name: "cline-cli", version: "3.0.38" },
+			},
 			toolPolicies: undefined,
 			initialMessages: undefined,
 		});

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -163,6 +163,35 @@ function buildCommandSessionConfig(
 	return sessionConfig;
 }
 
+/**
+ * Serializable client identity forwarded to the hub daemon via
+ * `runtimeOptions.client`. `extensionContext` itself is local-only (it holds
+ * live logger/telemetry objects), so the plain-data client descriptor is
+ * transported separately; the daemon rebuilds `extensionContext.client` from
+ * it so traces carry `clientName` / `clientVersion` for every provider —
+ * not only the Cline billing providers that bake `X-CLIENT-*` headers.
+ */
+function buildRuntimeOptionsClientContext(
+	input: StartSessionInput,
+): Record<string, JsonValue> | undefined {
+	const client = input.localRuntime?.extensionContext?.client;
+	const name = client?.name?.trim();
+	if (!name) {
+		return undefined;
+	}
+	return {
+		name,
+		...(client?.version ? { version: client.version } : {}),
+		...(client?.platform ? { platform: client.platform } : {}),
+		...(client?.platformVersion
+			? { platformVersion: client.platformVersion }
+			: {}),
+		...(client?.isMultiRoot !== undefined
+			? { isMultiRoot: client.isMultiRoot }
+			: {}),
+	};
+}
+
 function buildSessionHistoryMetadata(
 	input: StartSessionInput,
 ): Record<string, unknown> {
@@ -870,6 +899,7 @@ export class HubRuntimeHost implements RuntimeHost {
 		);
 		const plannedSessionId =
 			input.config.sessionId?.trim() || createSessionId();
+		const runtimeOptionsClient = buildRuntimeOptionsClientContext(input);
 		const sendCreateCommand = () =>
 			this.client.command("session.create", {
 				workspaceRoot: input.config.workspaceRoot?.trim() || input.config.cwd,
@@ -885,6 +915,7 @@ export class HubRuntimeHost implements RuntimeHost {
 					...(input.localRuntime?.configExtensions
 						? { configExtensions: input.localRuntime.configExtensions }
 						: {}),
+					...(runtimeOptionsClient ? { client: runtimeOptionsClient } : {}),
 				},
 				toolPolicies: toJsonRecord(
 					input.toolPolicies as Record<string, unknown> | undefined,
@@ -980,6 +1011,9 @@ export class HubRuntimeHost implements RuntimeHost {
 				};
 		let plannedSessionId: string | undefined;
 		let startSessionConfig: Record<string, unknown> | undefined;
+		const restoreRuntimeOptionsClient = startConfig
+			? buildRuntimeOptionsClientContext(startConfig)
+			: undefined;
 		if (startConfig) {
 			plannedSessionId =
 				startConfig.config.sessionId?.trim() || createSessionId();
@@ -1023,6 +1057,9 @@ export class HubRuntimeHost implements RuntimeHost {
 												configExtensions:
 													startConfig.localRuntime.configExtensions,
 											}
+										: {}),
+									...(restoreRuntimeOptionsClient
+										? { client: restoreRuntimeOptionsClient }
 										: {}),
 								},
 								toolPolicies: toJsonRecord(

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	parseRuntimeOptionsClientContext,
 	readSessionConnectionUpdate,
 	resolveSessionAutoApproveTools,
 	selectSessionTools,
@@ -60,6 +61,38 @@ describe("readSessionConnectionUpdate", () => {
 		expect(updates.reasoningEffort).toBeUndefined();
 		expect(Object.hasOwn(updates, "thinkingBudgetTokens")).toBe(true);
 		expect(updates.thinkingBudgetTokens).toBeUndefined();
+	});
+});
+
+describe("parseRuntimeOptionsClientContext", () => {
+	it("rebuilds the client context from runtimeOptions.client", () => {
+		expect(
+			parseRuntimeOptionsClientContext({
+				name: "cline-cli",
+				version: "3.0.38",
+				platform: "cli",
+				platformVersion: "3.0.38",
+				isMultiRoot: false,
+			}),
+		).toEqual({
+			name: "cline-cli",
+			version: "3.0.38",
+			platform: "cli",
+			platformVersion: "3.0.38",
+			isMultiRoot: false,
+		});
+	});
+
+	it("drops non-string optional fields and requires a name", () => {
+		expect(
+			parseRuntimeOptionsClientContext({ name: "cline-cli", version: 42 }),
+		).toEqual({ name: "cline-cli" });
+		expect(parseRuntimeOptionsClientContext({ version: "1.0.0" })).toBe(
+			undefined,
+		);
+		expect(parseRuntimeOptionsClientContext({ name: "   " })).toBe(undefined);
+		expect(parseRuntimeOptionsClientContext(undefined)).toBe(undefined);
+		expect(parseRuntimeOptionsClientContext("cline-cli")).toBe(undefined);
 	});
 });
 

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -1,4 +1,5 @@
 import type {
+	ClientContext,
 	HubCommandEnvelope,
 	HubReplyEnvelope,
 	JsonValue,
@@ -56,6 +57,37 @@ export function selectSessionTools<T extends { name: string }>(
 			(mode !== "yolo" || tool.name !== TASKS_TOOL_NAME) &&
 			isCoreBuiltinToolAvailable(tool.name, clientType),
 	);
+}
+
+/**
+ * Rebuild the caller's client identity from `runtimeOptions.client`.
+ * `extensionContext` is local-only and never crosses the hub transport, so
+ * the hub client forwards this plain-data descriptor instead; it becomes
+ * `localRuntime.extensionContext.client` on the daemon so session traces
+ * carry `clientName` / `clientVersion` for every provider, on both
+ * `session.create` and `session.restore`.
+ */
+export function parseRuntimeOptionsClientContext(
+	value: unknown,
+): ClientContext | undefined {
+	const record = asPlainRecord(value);
+	const name = typeof record?.name === "string" ? record.name.trim() : "";
+	if (!name) {
+		return undefined;
+	}
+	return {
+		name,
+		...(typeof record?.version === "string" ? { version: record.version } : {}),
+		...(typeof record?.platform === "string"
+			? { platform: record.platform }
+			: {}),
+		...(typeof record?.platformVersion === "string"
+			? { platformVersion: record.platformVersion }
+			: {}),
+		...(typeof record?.isMultiRoot === "boolean"
+			? { isMultiRoot: record.isMultiRoot }
+			: {}),
+	};
 }
 
 function readConnectionString(value: unknown): string | undefined {
@@ -266,6 +298,7 @@ export async function handleSessionCreate(
 	const configExtensions = parseRuntimeConfigExtensions(
 		runtimeOptions.configExtensions,
 	);
+	const clientContext = parseRuntimeOptionsClientContext(runtimeOptions.client);
 	logHubMessage("info", "session.create.runtime_build.begin", {
 		...baseLogContext,
 		sessionId,
@@ -318,6 +351,7 @@ export async function handleSessionCreate(
 				loadPrivateOnAuth: true,
 			},
 			configExtensions,
+			...(clientContext ? { extensionContext: { client: clientContext } } : {}),
 			...clientContributionRuntime.localRuntime,
 			extensions: [
 				...(ctx.sessionExtensions ?? []),
@@ -540,6 +574,9 @@ export async function handleSessionRestore(
 		const configExtensions = parseRuntimeConfigExtensions(
 			runtimeOptions.configExtensions,
 		);
+		const clientContext = parseRuntimeOptionsClientContext(
+			runtimeOptions.client,
+		);
 		const clientContributionRuntime = createHubClientContributionRuntime({
 			sessionId,
 			targetClientId: clientId,
@@ -600,6 +637,9 @@ export async function handleSessionRestore(
 							loadPrivateOnAuth: true,
 						},
 						configExtensions,
+						...(clientContext
+							? { extensionContext: { client: clientContext } }
+							: {}),
 						...clientContributionRuntime.localRuntime,
 						extensions: [
 							...(ctx.sessionExtensions ?? []),

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -541,6 +541,12 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 			modelId: config.modelId,
 			distinctId: input.distinctId,
 			sessionId: config.sessionId,
+			// Only the client identity: the full extensionContext carries
+			// lead-session workspace/session/automation context that delegated
+			// extension setups should not inherit implicitly.
+			extensionContext: config.extensionContext?.client
+				? { client: config.extensionContext.client }
+				: undefined,
 			cwd: config.cwd,
 			apiKey: config.apiKey ?? "",
 			baseUrl: config.baseUrl,


### PR DESCRIPTION
### Related Issue

Addresses johnwschoi's two follow-up review comments on #13473 (left after the first round of fixes from #13475 was merged): [P3 on `local-runtime-bootstrap.ts`](https://github.com/cline/cline/pull/13473#discussion_r3834376755) and [nit on `delegated-agent.ts`](https://github.com/cline/cline/pull/13473#discussion_r3834376761).

Note on base: #13473 and its base branch `bee/langfuse-sessions-main` were merged into `main` (and the branches deleted) before this follow-up landed, so this PR targets `main` directly. Both commits apply on top of the merged state.

### Description

**1. Hub sessions on non-Cline providers lacked `clientName` / `clientVersion` (P3)**

The header-based reconstruction added in #13475 only works for Cline billing providers, because `resolveProviderRequestHeaders` generates the `X-CLIENT-*` headers solely for `cline` / `cline-pass`. Hub sessions on any other provider — on both `session.create` and `session.restore` — still produced traces without client identity.

Rather than injecting Cline-branded headers into third-party provider requests (the daemon passes config headers through to non-Cline providers verbatim, so header-side threading would change outbound HTTP requests to Anthropic/OpenAI/etc.), the hub client now forwards a plain-data client descriptor via `runtimeOptions.client` on both the create and restore commands (`buildRuntimeOptionsClientContext` in `hub-runtime-host.ts`). The daemon parses it (`parseRuntimeOptionsClientContext` in `session-handlers.ts`) and rebuilds `localRuntime.extensionContext.client` in both `handleSessionCreate` and `handleSessionRestore`, so the bootstrap picks it up exactly like a local runtime, for every provider. The `X-CLIENT-*` header fallback from #13475 remains for older hub clients.

**2. Delegated configs dropped the parent client context (nit)**

`buildDelegatedAgentConfig` never carried `extensionContext`, so subagent and teammate traces omitted `clientName` / `clientVersion`. `DelegatedAgentRuntimeConfig` now holds the parent client identity and copies it onto the delegated `AgentConfig`. The runtime builder threads only `extensionContext.client` — not the full lead-session context (workspace/session/automation) — to keep delegated extension setups from implicitly inheriting lead-session ambient state.

### Test Procedure

- Updated `hub-runtime-host.test.ts`: the `session.create` payload assertion now covers `runtimeOptions.client` carrying `{ name, version }`.
- New `parseRuntimeOptionsClientContext` cases in `session-handlers.test.ts` (round-trip of all fields; name required; non-string fields dropped), matching that file's exported-helper convention.
- New case in `delegated-agent.test.ts`: delegated config preserves the parent `extensionContext.client`.
- Targeted run of the five affected test files: 71 passed. Full `@cline/core` unit suite: 2029 passed, with only the AGENTS.md-documented cloud-VM git `insteadOf` environment failure (plus two git-tmpdir tests that fail only under parallel load and pass in isolation, unrelated to this change). `bun run types` passes for all SDK packages; changed files are Biome-clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)