### PR TITLE
fix(docs): correct connector CLI flag names

### DIFF
--- a/docs/cli/connectors.mdx
+++ b/docs/cli/connectors.mdx
@@ -224,7 +224,7 @@ cline connect discord \
 Requires a service account credentials JSON file and public base URL.
 
 ```bash
-cline connect gchat --credentials <JSON> --base-url <URL>
+cline connect gchat --credentials-json <JSON> --base-url <URL>
 ```
 
 ## WhatsApp
@@ -232,7 +232,7 @@ cline connect gchat --credentials <JSON> --base-url <URL>
 Requires a phone number ID, access token, app secret, webhook verify token, and public base URL.
 
 ```bash
-cline connect whatsapp --phone-id <ID> --token <TOKEN> --app-secret <SECRET> --base-url <URL>
+cline connect whatsapp --phone-number-id <ID> --access-token <TOKEN> --app-secret <SECRET> --verify-token <VERIFY_TOKEN> --base-url <URL>
 ```
 
 ## Linear
@@ -240,7 +240,7 @@ cline connect whatsapp --phone-id <ID> --token <TOKEN> --app-secret <SECRET> --b
 Requires an API key, webhook signing secret, and public base URL.
 
 ```bash
-cline connect linear --api-key <KEY> --signing-secret <SECRET> --base-url <URL>
+cline connect linear --api-key <KEY> --webhook-secret <SECRET> --base-url <URL>
 ```
 
 ## Managing Connectors


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — submitting directly under the "small bug fixes, typo corrections" exception in the PR template. Happy to open an issue first if you'd prefer.

### Description

Three connector setup commands in `docs/cli/connectors.mdx` use flag names the commands don't define, so copying them as written fails with an unknown option error. The root program sets `.allowExcessArguments()` but not `.allowUnknownOption()`, so a wrong flag is a hard failure rather than being ignored.

| Doc said | Actual flag | Defined in |
| --- | --- | --- |
| `--credentials` | `--credentials-json` | `connectors/adapters/gchat.ts` |
| `--phone-id` | `--phone-number-id` | `connectors/adapters/whatsapp.ts` |
| `--token` | `--access-token` | `connectors/adapters/whatsapp.ts` |
| `--signing-secret` | `--webhook-secret` | `connectors/adapters/linear.ts` |

`--signing-secret` is a real flag, but it belongs to the Slack adapter. Linear's equivalent is `--webhook-secret`, described in its adapter as "Linear webhook signing secret" — which is probably how the mix-up happened.

I also added `--verify-token` to the WhatsApp example. The sentence directly above it already says the connector requires a webhook verify token, and `--verify-token` is defined in the adapter, but the example omitted it.

The Discord and Slack examples on the same page are correct and are untouched.

### Test Procedure

Docs-only change. I verified by comparison rather than by running the connectors, since they need real Meta/Google/Linear credentials and a public webhook URL that I don't have.

- Extracted every `.option(...)` flag from each adapter under `apps/cli/src/connectors/adapters/` and diffed it against the flags used in each `cline connect <adapter>` example on the page. That produced exactly the four mismatches above.
- Re-ran the same comparison after the edit: no unknown flags remain in any connector example.
- Confirmed the root program doesn't call `.allowUnknownOption()`, so these mismatches fail rather than being silently dropped.

Quickest way for a reviewer to confirm: `cline connect whatsapp --help` and compare against the page.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — not run: this touches only a `.mdx` file under `docs/`, with no code, and I didn't want to claim a test run I didn't do. Happy to run it if you want.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not a UI change.

### Additional Notes

Only `docs/cli/connectors.mdx` is touched. Disclosure: I used an AI assistant (Claude) to help find and verify this; the flag comparison above is reproducible from the adapter sources.
