### PR TITLE
fix(tools): preserve a file's own CRLF line endings across apply_patch updates

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
@@ -156,6 +156,83 @@ describe("createApplyPatchExecutor", () => {
 		);
 	});
 
+	it("preserves CRLF line endings when updating a CRLF file", async () => {
+		const filePath = path.join(tempDir, "note.txt");
+		await fs.writeFile(filePath, "alpha\r\nbeta\r\ngamma", "utf-8");
+		const execute = createApplyPatchExecutor();
+
+		// Models emit LF-only patch text even for CRLF files.
+		await execute(
+			{
+				input: [
+					"*** Update File: note.txt",
+					"@@",
+					" alpha",
+					"-beta",
+					"+BETA",
+					"+inserted",
+					" gamma",
+				].join("\n"),
+			},
+			tempDir,
+			{} as never,
+		);
+
+		await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+			"alpha\r\nBETA\r\ninserted\r\ngamma",
+		);
+	});
+
+	it("preserves CRLF line endings when a patch moves a CRLF file", async () => {
+		const filePath = path.join(tempDir, "old.txt");
+		await fs.writeFile(filePath, "one\r\ntwo", "utf-8");
+		const execute = createApplyPatchExecutor();
+
+		await execute(
+			{
+				input: [
+					"*** Update File: old.txt",
+					"*** Move to: new.txt",
+					"@@",
+					" one",
+					"-two",
+					"+TWO",
+				].join("\n"),
+			},
+			tempDir,
+			{} as never,
+		);
+
+		await expect(
+			fs.readFile(path.join(tempDir, "new.txt"), "utf-8"),
+		).resolves.toBe("one\r\nTWO");
+	});
+
+	it("updates a pure-LF file without introducing CRLF", async () => {
+		const filePath = path.join(tempDir, "lf.txt");
+		await fs.writeFile(filePath, "one\ntwo\nthree", "utf-8");
+		const execute = createApplyPatchExecutor();
+
+		await execute(
+			{
+				input: [
+					"*** Update File: lf.txt",
+					"@@",
+					" one",
+					"-two",
+					"+TWO",
+					" three",
+				].join("\n"),
+			},
+			tempDir,
+			{} as never,
+		);
+
+		await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+			"one\nTWO\nthree",
+		);
+	});
+
 	it("rejects incomplete patch sentinels", async () => {
 		const execute = createApplyPatchExecutor();
 

--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
@@ -20,7 +20,12 @@ import {
 	PatchParser,
 	type PatchWarning,
 } from "./apply-patch-parser";
-import { normalizeNewFileLineEndings } from "./line-endings";
+import {
+	detectLineEnding,
+	type LineEnding,
+	normalizeLineEndings,
+	normalizeNewFileLineEndings,
+} from "./line-endings";
 
 export interface PatchFileChange {
 	type: PatchActionType;
@@ -71,7 +76,7 @@ function resolveFilePath(
 	return resolved;
 }
 
-function normalizeLineEndings(input: string): string[] {
+function splitPatchInputLines(input: string): string[] {
 	return input.split("\n").map((line) => line.replace(/\r$/, ""));
 }
 
@@ -98,7 +103,7 @@ function trimWrapperLines(lines: string[]): string[] {
 }
 
 function normalizePatchInput(input: string): NormalizedPatchInput {
-	const rawLines = normalizeLineEndings(input);
+	const rawLines = splitPatchInputLines(input);
 	const beginIndex = rawLines.findIndex((line) =>
 		line.startsWith(PATCH_MARKERS.BEGIN),
 	);
@@ -187,17 +192,28 @@ function applyChunks(
 	return result.join("\n");
 }
 
+interface LoadedFiles {
+	/**
+	 * File contents normalized to LF. The parser and chunk math work in LF
+	 * space because models emit LF-only patch text even for CRLF files.
+	 */
+	files: Record<string, string>;
+	/** Each file's own EOL, restored onto the output after chunks apply. */
+	eols: Record<string, LineEnding>;
+}
+
 async function loadFiles(
 	lines: readonly string[],
 	cwd: string,
 	encoding: BufferEncoding,
 	restrictToCwd: boolean,
-): Promise<Record<string, string>> {
+): Promise<LoadedFiles> {
 	const filesToLoad = extractFilesForOperations(lines, [
 		PATCH_MARKERS.UPDATE,
 		PATCH_MARKERS.DELETE,
 	]);
 	const files: Record<string, string> = {};
+	const eols: Record<string, LineEnding> = {};
 
 	for (const filePath of filesToLoad) {
 		const absolutePath = resolveFilePath(cwd, filePath, restrictToCwd);
@@ -208,23 +224,34 @@ async function loadFiles(
 			throw new DiffError(`File not found: ${filePath}`);
 		}
 		files[filePath] = fileContent.replace(/\r\n/g, "\n");
+		eols[filePath] = detectLineEnding(fileContent);
 	}
 
-	return files;
+	return { files, eols };
 }
 
 function patchToChanges(
 	patch: ReturnType<PatchParser["parse"]>["patch"],
-	originalFiles: Record<string, string>,
+	loaded: LoadedFiles,
 ): Record<string, PatchFileChange> {
 	const changes: Record<string, PatchFileChange> = {};
+	const originalFiles = loaded.files;
+	// Chunk math ran in LF space; restore each file's own EOL on the way out
+	// so an UPDATE never rewrites a CRLF file to LF wholesale.
+	const withFileEol = (
+		filePath: string,
+		content: string | undefined,
+	): string | undefined =>
+		content === undefined
+			? undefined
+			: normalizeLineEndings(content, loaded.eols[filePath] ?? "\n");
 
 	for (const [filePath, action] of Object.entries(patch.actions)) {
 		switch (action.type) {
 			case PatchActionType.DELETE:
 				changes[filePath] = {
 					type: PatchActionType.DELETE,
-					oldContent: originalFiles[filePath],
+					oldContent: withFileEol(filePath, originalFiles[filePath]),
 				};
 				break;
 			case PatchActionType.ADD:
@@ -239,11 +266,10 @@ function patchToChanges(
 			case PatchActionType.UPDATE:
 				changes[filePath] = {
 					type: PatchActionType.UPDATE,
-					oldContent: originalFiles[filePath],
-					newContent: applyChunks(
-						originalFiles[filePath] ?? "",
-						action.chunks,
+					oldContent: withFileEol(filePath, originalFiles[filePath]),
+					newContent: withFileEol(
 						filePath,
+						applyChunks(originalFiles[filePath] ?? "", action.chunks, filePath),
 					),
 					movePath: action.movePath,
 				};
@@ -338,19 +364,19 @@ export async function computePatchChanges(
 ): Promise<{ changes: Record<string, PatchFileChange>; fuzz: number }> {
 	const { encoding = "utf-8", restrictToCwd = true } = options;
 	const normalizedInput = normalizePatchInput(patchText);
-	const currentFiles = await loadFiles(
+	const loaded = await loadFiles(
 		normalizedInput.lines,
 		cwd,
 		encoding,
 		restrictToCwd,
 	);
-	const parser = new PatchParser(normalizedInput.lines, currentFiles);
+	const parser = new PatchParser(normalizedInput.lines, loaded.files);
 	const { patch, fuzz } = parser.parse();
 	if (patch.warnings && patch.warnings.length > 0) {
 		throw new DiffError(formatSkippedHunkFailure(patch.warnings));
 	}
 
-	return { changes: patchToChanges(patch, currentFiles), fuzz };
+	return { changes: patchToChanges(patch, loaded), fuzz };
 }
 
 /**

--- a/sdk/packages/core/src/extensions/tools/executors/editor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.ts
@@ -9,7 +9,11 @@ import * as path from "node:path";
 import type { AgentToolContext } from "@cline/shared";
 import type { EditFileInput } from "../schemas";
 import type { EditorExecutor } from "../types";
-import { normalizeNewFileLineEndings } from "./line-endings";
+import {
+	detectLineEnding,
+	normalizeLineEndings,
+	normalizeNewFileLineEndings,
+} from "./line-endings";
 
 /**
  * Options for the editor executor
@@ -65,25 +69,10 @@ function countOccurrences(content: string, needle: string): number {
 	return content.split(needle).length - 1;
 }
 
-/**
- * Returns "\r\n" if "\r\n" appears anywhere in the content, otherwise "\n" —
- * including for content with no line breaks at all. Files are uniformly CRLF
- * or uniformly LF in practice; the mixed case that matters is a CRLF file
- * with LF-only lines inserted by earlier releases of this tool, and any
- * surviving "\r\n" — wherever it sits — should pull such a file back to
- * CRLF, which is why this checks for "\r\n" anywhere rather than looking at
- * the first line break. Reads produced via readline strip "\r", so models
- * emit LF-only text even for CRLF files; edits must be normalized to the
- * file's own EOL or they create mixed line endings and break subsequent
- * exact-match replacements.
- */
-function detectLineEnding(content: string): "\r\n" | "\n" {
-	return content.includes("\r\n") ? "\r\n" : "\n";
-}
-
-function normalizeLineEndings(text: string, eol: "\r\n" | "\n"): string {
-	return text.split(/\r\n|\n/).join(eol);
-}
+// Reads produced via readline strip "\r", so models emit LF-only text even
+// for CRLF files; edits must be normalized to the file's own EOL (see
+// ./line-endings) or they create mixed line endings and break subsequent
+// exact-match replacements.
 
 function createLineDiff(
 	oldContent: string,

--- a/sdk/packages/core/src/extensions/tools/executors/line-endings.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/line-endings.ts
@@ -1,8 +1,8 @@
 import * as os from "node:os";
 
 /**
- * Line-ending normalization for files created from scratch, shared by the
- * file-writing executors (editor, apply_patch). Internal to the executors.
+ * Line-ending helpers shared by the file-writing executors (editor,
+ * apply_patch). Internal to the executors.
  *
  * Models emit LF-only text (reads strip "\r", so they never see a file's
  * CRLF endings). Existing files keep their own detected EOL, but a new file
@@ -15,4 +15,23 @@ export function normalizeNewFileLineEndings(content: string): string {
 		return content.replaceAll("\n", "\r\n");
 	}
 	return content;
+}
+
+export type LineEnding = "\r\n" | "\n";
+
+/**
+ * Returns "\r\n" if "\r\n" appears anywhere in the content, otherwise "\n" —
+ * including for content with no line breaks at all. Files are uniformly CRLF
+ * or uniformly LF in practice; the mixed case that matters is a CRLF file
+ * with LF-only lines inserted by earlier releases of these tools, and any
+ * surviving "\r\n" — wherever it sits — should pull such a file back to
+ * CRLF, which is why this checks for "\r\n" anywhere rather than looking at
+ * the first line break.
+ */
+export function detectLineEnding(content: string): LineEnding {
+	return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+export function normalizeLineEndings(text: string, eol: LineEnding): string {
+	return text.split(/\r\n|\n/).join(eol);
 }


### PR DESCRIPTION
## Problem

`apply_patch` rewrites entire CRLF files to LF on every update ([ENG-1493](https://linear.app/cline-bot/issue/ENG-1493/diff-view-shows-large-diffs-on-windows-when-source-has-crlf-and), and the remaining half of the Windows line-endings investigation in [CLINE-3055](https://linear.app/cline-bot/issue/CLINE-3055/wrong-line-endings-cline-should-know-the-system-os-to-therefore) / #13504 — the new-file half shipped in #13521).

`loadFiles` normalizes originals to LF so the parser and chunk math can match the model's LF-only patch text, but the result was written back without restoring the file's own EOL. So a one-line patch to a CRLF file silently converted the whole file to LF — producing the huge every-line diffs reported on Windows, destroying `git blame`, and leaving mixed-EOL repos behind. Impact scale: ~500k `apply_patch` calls by ~7.5k Windows users in the last 14 days ran through this path.

## Fix

- `loadFiles` records each file's detected EOL alongside the LF-normalized content.
- Chunk math still runs entirely in LF space (unchanged).
- `patchToChanges` restores the file's own EOL onto `oldContent`/`newContent` on the way out, so UPDATE (including moves) writes the file back in its original endings. ADD keeps the platform-native normalization from #13521.
- `detectLineEnding`/`normalizeLineEndings` move from `editor.ts` into the shared `line-endings.ts` (unchanged semantics) so both executors use one implementation.

Since `computePatchChanges` now carries restored EOLs, the VS Code diff preview picks the fix up automatically. A mixed-EOL file comes out uniformly in its detected EOL (CRLF if any `\r\n` is present) — the same uniformity philosophy the `editor` executor already applies to edits (#13296).

## Testing

- New tests: CRLF preserved across an UPDATE, CRLF preserved across a move, and pure-LF files stay LF.
- Verified end-to-end via the dev CLI on a scratch project: editing a CRLF file through a real task preserves `\r\n` byte-for-byte.
- Full `@cline/core` vitest project (2081 tests) passes; sdk typecheck clean.
