### PR TITLE
fix: make OpenAI Codex (ChatGPT subscription) sign-in fail loudly instead of silently dead-ending

### DIFF
--- a/apps/vscode/src/core/controller/account/openAiCodexSignIn.ts
+++ b/apps/vscode/src/core/controller/account/openAiCodexSignIn.ts
@@ -27,7 +27,11 @@ export async function openAiCodexSignIn(controller: Controller, _: EmptyRequest)
 			.catch((error) => {
 				Logger.error("[openAiCodexSignIn] OAuth flow failed:", error)
 				const errorMessage = error instanceof Error ? error.message : String(error)
-				if (!errorMessage.includes("timed out")) {
+				// "Missing authorization code" is the abandoned-flow shape of a
+				// timeout here: the webview provides no manual code entry, so it
+				// only occurs when the callback wait expires without a redirect.
+				const isAbandonedFlow = errorMessage.includes("timed out") || errorMessage.includes("Missing authorization code")
+				if (!isAbandonedFlow) {
 					HostProvider.window.showMessage({
 						type: ShowMessageType.ERROR,
 						message: `OpenAI Codex sign in failed: ${errorMessage}`,

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -108,7 +108,6 @@ vi.mock("axios", () => ({
 }))
 
 const mockLoginClineOAuth = vi.hoisted(() => vi.fn())
-const mockLoginOpenAICodex = vi.hoisted(() => vi.fn())
 
 // Mock @cline/core OAuth functions
 vi.mock("@cline/core", async () => ({
@@ -128,7 +127,7 @@ vi.mock("@cline/core", async () => ({
 	}),
 	loginClineOAuth: mockLoginClineOAuth,
 	loginOcaOAuth: vi.fn(),
-	loginOpenAICodex: mockLoginOpenAICodex,
+	loginOpenAICodex: vi.fn(),
 	refreshClineToken: vi.fn(),
 	getValidClineCredentials: vi.fn(),
 	// Mirrors the SDK registry: cline-pass stores credentials under "cline".
@@ -499,40 +498,6 @@ describe("AuthService", () => {
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			expect(mockGlobalState.get("welcomeViewCompleted")).toBeUndefined()
-		})
-	})
-
-	describe("openAiCodexLogin() — concurrent sign-in clicks", () => {
-		it("dedupes a second click into the pending flow and re-opens the auth URL", async () => {
-			const { openExternal } = await import("@/utils/env")
-			let rejectLogin!: (error: Error) => void
-			mockLoginOpenAICodex.mockImplementationOnce((callbacks: { onAuth: (info: { url: string }) => void }) => {
-				callbacks.onAuth({ url: "https://auth.openai.com/oauth/authorize?test=1" })
-				return new Promise((_resolve, reject) => {
-					rejectLogin = reject
-				})
-			})
-
-			const first = authService.openAiCodexLogin()
-			await waitForCondition(() => vi.mocked(openExternal).mock.calls.length === 1)
-
-			// Second click while the flow is pending: no second loginOpenAICodex
-			// call (it would dead-end on the occupied callback port); the auth
-			// page is just re-opened.
-			const second = authService.openAiCodexLogin()
-			await waitForCondition(() => vi.mocked(openExternal).mock.calls.length === 2)
-			expect(mockLoginOpenAICodex).toHaveBeenCalledTimes(1)
-			expect(vi.mocked(openExternal).mock.calls[1][0]).toBe("https://auth.openai.com/oauth/authorize?test=1")
-
-			// Both callers observe the same outcome.
-			rejectLogin(new Error("login aborted"))
-			await expect(first).rejects.toThrow("login aborted")
-			await expect(second).rejects.toThrow("login aborted")
-
-			// The pending slot is cleared, so a later click starts a fresh flow.
-			mockLoginOpenAICodex.mockRejectedValueOnce(new Error("second flow"))
-			await expect(authService.openAiCodexLogin()).rejects.toThrow("second flow")
-			expect(mockLoginOpenAICodex).toHaveBeenCalledTimes(2)
 		})
 	})
 

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -108,6 +108,7 @@ vi.mock("axios", () => ({
 }))
 
 const mockLoginClineOAuth = vi.hoisted(() => vi.fn())
+const mockLoginOpenAICodex = vi.hoisted(() => vi.fn())
 
 // Mock @cline/core OAuth functions
 vi.mock("@cline/core", async () => ({
@@ -127,7 +128,7 @@ vi.mock("@cline/core", async () => ({
 	}),
 	loginClineOAuth: mockLoginClineOAuth,
 	loginOcaOAuth: vi.fn(),
-	loginOpenAICodex: vi.fn(),
+	loginOpenAICodex: mockLoginOpenAICodex,
 	refreshClineToken: vi.fn(),
 	getValidClineCredentials: vi.fn(),
 	// Mirrors the SDK registry: cline-pass stores credentials under "cline".
@@ -498,6 +499,40 @@ describe("AuthService", () => {
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			await new Promise((resolve) => setTimeout(resolve, 0))
 			expect(mockGlobalState.get("welcomeViewCompleted")).toBeUndefined()
+		})
+	})
+
+	describe("openAiCodexLogin() — concurrent sign-in clicks", () => {
+		it("dedupes a second click into the pending flow and re-opens the auth URL", async () => {
+			const { openExternal } = await import("@/utils/env")
+			let rejectLogin!: (error: Error) => void
+			mockLoginOpenAICodex.mockImplementationOnce((callbacks: { onAuth: (info: { url: string }) => void }) => {
+				callbacks.onAuth({ url: "https://auth.openai.com/oauth/authorize?test=1" })
+				return new Promise((_resolve, reject) => {
+					rejectLogin = reject
+				})
+			})
+
+			const first = authService.openAiCodexLogin()
+			await waitForCondition(() => vi.mocked(openExternal).mock.calls.length === 1)
+
+			// Second click while the flow is pending: no second loginOpenAICodex
+			// call (it would dead-end on the occupied callback port); the auth
+			// page is just re-opened.
+			const second = authService.openAiCodexLogin()
+			await waitForCondition(() => vi.mocked(openExternal).mock.calls.length === 2)
+			expect(mockLoginOpenAICodex).toHaveBeenCalledTimes(1)
+			expect(vi.mocked(openExternal).mock.calls[1][0]).toBe("https://auth.openai.com/oauth/authorize?test=1")
+
+			// Both callers observe the same outcome.
+			rejectLogin(new Error("login aborted"))
+			await expect(first).rejects.toThrow("login aborted")
+			await expect(second).rejects.toThrow("login aborted")
+
+			// The pending slot is cleared, so a later click starts a fresh flow.
+			mockLoginOpenAICodex.mockRejectedValueOnce(new Error("second flow"))
+			await expect(authService.openAiCodexLogin()).rejects.toThrow("second flow")
+			expect(mockLoginOpenAICodex).toHaveBeenCalledTimes(2)
 		})
 	})
 

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -22,6 +22,7 @@ import {
 import type { ApiProvider } from "@shared/api"
 import { AuthState, UserInfo } from "@shared/proto/cline/account"
 import type { EmptyRequest, String } from "@shared/proto/cline/common"
+import { ShowMessageType } from "@shared/proto/host/window"
 import axios from "axios"
 import { ClineEnv } from "@/config"
 import type { Controller } from "@/core/controller"
@@ -244,6 +245,7 @@ export class AuthService {
 	private _activeAuthStatusUpdateHandlers = new Set<StreamingResponseHandler<AuthState>>()
 	private _handlerToController = new Map<StreamingResponseHandler<AuthState>, Controller>()
 	private _refreshPromise: Promise<string | undefined> | null = null
+	private _pendingCodexLogin: { promise: Promise<void>; authUrl?: string } | null = null
 	private _telemetry?: ITelemetryService
 
 	private constructor() {}
@@ -743,38 +745,62 @@ export class AuthService {
 
 	/**
 	 * Initiate OpenAI Codex OAuth login.
+	 *
+	 * Concurrent calls are deduped: while a flow is pending it holds callback
+	 * port 1455, so starting a second flow would fail with "port in use"
+	 * against our own server. Instead, a repeat click re-opens the auth page
+	 * for the pending flow and awaits its result.
 	 */
 	async openAiCodexLogin(): Promise<void> {
-		try {
-			const callbacks = createOAuthClientCallbacks({
-				onPrompt: async (prompt) => prompt.defaultValue ?? "",
-				openUrl: async (url: string) => {
-					await openExternal(url)
-				},
-				onOpenUrlError: ({ url, error }) => {
-					Logger.error(`[SdkAuthService] Failed to open browser for Codex: ${url}:`, error)
-				},
-			})
-
-			const credentials = await loginOpenAICodex(callbacks)
-
-			// Store Codex credentials in providers.json
-			await this.saveCodexCredentials(credentials)
-			await openAiCodexOAuthManager.saveCredentials({
-				type: "openai-codex",
-				access_token: credentials.access,
-				refresh_token: credentials.refresh,
-				expires: credentials.expires,
-				email: credentials.email,
-				accountId: credentials.accountId,
-			})
-
-			// Notify webview of state change
-			await this.sendAuthStatusUpdate()
-		} catch (error) {
-			Logger.error("[SdkAuthService] OpenAI Codex OAuth login failed:", error)
-			throw error
+		if (this._pendingCodexLogin) {
+			if (this._pendingCodexLogin.authUrl) {
+				await openExternal(this._pendingCodexLogin.authUrl)
+			}
+			return this._pendingCodexLogin.promise
 		}
+
+		const pending: { promise: Promise<void>; authUrl?: string } = { promise: Promise.resolve() }
+		pending.promise = (async () => {
+			try {
+				const callbacks = createOAuthClientCallbacks({
+					onPrompt: async (prompt) => prompt.defaultValue ?? "",
+					openUrl: async (url: string) => {
+						pending.authUrl = url
+						await openExternal(url)
+					},
+					onOpenUrlError: ({ url, error }) => {
+						Logger.error(`[SdkAuthService] Failed to open browser for Codex: ${url}:`, error)
+						HostProvider.window.showMessage({
+							type: ShowMessageType.ERROR,
+							message: `Couldn't open your browser for OpenAI sign-in. Open this URL manually: ${url}`,
+						})
+					},
+				})
+
+				const credentials = await loginOpenAICodex(callbacks)
+
+				// Store Codex credentials in providers.json
+				await this.saveCodexCredentials(credentials)
+				await openAiCodexOAuthManager.saveCredentials({
+					type: "openai-codex",
+					access_token: credentials.access,
+					refresh_token: credentials.refresh,
+					expires: credentials.expires,
+					email: credentials.email,
+					accountId: credentials.accountId,
+				})
+
+				// Notify webview of state change
+				await this.sendAuthStatusUpdate()
+			} catch (error) {
+				Logger.error("[SdkAuthService] OpenAI Codex OAuth login failed:", error)
+				throw error
+			} finally {
+				this._pendingCodexLogin = null
+			}
+		})()
+		this._pendingCodexLogin = pending
+		return pending.promise
 	}
 
 	/**

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -245,7 +245,6 @@ export class AuthService {
 	private _activeAuthStatusUpdateHandlers = new Set<StreamingResponseHandler<AuthState>>()
 	private _handlerToController = new Map<StreamingResponseHandler<AuthState>, Controller>()
 	private _refreshPromise: Promise<string | undefined> | null = null
-	private _pendingCodexLogin: { promise: Promise<void>; authUrl?: string } | null = null
 	private _telemetry?: ITelemetryService
 
 	private constructor() {}
@@ -745,62 +744,44 @@ export class AuthService {
 
 	/**
 	 * Initiate OpenAI Codex OAuth login.
-	 *
-	 * Concurrent calls are deduped: while a flow is pending it holds callback
-	 * port 1455, so starting a second flow would fail with "port in use"
-	 * against our own server. Instead, a repeat click re-opens the auth page
-	 * for the pending flow and awaits its result.
 	 */
 	async openAiCodexLogin(): Promise<void> {
-		if (this._pendingCodexLogin) {
-			if (this._pendingCodexLogin.authUrl) {
-				await openExternal(this._pendingCodexLogin.authUrl)
-			}
-			return this._pendingCodexLogin.promise
+		try {
+			const callbacks = createOAuthClientCallbacks({
+				onPrompt: async (prompt) => prompt.defaultValue ?? "",
+				openUrl: async (url: string) => {
+					await openExternal(url)
+				},
+				onOpenUrlError: ({ url, error }) => {
+					// Same recovery the CLI offers ("open the URL above manually") —
+					// the toast is the extension's only place to surface the URL.
+					Logger.error(`[SdkAuthService] Failed to open browser for Codex: ${url}:`, error)
+					HostProvider.window.showMessage({
+						type: ShowMessageType.ERROR,
+						message: `Couldn't open your browser for OpenAI sign-in. Open this URL manually: ${url}`,
+					})
+				},
+			})
+
+			const credentials = await loginOpenAICodex(callbacks)
+
+			// Store Codex credentials in providers.json
+			await this.saveCodexCredentials(credentials)
+			await openAiCodexOAuthManager.saveCredentials({
+				type: "openai-codex",
+				access_token: credentials.access,
+				refresh_token: credentials.refresh,
+				expires: credentials.expires,
+				email: credentials.email,
+				accountId: credentials.accountId,
+			})
+
+			// Notify webview of state change
+			await this.sendAuthStatusUpdate()
+		} catch (error) {
+			Logger.error("[SdkAuthService] OpenAI Codex OAuth login failed:", error)
+			throw error
 		}
-
-		const pending: { promise: Promise<void>; authUrl?: string } = { promise: Promise.resolve() }
-		pending.promise = (async () => {
-			try {
-				const callbacks = createOAuthClientCallbacks({
-					onPrompt: async (prompt) => prompt.defaultValue ?? "",
-					openUrl: async (url: string) => {
-						pending.authUrl = url
-						await openExternal(url)
-					},
-					onOpenUrlError: ({ url, error }) => {
-						Logger.error(`[SdkAuthService] Failed to open browser for Codex: ${url}:`, error)
-						HostProvider.window.showMessage({
-							type: ShowMessageType.ERROR,
-							message: `Couldn't open your browser for OpenAI sign-in. Open this URL manually: ${url}`,
-						})
-					},
-				})
-
-				const credentials = await loginOpenAICodex(callbacks)
-
-				// Store Codex credentials in providers.json
-				await this.saveCodexCredentials(credentials)
-				await openAiCodexOAuthManager.saveCredentials({
-					type: "openai-codex",
-					access_token: credentials.access,
-					refresh_token: credentials.refresh,
-					expires: credentials.expires,
-					email: credentials.email,
-					accountId: credentials.accountId,
-				})
-
-				// Notify webview of state change
-				await this.sendAuthStatusUpdate()
-			} catch (error) {
-				Logger.error("[SdkAuthService] OpenAI Codex OAuth login failed:", error)
-				throw error
-			} finally {
-				this._pendingCodexLogin = null
-			}
-		})()
-		this._pendingCodexLogin = pending
-		return pending.promise
 	}
 
 	/**

--- a/apps/vscode/src/test/e2e/codex-oauth.test.ts
+++ b/apps/vscode/src/test/e2e/codex-oauth.test.ts
@@ -1,0 +1,86 @@
+import net from "node:net"
+import { expect } from "@playwright/test"
+import { e2e } from "./utils/helpers"
+
+async function waitForPortListening(port: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		for (const host of ["127.0.0.1", "::1"]) {
+			const connected = await new Promise<boolean>((resolve) => {
+				const socket = net.connect({ port, host }, () => {
+					socket.destroy()
+					resolve(true)
+				})
+				socket.once("error", () => resolve(false))
+			})
+			if (connected) return
+		}
+		await new Promise((r) => setTimeout(r, 200))
+	}
+	throw new Error(`Nothing listening on port ${port} after ${timeoutMs}ms`)
+}
+
+async function navigateToCodexProvider(sidebar: import("@playwright/test").Frame): Promise<void> {
+	await sidebar.getByText("Bring my own API key").click()
+	await sidebar.getByRole("button", { name: "Continue" }).click()
+	const providerSelectorInput = sidebar.getByTestId("provider-selector-input")
+	await providerSelectorInput.click({ delay: 100 })
+	await providerSelectorInput.pressSequentially("chatgpt", { delay: 50 })
+	await sidebar.getByTestId("provider-option-openai-codex").click({ delay: 100 })
+}
+
+async function occupy(host: string, port: number): Promise<net.Server> {
+	const srv = net.createServer()
+	await new Promise<void>((resolve, reject) => {
+		srv.once("error", reject)
+		srv.listen(port, host, () => resolve())
+	})
+	return srv
+}
+
+e2e("Codex sign-in fails fast with a port-in-use toast when 1455 is occupied", async ({ page, sidebar }) => {
+	// Occupy the fixed Codex OAuth callback port on both loopback families so
+	// the extension host cannot bind it regardless of how it resolves localhost.
+	const blockers: net.Server[] = []
+	for (const host of ["127.0.0.1", "::1"]) {
+		try {
+			blockers.push(await occupy(host, 1455))
+		} catch {}
+	}
+	expect(blockers.length).toBeGreaterThan(0)
+
+	try {
+		await navigateToCodexProvider(sidebar)
+
+		const signInButton = sidebar.getByRole("button", { name: "Sign in to OpenAI Codex" })
+		await expect(signInButton).toBeVisible()
+		await signInButton.click()
+
+		// The fix: an immediate, actionable error toast in the workbench
+		// (notifications live in the main window DOM, not the webview frame).
+		await expect(page.locator(".notifications-toasts").getByText(/Port 1455 is already in use/)).toBeVisible({
+			timeout: 15_000,
+		})
+	} finally {
+		await Promise.all(blockers.map((b) => new Promise<void>((resolve) => b.close(() => resolve()))))
+	}
+})
+
+e2e("Codex sign-in with port free binds the callback server and surfaces OAuth redirect errors", async ({ page, sidebar }) => {
+	await navigateToCodexProvider(sidebar)
+
+	const signInButton = sidebar.getByRole("button", { name: "Sign in to OpenAI Codex" })
+	await expect(signInButton).toBeVisible()
+	await signInButton.click()
+
+	// The SDK binds the callback server before opening the browser; prove the
+	// real port-free wiring by simulating the OAuth redirect the browser
+	// would deliver. An `error` callback settles regardless of state.
+	await waitForPortListening(1455, 15_000)
+	const response = await fetch("http://localhost:1455/auth/callback?error=access_denied")
+	expect(response.status).toBe(400)
+
+	await expect(page.locator(".notifications-toasts").getByText(/OAuth error: access_denied/)).toBeVisible({
+		timeout: 15_000,
+	})
+})

--- a/sdk/packages/core/src/auth/codex.test.ts
+++ b/sdk/packages/core/src/auth/codex.test.ts
@@ -1,6 +1,9 @@
+import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	getValidOpenAICodexCredentials,
+	loginOpenAICodex,
+	OPENAI_CODEX_OAUTH_CONFIG,
 	refreshOpenAICodexToken,
 } from "./codex";
 import type { OAuthCredentials } from "./types";
@@ -153,4 +156,106 @@ describe("auth/codex token lifecycle", () => {
 			"Failed to refresh OpenAI Codex token",
 		);
 	});
+});
+
+// Codex OAuth uses the fixed registered redirect port (1455). These tests
+// occupy that real port, so they are skipped in sandboxes where binding it is
+// not possible.
+const canBindCodexPort = await (async () => {
+	try {
+		const srv = net.createServer();
+		await new Promise<void>((resolve, reject) => {
+			srv.once("error", reject);
+			srv.listen(OPENAI_CODEX_OAUTH_CONFIG.callbackPort, "localhost", () =>
+				resolve(),
+			);
+		});
+		await new Promise<void>((resolve) => {
+			srv.close(() => resolve());
+		});
+		return true;
+	} catch {
+		return false;
+	}
+})();
+const codexPortIt = canBindCodexPort ? it : it.skip;
+
+async function occupyCodexPort(): Promise<net.Server> {
+	const blocker = net.createServer();
+	await new Promise<void>((resolve, reject) => {
+		blocker.once("error", reject);
+		blocker.listen(OPENAI_CODEX_OAUTH_CONFIG.callbackPort, "localhost", () =>
+			resolve(),
+		);
+	});
+	return blocker;
+}
+
+describe("auth/codex loginOpenAICodex — callback port unavailable", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	codexPortIt(
+		"fails fast before opening the browser when the port is occupied and no manual fallback exists",
+		async () => {
+			const blocker = await occupyCodexPort();
+			try {
+				const onAuth = vi.fn();
+				await expect(
+					loginOpenAICodex({ onAuth, onPrompt: async () => "" }),
+				).rejects.toThrow(/already in use/);
+				expect(onAuth).not.toHaveBeenCalled();
+			} finally {
+				await new Promise<void>((resolve) => {
+					blocker.close(() => resolve());
+				});
+			}
+		},
+	);
+
+	codexPortIt(
+		"continues via manual code entry when the port is occupied but a manual fallback exists",
+		async () => {
+			const accessToken = createJwt({
+				"https://api.openai.com/auth": { chatgpt_account_id: "acct-manual" },
+			});
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(
+							JSON.stringify({
+								access_token: accessToken,
+								refresh_token: "refresh-manual",
+								expires_in: 3600,
+								email: "manual@example.com",
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						),
+				),
+			);
+
+			const blocker = await occupyCodexPort();
+			try {
+				const onAuth = vi.fn();
+				const credentials = await loginOpenAICodex({
+					onAuth,
+					onPrompt: async () => "",
+					onManualCodeInput: async () => "manual-auth-code",
+				});
+				expect(onAuth).toHaveBeenCalledOnce();
+				expect(credentials).toMatchObject({
+					access: accessToken,
+					refresh: "refresh-manual",
+					accountId: "acct-manual",
+				});
+			} finally {
+				await new Promise<void>((resolve) => {
+					blocker.close(() => resolve());
+				});
+			}
+		},
+	);
 });

--- a/sdk/packages/core/src/auth/codex.ts
+++ b/sdk/packages/core/src/auth/codex.ts
@@ -311,6 +311,21 @@ export async function loginOpenAICodex(options: {
 		expectedState: state,
 	});
 
+	// startLocalOAuthServer returns a no-op server (empty callbackUrl, a
+	// waitForCallback that resolves null immediately) when every candidate
+	// port is occupied. Codex OAuth uses the fixed registered redirect
+	// http://localhost:1455/auth/callback, so without that port the browser
+	// callback can never be received. Unless the host offers manual code
+	// entry as a fallback, fail fast with an actionable error instead of
+	// opening a browser flow that silently dead-ends.
+	if (!server.callbackUrl && !options.onManualCodeInput) {
+		const error = new Error(
+			`Port ${callbackConfig.port} is already in use, so the OpenAI sign-in callback cannot be received. Close the application using that port (for example another Codex or Cline sign-in) and try again.`,
+		);
+		captureAuthFailed(options.telemetry, "openai-codex", error.message);
+		throw error;
+	}
+
 	options.onAuth({
 		url,
 		instructions: "Continue the authentication process in your browser.",
@@ -324,6 +339,9 @@ export async function loginOpenAICodex(options: {
 			onManualCodeInput: options.onManualCodeInput,
 			parseOptions: { allowHashCodeState: true },
 		});
+		if (authResult.error) {
+			throw new Error(`OAuth error: ${authResult.error}`);
+		}
 		if (authResult.state && authResult.state !== state) {
 			throw new Error("State mismatch");
 		}


### PR DESCRIPTION
### Related Issue

User report: clicking "Sign in to OpenAI Codex" on the ChatGPT subscription provider in the extension appears to do nothing. The settings keep showing the sign-in button and the model selector, with no visible response.

### Description

Codex OAuth uses the fixed registered redirect `http://localhost:1455/auth/callback`. When port 1455 is already occupied (for example by the Codex CLI, another editor's Codex sign-in, or a previous pending Cline sign-in still waiting on its 5-minute callback window), `startLocalOAuthServer` returns a silent no-op server whose `waitForCallback` resolves `null` immediately. `loginOpenAICodex` then opened the browser anyway and dead-ended: the callback could never be received, and hosts without a real prompt (the extension webview) collapsed into a generic "Missing authorization code" failure while the user was still signing in in the browser. From the user's perspective, the button just did not respond.

The fix lives in the SDK, where the flow is owned; the extension keeps calling the exact same `loginOpenAICodex` entry point the CLI uses, with no new host-side logic.

- `@cline/core` `loginOpenAICodex` now fails fast with an actionable "Port 1455 is already in use" error before opening the browser when the callback port cannot be bound, unless the host provides manual code entry (`onManualCodeInput`). Interactive manual-entry flows keep working; hosts without one no longer dead-end. This covers the extension, the CLI, and the desktop app identically.
- OAuth redirect errors (for example `access_denied`) are now surfaced as `OAuth error: ...` instead of being collapsed into "Missing authorization code".
- The extension's `onOpenUrlError` callback now shows an error notification containing the URL to open manually, mirroring the CLI's "Could not open browser automatically; open the URL above manually" output, instead of only logging.
- The abandoned-flow timeout shape ("Missing authorization code" after the 5-minute callback window expires with no redirect) no longer produces a confusing error toast, extending the existing "timed out" suppression in `openAiCodexSignIn.ts`.

### Test Procedure

- New SDK tests in `sdk/packages/core/src/auth/codex.test.ts`: sign-in fails fast (and never opens the browser) when port 1455 is occupied and no manual fallback exists; sign-in still completes via manual code entry when the port is occupied but a manual fallback is provided. All 61 `src/auth` tests pass.
- Full extension unit suite passes (1074 tests); typechecks pass for `@cline/core` and the extension host code; biome check is clean on the changed files.
- Manually verified in the VS Code extension dev host on a virtual display: with port 1455 occupied (both 127.0.0.1 and ::1) by another process, clicking "Sign in to OpenAI Codex" immediately shows the actionable port-in-use error and no browser opens; with the port free, clicking the button opens the browser to auth.openai.com as before with no error.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Port 1455 occupied by another process: clicking the sign-in button now immediately shows an actionable error instead of silently dead-ending (no browser opens):

![Error notification when port 1455 is in use](https://cursor.com/artifacts/c/art-845acd98-2ee2-4698-92d6-27a8c22615bf)

Port free: the normal flow is unchanged, the browser opens to the OpenAI auth page:

![Normal sign-in flow opens the browser to auth.openai.com](https://cursor.com/artifacts/c/art-28d97f17-60e7-4c81-9fea-89f5894ebdbe)

### Additional Notes

The likely real-world trigger for the report is a ChatGPT subscriber who also uses the Codex CLI or another tool holding port 1455, or who clicked the sign-in button more than once (the first pending flow holds the port for up to 5 minutes, making every subsequent click dead-end silently). With this change a repeat click while a flow is pending gets the same clear port-in-use error the CLI would print, and the flow becomes clickable again once the pending window closes.