### PR TITLE
fix(shared): honor localized XDG Documents directory

### DIFF
--- a/sdk/packages/shared/src/storage/paths.test.ts
+++ b/sdk/packages/shared/src/storage/paths.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	AGENT_CONFIG_DIRECTORY_NAME,
@@ -18,6 +18,7 @@ import {
 	resolveConnectorDataDir,
 	resolveConnectorSettingsPath,
 	resolveDbDataDir,
+	resolveDocumentsClineDirectoryPath,
 	resolveGlobalAgentsRulesPath,
 	resolveGlobalSettingsPath,
 	resolveHooksConfigSearchPaths,
@@ -27,6 +28,7 @@ import {
 	resolveSessionDataDir,
 	resolveTeamDataDir,
 	resolveWorkflowsConfigSearchPaths,
+	setHomeDir,
 } from "./paths";
 
 type EnvSnapshot = {
@@ -40,6 +42,7 @@ type EnvSnapshot = {
 	CLINE_PROVIDER_SETTINGS_PATH: string | undefined;
 	CLINE_SESSION_DATA_DIR: string | undefined;
 	CLINE_TEAM_DATA_DIR: string | undefined;
+	XDG_CONFIG_HOME: string | undefined;
 };
 
 function captureEnv(): EnvSnapshot {
@@ -54,6 +57,7 @@ function captureEnv(): EnvSnapshot {
 		CLINE_PROVIDER_SETTINGS_PATH: process.env.CLINE_PROVIDER_SETTINGS_PATH,
 		CLINE_SESSION_DATA_DIR: process.env.CLINE_SESSION_DATA_DIR,
 		CLINE_TEAM_DATA_DIR: process.env.CLINE_TEAM_DATA_DIR,
+		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
 	};
 }
 
@@ -70,6 +74,7 @@ function restoreEnv(snapshot: EnvSnapshot): void {
 		snapshot.CLINE_PROVIDER_SETTINGS_PATH;
 	process.env.CLINE_SESSION_DATA_DIR = snapshot.CLINE_SESSION_DATA_DIR;
 	process.env.CLINE_TEAM_DATA_DIR = snapshot.CLINE_TEAM_DATA_DIR;
+	process.env.XDG_CONFIG_HOME = snapshot.XDG_CONFIG_HOME;
 }
 
 describe("storage path resolution", () => {
@@ -210,6 +215,35 @@ describe("storage path resolution", () => {
 			join("/tmp/home", ".cline", "data", RULES_CONFIG_DIRECTORY_NAME),
 		);
 	});
+
+	it.runIf(process.platform === "linux")(
+		"resolves legacy global rules from the localized XDG Documents directory",
+		() => {
+			snapshot = captureEnv();
+			delete process.env.XDG_CONFIG_HOME;
+			const originalHomeDir = dirname(dirname(resolveGlobalAgentsRulesPath()));
+			const homeDir = mkdtempSync(join(tmpdir(), "cline-xdg-home-"));
+			mkdirSync(join(homeDir, ".config"), { recursive: true });
+			writeFileSync(
+				join(homeDir, ".config", "user-dirs.dirs"),
+				'XDG_DOCUMENTS_DIR="$HOME/Документы"\n',
+			);
+
+			try {
+				setHomeDir(homeDir);
+
+				expect(resolveDocumentsClineDirectoryPath()).toBe(
+					join(homeDir, "Документы", "Cline"),
+				);
+				expect(resolveRulesConfigSearchPaths()).toContain(
+					join(homeDir, "Документы", "Cline", "Rules"),
+				);
+			} finally {
+				setHomeDir(originalHomeDir);
+				rmSync(homeDir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("resolves legacy and new workflow paths, with .cline paths later for duplicate-name precedence", () => {
 		snapshot = captureEnv();

--- a/sdk/packages/shared/src/storage/paths.ts
+++ b/sdk/packages/shared/src/storage/paths.ts
@@ -138,8 +138,44 @@ export function resolveClineDir(): string {
 	return join(HOME_DIR, ".cline");
 }
 
+function resolveXdgDocumentsDirectoryPath(): string | undefined {
+	if (process.platform !== "linux") {
+		return undefined;
+	}
+
+	const configuredConfigHome = process.env.XDG_CONFIG_HOME?.trim();
+	const configHome =
+		configuredConfigHome && isAbsolute(configuredConfigHome)
+			? configuredConfigHome
+			: join(HOME_DIR, ".config");
+
+	let userDirs: string;
+	try {
+		userDirs = readFileSync(join(configHome, "user-dirs.dirs"), "utf8");
+	} catch {
+		return undefined;
+	}
+
+	const match = userDirs.match(
+		/^\s*XDG_DOCUMENTS_DIR\s*=\s*(?:"((?:\\.|[^"])*)"|'([^']*)'|([^#\r\n]*?))\s*(?:#.*)?$/m,
+	);
+	const configuredPath = (match?.[1] ?? match?.[2] ?? match?.[3])?.trim();
+	if (!configuredPath) {
+		return undefined;
+	}
+
+	const unescapedPath = configuredPath.replace(/\\(["\\$`])/g, "$1");
+	const expandedPath = unescapedPath.replace(
+		/^\$(?:\{HOME\}|HOME)(?=\/|$)/,
+		() => HOME_DIR,
+	);
+	return isAbsolute(expandedPath) ? expandedPath : undefined;
+}
+
 export function resolveDocumentsClineDirectoryPath(): string {
-	return join(HOME_DIR, "Documents", "Cline");
+	const documentsDir =
+		resolveXdgDocumentsDirectoryPath() ?? join(HOME_DIR, "Documents");
+	return join(documentsDir, "Cline");
 }
 
 type DocumentsExtensionName =


### PR DESCRIPTION
## Summary

- resolve Linux's legacy `Documents/Cline` extensions from `XDG_DOCUMENTS_DIR`
- expand the standard `$HOME` value without executing the config file, while preserving the existing fallback for missing or invalid XDG configuration
- cover a localized Cyrillic Documents directory through the global-rules search path

## Root cause

The JetBrains-facing UI honors `xdg-user-dir DOCUMENTS`, so it can write and toggle rules under `/home/user/Документы/Cline/Rules`. The shared SDK path resolver used by the model context always searched `~/Documents/Cline/Rules` instead. That split made the rules visible and enabled in the UI while keeping them out of the prompt.

Fixes #13432

## Testing

- `cd sdk && bun -F @cline/shared test` — 32 test files, 368 tests passed
- `cd sdk && bun -F @cline/shared typecheck`
- `biome 2.4.5 check sdk/packages/shared/src/storage/paths.ts sdk/packages/shared/src/storage/paths.test.ts`
- red/green regression: the new path test failed before the implementation (`Documents` instead of `Документы`) and all 36 path tests passed after it
