### PR TITLE
fix(core): apply default directory excludes to ripgrep search path

### DIFF
--- a/.changeset/search-default-dir-excludes.md
+++ b/.changeset/search-default-dir-excludes.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix search_files flooding results with dependency and build directories: the ripgrep search path now applies the default exclude list (node_modules, vendor, bin, obj, dist, etc.) explicitly instead of relying only on .gitignore, which ripgrep skips outside git repositories and which does not cover committed vendored dependencies

--- a/sdk/packages/core/src/extensions/tools/executors/search.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.test.ts
@@ -12,7 +12,59 @@ const ctx: AgentToolContext = {
 	iteration: 1,
 };
 
+async function writeDependencyDirFixture(dir: string): Promise<void> {
+	const files: Record<string, string> = {
+		"src/app.ts": "const needle = 1;\n",
+		"vendor/pkg/dep.go": "// needle in vendored dep\n",
+		"node_modules/pkg/index.js": "// needle in node_modules\n",
+		"bin/Debug/app.cs": "// needle in bin\n",
+		"obj/Debug/app.cs": "// needle in obj\n",
+	};
+	for (const [relativePath, content] of Object.entries(files)) {
+		const filePath = path.join(dir, relativePath);
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, content, "utf-8");
+	}
+}
+
 describe("createSearchExecutor", () => {
+	it("excludes dependency directories by default even without a .gitignore", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-search-"));
+		await writeDependencyDirFixture(dir);
+
+		try {
+			const search = createSearchExecutor();
+			const result = await search("needle", dir, ctx);
+
+			expect(result).toContain("src/app.ts");
+			expect(result).not.toContain("vendor/");
+			expect(result).not.toContain("node_modules/");
+			expect(result).not.toContain("bin/");
+			expect(result).not.toContain("obj/");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("excludes dependency directories in the non-ripgrep fallback path", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-search-"));
+		await writeDependencyDirFixture(dir);
+
+		try {
+			const search = createSearchExecutor();
+			// Lookahead is unsupported by ripgrep, forcing the fallback scan.
+			const result = await search("(?=needle)", dir, ctx);
+
+			expect(result).toContain("src/app.ts");
+			expect(result).not.toContain("vendor/");
+			expect(result).not.toContain("node_modules/");
+			expect(result).not.toContain("bin/");
+			expect(result).not.toContain("obj/");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("middle-truncates oversized search output with recovery guidance", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-search-"));
 		const filePath = path.join(dir, "large.ts");

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -102,6 +102,7 @@ const DEFAULT_INCLUDE_EXTENSIONS = [
 
 const DEFAULT_EXCLUDE_DIRS = [
 	"node_modules",
+	"vendor",
 	".git",
 	"dist",
 	"build",
@@ -166,18 +167,41 @@ function checkRipgrepAvailable(): Promise<boolean> {
 	});
 }
 
+/**
+ * Build `-g '!dir/'` exclusion globs for ripgrep. Ripgrep only applies
+ * .gitignore rules inside git repositories, and dependency/build directories
+ * (vendored deps, .NET bin/obj, etc.) are often committed or not gitignored,
+ * so the default excludes must be passed explicitly to keep them out of
+ * results — mirroring the filtering the non-ripgrep fallback already does.
+ */
+function buildRipgrepExcludeGlobs(excludeDirs: Iterable<string>): string[] {
+	const args: string[] = [];
+	for (const dir of excludeDirs) {
+		args.push("-g", `!${dir}/`);
+	}
+	return args;
+}
+
 function searchWithRipgrep(
 	query: string,
 	cwd: string,
 	maxResults: number,
 	contextLines: number,
+	excludeDirs: Iterable<string>,
 	timeoutMs: number = 5000,
 	abortSignal?: AbortSignal,
 ): Promise<SearchMatch[] | null> {
 	return new Promise((resolve) => {
 		const child = spawn(
 			"rg",
-			["--json", `--context=${contextLines}`, "--max-count=1", "-i", query],
+			[
+				"--json",
+				`--context=${contextLines}`,
+				"--max-count=1",
+				"-i",
+				...buildRipgrepExcludeGlobs(excludeDirs),
+				query,
+			],
 			{
 				cwd,
 				stdio: ["ignore", "pipe", "pipe"],
@@ -358,6 +382,7 @@ export function createSearchExecutor(
 				cwd,
 				maxResults,
 				contextLines,
+				excludeDirsSet,
 				5000,
 				context.signal,
 			);


### PR DESCRIPTION
### Related Issue

User report: `search_files` and `list_files` scan directories that should be ignored by default (vendor/, node_modules/, bin/, obj/), flooding results with thousands of irrelevant files in both VS Code and CLI.

### Description

Both the VS Code extension and the CLI route `search_files` to the SDK `search_codebase` tool (`createSearchExecutor` in `@cline/core`). Its primary ripgrep path invoked `rg` with no exclusion globs, relying entirely on ripgrep's built-in `.gitignore` handling. That handling has two holes that match the report exactly:

1. ripgrep only applies `.gitignore` rules when searching inside a git repository, so in non-git workspaces nothing is filtered at all.
2. Committed or unignored dependency/build directories (Go `vendor/`, .NET `bin/` and `obj/`, etc.) are searched even inside git repos.

The non-ripgrep fallback path already filtered these via `DEFAULT_EXCLUDE_DIRS`, so the two paths behaved inconsistently.

This PR:

- Passes the executor's exclude list to ripgrep as `-g '!dir/'` globs (gitignore-style, directory-only, matches at any depth), so the primary path filters the same directories the fallback already does. `.gitignore` handling is unaffected since negative `-g` globs only add exclusions.
- Adds the missing `vendor` entry to `DEFAULT_EXCLUDE_DIRS` (the list already had `node_modules`, `bin`, `obj`, `dist`, etc.).
- Adds regression tests covering both the ripgrep path and the fallback path.

Note on the `list_files` half of the report: after the SDK migration there is no dedicated `list_files` tool anymore. The `list_files` name aliases to `run_commands` (see `CONFIGURED_AGENT_TOOL_NAME_ALIASES` in `runtime-builder.ts`), so listing is whatever shell command the model runs. There is no executor-level filter to fix there; this PR fixes the search half, which is where the tool-level filtering gap was.

### Test Procedure

- New unit tests in `search.test.ts` create a fixture with matches in `src/`, `vendor/`, `node_modules/`, `bin/`, and `obj/` (no `.gitignore`, no git repo) and assert only `src/` results come back, on both the ripgrep path and the forced fallback path (`(?=...)` lookahead is unsupported by ripgrep).
- `bun -F @cline/core test:unit`: 2075 passed. Two failures are pre-existing environment artifacts, unrelated to this change: the documented `workspace-manifest` git `insteadOf` rewrite in cloud VMs, and a `checkpoint-restore` timeout flake under parallel load that passes in isolation.
- `bun run types` (all packages) and `bun biome check` on the changed files pass.
- Manual before/after on a fixture project with matches in `src/`, `vendor/`, `node_modules/`, `bin/`, `obj/`:

```
--- OLD invocation (what users see today) ---
bin/Debug/app.cs
node_modules/pkg/index.js
obj/Debug/app.cs
src/app.ts
vendor/lib/dep.go
--- NEW invocation ---
src/app.ts
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change; terminal evidence in the Test Procedure section.

### Additional Notes

The exclude list stays overridable via `SearchExecutorOptions.excludeDirs` for SDK consumers who need to search inside these directories.