### PR TITLE
docs(cli): document missing CLI commands

### DIFF
--- a/docs/cli/cli-reference.mdx
+++ b/docs/cli/cli-reference.mdx
@@ -48,20 +48,24 @@ Options:
   -h, --help                   display help for command
 
 Commands:
-  auth [options] [provider]    Authenticate a provider and configure what model is used
-  config [options]             Show current configuration
-  connect [options] [adapter]  Connect to an editor or IDE adapter
-  mcp                          Manage MCP servers
-  dev                          Developer tools and utilities
-  doctor                       Diagnose and fix configuration issues
-  history|h [options]          List session history or manage saved sessions
-  hook                         Handle a hook payload from stdin
-  plugin                       Manage Cline Plugins
-  schedule                     Manage scheduled tasks
-  hub                          Manage the local hub daemon
-  update [options]             Check for updates and install if available
-  version                      Show Cline CLI version number
-  kanban                       Launch the kanban app and exit
+  auth [options] [provider]          Authenticate a provider and configure what model is used
+  config [options]                   Show current configuration
+  connect [options] [adapter]        Connect to an editor or IDE adapter
+  mcp                                Manage MCP servers
+  dev                                Developer tools and utilities
+  doctor                             Diagnose and fix configuration issues
+  history|h [options]                List session history or manage saved sessions
+  hook                               Handle a hook payload from stdin
+  plugin                             Manage Cline Plugins
+  install|i [options] <source>       Install a Cline Plugin from an official keyword, npm, git, URL, or a local path
+  uninstall|remove [options] <name>  Uninstall a Cline Plugin by name or path
+  skill [args...]                    Manage Cline Skills via the open skills CLI (npx skills)
+  schedule                           Manage scheduled tasks
+  hub                                Manage the local hub daemon
+  dashboard [options]                Start the Cline Hub dashboard and open it in a browser
+  update [options]                   Check for updates and install if available
+  version                            Show Cline CLI version number
+  kanban                             Launch the kanban app and exit
 ```
 
 ## Global Options
@@ -192,6 +196,30 @@ Try it with the [TypeScript Navigation Plugin](https://github.com/cline/typescri
 cline plugin install https://github.com/cline/typescript-lsp-plugin.git
 ```
 
+### `install|i [options] <source>`
+
+Install a Cline Plugin from an official keyword, npm, git, URL, or a local path.
+
+```bash
+cline install <source>
+```
+
+### `uninstall|remove [options] <name>`
+
+Uninstall a Cline Plugin by name or path.
+
+```bash
+cline uninstall <name>
+```
+
+### `skill [args...]`
+
+Manage Cline Skills via the open skills CLI (`npx skills`).
+
+```bash
+cline skill
+```
+
 ### `schedule`
 
 Manage scheduled agents. See [Scheduling](/cli/scheduling).
@@ -206,6 +234,14 @@ Manage the local hub daemon.
 
 ```bash
 cline hub
+```
+
+### `dashboard [options]`
+
+Start the Cline Hub dashboard and open it in a browser.
+
+```bash
+cline dashboard
 ```
 
 ### `update [options]`


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — docs gap, submitted under the PR template's small-fix exception.

### Description

Four top-level commands are registered in `apps/cli/src/main.ts` but don't appear anywhere in the CLI reference:

| Command | Registered as | Description (from the source) |
| --- | --- | --- |
| `install` (alias `i`) | `.command("install")` | Install a Cline Plugin from an official keyword, npm, git, URL, or a local path |
| `uninstall` (aliases `remove`, `rm`) | `.command("uninstall")` | Uninstall a Cline Plugin by name or path |
| `skill` | `.command("skill")` | Manage Cline Skills via the open skills CLI (`npx skills`) |
| `dashboard` | `.command("dashboard")` | Start the Cline Hub dashboard and open it in a browser |

They're all normal user-facing commands — none are hidden via `hideHelp()` — so they show up in `cline --help` but not in the docs. `install`/`uninstall` in particular are the documented-nowhere half of the plugin workflow, even though `plugin` itself is documented.

This adds them to the "Help Menu (Source of Truth)" block and gives each one a section under `## Commands`, matching the existing formatting. The descriptions are copied from the `.description(...)` calls rather than written from scratch, and the aliases shown (`install|i`, `uninstall|remove`) follow how commander renders the first alias.

Two things worth flagging:

1. I couldn't run `cline --help` to regenerate that block verbatim (I'd have to build the CLI), so I derived the entries from the command registrations and re-aligned the description column to fit the longest new entry. If you'd rather regenerate the block from real help output, that's probably the better long-term fix and I'm happy to drop that half of the diff.
2. The block's existing order already doesn't match registration order in `main.ts` (for example `plugin` is registered third but listed ninth), and it lists `dev` and `history`, which aren't registered in `main.ts`. I didn't reorder anything — I inserted the new commands next to their closest relatives (`install`/`uninstall`/`skill` after `plugin`, `dashboard` after `hub`) and left the rest alone.

### Test Procedure

Docs-only change, verified by comparison:

- Extracted every top-level `.command("...")` registration from `apps/cli/src/main.ts` and diffed it against the commands listed in `cli-reference.mdx`. That produced exactly the four above.
- Checked each one's `.description(...)`, `.alias(...)`, `.argument(...)` and option count in the source so the entries match what the CLI actually exposes.
- Confirmed none of the four are hidden (`hideHelp()` is used only for `--act`, `--yolo` and `--team-name`), so they genuinely appear in help output.

A reviewer can confirm with `cline --help`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — not run: docs-only `.mdx` change, and I didn't want to claim a test run I didn't do.
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not a UI change.

### Additional Notes

Touches only `docs/cli/cli-reference.mdx`. Note this edits the same file as my other CLI-reference PR (missing root options) but a different section, so whichever lands second may need a trivial rebase. Happy to combine them if you'd prefer one PR.

Disclosure: I used an AI assistant (Claude) to help find and verify this.
