### PR TITLE
fix(docs): remove nonexistent --no-teams flag

### DIFF
--- a/docs/cli/agent-teams.mdx
+++ b/docs/cli/agent-teams.mdx
@@ -42,14 +42,6 @@ Team state is stored at `~/.cline/data/teams/[team-name]/` and includes:
 - Inter-agent mailbox
 - Mission log with activity history
 
-## Disabling Teams
-
-Teams are enabled by default. Disable them with:
-
-```bash
-cline --no-teams "your prompt"
-```
-
 ## Sub-Agents
 
 For simpler delegation within a single session (no persistent state), use [sub-agents](/features/subagents). Sub-agents run in parallel for read-only research and return focused reports to the main agent.


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small docs correction, submitted under the PR template's exception. Happy to open an issue first if you'd rather discuss it.

### Description

`docs/cli/agent-teams.mdx` had a "Disabling Teams" section telling people to run:

```bash
cline --no-teams "your prompt"
```

There is no `--no-teams` option. Searching the whole repo, that string appears only on that one documentation line — it isn't defined in `apps/cli/`, `sdk/`, or anywhere else.

It also can't work as a commander auto-negation. Commander generates `--no-x` only when a corresponding boolean `--x` option exists, and there's no `--teams` option; the only teams-related flag is `--team-name`, which is registered via `new Option(...).hideHelp()` in `apps/cli/src/commands/program.ts` and overrides the runtime team state name rather than toggling teams.

Because the root program calls `.allowExcessArguments()` but not `.allowUnknownOption()`, running the documented command doesn't quietly ignore the flag — it fails as an unknown option.

I removed the section rather than rewriting it, since I couldn't find any supported way to disable teams to document instead. If one does exist (a config key or env var I missed), say so and I'll document that here instead of deleting the section.

### Test Procedure

Docs-only change, verified by searching rather than running:

- `grep -rn -- "no-teams\|noTeams" apps sdk docs` returns exactly one hit: the documentation line this PR removes.
- Extracted every option string from `.option(...)` and `new Option(...)` across `apps/cli/src` (handling the multi-line definitions). The result contains `--team-name` but no `--teams`, so commander has nothing to negate.
- Confirmed the root command in `apps/cli/src/commands/program.ts` doesn't call `.allowUnknownOption()`, so an undefined flag is an error rather than a no-op.

A reviewer can confirm with `cline --help` — there's no `--no-teams` in the output.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — not run: this touches only a `.mdx` file under `docs/`, and I didn't want to claim a test run I didn't do.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not a UI change.

### Additional Notes

Disclosure: I used an AI assistant (Claude) to help find and verify this; the checks above are reproducible from the CLI sources.
