### PR TITLE
fix(cli): remove the $4.99 ClinePass promo copy

### DIFF
--- a/apps/cli/src/kanban-migration/notice-dialog.tsx
+++ b/apps/cli/src/kanban-migration/notice-dialog.tsx
@@ -71,7 +71,6 @@ export function MigrationNoticeContent(
 					latest open-weight coding models with enough quota for day-to-day
 					work, at a much lower cost than paying API costs directly.
 				</text>
-				<text selectable>Try it now with a limited-time promo for $4.99.</text>
 			</box>
 			<box flexDirection="row">
 				<text fg={palette.act} selectable>

--- a/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/provider-picker-helpers.ts
@@ -3,7 +3,6 @@ import {
 	type ProviderSettingsManager,
 	saveLocalProviderSettings,
 } from "@cline/core";
-import { CLI_PROMO_CODE } from "../../../utils/cline-pass-errors";
 import {
 	type DialogDismissKey,
 	isAnyKeyDismiss,
@@ -77,8 +76,5 @@ export function buildClinePassSubscriptionPageUrl(
 		appBaseUrl || DEFAULT_APP_BASE_URL,
 	);
 	url.searchParams.set("personal", "true");
-	if (CLI_PROMO_CODE) {
-		url.searchParams.set("code", CLI_PROMO_CODE);
-	}
 	return url.toString();
 }

--- a/apps/cli/src/utils/cline-pass-errors.ts
+++ b/apps/cli/src/utils/cline-pass-errors.ts
@@ -18,20 +18,11 @@ import { getClineEnvironmentConfig } from "@cline/shared";
 
 export { getClineOrgIndividualInferenceSubscriptionMessage };
 
-export const CLI_PROMO_CODE = "";
-
 export function getCliSubscriptionUrl(): string {
-	if (!CLI_PROMO_CODE) {
-		return new URL(
-			`/dashboard/subscription?personal=true`,
-			getClineEnvironmentConfig().appBaseUrl,
-		).toString();
-	}
-
-	return `${new URL(
-		`/promo?code=${CLI_PROMO_CODE}&personal=true`,
+	return new URL(
+		`/dashboard/subscription?personal=true`,
 		getClineEnvironmentConfig().appBaseUrl,
-	).toString()}`;
+	).toString();
 }
 
 export function getCliNotSubscribedMessage(): string {


### PR DESCRIPTION
### Related Issue

None — the ClinePass $4.99 first-month promo is being retired, so the product copy advertising it has to go with it.

### Description

The CLI shows a full-screen **"Try ClinePass"** dialog on first launch (`apps/cli/src/main.ts`, gated by `~/.cline/settings/cli-notices.json` and suppressed when the active provider is already `cline-pass`). Its second line read:

> Try it now with a limited-time promo for $4.99.

That's the discounted-first-month promo we're ending, so the line is removed. The dialog keeps the accurate part — ClinePass is $9.99/month — plus the subscription link and key hints.

**Why only the CLI:** I swept the whole repo for promo copy and this was the single in-product mention.

- VS Code extension (both `main` and the `legacy-extension` branch that ships stable) — no promo copy anywhere. `EntitlementError.tsx`, `ClinePassProvider.tsx`, and `clinePassSubscribe.ts` all say "Subscribe to ClinePass" with no price attached.
- Desktop app — onboarding says "Latest models with regular free promos. No API keys needed.", which is about the rotating **free-model** promos, not this one. Left alone.
- Cline hub — nothing.
- Docs (`docs/getting-started/clinepass.mdx` and four others) — all quote the flat $9.99/month, no discount. Nothing to change.

Note that anything outside this repo (marketing site, dashboard, `/promo` landing page) is not covered here and needs its own pass.

**Dead promo-code plumbing removed too.** `CLI_PROMO_CODE` in `apps/cli/src/utils/cline-pass-errors.ts` has been the empty string `""` since we removed the CLI promo-code flow (see the CLI changelog, "Removed the CLI promo code flow"). Both of its consumers therefore already took their non-promo branch:

- `getCliSubscriptionUrl()` — the `if (!CLI_PROMO_CODE)` early return always fired, so the `/promo?code=…&personal=true` URL was unreachable.
- `buildClinePassSubscriptionPageUrl()` — the `url.searchParams.set("code", …)` block never ran.

Both now build `/dashboard/subscription?personal=true` unconditionally. **No URL that any user can reach changes** — this is pure dead-branch deletion, which also means there's no leftover switch someone could flip to resurrect the promo by accident.

### Test Procedure

- `bunx tsc --noEmit -p tsconfig.json` in `apps/cli` — clean.
- `bun test ./src/tui/components/dialogs/provider-picker.test.ts ./src/kanban-migration/notice-dialog.test.ts ./src/utils/cline-pass-errors.test.ts` — 18 pass. `provider-picker.test.ts` asserts the exact subscription URL `buildClinePassSubscriptionPageUrl` produces, which is the direct guard on the plumbing removal, and it's green unchanged (confirming the promo branch really was dead).
- `bunx vitest run src/runtime/run-agent.test.ts` — 17 pass. This one derives its expected not-subscribed message from `getCliSubscriptionUrl()`, so it covers the other call site. (It needs vitest rather than `bun test` — it uses `vi.hoisted`.)
- `bunx biome check` on the three touched files — clean.

**What could break:** the dialog's copy `<box>` now wraps a single `<text>` instead of two. Layout is `flexDirection="column"` with no per-child spacing, so dropping a child just removes a line — no gap/padding math depends on the count.

The tuistory e2e test `"dismisses the ClinePass promo with any key and marks it as shown"` (`src/cli.tuistory.e2e.test.ts`) drives this exact dialog. It matches on `"Try ClinePass"`, `"Press Enter to open, any other key to close"`, and `"Open ClinePass"` — none of which this PR touches — so it needs no update. I did not run the tuistory suite locally (headless PTY harness); CI covers it.

### Type of Change

-   [x] 💅 Cosmetic Changes
-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

The dialog loses exactly one line. Before:

```
  Try ClinePass

  ClinePass is a $9.99/month subscription plan to get access to the
  latest open-weight coding models with enough quota for day-to-day
  work, at a much lower cost than paying API costs directly.
  Try it now with a limited-time promo for $4.99.      <-- removed

  https://app.cline.bot/dashboard/subscription?personal=true

  [ Open ClinePass ]
  Press Enter to open, any other key to close
```

### Additional Notes

No changelog entry: `apps/cli/CHANGELOG.md`'s newest section (3.0.57) is already published, and new sections get drafted at release time by the publish flow.
