### PR TITLE
Add suggested schedule templates to the desktop Schedules page

### DIFF
--- a/apps/examples/desktop-app/webview/components/ui/input.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
 				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 				className,

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-templates.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-templates.ts
@@ -1,0 +1,160 @@
+import { BookOpen, Bug, Newspaper, ShieldAlert } from "lucide-react";
+import type { ComponentType } from "react";
+
+export interface RoutineTemplate {
+	id: string;
+	title: string;
+	description: string;
+	icon: ComponentType<{ className?: string }>;
+	name: string;
+	prompt: string;
+	scheduleType: "daily" | "weekly";
+	scheduleDays: string[];
+	scheduleHour: string;
+	scheduleMinute: string;
+}
+
+const FIND_CRITICAL_BUGS_PROMPT = `You are an automated bug hunter that runs on a schedule. Dig through recent changes in this repository and catch severe correctness bugs before users hit them.
+
+## Scope
+
+Review the commits landed since your last run (roughly the past day). Only chase problems with serious consequences: data loss or corruption, crashes in critical paths, security regressions, races that drop writes, unbounded loops, resource leaks, and silent truncation of user data.
+
+Explicitly skip style nits, theoretical edge cases with no realistic trigger, and minor issues that would merely degrade UX.
+
+## How to investigate
+
+- Read beyond the diff. Follow the caller chain and downstream consumers so you understand the real blast radius of each change instead of pattern-matching on the patch.
+- For every suspect, construct the concrete sequence of events that makes it misbehave. If you cannot describe a plausible trigger, drop the finding.
+
+## When you find something
+
+- Apply the smallest fix you are confident in, and add or update a test to lock in the behavior when practical. No drive-by refactors in the same change.
+- Before opening a PR, check whether an open PR already fixes the same bug. If one exists, note that it is awaiting review with a link instead of duplicating it. If a previous fix was closed without merging, do not re-open one unless the relevant code has materially changed.
+- Only open a PR when you are highly confident the bug is real and the fix is correct. If PRs are not available in this workspace, commit the fix to a branch and describe it in your summary.
+
+## Wrap up
+
+Finish with a short report: what you inspected, and for each fix the bug, its impact, the root cause, and how you validated the change. If nothing clears the bar, a plain "no critical bugs found" summary is the expected outcome most runs.`;
+
+const SECURITY_SCAN_PROMPT = `You are a scheduled security reviewer for this repository. Find medium, high, or critical vulnerabilities with a genuine end-to-end attack path, not theoretical weaknesses.
+
+## Where to look
+
+- Authentication, session handling, and permission checks
+- Request handlers, RPC endpoints, webhook receivers, and other entry points
+- Raw SQL, shell execution, file-system access, and template rendering
+- Deserialization and parsing of untrusted input
+- Secrets handling and anything that logs sensitive values
+
+## Validation bar
+
+A finding only counts if you can walk the entire chain: who the attacker is, what input they control, how that input reaches the vulnerable code, and what impact they gain. Trace the code to confirm every step. Skip lint-level "unsafe API" observations that lack a real route in, and skip best-practice notes without concrete impact.
+
+## Avoiding repeats
+
+Keep a running log of past findings in a local notes file (for example \`security-findings.local.md\` in the workspace root, excluded from version control). Read it before scanning, do not re-report anything already listed, and append new validated findings after each run.
+
+## Reporting
+
+For each new validated finding, write up the severity, the affected file, the full attack path, and the highest-leverage remediation. Treat findings as sensitive: keep them in the local report, and do not open a PR or publish them elsewhere from this scan. If nothing new clears the bar, say so briefly and stop.`;
+
+const DAILY_DIGEST_PROMPT = `You write a daily engineering digest for this repository.
+
+## Task
+
+Review everything that landed in the last 24 hours (commits and merged PRs) and distill it into a brief a teammate could read in under a minute.
+
+## Cover
+
+- Changes that matter: new behavior, user-facing impact, and notable bug fixes
+- Risky territory: large diffs, sensitive subsystems touched, migrations, dependency or security updates
+- Loose ends: missing tests, TODOs introduced, rollout risks, likely follow-ups
+
+## Style
+
+- Group related changes into themes instead of listing every commit.
+- Tie every claim to a concrete commit or PR; never guess at intent or invent details.
+- Prioritize signal over completeness, and keep the whole digest easy to skim. On quiet days a two-line digest is fine.
+
+## Format
+
+Start with the date range covered, then 3-7 bullets of meaningful changes, then a short "Worth watching" section with 1-3 risks or pending follow-ups.`;
+
+const UPDATE_DOCS_PROMPT = `You are a documentation maintainer that runs on a schedule. Keep this repository's docs accurate as the code evolves.
+
+## Task
+
+Compare recent code changes against the existing documentation and close the gaps.
+
+## Priorities
+
+- Docs that recent changes made stale or wrong. Fix these first.
+- Recently touched subsystems with thin or missing coverage.
+- Public interfaces, developer setup and troubleshooting guides, and operational runbooks.
+
+## Standards
+
+- Verify every statement against the source code; never document behavior you have not confirmed.
+- Prefer updating existing pages over creating redundant new ones.
+- Explain intent and usage with concrete examples and constraints, and keep pages structured for scanning.
+- Match the style, tone, and location conventions of the docs already in this repository.
+
+## Output
+
+Open a focused, docs-only PR (or commit the updates to a branch if PRs are unavailable). Summarize which docs you added or updated, the code paths they now cover, and the knowledge gaps you closed. If everything is already accurate, report that and finish.`;
+
+export const ROUTINE_TEMPLATES: RoutineTemplate[] = [
+	{
+		id: "find-critical-bugs",
+		title: "Find critical bugs",
+		description:
+			"Sweep recent commits for high-severity bugs that slipped past review, and fix the ones with a concrete trigger.",
+		icon: Bug,
+		name: "Find critical bugs",
+		prompt: FIND_CRITICAL_BUGS_PROMPT,
+		scheduleType: "daily",
+		scheduleDays: ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"],
+		scheduleHour: "9",
+		scheduleMinute: "0",
+	},
+	{
+		id: "security-scan",
+		title: "Scan for vulnerabilities",
+		description:
+			"Audit the codebase for exploitable security issues with a validated end-to-end attack path.",
+		icon: ShieldAlert,
+		name: "Security scan",
+		prompt: SECURITY_SCAN_PROMPT,
+		scheduleType: "weekly",
+		scheduleDays: ["MON"],
+		scheduleHour: "8",
+		scheduleMinute: "0",
+	},
+	{
+		id: "daily-digest",
+		title: "Summarize changes daily",
+		description:
+			"Get a skimmable digest of everything that landed in the last 24 hours, plus risks worth watching.",
+		icon: Newspaper,
+		name: "Daily change digest",
+		prompt: DAILY_DIGEST_PROMPT,
+		scheduleType: "daily",
+		scheduleDays: ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"],
+		scheduleHour: "17",
+		scheduleMinute: "0",
+	},
+	{
+		id: "update-docs",
+		title: "Keep docs updated",
+		description:
+			"Refresh documentation whenever the code drifts away from it, verified against the source.",
+		icon: BookOpen,
+		name: "Update docs",
+		prompt: UPDATE_DOCS_PROMPT,
+		scheduleType: "weekly",
+		scheduleDays: ["FRI"],
+		scheduleHour: "10",
+		scheduleMinute: "0",
+	},
+];

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -86,6 +86,7 @@ import {
 	PageFrame,
 	PageHeader,
 } from "../page-layout";
+import { ROUTINE_TEMPLATES, type RoutineTemplate } from "./routine-templates";
 
 type DateTimeValue = number | string;
 
@@ -868,7 +869,7 @@ export function RoutineSchedulesContent({
 		}
 	};
 
-	const openCreateDialog = async () => {
+	const openCreateDialog = async (template?: RoutineTemplate) => {
 		setEditingSchedule(null);
 		setErrorMessage(null);
 		setCreateFormError(null);
@@ -893,13 +894,20 @@ export function RoutineSchedulesContent({
 				? rememberedModel
 				: (modelsForProvider[0] ?? createForm.model);
 		setCreateForm({
-			name: "",
-			scheduleType: "once",
+			name: template?.name ?? "",
+			scheduleType: template?.scheduleType ?? "once",
 			scheduleDate: defaultScheduleDate(),
-			scheduleHour: "9",
-			scheduleMinute: "0",
-			scheduleDays: ["MON", "TUE", "WED", "THU", "FRI"],
-			prompt: "Review PRs opened yesterday and summarize issues.",
+			scheduleHour: template?.scheduleHour ?? "9",
+			scheduleMinute: template?.scheduleMinute ?? "0",
+			scheduleDays: template?.scheduleDays ?? [
+				"MON",
+				"TUE",
+				"WED",
+				"THU",
+				"FRI",
+			],
+			prompt:
+				template?.prompt ?? "Review PRs opened yesterday and summarize issues.",
 			provider: preferredProvider,
 			model: preferredModel,
 			workspaceRoot: context.workspaceRoot || context.cwd,
@@ -1130,8 +1138,8 @@ export function RoutineSchedulesContent({
 				<PageEmptyState>Loading schedules...</PageEmptyState>
 			) : sortedSchedules.length === 0 ? (
 				<PageEmptyState>
-					No schedules found. Create a schedule to run routines on a recurring
-					basis.
+					No schedules yet. Start from a suggestion below, or create your own
+					with New Schedule.
 				</PageEmptyState>
 			) : (
 				<div className="flex flex-col gap-3">
@@ -1342,6 +1350,46 @@ export function RoutineSchedulesContent({
 						);
 					})}
 				</div>
+			)}
+
+			{!isLoading && (
+				<section className="mt-10">
+					<h2 className="text-sm font-semibold text-foreground">Suggested</h2>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Start from a ready-made prompt and adjust it before saving.
+					</p>
+					<div className="mt-3 grid gap-3 sm:grid-cols-2">
+						{ROUTINE_TEMPLATES.map((template) => {
+							const Icon = template.icon;
+							return (
+								<button
+									className="group flex items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-surface-hover-lighter"
+									key={template.id}
+									onClick={() => void openCreateDialog(template)}
+									type="button"
+								>
+									<div className="flex size-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors group-hover:text-primary">
+										<Icon className="size-4.5" />
+									</div>
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-2">
+											<h3 className="truncate text-sm font-semibold text-foreground">
+												{template.title}
+											</h3>
+											<span className="shrink-0 rounded-md border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
+												{template.scheduleType === "daily" ? "Daily" : "Weekly"}
+											</span>
+										</div>
+										<p className="mt-1 text-xs leading-5 text-muted-foreground">
+											{template.description}
+										</p>
+									</div>
+									<Plus className="mt-0.5 size-4 shrink-0 text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100" />
+								</button>
+							);
+						})}
+					</div>
+				</section>
 			)}
 			<Dialog
 				open={Boolean(viewingSchedule)}

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -1354,10 +1354,9 @@ export function RoutineSchedulesContent({
 
 			{!isLoading && (
 				<section className="mt-10">
-					<h2 className="text-sm font-semibold text-foreground">Suggested</h2>
-					<p className="mt-1 text-xs text-muted-foreground">
-						Start from a ready-made prompt and adjust it before saving.
-					</p>
+					<h2 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+						Suggested
+					</h2>
 					<div className="mt-3 grid gap-3 sm:grid-cols-2">
 						{ROUTINE_TEMPLATES.map((template) => {
 							const Icon = template.icon;

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -1083,6 +1083,16 @@ export function RoutineSchedulesContent({
 		[schedules],
 	);
 
+	// Hide suggestions the user has already created (matched by schedule name).
+	const visibleTemplates = useMemo(() => {
+		const existingNames = new Set(
+			schedules.map((schedule) => schedule.name.trim().toLowerCase()),
+		);
+		return ROUTINE_TEMPLATES.filter(
+			(template) => !existingNames.has(template.name.trim().toLowerCase()),
+		);
+	}, [schedules]);
+
 	const viewingExecutions = useMemo(() => {
 		if (!viewingSchedule) {
 			return [];
@@ -1352,13 +1362,13 @@ export function RoutineSchedulesContent({
 				</div>
 			)}
 
-			{!isLoading && (
+			{!isLoading && visibleTemplates.length > 0 && (
 				<section className="mt-10">
 					<h2 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
 						Suggested
 					</h2>
 					<div className="mt-3 grid gap-3 sm:grid-cols-2">
-						{ROUTINE_TEMPLATES.map((template) => {
+						{visibleTemplates.map((template) => {
 							const Icon = template.icon;
 							return (
 								<button


### PR DESCRIPTION
## Description

Adds a "Suggested" section to the desktop app's Schedules page with four ready-made schedule templates, so users can create useful scheduled routines in one click instead of starting from a blank prompt:

- Find critical bugs (daily): sweeps recent commits for high-severity correctness bugs with a concrete trigger and fixes them
- Scan for vulnerabilities (weekly): audits the codebase for exploitable security issues with a validated end-to-end attack path, keeping a local findings log to avoid repeats
- Summarize changes daily (daily): produces a skimmable digest of the last 24 hours plus a short watchlist
- Keep docs updated (weekly): compares recent code changes against docs and closes the gaps, verified against source

Each card shows an icon, title, description, and a cadence badge. Clicking a card opens the existing create dialog prefilled with the template's name, prompt, and schedule (frequency, days, time), so the user can review and tweak everything before saving. The section renders below the schedule list (and below the empty state when no schedules exist yet).

Implementation:
- New `routine-templates.ts` holds the template definitions (icon, title, description, prompt, default cadence)
- `openCreateDialog` in `routine-view.tsx` now accepts an optional template to prefill the form; behavior without a template is unchanged

Also fixes a pre-existing readability bug this surfaced: the `Input` component's `selection:bg-primary selection:text-primary-foreground` utilities conflict with the unlayered global `::selection` rule in `@cline/ui/theme/base.css`. The unlayered rule wins for the background (light translucent accent) while the Tailwind utility still applied white text, making auto-selected input text (e.g. the dialog's Name field on open) look white/invisible. Dropping the two selection utilities lets inputs use the theme's global selection style, matching every other element.

## Screenshots

Schedules page with the Suggested section:

![Schedules page with suggested template cards](https://cursor.com/artifacts/c/art-778e3c5e-472e-44e1-ae43-4e009ced3efb)

Clicking a card opens the create dialog prefilled with name, cadence, and prompt (selected Name text now readable):

![Create dialog prefilled from the Keep docs updated template with readable selected name text](https://cursor.com/artifacts/c/art-da496fda-2756-49cc-8036-a0720233acc5)

Created schedule in the list, with the Suggested section still available below:

![Schedule created from template shown in the list](https://cursor.com/artifacts/c/art-f96c4099-e47d-401e-8493-a8cf4991a7f9)

## Test Plan

- `bun run typecheck` in `apps/examples/desktop-app` passes; Biome check passes on all touched files
- Manual test in the running desktop webview (headless dev servers): cards render on the Schedules page, clicking a card opens the dialog prefilled with name, cadence, and the full prompt, and Create Schedule produces a working schedule with the correct next run time
- Verified the Name field's auto-selected text is now dark and readable on the light selection highlight