### PR TITLE
docs: remove outdated diff editing claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ npm install @cline/sdk
 
 ## Edits Code Across Your Project
 
-Cline reads your project structure, understands the relationships between files, and makes coordinated changes across your codebase. It monitors linter and compiler errors as it works, fixing issues like missing imports, type mismatches, and syntax errors before you even see them. In VS Code and JetBrains, every edit shows up as a diff you can review, modify, or revert. All changes are tracked with checkpoints, so you can easily undo the agent's work.
+Cline reads your project structure, understands the relationships between files, and makes coordinated changes across your codebase. It monitors linter and compiler errors as it works, fixing issues like missing imports, type mismatches, and syntax errors before you even see them. In VS Code and JetBrains, every edit shows up as a diff you can review or revert. All changes are tracked with checkpoints, so you can easily undo the agent's work.
 
 ## Runs Bash Commands
 


### PR DESCRIPTION
## Summary

- remove the README claim that diff previews can be modified directly
- align the wording with the read-only diff preview design from #12219

Fixes #13252

## Testing

Not run (documentation-only change).