### PR TITLE
fix(sdk): carry root overrides into the Node smoke-test sandbox

### DIFF
--- a/sdk/scripts/ci-node-smoke.ts
+++ b/sdk/scripts/ci-node-smoke.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -88,6 +88,13 @@ async function main(): Promise<void> {
 			shared: await packWorkspace("shared", packDir),
 		};
 
+		// Carry the repo root's dependency overrides into the sandbox so a broken
+		// third-party release that the root already pins around (e.g. the
+		// @sap-cloud-sdk 4.9.0 exports breakage) can't fail the smoke install.
+		const rootPackageJson = JSON.parse(
+			await readFile(join(root, "..", "package.json"), "utf8"),
+		) as { overrides?: Record<string, unknown> };
+
 		await writeFile(
 			join(smokeDir, "package.json"),
 			`${JSON.stringify(
@@ -101,6 +108,9 @@ async function main(): Promise<void> {
 						"@cline/llms": `file:${tarballs.llms}`,
 						"@cline/shared": `file:${tarballs.shared}`,
 					},
+					...(rootPackageJson.overrides
+						? { overrides: rootPackageJson.overrides }
+						: {}),
 				},
 				null,
 				2,


### PR DESCRIPTION
## Problem

The sdk-test workflow's **Smoke test SQLite under Node** step has failed on every PR since 2026-08-24 ~10:00 UTC ([example failing job](https://github.com/cline/cline/actions/runs/32757880948/job/97530376906)) with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './internal.js' is not defined by "exports" in .../node_modules/@sap-cloud-sdk/connectivity/package.json imported from .../node_modules/@sap-ai-sdk/ai-api/dist/utils/deployment-cache.js
```

@sap-cloud-sdk 4.9.0 (published 2026-08-24T09:58Z) breaks @sap-ai-sdk/ai-api 2.14.0, which declares `^4.8.0` and reaches us via `@jerome-benoit/sap-ai-provider` (a `@cline/llms` dependency). The repo root `package.json` already pins `@sap-cloud-sdk/*` to 4.6.0 in `overrides`, but `sdk/scripts/ci-node-smoke.ts` packs the SDK tarballs and runs a plain `npm install` in a fresh temp dir, where those root overrides don't apply — so the sandbox resolves the broken 4.9.0. This currently blocks e.g. #13512.

## Fix

The smoke script now copies the root `package.json`'s `overrides` block into the generated sandbox `package.json`, so the sandbox install resolves the same pinned versions as the repo. Reading it from the root (rather than hardcoding) keeps a single source of truth: future override changes propagate automatically, and no third-party release the root already pins around can break the smoke step independently.

## Verification

`bun sdk/scripts/ci-node-smoke.ts` locally (after `bun install` + `bun run build:sdk`): install succeeds and prints `SQLite smoke test passed`. Confirmed load-bearing: npm's latest `@sap-cloud-sdk/connectivity` is still 4.9.0 and `@sap-ai-sdk/ai-api` declares `^4.8.0`, so without the override the sandbox still resolves the broken release.