### PR TITLE
fix(webview): render an approval-pending low-stakes tool once, not twice

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.test.ts
@@ -51,6 +51,14 @@ const createAskMessage = (
 	ts,
 })
 
+const createAskToolMessage = (ts: number, tool: string): ClineMessage => ({
+	type: "ask",
+	ask: "tool",
+	text: JSON.stringify({ tool, path: "src/file.ts" }),
+	ts,
+	partial: false,
+})
+
 describe("filterVisibleMessages", () => {
 	it("hides exact user feedback echoes for selected follow-up options", () => {
 		const askMessage = createAskMessage(1, "followup", ["Use this", "Use that"], "Use this")
@@ -165,5 +173,22 @@ describe("groupLowStakesTools", () => {
 		expect(grouped).toHaveLength(2)
 		expect(grouped[0]).toMatchObject({ type: "say", say: "reasoning", text: "Planning next read" })
 		expect(isToolGroup(grouped[1])).toBe(true)
+	})
+
+	it("renders an approval-pending low-stakes tool once, as a standalone row", () => {
+		const grouped = groupLowStakesTools([createAskToolMessage(1, "readFile")])
+
+		expect(grouped).toHaveLength(1)
+		expect(isToolGroup(grouped[0])).toBe(false)
+		expect(grouped[0]).toMatchObject({ type: "ask", ask: "tool" })
+	})
+
+	it("finalizes the preceding group and renders the approval-pending tool once", () => {
+		const grouped = groupLowStakesTools([createToolMessage(1, "readFile"), createAskToolMessage(2, "searchFiles")])
+
+		expect(grouped).toHaveLength(2)
+		expect(isToolGroup(grouped[0])).toBe(true)
+		expect(grouped[0]).toHaveLength(1)
+		expect(grouped[1]).toMatchObject({ type: "ask", ask: "tool" })
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -592,11 +592,14 @@ export function groupLowStakesTools(groupedMessages: (ClineMessage | ClineMessag
 			}
 			absorbPending()
 			hasTools = true
-			toolGroup.push(message)
 			// If the streaming has stopped and the last message is still an ask,
-			// this means the tool requires user approval - show the old tool block UI.
+			// this means the tool requires user approval - show the old tool block UI
+			// as a standalone row instead of also absorbing it into the compact group
+			// (absorbing here would render the tool twice).
 			if (message.type === "ask" && !message.partial && isLast) {
 				pendingTools.push(message)
+			} else {
+				toolGroup.push(message)
 			}
 			continue
 		}


### PR DESCRIPTION
### Related Issue

Small self-contained bug fix (covered by the template's "small bug fixes may be submitted directly" exception).

### Description

`groupLowStakesTools` in `messageUtils.ts` renders an approval-pending low-stakes tool **twice**.

When a low-stakes tool (`readFile`, `searchFiles`, ...) is the last message and is still an `ask` awaiting user approval, the code pushes it into the compact `toolGroup` *and* into `pendingTools`:

```ts
toolGroup.push(message)
if (message.type === "ask" && !message.partial && isLast) {
    pendingTools.push(message)
}
```

At finalization, `commitToolGroup()` emits it inside a `_isToolGroup` row and `result.push(...pendingTools)` emits the same message again standalone — so the tool shows up as a grouped row *and* an approval block.

The fix makes the two branches mutually exclusive: an approval-pending last ask-tool renders as the standalone approval row only; otherwise it goes into the group. Because the divert is already guarded by `isLast`, this only affects the final message.

### Test Procedure

Added two cases to the existing `groupLowStakesTools` suite in `messageUtils.test.ts`. Both fail before the change and pass after.

Before (source reverted, tests present):

```
$ bunx vitest run messageUtils.test.ts -t approval-pending
 × groupLowStakesTools > renders an approval-pending low-stakes tool once, as a standalone row
   → expected [ …(2) ] to have a length of 1 but got 2
 × groupLowStakesTools > finalizes the preceding group and renders the approval-pending tool once
   → expected [ …(2), _isToolGroup: true ] to have a length of 1 but got 2
 Tests  2 failed | 11 skipped
```

After (fix in place):

```
$ bunx vitest run messageUtils.test.ts -t groupLowStakesTools
 ✓ src/components/chat/chat-view/utils/messageUtils.test.ts (13 tests | 6 skipped)
 Tests  7 passed | 6 skipped
```

No existing `groupLowStakesTools` test changed behavior; only the duplicate-render path is corrected.

---

**Rendered before/after test run:**

![before/after test run](https://github.com/user-attachments/assets/cd6354b7-2a62-4122-98e8-00183425dfe0)
