### PR TITLE
Add Desktop App and Cloud Platform to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,8 @@ body:
         - VSCode Extension
         - JetBrains Plugin
         - CLI
+        - Desktop App
+        - Cloud Platform
       default: 0
     validations:
       required: true
@@ -62,13 +64,15 @@ body:
   - type: textarea
     id: ide-diagnostics
     attributes:
-      label: IDE / CLI Diagnostics
+      label: Surface Diagnostics
       description: |
-        Paste the "About" diagnostics for your Cline surface. This captures the IDE build, runtime, and host details we need.
+        Paste the diagnostics for your Cline surface. This captures the build, runtime, and host details we need.
         - VSCode Extension: open `Help → About` (Windows/Linux) or `Code → About Visual Studio Code` (macOS), then copy the info.
         - JetBrains Plugin: open `Help → About` (Windows/Linux) or `<IDE name> → About` (macOS), then click `Copy` to grab build, runtime, OS, memory, and cores.
         - CLI: there is no About dialog. Run `cline --version` and paste the output.
-      placeholder: Paste the copied About info or `cline --version` output here.
+        - Desktop App: paste the app version from the Settings view.
+        - Cloud Platform: paste your browser name and version, plus the page URL where the issue occurred.
+      placeholder: Paste the copied About info, `cline --version` output, or browser/app details here.
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,7 +64,7 @@ body:
   - type: textarea
     id: ide-diagnostics
     attributes:
-      label: Surface Diagnostics
+      label: Diagnostics
       description: |
         Paste the diagnostics for your Cline surface. This captures the build, runtime, and host details we need.
         - VSCode Extension: open `Help → About` (Windows/Linux) or `Code → About Visual Studio Code` (macOS), then copy the info.


### PR DESCRIPTION
### Related Issue

N/A (small workflow/template change)

### Description

Our bug report issue template only listed VSCode Extension, JetBrains Plugin, and CLI as reportable Cline surfaces. This PR adds two new options to the "Cline Surface" dropdown:

- Desktop App
- Cloud Platform

It also updates the diagnostics section to cover the new surfaces: the field is renamed from "IDE / CLI Diagnostics" to "Surface Diagnostics", with instructions for Desktop App users to paste the app version from Settings, and for Cloud Platform users to include their browser version and the page URL where the issue occurred.

### Test Procedure

- Validated the YAML parses correctly and the dropdown structure is well-formed (5 options, default index 0 still points to VSCode Extension).
- Change is limited to the GitHub issue form definition; no application code is affected.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable (issue template YAML change only).

### Additional Notes

None