### PR TITLE
Redesign desktop Model Providers page and split voice input into its own settings page

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -481,7 +481,7 @@ export default function Home() {
 									}
 									parentSession={activeParentSession}
 									onOpenVoiceInputSettings={() =>
-										handleSettingsSectionChange("Models")
+										handleSettingsSectionChange("Voice")
 									}
 									onThreadStarted={handleThreadStarted}
 								/>

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -223,7 +223,7 @@ function SettingsSectionNavigation({
 			<span
 				className={cn("block", collapsed && "flex w-full justify-start")}
 				key={section}
-				title="Connect a model provider to set up voice input"
+				title="Configure a model provider to set up voice input"
 			>
 				{button}
 			</span>

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -24,6 +24,7 @@ import {
 	GitFork,
 	Loader2,
 	MessageSquarePlus,
+	Mic,
 	PanelLeftOpen,
 	Pencil,
 	Play,
@@ -103,6 +104,7 @@ import {
 } from "@/components/views/settings/sections";
 import { useAccount } from "@/contexts/account-context";
 import { useAgendaAutomation, useAgendaTasks } from "@/hooks/use-agenda-tasks";
+import { useHasConnectedProvider } from "@/hooks/use-has-connected-provider";
 import type {
 	SessionThread,
 	UseSessionHistoryResult,
@@ -163,6 +165,7 @@ function hubPort(url: string | null): string | null {
 const SETTINGS_SECTION_ICONS = {
 	General: SlidersHorizontal,
 	Models: Bot,
+	Voice: Mic,
 	Channels: Radio,
 	Schedules: Clock3,
 	Account: CircleUserRound,
@@ -183,8 +186,15 @@ function SettingsSectionNavigation({
 	collapsed: boolean;
 	onSelect: (section: SettingsSection) => void;
 }) {
+	// Voice input only works with a connected model provider, so its section
+	// stays disabled until one is set up (null = catalog still loading).
+	const hasConnectedProvider = useHasConnectedProvider();
 	const renderSectionButton = (section: SettingsSection) => {
 		const Icon = SETTINGS_SECTION_ICONS[section];
+		const disabled = section === "Voice" && hasConnectedProvider === false;
+		const title = disabled
+			? "Connect a model provider to set up voice input"
+			: section;
 		return (
 			<Button
 				aria-current={activeSection === section ? "page" : undefined}
@@ -195,9 +205,10 @@ function SettingsSectionNavigation({
 						"bg-surface-hover text-sidebar-foreground",
 					collapsed && "size-9 justify-center px-0",
 				)}
+				disabled={disabled}
 				key={section}
 				onClick={() => onSelect(section)}
-				title={section}
+				title={title}
 				type="button"
 				variant="sidebarItem"
 			>

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -192,10 +192,7 @@ function SettingsSectionNavigation({
 	const renderSectionButton = (section: SettingsSection) => {
 		const Icon = SETTINGS_SECTION_ICONS[section];
 		const disabled = section === "Voice" && hasConnectedProvider === false;
-		const title = disabled
-			? "Connect a model provider to set up voice input"
-			: section;
-		return (
+		const button = (
 			<Button
 				aria-current={activeSection === section ? "page" : undefined}
 				aria-label={section}
@@ -204,17 +201,32 @@ function SettingsSectionNavigation({
 					activeSection === section &&
 						"bg-surface-hover text-sidebar-foreground",
 					collapsed && "size-9 justify-center px-0",
+					disabled && !collapsed && "w-full",
 				)}
 				disabled={disabled}
-				key={section}
+				key={disabled ? undefined : section}
 				onClick={() => onSelect(section)}
-				title={title}
+				title={section}
 				type="button"
 				variant="sidebarItem"
 			>
 				<Icon className="size-4 shrink-0" />
 				{!collapsed ? <span className="truncate">{section}</span> : null}
 			</Button>
+		);
+		if (!disabled) {
+			return button;
+		}
+		// Disabled buttons swallow pointer events, so the explanation lives on
+		// a wrapping span for the native tooltip to work.
+		return (
+			<span
+				className={cn("block", collapsed && "flex w-full justify-start")}
+				key={section}
+				title="Connect a model provider to set up voice input"
+			>
+				{button}
+			</span>
 		);
 	};
 

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1328,7 +1328,7 @@ function ChatInputBarImpl({
 								title={
 									transcriptionTarget
 										? `${transcriptionTarget.supportsStreaming ? "Transcribe live" : "Transcribe"} with ${transcriptionTarget.providerName} / ${transcriptionTarget.modelName}`
-										: "Configure voice input in Settings → Models"
+										: "Configure voice input in Settings → Voice"
 								}
 							/>
 							{(!isBusy || canSend) && (

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
@@ -157,7 +157,7 @@ describe("ProviderListContent", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("groups providers into Connected, Popular, and All providers", async () => {
+	it("groups providers into Configured, Popular, and All providers", async () => {
 		const onConfigure = vi.fn();
 		await act(async () => {
 			root.render(
@@ -172,10 +172,10 @@ describe("ProviderListContent", () => {
 		const headings = Array.from(container.querySelectorAll("h2")).map(
 			(heading) => heading.textContent,
 		);
-		expect(headings).toEqual(["Connected", "Popular", "All providers"]);
+		expect(headings).toEqual(["Configured", "Popular", "All providers"]);
 		// No per-provider enable toggles anymore.
 		expect(container.querySelector('[role="switch"]')).toBeNull();
-		expect(container.textContent).toContain("1 connected");
+		expect(container.textContent).toContain("1 configured");
 
 		const rows = Array.from(container.querySelectorAll("button")).filter(
 			(button) => button.textContent?.includes("Anthropic"),
@@ -199,7 +199,7 @@ describe("ProviderListContent", () => {
 			Array.from(container.querySelectorAll("button")).find((button) =>
 				button.textContent?.includes(name),
 			);
-		expect(rowFor("Anthropic")?.textContent).toContain("Connected");
+		expect(rowFor("Anthropic")?.textContent).toContain("Configured");
 		expect(rowFor("Cline")?.textContent).toContain("Sign in");
 		expect(rowFor("ElevenLabs")?.textContent).toContain("API key");
 	});
@@ -284,7 +284,7 @@ describe("ProviderDetailContent auth flows", () => {
 		});
 
 		expect(container.textContent).toContain("Sign in with browser");
-		expect(container.textContent).toContain("Not connected");
+		expect(container.textContent).toContain("Not configured");
 		// The API key input stays collapsed until explicitly requested.
 		expect(container.querySelector('input[type="password"]')).toBeNull();
 
@@ -319,7 +319,7 @@ describe("ProviderDetailContent auth flows", () => {
 		});
 
 		expect(container.textContent).toContain("Signed in via browser");
-		expect(container.textContent).toContain("Connected");
+		expect(container.textContent).toContain("Configured");
 		const signOut = Array.from(container.querySelectorAll("button")).find(
 			(button) => button.textContent === "Sign out",
 		);

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
@@ -3,7 +3,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Provider, VoiceInputSelection } from "@/lib/provider-schema";
+import type { Provider } from "@/lib/provider-schema";
 import {
 	ProviderDetailContent,
 	ProviderListContent,
@@ -107,57 +107,40 @@ describe("ProviderDetailContent models", () => {
 	});
 });
 
-const voiceProviders: Provider[] = [
+const catalogProviders: Provider[] = [
+	{
+		id: "anthropic",
+		name: "Anthropic",
+		models: 4,
+		color: "#000000",
+		letter: "AN",
+		enabled: true,
+		apiKey: "sk-test",
+		capabilities: ["popular"],
+		modelList: [],
+	},
+	{
+		id: "cline",
+		name: "Cline",
+		models: 12,
+		color: "#000000",
+		letter: "CL",
+		enabled: false,
+		capabilities: ["oauth", "popular"],
+		modelList: [],
+	},
 	{
 		id: "elevenlabs",
 		name: "ElevenLabs",
 		models: 1,
 		color: "#000000",
 		letter: "EL",
-		enabled: true,
-		modelList: [
-			{
-				id: "scribe_v2",
-				name: "Scribe v2",
-				operation: "transcription",
-				inputModalities: ["audio"],
-				outputModalities: ["text"],
-			},
-		],
-	},
-	{
-		id: "groq",
-		name: "Groq",
-		models: 3,
-		color: "#000000",
-		letter: "GR",
-		enabled: true,
-		modelList: [
-			{
-				id: "whisper-large-v3",
-				name: "Whisper Large v3",
-				operation: "transcription",
-				inputModalities: ["audio"],
-				outputModalities: ["text"],
-			},
-			{
-				id: "whisper-large-v3-turbo",
-				name: "Whisper Large v3 Turbo",
-				operation: "transcription",
-				inputModalities: ["audio"],
-				outputModalities: ["text"],
-			},
-			{
-				id: "llama-chat",
-				name: "Llama Chat",
-				inputModalities: ["text"],
-				outputModalities: ["text"],
-			},
-		],
+		enabled: false,
+		modelList: [],
 	},
 ];
 
-describe("ProviderListContent voice input settings", () => {
+describe("ProviderListContent", () => {
 	let container: HTMLDivElement;
 	let root: Root;
 
@@ -174,74 +157,210 @@ describe("ProviderListContent voice input settings", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("lets the user choose and clear the voice provider and model", async () => {
-		const onVoiceInputChange = vi.fn();
-		let selection: VoiceInputSelection | undefined = {
-			providerId: "elevenlabs",
-			modelId: "scribe_v2",
-		};
-		const render = async () => {
-			await act(async () => {
-				root.render(
-					<ProviderListContent
-						onAddProvider={vi.fn()}
-						onConfigure={vi.fn()}
-						onToggle={vi.fn()}
-						onVoiceInputChange={onVoiceInputChange}
-						providers={voiceProviders}
-						voiceInput={selection}
-					/>,
-				);
-			});
-		};
-
-		await render();
-		const providerSelect = container.querySelector<HTMLSelectElement>(
-			'[aria-label="Voice input provider"]',
-		);
-		const modelSelect = container.querySelector<HTMLSelectElement>(
-			'[aria-label="Voice input model"]',
-		);
-		expect(providerSelect?.value).toBe("elevenlabs");
-		expect(modelSelect?.value).toBe("scribe_v2");
-
+	it("groups providers into Connected, Popular, and All providers", async () => {
+		const onConfigure = vi.fn();
 		await act(async () => {
-			if (!providerSelect) return;
-			providerSelect.value = "groq";
-			providerSelect.dispatchEvent(new Event("change", { bubbles: true }));
-		});
-		expect(onVoiceInputChange).toHaveBeenLastCalledWith({
-			providerId: "groq",
-			modelId: "whisper-large-v3",
-		});
-
-		selection = {
-			providerId: "groq",
-			modelId: "whisper-large-v3",
-		};
-		await render();
-		const groqModelSelect = container.querySelector<HTMLSelectElement>(
-			'[aria-label="Voice input model"]',
-		);
-		await act(async () => {
-			if (!groqModelSelect) return;
-			groqModelSelect.value = "whisper-large-v3-turbo";
-			groqModelSelect.dispatchEvent(new Event("change", { bubbles: true }));
-		});
-		expect(onVoiceInputChange).toHaveBeenLastCalledWith({
-			providerId: "groq",
-			modelId: "whisper-large-v3-turbo",
+			root.render(
+				<ProviderListContent
+					onAddProvider={vi.fn()}
+					onConfigure={onConfigure}
+					providers={catalogProviders}
+				/>,
+			);
 		});
 
-		const groqProviderSelect = container.querySelector<HTMLSelectElement>(
-			'[aria-label="Voice input provider"]',
+		const headings = Array.from(container.querySelectorAll("h2")).map(
+			(heading) => heading.textContent,
+		);
+		expect(headings).toEqual(["Connected", "Popular", "All providers"]);
+		// No per-provider enable toggles anymore.
+		expect(container.querySelector('[role="switch"]')).toBeNull();
+		expect(container.textContent).toContain("1 connected");
+
+		const rows = Array.from(container.querySelectorAll("button")).filter(
+			(button) => button.textContent?.includes("Anthropic"),
+		);
+		await act(async () => rows[0]?.click());
+		expect(onConfigure).toHaveBeenCalledWith("anthropic");
+	});
+
+	it("shows connection status and auth kind per row", async () => {
+		await act(async () => {
+			root.render(
+				<ProviderListContent
+					onAddProvider={vi.fn()}
+					onConfigure={vi.fn()}
+					providers={catalogProviders}
+				/>,
+			);
+		});
+
+		const rowFor = (name: string) =>
+			Array.from(container.querySelectorAll("button")).find((button) =>
+				button.textContent?.includes(name),
+			);
+		expect(rowFor("Anthropic")?.textContent).toContain("Connected");
+		expect(rowFor("Cline")?.textContent).toContain("Sign in");
+		expect(rowFor("ElevenLabs")?.textContent).toContain("API key");
+	});
+
+	it("filters providers by search across every group", async () => {
+		await act(async () => {
+			root.render(
+				<ProviderListContent
+					onAddProvider={vi.fn()}
+					onConfigure={vi.fn()}
+					providers={catalogProviders}
+				/>,
+			);
+		});
+
+		const search = container.querySelector<HTMLInputElement>(
+			'[aria-label="Search model providers"]',
 		);
 		await act(async () => {
-			if (!groqProviderSelect) return;
-			groqProviderSelect.value = "";
-			groqProviderSelect.dispatchEvent(new Event("change", { bubbles: true }));
+			const setter = Object.getOwnPropertyDescriptor(
+				HTMLInputElement.prototype,
+				"value",
+			)?.set;
+			setter?.call(search, "eleven");
+			search?.dispatchEvent(new Event("input", { bubbles: true }));
 		});
-		expect(onVoiceInputChange).toHaveBeenLastCalledWith(undefined);
+		expect(container.textContent).toContain("ElevenLabs");
+		expect(container.textContent).not.toContain("Anthropic");
+	});
+});
+
+describe("ProviderDetailContent auth flows", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+		// "cline" is a featured provider, so mounting its detail refreshes the
+		// model list; resolve it to keep the auth assertions deterministic.
+		loadProviderModelsMock.mockReset().mockResolvedValue([]);
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+		vi.restoreAllMocks();
+	});
+
+	const oauthProvider: Provider = {
+		id: "cline",
+		name: "Cline",
+		models: 0,
+		color: "#000",
+		letter: "CL",
+		enabled: false,
+		capabilities: ["oauth"],
+		configFields: [
+			{
+				path: "apiKey",
+				label: "API Key",
+				type: "password",
+				secret: true,
+			},
+		],
+		modelList: [],
+	};
+
+	it("shows browser sign-in instead of an API key field for OAuth providers", async () => {
+		const onOAuthLogin = vi.fn();
+		await act(async () => {
+			root.render(
+				<ProviderDetailContent
+					onBack={vi.fn()}
+					onOAuthLogin={onOAuthLogin}
+					onUpdate={vi.fn()}
+					provider={oauthProvider}
+				/>,
+			);
+		});
+
+		expect(container.textContent).toContain("Sign in with browser");
+		expect(container.textContent).toContain("Not connected");
+		// The API key input stays collapsed until explicitly requested.
+		expect(container.querySelector('input[type="password"]')).toBeNull();
+
+		const signIn = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.includes("Sign in with browser"),
+		);
+		await act(async () => signIn?.click());
+		expect(onOAuthLogin).toHaveBeenCalledOnce();
+
+		const manualKey = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.includes("Use an API key instead"),
+		);
+		await act(async () => manualKey?.click());
+		expect(container.querySelector('input[type="password"]')).not.toBeNull();
+	});
+
+	it("offers sign out when OAuth is connected", async () => {
+		const onDisconnect = vi.fn();
+		await act(async () => {
+			root.render(
+				<ProviderDetailContent
+					onBack={vi.fn()}
+					onDisconnect={onDisconnect}
+					onUpdate={vi.fn()}
+					provider={{
+						...oauthProvider,
+						enabled: true,
+						oauthAccessTokenPresent: true,
+					}}
+				/>,
+			);
+		});
+
+		expect(container.textContent).toContain("Signed in via browser");
+		expect(container.textContent).toContain("Connected");
+		const signOut = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Sign out",
+		);
+		await act(async () => signOut?.click());
+		expect(onDisconnect).toHaveBeenCalledOnce();
+	});
+
+	it("offers connect and disconnect for API-key providers", async () => {
+		const onConnect = vi.fn();
+		await act(async () => {
+			root.render(
+				<ProviderDetailContent
+					onBack={vi.fn()}
+					onConnect={onConnect}
+					onUpdate={vi.fn()}
+					provider={{ ...provider, enabled: false }}
+				/>,
+			);
+		});
+		const connect = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Connect",
+		);
+		await act(async () => connect?.click());
+		expect(onConnect).toHaveBeenCalledOnce();
+
+		const onDisconnect = vi.fn();
+		await act(async () => {
+			root.render(
+				<ProviderDetailContent
+					onBack={vi.fn()}
+					onDisconnect={onDisconnect}
+					onUpdate={vi.fn()}
+					provider={{ ...provider, apiKey: "sk-test" }}
+				/>,
+			);
+		});
+		const disconnect = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Disconnect",
+		);
+		await act(async () => disconnect?.click());
+		expect(onDisconnect).toHaveBeenCalledOnce();
 	});
 });
 

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.test.tsx
@@ -251,7 +251,7 @@ describe("ProviderDetailContent auth flows", () => {
 		vi.restoreAllMocks();
 	});
 
-	const oauthProvider: Provider = {
+	const signInProvider: Provider = {
 		id: "cline",
 		name: "Cline",
 		models: 0,
@@ -278,7 +278,7 @@ describe("ProviderDetailContent auth flows", () => {
 					onBack={vi.fn()}
 					onOAuthLogin={onOAuthLogin}
 					onUpdate={vi.fn()}
-					provider={oauthProvider}
+					provider={signInProvider}
 				/>,
 			);
 		});
@@ -310,7 +310,7 @@ describe("ProviderDetailContent auth flows", () => {
 					onDisconnect={onDisconnect}
 					onUpdate={vi.fn()}
 					provider={{
-						...oauthProvider,
+						...signInProvider,
 						enabled: true,
 						oauthAccessTokenPresent: true,
 					}}

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -220,11 +220,6 @@ function ProviderRow({
 			) : (
 				<AuthKindHint kind={authKind} />
 			)}
-			<p className="w-20 shrink-0 text-right text-xs text-muted-foreground max-[860px]:hidden">
-				{provider.models === null
-					? "On demand"
-					: `${provider.models} model${provider.models !== 1 ? "s" : ""}`}
-			</p>
 			<ChevronRight className="size-4 shrink-0 text-muted-foreground" />
 		</button>
 	);

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -121,18 +121,6 @@ function AuthKindHint({ kind }: { kind: ProviderAuthKind }) {
 	);
 }
 
-function ConnectedDot({ className }: { className?: string }) {
-	return (
-		<span
-			aria-hidden="true"
-			className={cn(
-				"inline-block size-1.5 shrink-0 rounded-full bg-emerald-500",
-				className,
-			)}
-		/>
-	);
-}
-
 function getInitialConfigValues(
 	provider: Provider,
 ): Record<string, ProviderConfigFieldPrimitive> {
@@ -213,9 +201,8 @@ function ProviderRow({
 				{provider.name}
 			</p>
 			{connected ? (
-				<span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-					<ConnectedDot />
-					Connected
+				<span className="shrink-0 text-xs font-medium text-muted-foreground">
+					Configured
 				</span>
 			) : (
 				<AuthKindHint kind={authKind} />
@@ -322,7 +309,7 @@ export function ProviderListContent({
 						<p className="mt-3 text-base leading-6 text-muted-foreground">
 							{connectedCount === 0
 								? "Connect a provider to start using models."
-								: `${connectedCount} connected · ${providers.length} available`}
+								: `${connectedCount} configured · ${providers.length} available`}
 						</p>
 					</div>
 					<Button
@@ -367,7 +354,7 @@ export function ProviderListContent({
 
 					{connectedProviders.length > 0 ? (
 						<>
-							<ProviderSectionHeading title="Connected" />
+							<ProviderSectionHeading title="Configured" />
 							{renderRows(connectedProviders)}
 						</>
 					) : null}
@@ -757,17 +744,14 @@ export function ProviderDetailContent({
 			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
 				{oauthConnected ? (
 					<div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
-						<div className="flex min-w-0 items-center gap-2.5">
-							<ConnectedDot className="size-2" />
-							<div className="min-w-0">
-								<p className="text-sm font-medium text-foreground">
-									Signed in via browser
-								</p>
-								<p className="text-xs text-muted-foreground">
-									This provider authenticates with your account — no API key
-									needed.
-								</p>
-							</div>
+						<div className="min-w-0">
+							<p className="text-sm font-medium text-foreground">
+								Signed in via browser
+							</p>
+							<p className="text-xs text-muted-foreground">
+								This provider authenticates with your account — no API key
+								needed.
+							</p>
 						</div>
 						{onDisconnect ? (
 							<Button
@@ -785,7 +769,7 @@ export function ProviderDetailContent({
 					<div className="flex flex-col">
 						<div className="mb-2 flex items-center justify-between gap-4">
 							<p className="text-sm text-muted-foreground">
-								Connected with an API key.
+								Configured with an API key.
 							</p>
 							{onDisconnect ? (
 								<Button
@@ -857,17 +841,14 @@ export function ProviderDetailContent({
 		) : authKind === "local" ? (
 			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
 				<div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
-					<div className="flex min-w-0 items-center gap-2.5">
-						{connected ? <ConnectedDot className="size-2" /> : null}
-						<div className="min-w-0">
-							<p className="text-sm font-medium text-foreground">
-								Uses your local CLI sign-in
-							</p>
-							<p className="text-xs text-muted-foreground">
-								Credentials come from the provider's own CLI on this machine —
-								no API key needed.
-							</p>
-						</div>
+					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">
+							Uses your local CLI sign-in
+						</p>
+						<p className="text-xs text-muted-foreground">
+							Credentials come from the provider's own CLI on this machine — no
+							API key needed.
+						</p>
 					</div>
 					{connected
 						? onDisconnect && (
@@ -919,7 +900,7 @@ export function ProviderDetailContent({
 					) : (
 						<>
 							<p className="text-xs text-muted-foreground">
-								Saving an API key connects this provider automatically. Use
+								Saving an API key configures this provider automatically. Use
 								Connect if it reads credentials from your environment or a
 								local endpoint.
 							</p>
@@ -972,16 +953,8 @@ export function ProviderDetailContent({
 					>
 						{provider.name}
 					</h1>
-					<span
-						className={cn(
-							"inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
-							connected
-								? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-								: "text-muted-foreground",
-						)}
-					>
-						{connected ? <ConnectedDot /> : null}
-						{connected ? "Connected" : "Not connected"}
+					<span className="inline-flex shrink-0 items-center rounded-full border px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+						{connected ? "Configured" : "Not configured"}
 					</span>
 				</div>
 

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -133,27 +133,6 @@ function ConnectedDot({ className }: { className?: string }) {
 	);
 }
 
-function ProviderAvatar({
-	provider,
-	className,
-}: {
-	provider: Provider;
-	className?: string;
-}) {
-	return (
-		<span
-			aria-hidden="true"
-			className={cn(
-				"grid size-8 shrink-0 place-items-center rounded-lg text-xs font-semibold text-white",
-				className,
-			)}
-			style={{ backgroundColor: provider.color }}
-		>
-			{provider.letter}
-		</span>
-	);
-}
-
 function getInitialConfigValues(
 	provider: Provider,
 ): Record<string, ProviderConfigFieldPrimitive> {
@@ -230,15 +209,9 @@ function ProviderRow({
 			onClick={() => onConfigure(provider.id)}
 			type="button"
 		>
-			<ProviderAvatar provider={provider} />
-			<div className="flex min-w-0 flex-1 items-baseline gap-2">
-				<p className="truncate text-base font-semibold text-foreground">
-					{provider.name}
-				</p>
-				<p className="shrink-0 truncate font-mono text-xs text-muted-foreground">
-					{provider.id}
-				</p>
-			</div>
+			<p className="min-w-0 flex-1 truncate text-base font-semibold text-foreground">
+				{provider.name}
+			</p>
 			{connected ? (
 				<span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
 					<ConnectedDot />
@@ -996,19 +969,14 @@ export function ProviderDetailContent({
 							<ArrowLeft className="h-4 w-4" />
 						)}
 					</Button>
-					<div className="flex min-w-0 flex-1 items-baseline gap-2">
-						<h1
-							className={cn(
-								"truncate font-semibold leading-[1.15] text-foreground",
-								isPanel ? "text-2xl" : "text-3xl",
-							)}
-						>
-							{provider.name}
-						</h1>
-						<p className="shrink-0 font-mono text-xs text-muted-foreground">
-							{provider.id}
-						</p>
-					</div>
+					<h1
+						className={cn(
+							"min-w-0 flex-1 truncate font-semibold leading-[1.15] text-foreground",
+							isPanel ? "text-2xl" : "text-3xl",
+						)}
+					>
+						{provider.name}
+					</h1>
 					<span
 						className={cn(
 							"inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -3,16 +3,20 @@
 import {
 	ArrowLeft,
 	Brain,
+	ChevronDown,
 	ChevronRight,
 	Copy,
 	ExternalLink,
 	Eye,
 	EyeOff,
 	FileIcon,
+	Globe,
 	ImageIcon,
+	KeyRound,
 	Link as LinkIcon,
 	Loader2,
 	Mic,
+	MonitorSmartphone,
 	Plus,
 	PlusCircle,
 	RefreshCw,
@@ -26,19 +30,19 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Switch } from "@/components/ui/switch";
 import { openExternalUrl } from "@/lib/desktop-client";
-import { getProviderApiKeyUrl } from "@/lib/provider-key-urls";
 import {
-	isDedicatedTranscriptionModel,
-	loadProviderModels,
-	supportsAudio,
-} from "@/lib/provider-model-catalog";
+	getProviderAuthKind,
+	isProviderConnected,
+	type ProviderAuthKind,
+} from "@/lib/provider-connection";
+import { getProviderApiKeyUrl } from "@/lib/provider-key-urls";
+import { loadProviderModels, supportsAudio } from "@/lib/provider-model-catalog";
 import type {
 	Provider,
 	ProviderConfigField,
 	ProviderConfigFieldPrimitive,
 	ProviderModel,
 	ProviderSettingsUpdate,
-	VoiceInputSelection,
 } from "@/lib/provider-schema";
 import { cn } from "@/lib/utils";
 
@@ -97,8 +101,58 @@ function writeFavoriteModels(value: Record<string, string[]>): void {
 }
 
 // -----------------------------------------------------------
-// Provider LIST content (the grid of all providers)
+// Shared bits
 // -----------------------------------------------------------
+
+const AUTH_KIND_LABEL: Record<ProviderAuthKind, string> = {
+	oauth: "Sign in",
+	local: "Local CLI",
+	"api-key": "API key",
+};
+
+function AuthKindHint({ kind }: { kind: ProviderAuthKind }) {
+	const Icon =
+		kind === "oauth" ? Globe : kind === "local" ? MonitorSmartphone : KeyRound;
+	return (
+		<span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+			<Icon aria-hidden="true" className="size-3" />
+			{AUTH_KIND_LABEL[kind]}
+		</span>
+	);
+}
+
+function ConnectedDot({ className }: { className?: string }) {
+	return (
+		<span
+			aria-hidden="true"
+			className={cn(
+				"inline-block size-1.5 shrink-0 rounded-full bg-emerald-500",
+				className,
+			)}
+		/>
+	);
+}
+
+function ProviderAvatar({
+	provider,
+	className,
+}: {
+	provider: Provider;
+	className?: string;
+}) {
+	return (
+		<span
+			aria-hidden="true"
+			className={cn(
+				"grid size-8 shrink-0 place-items-center rounded-lg text-xs font-semibold text-white",
+				className,
+			)}
+			style={{ backgroundColor: provider.color }}
+		>
+			{provider.letter}
+		</span>
+	);
+}
 
 function getInitialConfigValues(
 	provider: Provider,
@@ -152,50 +206,127 @@ function coerceFieldValue(
 	return trimmed;
 }
 
+// -----------------------------------------------------------
+// Provider LIST content
+// -----------------------------------------------------------
+
+function ProviderRow({
+	provider,
+	onConfigure,
+	selected,
+}: {
+	provider: Provider;
+	onConfigure: (id: string) => void;
+	selected: boolean;
+}) {
+	const connected = isProviderConnected(provider);
+	const authKind = getProviderAuthKind(provider);
+	return (
+		<button
+			className={cn(
+				"flex min-h-12 w-full items-center gap-3 border-b px-2 py-2 text-left hover:bg-surface-hover-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+				selected && "bg-surface-hover",
+			)}
+			onClick={() => onConfigure(provider.id)}
+			type="button"
+		>
+			<ProviderAvatar provider={provider} />
+			<div className="flex min-w-0 flex-1 items-baseline gap-2">
+				<p className="truncate text-base font-semibold text-foreground">
+					{provider.name}
+				</p>
+				<p className="shrink-0 truncate font-mono text-xs text-muted-foreground">
+					{provider.id}
+				</p>
+			</div>
+			{connected ? (
+				<span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+					<ConnectedDot />
+					Connected
+				</span>
+			) : (
+				<AuthKindHint kind={authKind} />
+			)}
+			<p className="w-20 shrink-0 text-right text-xs text-muted-foreground max-[860px]:hidden">
+				{provider.models === null
+					? "On demand"
+					: `${provider.models} model${provider.models !== 1 ? "s" : ""}`}
+			</p>
+			<ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+		</button>
+	);
+}
+
+function ProviderSectionHeading({
+	title,
+	description,
+}: {
+	title: string;
+	description?: string;
+}) {
+	return (
+		<div className="mb-2 mt-8 first:mt-0">
+			<h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+				{title}
+			</h2>
+			{description ? (
+				<p className="mt-1 text-sm text-muted-foreground">{description}</p>
+			) : null}
+		</div>
+	);
+}
+
 export function ProviderListContent({
 	providers,
-	onToggle,
 	onConfigure,
 	onAddProvider,
-	onVoiceInputChange,
 	selectedProviderId,
 	variant = "page",
-	voiceInput,
-	voiceInputSaving = false,
 }: {
 	providers: Provider[];
-	onToggle: (id: string) => void;
 	onConfigure: (id: string) => void;
 	onAddProvider: () => void;
-	onVoiceInputChange: (selection: VoiceInputSelection | undefined) => void;
 	selectedProviderId?: string | null;
 	variant?: "page" | "panel";
-	voiceInput?: VoiceInputSelection;
-	voiceInputSaving?: boolean;
 }) {
-	const [providerSearchOpen, setProviderSearchOpen] = useState(false);
 	const [providerSearch, setProviderSearch] = useState("");
-	const enabledProviderCount = providers.filter(
-		(provider) => provider.enabled,
-	).length;
+	const isPanel = variant === "panel";
+
 	const providerSearchQuery = providerSearch.trim().toLowerCase();
 	const filteredProviders = providerSearchQuery
-		? providers.filter((provider) =>
-				provider.name.toLowerCase().includes(providerSearchQuery),
+		? providers.filter(
+				(provider) =>
+					provider.name.toLowerCase().includes(providerSearchQuery) ||
+					provider.id.toLowerCase().includes(providerSearchQuery),
 			)
 		: providers;
-	const isPanel = variant === "panel";
-	const voiceProviders = providers
-		.filter((provider) => provider.enabled)
-		.map((provider) => ({
-			provider,
-			models: (provider.modelList ?? []).filter(isDedicatedTranscriptionModel),
-		}))
-		.filter((entry) => entry.models.length > 0);
-	const selectedVoiceProvider = voiceProviders.find(
-		(entry) => entry.provider.id === voiceInput?.providerId,
+
+	const connectedProviders = filteredProviders.filter(isProviderConnected);
+	const availableProviders = filteredProviders.filter(
+		(provider) => !isProviderConnected(provider),
 	);
-	const selectedVoiceModels = selectedVoiceProvider?.models ?? [];
+	// The catalog arrives sorted by popular rank, then name; "popular" entries
+	// surface first so the common providers don't drown in the long tail.
+	const popularProviders = availableProviders.filter((provider) =>
+		provider.capabilities?.includes("popular"),
+	);
+	const otherProviders = availableProviders.filter(
+		(provider) => !provider.capabilities?.includes("popular"),
+	);
+	const connectedCount = providers.filter(isProviderConnected).length;
+
+	const renderRows = (entries: Provider[]) => (
+		<div className="overflow-hidden border-t">
+			{entries.map((provider) => (
+				<ProviderRow
+					key={provider.id}
+					onConfigure={onConfigure}
+					provider={provider}
+					selected={selectedProviderId === provider.id}
+				/>
+			))}
+		</div>
+	);
 
 	return (
 		<ScrollArea className="h-full">
@@ -207,7 +338,7 @@ export function ProviderListContent({
 			>
 				<div
 					className={cn(
-						"mb-8 flex items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch",
+						"mb-6 flex items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch",
 						isPanel ? "max-w-none" : "max-w-2xl",
 					)}
 				>
@@ -221,182 +352,198 @@ export function ProviderListContent({
 							Model Providers
 						</h1>
 						<p className="mt-3 text-base leading-6 text-muted-foreground">
-							{providers.length} available &middot; {enabledProviderCount}{" "}
-							enabled
+							{connectedCount === 0
+								? "Connect a provider to start using models."
+								: `${connectedCount} connected · ${providers.length} available`}
 						</p>
 					</div>
-					<div className="flex shrink-0 items-center gap-2 max-[860px]:justify-start">
-						<Button
-							aria-label="Search providers"
-							className="size-8 rounded-md"
-							onClick={() => setProviderSearchOpen((open) => !open)}
-							size="icon-sm"
-							type="button"
-							variant={providerSearchOpen ? "default" : "secondary"}
-						>
-							<Search className="size-4" />
-						</Button>
-						<Button
-							className="h-8 rounded-md bg-foreground px-3 text-sm text-background hover:bg-foreground/90"
-							onClick={onAddProvider}
-							type="button"
-						>
-							<PlusCircle className="size-4" />
-							Add provider
-						</Button>
+					<Button
+						className="h-8 shrink-0 rounded-md bg-foreground px-3 text-sm text-background hover:bg-foreground/90 max-[860px]:self-start"
+						onClick={onAddProvider}
+						type="button"
+					>
+						<PlusCircle className="size-4" />
+						Add provider
+					</Button>
+				</div>
+
+				<div className={cn("mb-6", isPanel ? "max-w-none" : "max-w-2xl")}>
+					<div className="flex h-9 items-center gap-2 rounded border bg-background px-3">
+						<Search className="size-4 shrink-0 text-muted-foreground" />
+						<Input
+							aria-label="Search model providers"
+							className="h-7 border-0 bg-transparent px-0 text-sm"
+							onChange={(event) => setProviderSearch(event.target.value)}
+							placeholder="Search providers"
+							value={providerSearch}
+						/>
+						{providerSearch ? (
+							<button
+								aria-label="Clear provider search"
+								className="grid size-5 place-items-center rounded text-muted-foreground hover:text-foreground"
+								onClick={() => setProviderSearch("")}
+								type="button"
+							>
+								<X className="size-3.5" />
+							</button>
+						) : null}
 					</div>
 				</div>
 
-				<div
-					className={cn(
-						"mb-7 border-y py-4",
-						isPanel ? "max-w-none" : "max-w-[42rem]",
-					)}
-				>
-					<div className="mb-3">
-						<h2 className="text-[17px] font-semibold text-foreground">
-							Voice input
-						</h2>
-						<p className="mt-1 text-sm leading-5 text-muted-foreground">
-							Choose the configured audio-to-text model used by the microphone
-							in chat. Streaming models show text live; other models transcribe
-							after recording stops.
-						</p>
-					</div>
-					<div className="grid grid-cols-2 gap-3 max-[720px]:grid-cols-1">
-						<label className="space-y-1.5 text-sm text-muted-foreground">
-							<span>Provider</span>
-							<select
-								aria-label="Voice input provider"
-								className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
-								disabled={voiceInputSaving}
-								onChange={(event) => {
-									const providerId = event.target.value;
-									if (!providerId) {
-										onVoiceInputChange(undefined);
-										return;
-									}
-									const entry = voiceProviders.find(
-										(candidate) => candidate.provider.id === providerId,
-									);
-									const modelId = entry?.models[0]?.id;
-									if (modelId) {
-										onVoiceInputChange({ providerId, modelId });
-									}
-								}}
-								value={selectedVoiceProvider?.provider.id ?? ""}
-							>
-								<option value="">Not configured</option>
-								{voiceProviders.map(({ provider }) => (
-									<option key={provider.id} value={provider.id}>
-										{provider.name}
-									</option>
-								))}
-							</select>
-						</label>
-						<label className="space-y-1.5 text-sm text-muted-foreground">
-							<span>Model</span>
-							<select
-								aria-label="Voice input model"
-								className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
-								disabled={!selectedVoiceProvider || voiceInputSaving}
-								onChange={(event) => {
-									if (!selectedVoiceProvider || !event.target.value) return;
-									onVoiceInputChange({
-										providerId: selectedVoiceProvider.provider.id,
-										modelId: event.target.value,
-									});
-								}}
-								value={voiceInput?.modelId ?? ""}
-							>
-								{selectedVoiceModels.length === 0 ? (
-									<option value="">Enable an audio provider first</option>
-								) : null}
-								{selectedVoiceModels.map((model) => (
-									<option key={model.id} value={model.id}>
-										{model.name}
-										{model.operationModes?.includes("streaming")
-											? " (Live)"
-											: ""}
-									</option>
-								))}
-							</select>
-						</label>
-					</div>
-				</div>
-
-				{providerSearchOpen ? (
-					<div className={cn("mb-4", isPanel ? "max-w-none" : "max-w-2xl")}>
-						<div className="flex h-9 items-center gap-2 rounded border bg-background px-3">
-							<Search className="size-4 shrink-0 text-muted-foreground" />
-							<Input
-								aria-label="Search model providers"
-								autoFocus
-								className="h-7 border-0 bg-transparent px-0 text-sm"
-								onChange={(event) => setProviderSearch(event.target.value)}
-								placeholder="Search providers"
-								value={providerSearch}
-							/>
-						</div>
-					</div>
-				) : null}
-
-				<div
-					className={cn(
-						"overflow-hidden",
-						isPanel ? "max-w-none" : "max-w-2xl",
-					)}
-				>
+				<div className={cn(isPanel ? "max-w-none" : "max-w-2xl")}>
 					{filteredProviders.length === 0 ? (
-						<div className="border-b px-2 py-6 text-base text-muted-foreground">
+						<div className="border-y px-2 py-6 text-base text-muted-foreground">
 							No providers match "{providerSearch.trim()}".
 						</div>
 					) : null}
-					{filteredProviders.map((prov) => (
-						<div
-							className={cn(
-								"flex min-h-11 items-center gap-4 border-b px-2 py-2 hover:bg-surface-hover-lighter",
-								selectedProviderId === prov.id && "bg-surface-hover",
-							)}
-							key={prov.id}
-						>
-							<button
-								className="flex min-w-0 flex-1 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								onClick={() => onConfigure(prov.id)}
-								type="button"
-							>
-								<div className="flex min-w-0 flex-1 items-baseline gap-2">
-									<p className="truncate text-lg font-semibold text-foreground">
-										{prov.name}
-									</p>
-									<p className="shrink-0 truncate font-mono text-xs text-muted-foreground">
-										{prov.id}
-									</p>
-								</div>
-								<p className="shrink-0 text-[15px] text-muted-foreground">
-									{prov.models === null
-										? "Models load on demand"
-										: `${prov.models} model${prov.models !== 1 ? "s" : ""}`}
-								</p>
-							</button>
-							<Switch
-								aria-label={`Toggle ${prov.name}`}
-								checked={prov.enabled}
-								onCheckedChange={() => onToggle(prov.id)}
+
+					{connectedProviders.length > 0 ? (
+						<>
+							<ProviderSectionHeading title="Connected" />
+							{renderRows(connectedProviders)}
+						</>
+					) : null}
+
+					{popularProviders.length > 0 ? (
+						<>
+							<ProviderSectionHeading
+								description={
+									connectedProviders.length === 0 && !providerSearchQuery
+										? "Sign in or add an API key to connect."
+										: undefined
+								}
+								title="Popular"
 							/>
-							<button
-								aria-label={`Configure ${prov.name}`}
-								className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground  hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								onClick={() => onConfigure(prov.id)}
-								type="button"
-							>
-								<ChevronRight className="size-4" />
-							</button>
-						</div>
-					))}
+							{renderRows(popularProviders)}
+						</>
+					) : null}
+
+					{otherProviders.length > 0 ? (
+						<>
+							<ProviderSectionHeading title="All providers" />
+							{renderRows(otherProviders)}
+						</>
+					) : null}
 				</div>
 			</div>
 		</ScrollArea>
+	);
+}
+
+// -----------------------------------------------------------
+// Provider DETAIL content
+// -----------------------------------------------------------
+
+function ConfigFieldRow({
+	field,
+	value,
+	provider,
+	shown,
+	onToggleShown,
+	onDraftChange,
+	onCommit,
+}: {
+	field: ProviderConfigField;
+	value: ProviderConfigFieldPrimitive | undefined;
+	provider: Provider;
+	shown: boolean;
+	onToggleShown: () => void;
+	onDraftChange: (value: string) => void;
+	onCommit: (value: string | boolean) => void;
+}) {
+	const valueText = fieldValueToString(value);
+	const isSecret = field.type === "password" || field.secret;
+	const providerKeyUrl = getProviderApiKeyUrl(provider);
+	return (
+		<div className="grid min-h-18 grid-cols-[minmax(12rem,0.55fr)_minmax(16rem,0.45fr)] items-center gap-6 border-b py-4 max-[900px]:grid-cols-1 max-[900px]:gap-3">
+			<header>
+				<h3 className="text-lg font-semibold text-foreground">{field.label}</h3>
+				{field.description ? (
+					<p className="mt-1 text-base leading-relaxed text-muted-foreground">
+						{field.description}
+					</p>
+				) : null}
+				{field.path === "apiKey" && providerKeyUrl ? (
+					<button
+						className="mt-1 inline-flex items-center gap-1 text-sm text-primary underline-offset-2 transition-colors hover:underline"
+						onClick={() => void openExternalUrl(providerKeyUrl)}
+						type="button"
+					>
+						{provider.docLabel || `Get a ${provider.name} API key`}
+						<ExternalLink className="size-3.5" />
+					</button>
+				) : null}
+			</header>
+			{field.type === "boolean" ? (
+				<div className="flex items-center justify-end">
+					<span className="text-sm text-muted-foreground">{field.label}</span>
+					<Switch
+						checked={Boolean(value)}
+						onCheckedChange={(checked) => onCommit(checked)}
+					/>
+				</div>
+			) : field.type === "select" ? (
+				<select
+					className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+					onChange={(event) => onCommit(event.target.value)}
+					value={valueText}
+				>
+					<option value="">Not set</option>
+					{field.options?.map((option) => (
+						<option key={String(option.value)} value={String(option.value)}>
+							{option.label}
+						</option>
+					))}
+				</select>
+			) : (
+				<div className="flex h-9 items-center gap-2 rounded border border-border bg-background px-3">
+					{field.type === "url" ? (
+						<LinkIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+					) : null}
+					<Input
+						className="h-7 flex-1 border-0 bg-transparent px-0 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+						onBlur={() => onCommit(valueText)}
+						onChange={(event) => onDraftChange(event.target.value)}
+						placeholder={field.placeholder}
+						spellCheck={false}
+						type={
+							isSecret && !shown
+								? "password"
+								: field.type === "number"
+									? "number"
+									: field.type === "url"
+										? "url"
+										: "text"
+						}
+						value={valueText}
+					/>
+					{isSecret ? (
+						<>
+							<Button
+								aria-label={shown ? "Hide secret" : "Show secret"}
+								className="rounded-md p-1 text-muted-foreground hover:text-foreground "
+								onClick={onToggleShown}
+								variant="ghost"
+							>
+								{shown ? (
+									<EyeOff className="h-4 w-4" />
+								) : (
+									<Eye className="h-4 w-4" />
+								)}
+							</Button>
+							<Button
+								aria-label={`Copy ${field.label}`}
+								className="rounded-md p-1 text-muted-foreground hover:text-foreground "
+								onClick={() => navigator.clipboard.writeText(valueText)}
+								variant="ghost"
+							>
+								<Copy className="h-4 w-4" />
+							</Button>
+						</>
+					) : null}
+				</div>
+			)}
+		</div>
 	);
 }
 
@@ -410,6 +557,8 @@ export function ProviderDetailContent({
 	modelsError,
 	onOAuthLogin,
 	oauthLoginPending = false,
+	onConnect,
+	onDisconnect,
 	variant = "page",
 }: {
 	provider: Provider;
@@ -421,12 +570,15 @@ export function ProviderDetailContent({
 	modelsError?: string | null;
 	onOAuthLogin?: () => void;
 	oauthLoginPending?: boolean;
+	onConnect?: () => void;
+	onDisconnect?: () => void;
 	variant?: "page" | "panel";
 }) {
 	const [shownSecrets, setShownSecrets] = useState<Record<string, boolean>>({});
 	const [localConfigValues, setLocalConfigValues] = useState<
 		Record<string, ProviderConfigFieldPrimitive>
 	>(() => getInitialConfigValues(provider));
+	const [manualKeyExpanded, setManualKeyExpanded] = useState(false);
 	const [modelSearchState, setModelSearchState] = useState<{
 		providerId: string;
 		value: string;
@@ -442,9 +594,11 @@ export function ProviderDetailContent({
 	const [favoriteModels, setFavoriteModels] = useState(readFavoriteModels);
 	const copiedModelTimeoutRef = useRef<number | undefined>(undefined);
 
+	const authKind = getProviderAuthKind(provider);
+	const connected = isProviderConnected(provider);
 	const configFields = provider.configFields ?? [];
+	const apiKeyField = configFields.find((field) => field.path === "apiKey");
 	const apiKeyValue = fieldValueToString(localConfigValues.apiKey);
-	const providerKeyUrl = getProviderApiKeyUrl(provider);
 	// The catalog's modelList is fetched without the recommended-feed overlay
 	// (the catalog must not block on the feed); featured providers refresh
 	// their list here so tier badges and live entries can render. The result
@@ -541,6 +695,44 @@ export function ProviderDetailContent({
 		onUpdate(updates);
 	};
 
+	const handleDisconnect = () => {
+		// The persisted entry is being removed; clear the local drafts so
+		// stale secrets don't linger in the inputs.
+		setShownSecrets({});
+		setManualKeyExpanded(false);
+		setLocalConfigValues(
+			getInitialConfigValues({
+				...provider,
+				apiKey: undefined,
+				configValues: undefined,
+			}),
+		);
+		onDisconnect?.();
+	};
+
+	const renderConfigFieldRow = (field: ProviderConfigField) => (
+		<ConfigFieldRow
+			field={field}
+			key={field.path}
+			onCommit={(value) => commitField(field, value)}
+			onDraftChange={(value) =>
+				setLocalConfigValues((current) => ({
+					...current,
+					[field.path]: value,
+				}))
+			}
+			onToggleShown={() =>
+				setShownSecrets((current) => ({
+					...current,
+					[field.path]: !(current[field.path] ?? false),
+				}))
+			}
+			provider={provider}
+			shown={shownSecrets[field.path] ?? false}
+			value={localConfigValues[field.path]}
+		/>
+	);
+
 	const copyModelId = (modelId: string) => {
 		if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
 			return;
@@ -590,6 +782,196 @@ export function ProviderDetailContent({
 		});
 	};
 
+	const oauthConnected = Boolean(provider.oauthAccessTokenPresent);
+
+	const connectionSection =
+		authKind === "oauth" ? (
+			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
+				{oauthConnected ? (
+					<div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+						<div className="flex min-w-0 items-center gap-2.5">
+							<ConnectedDot className="size-2" />
+							<div className="min-w-0">
+								<p className="text-sm font-medium text-foreground">
+									Signed in via browser
+								</p>
+								<p className="text-xs text-muted-foreground">
+									This provider authenticates with your account — no API key
+									needed.
+								</p>
+							</div>
+						</div>
+						{onDisconnect ? (
+							<Button
+								className="shrink-0"
+								onClick={handleDisconnect}
+								size="sm"
+								type="button"
+								variant="outline"
+							>
+								Sign out
+							</Button>
+						) : null}
+					</div>
+				) : connected && apiKeyValue ? (
+					<div className="flex flex-col">
+						<div className="mb-2 flex items-center justify-between gap-4">
+							<p className="text-sm text-muted-foreground">
+								Connected with an API key.
+							</p>
+							{onDisconnect ? (
+								<Button
+									className="shrink-0"
+									onClick={handleDisconnect}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									Disconnect
+								</Button>
+							) : null}
+						</div>
+						{apiKeyField ? renderConfigFieldRow(apiKeyField) : null}
+					</div>
+				) : (
+					<div className="rounded-lg border px-4 py-4">
+						<p className="text-sm font-medium text-foreground">
+							Sign in to {provider.name}
+						</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Connects through your browser. No API key needed.
+						</p>
+						{onOAuthLogin ? (
+							<Button
+								className="mt-3 inline-flex items-center gap-2"
+								disabled={oauthLoginPending}
+								onClick={onOAuthLogin}
+								type="button"
+								variant="default"
+							>
+								{oauthLoginPending ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : null}
+								<span>
+									{oauthLoginPending
+										? "Waiting for browser..."
+										: "Sign in with browser"}
+								</span>
+							</Button>
+						) : null}
+						{apiKeyField ? (
+							<div className="mt-3">
+								<Button
+									aria-expanded={manualKeyExpanded}
+									className="-ml-2"
+									onClick={() => setManualKeyExpanded((open) => !open)}
+									size="sm"
+									type="button"
+									variant="ghost"
+								>
+									Use an API key instead
+									<ChevronDown
+										aria-hidden="true"
+										className={cn(
+											"size-3.5 transition-transform",
+											manualKeyExpanded && "rotate-180",
+										)}
+									/>
+								</Button>
+								{manualKeyExpanded ? (
+									<div className="mt-1">{renderConfigFieldRow(apiKeyField)}</div>
+								) : null}
+							</div>
+						) : null}
+					</div>
+				)}
+			</section>
+		) : authKind === "local" ? (
+			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
+				<div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+					<div className="flex min-w-0 items-center gap-2.5">
+						{connected ? <ConnectedDot className="size-2" /> : null}
+						<div className="min-w-0">
+							<p className="text-sm font-medium text-foreground">
+								Uses your local CLI sign-in
+							</p>
+							<p className="text-xs text-muted-foreground">
+								Credentials come from the provider's own CLI on this machine —
+								no API key needed.
+							</p>
+						</div>
+					</div>
+					{connected
+						? onDisconnect && (
+								<Button
+									className="shrink-0"
+									onClick={handleDisconnect}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									Disconnect
+								</Button>
+							)
+						: onConnect && (
+								<Button
+									className="shrink-0"
+									onClick={onConnect}
+									size="sm"
+									type="button"
+								>
+									Connect
+								</Button>
+							)}
+				</div>
+			</section>
+		) : (
+			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
+				{configFields.length > 0 ? (
+					<div className="flex flex-col">{configFields.map(renderConfigFieldRow)}</div>
+				) : null}
+				<div className="mt-4 flex items-center justify-between gap-4">
+					{connected ? (
+						<>
+							<p className="text-xs text-muted-foreground">
+								Changes to the fields above are saved automatically.
+							</p>
+							{onDisconnect ? (
+								<Button
+									className="shrink-0"
+									onClick={handleDisconnect}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									Disconnect
+								</Button>
+							) : null}
+						</>
+					) : (
+						<>
+							<p className="text-xs text-muted-foreground">
+								Saving an API key connects this provider automatically. Use
+								Connect if it reads credentials from your environment or a
+								local endpoint.
+							</p>
+							{onConnect ? (
+								<Button
+									className="shrink-0"
+									onClick={onConnect}
+									size="sm"
+									type="button"
+									variant="outline"
+								>
+									Connect
+								</Button>
+							) : null}
+						</>
+					)}
+				</div>
+			</section>
+		);
+
 	return (
 		<ScrollArea className="h-full">
 			<div
@@ -614,7 +996,7 @@ export function ProviderDetailContent({
 							<ArrowLeft className="h-4 w-4" />
 						)}
 					</Button>
-					<div className="flex min-w-0 items-baseline gap-2">
+					<div className="flex min-w-0 flex-1 items-baseline gap-2">
 						<h1
 							className={cn(
 								"truncate font-semibold leading-[1.15] text-foreground",
@@ -627,162 +1009,20 @@ export function ProviderDetailContent({
 							{provider.id}
 						</p>
 					</div>
+					<span
+						className={cn(
+							"inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+							connected
+								? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+								: "text-muted-foreground",
+						)}
+					>
+						{connected ? <ConnectedDot /> : null}
+						{connected ? "Connected" : "Not connected"}
+					</span>
 				</div>
 
-				{configFields.length > 0 ? (
-					<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
-						<div className="flex flex-col">
-							{configFields.map((field) => {
-								const value = localConfigValues[field.path];
-								const valueText = fieldValueToString(value);
-								const isSecret = field.type === "password" || field.secret;
-								const isShown = shownSecrets[field.path] ?? false;
-								return (
-									<div
-										className="grid min-h-18 grid-cols-[minmax(12rem,0.55fr)_minmax(16rem,0.45fr)] items-center gap-6 border-b py-4 max-[900px]:grid-cols-1 max-[900px]:gap-3"
-										key={field.path}
-									>
-										<header>
-											<h3 className="text-lg font-semibold text-foreground">
-												{field.label}
-											</h3>
-											{field.description ? (
-												<p className="mt-1 text-base leading-relaxed text-muted-foreground">
-													{field.description}
-												</p>
-											) : null}
-											{field.path === "apiKey" && providerKeyUrl ? (
-												<button
-													className="mt-1 inline-flex items-center gap-1 text-sm text-primary underline-offset-2 transition-colors hover:underline"
-													onClick={() => void openExternalUrl(providerKeyUrl)}
-													type="button"
-												>
-													{provider.docLabel ||
-														`Get a ${provider.name} API key`}
-													<ExternalLink className="size-3.5" />
-												</button>
-											) : null}
-										</header>
-										{field.type === "boolean" ? (
-											<div className="flex items-center justify-end">
-												<span className="text-sm text-muted-foreground">
-													{field.label}
-												</span>
-												<Switch
-													checked={Boolean(value)}
-													onCheckedChange={(checked) =>
-														commitField(field, checked)
-													}
-												/>
-											</div>
-										) : field.type === "select" ? (
-											<select
-												className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
-												onChange={(event) =>
-													commitField(field, event.target.value)
-												}
-												value={valueText}
-											>
-												<option value="">Not set</option>
-												{field.options?.map((option) => (
-													<option
-														key={String(option.value)}
-														value={String(option.value)}
-													>
-														{option.label}
-													</option>
-												))}
-											</select>
-										) : (
-											<div className="flex h-9 items-center gap-2 rounded border border-border bg-background px-3">
-												{field.type === "url" ? (
-													<LinkIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-												) : null}
-												<Input
-													className="h-7 flex-1 border-0 bg-transparent px-0 text-sm text-foreground outline-none placeholder:text-muted-foreground"
-													onBlur={() => commitField(field, valueText)}
-													onChange={(event) =>
-														setLocalConfigValues((current) => ({
-															...current,
-															[field.path]: event.target.value,
-														}))
-													}
-													placeholder={field.placeholder}
-													spellCheck={false}
-													type={
-														isSecret && !isShown
-															? "password"
-															: field.type === "number"
-																? "number"
-																: field.type === "url"
-																	? "url"
-																	: "text"
-													}
-													value={valueText}
-												/>
-												{isSecret ? (
-													<>
-														<Button
-															aria-label={
-																isShown ? "Hide secret" : "Show secret"
-															}
-															className="rounded-md p-1 text-muted-foreground hover:text-foreground "
-															onClick={() =>
-																setShownSecrets((current) => ({
-																	...current,
-																	[field.path]: !isShown,
-																}))
-															}
-															variant="ghost"
-														>
-															{isShown ? (
-																<EyeOff className="h-4 w-4" />
-															) : (
-																<Eye className="h-4 w-4" />
-															)}
-														</Button>
-														<Button
-															aria-label={`Copy ${field.label}`}
-															className="rounded-md p-1 text-muted-foreground hover:text-foreground "
-															onClick={() =>
-																navigator.clipboard.writeText(valueText)
-															}
-															variant="ghost"
-														>
-															<Copy className="h-4 w-4" />
-														</Button>
-													</>
-												) : null}
-											</div>
-										)}
-									</div>
-								);
-							})}
-						</div>
-					</section>
-				) : null}
-
-				{!apiKeyValue && !provider.oauthAccessTokenPresent && onOAuthLogin ? (
-					<div className="mb-8">
-						<Button
-							className="inline-flex items-center gap-2 w-full"
-							disabled={oauthLoginPending}
-							onClick={onOAuthLogin}
-							variant="default"
-						>
-							{oauthLoginPending ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
-							) : null}
-							<span>Login via Browser</span>
-						</Button>
-					</div>
-				) : null}
-				{provider.oauthAccessTokenPresent ? (
-					<p className="mb-8 text-xs text-muted-foreground">
-						OAuth is connected. Manual credentials remain available when this
-						provider supports them.
-					</p>
-				) : null}
+				{connectionSection}
 
 				{/* Models section */}
 				<section

--- a/apps/examples/desktop-app/webview/components/views/settings/sections.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/sections.ts
@@ -8,6 +8,7 @@
 export const SETTINGS_SECTIONS = [
 	"General",
 	"Models",
+	"Voice",
 	"Channels",
 	"Schedules",
 	"Account",

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -126,6 +126,14 @@ export function SettingsView({
 		null,
 	);
 	const [addingProvider, setAddingProvider] = useState(false);
+	// Bumped by every optimistic provider mutation and catalog load. An
+	// in-flight catalog response is discarded when the generation moved on,
+	// so an older disk snapshot can never overwrite a newer edit.
+	const catalogGenerationRef = useRef(0);
+	// Bumped when a failed save resyncs the catalog from disk; keys the
+	// detail panel so its local field drafts remount from the reloaded
+	// props instead of keeping unpersisted values.
+	const [detailResetToken, setDetailResetToken] = useState(0);
 
 	useEffect(() => {
 		if (section !== "Models") {
@@ -163,14 +171,21 @@ export function SettingsView({
 			return;
 		}
 
+		const generation = ++catalogGenerationRef.current;
 		setProvidersLoading(true);
 		setProviderCatalogError(null);
 		try {
 			const payload = await desktopClient.invoke<ProviderCatalogResponse>(
 				"list_provider_catalog",
 			);
+			if (generation !== catalogGenerationRef.current) {
+				return;
+			}
 			setProvidersWithCache(payload.providers);
 		} catch (error) {
+			if (generation !== catalogGenerationRef.current) {
+				return;
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			setProviderCatalogError(message);
 			setProviders([]);
@@ -215,8 +230,10 @@ export function SettingsView({
 				window.alert(`Failed to save provider settings for ${id}: ${message}`);
 				// The optimistic list update no longer matches disk; reload the
 				// catalog so the view doesn't keep showing (and caching) a
-				// connection state that was never persisted.
+				// connection state that was never persisted, and remount the
+				// detail panel so its field drafts resync to the reloaded state.
 				providerCatalogCache = null;
+				setDetailResetToken((token) => token + 1);
 				void loadProviderCatalog();
 				return false;
 			} finally {
@@ -233,6 +250,7 @@ export function SettingsView({
 			// Persist an (empty) settings entry so the provider is enabled with
 			// whatever credentials it resolves at runtime (env vars, local CLI,
 			// keyless endpoints).
+			catalogGenerationRef.current++;
 			setProvidersWithCache((prev) =>
 				prev.map((p) => (p.id === id ? { ...p, enabled: true } : p)),
 			);
@@ -243,6 +261,7 @@ export function SettingsView({
 
 	const disconnectProvider = useCallback(
 		async (id: string) => {
+			catalogGenerationRef.current++;
 			setProvidersWithCache((prev) =>
 				prev.map((p) =>
 					p.id === id
@@ -272,6 +291,7 @@ export function SettingsView({
 		(id: string, updates: ProviderSettingsUpdate) => {
 			// Saving settings creates the provider's persisted entry, which is
 			// what "connected" means for keyless providers — reflect it locally.
+			catalogGenerationRef.current++;
 			setProvidersWithCache((prev) =>
 				prev.map((p) =>
 					p.id === id
@@ -467,7 +487,7 @@ export function SettingsView({
 			/>
 			<aside className="min-h-0 overflow-hidden border-l bg-background max-[1100px]:border-l-0 max-[1100px]:border-t">
 				<ProviderDetailContent
-					key={selectedProvider.id}
+					key={`${selectedProvider.id}:${detailResetToken}`}
 					modelsError={modelsErrorByProvider[selectedProvider.id] ?? null}
 					modelsLoading={modelsLoadingByProvider[selectedProvider.id] ?? false}
 					oauthLoginPending={oauthSigningProviderId === selectedProvider.id}

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/app-icon";
 import { desktopClient } from "@/lib/desktop-client";
 import { resetOnboarding } from "@/lib/onboarding";
+import { getProviderAuthKind } from "@/lib/provider-connection";
 import {
 	fetchProviderCatalog,
 	invalidateProviderCatalogCache,
@@ -37,7 +38,6 @@ import type {
 	ProviderCatalogResponse,
 	ProviderModelsResponse,
 	ProviderSettingsUpdate,
-	VoiceInputSelection,
 } from "@/lib/provider-schema";
 import {
 	type HubAccent,
@@ -67,6 +67,7 @@ import {
 import { RoutineSchedulesContent } from "./routine-view";
 import type { SettingsSection } from "./sections";
 import { toSettingsPatch } from "./settings-patch";
+import { VoiceInputContent } from "./voice-input-view";
 
 // Nav categories live in ./sections so the always-mounted sidebar can import
 // them without pulling this module graph into the initial bundle.
@@ -88,7 +89,6 @@ let providerCatalogCache: {
 	providers: Provider[];
 	fetchedAt: number;
 } | null = null;
-let voiceInputCache: VoiceInputSelection | undefined;
 
 // -----------------------------------------------------------
 // Component
@@ -126,10 +126,6 @@ export function SettingsView({
 		null,
 	);
 	const [addingProvider, setAddingProvider] = useState(false);
-	const [voiceInput, setVoiceInput] = useState<VoiceInputSelection | undefined>(
-		() => voiceInputCache,
-	);
-	const [voiceInputSaving, setVoiceInputSaving] = useState(false);
 
 	useEffect(() => {
 		if (section !== "Models") {
@@ -162,7 +158,6 @@ export function SettingsView({
 			now - providerCatalogCache.fetchedAt < PROVIDER_CATALOG_CACHE_TTL_MS
 		) {
 			setProviders(providerCatalogCache.providers);
-			setVoiceInput(voiceInputCache);
 			setProvidersLoading(false);
 			setProviderCatalogError(null);
 			return;
@@ -175,8 +170,6 @@ export function SettingsView({
 				"list_provider_catalog",
 			);
 			setProvidersWithCache(payload.providers);
-			voiceInputCache = payload.voiceInput;
-			setVoiceInput(payload.voiceInput);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			setProviderCatalogError(message);
@@ -230,63 +223,57 @@ export function SettingsView({
 		[],
 	);
 
-	const toggleProvider = useCallback(
+	const connectProvider = useCallback(
 		(id: string) => {
+			// Persist an (empty) settings entry so the provider is enabled with
+			// whatever credentials it resolves at runtime (env vars, local CLI,
+			// keyless endpoints).
 			setProvidersWithCache((prev) =>
-				prev.map((p) => {
-					if (p.id !== id) {
-						return p;
-					}
-					const nextEnabled = !p.enabled;
-					const clearsVoiceInput =
-						!nextEnabled && voiceInput?.providerId === id;
-					void persistProviderSettings(id, { enabled: nextEnabled }).then(
-						(saved) => {
-							if (saved && clearsVoiceInput) {
-								voiceInputCache = undefined;
-								setVoiceInput(undefined);
-								notifyVoiceInputSettingsChanged();
-							}
-						},
-					);
-					return { ...p, enabled: nextEnabled };
-				}),
+				prev.map((p) => (p.id === id ? { ...p, enabled: true } : p)),
 			);
+			void persistProviderSettings(id, { enabled: true });
 		},
-		[persistProviderSettings, setProvidersWithCache, voiceInput],
+		[persistProviderSettings, setProvidersWithCache],
 	);
 
-	const updateVoiceInput = useCallback(
-		async (selection: VoiceInputSelection | undefined) => {
-			setVoiceInputSaving(true);
-			try {
-				const result = await desktopClient.invoke<{
-					voiceInput?: VoiceInputSelection;
-				}>("save_voice_input_settings", {
-					provider: selection?.providerId,
-					model: selection?.modelId,
-				});
-				voiceInputCache = result.voiceInput;
-				setVoiceInput(result.voiceInput);
+	const disconnectProvider = useCallback(
+		async (id: string) => {
+			setProvidersWithCache((prev) =>
+				prev.map((p) =>
+					p.id === id
+						? {
+								...p,
+								enabled: false,
+								apiKey: undefined,
+								oauthAccessTokenPresent: false,
+							}
+						: p,
+				),
+			);
+			const saved = await persistProviderSettings(id, { enabled: false });
+			if (saved) {
+				// Disconnecting removes the persisted entry (and the sidecar drops
+				// a voice-input selection pointing at it); reload so the view and
+				// the chat microphone reflect the real on-disk state.
+				providerCatalogCache = null;
 				notifyVoiceInputSettingsChanged();
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				window.alert(`Failed to save voice input settings: ${message}`);
-			} finally {
-				setVoiceInputSaving(false);
+				await loadProviderCatalog();
 			}
 		},
-		[],
+		[loadProviderCatalog, persistProviderSettings, setProvidersWithCache],
 	);
 
 	const updateProvider = useCallback(
 		(id: string, updates: ProviderSettingsUpdate) => {
+			// Saving settings creates the provider's persisted entry, which is
+			// what "connected" means for keyless providers — reflect it locally.
 			setProvidersWithCache((prev) =>
 				prev.map((p) =>
 					p.id === id
 						? {
 								...p,
 								...updates,
+								enabled: true,
 								configValues: updates.configValues
 									? {
 											...(p.configValues ?? {}),
@@ -364,7 +351,7 @@ export function SettingsView({
 		: null;
 
 	const usesOAuth = (provider: Provider) =>
-		provider.capabilities?.includes("oauth") ?? false;
+		getProviderAuthKind(provider) === "oauth";
 
 	const runOAuthProviderLogin = async (id: string) => {
 		setOauthSigningProviderId(id);
@@ -469,20 +456,19 @@ export function SettingsView({
 			<ProviderListContent
 				onAddProvider={openAddProvider}
 				onConfigure={openProviderDetail}
-				onToggle={toggleProvider}
-				onVoiceInputChange={(selection) => void updateVoiceInput(selection)}
 				providers={providers}
 				selectedProviderId={selectedProvider.id}
 				variant="panel"
-				voiceInput={voiceInput}
-				voiceInputSaving={voiceInputSaving}
 			/>
 			<aside className="min-h-0 overflow-hidden border-l bg-background max-[1100px]:border-l-0 max-[1100px]:border-t">
 				<ProviderDetailContent
+					key={selectedProvider.id}
 					modelsError={modelsErrorByProvider[selectedProvider.id] ?? null}
 					modelsLoading={modelsLoadingByProvider[selectedProvider.id] ?? false}
 					oauthLoginPending={oauthSigningProviderId === selectedProvider.id}
 					onBack={backToProviderList}
+					onConnect={() => connectProvider(selectedProvider.id)}
+					onDisconnect={() => void disconnectProvider(selectedProvider.id)}
 					onLoadModels={() => void loadProviderModels(selectedProvider.id)}
 					onUpdateModels={(models) =>
 						void updateProviderModels(selectedProvider.id, models)
@@ -502,17 +488,17 @@ export function SettingsView({
 		<ProviderListContent
 			onAddProvider={openAddProvider}
 			onConfigure={openProviderDetail}
-			onToggle={toggleProvider}
-			onVoiceInputChange={(selection) => void updateVoiceInput(selection)}
 			providers={providers}
-			voiceInput={voiceInput}
-			voiceInputSaving={voiceInputSaving}
 		/>
 	);
 
 	const content =
 		activeNav === "Models" ? (
 			providerContent
+		) : activeNav === "Voice" ? (
+			<VoiceInputContent
+				onOpenModelProviders={() => onNavigateSection("Models")}
+			/>
 		) : activeNav === "Plugins" ? (
 			<PluginsHubView
 				onOpenMarketplace={() => onNavigateSection("Marketplace")}

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -159,7 +159,13 @@ export function SettingsView({
 		[],
 	);
 
-	const loadProviderCatalog = useCallback(async () => {
+	/**
+	 * Loads the catalog into view state. Resolves to false when the response
+	 * was discarded because a newer mutation or load superseded it while in
+	 * flight (so an older disk snapshot never overwrites a newer edit);
+	 * callers needing an authoritative resync should retry on false.
+	 */
+	const loadProviderCatalog = useCallback(async (): Promise<boolean> => {
 		const now = Date.now();
 		if (
 			providerCatalogCache &&
@@ -168,7 +174,7 @@ export function SettingsView({
 			setProviders(providerCatalogCache.providers);
 			setProvidersLoading(false);
 			setProviderCatalogError(null);
-			return;
+			return true;
 		}
 
 		const generation = ++catalogGenerationRef.current;
@@ -179,12 +185,12 @@ export function SettingsView({
 				"list_provider_catalog",
 			);
 			if (generation !== catalogGenerationRef.current) {
-				return;
+				return false;
 			}
 			setProvidersWithCache(payload.providers);
 		} catch (error) {
 			if (generation !== catalogGenerationRef.current) {
-				return;
+				return false;
 			}
 			const message = error instanceof Error ? error.message : String(error);
 			setProviderCatalogError(message);
@@ -192,6 +198,7 @@ export function SettingsView({
 		} finally {
 			setProvidersLoading(false);
 		}
+		return true;
 	}, [setProvidersWithCache]);
 
 	useEffect(() => {
@@ -228,13 +235,19 @@ export function SettingsView({
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				window.alert(`Failed to save provider settings for ${id}: ${message}`);
-				// The optimistic list update no longer matches disk; reload the
-				// catalog so the view doesn't keep showing (and caching) a
-				// connection state that was never persisted, and remount the
-				// detail panel so its field drafts resync to the reloaded state.
-				providerCatalogCache = null;
+				// The optimistic list update no longer matches disk: resync from
+				// the authoritative catalog. Retry when a concurrent edit
+				// superseded the in-flight response (that edit performs no
+				// reload of its own), then remount the detail panel so its
+				// field drafts re-seed from the reloaded state — not before,
+				// or they would re-capture the unpersisted optimistic values.
+				for (let attempt = 0; attempt < 3; attempt++) {
+					providerCatalogCache = null;
+					if (await loadProviderCatalog()) {
+						break;
+					}
+				}
 				setDetailResetToken((token) => token + 1);
-				void loadProviderCatalog();
 				return false;
 			} finally {
 				// Keep the shared short-lived catalog cache (composer model

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -213,6 +213,11 @@ export function SettingsView({
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				window.alert(`Failed to save provider settings for ${id}: ${message}`);
+				// The optimistic list update no longer matches disk; reload the
+				// catalog so the view doesn't keep showing (and caching) a
+				// connection state that was never persisted.
+				providerCatalogCache = null;
+				void loadProviderCatalog();
 				return false;
 			} finally {
 				// Keep the shared short-lived catalog cache (composer model
@@ -220,7 +225,7 @@ export function SettingsView({
 				invalidateProviderCatalogCache();
 			}
 		},
-		[],
+		[loadProviderCatalog],
 	);
 
 	const connectProvider = useCallback(

--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Provider } from "@/lib/provider-schema";
+import { defaultTranscriptionModel, VoiceInputContent } from "./voice-input-view";
+
+const { fetchProviderCatalogMock, invokeMock, notifyMock } = vi.hoisted(() => ({
+	fetchProviderCatalogMock: vi.fn(),
+	invokeMock: vi.fn(),
+	notifyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/provider-model-catalog", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/provider-model-catalog")>();
+	return {
+		...actual,
+		fetchProviderCatalog: fetchProviderCatalogMock,
+		notifyVoiceInputSettingsChanged: notifyMock,
+	};
+});
+
+vi.mock("@/lib/desktop-client", () => ({
+	desktopClient: { invoke: invokeMock },
+	openExternalUrl: vi.fn(),
+}));
+
+const transcriptionProvider: Provider = {
+	id: "elevenlabs",
+	name: "ElevenLabs",
+	models: 2,
+	color: "#000000",
+	letter: "EL",
+	enabled: true,
+	apiKey: "sk-test",
+	modelList: [
+		{
+			id: "scribe_v1",
+			name: "Scribe v1",
+			operation: "transcription",
+			inputModalities: ["audio"],
+			outputModalities: ["text"],
+		},
+		{
+			id: "scribe_v2_realtime",
+			name: "Scribe v2 Realtime",
+			operation: "transcription",
+			operationModes: ["streaming"],
+			inputModalities: ["audio"],
+			outputModalities: ["text"],
+		},
+	],
+};
+
+const unconnectedProvider: Provider = {
+	...transcriptionProvider,
+	id: "groq",
+	name: "Groq",
+	enabled: false,
+	apiKey: undefined,
+};
+
+describe("defaultTranscriptionModel", () => {
+	it("prefers streaming models, then the first transcription model", () => {
+		expect(
+			defaultTranscriptionModel(transcriptionProvider.modelList ?? [])?.id,
+		).toBe("scribe_v2_realtime");
+		expect(
+			defaultTranscriptionModel([
+				{ id: "batch-only", name: "Batch", operation: "transcription" },
+			])?.id,
+		).toBe("batch-only");
+	});
+});
+
+describe("VoiceInputContent", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+		fetchProviderCatalogMock.mockReset();
+		invokeMock.mockReset();
+		notifyMock.mockReset();
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+	});
+
+	const render = async (onOpenModelProviders = vi.fn()) => {
+		await act(async () => {
+			root.render(
+				<VoiceInputContent onOpenModelProviders={onOpenModelProviders} />,
+			);
+		});
+		return onOpenModelProviders;
+	};
+
+	it("locks the page until a voice-capable provider is connected", async () => {
+		fetchProviderCatalogMock.mockResolvedValue({
+			providers: [unconnectedProvider],
+			settingsPath: "/tmp/providers.json",
+		});
+		const onOpenModelProviders = await render();
+
+		expect(container.textContent).toContain(
+			"Voice input needs a connected model provider",
+		);
+		const openProviders = Array.from(
+			container.querySelectorAll("button"),
+		).find((button) => button.textContent?.includes("Open Model Providers"));
+		await act(async () => openProviders?.click());
+		expect(onOpenModelProviders).toHaveBeenCalledOnce();
+	});
+
+	it("explains when connected providers offer no transcription models", async () => {
+		fetchProviderCatalogMock.mockResolvedValue({
+			providers: [
+				{
+					...transcriptionProvider,
+					id: "anthropic",
+					name: "Anthropic",
+					modelList: [{ id: "claude", name: "Claude" }],
+				},
+				unconnectedProvider,
+			],
+			settingsPath: "/tmp/providers.json",
+		});
+		await render();
+
+		expect(container.textContent).toContain(
+			"None of your connected providers offer speech-to-text models",
+		);
+		expect(container.textContent).toContain("Groq");
+	});
+
+	it("enables voice input with the default (streaming) model preselected", async () => {
+		fetchProviderCatalogMock.mockResolvedValue({
+			providers: [transcriptionProvider],
+			settingsPath: "/tmp/providers.json",
+		});
+		invokeMock.mockResolvedValue({
+			voiceInput: {
+				providerId: "elevenlabs",
+				modelId: "scribe_v2_realtime",
+			},
+		});
+		await render();
+
+		const toggle = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Enable voice input"]',
+		);
+		expect(toggle?.getAttribute("aria-checked")).toBe("false");
+		await act(async () => toggle?.click());
+
+		expect(invokeMock).toHaveBeenCalledWith("save_voice_input_settings", {
+			provider: "elevenlabs",
+			model: "scribe_v2_realtime",
+		});
+		expect(notifyMock).toHaveBeenCalled();
+		const selected = container.querySelector('[role="radio"][aria-checked="true"]');
+		expect(selected?.textContent).toContain("Scribe v2 Realtime");
+		expect(selected?.textContent).toContain("Default");
+	});
+
+	it("saves model changes and clears the selection when disabled", async () => {
+		fetchProviderCatalogMock.mockResolvedValue({
+			providers: [transcriptionProvider],
+			settingsPath: "/tmp/providers.json",
+			voiceInput: { providerId: "elevenlabs", modelId: "scribe_v2_realtime" },
+		});
+		invokeMock.mockResolvedValue({
+			voiceInput: { providerId: "elevenlabs", modelId: "scribe_v1" },
+		});
+		await render();
+
+		const batchModel = Array.from(
+			container.querySelectorAll<HTMLButtonElement>('[role="radio"]'),
+		).find((button) => button.textContent?.includes("Scribe v1"));
+		await act(async () => batchModel?.click());
+		expect(invokeMock).toHaveBeenLastCalledWith("save_voice_input_settings", {
+			provider: "elevenlabs",
+			model: "scribe_v1",
+		});
+
+		invokeMock.mockResolvedValue({});
+		const toggle = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Enable voice input"]',
+		);
+		await act(async () => toggle?.click());
+		expect(invokeMock).toHaveBeenLastCalledWith("save_voice_input_settings", {
+			provider: undefined,
+			model: undefined,
+		});
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.test.tsx
@@ -111,7 +111,7 @@ describe("VoiceInputContent", () => {
 		const onOpenModelProviders = await render();
 
 		expect(container.textContent).toContain(
-			"Voice input needs a connected model provider",
+			"Voice input needs a configured model provider",
 		);
 		const openProviders = Array.from(
 			container.querySelectorAll("button"),
@@ -136,7 +136,7 @@ describe("VoiceInputContent", () => {
 		await render();
 
 		expect(container.textContent).toContain(
-			"None of your connected providers offer speech-to-text models",
+			"None of your configured providers offer speech-to-text models",
 		);
 		expect(container.textContent).toContain("Groq");
 	});

--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
@@ -173,8 +173,8 @@ export function VoiceInputContent({
 					<Mic aria-hidden="true" className="size-6 text-muted-foreground" />
 					<p className="text-base font-medium text-foreground">
 						{hasConnected
-							? "None of your connected providers offer speech-to-text models"
-							: "Voice input needs a connected model provider"}
+							? "None of your configured providers offer speech-to-text models"
+							: "Voice input needs a configured model provider"}
 					</p>
 					<p className="text-sm text-muted-foreground">
 						{voiceCapableProviderNames.length > 0

--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { AudioLines, Mic, Radio } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { desktopClient } from "@/lib/desktop-client";
+import { isProviderConnected } from "@/lib/provider-connection";
+import {
+	fetchProviderCatalog,
+	isDedicatedTranscriptionModel,
+	notifyVoiceInputSettingsChanged,
+} from "@/lib/provider-model-catalog";
+import type {
+	Provider,
+	ProviderModel,
+	VoiceInputSelection,
+} from "@/lib/provider-schema";
+import { cn } from "@/lib/utils";
+import { PageFrame, PageHeader } from "../page-layout";
+
+type VoiceProviderEntry = {
+	provider: Provider;
+	models: ProviderModel[];
+};
+
+/**
+ * The model preselected when the user enables voice input or switches
+ * provider: streaming (live) transcription when available, else the first
+ * transcription model the provider offers.
+ */
+export function defaultTranscriptionModel(
+	models: ProviderModel[],
+): ProviderModel | undefined {
+	return (
+		models.find((model) => model.operationModes?.includes("streaming")) ??
+		models[0]
+	);
+}
+
+function isStreamingModel(model: ProviderModel): boolean {
+	return model.operationModes?.includes("streaming") === true;
+}
+
+export function VoiceInputContent({
+	onOpenModelProviders,
+}: {
+	onOpenModelProviders: () => void;
+}) {
+	const [providers, setProviders] = useState<Provider[] | null>(null);
+	const [voiceInput, setVoiceInput] = useState<VoiceInputSelection | undefined>(
+		undefined,
+	);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [saveError, setSaveError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		void fetchProviderCatalog()
+			.then((payload) => {
+				if (cancelled) return;
+				setProviders(payload.providers ?? []);
+				setVoiceInput(payload.voiceInput);
+				setLoadError(null);
+			})
+			.catch((error) => {
+				if (cancelled) return;
+				setLoadError(error instanceof Error ? error.message : String(error));
+				setProviders([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const connectedProviders = (providers ?? []).filter(isProviderConnected);
+	const voiceProviders: VoiceProviderEntry[] = connectedProviders
+		.map((provider) => ({
+			provider,
+			models: (provider.modelList ?? []).filter(isDedicatedTranscriptionModel),
+		}))
+		.filter((entry) => entry.models.length > 0);
+	// Providers that would qualify once connected, so the empty states can
+	// point the user at something actionable.
+	const voiceCapableProviderNames = (providers ?? [])
+		.filter((provider) =>
+			(provider.modelList ?? []).some(isDedicatedTranscriptionModel),
+		)
+		.map((provider) => provider.name);
+
+	const selectedEntry = voiceProviders.find(
+		(entry) => entry.provider.id === voiceInput?.providerId,
+	);
+
+	const save = useCallback(
+		async (selection: VoiceInputSelection | undefined) => {
+			const previous = voiceInput;
+			setVoiceInput(selection);
+			setSaving(true);
+			setSaveError(null);
+			try {
+				const result = await desktopClient.invoke<{
+					voiceInput?: VoiceInputSelection;
+				}>("save_voice_input_settings", {
+					provider: selection?.providerId,
+					model: selection?.modelId,
+				});
+				setVoiceInput(result.voiceInput);
+				notifyVoiceInputSettingsChanged();
+			} catch (error) {
+				setVoiceInput(previous);
+				setSaveError(error instanceof Error ? error.message : String(error));
+			} finally {
+				setSaving(false);
+			}
+		},
+		[voiceInput],
+	);
+
+	const enableWithDefaults = useCallback(() => {
+		const entry = voiceProviders[0];
+		const model = entry ? defaultTranscriptionModel(entry.models) : undefined;
+		if (!entry || !model) return;
+		void save({ providerId: entry.provider.id, modelId: model.id });
+	}, [save, voiceProviders]);
+
+	const selectProvider = useCallback(
+		(providerId: string) => {
+			const entry = voiceProviders.find(
+				(candidate) => candidate.provider.id === providerId,
+			);
+			const model = entry ? defaultTranscriptionModel(entry.models) : undefined;
+			if (!entry || !model) return;
+			void save({ providerId: entry.provider.id, modelId: model.id });
+		},
+		[save, voiceProviders],
+	);
+
+	const header = (
+		<PageHeader
+			description="Speak instead of typing: the microphone in chat transcribes your voice with the model chosen here. Live models show text as you speak; others transcribe when the recording stops."
+			title="Voice input"
+		/>
+	);
+
+	if (providers === null) {
+		return (
+			<PageFrame>
+				{header}
+				<p className="text-sm text-muted-foreground">Loading providers...</p>
+			</PageFrame>
+		);
+	}
+
+	if (loadError) {
+		return (
+			<PageFrame>
+				{header}
+				<p className="text-sm text-destructive">
+					Failed to load providers: {loadError}
+				</p>
+			</PageFrame>
+		);
+	}
+
+	if (voiceProviders.length === 0) {
+		const hasConnected = connectedProviders.length > 0;
+		return (
+			<PageFrame>
+				{header}
+				<div className="flex max-w-2xl flex-col items-start gap-3 rounded-lg border border-dashed px-6 py-8">
+					<Mic aria-hidden="true" className="size-6 text-muted-foreground" />
+					<p className="text-base font-medium text-foreground">
+						{hasConnected
+							? "None of your connected providers offer speech-to-text models"
+							: "Voice input needs a connected model provider"}
+					</p>
+					<p className="text-sm text-muted-foreground">
+						{voiceCapableProviderNames.length > 0
+							? `Connect a provider with transcription models — for example ${voiceCapableProviderNames
+									.slice(0, 4)
+									.join(", ")} — and this page unlocks automatically.`
+							: "Connect a provider with transcription models and this page unlocks automatically."}
+					</p>
+					<Button onClick={onOpenModelProviders} size="sm" type="button">
+						Open Model Providers
+					</Button>
+				</div>
+			</PageFrame>
+		);
+	}
+
+	const enabled = Boolean(voiceInput);
+
+	return (
+		<PageFrame>
+			{header}
+			<section className="max-w-2xl">
+				<div className="flex items-center justify-between gap-5 border-y py-4">
+					<div className="flex flex-col gap-1">
+						<p className="text-base font-semibold text-foreground">
+							Enable voice input
+						</p>
+						<p className="text-sm text-muted-foreground">
+							Turns on the microphone button in chat. A default model is
+							preselected — adjust it below.
+						</p>
+					</div>
+					<Switch
+						aria-label="Enable voice input"
+						checked={enabled}
+						disabled={saving}
+						onCheckedChange={(checked) => {
+							if (checked) enableWithDefaults();
+							else void save(undefined);
+						}}
+					/>
+				</div>
+
+				{saveError ? (
+					<p className="mt-3 text-xs text-destructive" role="alert">
+						Failed to save voice input settings: {saveError}
+					</p>
+				) : null}
+
+				{enabled ? (
+					<>
+						<div className="mt-6">
+							<p className="mb-2 text-sm font-semibold text-foreground">
+								Provider
+							</p>
+							<div className="flex flex-wrap gap-2">
+								{voiceProviders.map(({ provider }) => {
+									const isSelected = voiceInput?.providerId === provider.id;
+									return (
+										<button
+											aria-pressed={isSelected}
+											className={cn(
+												"flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+												isSelected
+													? "border-primary/40 bg-primary/8 text-foreground"
+													: "text-muted-foreground hover:bg-surface-hover-lighter hover:text-foreground",
+											)}
+											disabled={saving}
+											key={provider.id}
+											onClick={() => selectProvider(provider.id)}
+											type="button"
+										>
+											<span
+												aria-hidden="true"
+												className="grid size-5 shrink-0 place-items-center rounded text-[0.6rem] font-semibold text-white"
+												style={{ backgroundColor: provider.color }}
+											>
+												{provider.letter}
+											</span>
+											{provider.name}
+										</button>
+									);
+								})}
+							</div>
+						</div>
+
+						{selectedEntry ? (
+							<div className="mt-6">
+								<p className="mb-2 text-sm font-semibold text-foreground">
+									Model
+								</p>
+								<div
+									aria-label="Voice input model"
+									className="overflow-hidden rounded-lg border"
+									role="radiogroup"
+								>
+									{selectedEntry.models.map((model) => {
+										const isSelected = voiceInput?.modelId === model.id;
+										const isDefault =
+											defaultTranscriptionModel(selectedEntry.models)?.id ===
+											model.id;
+										return (
+											<button
+												aria-checked={isSelected}
+												className={cn(
+													"flex w-full items-center gap-3 border-b px-4 py-3 text-left last:border-b-0 hover:bg-surface-hover-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+													isSelected && "bg-surface-hover",
+												)}
+												disabled={saving}
+												key={model.id}
+												onClick={() =>
+													void save({
+														providerId: selectedEntry.provider.id,
+														modelId: model.id,
+													})
+												}
+												role="radio"
+												type="button"
+											>
+												<span
+													aria-hidden="true"
+													className={cn(
+														"grid size-4 shrink-0 place-items-center rounded-full border",
+														isSelected
+															? "border-primary"
+															: "border-muted-foreground/40",
+													)}
+												>
+													{isSelected ? (
+														<span className="size-2 rounded-full bg-primary" />
+													) : null}
+												</span>
+												<div className="min-w-0 flex-1">
+													<div className="flex min-w-0 items-center gap-2">
+														<span className="truncate text-sm text-foreground">
+															{model.name}
+														</span>
+														{isStreamingModel(model) ? (
+															<span className="inline-flex shrink-0 items-center gap-1 rounded bg-surface-hover px-1.5 py-px text-[0.625rem] font-medium uppercase tracking-wide text-muted-foreground">
+																<Radio aria-hidden="true" className="size-3" />
+																Live
+															</span>
+														) : (
+															<span className="inline-flex shrink-0 items-center gap-1 rounded bg-surface-hover px-1.5 py-px text-[0.625rem] font-medium uppercase tracking-wide text-muted-foreground">
+																<AudioLines
+																	aria-hidden="true"
+																	className="size-3"
+																/>
+																After recording
+															</span>
+														)}
+														{isDefault ? (
+															<span className="shrink-0 text-[0.625rem] font-medium uppercase tracking-wide text-muted-foreground">
+																Default
+															</span>
+														) : null}
+													</div>
+													<p className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+														{model.id}
+													</p>
+												</div>
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						) : null}
+					</>
+				) : null}
+			</section>
+		</PageFrame>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
@@ -247,13 +247,6 @@ export function VoiceInputContent({
 											onClick={() => selectProvider(provider.id)}
 											type="button"
 										>
-											<span
-												aria-hidden="true"
-												className="grid size-5 shrink-0 place-items-center rounded text-[0.6rem] font-semibold text-white"
-												style={{ backgroundColor: provider.color }}
-											>
-												{provider.letter}
-											</span>
 											{provider.name}
 										</button>
 									);

--- a/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
@@ -11,14 +11,7 @@ export const CHAT_WS_ENDPOINT_RETRY_DELAY_MS = 100;
 export const CHAT_WS_RECONNECT_BASE_DELAY_MS = 300;
 export const CHAT_WS_RECONNECT_MAX_DELAY_MS = 3000;
 export const CHAT_WS_REQUEST_TIMEOUT_MS = 120000;
-export const OAUTH_MANAGED_PROVIDERS = new Set([
-	"cline",
-	// ClinePass shares the Cline account OAuth credentials (its auth handler
-	// stores under the "cline" provider), so it never has its own API key.
-	"cline-pass",
-	"oca",
-	"openai-codex",
-]);
+export { OAUTH_PROVIDER_IDS as OAUTH_MANAGED_PROVIDERS } from "@/lib/provider-connection";
 
 export const DEFAULT_CHAT_CONFIG: ChatSessionConfig = {
 	sessionId: undefined,

--- a/apps/examples/desktop-app/webview/hooks/use-has-connected-provider.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-has-connected-provider.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isProviderConnected } from "@/lib/provider-connection";
+import {
+	fetchProviderCatalog,
+	subscribeToProviderCatalogInvalidation,
+} from "@/lib/provider-model-catalog";
+
+/**
+ * Whether at least one model provider is connected (usable for turns).
+ * Returns null while unknown so callers can avoid flashing a disabled state
+ * before the catalog loads. Stays current across credential changes via the
+ * shared catalog invalidation channel.
+ */
+export function useHasConnectedProvider(): boolean | null {
+	const [hasConnectedProvider, setHasConnectedProvider] = useState<
+		boolean | null
+	>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		const load = () => {
+			// Failures (including an unavailable transport) keep the last known
+			// value; the catalog fetch is retried on the next invalidation.
+			try {
+				void Promise.resolve(fetchProviderCatalog())
+					.then((payload) => {
+						if (cancelled) return;
+						setHasConnectedProvider(
+							(payload?.providers ?? []).some(isProviderConnected),
+						);
+					})
+					.catch(() => {});
+			} catch {}
+		};
+		load();
+		const unsubscribe = subscribeToProviderCatalogInvalidation(load);
+		return () => {
+			cancelled = true;
+			unsubscribe();
+		};
+	}, []);
+
+	return hasConnectedProvider;
+}

--- a/apps/examples/desktop-app/webview/lib/provider-connection.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-connection.ts
@@ -1,6 +1,42 @@
 import type { Provider } from "@/lib/provider-schema";
 
 /**
+ * Providers whose credentials are managed through an OAuth sign-in flow
+ * rather than a pasted API key. Mirrors the SDK's provider auth registry
+ * (see sdk/packages/core/src/auth/provider-auth-registry.ts); the catalog's
+ * "oauth" capability is the primary signal and this set is the fallback for
+ * entries whose capability metadata is incomplete.
+ */
+export const OAUTH_PROVIDER_IDS = new Set([
+	"cline",
+	// ClinePass shares the Cline account OAuth credentials (its auth handler
+	// stores under the "cline" provider), so it never has its own API key.
+	"cline-pass",
+	"oca",
+	"openai-codex",
+]);
+
+export type ProviderAuthKind = "oauth" | "local" | "api-key";
+
+/**
+ * How a provider expects to be authenticated, which drives which connect UI
+ * to show: a browser sign-in button (oauth), a "uses your local CLI" notice
+ * (local), or credential fields (api-key).
+ */
+export function getProviderAuthKind(provider: Provider): ProviderAuthKind {
+	if (
+		provider.capabilities?.includes("oauth") ||
+		OAUTH_PROVIDER_IDS.has(provider.id)
+	) {
+		return "oauth";
+	}
+	if (provider.capabilities?.includes("local-auth")) {
+		return "local";
+	}
+	return "api-key";
+}
+
+/**
  * Whether a provider from the catalog is usable for turns, for the purpose
  * of the first-run "connect a model" notice. Plain API keys and OAuth are
  * definitive. Beyond those, an enabled provider counts as connected unless


### PR DESCRIPTION
## Summary

Reworks the desktop app's Model Providers settings page around how providers actually authenticate (mirroring the CLI TUI's onboarding and provider picker flows), and moves voice input out of that page into its own gated Settings section.

### Model Providers page

- Providers are grouped into **Configured**, **Popular**, and **All providers** sections with an always-visible search. Each row shows just the provider name and how it connects (Sign in / API key / Local CLI); providers with saved settings show a neutral "Configured" status (deliberately not a green "connected" indicator, since it's stored configuration rather than a live connection).
- Removed the per-provider enable **toggles** ("enabled" just meant "has a settings entry on disk", which let users toggle on providers with no credentials).
- The provider detail panel now branches on auth method:
  - **OAuth providers** (Cline, ClinePass, ChatGPT, OCA) show a "Sign in with browser" card instead of an API key field. Providers that also accept a manual key (e.g. Cline) get a collapsed "Use an API key instead" escape hatch. When signed in, the panel shows "Signed in via browser" with a **Sign out** action.
  - **Local-auth providers** (e.g. Codex CLI) explain that credentials come from the local CLI, with Connect/Disconnect.
  - **API-key providers** keep the credential fields (saving a key still configures the provider automatically) plus explicit **Connect** (for env-var/keyless setups like Ollama) and **Disconnect** actions.
- Disconnecting removes the persisted settings entry and reloads the catalog so the UI reflects the real on-disk state.

![Model Providers list with Configured/Popular groups and the Cline detail panel](https://cursor.com/artifacts/c/art-ec5c9cf6-b799-4dd4-9c3c-c3e37217da0d)

### Voice input page

- New **Settings > Voice** section. The old provider/model dropdowns crammed at the top of the providers page are gone.
- Only **configured** providers with dedicated transcription models are offered (previously any toggled-on provider appeared, even without credentials).
- The sidebar nav item is disabled (with an explanatory tooltip) until at least one model provider is configured; the page itself shows guidance (which providers offer speech-to-text) when configured providers have no transcription models.
- Turning voice input on preselects a **default model** automatically (streaming/live model preferred), so the chat microphone works with one click. Models render as a radio list with Live / After-recording badges and the default marked.
- The chat mic's "configure voice input" affordance now deep-links to Settings > Voice.

![Disabled Voice nav item with tooltip in fresh state](https://cursor.com/artifacts/c/art-b0ec589a-3f45-4ddc-83f3-bc35c55ed650)
![Voice page with default streaming model preselected](https://cursor.com/artifacts/c/art-93d631c0-f405-4f1c-8c8e-7b55df7d3777)

### Implementation notes

- `getProviderAuthKind` + shared `OAUTH_PROVIDER_IDS` live in `webview/lib/provider-connection.ts`; `hooks/chat-session/constants.ts` re-exports the set to avoid drift.
- New `useHasConnectedProvider` hook keeps the sidebar gating current via the existing catalog-invalidation channel.
- The provider detail is now keyed by provider id so field drafts and shown-secret state no longer leak across provider switches.

## Testing

- `bun run typecheck` passes.
- Full webview vitest suite passes (54 files, 574 tests), including new tests for list grouping/search, OAuth sign-in/sign-out and manual-key escape hatch, Connect/Disconnect, voice page gating, and default-model preselection.
- Manually exercised end to end in the headless dev app (sidecar + Next.js): configured a provider via API key, watched it move to the Configured group and unlock the Voice page, enabled voice input with the default live model preselected, switched models, then disconnected and confirmed the Voice section locks again.