### PR TITLE
fix(hub): exclude subagent rows from session.list by default

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -463,7 +463,12 @@ async function listSessionsFromSidecarManager(
 
 	if (ctx.hubClient) {
 		try {
-			const reply = await ctx.hubClient.command("session.list", { limit: max });
+			// The history tree renders subagent child rows, which session.list
+			// excludes unless requested.
+			const reply = await ctx.hubClient.command("session.list", {
+				limit: max,
+				includeSubagents: true,
+			});
 			const sessions = Array.isArray(reply.payload?.sessions)
 				? reply.payload.sessions
 				: [];

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Cline SDK Changelog
 
+## Unreleased
+
+- The hub's `session.list` no longer returns subagent/team-task child rows by default. These are persistence-only history records, not attachable sessions, and clients that picked "the latest session" from the list could latch onto one and break (wrong transcript, `session not found` on every send). Clients that render session trees pass `includeSubagents: true`; the hub-backed runtime host keeps returning them for parity with the local runtime host
+- Sending input to a subagent session id now fails fast with a structured `session_not_sendable` error instead of a raw `session not found: <id>` thrown from inside the runtime host
+
 ## 0.0.77
 
 - The `tasks` tool (durable todos and one-time or recurring agent schedules) is now scoped to the clients that can service it. Hosts declare their client type and the core tool catalog resolves availability centrally, so CLI and VS Code sessions no longer register a tool they cannot act on; hub sessions resolve the same way from the requesting client's metadata

--- a/sdk/packages/core/src/hub/client/session-client.ts
+++ b/sdk/packages/core/src/hub/client/session-client.ts
@@ -585,10 +585,14 @@ export class HubSessionClient {
 		};
 	}
 
-	async listSessions(input?: { limit?: number }): Promise<HubSessionRow[]> {
+	async listSessions(input?: {
+		limit?: number;
+		includeSubagents?: boolean;
+	}): Promise<HubSessionRow[]> {
 		await this.ensureMetadataApplied();
 		const reply = await this.client.command("session.list", {
 			limit: input?.limit ?? 200,
+			...(input?.includeSubagents ? { includeSubagents: true } : {}),
 		});
 		const sessions = Array.isArray(reply.payload?.sessions)
 			? (reply.payload?.sessions as Record<string, unknown>[])

--- a/sdk/packages/core/src/hub/client/ui-client.ts
+++ b/sdk/packages/core/src/hub/client/ui-client.ts
@@ -81,8 +81,14 @@ export class HubUIClient {
 			: [];
 	}
 
-	async listSessions(limit = 200): Promise<SessionRecord[]> {
-		const reply = await this.client.command("session.list", { limit });
+	async listSessions(
+		limit = 200,
+		options?: { includeSubagents?: boolean },
+	): Promise<SessionRecord[]> {
+		const reply = await this.client.command("session.list", {
+			limit,
+			...(options?.includeSubagents ? { includeSubagents: true } : {}),
+		});
 		return Array.isArray(reply.payload?.sessions)
 			? (reply.payload.sessions as SessionRecord[])
 			: [];

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -1303,7 +1303,12 @@ export class HubRuntimeHost implements RuntimeHost {
 	}
 
 	async listSessions(limit = 100): Promise<SessionRecord[]> {
-		const reply = await this.client.command("session.list", { limit });
+		// RuntimeHost parity: LocalRuntimeHost.listSessions returns subagent
+		// rows, so the hub-backed host requests them too.
+		const reply = await this.client.command("session.list", {
+			limit,
+			includeSubagents: true,
+		});
 		const snapshots = Array.isArray(reply.payload?.snapshots)
 			? reply.payload.snapshots.flatMap((value) => {
 					const snapshot = parseCoreSessionSnapshot(value);

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -465,6 +465,74 @@ describe("HubServerTransport boundaries", () => {
 		expect(readSessionMessages).toHaveBeenCalledWith("session-1");
 	});
 
+	it("excludes subagent rows from session list unless requested", async () => {
+		const rootSession = {
+			sessionId: "root-1",
+			source: "cli",
+			status: "running",
+			startedAt: new Date(0).toISOString(),
+			updatedAt: new Date(0).toISOString(),
+			workspaceRoot: "/tmp/project",
+			cwd: "/tmp/project",
+			interactive: true,
+			provider: "cline",
+			model: "test-model",
+			enableTools: true,
+			enableSpawn: true,
+			enableTeams: true,
+			isSubagent: false,
+		};
+		const teamTaskSession = {
+			...rootSession,
+			sessionId: "root-1__teamtask__lead__abc123",
+			source: "subagent",
+			parentSessionId: "root-1",
+			isSubagent: true,
+		};
+		const transport = createTransport({
+			sessionHost: {
+				subscribe: vi.fn(),
+				startSession: vi.fn(),
+				stopSession: vi.fn(),
+				runTurn: vi.fn(),
+				abort: vi.fn(),
+				dispose: vi.fn(),
+				getSession: vi.fn(),
+				getAccumulatedUsage: vi.fn().mockResolvedValue(undefined),
+				listSessions: vi.fn().mockResolvedValue([rootSession, teamTaskSession]),
+				deleteSession: vi.fn(),
+				updateSession: vi.fn(),
+				dispatchHookEvent: vi.fn(),
+				readSessionMessages: vi.fn(),
+			} as never,
+		});
+
+		const defaultReply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-list-default",
+			command: "session.list",
+			payload: { limit: 10 },
+		});
+		const sessions = defaultReply.payload?.sessions as Array<{
+			sessionId: string;
+		}>;
+		expect(sessions.map((session) => session.sessionId)).toEqual(["root-1"]);
+
+		const optInReply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-list-subagents",
+			command: "session.list",
+			payload: { limit: 10, includeSubagents: true },
+		});
+		const allSessions = optInReply.payload?.sessions as Array<{
+			sessionId: string;
+		}>;
+		expect(allSessions.map((session) => session.sessionId)).toEqual([
+			"root-1",
+			"root-1__teamtask__lead__abc123",
+		]);
+	});
+
 	it("keeps interactive approval requests pending until a response arrives", async () => {
 		vi.useFakeTimers();
 		try {

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
@@ -71,6 +71,36 @@ describe("run handlers", () => {
 		);
 	});
 
+	it("rejects input to a subagent history row with a structured error", async () => {
+		const runTurn = vi.fn();
+		const ctx = createContext({
+			getSession: vi.fn().mockResolvedValue({
+				sessionId: "root__teamtask__lead__abc123",
+				isSubagent: true,
+			}),
+			runTurn,
+		});
+
+		await expect(
+			handleSessionInput(ctx, {
+				version: "v1",
+				command: "session.send_input",
+				requestId: "req-subagent",
+				clientId: "client-1",
+				sessionId: "root__teamtask__lead__abc123",
+				payload: { prompt: "go" },
+			}),
+		).resolves.toMatchObject({
+			error: { code: "session_not_sendable" },
+			ok: false,
+		});
+
+		expect(runTurn).not.toHaveBeenCalled();
+		expect(ctx.events).not.toContainEqual(
+			expect.objectContaining({ event: "run.started" }),
+		);
+	});
+
 	it("does not publish run start for an unknown session", async () => {
 		const runTurn = vi.fn();
 		const ctx = createContext({

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
@@ -227,6 +227,16 @@ export async function handleSessionInput(
 	if (!session) {
 		return sessionNotFoundReply(envelope, sessionId);
 	}
+	if (session.isSubagent) {
+		// Subagent/team-task rows are persisted history records, never live
+		// sessions. Without this guard the turn fails deep in the runtime
+		// host with a raw "session not found: <id>" error.
+		return errorReply(
+			envelope,
+			"session_not_sendable",
+			`Session ${sessionId} is a subagent history record and cannot accept input. Send to its root session instead.`,
+		);
+	}
 	ctx.publish(
 		ctx.buildEvent(
 			"run.started",

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -911,10 +911,21 @@ export async function handleSessionList(
 ): Promise<HubReplyEnvelope> {
 	const limit =
 		typeof envelope.payload?.limit === "number" ? envelope.payload.limit : 200;
-	const records = await ctx.sessionHost.listSessions(limit);
-	const sessions = records.map((session) =>
-		toHubSessionRecord(session, ctx.sessionState.get(session.sessionId)),
-	);
+	// Subagent and team-task child rows are persistence-only history records,
+	// not attachable sessions: sending input to one fails because it never
+	// exists in the runtime host's live session map. Clients that render
+	// session trees opt in explicitly.
+	const includeSubagents = envelope.payload?.includeSubagents === true;
+	// Over-fetch when filtering so a burst of child rows cannot crowd root
+	// sessions out of the requested page.
+	const scanLimit = includeSubagents ? limit : Math.min(limit * 5, 1000);
+	const records = await ctx.sessionHost.listSessions(scanLimit);
+	const sessions = records
+		.filter((session) => includeSubagents || !session.isSubagent)
+		.slice(0, limit)
+		.map((session) =>
+			toHubSessionRecord(session, ctx.sessionState.get(session.sessionId)),
+		);
 	return okReply(envelope, {
 		sessions,
 	});


### PR DESCRIPTION
## Summary

Follow-up to a Cline Cloud incident where a web client permanently broke after a reconnect (client-side fix in cline/core-platform#3239).

Subagent and team-task child session rows (ids like `<root>__teamtask__<agent>__<id>`) are persistence-only history records. They are never registered in the runtime host's live session map, so they cannot accept input, but the hub's `session.list` returned them alongside root sessions with nothing marking them as non-attachable. Any client that picks "the most recent session" from the list can latch onto one after a reconnect: it renders the child row's transcript and status, and every send fails deep in the runtime host with a raw `session not found: <id>` error. This fixes the class of bug at the source instead of once per client:

- `session.list` excludes subagent rows by default. Clients that render session trees opt in with `includeSubagents: true`. The handler over-fetches when filtering so child rows cannot crowd roots out of the requested page.
- `session.send_input` / `run.start` to a subagent row now fails fast with a structured `session_not_sendable` error instead of the raw runtime-host throw.
- Opted in the consumers that legitimately want child rows: the desktop app sidecar (history tree) and `HubRuntimeHost.listSessions` (parity with `LocalRuntimeHost`, which includes them).
- `HubSessionClient.listSessions` and `HubUiClient.listSessions` accept the opt-in and omit the flag otherwise. Audited the remaining `session.list` consumers: the CLI update gate only reads participants (roots only), and the connector cleanup already filtered child rows out itself.

Older hubs ignore the new payload field, and newer clients against older hubs simply receive the unfiltered list, so the flag degrades cleanly in both directions.

Related known issue, not addressed here: subagent rows record `pid: process.ppid`, which is 0 in cloud pods (node runs as PID 1), so `reconcileDeadSessions` marks live team tasks failed on the next list call. That needs its own fix.

## Test plan

- [x] New boundary test: `session.list` returns only root sessions by default and includes child rows with `includeSubagents: true`
- [x] New run-handler test: input to a subagent row returns `session_not_sendable` without starting a run
- [x] Full hub suite passes: 290 tests across 28 files
- [x] Biome and tsc clean on changed files