### PR TITLE
fix(hub): address drain/upgrade review findings (un-drain on abort, drain --off, WAL, lock degrade, shared retire, replay guards)

### DIFF
--- a/apps/cli/src/commands/hub.test.ts
+++ b/apps/cli/src/commands/hub.test.ts
@@ -3,16 +3,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const {
 	mockClearHubDiscovery,
 	mockEnsureDetachedHubServer,
+	mockLocalHubHasNoActiveSessions,
 	mockProbeHubServer,
 	mockReadHubDiscovery,
+	mockRequestHubDrain,
 	mockResolveProductionHubOwnerContext,
 	mockResolveSharedHubOwnerContext,
 	mockStopLocalHubServerGracefully,
 } = vi.hoisted(() => ({
 	mockClearHubDiscovery: vi.fn(),
 	mockEnsureDetachedHubServer: vi.fn(),
+	mockLocalHubHasNoActiveSessions: vi.fn(),
 	mockProbeHubServer: vi.fn(),
 	mockReadHubDiscovery: vi.fn(),
+	mockRequestHubDrain: vi.fn(),
 	mockResolveProductionHubOwnerContext: vi.fn(() => ({
 		ownerId: "hub-production",
 		discoveryPath: "/tmp/cline-data/locks/hub/production.json",
@@ -27,8 +31,10 @@ const {
 vi.mock("@cline/core", () => ({
 	clearHubDiscovery: mockClearHubDiscovery,
 	ensureDetachedHubServer: mockEnsureDetachedHubServer,
+	localHubHasNoActiveSessions: mockLocalHubHasNoActiveSessions,
 	probeHubServer: mockProbeHubServer,
 	readHubDiscovery: mockReadHubDiscovery,
+	requestHubDrain: mockRequestHubDrain,
 	resolveProductionHubOwnerContext: mockResolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext: mockResolveSharedHubOwnerContext,
 	stopLocalHubServerGracefully: mockStopLocalHubServerGracefully,
@@ -93,6 +99,147 @@ describe("createHubCommand", () => {
 			cliVersion,
 			coreVersion: "0.0.62",
 		});
+	});
+
+	function createCommand() {
+		const output: string[] = [];
+		const errors: string[] = [];
+		let exitCode = 0;
+		const cmd = createHubCommand(
+			{
+				writeln: (text) => {
+					output.push(text ?? "");
+				},
+				writeErr: (text) => {
+					errors.push(text);
+				},
+			},
+			(code) => {
+				exitCode = code;
+			},
+		);
+		return {
+			cmd,
+			output,
+			errors,
+			exitCode: () => exitCode,
+		};
+	}
+
+	it("sends an un-drain request with drain --off", async () => {
+		mockReadHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "token",
+		});
+		mockRequestHubDrain.mockResolvedValue(true);
+
+		const { cmd, output, exitCode } = createCommand();
+		await cmd.parseAsync(["drain", "--off"], { from: "user" });
+
+		expect(exitCode()).toBe(0);
+		expect(mockRequestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"token",
+			"cline hub drain --off",
+			{ off: true },
+		);
+		expect(JSON.parse(output[0] || "")).toEqual({
+			draining: false,
+			url: "ws://127.0.0.1:25463/hub",
+		});
+	});
+
+	it("drains without the off flag by default", async () => {
+		mockReadHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "token",
+		});
+		mockRequestHubDrain.mockResolvedValue(true);
+
+		const { cmd, output, exitCode } = createCommand();
+		await cmd.parseAsync(["drain"], { from: "user" });
+
+		expect(exitCode()).toBe(0);
+		expect(mockRequestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"token",
+			"cline hub drain",
+			{ off: false },
+		);
+		expect(JSON.parse(output[0] || "")).toEqual({
+			draining: true,
+			url: "ws://127.0.0.1:25463/hub",
+		});
+	});
+
+	it("replaces an idle hub with upgrade --wait 0 instead of skipping the idle check", async () => {
+		mockReadHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "token",
+		});
+		mockRequestHubDrain.mockResolvedValue(true);
+		mockLocalHubHasNoActiveSessions.mockResolvedValue(true);
+		mockStopLocalHubServerGracefully.mockResolvedValue(true);
+		mockEnsureDetachedHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+		});
+
+		const { cmd, output, errors, exitCode } = createCommand();
+		await cmd.parseAsync(["upgrade", "--wait", "0"], { from: "user" });
+
+		expect(errors).toEqual([]);
+		expect(exitCode()).toBe(0);
+		expect(mockLocalHubHasNoActiveSessions).toHaveBeenCalled();
+		expect(mockStopLocalHubServerGracefully).toHaveBeenCalled();
+		expect(mockEnsureDetachedHubServer).toHaveBeenCalled();
+		// The drain was never lifted manually: the drained hub was replaced.
+		expect(mockRequestHubDrain).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(output[0] || "")).toEqual({
+			upgraded: true,
+			url: "ws://127.0.0.1:25463/hub",
+		});
+	});
+
+	it("un-drains the hub when upgrade aborts because sessions are still active", async () => {
+		mockReadHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "token",
+		});
+		mockRequestHubDrain.mockResolvedValue(true);
+		mockLocalHubHasNoActiveSessions.mockResolvedValue(false);
+
+		const { cmd, errors, exitCode } = createCommand();
+		await cmd.parseAsync(["upgrade", "--wait", "0"], { from: "user" });
+
+		expect(exitCode()).toBe(1);
+		expect(errors[0]).toContain("still serving sessions");
+		expect(mockStopLocalHubServerGracefully).not.toHaveBeenCalled();
+		expect(mockEnsureDetachedHubServer).not.toHaveBeenCalled();
+		expect(mockRequestHubDrain).toHaveBeenCalledTimes(2);
+		expect(mockRequestHubDrain).toHaveBeenLastCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"token",
+			"cline hub upgrade aborted",
+			{ off: true },
+		);
+	});
+
+	it("rejects a non-numeric upgrade --wait instead of treating it as an expired deadline", async () => {
+		mockReadHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "token",
+		});
+
+		const { cmd } = createCommand();
+		cmd.configureOutput({ writeErr: () => {} });
+		for (const sub of cmd.commands) {
+			sub.configureOutput({ writeErr: () => {} });
+		}
+		await expect(
+			cmd.parseAsync(["upgrade", "--wait", "soon"], { from: "user" }),
+		).rejects.toThrow("--wait requires a non-negative number of seconds.");
+		expect(mockRequestHubDrain).not.toHaveBeenCalled();
 	});
 
 	it("passes the selected owner to graceful stop", async () => {

--- a/apps/cli/src/commands/hub.ts
+++ b/apps/cli/src/commands/hub.ts
@@ -10,7 +10,7 @@ import {
 	stopLocalHubServerGracefully,
 } from "@cline/core";
 import { formatUptime, resolveClineBuildEnv } from "@cline/shared";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { version as cliVersion } from "../../package.json";
 
 interface HubCommandIo {
@@ -54,6 +54,16 @@ function resolveCliHubOwnerContext() {
 	return resolveClineBuildEnv() === "production"
 		? resolveProductionHubOwnerContext()
 		: resolveSharedHubOwnerContext();
+}
+
+function parseWaitSeconds(value: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (Number.isNaN(parsed) || parsed < 0) {
+		throw new InvalidArgumentError(
+			"--wait requires a non-negative number of seconds.",
+		);
+	}
+	return parsed;
 }
 
 export function createHubCommand(
@@ -156,8 +166,9 @@ export function createHubCommand(
 		.command("drain")
 		.description("Refuse new mutating work while accepted runs finish")
 		.option("--reason <text>", "Why the hub is draining")
+		.option("--off", "Lift the drain and accept new mutating work again")
 		.action(
-			action(async (cmdOptions: { reason?: string }) => {
+			action(async (cmdOptions: { reason?: string; off?: boolean }) => {
 				const owner = resolveCliHubOwnerContext();
 				const discovery = await readHubDiscovery(owner.discoveryPath);
 				if (!discovery?.url) {
@@ -165,15 +176,22 @@ export function createHubCommand(
 					fail();
 					return;
 				}
-				const drained = await requestHubDrain(
+				const draining = cmdOptions.off !== true;
+				const ok = await requestHubDrain(
 					discovery.url,
 					discovery.authToken,
-					cmdOptions.reason ?? "cline hub drain",
+					cmdOptions.reason ??
+						(draining ? "cline hub drain" : "cline hub drain --off"),
+					{ off: !draining },
 				);
-				io.writeln(JSON.stringify({ draining: drained, url: discovery.url }));
-				if (!drained) {
+				if (!ok) {
+					io.writeErr(
+						draining ? "Hub drain request failed." : "Hub un-drain request failed.",
+					);
 					fail();
+					return;
 				}
+				io.writeln(JSON.stringify({ draining, url: discovery.url }));
 			}),
 		);
 
@@ -185,7 +203,7 @@ export function createHubCommand(
 		.option(
 			"--wait <seconds>",
 			"How long to wait for the hub to go idle",
-			(value) => Number.parseInt(value, 10),
+			parseWaitSeconds,
 			120,
 		)
 		.action(
@@ -199,31 +217,51 @@ export function createHubCommand(
 				const owner = resolveCliHubOwnerContext();
 				const discovery = await readHubDiscovery(owner.discoveryPath);
 				if (discovery?.url) {
-					await requestHubDrain(
+					const drained = await requestHubDrain(
 						discovery.url,
 						discovery.authToken,
 						"cline hub upgrade",
 					).catch(() => false);
-					const deadline = Date.now() + cmdOptions.wait * 1_000;
-					let idle = false;
-					while (Date.now() < deadline) {
-						idle = await localHubHasNoActiveSessions(
+					// An aborted upgrade must hand the hub back: leaving it
+					// draining refuses all new mutating work until a restart.
+					const undrain = async (): Promise<void> => {
+						if (!drained) {
+							return;
+						}
+						await requestHubDrain(
 							discovery.url,
 							discovery.authToken,
-						).catch(() => true);
-						if (idle) {
-							break;
+							"cline hub upgrade aborted",
+							{ off: true },
+						).catch(() => false);
+					};
+					try {
+						const deadline = Date.now() + cmdOptions.wait * 1_000;
+						let idle = false;
+						// Check at least once so --wait 0 still observes an idle hub.
+						for (;;) {
+							idle = await localHubHasNoActiveSessions(
+								discovery.url,
+								discovery.authToken,
+							).catch(() => true);
+							if (idle || Date.now() >= deadline) {
+								break;
+							}
+							await new Promise((resolve) => setTimeout(resolve, 1_000));
 						}
-						await new Promise((resolve) => setTimeout(resolve, 1_000));
+						if (!idle) {
+							await undrain();
+							io.writeErr(
+								"Hub is still serving sessions after the wait window; not replacing it. Re-run with a longer --wait, or finish the sessions first.",
+							);
+							fail();
+							return;
+						}
+						await stopHubServer(opts.cwd);
+					} catch (error) {
+						await undrain();
+						throw error;
 					}
-					if (!idle) {
-						io.writeErr(
-							"Hub is still serving sessions after the wait window; not replacing it. Re-run with a longer --wait, or finish the sessions first.",
-						);
-						fail();
-						return;
-					}
-					await stopHubServer(opts.cwd);
 				}
 				const { url } = await ensureDetachedHubServer(opts.cwd, {
 					host: opts.host,

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -1433,3 +1433,42 @@ describe("hasActiveHubSessions", () => {
 		).toBe(false);
 	});
 });
+
+describe("requestHubDrain", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("posts /drain with the reason and no off param by default", async () => {
+		const fetchMock = vi.fn(async (_input: unknown, _init?: unknown) => ({
+			ok: true,
+		}));
+		vi.stubGlobal("fetch", fetchMock);
+		const { requestHubDrain } = await import(".");
+
+		await expect(
+			requestHubDrain("ws://127.0.0.1:25463/hub", "token", "upgrade"),
+		).resolves.toBe(true);
+		const requested = new URL(String(fetchMock.mock.calls[0]?.[0]));
+		expect(requested.pathname).toBe("/drain");
+		expect(requested.searchParams.get("reason")).toBe("upgrade");
+		expect(requested.searchParams.get("off")).toBeNull();
+	});
+
+	it("sets the off param so a drain can be lifted", async () => {
+		const fetchMock = vi.fn(async (_input: unknown, _init?: unknown) => ({
+			ok: true,
+		}));
+		vi.stubGlobal("fetch", fetchMock);
+		const { requestHubDrain } = await import(".");
+
+		await expect(
+			requestHubDrain("ws://127.0.0.1:25463/hub", "token", "upgrade aborted", {
+				off: true,
+			}),
+		).resolves.toBe(true);
+		const requested = new URL(String(fetchMock.mock.calls[0]?.[0]));
+		expect(requested.pathname).toBe("/drain");
+		expect(requested.searchParams.get("off")).toBe("1");
+	});
+});

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -1109,11 +1109,16 @@ export async function ensureCompatibleLocalHubUrl(
  * Ask a hub to stop admitting new mutating work (sessions, runs) while its
  * accepted work finishes. Best-effort: pre-drain hubs answer 404 and the
  * caller proceeds without it.
+ *
+ * Pass `{ off: true }` to lift a drain (`POST /drain?off`): an aborted
+ * upgrade must be able to hand the hub back instead of leaving it refusing
+ * work until a restart.
  */
 export async function requestHubDrain(
 	url: string,
 	authToken?: string,
 	reason?: string,
+	options?: { off?: boolean },
 ): Promise<boolean> {
 	const parsed = new URL(url);
 	const resolvedAuthToken =
@@ -1127,6 +1132,9 @@ export async function requestHubDrain(
 	parsed.hash = "";
 	if (reason) {
 		parsed.searchParams.set("reason", reason);
+	}
+	if (options?.off) {
+		parsed.searchParams.set("off", "1");
 	}
 	const response = await fetch(parsed, {
 		method: "POST",

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -406,6 +406,16 @@ describe("ensureDetachedHubServer", () => {
 				"ws://127.0.0.1:25463/hub",
 				"old-token",
 			);
+			// Retirement is drain-first: the hub refuses new work before it is
+			// asked to shut down.
+			expect(requestHubDrain).toHaveBeenCalledWith(
+				"ws://127.0.0.1:25463/hub",
+				"old-token",
+				"retired by newer install",
+			);
+			expect(requestHubDrain.mock.invocationCallOrder[0]).toBeLessThan(
+				requestHubShutdown.mock.invocationCallOrder[0] ?? 0,
+			);
 			expect(kill).not.toHaveBeenCalledWith(12345, "SIGTERM");
 			expect(clearHubDiscovery).toHaveBeenCalledWith("/tmp/hub-discovery.json");
 			expect(spawn).toHaveBeenCalledOnce();
@@ -542,6 +552,10 @@ describe("ensureDetachedHubServer", () => {
 
 			await pending;
 			expect(spawn).not.toHaveBeenCalled();
+			// The hub survived the retirement attempt, so its discovery record
+			// must not be cleared — clearing it would leave the live daemon
+			// undiscoverable.
+			expect(clearHubDiscovery).not.toHaveBeenCalled();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -196,7 +196,13 @@ async function waitForHubToRetire(
 	return false;
 }
 
-async function retireDiscoveredHub(
+/**
+ * Gracefully retire a discovered hub. Shared by every replacement path
+ * (detached ensure, in-process ensure) so retirement always means the same
+ * thing: drain first, then an authenticated shutdown, SIGTERM only as a
+ * last resort, and discovery cleared only once the hub is actually gone.
+ */
+export async function retireDiscoveredHub(
 	record: { url: string; authToken?: string; pid?: number },
 	discoveryPath: string,
 ): Promise<boolean> {
@@ -254,8 +260,8 @@ export type HubRetirementOutcome =
  * replacement path for a Hub that is wedged or too old to answer the query;
  * only a Hub that positively reports live sessions is spared.
  */
-async function hubHasLiveSessions(
-	record: HubServerProbeRecord,
+export async function hubHasLiveSessions(
+	record: Pick<HubServerProbeRecord, "url" | "authToken">,
 ): Promise<boolean> {
 	try {
 		return !(await localHubHasNoActiveSessions(record.url, record.authToken));

--- a/sdk/packages/core/src/hub/discovery/instance-lock.degraded.test.ts
+++ b/sdk/packages/core/src/hub/discovery/instance-lock.degraded.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { loadSqliteDb } = vi.hoisted(() => ({
+	loadSqliteDb: vi.fn<(path: string) => unknown>(() => {
+		throw new Error("SQLite is unavailable in this runtime");
+	}),
+}));
+
+// Simulates runtimes with a broken or missing SQLite backend (e.g.
+// node:sqlite unavailable) without touching a real database.
+vi.mock("@cline/shared/db", () => ({ loadSqliteDb }));
+
+import {
+	HubInstanceLock,
+	HubLockHeldError,
+	resolveHubInstanceLockPath,
+} from "./instance-lock";
+
+describe("HubInstanceLock without a usable SQLite backend", () => {
+	function tempLockFile(): string {
+		return resolveHubInstanceLockPath(
+			join(mkdtempSync(join(tmpdir(), "cline-hub-lock-")), "discovery.json"),
+		);
+	}
+
+	it("degrades to an unheld lock when the lock database cannot be loaded", () => {
+		loadSqliteDb.mockImplementationOnce(() => {
+			throw new Error("SQLite is unavailable in this runtime");
+		});
+		const lockFile = tempLockFile();
+		const lock = HubInstanceLock.acquire(lockFile);
+		expect(lock.held).toBe(false);
+		expect(lock.lockFile).toBe(lockFile);
+		expect(() => lock.release()).not.toThrow();
+	});
+
+	it("degrades on a non-busy failure instead of propagating it", () => {
+		const close = vi.fn();
+		loadSqliteDb.mockImplementationOnce(() => ({
+			exec: (sql: string) => {
+				if (sql.includes("BEGIN EXCLUSIVE")) {
+					throw new Error("SQLITE_IOERR: disk I/O error");
+				}
+			},
+			prepare: vi.fn(),
+			close,
+		}));
+		const lock = HubInstanceLock.acquire(tempLockFile());
+		expect(lock.held).toBe(false);
+		expect(close).toHaveBeenCalled();
+	});
+
+	it("still surfaces a held lock as HubLockHeldError", () => {
+		loadSqliteDb.mockImplementationOnce(() => ({
+			exec: (sql: string) => {
+				if (sql.includes("BEGIN EXCLUSIVE")) {
+					throw Object.assign(new Error("database is locked"), {
+						code: "SQLITE_BUSY",
+					});
+				}
+			},
+			prepare: vi.fn(),
+			close: vi.fn(),
+		}));
+		expect(() => HubInstanceLock.acquire(tempLockFile())).toThrow(
+			HubLockHeldError,
+		);
+	});
+});

--- a/sdk/packages/core/src/hub/discovery/instance-lock.ts
+++ b/sdk/packages/core/src/hub/discovery/instance-lock.ts
@@ -55,7 +55,7 @@ export class HubInstanceLock {
 	private db: SqliteDb | undefined;
 	readonly lockFile: string;
 
-	private constructor(lockFile: string, db: SqliteDb) {
+	private constructor(lockFile: string, db: SqliteDb | undefined) {
 		this.lockFile = lockFile;
 		this.db = db;
 	}
@@ -82,11 +82,23 @@ export class HubInstanceLock {
 	/**
 	 * Attempt to take exclusive ownership of a Hub owner context. Throws
 	 * `HubLockHeldError` when another live process holds it.
+	 *
+	 * Only a positively held lock (SQLITE_BUSY/LOCKED) refuses startup. Any
+	 * other failure — SQLite unavailable in this runtime, an unwritable lock
+	 * directory — degrades to an unheld lock (`held === false`) and the Hub
+	 * starts without singleton enforcement, matching how the event log and
+	 * run queue already degrade rather than making SQLite a hard requirement.
 	 */
 	static acquire(lockFile: string): HubInstanceLock {
-		mkdirSync(dirname(lockFile), { recursive: true });
-		const existed = existsSync(lockFile);
-		const db = loadSqliteDb(lockFile);
+		let existed = false;
+		let db: SqliteDb;
+		try {
+			mkdirSync(dirname(lockFile), { recursive: true });
+			existed = existsSync(lockFile);
+			db = loadSqliteDb(lockFile);
+		} catch {
+			return new HubInstanceLock(lockFile, undefined);
+		}
 		try {
 			// Fail immediately instead of queueing behind the current holder.
 			db.exec("PRAGMA busy_timeout = 0;");
@@ -96,7 +108,7 @@ export class HubInstanceLock {
 			if (isBusy(error)) {
 				throw new HubLockHeldError(lockFile);
 			}
-			throw error;
+			return new HubInstanceLock(lockFile, undefined);
 		}
 		if (!existed) {
 			try {

--- a/sdk/packages/core/src/hub/server/browser-websocket.test.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.test.ts
@@ -481,4 +481,144 @@ describe("BrowserWebSocketHubAdapter", () => {
 			);
 		expect(delivered).toHaveLength(1);
 	});
+
+	it("advances the replay cursor past events skipped by eventId dedupe", async () => {
+		// The same eventId appended twice to the durable log (e.g. a pending
+		// approval re-issued and re-logged) used to wedge replay: the skipped
+		// duplicate never advanced lastDelivered, so the same page was
+		// refetched forever.
+		const duplicate = (sequence: number): HubEventEnvelope => ({
+			version: "v1",
+			event: "approval.requested",
+			eventId: "hevt_duplicated",
+			sessionId: "session-1",
+			timestamp: Date.now(),
+			sequence,
+		});
+		const transport = {
+			command: vi.fn(),
+			subscribe: vi.fn(() => () => {}),
+			replayEventsAfter: vi.fn((sinceSequence: number) => {
+				if (sinceSequence === 0) return [duplicate(1)];
+				if (sinceSequence === 1) return [duplicate(2)];
+				return [];
+			}),
+		};
+		const socket = createSocket();
+		new BrowserWebSocketHubAdapter(transport).attach(socket);
+
+		socket.emitMessage(
+			JSON.stringify({
+				kind: "stream.subscribe",
+				clientId: "resumer",
+				sessionId: "session-1",
+				sinceSequence: 0,
+			}),
+		);
+
+		await vi.waitFor(() =>
+			expect(transport.replayEventsAfter).toHaveBeenCalledWith(2, {
+				sessionId: "session-1",
+				limit: 200,
+			}),
+		);
+		expect(transport.replayEventsAfter).toHaveBeenCalledTimes(3);
+		const delivered = socket.sent
+			.map((entry) => JSON.parse(entry))
+			.filter((frame) => frame.kind === "event");
+		expect(delivered).toHaveLength(1);
+		expect(delivered[0]?.envelope.sequence).toBe(1);
+	});
+
+	it("stops replay when a misbehaving source never advances the cursor", async () => {
+		const stuck: HubEventEnvelope = {
+			version: "v1",
+			event: "assistant.delta",
+			eventId: "hevt_stuck",
+			sessionId: "session-1",
+			timestamp: Date.now(),
+			sequence: 1,
+		};
+		const transport = {
+			command: vi.fn(),
+			subscribe: vi.fn(() => () => {}),
+			// Always returns the same non-empty page regardless of the cursor.
+			replayEventsAfter: vi.fn(() => [stuck]),
+		};
+		const socket = createSocket();
+		new BrowserWebSocketHubAdapter(transport).attach(socket);
+
+		socket.emitMessage(
+			JSON.stringify({
+				kind: "stream.subscribe",
+				clientId: "resumer",
+				sessionId: "session-1",
+				sinceSequence: 0,
+			}),
+		);
+
+		await vi.waitFor(() =>
+			expect(transport.replayEventsAfter).toHaveBeenCalledTimes(2),
+		);
+		// Give a would-be third iteration time to run; the guard must break out.
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		expect(transport.replayEventsAfter).toHaveBeenCalledTimes(2);
+		const delivered = socket.sent
+			.map((entry) => JSON.parse(entry))
+			.filter((frame) => frame.kind === "event");
+		expect(delivered).toHaveLength(1);
+	});
+
+	it("drops replay dedupe state once the buffered flush completes", async () => {
+		const stamped: HubEventEnvelope = {
+			version: "v1",
+			event: "approval.requested",
+			eventId: "hevt_reissued",
+			sessionId: "session-1",
+			timestamp: Date.now(),
+			sequence: 1,
+		};
+		let liveListener: ((event: HubEventEnvelope) => void) | undefined;
+		const transport = {
+			command: vi.fn(),
+			subscribe: vi.fn(
+				(_clientId: string, listener: (event: HubEventEnvelope) => void) => {
+					liveListener = listener;
+					return () => {};
+				},
+			),
+			replayEventsAfter: vi.fn((sinceSequence: number) =>
+				sinceSequence === 0 ? [stamped] : [],
+			),
+		};
+		const socket = createSocket();
+		new BrowserWebSocketHubAdapter(transport).attach(socket);
+
+		socket.emitMessage(
+			JSON.stringify({
+				kind: "stream.subscribe",
+				clientId: "late-reader",
+				sessionId: "session-1",
+				sinceSequence: 0,
+			}),
+		);
+		await vi.waitFor(() =>
+			expect(transport.replayEventsAfter).toHaveBeenCalledTimes(2),
+		);
+		// Let the buffered-flush finally-block complete.
+		await new Promise((resolve) => setTimeout(resolve, 25));
+
+		// A live re-issue after replay (sequence-less, e.g. a pending approval
+		// re-raised much later) follows the live-only contract: it is delivered,
+		// not swallowed by replay-era dedupe state.
+		liveListener?.({ ...stamped, sequence: undefined });
+		const delivered = socket.sent
+			.map((entry) => JSON.parse(entry))
+			.filter(
+				(frame) =>
+					frame.kind === "event" &&
+					frame.envelope.eventId === "hevt_reissued",
+			);
+		expect(delivered).toHaveLength(2);
+	});
 });

--- a/sdk/packages/core/src/hub/server/browser-websocket.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.ts
@@ -21,6 +21,13 @@ import { logHubMessage } from "./hub-server-logging";
 type HubCommandFrame = HubTransportFrame & { kind: "command" };
 
 const HUB_EVENT_REPLAY_PAGE_SIZE = 200;
+/**
+ * Hard ceiling on replay pages per subscribe. At the default page size this
+ * covers the event log's full retention cap; a replay source that still has
+ * more after this is misbehaving, and live delivery takes over from wherever
+ * the cursor reached.
+ */
+const HUB_EVENT_REPLAY_MAX_PAGES = 1_000;
 
 export interface BrowserHubSocketLike {
 	send(data: string): void;
@@ -343,21 +350,24 @@ export class BrowserWebSocketHubAdapter {
 						// mutating the original) share the same eventId. The sequence
 						// cursor alone can't catch that: dedupe by eventId too, or the
 						// buffer flush below re-delivers it after replay already did.
-						const deliveredEventIds = new Set<string>();
+						// The set exists only for that replay/flush window — it is
+						// dropped once the flush completes so it cannot grow for the
+						// lifetime of the socket.
+						let deliveredEventIds: Set<string> | undefined = new Set<string>();
 						const deliver = (envelope: HubEventEnvelope): void => {
-							if (envelope.eventId && deliveredEventIds.has(envelope.eventId)) {
-								return;
-							}
-							if (
-								typeof envelope.sequence === "number" &&
-								envelope.sequence <= lastDelivered
-							) {
-								return;
-							}
 							if (typeof envelope.sequence === "number") {
+								if (envelope.sequence <= lastDelivered) {
+									return;
+								}
+								// Advance the cursor before any eventId dedupe: a skipped
+								// duplicate must still move replay forward, or the next
+								// page refetches it forever.
 								lastDelivered = envelope.sequence;
 							}
-							if (envelope.eventId) {
+							if (envelope.eventId && deliveredEventIds) {
+								if (deliveredEventIds.has(envelope.eventId)) {
+									return;
+								}
 								deliveredEventIds.add(envelope.eventId);
 							}
 							onEvent(envelope);
@@ -376,7 +386,9 @@ export class BrowserWebSocketHubAdapter {
 						);
 						subscriptions.set(key, unsubscribe);
 						try {
-							while (!closed) {
+							let pages = 0;
+							while (!closed && pages < HUB_EVENT_REPLAY_MAX_PAGES) {
+								const pageCursor = lastDelivered;
 								const page = this.transport.replayEventsAfter(lastDelivered, {
 									sessionId: frame.sessionId,
 									limit: HUB_EVENT_REPLAY_PAGE_SIZE,
@@ -387,6 +399,12 @@ export class BrowserWebSocketHubAdapter {
 								for (const envelope of page) {
 									deliver(envelope);
 								}
+								if (lastDelivered <= pageCursor) {
+									// The cursor did not move, so the next fetch would return
+									// this same page again. Stop instead of spinning.
+									break;
+								}
+								pages += 1;
 								// Yield between pages so replay never starves the socket.
 								await new Promise<void>((resolveYield) =>
 									setTimeout(resolveYield, 0),
@@ -398,6 +416,9 @@ export class BrowserWebSocketHubAdapter {
 								deliver(envelope);
 							}
 							buffered.length = 0;
+							// Replay/flush dedupe is over; from here the subscription is
+							// live-only and must not accumulate per-event state.
+							deliveredEventIds = undefined;
 						}
 						break;
 					}

--- a/sdk/packages/core/src/hub/server/hub-event-log.test.ts
+++ b/sdk/packages/core/src/hub/server/hub-event-log.test.ts
@@ -1,4 +1,8 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { HubEventEnvelope } from "@cline/shared";
+import { loadSqliteDb } from "@cline/shared/db";
 import { describe, expect, it } from "vitest";
 import { HubEventLogStore } from "./hub-event-log";
 
@@ -18,6 +22,25 @@ function envelope(
 }
 
 describe("HubEventLogStore", () => {
+	it("opens its database in WAL mode", () => {
+		const dbPath = join(
+			mkdtempSync(join(tmpdir(), "cline-hub-events-")),
+			"hub-events.db",
+		);
+		const log = new HubEventLogStore({ dbPath });
+		log.append(envelope("run.started", "s1"));
+		log.close();
+		// WAL is persistent: a fresh connection observes the configured mode.
+		const db = loadSqliteDb(dbPath);
+		try {
+			expect(
+				String(db.prepare("PRAGMA journal_mode;").get()?.journal_mode),
+			).toBe("wal");
+		} finally {
+			db.close?.();
+		}
+	});
+
 	it("stamps a monotonically increasing global sequence", () => {
 		const log = new HubEventLogStore({ dbPath: ":memory:" });
 		const first = log.append(envelope("run.started", "s1"));

--- a/sdk/packages/core/src/hub/server/hub-event-log.ts
+++ b/sdk/packages/core/src/hub/server/hub-event-log.ts
@@ -60,6 +60,11 @@ export class HubEventLogStore {
 		);
 		this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS;
 		this.maxRows = options.maxRows ?? DEFAULT_MAX_ROWS;
+		// Every streaming chunk lands here as an INSERT; WAL keeps those
+		// appends from serializing against replay reads, and the busy timeout
+		// matches the other SQLite stores instead of failing fast on contention.
+		this.db.exec("PRAGMA journal_mode = WAL;");
+		this.db.exec("PRAGMA busy_timeout = 5000;");
 		this.db.exec(`
 			CREATE TABLE IF NOT EXISTS hub_events (
 				sequence INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -85,7 +90,7 @@ export class HubEventLogStore {
 			return envelope;
 		}
 		const createdAt = envelope.timestamp ?? Date.now();
-		this.db
+		const inserted = this.db
 			.prepare(
 				`INSERT INTO hub_events (event, session_id, envelope_json, created_at)
 				 VALUES (?, ?, ?, ?);`,
@@ -97,10 +102,14 @@ export class HubEventLogStore {
 				JSON.stringify(envelope),
 				createdAt,
 			);
-		const row = this.db
-			.prepare("SELECT MAX(sequence) AS sequence FROM hub_events;")
-			.get();
-		return { ...envelope, sequence: Number(row?.sequence ?? 0) };
+		// The AUTOINCREMENT primary key IS the sequence, so the insert's own
+		// rowid stamps it without a second round-trip per streaming chunk.
+		const rowid = inserted?.lastInsertRowid;
+		const sequence =
+			typeof rowid === "number" || typeof rowid === "bigint"
+				? Number(rowid)
+				: this.lastSequence();
+		return { ...envelope, sequence };
 	}
 
 	/** Events after `sequence`, oldest first, optionally scoped to a session. */

--- a/sdk/packages/core/src/hub/server/hub-run-queue.test.ts
+++ b/sdk/packages/core/src/hub/server/hub-run-queue.test.ts
@@ -1,7 +1,30 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSqliteDb } from "@cline/shared/db";
 import { describe, expect, it } from "vitest";
 import { HubRunAdmissionRejectedError, HubRunQueue } from "./hub-run-queue";
 
 describe("HubRunQueue", () => {
+	it("opens its database in WAL mode", () => {
+		const dbPath = join(
+			mkdtempSync(join(tmpdir(), "cline-hub-runs-")),
+			"hub-runs.db",
+		);
+		const queue = new HubRunQueue({ dbPath });
+		queue.admit("s1", { prompt: "one" });
+		queue.close();
+		// WAL is persistent: a fresh connection observes the configured mode.
+		const db = loadSqliteDb(dbPath);
+		try {
+			expect(
+				String(db.prepare("PRAGMA journal_mode;").get()?.journal_mode),
+			).toBe("wal");
+		} finally {
+			db.close?.();
+		}
+	});
+
 	it("acks admission immediately with runId, acceptedAt, and queue position", () => {
 		const queue = new HubRunQueue({ dbPath: ":memory:" });
 		const first = queue.admit("s1", { prompt: "one" }, "client-a");

--- a/sdk/packages/core/src/hub/server/hub-run-queue.ts
+++ b/sdk/packages/core/src/hub/server/hub-run-queue.ts
@@ -92,6 +92,11 @@ export class HubRunQueue {
 		);
 		this.maxPendingPerSession =
 			options.maxPendingPerSession ?? DEFAULT_MAX_PENDING_PER_SESSION;
+		// WAL + a busy timeout, matching the other SQLite stores: admissions
+		// and state transitions must not serialize against run.list readers or
+		// fail fast when another handle briefly holds the write lock.
+		this.db.exec("PRAGMA journal_mode = WAL;");
+		this.db.exec("PRAGMA busy_timeout = 5000;");
 		this.db.exec(`
 			CREATE TABLE IF NOT EXISTS hub_runs (
 				accepted_seq INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ensure-retire.test.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ensure-retire.test.ts
@@ -1,0 +1,209 @@
+/**
+ * ensureHubWebSocketServer replacement rules for a live-but-unusable
+ * discovered hub. They must agree with the detached-daemon ensure path:
+ * a hub serving sessions is attached to (never ambushed), and retirement
+ * goes through the shared retireDiscoveredHub (drain first, discovery
+ * cleared only when the hub actually went away).
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@ai-sdk/provider-utils", () => ({
+	createProviderDefinedToolFactory: vi.fn(() => vi.fn()),
+}));
+
+const {
+	hubHasLiveSessions,
+	retireDiscoveredHub,
+	verifyHubConnection,
+	probeHubServer,
+	readHubDiscovery,
+	clearHubDiscovery,
+	isManagedHubReusable,
+} = vi.hoisted(() => ({
+	hubHasLiveSessions: vi.fn(),
+	retireDiscoveredHub: vi.fn(),
+	verifyHubConnection: vi.fn(),
+	probeHubServer: vi.fn(),
+	readHubDiscovery: vi.fn(),
+	clearHubDiscovery: vi.fn(async () => undefined),
+	isManagedHubReusable: vi.fn(() => false),
+}));
+
+vi.mock("../daemon", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	hubHasLiveSessions,
+	retireDiscoveredHub,
+}));
+
+vi.mock("../client", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	verifyHubConnection,
+}));
+
+vi.mock("../discovery", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	probeHubServer,
+	readHubDiscovery,
+	clearHubDiscovery,
+	isManagedHubReusable,
+}));
+
+import type { HubWebSocketServer } from "./hub-server-options";
+import { ensureHubWebSocketServer } from "./hub-websocket-server";
+
+const STALE_URL = "ws://127.0.0.1:39999/hub";
+
+function createOwner() {
+	const root = mkdtempSync(join(tmpdir(), "cline-hub-ensure-retire-"));
+	return {
+		ownerId: "hub-ensure-retire-test",
+		discoveryPath: join(root, "discovery.json"),
+	};
+}
+
+function stubSessionHost() {
+	return {
+		subscribe: vi.fn(() => () => {}),
+		startSession: vi.fn(),
+		runTurn: vi.fn(),
+		stopSession: vi.fn(async () => {}),
+		abort: vi.fn(async () => {}),
+		dispose: vi.fn(async () => {}),
+		getSession: vi.fn(async () => undefined),
+		getAccumulatedUsage: vi.fn(async () => undefined),
+		listSessions: vi.fn(async () => []),
+		deleteSession: vi.fn(async () => false),
+		updateSession: vi.fn(async () => ({ updated: false })),
+		updateSessionCompactionState: vi.fn(async () => ({ updated: false })),
+		readSessionCompactionState: vi.fn(async () => undefined),
+		readSessionMessages: vi.fn(async () => []),
+		dispatchHookEvent: vi.fn(async () => {}),
+		restoreSession: vi.fn(),
+	} as never;
+}
+
+function ensureOptions(owner: ReturnType<typeof createOwner>) {
+	const root = mkdtempSync(join(tmpdir(), "cline-hub-ensure-ws-"));
+	return {
+		owner,
+		host: "127.0.0.1",
+		port: 0,
+		pathname: "/hub",
+		workspaceRoot: root,
+		runtimeHandlers: {
+			startSession: vi.fn(),
+			sendSession: vi.fn(),
+			abortSession: vi.fn(),
+			stopSession: vi.fn(),
+		},
+		scheduleOptions: { dbPath: ":memory:" },
+		taskOptions: {
+			dbPath: join(root, "tasks.db"),
+			globalSpecsDir: join(root, "specs"),
+			watchFiles: false,
+		},
+		eventLog: { dbPath: ":memory:" },
+		runQueue: { dbPath: ":memory:" },
+		sessionHost: stubSessionHost(),
+	} as never;
+}
+
+describe("ensureHubWebSocketServer retire path", () => {
+	const servers = new Set<HubWebSocketServer>();
+
+	afterEach(async () => {
+		for (const server of servers) {
+			await server.close().catch(() => undefined);
+		}
+		servers.clear();
+		vi.clearAllMocks();
+		clearHubDiscovery.mockResolvedValue(undefined);
+		isManagedHubReusable.mockReturnValue(false);
+	});
+
+	it("attaches to a busy unusable hub instead of retiring it", async () => {
+		const owner = createOwner();
+		readHubDiscovery.mockResolvedValue({
+			url: STALE_URL,
+			authToken: "busy-token",
+			pid: 4242,
+		});
+		probeHubServer.mockResolvedValue({
+			url: STALE_URL,
+			protocolVersion: "v1",
+			buildId: "old-build",
+			pid: 4242,
+		});
+		hubHasLiveSessions.mockResolvedValue(true);
+		verifyHubConnection.mockResolvedValue(true);
+
+		const result = await ensureHubWebSocketServer(ensureOptions(owner));
+
+		expect(result).toMatchObject({
+			url: STALE_URL,
+			authToken: "busy-token",
+			action: "reuse",
+		});
+		expect(hubHasLiveSessions).toHaveBeenCalledWith({
+			url: STALE_URL,
+			authToken: "busy-token",
+			pid: 4242,
+		});
+		expect(retireDiscoveredHub).not.toHaveBeenCalled();
+		expect(clearHubDiscovery).not.toHaveBeenCalled();
+	});
+
+	it("retires an idle unusable hub through the shared drain-first retirement", async () => {
+		const owner = createOwner();
+		readHubDiscovery.mockResolvedValue({
+			url: STALE_URL,
+			authToken: "old-token",
+			pid: 4242,
+		});
+		probeHubServer.mockResolvedValue({
+			url: STALE_URL,
+			protocolVersion: "v1",
+			buildId: "old-build",
+			pid: 4242,
+		});
+		hubHasLiveSessions.mockResolvedValue(false);
+		retireDiscoveredHub.mockResolvedValue(true);
+
+		const result = await ensureHubWebSocketServer(ensureOptions(owner));
+		if (result.server) {
+			servers.add(result.server);
+		}
+
+		expect(retireDiscoveredHub).toHaveBeenCalledWith(
+			{ url: STALE_URL, authToken: "old-token", pid: 4242 },
+			owner.discoveryPath,
+		);
+		// Discovery is retireDiscoveredHub's responsibility (cleared only when
+		// the hub actually retired); the ensure path must not clear it itself.
+		expect(clearHubDiscovery).not.toHaveBeenCalled();
+		expect(result.action).toBe("started");
+		expect(result.url).not.toBe(STALE_URL);
+	});
+
+	it("clears discovery for a stale record whose endpoint is gone", async () => {
+		const owner = createOwner();
+		readHubDiscovery.mockResolvedValue({
+			url: STALE_URL,
+			authToken: "gone-token",
+		});
+		probeHubServer.mockResolvedValue(undefined);
+
+		const result = await ensureHubWebSocketServer(ensureOptions(owner));
+		if (result.server) {
+			servers.add(result.server);
+		}
+
+		expect(clearHubDiscovery).toHaveBeenCalledWith(owner.discoveryPath);
+		expect(retireDiscoveredHub).not.toHaveBeenCalled();
+		expect(result.action).toBe("started");
+	});
+});

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -11,9 +11,9 @@ import { WebSocketServer } from "ws";
 import corePackage from "../../../package.json";
 import {
 	rememberRecoverableLocalHubUrl,
-	requestHubShutdown,
 	verifyHubConnection,
 } from "../client";
+import { hubHasLiveSessions, retireDiscoveredHub } from "../daemon";
 import {
 	clearHubDiscovery,
 	clearHubDiscoveryIfOwned,
@@ -36,6 +36,7 @@ import {
 	resolveHubInstanceLockPath,
 } from "../discovery/instance-lock";
 import { BrowserWebSocketHubAdapter } from "./browser-websocket";
+import { logHubMessage } from "./hub-server-logging";
 import type {
 	EnsuredHubWebSocketServerResult,
 	EnsureHubWebSocketServerOptions,
@@ -363,6 +364,14 @@ export async function startHubWebSocketServer(
 	const instanceLock = HubInstanceLock.acquire(
 		resolveHubInstanceLockPath(owner.discoveryPath),
 	);
+	if (!instanceLock.held) {
+		// SQLite is unavailable in this runtime, so singleton enforcement is
+		// off; the Hub still serves (the event log and run queue degrade the
+		// same way) rather than refusing to start over a missing lock backend.
+		logHubMessage("warn", "instance_lock.unavailable", {
+			lockFile: instanceLock.lockFile,
+		});
+	}
 	let transport: HubServerTransport;
 	try {
 		// The resolved owner context flows into the transport so its durable
@@ -862,27 +871,42 @@ export async function ensureHubWebSocketServer(
 			// A live hub that cannot be reused must be retired before a
 			// successor can exist: singleton ownership is lock-enforced, so
 			// starting a replacement while it lives would (correctly) fail
-			// with the instance lock held. Ask it to stop and wait it out.
+			// with the instance lock held. Retirement follows the same rules
+			// as the detached-daemon ensure path (retireDiscoveredHub): never
+			// ambush a hub that is still serving sessions, drain before the
+			// shutdown request, and clear discovery only once the hub is
+			// actually gone — clearing the record of a survivor would leave a
+			// live daemon undiscoverable.
 			if (healthy?.url) {
-				await requestHubShutdown(healthy.url, discovered.authToken).catch(
-					() => false,
-				);
-				const retireDeadline = Date.now() + ENSURE_RETIRE_WAIT_MS;
-				while (Date.now() < retireDeadline) {
-					const stillAlive = await probeHubServer(healthy.url, {
-						authToken: discovered.authToken,
-					}).catch(() => undefined);
-					if (!stillAlive?.url) {
-						break;
+				const retirementRecord = {
+					url: healthy.url,
+					authToken: discovered.authToken,
+					pid: healthy.pid ?? discovered.pid,
+				};
+				if (await hubHasLiveSessions(retirementRecord)) {
+					// Busy: attach to the older hub instead of replacing it,
+					// mirroring the daemon's deferred_busy handling. If it
+					// cannot be attached either, leave it running — starting
+					// below surfaces the instance-lock conflict instead of
+					// tearing down live sessions.
+					if (
+						await verifyHubConnection(healthy.url, {
+							authToken: discovered.authToken,
+						})
+					) {
+						return rememberIfManaged({
+							url: healthy.url,
+							authToken: discovered.authToken,
+							action: "reuse",
+						});
 					}
-					await new Promise((resolve) =>
-						setTimeout(resolve, ENSURE_RETIRE_POLL_MS),
-					);
+				} else {
+					await retireDiscoveredHub(retirementRecord, owner.discoveryPath);
 				}
+			} else {
+				// A discovered endpoint that cannot even be probed is stale.
+				await clearHubDiscovery(owner.discoveryPath);
 			}
-
-			// A discovered endpoint that cannot be authenticated/verified is stale.
-			await clearHubDiscovery(owner.discoveryPath);
 		}
 
 		const start = async (

--- a/sdk/packages/shared/src/db/sqlite-db.ts
+++ b/sdk/packages/shared/src/db/sqlite-db.ts
@@ -4,7 +4,10 @@ import { dirname } from "node:path";
 import { getErrorCode, getErrorMessage } from "../parse/error";
 
 export type SqliteStatement = {
-	run: (...params: unknown[]) => { changes?: number };
+	run: (...params: unknown[]) => {
+		changes?: number;
+		lastInsertRowid?: number | bigint;
+	};
 	get: (...params: unknown[]) => Record<string, unknown> | null;
 	all: (...params: unknown[]) => Record<string, unknown>[];
 };


### PR DESCRIPTION
Addresses saoudrizwan's review findings 1–5 on #13468. Targets `bee/cline-hub-refactor`.

## 1 (blocker): `cline hub upgrade` can no longer brick the hub
- The idle check now runs **at least once**, so `--wait 0` observes an idle hub instead of skipping straight to the (previously wrong) "still serving sessions" error (`apps/cli/src/commands/hub.ts`).
- Every abort path un-drains before returning: the busy-abort path and any error thrown between drain and stop send `POST /drain?off`.
- Non-numeric `--wait` is rejected with `InvalidArgumentError` instead of parsing to `NaN` (which made the deadline immediately expired).
- `requestHubDrain` gained an `{ off: true }` option that sets the `off` query param, making `POST /drain?off` reachable from shipped code, and `cline hub drain --off` now exists.

Verified end to end against a real hub (see PR checks section below).

## 2: WAL for the hub stores
- `HubEventLogStore` and `HubRunQueue` now set `PRAGMA journal_mode = WAL` and `busy_timeout = 5000`, matching the other SQLite stores.
- `append` stamps the sequence from the INSERT's own `lastInsertRowid` (exposed on the shared `SqliteStatement` type) instead of a second `SELECT MAX(sequence)` round-trip per streaming chunk; falls back to `lastSequence()` if a wrapper doesn't surface it.

## 3: instance lock degrades without SQLite
- Only SQLITE_BUSY/LOCKED still raises `HubLockHeldError`. Any other failure (SQLite unavailable, unwritable lock dir, non-busy exec errors) returns an unheld lock and the hub starts without singleton enforcement — the same degradation policy as the event log and run queue. The server logs `instance_lock.unavailable` when this happens.

## 4: ensure-path retirement agrees with `retireDiscoveredHub`
- `ensureHubWebSocketServer` now delegates to the daemon's exported `retireDiscoveredHub` (drain first, authenticated shutdown, SIGTERM only at an observed-alive pid, discovery cleared **only when the hub actually retired**) and applies the same busy check: a hub still serving sessions is attached to (`action: "reuse"`) instead of being ambushed; discovery is cleared unconditionally only for a record whose endpoint no longer answers probes.

## 5: replay adapter can no longer stick or grow unbounded
- `lastDelivered` advances **before** eventId dedupe, so a skipped duplicate still moves the cursor (this was the infinite-refetch hazard).
- The replay loop stops when a page fails to advance the cursor and is capped at 1,000 pages (covers the full event-log retention at the default page size).
- The eventId dedupe set exists only for the replay/buffered-flush window and is dropped afterward — live-only delivery accumulates no per-event state for the socket lifetime.

## Tests
- CLI: `upgrade --wait 0` replaces an idle hub; busy abort un-drains (`drain?off` requested); `drain --off`; non-numeric `--wait` rejected.
- Core: `requestHubDrain` off-param wiring; degraded instance lock (missing backend, non-busy failure, busy still throws); WAL mode asserted on fresh connections for both stores; replay cursor-advance/stall-guard/dedupe-drop; ensure-path busy-attach, idle-retire-via-shared-helper, stale-clear; daemon retire pinned as drain-before-shutdown and no discovery clear for a survivor.

## End-to-end verification (real hub, CLI from source)
- `cline hub drain` → `/health` shows `draining: true`; `cline hub drain --off` → `draining: false`.
- `cline hub upgrade --wait 0` on an **idle** hub: replaced it (new pid), new hub `draining: false` (previously: aborted with the wrong error and left the hub draining until restart).
- With a live session participant attached, `cline hub upgrade --wait 0`: aborts with the (now accurate) busy error, exit 1, and the hub is **not** left draining — a `session.create` immediately after succeeds.

Test suites: `@cline/shared` (367), `@cline/core` unit (2055 passed; 3 failures are pre-existing cloud-VM git artifacts in `workspace-manifest`/`checkpoint-restore`, per AGENTS.md), `@cline/cli` unit (1162 passed; 1 pre-existing git worktree env failure). Typecheck clean for core and cli.

Not taken (out of scope per instructions): the JetBrains CI process note.