### PR TITLE
Hide task costs on vscode when ClinePass is selected

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/catalog.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.ts
@@ -48,13 +48,13 @@ const DEFAULT_MODEL_CATALOG_CONFIG: ModelCatalogConfig = {
 }
 
 /**
- * Normalize the SDK's usage-cost-display answer (string union) into the
- * extension's {@link UsageCostDisplay} type. The SDK function takes a
- * provider id (not metadata) and consults its own registry; we forward
- * the id and trust the answer rather than re-parsing the metadata bag.
+ * Read the SDK's usage-cost-display answer for a provider. The SDK
+ * function takes a provider id (not metadata) and consults its own
+ * registry; we forward the id and trust the answer rather than
+ * re-parsing the metadata bag.
  */
 function readUsageCostDisplay(providerId: string): UsageCostDisplay {
-	return resolveProviderUsageCostDisplay(providerId) === "hide" ? "hide" : "show"
+	return resolveProviderUsageCostDisplay(providerId)
 }
 
 function makeCacheKey(providerId: ProviderId, fingerprint: Fingerprint): CacheKey {

--- a/apps/vscode/src/sdk/model-catalog/contracts.ts
+++ b/apps/vscode/src/sdk/model-catalog/contracts.ts
@@ -263,11 +263,13 @@ export interface Disposable {
 /**
  * SDK-driven hint for how to display per-token / total cost in the UI.
  * Mirrors `ProviderUsageCostDisplay` from `@cline/llms` and the CLI's
- * `shouldShowCliUsageCost` consumer. When `"hide"`, downstream UIs MUST
- * suppress per-token pricing rows (in model info cards) and total-cost
- * lines (in task summaries / status bars).
+ * `shouldShowCliUsageCost` consumer. Anything other than `"show"` means
+ * downstream UIs MUST suppress per-token pricing rows (in model info
+ * cards) and total-cost lines (in task summaries / status bars);
+ * `"subscription"` additionally signals that usage is covered by the
+ * user's subscription (e.g. ClinePass, ChatGPT Plus/Pro).
  */
-export type UsageCostDisplay = "show" | "hide"
+export type UsageCostDisplay = "show" | "hide" | "subscription"
 
 export interface ProviderListing {
 	readonly id: ProviderId

--- a/apps/vscode/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -92,8 +92,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	// Local providers report no cost; the openai-compatible provider can
 	// report cost only when the user has supplied both prices. For every
 	// other provider, the SDK is the source of truth for whether to render
-	// per-task cost: providers with `metadata.usageCostDisplay = "hide"`
-	// (e.g. ChatGPT Plus/Pro subscription) are filtered out here. This
+	// per-task cost: providers with `metadata.usageCostDisplay` set to
+	// "hide" or "subscription" (e.g. ClinePass, ChatGPT Plus/Pro
+	// subscription) are filtered out here. This
 	// mirrors the CLI's `shouldShowCliUsageCost` consumer and removes the
 	// previous extension-side hard-coded "openai-codex" check.
 	const usageCostDisplay = useProviderUsageCostDisplay(modeFields.apiProvider)

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { useProviderListings } from "./useProviderListings"
+import { useProviderUsageCostDisplay } from "./useProviderUsageCostDisplay"
+
+vi.mock("./useProviderListings", () => ({
+	useProviderListings: vi.fn(),
+}))
+
+const mockUseProviderListings = vi.mocked(useProviderListings)
+
+function withListings(providers: Array<{ id: string; usageCostDisplay: string }>) {
+	mockUseProviderListings.mockReturnValue({
+		providers,
+		isLoading: false,
+		error: undefined,
+		refresh: vi.fn(),
+	} as unknown as ReturnType<typeof useProviderListings>)
+}
+
+describe("useProviderUsageCostDisplay", () => {
+	it("hides cost for providers the SDK marks as subscription", () => {
+		withListings([{ id: "cline-pass", usageCostDisplay: "subscription" }])
+		const { result } = renderHook(() => useProviderUsageCostDisplay("cline-pass"))
+		expect(result.current).toBe("hide")
+	})
+
+	it("hides cost for providers the SDK marks as hide", () => {
+		withListings([{ id: "some-provider", usageCostDisplay: "hide" }])
+		const { result } = renderHook(() => useProviderUsageCostDisplay("some-provider"))
+		expect(result.current).toBe("hide")
+	})
+
+	it("shows cost for providers marked show and for unknown providers", () => {
+		withListings([{ id: "openrouter", usageCostDisplay: "show" }])
+		expect(renderHook(() => useProviderUsageCostDisplay("openrouter")).result.current).toBe("show")
+		expect(renderHook(() => useProviderUsageCostDisplay("anthropic")).result.current).toBe("show")
+		expect(renderHook(() => useProviderUsageCostDisplay(undefined)).result.current).toBe("show")
+	})
+})

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
@@ -8,12 +8,12 @@ import { useProviderListings } from "./useProviderListings"
  * `apps/vscode/src/sdk/model-catalog/catalog.ts`) and is propagated
  * through the `ProviderListing.usage_cost_display` gRPC field.
  *
- * Returns `"hide"` when the SDK reports a subscription-style provider
- * whose per-token / total cost displays should be suppressed (matches
- * the CLI's `shouldShowCliUsageCost` consumer in `sdk/apps/cli`). Falls
- * back to `"show"` while the listings are still loading or for any
- * provider the SDK does not explicitly mark — the same default policy
- * the SDK and CLI use.
+ * Returns `"hide"` when the SDK reports `"hide"` or `"subscription"` —
+ * either way per-token / total cost displays should be suppressed
+ * (matches the CLI's `shouldShowCliUsageCost`, which only shows cost
+ * for `"show"`). Falls back to `"show"` while the listings are still
+ * loading or for any provider the SDK does not explicitly mark — the
+ * same default policy the SDK and CLI use.
  *
  * Webview consumers must pass the returned value into
  * `ModelInfoView.hideUsageCost` (and equivalent cost-display sites)
@@ -28,6 +28,6 @@ export function useProviderUsageCostDisplay(providerId: string | undefined): "sh
 			return "show"
 		}
 		const listing = providers.find((p) => p.id === providerId)
-		return listing?.usageCostDisplay === "hide" ? "hide" : "show"
+		return listing?.usageCostDisplay === "hide" || listing?.usageCostDisplay === "subscription" ? "hide" : "show"
 	}, [providers, providerId])
 }


### PR DESCRIPTION
### Description

This PR hides cost information when a subscription-based provider is selected.
<img width="297" height="889" alt="image" src="https://github.com/user-attachments/assets/bfdf22b1-9cf6-4599-bcbe-700afe4ce222" />

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)