### PR TITLE
Hide Channels and Agents sections from desktop app sidebar

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/sections.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/sections.ts
@@ -5,7 +5,7 @@
  * initial chat bundle. The heavy views load on demand via next/dynamic.
  */
 
-export const SETTINGS_SECTIONS = [
+const ALL_SETTINGS_SECTIONS = [
 	"General",
 	"Models",
 	"Channels",
@@ -16,7 +16,7 @@ export const SETTINGS_SECTIONS = [
 // Mirrors the Cline Hub dashboard's Customizations nav group. Plugins is the
 // unified hub for installed plugins, MCP servers, and skills; Marketplace is
 // the full catalog page for installing more.
-export const CUSTOMIZATION_SECTIONS = [
+const ALL_CUSTOMIZATION_SECTIONS = [
 	"Plugins",
 	"Marketplace",
 	"Hooks",
@@ -26,5 +26,20 @@ export const CUSTOMIZATION_SECTIONS = [
 ] as const;
 
 export type SettingsSection =
-	| (typeof SETTINGS_SECTIONS)[number]
-	| (typeof CUSTOMIZATION_SECTIONS)[number];
+	| (typeof ALL_SETTINGS_SECTIONS)[number]
+	| (typeof ALL_CUSTOMIZATION_SECTIONS)[number];
+
+// Temporarily hidden from the sidebar. The views and routes still exist —
+// remove a section from this set to surface it again.
+const HIDDEN_SECTIONS: ReadonlySet<SettingsSection> = new Set([
+	"Channels",
+	"Agents",
+]);
+
+export const SETTINGS_SECTIONS = ALL_SETTINGS_SECTIONS.filter(
+	(section) => !HIDDEN_SECTIONS.has(section),
+);
+
+export const CUSTOMIZATION_SECTIONS = ALL_CUSTOMIZATION_SECTIONS.filter(
+	(section) => !HIDDEN_SECTIONS.has(section),
+);


### PR DESCRIPTION
### Description

Hides the Channels and Agents entries from the desktop app's settings sidebar for now, without removing the underlying pages.

- `sections.ts` keeps the full section lists (and the `SettingsSection` type unchanged) but filters a `HIDDEN_SECTIONS` set out of the exported `SETTINGS_SECTIONS` / `CUSTOMIZATION_SECTIONS` nav arrays.
- The Channels and Agents views, routes, and icon mappings are untouched, so restoring them later is a one-line change (remove the section from `HIDDEN_SECTIONS`).

Settings sidebar after the change (no Channels under Settings, no Agents under Customizations):

![Settings sidebar without Channels and Agents](https://cursor.com/artifacts/c/art-181f9077-ca59-4d10-b683-189d21257887)

### Test Procedure

- `bun run typecheck` in `apps/examples/desktop-app` passes.
- Vitest suites pass: `test:chat-ui` (117 tests) plus the sidebar and settings view tests (40 tests).
- Manually verified in the running app (sidecar + web UI) that the settings sidebar no longer shows Channels or Agents, and that the remaining settings pages (General, Models) still render correctly.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Code refactor (non-breaking change which improves code structure)
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow/CI changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)