### PR TITLE
ci: add Langfuse secrets to nightly build

### DIFF
--- a/.github/workflows/ext-vscode-publish-nightly.yml
+++ b/.github/workflows/ext-vscode-publish-nightly.yml
@@ -151,6 +151,9 @@ jobs:
         working-directory: next-src/apps/vscode
         env:
           CLINE_ENVIRONMENT: production
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
           TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
           ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
           # Inlined by esbuild: attributes every telemetry event with


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Make the Langfuse secret key, public key, and base URL available to the SDK-based bundle during the combined nightly extension build. Values are sourced from the `PublishNightly` environment's GitHub secrets and are not committed to the repository.

### Test Procedure

- Verified the PR diff contains only three environment mappings in `ext-vscode-publish-nightly.yml`.
- Ran `git diff --check` successfully.
- Parsed the workflow successfully with Ruby's YAML parser.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable.

### Additional Notes

The `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_BASE_URL` secrets must be configured in the `PublishNightly` GitHub environment.
