### PR TITLE
desktop: sidebar navigation cleanup with New/Schedule/Customize rows and dialog-based search

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -431,17 +431,11 @@ export default function Home() {
 							onHome={handleHome}
 							onNavigateBack={handleNavigateBack}
 							onNavigateForward={handleNavigateForward}
-							onOpenSessionById={handleOpenSessionById}
 							onSettingsSectionChange={handleSettingsSectionChange}
 							sessionHistory={sessionHistory}
 							setView={handleViewChange}
 							settingsSection={settingsSection}
 							view={view}
-							workspaceRoot={
-								activeThread?.historySession?.workspaceRoot ||
-								activeThread?.historySession?.cwd ||
-								historyWorkspacePaths[0]
-							}
 							canNavigateBack={navigation.back.length > 0}
 							canNavigateForward={navigation.forward.length > 0}
 						/>

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -431,7 +431,6 @@ export default function Home() {
 							onHome={handleHome}
 							onNavigateBack={handleNavigateBack}
 							onNavigateForward={handleNavigateForward}
-							onNewThread={handleNewThread}
 							onOpenSessionById={handleOpenSessionById}
 							onSettingsSectionChange={handleSettingsSectionChange}
 							sessionHistory={sessionHistory}

--- a/apps/examples/desktop-app/webview/components/agenda-ui-hidden.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agenda-ui-hidden.test.tsx
@@ -55,6 +55,7 @@ function makeSessionHistory(): UseSessionHistoryResult {
 		forkThread: vi.fn(),
 		hasLoadedHistory: true,
 		isLoadingMore: false,
+		loadAllSessions: vi.fn(async () => true),
 		loadOlderSessions: vi.fn(),
 		loadMoreSessions: vi.fn(),
 		mayHaveMoreSessions: false,

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -920,8 +920,9 @@ describe("AgentSidebar session organization", () => {
 		expect(onNavigateForward).toHaveBeenCalledOnce();
 	});
 
-	it("gives New Task its own full-width row that navigates home", async () => {
+	it("stacks New, Schedule, and Customize as full-width rows below the logo", async () => {
 		const onHome = vi.fn();
+		const onSettingsSectionChange = vi.fn();
 		await act(async () => {
 			root.render(
 				<AccountProvider>
@@ -929,7 +930,7 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={onHome}
-							onSettingsSectionChange={vi.fn()}
+							onSettingsSectionChange={onSettingsSectionChange}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
 							settingsSection="General"
@@ -941,18 +942,65 @@ describe("AgentSidebar session organization", () => {
 		});
 
 		const logo = container.querySelector('[aria-label="Cline home"]');
-		const showAgenda = container.querySelector('[aria-label="Show Agenda"]');
-		const newTask = container.querySelector('[aria-label="New Task"]');
+		const actionsNav = container.querySelector(
+			'[aria-label="Sidebar actions"]',
+		);
 		expect(logo).not.toBeNull();
-		expect(showAgenda).not.toBeNull();
-		expect(newTask).not.toBeNull();
-		// The action reads as a labeled row, not an ambiguous icon in the
-		// header cluster, and it lives outside the logo row.
-		expect(newTask?.textContent).toBe("New Task");
-		expect(newTask?.className).toContain("w-full");
-		expect(newTask?.parentElement).not.toBe(logo?.parentElement);
-		await click(newTask as Element);
+		expect(actionsNav).not.toBeNull();
+		// The rows read as labeled full-width entries stacked outside the
+		// logo row, not ambiguous icons in the header cluster.
+		const rows = [
+			...(actionsNav?.querySelectorAll<HTMLButtonElement>("button") ?? []),
+		];
+		expect(rows.map((row) => row.textContent)).toEqual([
+			"New",
+			"Schedule",
+			"Customize",
+		]);
+		for (const row of rows) {
+			expect(row.className).toContain("w-full");
+		}
+		expect(actionsNav?.contains(logo as Element)).toBe(false);
+
+		await click(buttonWithText("New", actionsNav as ParentNode));
 		expect(onHome).toHaveBeenCalledOnce();
+		await click(buttonWithText("Schedule", actionsNav as ParentNode));
+		expect(onSettingsSectionChange).toHaveBeenCalledWith("Schedules");
+		await click(buttonWithText("Customize", actionsNav as ParentNode));
+		expect(onSettingsSectionChange).toHaveBeenCalledWith("Plugins");
+	});
+
+	it("always shows the session search bar above the sessions list", async () => {
+		await act(async () => {
+			root.render(
+				<AccountProvider>
+					<SidebarProvider>
+						<AgentSidebar
+							activeSessionId={null}
+							onHome={vi.fn()}
+							onSettingsSectionChange={vi.fn()}
+							sessionHistory={makeSessionHistory(
+								[makeThread("alpha", 1), makeThread("beta", 1)],
+								vi.fn(),
+							)}
+							setView={vi.fn()}
+							settingsSection="General"
+							view="chat"
+						/>
+					</SidebarProvider>
+				</AccountProvider>,
+			);
+		});
+
+		const search = container.querySelector<HTMLInputElement>(
+			'input[aria-label="Search sessions"]',
+		);
+		expect(search).not.toBeNull();
+		expect(search?.placeholder).toBe("Search sessions...");
+
+		await changeField(search as HTMLInputElement, "alpha");
+		expect(sessionIsVisible("alpha session 1")).toBe(true);
+		expect(sessionIsVisible("beta session 1")).toBe(false);
 	});
 
 	it("uses only the Cline logo for home in the collapsed sidebar", async () => {
@@ -975,7 +1023,9 @@ describe("AgentSidebar session organization", () => {
 		});
 
 		expect(container.querySelector('[aria-label="Cline home"]')).not.toBeNull();
-		expect(container.querySelector('[aria-label="New Task"]')).toBeNull();
+		expect(
+			container.querySelector('[aria-label="Sidebar actions"]'),
+		).toBeNull();
 		expect(
 			container.querySelector('[aria-label="Expand sidebar"]')?.className,
 		).toContain("mt-auto");

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-import type { AgendaTaskRecord } from "@cline/shared";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,13 +17,6 @@ import type {
 
 const desktopMocks = vi.hoisted(() => ({
 	invoke: vi.fn(),
-	createAgendaTask: vi.fn(),
-	listAgendaTasks: vi.fn(),
-	approveAgendaTask: vi.fn(),
-	cancelAgendaTask: vi.fn(),
-	runAgendaTask: vi.fn(),
-	getAgendaAutomationPolicy: vi.fn(),
-	setAgendaAutomationPolicy: vi.fn(),
 	subscribe: vi.fn(() => () => undefined),
 	subscribeTransportState: vi.fn(() => () => undefined),
 }));
@@ -145,23 +137,6 @@ beforeEach(() => {
 	window.localStorage.clear();
 	invoke.mockReset();
 	invoke.mockRejectedValue(new Error("No Cline account auth token found"));
-	desktopMocks.createAgendaTask.mockReset();
-	desktopMocks.listAgendaTasks.mockReset();
-	desktopMocks.listAgendaTasks.mockResolvedValue([]);
-	desktopMocks.approveAgendaTask.mockReset();
-	desktopMocks.cancelAgendaTask.mockReset();
-	desktopMocks.runAgendaTask.mockReset();
-	desktopMocks.getAgendaAutomationPolicy.mockReset();
-	desktopMocks.getAgendaAutomationPolicy.mockResolvedValue({
-		scopeKey: "global",
-		mode: "manual",
-		applyToAgentCreated: true,
-		maxConcurrentRuns: 1,
-		maxChainDepth: 3,
-		maxStartsPerHour: 20,
-		updatedAt: "2026-08-13T00:00:00.000Z",
-	});
-	desktopMocks.setAgendaAutomationPolicy.mockReset();
 	desktopMocks.subscribe.mockReset();
 	desktopMocks.subscribe.mockImplementation(() => () => undefined);
 	desktopMocks.subscribeTransportState.mockReset();
@@ -179,6 +154,17 @@ beforeEach(() => {
 	HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
 	HTMLElement.prototype.setPointerCapture = vi.fn();
 	HTMLElement.prototype.releasePointerCapture = vi.fn();
+	HTMLElement.prototype.scrollIntoView = vi.fn();
+	// cmdk (the search dialog) observes its list size; jsdom has no
+	// ResizeObserver implementation.
+	vi.stubGlobal(
+		"ResizeObserver",
+		class {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		},
+	);
 	container = document.createElement("div");
 	document.body.appendChild(container);
 	root = createRoot(container);
@@ -191,251 +177,6 @@ afterEach(async () => {
 });
 
 describe("AgentSidebar session organization", () => {
-	it("shows an unread dot when a new Todo item arrives and clears it on open", async () => {
-		const eventHandlers = new Map<string, () => void>();
-		desktopMocks.subscribe.mockImplementation(
-			(eventName: string, handler: () => void) => {
-				eventHandlers.set(eventName, handler);
-				return () => eventHandlers.delete(eventName);
-			},
-		);
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-					/>
-				</SidebarProvider>,
-			);
-		});
-		await vi.waitFor(() =>
-			expect(desktopMocks.listAgendaTasks).toHaveBeenCalled(),
-		);
-		expect(
-			container.querySelector('[data-testid="new-todo-indicator"]'),
-		).toBeNull();
-
-		desktopMocks.listAgendaTasks.mockResolvedValue([makeAgendaTask()]);
-		await act(async () => {
-			eventHandlers.get("task.created")?.();
-		});
-		await vi.waitFor(() =>
-			expect(
-				container.querySelector('[data-testid="new-todo-indicator"]'),
-			).not.toBeNull(),
-		);
-
-		await click(
-			container.querySelector('[aria-label="Show Agenda"]') as Element,
-		);
-		expect(
-			container.querySelector('[data-testid="new-todo-indicator"]'),
-		).toBeNull();
-	});
-
-	it("shows pending Agenda work and requires approval before run", async () => {
-		const task = makeAgendaTask();
-		desktopMocks.listAgendaTasks.mockResolvedValue([task]);
-		desktopMocks.approveAgendaTask.mockResolvedValue({
-			...task,
-			status: "approved",
-			revision: 2,
-		});
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-						workspaceRoot="/projects/current"
-					/>
-				</SidebarProvider>,
-			);
-			await Promise.resolve();
-		});
-		await click(
-			container.querySelector('[aria-label="Show Agenda"]') as Element,
-		);
-
-		expect(container.textContent).toContain("Review PR checks");
-		expect(container.textContent).toContain("cline");
-		expect(container.textContent).not.toContain("P1 · pending approval");
-		expect(desktopMocks.listAgendaTasks).toHaveBeenCalledWith({
-			statuses: ["pending_approval", "approved", "in_progress", "failed"],
-			workspaceRoot: "/projects/current",
-			limit: 200,
-		});
-		const approve = container.querySelector(
-			'[aria-label="Approve Review PR checks"]',
-		);
-		expect(approve).not.toBeNull();
-		expect(approve?.className).toContain("text-emerald-500!");
-		expect(
-			container.querySelector('[aria-label="Cancel Review PR checks"]')
-				?.className,
-		).toContain("text-destructive!");
-		expect(approve?.closest(".group")?.className).toContain("max-w-full");
-		expect(
-			buttonWithText("Review PR checks").querySelector(".truncate"),
-		).not.toBeNull();
-		expect(
-			container.querySelector('[aria-label="Run Review PR checks"]'),
-		).toBeNull();
-
-		await click(buttonWithText("Review PR checks"));
-		expect(desktopMocks.approveAgendaTask).not.toHaveBeenCalled();
-		expect(document.body.textContent).toContain(
-			"Review CI and report failures.",
-		);
-		expect(buttonWithText("Reject", document)).toBeDefined();
-		await click(buttonWithText("Approve", document));
-		expect(desktopMocks.approveAgendaTask).toHaveBeenCalledWith({
-			taskId: "task-1",
-			expectedRevision: 1,
-		});
-	});
-
-	it("uses each displayed Agenda revision when running or cancelling", async () => {
-		const runnable = makeAgendaTask({
-			taskId: "task-run",
-			title: "Run task",
-			status: "approved",
-			revision: 4,
-		});
-		const cancellable = makeAgendaTask({
-			taskId: "task-cancel",
-			title: "Cancel task",
-			status: "approved",
-			revision: 9,
-		});
-		desktopMocks.listAgendaTasks.mockResolvedValue([runnable, cancellable]);
-		desktopMocks.runAgendaTask.mockResolvedValue({
-			task: { ...runnable, status: "in_progress" },
-		});
-		desktopMocks.cancelAgendaTask.mockResolvedValue({
-			...cancellable,
-			status: "cancelled",
-		});
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-					/>
-				</SidebarProvider>,
-			);
-			await Promise.resolve();
-		});
-		await click(
-			container.querySelector('[aria-label="Show Agenda"]') as Element,
-		);
-
-		await click(
-			container.querySelector('[aria-label="Run Run task"]') as Element,
-		);
-		expect(desktopMocks.runAgendaTask).toHaveBeenCalledWith({
-			taskId: "task-run",
-			expectedRevision: 4,
-		});
-
-		await click(
-			container.querySelector('[aria-label="Cancel Cancel task"]') as Element,
-		);
-		expect(desktopMocks.cancelAgendaTask).toHaveBeenCalledWith({
-			taskId: "task-cancel",
-			expectedRevision: 9,
-		});
-	});
-
-	it("creates a workspace task with the selected priority, expiry, and model", async () => {
-		const created = makeAgendaTask({
-			taskId: "task-created",
-			title: "Investigate the regression",
-		});
-		desktopMocks.createAgendaTask.mockResolvedValue(created);
-		window.localStorage.setItem(
-			"cline.code.model-selection.v1",
-			JSON.stringify({
-				lastProvider: "openrouter",
-				lastModelByProvider: { openrouter: "anthropic/claude-sonnet-4.6" },
-			}),
-		);
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-						workspaceRoot="/projects/current"
-					/>
-				</SidebarProvider>,
-			);
-			await Promise.resolve();
-		});
-
-		expect(container.querySelector('[aria-label="Agenda"]')).toBeNull();
-		await click(
-			container.querySelector('[aria-label="Show Agenda"]') as Element,
-		);
-		await click(
-			container.querySelector('[aria-label="Create Todo item"]') as Element,
-		);
-		const title =
-			document.querySelector<HTMLInputElement>("#agenda-task-title");
-		const instructions = document.querySelector<HTMLTextAreaElement>(
-			"#agenda-task-instructions",
-		);
-		expect(title).not.toBeNull();
-		expect(instructions).not.toBeNull();
-		await changeField(title as HTMLInputElement, "Investigate the regression");
-		await changeField(
-			instructions as HTMLTextAreaElement,
-			"Inspect the failing build and implement a fix.",
-		);
-		await click(buttonWithText("Add to Agenda", document));
-
-		await vi.waitFor(() =>
-			expect(desktopMocks.createAgendaTask).toHaveBeenCalledOnce(),
-		);
-		const input = desktopMocks.createAgendaTask.mock.calls[0]?.[0];
-		expect(input).toMatchObject({
-			type: "todo",
-			title: "Investigate the regression",
-			instructions: "Inspect the failing build and implement a fix.",
-			scope: "workspace",
-			workspaceRoot: "/projects/current",
-			priority: 3,
-			modelSelection: {
-				providerId: "openrouter",
-				modelId: "anthropic/claude-sonnet-4.6",
-			},
-			automationEligible: true,
-		});
-		expect(Date.parse(input.expiresAt)).toBeGreaterThan(Date.now());
-	});
-
 	it("filters scheduled sessions without changing their titles", async () => {
 		const scheduled = {
 			...makeThread("scheduled", 1),
@@ -970,7 +711,11 @@ describe("AgentSidebar session organization", () => {
 		expect(onSettingsSectionChange).toHaveBeenCalledWith("Plugins");
 	});
 
-	it("always shows the session search bar above the sessions list", async () => {
+	it("opens session search in a dialog from the logo-row icon", async () => {
+		const sessionHistory = makeSessionHistory(
+			[makeThread("alpha", 1), makeThread("beta", 1)],
+			vi.fn(),
+		);
 		await act(async () => {
 			root.render(
 				<AccountProvider>
@@ -979,10 +724,7 @@ describe("AgentSidebar session organization", () => {
 							activeSessionId={null}
 							onHome={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
-							sessionHistory={makeSessionHistory(
-								[makeThread("alpha", 1), makeThread("beta", 1)],
-								vi.fn(),
-							)}
+							sessionHistory={sessionHistory}
 							setView={vi.fn()}
 							settingsSection="General"
 							view="chat"
@@ -992,15 +734,38 @@ describe("AgentSidebar session organization", () => {
 			);
 		});
 
-		const search = container.querySelector<HTMLInputElement>(
-			'input[aria-label="Search sessions"]',
+		// Search lives behind the logo-row icon, not an inline sidebar input.
+		expect(container.querySelector("input")).toBeNull();
+		const searchButton = container.querySelector(
+			'button[aria-label="Search sessions"]',
 		);
-		expect(search).not.toBeNull();
-		expect(search?.placeholder).toBe("Search sessions...");
+		expect(searchButton).not.toBeNull();
+		await click(searchButton as Element);
 
-		await changeField(search as HTMLInputElement, "alpha");
-		expect(sessionIsVisible("alpha session 1")).toBe(true);
-		expect(sessionIsVisible("beta session 1")).toBe(false);
+		const searchInput = await vi.waitFor(() => {
+			const input = document.querySelector<HTMLInputElement>(
+				'[data-slot="command-input"]',
+			);
+			expect(input).not.toBeNull();
+			return input as HTMLInputElement;
+		});
+		expect(searchInput.placeholder).toBe("Search sessions...");
+
+		await changeField(searchInput, "alpha");
+		const match = await vi.waitFor(() => {
+			const items = [
+				...document.querySelectorAll<HTMLElement>('[data-slot="command-item"]'),
+			];
+			expect(items).toHaveLength(1);
+			return items[0] as HTMLElement;
+		});
+		expect(match.textContent).toContain("alpha session 1");
+
+		await click(match);
+		expect(sessionHistory.openThread).toHaveBeenCalledWith("alpha-1");
+		await vi.waitFor(() =>
+			expect(document.querySelector('[data-slot="command-input"]')).toBeNull(),
+		);
 	});
 
 	it("uses only the Cline logo for home in the collapsed sidebar", async () => {
@@ -1109,29 +874,3 @@ describe("AgentSidebar session organization", () => {
 		).toContain("Settings");
 	});
 });
-
-function makeAgendaTask(
-	overrides: Partial<AgendaTaskRecord> = {},
-): AgendaTaskRecord {
-	return {
-		taskId: "task-1",
-		type: "follow-up",
-		status: "pending_approval",
-		title: "Review PR checks",
-		description: "Confirm that CI passed.",
-		instructions: "Review CI and report failures.",
-		scope: "workspace",
-		workspaceRoot: "/projects/cline",
-		resourcePaths: [],
-		priority: 1,
-		availableAt: "2026-08-13T00:00:00.000Z",
-		expiresAt: "2099-08-20T00:00:00.000Z",
-		automationEligible: true,
-		revision: 1,
-		createdBy: { kind: "agent" },
-		updatedBy: { kind: "agent" },
-		createdAt: "2026-08-13T00:00:00.000Z",
-		updatedAt: "2026-08-13T00:00:00.000Z",
-		...overrides,
-	};
-}

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -450,7 +450,6 @@ describe("AgentSidebar session organization", () => {
 					<AgentSidebar
 						activeSessionId={null}
 						onHome={vi.fn()}
-						onNewThread={vi.fn()}
 						onSettingsSectionChange={vi.fn()}
 						sessionHistory={makeSessionHistory([scheduled, regular], vi.fn())}
 						setView={vi.fn()}
@@ -527,7 +526,6 @@ describe("AgentSidebar session organization", () => {
 					<AgentSidebar
 						activeSessionId={null}
 						onHome={vi.fn()}
-						onNewThread={vi.fn()}
 						onSettingsSectionChange={vi.fn()}
 						sessionHistory={makeSessionHistory([], vi.fn(), {
 							hasLoadedHistory: false,
@@ -553,7 +551,6 @@ describe("AgentSidebar session organization", () => {
 					<AgentSidebar
 						activeSessionId={null}
 						onHome={vi.fn()}
-						onNewThread={vi.fn()}
 						onSettingsSectionChange={vi.fn()}
 						sessionHistory={makeSessionHistory([], vi.fn(), {
 							hasLoadedHistory: true,
@@ -626,7 +623,6 @@ describe("AgentSidebar session organization", () => {
 					<AgentSidebar
 						activeSessionId={null}
 						onHome={vi.fn()}
-						onNewThread={vi.fn()}
 						onSettingsSectionChange={vi.fn()}
 						sessionHistory={sessionHistory}
 						setView={vi.fn()}
@@ -688,7 +684,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -734,7 +729,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={onSettingsSectionChange}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={setView}
@@ -768,7 +762,6 @@ describe("AgentSidebar session organization", () => {
 							<AgentSidebar
 								activeSessionId={null}
 								onHome={vi.fn()}
-								onNewThread={vi.fn()}
 								onSettingsSectionChange={vi.fn()}
 								sessionHistory={makeSessionHistory([], vi.fn())}
 								setView={vi.fn()}
@@ -818,7 +811,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={onHome}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -867,7 +859,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -906,7 +897,6 @@ describe("AgentSidebar session organization", () => {
 							onHome={vi.fn()}
 							onNavigateBack={onNavigateBack}
 							onNavigateForward={onNavigateForward}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -930,16 +920,15 @@ describe("AgentSidebar session organization", () => {
 		expect(onNavigateForward).toHaveBeenCalledOnce();
 	});
 
-	it("places the logo and icon-only new-session action below the title bar", async () => {
-		const onNewThread = vi.fn();
+	it("gives New Task its own full-width row that navigates home", async () => {
+		const onHome = vi.fn();
 		await act(async () => {
 			root.render(
 				<AccountProvider>
 					<SidebarProvider>
 						<AgentSidebar
 							activeSessionId={null}
-							onHome={vi.fn()}
-							onNewThread={onNewThread}
+							onHome={onHome}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -953,13 +942,17 @@ describe("AgentSidebar session organization", () => {
 
 		const logo = container.querySelector('[aria-label="Cline home"]');
 		const showAgenda = container.querySelector('[aria-label="Show Agenda"]');
-		const newSession = container.querySelector('[aria-label="New Session"]');
+		const newTask = container.querySelector('[aria-label="New Task"]');
 		expect(logo).not.toBeNull();
 		expect(showAgenda).not.toBeNull();
-		expect(newSession).not.toBeNull();
-		expect(newSession?.textContent).toBe("");
-		await click(newSession as Element);
-		expect(onNewThread).toHaveBeenCalledOnce();
+		expect(newTask).not.toBeNull();
+		// The action reads as a labeled row, not an ambiguous icon in the
+		// header cluster, and it lives outside the logo row.
+		expect(newTask?.textContent).toBe("New Task");
+		expect(newTask?.className).toContain("w-full");
+		expect(newTask?.parentElement).not.toBe(logo?.parentElement);
+		await click(newTask as Element);
+		expect(onHome).toHaveBeenCalledOnce();
 	});
 
 	it("uses only the Cline logo for home in the collapsed sidebar", async () => {
@@ -970,7 +963,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -983,7 +975,7 @@ describe("AgentSidebar session organization", () => {
 		});
 
 		expect(container.querySelector('[aria-label="Cline home"]')).not.toBeNull();
-		expect(container.querySelector('[aria-label="New Session"]')).toBeNull();
+		expect(container.querySelector('[aria-label="New Task"]')).toBeNull();
 		expect(
 			container.querySelector('[aria-label="Expand sidebar"]')?.className,
 		).toContain("mt-auto");
@@ -997,7 +989,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}
@@ -1046,7 +1037,6 @@ describe("AgentSidebar session organization", () => {
 						<AgentSidebar
 							activeSessionId={null}
 							onHome={vi.fn()}
-							onNewThread={vi.fn()}
 							onSettingsSectionChange={vi.fn()}
 							sessionHistory={makeSessionHistory([], vi.fn())}
 							setView={vi.fn()}

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -54,6 +54,7 @@ function makeSessionHistory(
 		forkThread: vi.fn(),
 		hasLoadedHistory: options.hasLoadedHistory ?? true,
 		isLoadingMore: false,
+		loadAllSessions: vi.fn(async () => true),
 		loadOlderSessions: options.loadOlderSessions ?? vi.fn(),
 		loadMoreSessions,
 		mayHaveMoreSessions: options.mayHaveMoreSessions ?? false,
@@ -741,6 +742,8 @@ describe("AgentSidebar session organization", () => {
 		);
 		expect(searchButton).not.toBeNull();
 		await click(searchButton as Element);
+		// Opening search pulls the full history so unloaded sessions match too.
+		expect(sessionHistory.loadAllSessions).toHaveBeenCalledOnce();
 
 		const searchInput = await vi.waitFor(() => {
 			const input = document.querySelector<HTMLInputElement>(

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -1,23 +1,13 @@
 "use client";
 
-import type {
-	AgendaTaskPriority,
-	AgendaTaskRecord,
-	AgendaTaskType,
-	HubTaskCreateInput,
-} from "@cline/shared";
-import { isChatWorkspacePath } from "@cline/shared/browser";
 import {
 	ArrowDownUp,
 	ArrowLeft,
 	ArrowRight,
 	Blocks,
 	Bot,
-	Check,
 	ChevronDown,
-	ChevronRight,
 	CircleUserRound,
-	ClipboardList,
 	Clock3,
 	Code,
 	FileText,
@@ -27,7 +17,6 @@ import {
 	Loader2,
 	PanelLeftOpen,
 	Pencil,
-	Play,
 	Plug,
 	Plus,
 	Radio,
@@ -38,8 +27,6 @@ import {
 	Store,
 	Trash2,
 	Wrench,
-	X,
-	Zap,
 } from "lucide-react";
 import {
 	type ReactNode,
@@ -49,7 +36,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { AgendaTaskReviewDialog } from "@/components/agenda-task-review-dialog";
 import { AppUpdateIndicator } from "@/components/app-update-indicator";
 import { ClineLogo } from "@/components/cline-logo";
 import {
@@ -65,19 +51,18 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+	CommandDialog,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
 	ContextMenu,
 	ContextMenuContent,
 	ContextMenuItem,
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import {
-	Dialog,
-	DialogContent,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -95,7 +80,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useSidebar } from "@/components/ui/sidebar";
-import { Textarea } from "@/components/ui/textarea";
 import { normalizeTitle } from "@/components/utils";
 import {
 	CUSTOMIZATION_SECTIONS,
@@ -103,7 +87,6 @@ import {
 	type SettingsSection,
 } from "@/components/views/settings/sections";
 import { useAccount } from "@/contexts/account-context";
-import { useAgendaAutomation, useAgendaTasks } from "@/hooks/use-agenda-tasks";
 import type {
 	SessionThread,
 	UseSessionHistoryResult,
@@ -115,7 +98,6 @@ import {
 	productNameForVersion,
 } from "@/lib/app-channel";
 import { desktopClient } from "@/lib/desktop-client";
-import { readModelSelectionStorageFromWindow } from "@/lib/model-selection";
 import {
 	ALL_SESSION_SOURCES,
 	filterSessionsBySource,
@@ -135,7 +117,6 @@ type AppView = "chat" | "sessions" | "settings";
 const filterOptions = ["All", "Running", "Schedules", "Favorites"] as const;
 type FilterOption = (typeof filterOptions)[number];
 type SidebarSortMode = "time" | "project";
-type SidebarContent = "sessions" | "agenda";
 type DesktopProcessContext = {
 	appVersion?: unknown;
 	hub?: {
@@ -240,28 +221,24 @@ export function AgentSidebar({
 	onHome,
 	onNavigateBack,
 	onNavigateForward,
-	onOpenSessionById,
 	onSettingsSectionChange,
 	setView,
 	settingsSection,
 	view,
 	activeSessionId,
 	sessionHistory,
-	workspaceRoot,
 }: {
 	canNavigateBack?: boolean;
 	canNavigateForward?: boolean;
 	onHome: () => void;
 	onNavigateBack?: () => void;
 	onNavigateForward?: () => void;
-	onOpenSessionById?: (sessionId: string) => void | Promise<void>;
 	onSettingsSectionChange: (section: SettingsSection) => void;
 	setView: (view: AppView) => void;
 	settingsSection: SettingsSection;
 	view: AppView;
 	activeSessionId?: string | null;
 	sessionHistory: UseSessionHistoryResult;
-	workspaceRoot?: string;
 }) {
 	const { isMobile, setOpen, setOpenMobile, state } = useSidebar();
 	const isCollapsed = !isMobile && state === "collapsed";
@@ -292,11 +269,7 @@ export function AgentSidebar({
 	const [filter, setFilter] = useState<FilterOption>("All");
 	const [sourceFilter, setSourceFilter] = useState(ALL_SESSION_SOURCES);
 	const [sortMode, setSortMode] = useState<SidebarSortMode>("time");
-	const [sidebarContent, setSidebarContent] =
-		useState<SidebarContent>("sessions");
-	const [hasNewTodoTasks, setHasNewTodoTasks] = useState(false);
-	const knownAgendaTaskIdsRef = useRef<Set<string> | null>(null);
-	const [searchQuery, setSearchQuery] = useState("");
+	const [searchOpen, setSearchOpen] = useState(false);
 	const [showMoreCount, setShowMoreCount] = useState(
 		INITIAL_VISIBLE_THREAD_COUNT,
 	);
@@ -313,38 +286,6 @@ export function AgentSidebar({
 	>({});
 	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const [hubStatus, setHubStatus] = useState<HubStatus | null>(null);
-	const normalizedWorkspaceRoot = workspaceRoot?.trim() ?? "";
-	const agendaWorkspaceRoot =
-		normalizedWorkspaceRoot && !isChatWorkspacePath(normalizedWorkspaceRoot)
-			? normalizedWorkspaceRoot
-			: undefined;
-	const agenda = useAgendaTasks(
-		{
-			statuses: ["pending_approval", "approved", "in_progress", "failed"],
-			workspaceRoot: agendaWorkspaceRoot,
-			limit: 200,
-		},
-		view !== "settings",
-	);
-	const agendaAutomation = useAgendaAutomation(view !== "settings");
-
-	useEffect(() => {
-		if (view === "settings") {
-			knownAgendaTaskIdsRef.current = null;
-			return;
-		}
-		if (agenda.isLoading) return;
-		const currentTaskIds = new Set(agenda.tasks.map((task) => task.taskId));
-		const knownTaskIds = knownAgendaTaskIdsRef.current;
-		if (
-			knownTaskIds !== null &&
-			sidebarContent !== "agenda" &&
-			agenda.tasks.some((task) => !knownTaskIds.has(task.taskId))
-		) {
-			setHasNewTodoTasks(true);
-		}
-		knownAgendaTaskIdsRef.current = currentTaskIds;
-	}, [agenda.isLoading, agenda.tasks, sidebarContent, view]);
 
 	const loadProcessContext = useCallback(async () => {
 		try {
@@ -386,16 +327,7 @@ export function AgentSidebar({
 
 	const sourceOptions = useMemo(() => getSessionSources(threads), [threads]);
 	const filteredThreads = useMemo(() => {
-		let filtered = filterSessionsBySource(threads, sourceFilter);
-		if (searchQuery) {
-			const q = searchQuery.toLowerCase();
-			filtered = filtered.filter(
-				(t) =>
-					t.title.toLowerCase().includes(q) ||
-					t.codebase.toLowerCase().includes(q) ||
-					t.workspacePath.toLowerCase().includes(q),
-			);
-		}
+		const filtered = filterSessionsBySource(threads, sourceFilter);
 		switch (filter) {
 			case "Running":
 				return filtered.filter((t) => t.status === "running");
@@ -406,29 +338,10 @@ export function AgentSidebar({
 			default:
 				return filtered;
 		}
-	}, [filter, searchQuery, sourceFilter, threads]);
+	}, [filter, sourceFilter, threads]);
 	const closeMobileSidebar = useCallback(() => {
 		if (isMobile) setOpenMobile(false);
 	}, [isMobile, setOpenMobile]);
-	const openAgendaSession = useCallback(
-		(task: AgendaTaskRecord) => {
-			if (!task.lastSessionId) return;
-			void onOpenSessionById?.(task.lastSessionId);
-			closeMobileSidebar();
-		},
-		[closeMobileSidebar, onOpenSessionById],
-	);
-	const runAgendaTask = useCallback(
-		async (task: AgendaTaskRecord) => {
-			try {
-				const started = await agenda.runTask(task);
-				if (started.lastSessionId) openAgendaSession(started);
-			} catch {
-				// The queue hook exposes the error inline and refreshes after recovery.
-			}
-		},
-		[agenda.runTask, openAgendaSession],
-	);
 
 	const openThread = useCallback(
 		(threadId: string) => {
@@ -463,12 +376,13 @@ export function AgentSidebar({
 	const navigateForward = useCallback(() => {
 		onNavigateForward?.();
 	}, [onNavigateForward]);
-	const toggleSidebarContent = useCallback(() => {
-		const next = sidebarContent === "agenda" ? "sessions" : "agenda";
-		setSidebarContent(next);
-		if (next === "agenda") setHasNewTodoTasks(false);
-		if (next === "agenda" && view === "settings") setView("chat");
-	}, [setView, sidebarContent, view]);
+	const openSearchResult = useCallback(
+		(threadId: string) => {
+			setSearchOpen(false);
+			openThread(threadId);
+		},
+		[openThread],
+	);
 
 	const startRenameThread = useCallback((thread: Thread) => {
 		setEditingSessionId(thread.id);
@@ -533,7 +447,7 @@ export function AgentSidebar({
 	);
 	const showTimeShowMore =
 		sessionThreads.length > showMoreCount ||
-		(filter === "All" && !searchQuery && mayHaveMoreSessions);
+		(filter === "All" && mayHaveMoreSessions);
 	const projectGroups = useMemo(
 		() => groupThreadsByProject([...pinnedThreads, ...sessionThreads]),
 		[pinnedThreads, sessionThreads],
@@ -784,29 +698,14 @@ export function AgentSidebar({
 					{!isCollapsed ? (
 						<div className="flex items-center gap-1">
 							<Button
-								aria-label={
-									sidebarContent === "agenda" ? "Show Sessions" : "Show Agenda"
-								}
-								aria-pressed={sidebarContent === "agenda"}
-								className={cn(
-									"relative size-8 shrink-0 justify-center px-0",
-									sidebarContent === "agenda" &&
-										"bg-surface-hover text-sidebar-foreground",
-								)}
-								onClick={toggleSidebarContent}
-								title={
-									sidebarContent === "agenda" ? "Show Sessions" : "Show Agenda"
-								}
+								aria-label="Search sessions"
+								className="size-8 shrink-0 justify-center px-0"
+								onClick={() => setSearchOpen(true)}
+								title="Search sessions"
 								type="button"
 								variant="sidebarItem"
 							>
-								<ClipboardList className="size-4" />
-								{hasNewTodoTasks ? (
-									<span
-										className="absolute right-1 top-1 size-1.5 rounded-full bg-primary"
-										data-testid="new-todo-indicator"
-									/>
-								) : null}
+								<Search className="size-4" />
 							</Button>
 						</div>
 					) : null}
@@ -891,36 +790,6 @@ export function AgentSidebar({
 							onSelect={openSettingsSection}
 						/>
 					</div>
-				) : sidebarContent === "agenda" ? (
-					<AgendaSection
-						automatic={
-							agendaAutomation.policy !== null &&
-							agendaAutomation.policy.mode !== "manual"
-						}
-						automationDisabled={
-							agendaAutomation.isLoading || agendaAutomation.isUpdating
-						}
-						error={agenda.error ?? agendaAutomation.error}
-						isLoading={agenda.isLoading}
-						onCreate={agenda.createTask}
-						onApprove={agenda.approveTask}
-						onCancel={(task) => {
-							return agenda.cancelTask(task).catch(() => undefined);
-						}}
-						onOpen={openAgendaSession}
-						onRun={(task) => void runAgendaTask(task)}
-						onToggleAutomation={() => {
-							void agendaAutomation
-								.setAutomatic(
-									agendaAutomation.policy?.mode !== "auto_start" &&
-										agendaAutomation.policy?.mode !== "unattended",
-								)
-								.catch(() => undefined);
-						}}
-						pendingTaskIds={agenda.pendingTaskIds}
-						tasks={agenda.tasks}
-						workspaceRoot={agendaWorkspaceRoot}
-					/>
 				) : (
 					<>
 						<div className="mt-5 shrink-0 pl-4 pr-2">
@@ -939,16 +808,6 @@ export function AgentSidebar({
 									{sortMenu}
 									{filterMenu}
 								</div>
-							</div>
-							<div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden rounded-md border border-sidebar-border bg-background/70 px-2 py-1">
-								<Search className="size-3.5 shrink-0 text-muted-foreground" />
-								<Input
-									aria-label="Search sessions"
-									className="h-7 min-w-0 flex-1 border-0 bg-transparent px-0 text-sm text-sidebar-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:ring-0"
-									onChange={(e) => setSearchQuery(e.target.value)}
-									placeholder="Search sessions..."
-									value={searchQuery}
-								/>
 							</div>
 						</div>
 
@@ -1002,9 +861,7 @@ export function AgentSidebar({
 												? displayedThreads.length === 0
 												: projectGroups.length === 0) && (
 												<div className="px-2 py-4 text-xs text-muted-foreground">
-													{searchQuery
-														? "No sessions match your search."
-														: "No sessions found in history."}
+													No sessions found in history.
 												</div>
 											)}
 										</>
@@ -1041,7 +898,6 @@ export function AgentSidebar({
 									)}
 									{sortMode === "project" &&
 										filter === "All" &&
-										!searchQuery &&
 										mayHaveMoreSessions && (
 											<Button
 												className="pl-0!"
@@ -1142,6 +998,31 @@ export function AgentSidebar({
 					)}
 				</div>
 			</div>
+			<CommandDialog
+				description="Search sessions by title, project, or path"
+				onOpenChange={setSearchOpen}
+				open={searchOpen}
+				title="Search sessions"
+			>
+				<CommandInput placeholder="Search sessions..." />
+				<CommandList>
+					<CommandEmpty>No sessions found.</CommandEmpty>
+					{threads.map((thread) => (
+						<CommandItem
+							key={thread.id}
+							onSelect={() => openSearchResult(thread.id)}
+							value={`${normalizeTitle(thread.title)} ${thread.codebase} ${thread.workspacePath} ${thread.id}`}
+						>
+							<span className="min-w-0 flex-1 truncate">
+								{normalizeTitle(thread.title)}
+							</span>
+							<span className="shrink-0 text-xs text-muted-foreground">
+								{thread.time}
+							</span>
+						</CommandItem>
+					))}
+				</CommandList>
+			</CommandDialog>
 			<AlertDialog
 				open={deleteConfirmThread !== null}
 				onOpenChange={(open) => {
@@ -1188,421 +1069,6 @@ export function AgentSidebar({
 				</AlertDialogContent>
 			</AlertDialog>
 		</>
-	);
-}
-
-function AgendaSection({
-	tasks,
-	workspaceRoot,
-	isLoading,
-	error,
-	pendingTaskIds,
-	automatic,
-	automationDisabled,
-	onApprove,
-	onRun,
-	onOpen,
-	onCancel,
-	onToggleAutomation,
-	onCreate,
-}: {
-	tasks: AgendaTaskRecord[];
-	workspaceRoot?: string;
-	isLoading: boolean;
-	error: string | null;
-	pendingTaskIds: ReadonlySet<string>;
-	automatic: boolean;
-	automationDisabled: boolean;
-	onApprove: (task: AgendaTaskRecord) => Promise<AgendaTaskRecord>;
-	onRun: (task: AgendaTaskRecord) => void;
-	onOpen: (task: AgendaTaskRecord) => void;
-	onCancel: (task: AgendaTaskRecord) => void | Promise<void>;
-	onToggleAutomation: () => void;
-	onCreate: (input: HubTaskCreateInput) => Promise<AgendaTaskRecord>;
-}) {
-	const [createOpen, setCreateOpen] = useState(false);
-	const [reviewTask, setReviewTask] = useState<AgendaTaskRecord | null>(null);
-	const [creating, setCreating] = useState(false);
-	const [title, setTitle] = useState("");
-	const [instructions, setInstructions] = useState("");
-	const [type, setType] = useState<AgendaTaskType>("todo");
-	const [priority, setPriority] = useState<AgendaTaskPriority>(3);
-	const [scope, setScope] = useState<"workspace" | "global">(
-		workspaceRoot ? "workspace" : "global",
-	);
-	const [expiresAt, setExpiresAt] = useState(() =>
-		new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 16),
-	);
-	const resetCreateForm = () => {
-		setTitle("");
-		setInstructions("");
-		setType("todo");
-		setPriority(3);
-		setScope(workspaceRoot ? "workspace" : "global");
-		setExpiresAt(
-			new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 16),
-		);
-	};
-	const submitCreate = async () => {
-		const normalizedTitle = title.trim();
-		const normalizedInstructions = instructions.trim();
-		if (!normalizedTitle || !normalizedInstructions || !expiresAt) return;
-		const expiration = new Date(expiresAt);
-		if (Number.isNaN(expiration.getTime())) return;
-		setCreating(true);
-		try {
-			const rememberedModel = readModelSelectionStorageFromWindow();
-			const providerId = rememberedModel.lastProvider.trim();
-			const modelId = providerId
-				? rememberedModel.lastModelByProvider[providerId]?.trim()
-				: undefined;
-			await onCreate({
-				type,
-				title: normalizedTitle,
-				instructions: normalizedInstructions,
-				scope: scope === "workspace" && workspaceRoot ? "workspace" : "global",
-				workspaceRoot:
-					scope === "workspace" && workspaceRoot ? workspaceRoot : undefined,
-				priority,
-				modelSelection: providerId
-					? { providerId, ...(modelId ? { modelId } : {}) }
-					: undefined,
-				expiresAt: expiration.toISOString(),
-				automationEligible: true,
-			});
-			setCreateOpen(false);
-			resetCreateForm();
-		} catch {
-			// The Agenda hook surfaces the manager's structured error inline.
-		} finally {
-			setCreating(false);
-		}
-	};
-	return (
-		<section
-			aria-label="Agenda"
-			className="mt-4 flex min-h-0 flex-1 flex-col px-2"
-		>
-			<div className="flex h-8 items-center justify-between px-2">
-				<span className="text-sm font-medium text-muted-foreground">Todo</span>
-				<div className="flex items-center">
-					<Button
-						aria-label={
-							automatic ? "Pause Agenda automation" : "Automate Agenda"
-						}
-						aria-pressed={automatic}
-						className={cn(
-							"size-7 p-0 text-muted-foreground",
-							automatic && "text-emerald-500",
-						)}
-						disabled={automationDisabled}
-						onClick={onToggleAutomation}
-						title={
-							automatic
-								? "Auto mode: click to switch to manual"
-								: "Manual mode: click to automate eligible trusted work"
-						}
-						type="button"
-						variant="ghost"
-					>
-						{automationDisabled ? (
-							<Loader2 className="size-3.5 animate-spin" />
-						) : (
-							<Zap className={cn("size-3.5", automatic && "fill-current")} />
-						)}
-					</Button>
-					<Dialog
-						onOpenChange={(open) => {
-							setCreateOpen(open);
-							if (open) setScope(workspaceRoot ? "workspace" : "global");
-						}}
-						open={createOpen}
-					>
-						<DialogTrigger asChild>
-							<Button
-								aria-label="Create Todo item"
-								className="size-7 p-0 text-muted-foreground"
-								title="Create task"
-								type="button"
-								variant="ghost"
-							>
-								<Plus className="size-3.5" />
-							</Button>
-						</DialogTrigger>
-						<DialogContent className="sm:max-w-md">
-							<DialogHeader>
-								<DialogTitle>Create Todo Item</DialogTitle>
-							</DialogHeader>
-							<div className="space-y-3">
-								<label
-									className="block space-y-1 text-xs"
-									htmlFor="agenda-task-title"
-								>
-									<span className="text-muted-foreground">Title</span>
-									<Input
-										autoFocus
-										id="agenda-task-title"
-										onChange={(event) => setTitle(event.target.value)}
-										placeholder="What needs attention?"
-										value={title}
-									/>
-								</label>
-								<label
-									className="block space-y-1 text-xs"
-									htmlFor="agenda-task-instructions"
-								>
-									<span className="text-muted-foreground">Instructions</span>
-									<Textarea
-										id="agenda-task-instructions"
-										onChange={(event) => setInstructions(event.target.value)}
-										placeholder="Describe the outcome and any relevant files."
-										rows={4}
-										value={instructions}
-									/>
-								</label>
-								<div className="grid grid-cols-3 gap-2">
-									<label className="space-y-1 text-xs">
-										<span className="text-muted-foreground">Type</span>
-										<select
-											className="h-9 w-full rounded-md border border-input bg-background px-2"
-											onChange={(event) =>
-												setType(event.target.value as AgendaTaskType)
-											}
-											value={type}
-										>
-											{[
-												"todo",
-												"follow-up",
-												"suggestion",
-												"handoff",
-												"idea",
-												"reminder",
-											].map((value) => (
-												<option key={value} value={value}>
-													{value}
-												</option>
-											))}
-										</select>
-									</label>
-									<label className="space-y-1 text-xs">
-										<span className="text-muted-foreground">Priority</span>
-										<select
-											className="h-9 w-full rounded-md border border-input bg-background px-2"
-											onChange={(event) =>
-												setPriority(
-													Number(event.target.value) as AgendaTaskPriority,
-												)
-											}
-											value={priority}
-										>
-											{[0, 1, 2, 3, 4, 5].map((value) => (
-												<option key={value} value={value}>
-													P{value}
-												</option>
-											))}
-										</select>
-									</label>
-									<label className="space-y-1 text-xs">
-										<span className="text-muted-foreground">Scope</span>
-										<select
-											className="h-9 w-full rounded-md border border-input bg-background px-2"
-											onChange={(event) =>
-												setScope(event.target.value as "workspace" | "global")
-											}
-											value={scope}
-										>
-											{workspaceRoot ? (
-												<option value="workspace">Project</option>
-											) : null}
-											<option value="global">General</option>
-										</select>
-									</label>
-								</div>
-								<label
-									className="block space-y-1 text-xs"
-									htmlFor="agenda-task-expires-at"
-								>
-									<span className="text-muted-foreground">Expires</span>
-									<Input
-										id="agenda-task-expires-at"
-										onChange={(event) => setExpiresAt(event.target.value)}
-										type="datetime-local"
-										value={expiresAt}
-									/>
-								</label>
-							</div>
-							<DialogFooter>
-								<Button
-									disabled={
-										creating ||
-										!title.trim() ||
-										!instructions.trim() ||
-										!expiresAt
-									}
-									onClick={() => void submitCreate()}
-									type="button"
-								>
-									{creating ? (
-										<Loader2 className="size-4 animate-spin" />
-									) : null}
-									Add to Agenda
-								</Button>
-							</DialogFooter>
-						</DialogContent>
-					</Dialog>
-				</div>
-			</div>
-			{/* Radix ScrollArea wraps its children in a display:table element. A long
-			    task title can therefore widen the table beyond the sidebar and push the
-			    action buttons off-screen, so this fixed-width list uses native scrolling. */}
-			<div className="min-h-0 w-full min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain">
-				<div className="w-full min-w-0 max-w-full space-y-1">
-					{isLoading && tasks.length === 0 ? (
-						<div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
-							<Loader2 className="size-3 animate-spin" />
-							Loading Agenda…
-						</div>
-					) : null}
-					{tasks.map((task) => {
-						const pending = pendingTaskIds.has(task.taskId);
-						const requiresFileReview =
-							task.updatedBy.kind === "system" &&
-							task.updatedBy.id === "file_reconciler" &&
-							task.status === "pending_approval";
-						const canOpen = Boolean(task.lastSessionId);
-						const canRun =
-							task.status === "approved" || task.status === "failed";
-						const taskWorkspaceName =
-							task.scope === "workspace"
-								? workspaceDisplayName(task.workspaceRoot ?? task.cwd ?? "") ||
-									"Workspace"
-								: "General";
-						return (
-							<div
-								className="group flex w-full min-w-0 max-w-full flex-col items-stretch overflow-hidden rounded-md px-2 py-1.5 hover:bg-surface-hover"
-								key={task.taskId}
-								title={
-									requiresFileReview
-										? "File-created or edited tasks always require manual review."
-										: task.description || task.instructions
-								}
-							>
-								<button
-									className="w-full min-w-0 overflow-hidden text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-									onClick={() => setReviewTask(task)}
-									type="button"
-								>
-									<span className="block truncate text-xs text-sidebar-foreground">
-										{task.title}
-									</span>
-								</button>
-								<div className="flex min-w-0 items-center justify-between">
-									<span className="min-w-0 truncate text-[10px] capitalize text-muted-foreground">
-										{taskWorkspaceName}
-										{task.status !== "pending_approval"
-											? ` · ${task.status.replace("_", " ")}`
-											: ""}
-										{requiresFileReview ? " · file review" : ""}
-									</span>
-									<div className="flex shrink-0 items-center">
-										{pending ? (
-											<Loader2 className="mx-1 size-3 animate-spin text-muted-foreground" />
-										) : task.status === "pending_approval" ? (
-											<AgendaIconButton
-												className="text-emerald-500! hover:text-emerald-400!"
-												icon={<Check className="size-3" />}
-												label={`Approve ${task.title}`}
-												onClick={() => setReviewTask(task)}
-											/>
-										) : canRun ? (
-											<AgendaIconButton
-												icon={<Play className="size-3 fill-current" />}
-												label={`Run ${task.title}`}
-												onClick={() => onRun(task)}
-											/>
-										) : canOpen ? (
-											<AgendaIconButton
-												icon={<ChevronRight className="size-3" />}
-												label={`Open session for ${task.title}`}
-												onClick={() => onOpen(task)}
-											/>
-										) : null}
-										{!pending ? (
-											<AgendaIconButton
-												className="text-destructive! hover:text-destructive!"
-												icon={<X className="size-3" />}
-												label={`Cancel ${task.title}`}
-												onClick={() => onCancel(task)}
-											/>
-										) : null}
-									</div>
-								</div>
-							</div>
-						);
-					})}
-					{!isLoading && tasks.length === 0 && !error ? (
-						<p className="px-2 py-1 text-[11px] text-muted-foreground">
-							Nothing waiting for review.
-						</p>
-					) : null}
-					{error ? (
-						<p
-							className="truncate px-2 py-1 text-[11px] text-destructive"
-							title={error}
-						>
-							{error}
-						</p>
-					) : null}
-				</div>
-			</div>
-			<AgendaTaskReviewDialog
-				onConfirm={async (task) => {
-					try {
-						await onApprove(task);
-						setReviewTask(null);
-					} catch {
-						// The Agenda hook keeps the manager error visible in this section.
-					}
-				}}
-				onOpenChange={(open) => {
-					if (!open) setReviewTask(null);
-				}}
-				onReject={async (task) => {
-					await onCancel(task);
-					setReviewTask(null);
-				}}
-				open={reviewTask !== null}
-				pending={reviewTask ? pendingTaskIds.has(reviewTask.taskId) : false}
-				task={reviewTask}
-			/>
-		</section>
-	);
-}
-
-function AgendaIconButton({
-	className,
-	icon,
-	label,
-	onClick,
-}: {
-	className?: string;
-	icon: ReactNode;
-	label: string;
-	onClick: () => void;
-}) {
-	return (
-		<button
-			aria-label={label}
-			className={cn(
-				"flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-background/70 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
-				className,
-			)}
-			onClick={onClick}
-			title={label}
-			type="button"
-		>
-			{icon}
-		</button>
 	);
 }
 

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -9,10 +9,11 @@ import type {
 import { isChatWorkspacePath } from "@cline/shared/browser";
 import {
 	ArrowDownUp,
+	ArrowLeft,
+	ArrowRight,
 	Bot,
 	Check,
 	ChevronDown,
-	ChevronLeft,
 	ChevronRight,
 	CircleUserRound,
 	ClipboardList,
@@ -239,7 +240,6 @@ export function AgentSidebar({
 	onHome,
 	onNavigateBack,
 	onNavigateForward,
-	onNewThread,
 	onOpenSessionById,
 	onSettingsSectionChange,
 	setView,
@@ -254,7 +254,6 @@ export function AgentSidebar({
 	onHome: () => void;
 	onNavigateBack?: () => void;
 	onNavigateForward?: () => void;
-	onNewThread?: () => void;
 	onOpenSessionById?: (sessionId: string) => void | Promise<void>;
 	onSettingsSectionChange: (section: SettingsSection) => void;
 	setView: (view: AppView) => void;
@@ -446,10 +445,6 @@ export function AgentSidebar({
 		[closeMobileSidebar, openHistoryThread],
 	);
 
-	const openNewThread = useCallback(() => {
-		onNewThread?.();
-		closeMobileSidebar();
-	}, [closeMobileSidebar, onNewThread]);
 	const openHome = useCallback(() => {
 		onHome();
 		closeMobileSidebar();
@@ -692,7 +687,7 @@ export function AgentSidebar({
 						<>
 							<Button
 								aria-label="Previous page"
-								className="size-7 text-muted-foreground hover:bg-surface-hover"
+								className="size-8 text-muted-foreground hover:bg-surface-hover hover:text-sidebar-foreground"
 								disabled={!canNavigateBack}
 								onClick={navigateBack}
 								size="icon"
@@ -700,11 +695,11 @@ export function AgentSidebar({
 								type="button"
 								variant="ghost"
 							>
-								<ChevronLeft className="size-4" />
+								<ArrowLeft className="size-4.5" />
 							</Button>
 							<Button
 								aria-label="Next page"
-								className="size-7 text-muted-foreground hover:text-sidebar-foreground"
+								className="size-8 text-muted-foreground hover:bg-surface-hover hover:text-sidebar-foreground"
 								disabled={!canNavigateForward}
 								onClick={navigateForward}
 								size="icon"
@@ -712,7 +707,7 @@ export function AgentSidebar({
 								type="button"
 								variant="ghost"
 							>
-								<ChevronRight className="size-4" />
+								<ArrowRight className="size-4.5" />
 							</Button>
 						</>
 					) : null}
@@ -820,19 +815,24 @@ export function AgentSidebar({
 									/>
 								) : null}
 							</Button>
-							<Button
-								aria-label="New Session"
-								className="size-8 shrink-0 justify-center px-0"
-								onClick={openNewThread}
-								title="New Session"
-								type="button"
-								variant="sidebarItem"
-							>
-								<MessageSquarePlus className="size-4" />
-							</Button>
 						</div>
 					) : null}
 				</div>
+
+				{!isCollapsed ? (
+					<div className="mt-1 shrink-0 px-2">
+						<Button
+							aria-label="New Task"
+							onClick={openHome}
+							title="New Task"
+							type="button"
+							variant="sidebarItem"
+						>
+							<MessageSquarePlus className="size-4 shrink-0" />
+							<span className="truncate">New Task</span>
+						</Button>
+					</div>
+				) : null}
 
 				{isCollapsed ? (
 					<div className="mt-2 flex min-h-0 flex-1 flex-col items-start gap-1 px-1.5">

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -11,6 +11,7 @@ import {
 	ArrowDownUp,
 	ArrowLeft,
 	ArrowRight,
+	Blocks,
 	Bot,
 	Check,
 	ChevronDown,
@@ -24,7 +25,6 @@ import {
 	FolderTree,
 	GitFork,
 	Loader2,
-	MessageSquarePlus,
 	PanelLeftOpen,
 	Pencil,
 	Play,
@@ -296,7 +296,6 @@ export function AgentSidebar({
 		useState<SidebarContent>("sessions");
 	const [hasNewTodoTasks, setHasNewTodoTasks] = useState(false);
 	const knownAgendaTaskIdsRef = useRef<Set<string> | null>(null);
-	const [searchOpen, setSearchOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [showMoreCount, setShowMoreCount] = useState(
 		INITIAL_VISIBLE_THREAD_COUNT,
@@ -384,12 +383,6 @@ export function AgentSidebar({
 	useEffect(() => {
 		void loadProcessContext();
 	}, [loadProcessContext]);
-
-	useEffect(() => {
-		if (isCollapsed && searchOpen) {
-			setSearchOpen(false);
-		}
-	}, [isCollapsed, searchOpen]);
 
 	const sourceOptions = useMemo(() => getSessionSources(threads), [threads]);
 	const filteredThreads = useMemo(() => {
@@ -820,18 +813,53 @@ export function AgentSidebar({
 				</div>
 
 				{!isCollapsed ? (
-					<div className="mt-1 shrink-0 px-2">
+					<nav
+						aria-label="Sidebar actions"
+						className="mt-1 flex shrink-0 flex-col gap-0.5 px-2"
+					>
 						<Button
-							aria-label="New Task"
+							aria-label="New"
 							onClick={openHome}
-							title="New Task"
+							title="Start a new task"
 							type="button"
 							variant="sidebarItem"
 						>
-							<MessageSquarePlus className="size-4 shrink-0" />
-							<span className="truncate">New Task</span>
+							<Plus className="size-4 shrink-0" />
+							<span className="truncate">New</span>
 						</Button>
-					</div>
+						<Button
+							aria-label="Schedule"
+							className={cn(
+								view === "settings" &&
+									settingsSection === "Schedules" &&
+									"bg-surface-hover text-sidebar-foreground",
+							)}
+							onClick={() => openSettingsSection("Schedules")}
+							title="Schedules"
+							type="button"
+							variant="sidebarItem"
+						>
+							<Clock3 className="size-4 shrink-0" />
+							<span className="truncate">Schedule</span>
+						</Button>
+						<Button
+							aria-label="Customize"
+							className={cn(
+								view === "settings" &&
+									(
+										CUSTOMIZATION_SECTIONS as readonly SettingsSection[]
+									).includes(settingsSection) &&
+									"bg-surface-hover text-sidebar-foreground",
+							)}
+							onClick={() => openSettingsSection("Plugins")}
+							title="Customize Cline with plugins, rules, and more"
+							type="button"
+							variant="sidebarItem"
+						>
+							<Blocks className="size-4 shrink-0" />
+							<span className="truncate">Customize</span>
+						</Button>
+					</nav>
 				) : null}
 
 				{isCollapsed ? (
@@ -908,33 +936,20 @@ export function AgentSidebar({
 									{sortMode === "time" ? "Sessions" : "Projects"}
 								</button>
 								<div className="flex shrink-0 items-center gap-0.5">
-									<Button
-										aria-label="Search sessions"
-										className="m-0! size-8 p-0! text-muted-foreground hover:bg-surface-hover"
-										onClick={() => setSearchOpen((current) => !current)}
-										size="icon"
-										title="Search sessions"
-										type="button"
-										variant="ghost"
-									>
-										<Search className="size-3.5" />
-									</Button>
 									{sortMenu}
 									{filterMenu}
 								</div>
 							</div>
-							{searchOpen ? (
-								<div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden rounded-md border border-sidebar-border bg-background/70 px-2 py-1">
-									<Search className="size-4 shrink-0" />
-									<Input
-										className="h-7 min-w-0 flex-1 border-0 bg-transparent px-0 text-sm text-sidebar-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:ring-0"
-										autoFocus={true}
-										onChange={(e) => setSearchQuery(e.target.value)}
-										placeholder="Search sessions..."
-										value={searchQuery}
-									/>
-								</div>
-							) : null}
+							<div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden rounded-md border border-sidebar-border bg-background/70 px-2 py-1">
+								<Search className="size-3.5 shrink-0 text-muted-foreground" />
+								<Input
+									aria-label="Search sessions"
+									className="h-7 min-w-0 flex-1 border-0 bg-transparent px-0 text-sm text-sidebar-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:ring-0"
+									onChange={(e) => setSearchQuery(e.target.value)}
+									placeholder="Search sessions..."
+									value={searchQuery}
+								/>
+							</div>
 						</div>
 
 						<div className="mt-1 min-h-0 w-full flex-1">

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -255,6 +255,7 @@ export function AgentSidebar({
 		forkThread: forkHistoryThread,
 		hasLoadedHistory,
 		isLoadingMore,
+		loadAllSessions,
 		loadOlderSessions,
 		loadMoreSessions,
 		mayHaveMoreSessions,
@@ -376,6 +377,12 @@ export function AgentSidebar({
 	const navigateForward = useCallback(() => {
 		onNavigateForward?.();
 	}, [onNavigateForward]);
+	const openSearch = useCallback(() => {
+		setSearchOpen(true);
+		// The sidebar only pages in recent history; pull the rest so older
+		// sessions are searchable too.
+		void loadAllSessions();
+	}, [loadAllSessions]);
 	const openSearchResult = useCallback(
 		(threadId: string) => {
 			setSearchOpen(false);
@@ -700,7 +707,7 @@ export function AgentSidebar({
 							<Button
 								aria-label="Search sessions"
 								className="size-8 shrink-0 justify-center px-0"
-								onClick={() => setSearchOpen(true)}
+								onClick={openSearch}
 								title="Search sessions"
 								type="button"
 								variant="sidebarItem"
@@ -1006,7 +1013,11 @@ export function AgentSidebar({
 			>
 				<CommandInput placeholder="Search sessions..." />
 				<CommandList>
-					<CommandEmpty>No sessions found.</CommandEmpty>
+					<CommandEmpty>
+						{isLoadingMore
+							? "Searching older sessions..."
+							: "No sessions found."}
+					</CommandEmpty>
 					{threads.map((thread) => (
 						<CommandItem
 							key={thread.id}


### PR DESCRIPTION
### Related Issue

N/A (internal UX cleanup)

### Description

The sidebar's top chrome was confusing: the back/forward controls were small chevrons, the new-session action was an ambiguous icon crammed next to the logo, the only way home was clicking the Cline logo (which nothing hinted at), and session search was hidden behind a toggle that expanded an inline input.

This PR reworks the sidebar chrome in `apps/examples/desktop-app`:

- Back/forward now use browser-style straight arrow icons (`ArrowLeft`/`ArrowRight`) and are slightly bigger (icon `size-4.5` in a `size-8` button, up from `size-4` in `size-7`).
- Below the logo row there is a stack of three full-width labeled rows, each highlighting the whole row on hover:
  - New (plus icon): navigates home and starts a fresh task via the existing home action, so starting a new task is the obvious, labeled way home (the logo still works as before).
  - Schedule (clock icon): opens Settings > Schedules, with an active state while that section is open.
  - Customize (blocks icon): opens the Customizations sections (Plugins first), with an active state while any customization section is open.
- Session search now lives in a command dialog: a search icon sits at the right of the logo row and opens a centered cmdk dialog listing sessions. Typing filters live, and selecting a result opens that session and closes the dialog. The inline sidebar search input is gone.
- The search icon replaces the agenda/tasks clipboard toggle in the logo row. That made the sidebar's Agenda panel unreachable, so the dead sidebar Agenda code (panel, create-task dialog, unread-dot tracking, hooks usage) is removed too. The Agenda feature itself is untouched: the welcome screen still surfaces agenda tasks, and the hooks/review dialog modules remain.
- Removed the now-unused `onNewThread`, `onOpenSessionById`, and `workspaceRoot` props from `AgentSidebar`.

### Test Procedure

- `bun run typecheck` passes.
- `bunx vitest run webview/components/agent-sidebar.test.tsx` passes (18 tests), including new assertions that the three rows render full-width outside the logo row and fire home / `Schedules` / `Plugins`, and that the search icon opens a dialog that filters sessions and opens the selected one. Agenda-panel tests were removed with the panel.
- `biome check` is clean on the changed files.
- Manually verified in the headless dev app (`dev:headless` + browser): hovered each row (full-row highlight), Schedule opened Settings > Schedules, Customize opened Plugins, New returned to a fresh task view, back/forward arrows navigated history, and the search dialog opened from the logo-row icon, filtered on "17", and opened the matching session on click.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Sidebar top chrome (arrow navigation, search icon in the logo row, New/Schedule/Customize rows, no inline search):

![Sidebar close-up with search icon and New, Schedule, Customize rows](https://cursor.com/artifacts/c/art-bb65e8f5-3f60-49ae-8759-2928a4f9bac4)

Search dialog open with a query typed, best match ranked first:

![Session search dialog filtering sessions](https://cursor.com/artifacts/c/art-cd1124ec-4812-45b0-a69a-5b921ae8ddeb)

### Additional Notes

None.