### PR TITLE
feat(desktop): Customize hub, sidebar overhaul, and settings polish

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -65,6 +65,7 @@ import {
 	markOnboardingCompleted,
 	ONBOARDING_RESET_EVENT,
 } from "@/lib/onboarding";
+import { requestPromptInputFocus } from "@/lib/prompt-input-focus";
 import { isProviderConnected } from "@/lib/provider-connection";
 import {
 	fetchProviderCatalog,
@@ -220,6 +221,7 @@ export default function Home() {
 
 	const handleNewThread = useCallback(() => {
 		dispatchApp({ type: "new-thread", threadId: makeThreadId() });
+		requestPromptInputFocus();
 	}, []);
 
 	const completeOnboarding = useCallback(() => {
@@ -289,6 +291,7 @@ export default function Home() {
 			return;
 		}
 		navigateWith({ view: "chat" });
+		requestPromptInputFocus();
 	}, [activeThread, handleNewThread, navigateWith]);
 	const handleViewChange = useCallback(
 		(nextView: DesktopAppView) => {
@@ -296,6 +299,13 @@ export default function Home() {
 		},
 		[navigateWith],
 	);
+	// The sidebar's New row reads as selected while the fresh, not-yet-started
+	// task page is showing; once the task starts the session row takes over.
+	const newTaskActive =
+		view === "chat" &&
+		activeThread !== undefined &&
+		!activeThread.hasStarted &&
+		!activeThread.historySession;
 	const handleSettingsSectionChange = useCallback(
 		(section: SettingsSection) => {
 			navigateWith({ settingsSection: section, view: "settings" });
@@ -428,6 +438,7 @@ export default function Home() {
 					>
 						<AgentSidebar
 							activeSessionId={activeHistorySessionId}
+							newTaskActive={newTaskActive}
 							onHome={handleHome}
 							onNavigateBack={handleNavigateBack}
 							onNavigateForward={handleNavigateForward}

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -116,6 +116,14 @@ function sessionIsVisible(title: string): boolean {
 	);
 }
 
+function sessionRow(title: string): HTMLButtonElement {
+	const row = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+		(button) => button.querySelector("span")?.textContent === title,
+	);
+	expect(row).toBeDefined();
+	return row as HTMLButtonElement;
+}
+
 const signedInUser = {
 	id: "user-1",
 	email: "beatrix@cline.bot",
@@ -179,145 +187,95 @@ afterEach(async () => {
 });
 
 describe("AgentSidebar session organization", () => {
-	it("groups scheduled sessions into a collapsible Scheduled section", async () => {
+	it("marks scheduled sessions with a clock icon in the row", async () => {
 		const scheduled = {
-			...makeThread("scheduled", 1),
+			...makeThread("alpha", 1),
 			source: "core",
 			isScheduled: true,
 		};
-		const regular = { ...makeThread("regular", 1), source: "core" };
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						activeSessionId={null}
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([scheduled, regular], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-					/>
-				</SidebarProvider>,
-			);
-		});
-
-		expect(sessionIsVisible("scheduled session 1")).toBe(true);
-		expect(sessionIsVisible("regular session 1")).toBe(true);
-		const scheduledHeader = buttonWithText("Scheduled");
-		const tasksHeader = buttonWithText("Tasks");
-		expect(scheduledHeader.getAttribute("aria-expanded")).toBe("true");
-		expect(tasksHeader.getAttribute("aria-expanded")).toBe("true");
-
-		// The scheduled and pinned categories replaced the old filter options.
-		await click(
-			container.querySelector('[aria-label="Filter sessions"]') as Element,
-		);
-		await vi.waitFor(() => {
-			expect(
-				document.querySelectorAll('[role="menuitemradio"]').length,
-			).toBeGreaterThan(0);
-		});
-		const filterOptionLabels = [
-			...document.querySelectorAll<HTMLElement>('[role="menuitemradio"]'),
-		].map((option) => option.textContent);
-		expect(filterOptionLabels).not.toContain("Schedules");
-		expect(filterOptionLabels).not.toContain("Favorites");
-
-		await click(scheduledHeader);
-		expect(sessionIsVisible("scheduled session 1")).toBe(false);
-		expect(sessionIsVisible("regular session 1")).toBe(true);
-	});
-
-	it("shows pinned sessions in a Pinned section ahead of Tasks", async () => {
-		const pinned = { ...makeThread("pinned", 1), pinned: true };
-		const regular = makeThread("regular", 1);
-
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						activeSessionId={null}
-						onHome={vi.fn()}
-						onNewThread={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([regular, pinned], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-					/>
-				</SidebarProvider>,
-			);
-		});
-
-		expect(sessionIsVisible("pinned session 1")).toBe(true);
-		expect(sessionIsVisible("regular session 1")).toBe(true);
-		expect(container.querySelector('[aria-label="Pinned"]')).not.toBeNull();
-		const pinnedHeader = buttonWithText("Pinned");
-		const tasksHeader = buttonWithText("Tasks");
-		expect(
-			pinnedHeader.compareDocumentPosition(tasksHeader) &
-				Node.DOCUMENT_POSITION_FOLLOWING,
-		).toBeTruthy();
-
-		await click(pinnedHeader);
-		expect(sessionIsVisible("pinned session 1")).toBe(false);
-		expect(sessionIsVisible("regular session 1")).toBe(true);
-	});
-
-	it("keeps growing history when a fetch adds no tasks and more remain", async () => {
-		const scheduled = Array.from({ length: 8 }, (_, index) => ({
-			...makeThread("cron", index + 1),
+		const pinnedScheduled = {
+			...makeThread("alpha", 2),
 			isScheduled: true,
-		}));
-		const tasks = Array.from({ length: 5 }, (_, index) =>
-			makeThread("plain", index + 1),
-		);
-		const loadOlderSessions = vi.fn(async () => true);
-		const renderSidebar = async (isLoadingMore: boolean) => {
-			await act(async () => {
-				root.render(
-					<SidebarProvider>
-						<AgentSidebar
-							activeSessionId={null}
-							onHome={vi.fn()}
-							onSettingsSectionChange={vi.fn()}
-							sessionHistory={makeSessionHistory(
-								[...scheduled, ...tasks],
-								vi.fn(),
-								{
-									isLoadingMore,
-									loadOlderSessions,
-									mayHaveMoreSessions: true,
-								},
-							)}
-							setView={vi.fn()}
-							settingsSection="General"
-							view="chat"
-						/>
-					</SidebarProvider>,
-				);
-			});
+			pinned: true,
 		};
+		const regular = { ...makeThread("alpha", 3), source: "core" };
 
-		await renderSidebar(false);
-		expect(loadOlderSessions).not.toHaveBeenCalled();
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory(
+							[scheduled, pinnedScheduled, regular],
+							vi.fn(),
+						)}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
 
-		// Five loaded tasks cannot fill the requested page of 20, so the
-		// page-fill effect grows the history window.
-		await click(buttonWithText("Show more"));
-		expect(loadOlderSessions).toHaveBeenCalledOnce();
+		// The clock marks scheduled rows inline; a pinned scheduled session
+		// shows both indicators at once.
+		expect(
+			sessionRow("alpha session 1").querySelector('[aria-label="Scheduled"]'),
+		).not.toBeNull();
+		expect(
+			sessionRow("alpha session 1").querySelector('[aria-label="Pinned"]'),
+		).toBeNull();
+		expect(
+			sessionRow("alpha session 2").querySelector('[aria-label="Scheduled"]'),
+		).not.toBeNull();
+		expect(
+			sessionRow("alpha session 2").querySelector('[aria-label="Pinned"]'),
+		).not.toBeNull();
+		expect(
+			sessionRow("alpha session 3").querySelector('[aria-label="Scheduled"]'),
+		).toBeNull();
 
-		// Simulate that fetch settling without adding any tasks (the batch was
-		// all scheduled sessions): with more history remaining, the effect
-		// asks again instead of leaving the click without visible progress.
-		await renderSidebar(true);
-		await renderSidebar(false);
-		expect(loadOlderSessions).toHaveBeenCalledTimes(2);
+		// The old Pinned/Scheduled/Tasks category sections are gone.
+		expect(container.textContent).not.toContain("Scheduled");
+		expect(container.textContent).not.toContain("Tasks");
 	});
 
-	it("halts page-fill retries after a failed fetch until the next click", async () => {
+	it("pins sessions to the top of their project group", async () => {
+		const pinned = { ...makeThread("alpha", 3), pinned: true };
+		const threads = [makeThread("alpha", 1), makeThread("alpha", 2), pinned];
+
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory(threads, vi.fn())}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		// The pinned session leads its project group despite being the oldest
+		// entry in history order, and carries the pin icon inline.
+		const pinnedRow = sessionRow("alpha session 3");
+		expect(pinnedRow.querySelector('[aria-label="Pinned"]')).not.toBeNull();
+		for (const title of ["alpha session 1", "alpha session 2"]) {
+			expect(
+				pinnedRow.compareDocumentPosition(sessionRow(title)) &
+					Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		}
+		expect(container.textContent).not.toContain("Pinned");
+	});
+
+	it("loads older history only on explicit Show more clicks", async () => {
 		const tasks = Array.from({ length: 5 }, (_, index) =>
 			makeThread("plain", index + 1),
 		);
@@ -348,13 +306,12 @@ describe("AgentSidebar session organization", () => {
 		await click(buttonWithText("Show more"));
 		expect(loadOlderSessions).toHaveBeenCalledOnce();
 
-		// The failed fetch settles with nothing changed; retrying automatically
-		// would loop the same failing request and re-toast the error forever.
+		// A settled fetch never triggers an automatic follow-up request; only
+		// another explicit click asks for more history.
 		await renderSidebar(true);
 		await renderSidebar(false);
 		expect(loadOlderSessions).toHaveBeenCalledOnce();
 
-		// An explicit click clears the halt and retries.
 		await click(buttonWithText("Show more"));
 		expect(loadOlderSessions).toHaveBeenCalledTimes(2);
 	});
@@ -366,7 +323,6 @@ describe("AgentSidebar session organization", () => {
 					<AgentSidebar
 						activeSessionId={null}
 						onHome={vi.fn()}
-						onNewThread={vi.fn()}
 						onSettingsSectionChange={vi.fn()}
 						sessionHistory={makeSessionHistory(
 							[makeThread("plain", 1)],
@@ -507,7 +463,7 @@ describe("AgentSidebar session organization", () => {
 		);
 	});
 
-	it("defaults to time and keeps project expansion scoped to one project", async () => {
+	it("always groups sessions by project and scopes expansion to one project", async () => {
 		const threads = [
 			...Array.from({ length: 12 }, (_, index) =>
 				makeThread("alpha", index + 1),
@@ -539,54 +495,28 @@ describe("AgentSidebar session organization", () => {
 			);
 		});
 
-		expect(
-			container.querySelector('[aria-label="Sort sessions: Time"]'),
-		).not.toBeNull();
-		expect(sessionIsVisible("alpha session 10")).toBe(true);
-		expect(sessionIsVisible("alpha session 11")).toBe(false);
-		expect(sessionIsVisible("beta session 1")).toBe(false);
-
-		// The first page grows purely from already-loaded sessions (24 loaded,
-		// 20 requested), so no history fetch is needed.
-		await click(buttonWithText("Show more"));
-		expect(sessionIsVisible("alpha session 11")).toBe(true);
-		expect(loadMoreSessions).not.toHaveBeenCalled();
-		expect(loadOlderSessions).not.toHaveBeenCalled();
-
-		// The next page (30) exceeds the 24 loaded sessions, so the whole
-		// history window grows.
-		await click(buttonWithText("Show more"));
-		expect(sessionIsVisible("beta session 12")).toBe(true);
-		expect(loadOlderSessions).toHaveBeenCalledOnce();
-
-		await click(
-			container.querySelector('[aria-label="Sort sessions: Time"]') as Element,
-		);
-		const projectOption = await vi.waitFor(() => {
-			const option = [
-				...document.querySelectorAll<HTMLElement>('[role="menuitemradio"]'),
-			].find((candidate) => candidate.textContent?.includes("Sort by project"));
-			expect(option).toBeDefined();
-			return option as HTMLElement;
-		});
-		await click(projectOption);
-
-		await vi.waitFor(() => {
-			expect(
-				container.querySelector('[aria-label="Sort sessions: Project"]'),
-			).not.toBeNull();
-		});
+		// The sort toggle is gone: grouping is always by project.
+		expect(container.querySelector('[aria-label^="Sort sessions"]')).toBeNull();
 		expect(container.textContent).toContain("alpha");
 		expect(container.textContent).toContain("beta");
+		expect(sessionIsVisible("alpha session 10")).toBe(true);
 		expect(sessionIsVisible("alpha session 11")).toBe(false);
+		expect(sessionIsVisible("beta session 10")).toBe(true);
 		expect(sessionIsVisible("beta session 11")).toBe(false);
 
+		// Expanding one project leaves the others' pagination untouched.
 		await click(buttonWithText("Show more in alpha"));
 		expect(sessionIsVisible("alpha session 11")).toBe(true);
 		expect(sessionIsVisible("beta session 11")).toBe(false);
+		expect(loadMoreSessions).not.toHaveBeenCalled();
 
-		await click(buttonWithText("Load older projects"));
-		expect(loadOlderSessions).toHaveBeenCalledTimes(2);
+		// The trailing Show more button grows the loaded history window.
+		const globalShowMore = [
+			...container.querySelectorAll<HTMLButtonElement>("button"),
+		].find((button) => button.textContent?.trim() === "Show more");
+		expect(globalShowMore).toBeDefined();
+		await click(globalShowMore as HTMLButtonElement);
+		expect(loadOlderSessions).toHaveBeenCalledOnce();
 	});
 
 	it("shows the signed-in account and active organization in the footer", async () => {
@@ -666,8 +596,9 @@ describe("AgentSidebar session organization", () => {
 		expect(setView).not.toHaveBeenCalled();
 	});
 
-	it("suppresses the settings gear hover state while the Account screen is open", async () => {
+	it("opens the General settings section from the gear in any section", async () => {
 		invoke.mockResolvedValue(signedInUser);
+		const onSettingsSectionChange = vi.fn();
 
 		const renderSidebar = async (settingsSection: "Account" | "General") => {
 			await act(async () => {
@@ -677,7 +608,7 @@ describe("AgentSidebar session organization", () => {
 							<AgentSidebar
 								activeSessionId={null}
 								onHome={vi.fn()}
-								onSettingsSectionChange={vi.fn()}
+								onSettingsSectionChange={onSettingsSectionChange}
 								sessionHistory={makeSessionHistory([], vi.fn())}
 								setView={vi.fn()}
 								settingsSection={settingsSection}
@@ -694,13 +625,19 @@ describe("AgentSidebar session organization", () => {
 			});
 		};
 
+		// The Account screen leaves the gear un-highlighted, but clicking it
+		// still navigates to General rather than acting as a no-op.
+		// (split on spaces: the variant's hover:bg-surface-hover would match a
+		// plain substring check)
 		const gearOnAccount = await renderSidebar("Account");
-		expect(gearOnAccount.className).toContain("hover:bg-transparent");
-		expect(gearOnAccount.className).not.toContain("bg-surface-hover");
+		expect(gearOnAccount.className.split(" ")).not.toContain(
+			"bg-surface-hover",
+		);
+		await click(gearOnAccount);
+		expect(onSettingsSectionChange).toHaveBeenCalledWith("General");
 
 		const gearOnGeneral = await renderSidebar("General");
-		expect(gearOnGeneral.className).not.toContain("hover:bg-transparent");
-		expect(gearOnGeneral.className).toContain("bg-surface-hover");
+		expect(gearOnGeneral.className.split(" ")).toContain("bg-surface-hover");
 	});
 
 	it("shows the desktop app version and connected Hub when the logo is hovered", async () => {
@@ -882,7 +819,42 @@ describe("AgentSidebar session organization", () => {
 		await click(buttonWithText("Schedule", actionsNav as ParentNode));
 		expect(onSettingsSectionChange).toHaveBeenCalledWith("Schedules");
 		await click(buttonWithText("Customize", actionsNav as ParentNode));
-		expect(onSettingsSectionChange).toHaveBeenCalledWith("Plugins");
+		expect(onSettingsSectionChange).toHaveBeenCalledWith("Customize");
+	});
+
+	it("highlights the New row only while the new-task page is active", async () => {
+		const renderSidebar = async (newTaskActive: boolean) => {
+			await act(async () => {
+				root.render(
+					<AccountProvider>
+						<SidebarProvider>
+							<AgentSidebar
+								activeSessionId={null}
+								newTaskActive={newTaskActive}
+								onHome={vi.fn()}
+								onSettingsSectionChange={vi.fn()}
+								sessionHistory={makeSessionHistory([], vi.fn())}
+								setView={vi.fn()}
+								settingsSection="General"
+								view="chat"
+							/>
+						</SidebarProvider>
+					</AccountProvider>,
+				);
+			});
+			return buttonWithText(
+				"New",
+				container.querySelector('[aria-label="Sidebar actions"]') as ParentNode,
+			);
+		};
+
+		const activeRow = await renderSidebar(true);
+		expect(activeRow.className.split(" ")).toContain("bg-surface-hover");
+		expect(activeRow.getAttribute("aria-current")).toBe("page");
+
+		const inactiveRow = await renderSidebar(false);
+		expect(inactiveRow.className.split(" ")).not.toContain("bg-surface-hover");
+		expect(inactiveRow.getAttribute("aria-current")).toBeNull();
 	});
 
 	it("opens session search in a dialog from the logo-row icon", async () => {

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-	ArrowDownUp,
 	ArrowLeft,
 	ArrowRight,
 	Blocks,
@@ -9,25 +8,19 @@ import {
 	ChevronDown,
 	CircleUserRound,
 	Clock3,
-	Code,
-	FileText,
 	Filter,
-	FolderTree,
 	GitFork,
 	Loader2,
 	Mic,
 	PanelLeftOpen,
 	Pencil,
 	Pin,
-	Plug,
 	Plus,
 	Radio,
 	Search,
 	Settings,
 	SlidersHorizontal,
-	Store,
 	Trash2,
-	Wrench,
 } from "lucide-react";
 import {
 	type ReactNode,
@@ -118,8 +111,6 @@ type AppView = "chat" | "sessions" | "settings";
 
 const filterOptions = ["All", "Running"] as const;
 type FilterOption = (typeof filterOptions)[number];
-type SidebarSortMode = "time" | "project";
-type SessionCategory = "pinned" | "scheduled" | "tasks";
 type DesktopProcessContext = {
 	appVersion?: unknown;
 	hub?: {
@@ -152,12 +143,7 @@ const SETTINGS_SECTION_ICONS = {
 	Channels: Radio,
 	Schedules: Clock3,
 	Account: CircleUserRound,
-	Plugins: Plug,
-	Marketplace: Store,
-	Hooks: Code,
-	Rules: FileText,
-	Agents: Bot,
-	Tools: Wrench,
+	Customize: Blocks,
 } satisfies Record<SettingsSection, typeof Settings>;
 
 function SettingsSectionNavigation({
@@ -226,15 +212,18 @@ function SettingsSectionNavigation({
 					Settings
 				</p>
 			) : null}
-			{SETTINGS_SECTIONS.map(renderSectionButton)}
-			{!collapsed ? (
-				<p className="px-2 pb-2 pt-4 text-sm font-medium text-muted-foreground">
-					Customizations
-				</p>
-			) : (
-				<div className="my-2 h-px w-6 shrink-0 bg-sidebar-border" />
-			)}
-			{CUSTOMIZATION_SECTIONS.map(renderSectionButton)}
+			{/* Schedules and Customize already have dedicated rows at the top of
+			    the expanded sidebar, so the section nav skips them there. The
+			    collapsed sidebar has no action rows and keeps both reachable. */}
+			{SETTINGS_SECTIONS.filter(
+				(section) => collapsed || section !== "Schedules",
+			).map(renderSectionButton)}
+			{collapsed ? (
+				<>
+					<div className="my-2 h-px w-6 shrink-0 bg-sidebar-border" />
+					{CUSTOMIZATION_SECTIONS.map(renderSectionButton)}
+				</>
+			) : null}
 		</nav>
 	);
 }
@@ -242,6 +231,7 @@ function SettingsSectionNavigation({
 export function AgentSidebar({
 	canNavigateBack = false,
 	canNavigateForward = false,
+	newTaskActive = false,
 	onHome,
 	onNavigateBack,
 	onNavigateForward,
@@ -254,6 +244,8 @@ export function AgentSidebar({
 }: {
 	canNavigateBack?: boolean;
 	canNavigateForward?: boolean;
+	/** Highlights the New row while the fresh, not-yet-started task page is showing. */
+	newTaskActive?: boolean;
 	onHome: () => void;
 	onNavigateBack?: () => void;
 	onNavigateForward?: () => void;
@@ -292,17 +284,15 @@ export function AgentSidebar({
 	const activeThread = activeSessionId ?? "";
 	const [filter, setFilter] = useState<FilterOption>("All");
 	const [sourceFilter, setSourceFilter] = useState(ALL_SESSION_SOURCES);
-	const [sortMode, setSortMode] = useState<SidebarSortMode>("time");
 	const [searchOpen, setSearchOpen] = useState(false);
-	const [showMoreCount, setShowMoreCount] = useState(
-		INITIAL_VISIBLE_THREAD_COUNT,
+	// Drives the gradient fade under the Sessions header once the list is
+	// scrolled, so rows fade out instead of clipping against the header.
+	const [sessionListScrolled, setSessionListScrolled] = useState(false);
+	// The session-detail hover card is controlled from up here so scrolling
+	// the list can dismiss it (Radix gets no pointer events during scroll).
+	const [hoverCardThreadId, setHoverCardThreadId] = useState<string | null>(
+		null,
 	);
-	const [scheduledVisibleCount, setScheduledVisibleCount] = useState(
-		INITIAL_VISIBLE_THREAD_COUNT,
-	);
-	const [collapsedSections, setCollapsedSections] = useState<
-		Set<SessionCategory>
-	>(() => new Set());
 	const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
 	const [editingTitle, setEditingTitle] = useState("");
 	const [deleteConfirmThread, setDeleteConfirmThread] = useState<Thread | null>(
@@ -383,10 +373,12 @@ export function AgentSidebar({
 		setView("sessions");
 		closeMobileSidebar();
 	}, [closeMobileSidebar, setView]);
+	// The gear is a shortcut to the General settings page rather than a
+	// resume-last-section toggle.
 	const openSettings = useCallback(() => {
-		setView("settings");
+		onSettingsSectionChange("General");
 		closeMobileSidebar();
-	}, [closeMobileSidebar, setView]);
+	}, [closeMobileSidebar, onSettingsSectionChange]);
 	const openSettingsSection = useCallback(
 		(section: SettingsSection) => {
 			onSettingsSectionChange(section);
@@ -460,79 +452,17 @@ export function AgentSidebar({
 		[deleteHistoryThread],
 	);
 
-	const pinnedThreads = useMemo(
-		() => filteredThreads.filter((t) => t.pinned),
-		[filteredThreads],
-	);
-	const scheduledThreads = useMemo(
-		() => filteredThreads.filter((t) => !t.pinned && t.isScheduled),
-		[filteredThreads],
-	);
-	const taskThreads = useMemo(
-		() => filteredThreads.filter((t) => !t.pinned && !t.isScheduled),
-		[filteredThreads],
-	);
-	// Category headers only appear once there is something to categorize;
-	// a lone "Tasks" header over the whole list would be noise.
-	const showCategorySections =
-		pinnedThreads.length > 0 || scheduledThreads.length > 0;
-	const showTimeShowMore =
-		taskThreads.length > showMoreCount ||
-		(filter === "All" && mayHaveMoreSessions);
-	// A failed fetch leaves the task count and has-more state unchanged, which
-	// are exactly the conditions the page-fill effect fires on; without this
-	// halt it would retry a failing request (and re-toast the error) forever.
-	// The next explicit "Show more" click clears the halt to retry.
-	const pageFillFailedRef = useRef(false);
-	// A "Show more" click can outpace the loaded history: showMoreCount counts
-	// only Tasks rows while the backend limit counts all sessions, and a
-	// fetched batch can consist entirely of pinned or scheduled sessions. Keep
-	// growing the history window until the requested Tasks page fills or
-	// history runs out, so every click makes visible progress. The
-	// isLoadingMore dependency retriggers the check after each fetch settles.
-	useEffect(() => {
-		if (
-			sortMode !== "time" ||
-			filter !== "All" ||
-			isLoadingMore ||
-			!mayHaveMoreSessions ||
-			showMoreCount <= INITIAL_VISIBLE_THREAD_COUNT ||
-			taskThreads.length >= showMoreCount ||
-			pageFillFailedRef.current
-		) {
-			return;
-		}
-		void loadOlderSessions().then((loaded) => {
-			if (!loaded) {
-				pageFillFailedRef.current = true;
-			}
-		});
-	}, [
-		filter,
-		isLoadingMore,
-		loadOlderSessions,
-		mayHaveMoreSessions,
-		showMoreCount,
-		sortMode,
-		taskThreads.length,
-	]);
+	// Pinned threads lead the concatenation, and groupThreadsByProject keeps
+	// insertion order, so each project group reads pinned-by-recency first,
+	// then the rest by recency.
 	const projectGroups = useMemo(
 		() =>
 			groupThreadsByProject([
-				...pinnedThreads,
+				...filteredThreads.filter((t) => t.pinned),
 				...filteredThreads.filter((t) => !t.pinned),
 			]),
-		[filteredThreads, pinnedThreads],
+		[filteredThreads],
 	);
-
-	const toggleSection = useCallback((section: SessionCategory) => {
-		setCollapsedSections((current) => {
-			const next = new Set(current);
-			if (next.has(section)) next.delete(section);
-			else next.add(section);
-			return next;
-		});
-	}, []);
 	const toggleProject = useCallback((project: string) => {
 		setCollapsedProjects((current) => {
 			const next = new Set(current);
@@ -567,8 +497,6 @@ export function AgentSidebar({
 				<DropdownMenuRadioGroup
 					onValueChange={(value) => {
 						setFilter(value as FilterOption);
-						setShowMoreCount(INITIAL_VISIBLE_THREAD_COUNT);
-						setScheduledVisibleCount(INITIAL_VISIBLE_THREAD_COUNT);
 						setProjectVisibleCounts({});
 					}}
 					value={filter}
@@ -586,8 +514,6 @@ export function AgentSidebar({
 						<DropdownMenuRadioGroup
 							onValueChange={(value) => {
 								setSourceFilter(value);
-								setShowMoreCount(INITIAL_VISIBLE_THREAD_COUNT);
-								setScheduledVisibleCount(INITIAL_VISIBLE_THREAD_COUNT);
 								setProjectVisibleCounts({});
 							}}
 							value={sourceFilter}
@@ -606,46 +532,18 @@ export function AgentSidebar({
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
-	const sortMenu = (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button
-					aria-label={`Sort sessions: ${sortMode === "time" ? "Time" : "Project"}`}
-					className="m-0! inline-flex size-8 items-center justify-center rounded-md p-0! text-muted-foreground hover:bg-surface-hover hover:text-sidebar-foreground"
-					size="icon"
-					title={sortMode === "time" ? "Sort by time" : "Sort by project"}
-					variant="ghost"
-				>
-					<ArrowDownUp className="size-3.5" />
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" className="w-44">
-				<DropdownMenuRadioGroup
-					onValueChange={(value) => {
-						if (value === "time" || value === "project") {
-							setSortMode(value);
-						}
-					}}
-					value={sortMode}
-				>
-					<DropdownMenuRadioItem value="time">
-						<Clock3 className="size-4" />
-						Sort by time
-					</DropdownMenuRadioItem>
-					<DropdownMenuRadioItem value="project">
-						<FolderTree className="size-4" />
-						Sort by project
-					</DropdownMenuRadioItem>
-				</DropdownMenuRadioGroup>
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
 	const threadItem = (thread: Thread) => (
 		<ThreadItem
 			editTitle={editingTitle}
 			editing={editingSessionId === thread.id}
+			hoverCardOpen={hoverCardThreadId === thread.id}
 			isActive={activeThread === thread.id}
 			key={thread.id}
+			onHoverCardOpenChange={(open) =>
+				setHoverCardThreadId((current) =>
+					open ? thread.id : current === thread.id ? null : current,
+				)
+			}
 			onCancelRename={cancelRenameThread}
 			onClick={() => openThread(thread.id)}
 			onCommitRename={() => void commitRenameThread(thread)}
@@ -661,38 +559,6 @@ export function AgentSidebar({
 			unread={unreadSessionIds.has(thread.id)}
 		/>
 	);
-	const timeShowMoreButton = (
-		<Button
-			// `pl-0!`: the default button size adds
-			// `has-[>svg]:px-3`, and that modifier beats a plain
-			// `pl-0` on specificity, so the icon child was
-			// re-indenting the row.
-			className="pl-0!"
-			disabled={isLoadingMore}
-			onClick={() => {
-				// Raising the page size is enough: the page-fill effect fetches
-				// older history whenever loaded tasks cannot fill the page. An
-				// explicit click also retries after a failed fetch halted it.
-				pageFillFailedRef.current = false;
-				setShowMoreCount(showMoreCount + INITIAL_VISIBLE_THREAD_COUNT);
-			}}
-			type="button"
-			variant="sidebarText"
-		>
-			{isLoadingMore ? (
-				<>
-					<Loader2 className="size-3 animate-spin" />
-					Loading...
-				</>
-			) : (
-				<div className="ml-2 flex items-center gap-1">
-					Show more
-					<ChevronDown className="size-3" />
-				</div>
-			)}
-		</Button>
-	);
-
 	return (
 		<>
 			<div className="flex h-full min-h-0 w-full min-w-0 shrink-0 flex-col overflow-hidden bg-sidebar text-sidebar-foreground">
@@ -830,7 +696,11 @@ export function AgentSidebar({
 						className="mt-1 flex shrink-0 flex-col gap-0.5 px-2"
 					>
 						<Button
+							aria-current={newTaskActive ? "page" : undefined}
 							aria-label="New"
+							className={cn(
+								newTaskActive && "bg-surface-hover text-sidebar-foreground",
+							)}
 							onClick={openHome}
 							title="Start a new task"
 							type="button"
@@ -863,7 +733,7 @@ export function AgentSidebar({
 									).includes(settingsSection) &&
 									"bg-surface-hover text-sidebar-foreground",
 							)}
-							onClick={() => openSettingsSection("Plugins")}
+							onClick={() => openSettingsSection("Customize")}
 							title="Customize Cline with plugins, rules, and more"
 							type="button"
 							variant="sidebarItem"
@@ -915,157 +785,102 @@ export function AgentSidebar({
 									onClick={openSessions}
 									type="button"
 								>
-									{sortMode === "time" ? "Sessions" : "Projects"}
+									Sessions
 								</button>
 								<div className="flex shrink-0 items-center gap-0.5">
-									{sortMenu}
 									{filterMenu}
 								</div>
 							</div>
 						</div>
 
-						<div className="mt-1 min-h-0 w-full flex-1">
-							<ScrollArea className="h-full min-h-0 w-full min-w-0">
+						<div className="relative mt-1 min-h-0 w-full flex-1">
+							<div
+								aria-hidden="true"
+								className={cn(
+									"pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-sidebar via-sidebar/70 to-transparent transition-opacity duration-200",
+									sessionListScrolled ? "opacity-100" : "opacity-0",
+								)}
+							/>
+							<ScrollArea
+								className="h-full min-h-0 w-full min-w-0"
+								onScrollCapture={(event) => {
+									const target = event.target as HTMLElement | null;
+									if (target?.dataset.slot === "scroll-area-viewport") {
+										setSessionListScrolled(target.scrollTop > 0);
+									}
+									setHoverCardThreadId(null);
+								}}
+							>
 								<div className="flex min-w-0 flex-col gap-0.5 pb-3 px-2">
 									{/* Empty-state copy is reserved for a definitive zero-
 									    session answer from the backend: before the first
 									    response (or while a failed fetch is being retried)
 									    "No sessions found" would read as lost history. */}
 									{!hasLoadedHistory && threads.length === 0 ? (
-										<div className="p-4 text-xs text-muted-foreground">
+										<div className="p-4 text-sm text-muted-foreground">
 											Loading session history...
 										</div>
 									) : (
 										<>
-											{sortMode === "time" ? (
-												showCategorySections ? (
-													<>
-														{pinnedThreads.length > 0 ? (
-															<CategorySection
-																collapsed={collapsedSections.has("pinned")}
-																count={pinnedThreads.length}
-																label="Pinned"
-																onToggle={() => toggleSection("pinned")}
+											{projectGroups.map((project) => {
+												const visibleCount =
+													projectVisibleCounts[project.id] ??
+													INITIAL_VISIBLE_THREAD_COUNT;
+												return (
+													<ProjectSection
+														collapsed={collapsedProjects.has(project.id)}
+														key={project.id}
+														label={project.label}
+														onToggle={() => toggleProject(project.id)}
+													>
+														{project.threads
+															.slice(0, visibleCount)
+															.map(threadItem)}
+														{project.threads.length > visibleCount ? (
+															<Button
+																className="max-w-full pl-2!"
+																onClick={() => showMoreForProject(project.id)}
+																type="button"
+																variant="sidebarText"
 															>
-																{pinnedThreads.map(threadItem)}
-															</CategorySection>
-														) : null}
-														{scheduledThreads.length > 0 ? (
-															<CategorySection
-																collapsed={collapsedSections.has("scheduled")}
-																count={scheduledThreads.length}
-																label="Scheduled"
-																onToggle={() => toggleSection("scheduled")}
-															>
-																{scheduledThreads
-																	.slice(0, scheduledVisibleCount)
-																	.map(threadItem)}
-																{scheduledThreads.length >
-																scheduledVisibleCount ? (
-																	<Button
-																		className="pl-0!"
-																		onClick={() =>
-																			setScheduledVisibleCount(
-																				(current) =>
-																					current +
-																					INITIAL_VISIBLE_THREAD_COUNT,
-																			)
-																		}
-																		type="button"
-																		variant="sidebarText"
-																	>
-																		<div className="ml-2 flex items-center gap-1">
-																			Show more
-																			<ChevronDown className="size-3" />
-																		</div>
-																	</Button>
-																) : null}
-															</CategorySection>
-														) : null}
-														{taskThreads.length > 0 || showTimeShowMore ? (
-															<CategorySection
-																collapsed={collapsedSections.has("tasks")}
-																count={taskThreads.length}
-																label="Tasks"
-																onToggle={() => toggleSection("tasks")}
-															>
-																{taskThreads
-																	.slice(0, showMoreCount)
-																	.map(threadItem)}
-																{showTimeShowMore ? timeShowMoreButton : null}
-															</CategorySection>
-														) : null}
-													</>
-												) : (
-													taskThreads.slice(0, showMoreCount).map(threadItem)
-												)
-											) : (
-												projectGroups.map((project) => {
-													const visibleCount =
-														projectVisibleCounts[project.id] ??
-														INITIAL_VISIBLE_THREAD_COUNT;
-													return (
-														<ProjectSection
-															collapsed={collapsedProjects.has(project.id)}
-															key={project.id}
-															label={project.label}
-															onToggle={() => toggleProject(project.id)}
-														>
-															{project.threads
-																.slice(0, visibleCount)
-																.map(threadItem)}
-															{project.threads.length > visibleCount ? (
-																<Button
-																	className="pl-2!"
-																	onClick={() => showMoreForProject(project.id)}
-																	type="button"
-																	variant="sidebarText"
-																>
+																<span className="min-w-0 truncate">
 																	Show more in {project.label}
-																	<ChevronDown className="size-3" />
-																</Button>
-															) : null}
-														</ProjectSection>
-													);
-												})
-											)}
+																</span>
+																<ChevronDown className="size-3" />
+															</Button>
+														) : null}
+													</ProjectSection>
+												);
+											})}
 
-											{(sortMode === "time"
-												? filteredThreads.length === 0
-												: projectGroups.length === 0) && (
-												<div className="px-2 py-4 text-xs text-muted-foreground">
+											{projectGroups.length === 0 && (
+												<div className="px-2 py-4 text-sm text-muted-foreground">
 													No sessions found in history.
 												</div>
 											)}
 										</>
 									)}
-									{sortMode === "time" &&
-										!showCategorySections &&
-										showTimeShowMore &&
-										timeShowMoreButton}
-									{sortMode === "project" &&
-										filter === "All" &&
-										mayHaveMoreSessions && (
-											<Button
-												className="pl-0!"
-												disabled={isLoadingMore}
-												onClick={() => void loadOlderSessions()}
-												type="button"
-												variant="sidebarText"
-											>
-												{isLoadingMore ? (
-													<>
-														<Loader2 className="size-3 animate-spin" />
-														Loading older projects...
-													</>
-												) : (
-													<>
-														Load older projects
-														<ChevronDown className="size-3" />
-													</>
-												)}
-											</Button>
-										)}
+									{filter === "All" && mayHaveMoreSessions && (
+										<Button
+											className="px-2!"
+											disabled={isLoadingMore}
+											onClick={() => void loadOlderSessions()}
+											type="button"
+											variant="sidebarText"
+										>
+											{isLoadingMore ? (
+												<>
+													<Loader2 className="size-3 animate-spin" />
+													Loading...
+												</>
+											) : (
+												<>
+													Show more
+													<ChevronDown className="size-3" />
+												</>
+											)}
+										</Button>
+									)}
 								</div>
 							</ScrollArea>
 						</div>
@@ -1111,11 +926,8 @@ export function AgentSidebar({
 								className={cn(
 									"size-9 shrink-0 justify-center px-0",
 									view === "settings" &&
-										(settingsSection !== "Account"
-											? "bg-surface-hover text-sidebar-foreground"
-											: // Clicking the gear is a no-op while the Account (profile)
-												// screen is open, so don't hint interactivity on hover.
-												"hover:bg-transparent hover:text-muted-foreground"),
+										settingsSection !== "Account" &&
+										"bg-surface-hover text-sidebar-foreground",
 								)}
 								onClick={openSettings}
 								title="Settings"
@@ -1223,44 +1035,6 @@ export function AgentSidebar({
 	);
 }
 
-function CategorySection({
-	label,
-	count,
-	collapsed,
-	onToggle,
-	children,
-}: {
-	label: string;
-	count: number;
-	collapsed: boolean;
-	onToggle: () => void;
-	children: ReactNode;
-}) {
-	return (
-		<div className="mb-1 min-w-0">
-			<button
-				aria-expanded={!collapsed}
-				className="flex h-7 w-full min-w-0 items-center gap-1 rounded-md px-1 text-left text-xs font-medium text-muted-foreground hover:bg-surface-hover-lighter hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
-				onClick={onToggle}
-				title={label}
-				type="button"
-			>
-				<ChevronDown
-					className={cn(
-						"size-3 shrink-0 transition-transform",
-						collapsed && "-rotate-90",
-					)}
-				/>
-				<span className="block min-w-0 truncate">{label}</span>
-				<span className="ml-auto pr-1 text-[10px] tabular-nums">{count}</span>
-			</button>
-			{!collapsed ? (
-				<div className="flex min-w-0 flex-col gap-0.5">{children}</div>
-			) : null}
-		</div>
-	);
-}
-
 function ProjectSection({
 	label,
 	collapsed,
@@ -1298,8 +1072,10 @@ function ThreadItem({
 	thread,
 	editTitle,
 	editing,
+	hoverCardOpen,
 	isActive,
 	onClick,
+	onHoverCardOpenChange,
 	onCancelRename,
 	onCommitRename,
 	onEditTitleChange,
@@ -1313,8 +1089,10 @@ function ThreadItem({
 	thread: Thread;
 	editTitle: string;
 	editing: boolean;
+	hoverCardOpen: boolean;
 	isActive: boolean;
 	onClick: () => void;
+	onHoverCardOpenChange: (open: boolean) => void;
 	onCancelRename: () => void;
 	onCommitRename: () => void;
 	onEditTitleChange: (title: string) => void;
@@ -1363,7 +1141,12 @@ function ThreadItem({
 
 	return (
 		<ContextMenu>
-			<HoverCard openDelay={0} closeDelay={100}>
+			<HoverCard
+				closeDelay={100}
+				onOpenChange={onHoverCardOpenChange}
+				open={hoverCardOpen}
+				openDelay={0}
+			>
 				<ContextMenuTrigger asChild>
 					<HoverCardTrigger asChild>
 						<button
@@ -1380,14 +1163,18 @@ function ThreadItem({
 							<span className="block max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
 								{title}
 							</span>
-							<span className="flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-								{thread.pinned ? (
-									<Pin aria-label="Pinned" className="size-3 fill-current" />
-								) : statusDotClass ? (
+							<span className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
+								{statusDotClass ? (
 									<span
 										aria-hidden="true"
 										className={cn("size-1.5 rounded-full", statusDotClass)}
 									/>
+								) : null}
+								{thread.isScheduled ? (
+									<Clock3 aria-label="Scheduled" className="size-3" />
+								) : null}
+								{thread.pinned ? (
+									<Pin aria-label="Pinned" className="size-3 fill-current" />
 								) : null}
 								<span>{thread.time}</span>
 							</span>

--- a/apps/examples/desktop-app/webview/components/ui/button.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/button.tsx
@@ -24,13 +24,15 @@ const buttonVariants = cva(
 				sidebarItem:
 					"!h-auto w-full justify-start text-left gap-2 rounded-md !px-2 py-2 !text-sm font-medium text-muted-foreground hover:bg-surface-hover hover:text-sidebar-foreground",
 				sidebarText:
-					"!h-auto justify-start gap-1 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-sidebar-foreground",
+					"!h-auto justify-start gap-1 px-3 py-1.5 !text-sm font-normal text-muted-foreground hover:text-sidebar-foreground",
 				text: "bg-transparent text-sm font-medium text-muted-foreground hover:text-foreground",
 			},
 			size: {
 				default: "h-9 px-4 py-2 has-[>svg]:pl-2 has-[>svg]:pr-2.5 text-base",
 				sm: "h-8 gap-1.5 px-2.5 py-1.5 has-[>svg]:pl-2.5 has-[>svg]:pr-3 text-sm",
-				xs: "h-7 gap-1.5 px-2.5 py-1.5 has-[>svg]:size-3 text-xs",
+				// (has-[>svg]:size-3 was a leftover from when xs was a 12px micro
+				// button; it collapsed any xs button containing an icon.)
+				xs: "h-7 gap-1.5 px-2.5 py-1.5 has-[>svg]:px-2 text-xs",
 				lg: "h-10 rounded-md px-6 has-[>svg]:px-4 text-lg",
 				icon: "size-5",
 				"icon-sm": "size-3 p-1",

--- a/apps/examples/desktop-app/webview/components/ui/sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/sidebar.tsx
@@ -33,7 +33,9 @@ const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 const SIDEBAR_WIDTH_COOKIE_NAME = "sidebar_width";
-const SIDEBAR_MIN_WIDTH = 224;
+// Floor keeps session rows legible: below this the thread titles are fully
+// truncated away and row metadata (timestamps, pins) starts clipping.
+const SIDEBAR_MIN_WIDTH = 260;
 const SIDEBAR_MAX_WIDTH = 560;
 
 function clampSidebarWidth(value: number): number {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -903,14 +903,11 @@ describe("ChatInputBar", () => {
 		expect(promptInput?.parentElement?.className).toContain("items-start");
 		expect(promptInput?.parentElement?.contains(sendTrigger)).toBe(true);
 		expect(promptInput?.parentElement?.contains(stopTrigger)).toBe(true);
-		expect(promptInput?.parentElement?.contains(speechTrigger)).toBe(true);
+		// The mic button is hidden for now (SHOW_VOICE_INPUT_BUTTON).
+		expect(speechTrigger).toBeNull();
 		expect(sendTrigger?.parentElement?.className).toContain("self-end");
 		expect(rightControls?.contains(sendTrigger)).toBe(false);
-		expect(rightControls?.contains(speechTrigger ?? null)).toBe(false);
-		expect(speechTrigger?.parentElement?.nextElementSibling).toBe(sendTrigger);
 		expect(leftControls?.parentElement).toBe(rightControls?.parentElement);
-		await act(async () => speechTrigger?.click());
-		expect(onOpenVoiceInputSettings).toHaveBeenCalledOnce();
 	});
 
 	it("selects High from the supported model thinking menu", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -40,6 +40,7 @@ import {
 	readModelSelectionStorageFromWindow,
 	writeModelSelectionStorageToWindow,
 } from "@/lib/model-selection";
+import { subscribeToPromptInputFocus } from "@/lib/prompt-input-focus";
 import { normalizeProviderId } from "@/lib/provider-id";
 import {
 	loadProviderModelCatalog,
@@ -50,6 +51,7 @@ import {
 } from "@/lib/provider-model-catalog";
 import type { ProviderModel } from "@/lib/provider-schema";
 import { cn } from "@/lib/utils";
+
 import { startVercelStreamingTranscription } from "@/lib/vercel-streaming-transcription";
 import { MAX_RECORDED_AUDIO_BYTES } from "@/lib/voice-input-limits";
 import { WorkspaceSelector as WorkspaceSelectorImpl } from "./workspace-selector";
@@ -344,7 +346,6 @@ function ChatInputBarImpl({
 	onSteerPromptInQueue,
 	onEditPromptInQueue,
 	onRemovePromptInQueue,
-	onOpenVoiceInputSettings,
 	summary,
 }: ChatInputBarProps) {
 	const {
@@ -362,6 +363,15 @@ function ChatInputBarImpl({
 	const latestDraftVersionRef = useRef(promptDraft.version);
 	latestDraftVersionRef.current = promptDraft.version;
 	const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
+	// The sidebar's "New" action asks the prompt input to grab focus through a
+	// window event (see lib/prompt-input-focus.ts).
+	useEffect(
+		() =>
+			subscribeToPromptInputFocus(() => {
+				promptInputRef.current?.focus();
+			}),
+		[],
+	);
 	const batchTranscriptSessionRef = useRef<{
 		start: number;
 		end: number;
@@ -1293,44 +1303,34 @@ function ChatInputBarImpl({
 									<CircleStop className="size-3" />
 								</button>
 							)}
-							<SpeechInput
-								allowUnavailableClick={!transcriptionTarget}
-								key={
-									transcriptionTarget
-										? `${transcriptionTarget.providerId}:${transcriptionTarget.modelId}:${transcriptionTarget.supportsStreaming ? "streaming" : "auto"}`
-										: "unconfigured"
-								}
-								onActiveChange={handleSpeechInputActiveChange}
-								onAudioRecorded={handleAudioRecorded}
-								onClick={(event) => {
-									if (!transcriptionTarget) {
-										event.preventDefault();
-										onOpenVoiceInputSettings?.();
+							{/* The mic button only appears once a voice model is
+							    configured in Settings → Voice; unconfigured users
+							    don't get a dead control. */}
+							{transcriptionTarget ? (
+								<SpeechInput
+									key={`${transcriptionTarget.providerId}:${transcriptionTarget.modelId}:${transcriptionTarget.supportsStreaming ? "streaming" : "auto"}`}
+									onActiveChange={handleSpeechInputActiveChange}
+									onAudioRecorded={handleAudioRecorded}
+									onError={handleSpeechInputError}
+									onProcessingChange={setSpeechInputProcessing}
+									onStartStreaming={
+										transcriptionTarget.supportsStreaming
+											? handleStartStreamingTranscription
+											: undefined
 									}
-								}}
-								onError={handleSpeechInputError}
-								onProcessingChange={setSpeechInputProcessing}
-								onStartStreaming={
-									transcriptionTarget?.supportsStreaming
-										? handleStartStreamingTranscription
-										: undefined
-								}
-								onStreamingEnd={handleStreamingTranscriptionEnd}
-								onStreamingStart={handleStreamingTranscriptionStart}
-								onTranscriptionChange={
-									transcriptionTarget?.supportsStreaming
-										? undefined
-										: handleTranscriptionChange
-								}
-								recordingMode={
-									transcriptionTarget?.supportsStreaming ? "streaming" : "auto"
-								}
-								title={
-									transcriptionTarget
-										? `${transcriptionTarget.supportsStreaming ? "Transcribe live" : "Transcribe"} with ${transcriptionTarget.providerName} / ${transcriptionTarget.modelName}`
-										: "Configure voice input in Settings → Voice"
-								}
-							/>
+									onStreamingEnd={handleStreamingTranscriptionEnd}
+									onStreamingStart={handleStreamingTranscriptionStart}
+									onTranscriptionChange={
+										transcriptionTarget.supportsStreaming
+											? undefined
+											: handleTranscriptionChange
+									}
+									recordingMode={
+										transcriptionTarget.supportsStreaming ? "streaming" : "auto"
+									}
+									title={`${transcriptionTarget.supportsStreaming ? "Transcribe live" : "Transcribe"} with ${transcriptionTarget.providerName} / ${transcriptionTarget.modelName}`}
+								/>
+							) : null}
 							{(!isBusy || canSend) && (
 								<button
 									aria-label="Send message"

--- a/apps/examples/desktop-app/webview/components/views/marketplace-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-view.tsx
@@ -1007,22 +1007,17 @@ export function MarketplaceView({
 						/>
 					))}
 				</div>
-				<div className="flex min-h-8 shrink-0 items-center gap-2 text-sm text-muted-foreground">
-					<span className="font-medium text-foreground">
-						{catalogEntries.length}
-					</span>
-					<span>{catalogEntries.length === 1 ? "result" : "results"}</span>
-					{selectedTag ? (
-						<Button
-							onClick={() => setSelectedTag(null)}
-							size="sm"
-							type="button"
-							variant="ghost"
-						>
-							Clear filters
-						</Button>
-					) : null}
-				</div>
+				{selectedTag ? (
+					<Button
+						className="shrink-0 self-start md:self-auto"
+						onClick={() => setSelectedTag(null)}
+						size="sm"
+						type="button"
+						variant="ghost"
+					>
+						Clear filters
+					</Button>
+				) : null}
 			</div>
 		) : null;
 
@@ -1219,7 +1214,7 @@ export function MarketplaceView({
 							onToggleExpanded={toggleExpanded}
 							onUninstall={uninstallEntry}
 							tagLabels={tagLabels}
-							title={variant === "directory" ? undefined : "Marketplace"}
+							title={variant === "directory" ? undefined : "Browse"}
 						/>
 					) : null}
 				</div>

--- a/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/account-view.tsx
@@ -24,12 +24,12 @@ import {
 	UserCircleIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAccount } from "@/contexts/account-context";
 import { isClineAccountNotAuthenticatedResult } from "@/lib/cline-account-state";
 import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import { invalidateProviderCatalogCache } from "@/lib/provider-model-catalog";
 import { cn } from "@/lib/utils";
+import { PageFrame, PageHeader } from "../page-layout";
 
 const DASHBOARD_URL = "https://app.cline.bot/dashboard";
 const USAGE_DASHBOARD_URL = "https://app.cline.bot/dashboard/usage";
@@ -554,12 +554,11 @@ export function AccountView() {
 	);
 
 	return (
-		<ScrollArea className="h-full">
-			<div className="mx-auto max-w-3xl px-8 py-6">
-				{/* Header */}
-				<div className="mb-6 flex items-center justify-between">
-					<h2 className="text-2xl font-semibold text-foreground">Account</h2>
-					{user && (
+		<PageFrame contentClassName="max-w-3xl">
+			<PageHeader
+				title="Account"
+				actions={
+					user ? (
 						<button
 							type="button"
 							disabled={accountActionPending !== null}
@@ -567,284 +566,284 @@ export function AccountView() {
 							className="flex items-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-medium text-muted-foreground hover:bg-surface-hover hover:text-foreground disabled:opacity-60"
 						>
 							{accountActionPending === "sign-out" ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
+								<Loader2 className="size-4 animate-spin" />
 							) : (
-								<LogOut className="h-4 w-4" />
+								<LogOut className="size-4" />
 							)}
 							{accountActionPending === "sign-out" ? "Signing Out" : "Sign Out"}
 						</button>
-					)}
-				</div>
+					) : undefined
+				}
+			/>
 
-				{/* Tabs */}
-				<div className="mb-6 flex items-center gap-0 border-b border-border">
-					{tabs.map((tab) => {
-						const disabled = !user && tab !== "overview";
-						return (
-							<button
-								key={tab}
-								type="button"
-								disabled={disabled}
-								onClick={() => setActiveTab(tab)}
-								className={cn(
-									"relative px-4 py-2.5 text-sm font-medium capitalize transition-colors",
-									activeTab === tab
-										? "text-foreground"
-										: "text-muted-foreground hover:text-foreground",
-									disabled &&
-										"cursor-not-allowed opacity-45 hover:text-muted-foreground",
-								)}
-							>
-								{tab}
-								{activeTab === tab && (
-									<span className="absolute inset-x-0 -bottom-px h-0.5 bg-foreground" />
-								)}
-							</button>
-						);
-					})}
-				</div>
+			{/* Tabs */}
+			<div className="mb-6 flex items-center gap-0 border-b border-border">
+				{tabs.map((tab) => {
+					const disabled = !user && tab !== "overview";
+					return (
+						<button
+							key={tab}
+							type="button"
+							disabled={disabled}
+							onClick={() => setActiveTab(tab)}
+							className={cn(
+								"relative px-4 py-2.5 text-sm font-medium capitalize transition-colors",
+								activeTab === tab
+									? "text-foreground"
+									: "text-muted-foreground hover:text-foreground",
+								disabled &&
+									"cursor-not-allowed opacity-45 hover:text-muted-foreground",
+							)}
+						>
+							{tab}
+							{activeTab === tab && (
+								<span className="absolute inset-x-0 -bottom-px h-0.5 bg-foreground" />
+							)}
+						</button>
+					);
+				})}
+			</div>
 
-				{/* Overview Tab */}
-				{activeTab === "overview" && (
-					<div className="flex flex-col gap-6">
-						{overviewLoading && renderLoading()}
-						{!overviewLoading && signedOut && renderSignedOut()}
-						{overviewError && renderError(overviewError, loadOverview)}
-						{!overviewLoading && !signedOut && !overviewError && user && (
-							<>
-								{/* User Profile Card */}
-								<div className="rounded-lg border border-border p-5">
-									<div className="flex items-start gap-4">
-										<div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-(--accent-a3) text-2xl font-bold text-primary">
-											{user.displayName?.charAt(0) ??
-												user.email?.charAt(0) ??
-												"?"}
-										</div>
-										<div className="min-w-0 flex-1">
-											<h3 className="text-lg font-semibold text-foreground">
-												{user.displayName || user.email}
-											</h3>
-											<p className="mt-0.5 text-sm text-muted-foreground">
-												{user.email}
-											</p>
-											<p className="mt-2 text-xs text-muted-foreground">
-												Member since {formatDate(user.createdAt)}
-											</p>
-										</div>
-										<button
-											type="button"
-											title="Open dashboard"
-											onClick={() => void openExternalUrl(DASHBOARD_URL)}
-											className="rounded-md p-1.5 text-muted-foreground hover:bg-surface-hover hover:text-foreground"
-										>
-											<ExternalLink className="h-4 w-4" />
-										</button>
+			{/* Overview Tab */}
+			{activeTab === "overview" && (
+				<div className="flex flex-col gap-6">
+					{overviewLoading && renderLoading()}
+					{!overviewLoading && signedOut && renderSignedOut()}
+					{overviewError && renderError(overviewError, loadOverview)}
+					{!overviewLoading && !signedOut && !overviewError && user && (
+						<>
+							{/* User Profile Card */}
+							<div className="rounded-lg border border-border p-5">
+								<div className="flex items-start gap-4">
+									<div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-(--accent-a3) text-2xl font-bold text-primary">
+										{user.displayName?.charAt(0) ??
+											user.email?.charAt(0) ??
+											"?"}
 									</div>
+									<div className="min-w-0 flex-1">
+										<h3 className="text-lg font-semibold text-foreground">
+											{user.displayName || user.email}
+										</h3>
+										<p className="mt-0.5 text-sm text-muted-foreground">
+											{user.email}
+										</p>
+										<p className="mt-2 text-xs text-muted-foreground">
+											Member since {formatDate(user.createdAt)}
+										</p>
+									</div>
+									<button
+										type="button"
+										title="Open dashboard"
+										onClick={() => void openExternalUrl(DASHBOARD_URL)}
+										className="rounded-md p-1.5 text-muted-foreground hover:bg-surface-hover hover:text-foreground"
+									>
+										<ExternalLink className="h-4 w-4" />
+									</button>
 								</div>
+							</div>
 
-								{/* Balance Card */}
-								{displayedBalance !== null && (
-									<div className="rounded-lg border border-border p-5">
-										<div className="flex items-center justify-between mb-4">
-											<div className="flex items-center gap-3">
-												<CreditCard className="h-5 w-5 text-primary" />
-												<h3 className="text-sm font-semibold text-foreground">
-													{activeOrganization
-														? `${activeOrganization.name} Balance`
-														: "Credits Balance"}
-												</h3>
-											</div>
-											<button
-												type="button"
-												onClick={() =>
-													void openExternalUrl(
-														activeOrganization
-															? ORGANIZATION_CREDITS_URL
-															: USER_CREDITS_URL,
-													)
-												}
-												className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-surface-hover hover:text-foreground transition-colors"
-											>
-												<Plus className="h-3.5 w-3.5" />
-												Credit
-											</button>
-										</div>
-										<div className="flex items-baseline gap-2">
-											<span className="text-3xl font-bold text-foreground">
-												${formatCreditBalance(displayedBalance)}
-											</span>
-										</div>
-										{activeOrganization && balance && (
-											<p className="mt-2 text-xs text-muted-foreground">
-												Personal account: {formatCreditBalance(balance.balance)}{" "}
-												credits
-											</p>
-										)}
-									</div>
-								)}
-
-								{/* Organizations */}
+							{/* Balance Card */}
+							{displayedBalance !== null && (
 								<div className="rounded-lg border border-border p-5">
 									<div className="flex items-center justify-between mb-4">
 										<div className="flex items-center gap-3">
-											<Building className="h-5 w-5 text-muted-foreground" />
+											<CreditCard className="h-5 w-5 text-primary" />
 											<h3 className="text-sm font-semibold text-foreground">
-												Organizations
+												{activeOrganization
+													? `${activeOrganization.name} Balance`
+													: "Credits Balance"}
 											</h3>
 										</div>
 										<button
 											type="button"
 											onClick={() =>
-												void openExternalUrl(CREATE_ORGANIZATION_URL)
+												void openExternalUrl(
+													activeOrganization
+														? ORGANIZATION_CREDITS_URL
+														: USER_CREDITS_URL,
+												)
 											}
-											className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-surface-hover hover:text-foreground "
+											className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-surface-hover hover:text-foreground transition-colors"
 										>
 											<Plus className="h-3.5 w-3.5" />
-											Create
+											Credit
 										</button>
 									</div>
-									<div className="flex flex-col gap-2">
-										{renderAccountRow({
-											key: "personal",
-											name: "Personal",
-											subtitle: user.email ?? "Personal account",
-											icon: <User className="h-4 w-4" />,
-											active: !activeOrganization,
-											switching: switchTargetId === "",
-											onSelect: () => void switchAccount(null),
-										})}
-										{organizations.map((org) =>
-											renderAccountRow({
-												key: org.organizationId,
-												name: org.name,
-												subtitle: org.roles.join(", "),
-												icon: org.name.charAt(0),
-												active: org.active,
-												switching: switchTargetId === org.organizationId,
-												onSelect: () => void switchAccount(org.organizationId),
-											}),
-										)}
+									<div className="flex items-baseline gap-2">
+										<span className="text-3xl font-bold text-foreground">
+											${formatCreditBalance(displayedBalance)}
+										</span>
 									</div>
+									{activeOrganization && balance && (
+										<p className="mt-2 text-xs text-muted-foreground">
+											Personal account: {formatCreditBalance(balance.balance)}{" "}
+											credits
+										</p>
+									)}
 								</div>
-							</>
-						)}
-					</div>
-				)}
+							)}
 
-				{/* Usage Tab */}
-				{activeTab === "usage" && (
-					<div>
-						<p className="mb-6 text-sm text-muted-foreground">
-							{activeOrganization
-								? `Recent API usage and token consumption for ${activeOrganization.name}.`
-								: "Recent API usage and token consumption across all providers."}
-						</p>
-						{usageLoading && renderLoading()}
-						{usageError && renderError(usageError, loadUsage)}
-						{!usageLoading && !usageError && usageLoaded && (
-							<div className="overflow-hidden rounded-lg border border-border">
-								<div className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
-									<span>Model</span>
-									<span className="text-right">Tokens</span>
-									<span className="text-right">Credits</span>
-									<span className="text-right">Time</span>
-								</div>
-								{usageTransactions.length === 0 ? (
-									<p className="px-4 py-8 text-center text-sm text-muted-foreground">
-										No usage transactions yet.
-									</p>
-								) : (
-									<div className="divide-y divide-border">
-										{usageTransactions.map((tx) => (
-											<div
-												key={tx.id}
-												className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
-											>
-												<div className="min-w-0">
-													<p className="font-medium text-foreground truncate">
-														{tx.aiModelName}
-													</p>
-													<p className="text-xs text-muted-foreground">
-														{tx.aiInferenceProviderName}
-													</p>
-												</div>
-												<div className="text-right text-muted-foreground">
-													{tx.totalTokens.toLocaleString()}
-												</div>
-												<div className="text-right text-foreground font-medium">
-													{formatCreditBalance(tx.creditsUsed)}
-												</div>
-												<div className="text-right text-xs text-muted-foreground">
-													<p>{formatDate(tx.createdAt)}</p>
-													<p>{formatTime(tx.createdAt)}</p>
-												</div>
-											</div>
-										))}
+							{/* Organizations */}
+							<div className="rounded-lg border border-border p-5">
+								<div className="flex items-center justify-between mb-4">
+									<div className="flex items-center gap-3">
+										<Building className="h-5 w-5 text-muted-foreground" />
+										<h3 className="text-sm font-semibold text-foreground">
+											Organizations
+										</h3>
 									</div>
-								)}
-								<div className="flex justify-center border-t border-border px-4 py-3">
 									<button
 										type="button"
-										onClick={() => void openExternalUrl(USAGE_DASHBOARD_URL)}
-										className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+										onClick={() =>
+											void openExternalUrl(CREATE_ORGANIZATION_URL)
+										}
+										className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-surface-hover hover:text-foreground "
 									>
-										See More
-										<ExternalLink className="h-3.5 w-3.5" />
+										<Plus className="h-3.5 w-3.5" />
+										Create
 									</button>
 								</div>
+								<div className="flex flex-col gap-2">
+									{renderAccountRow({
+										key: "personal",
+										name: "Personal",
+										subtitle: user.email ?? "Personal account",
+										icon: <User className="h-4 w-4" />,
+										active: !activeOrganization,
+										switching: switchTargetId === "",
+										onSelect: () => void switchAccount(null),
+									})}
+									{organizations.map((org) =>
+										renderAccountRow({
+											key: org.organizationId,
+											name: org.name,
+											subtitle: org.roles.join(", "),
+											icon: org.name.charAt(0),
+											active: org.active,
+											switching: switchTargetId === org.organizationId,
+											onSelect: () => void switchAccount(org.organizationId),
+										}),
+									)}
+								</div>
 							</div>
-						)}
-					</div>
-				)}
+						</>
+					)}
+				</div>
+			)}
 
-				{/* Billing Tab */}
-				{activeTab === "billing" && (
-					<div>
-						<p className="mb-6 text-sm text-muted-foreground">
-							Payment history and credit purchases.
-						</p>
-						{billingLoading && renderLoading()}
-						{billingError && renderError(billingError, loadBilling)}
-						{!billingLoading &&
-							!billingError &&
-							billingLoaded &&
-							(paymentTransactions.length === 0 ? (
-								<p className="py-8 text-center text-sm text-muted-foreground">
-									No payment transactions yet.
+			{/* Usage Tab */}
+			{activeTab === "usage" && (
+				<div>
+					<p className="mb-6 text-sm text-muted-foreground">
+						{activeOrganization
+							? `Recent API usage and token consumption for ${activeOrganization.name}.`
+							: "Recent API usage and token consumption across all providers."}
+					</p>
+					{usageLoading && renderLoading()}
+					{usageError && renderError(usageError, loadUsage)}
+					{!usageLoading && !usageError && usageLoaded && (
+						<div className="overflow-hidden rounded-lg border border-border">
+							<div className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
+								<span>Model</span>
+								<span className="text-right">Tokens</span>
+								<span className="text-right">Credits</span>
+								<span className="text-right">Time</span>
+							</div>
+							{usageTransactions.length === 0 ? (
+								<p className="px-4 py-8 text-center text-sm text-muted-foreground">
+									No usage transactions yet.
 								</p>
 							) : (
-								<div className="rounded-lg border border-border overflow-hidden">
-									<div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
-										<span>Date</span>
-										<span className="text-right">Amount</span>
-										<span className="text-right">Credits</span>
-									</div>
-									<div className="divide-y divide-border">
-										{paymentTransactions.map((tx) => (
-											<div
-												key={`${tx.paidAt}-${tx.amountCents}-${tx.credits}`}
-												className="grid grid-cols-[1fr_auto_auto] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
-											>
-												<div className="flex items-center gap-3">
-													<Receipt className="h-4 w-4 text-muted-foreground" />
-													<span className="text-foreground">
-														{formatDate(tx.paidAt)}
-													</span>
-												</div>
-												<div className="text-right text-foreground font-medium">
-													${(tx.amountCents / 100).toFixed(2)}
-												</div>
-												<div className="text-right text-primary font-medium">
-													+{formatCreditBalance(tx.credits)}
-												</div>
+								<div className="divide-y divide-border">
+									{usageTransactions.map((tx) => (
+										<div
+											key={tx.id}
+											className="grid grid-cols-[minmax(0,1fr)_5.5rem_4.5rem_5.5rem] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
+										>
+											<div className="min-w-0">
+												<p className="font-medium text-foreground truncate">
+													{tx.aiModelName}
+												</p>
+												<p className="text-xs text-muted-foreground">
+													{tx.aiInferenceProviderName}
+												</p>
 											</div>
-										))}
-									</div>
+											<div className="text-right text-muted-foreground">
+												{tx.totalTokens.toLocaleString()}
+											</div>
+											<div className="text-right text-foreground font-medium">
+												{formatCreditBalance(tx.creditsUsed)}
+											</div>
+											<div className="text-right text-xs text-muted-foreground">
+												<p>{formatDate(tx.createdAt)}</p>
+												<p>{formatTime(tx.createdAt)}</p>
+											</div>
+										</div>
+									))}
 								</div>
-							))}
-					</div>
-				)}
-			</div>
-		</ScrollArea>
+							)}
+							<div className="flex justify-center border-t border-border px-4 py-3">
+								<button
+									type="button"
+									onClick={() => void openExternalUrl(USAGE_DASHBOARD_URL)}
+									className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+								>
+									See More
+									<ExternalLink className="h-3.5 w-3.5" />
+								</button>
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Billing Tab */}
+			{activeTab === "billing" && (
+				<div>
+					<p className="mb-6 text-sm text-muted-foreground">
+						Payment history and credit purchases.
+					</p>
+					{billingLoading && renderLoading()}
+					{billingError && renderError(billingError, loadBilling)}
+					{!billingLoading &&
+						!billingError &&
+						billingLoaded &&
+						(paymentTransactions.length === 0 ? (
+							<p className="py-8 text-center text-sm text-muted-foreground">
+								No payment transactions yet.
+							</p>
+						) : (
+							<div className="rounded-lg border border-border overflow-hidden">
+								<div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-border bg-secondary/50 px-4 py-2.5 text-xs font-medium text-muted-foreground">
+									<span>Date</span>
+									<span className="text-right">Amount</span>
+									<span className="text-right">Credits</span>
+								</div>
+								<div className="divide-y divide-border">
+									{paymentTransactions.map((tx) => (
+										<div
+											key={`${tx.paidAt}-${tx.amountCents}-${tx.credits}`}
+											className="grid grid-cols-[1fr_auto_auto] gap-4 px-4 py-3 text-sm hover:bg-surface-hover"
+										>
+											<div className="flex items-center gap-3">
+												<Receipt className="h-4 w-4 text-muted-foreground" />
+												<span className="text-foreground">
+													{formatDate(tx.paidAt)}
+												</span>
+											</div>
+											<div className="text-right text-foreground font-medium">
+												${(tx.amountCents / 100).toFixed(2)}
+											</div>
+											<div className="text-right text-primary font-medium">
+												+{formatCreditBalance(tx.credits)}
+											</div>
+										</div>
+									))}
+								</div>
+							</div>
+						))}
+				</div>
+			)}
+		</PageFrame>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/settings/add-provider.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/add-provider.tsx
@@ -53,10 +53,13 @@ interface NewProviderForm {
 }
 
 export function AddProviderContent({
+	variant = "page",
 	onBack,
 	onSave,
 	existingProviderIds,
 }: {
+	/** "dialog" renders only the form body for use inside a Dialog. */
+	variant?: "page" | "dialog";
 	onBack: () => void;
 	onSave: (payload: AddProviderPayload) => Promise<void>;
 	existingProviderIds: string[];
@@ -180,6 +183,290 @@ export function AddProviderContent({
 		}
 	};
 
+	const content = (
+		<div className="flex flex-col gap-6">
+			<div className="rounded-lg border border-border p-5">
+				<h3 className="mb-4 text-sm font-semibold text-foreground">
+					OpenAI-Compatible Provider
+				</h3>
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div>
+						<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+							Provider ID
+						</Label>
+						<input
+							type="text"
+							value={form.providerId}
+							onChange={(e) =>
+								setForm((prev) => ({ ...prev, providerId: e.target.value }))
+							}
+							placeholder="my-provider"
+							className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+						/>
+						<p className="mt-1.5 text-xs text-muted-foreground">
+							Lowercase ID used in provider registry.
+						</p>
+						{duplicateProviderId ? (
+							<p className="mt-1 text-xs text-destructive">
+								This provider ID already exists.
+							</p>
+						) : null}
+					</div>
+					<div>
+						<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+							Provider Name
+						</Label>
+						<input
+							type="text"
+							value={form.name}
+							onChange={(e) =>
+								setForm((prev) => ({ ...prev, name: e.target.value }))
+							}
+							placeholder="My Provider"
+							className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div className="rounded-lg border border-border p-5">
+				<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+					Base URL
+				</Label>
+				<input
+					type="url"
+					value={form.baseUrl}
+					onChange={(e) =>
+						setForm((prev) => ({ ...prev, baseUrl: e.target.value }))
+					}
+					placeholder="https://api.example.com/v1"
+					className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+				/>
+			</div>
+
+			<div className="rounded-lg border border-border p-5">
+				<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+					Model Source URL (Optional)
+				</Label>
+				<input
+					type="url"
+					value={form.modelsSourceUrl}
+					onChange={(e) =>
+						setForm((prev) => ({
+							...prev,
+							modelsSourceUrl: e.target.value,
+						}))
+					}
+					placeholder="https://api.example.com/v1/models"
+					className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+				/>
+				<p className="mt-1.5 text-xs text-muted-foreground">
+					Supported JSON: OpenAI `/models` shape with a `data` array, or a
+					direct model array.
+				</p>
+			</div>
+
+			<div className="rounded-lg border border-border p-5">
+				<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+					Models
+				</Label>
+				<ModelIdInput models={form.models} onChange={updateModels} />
+				<p className="mt-1.5 text-xs text-muted-foreground">
+					Add at least one model or set a Model Source URL.
+				</p>
+			</div>
+
+			{form.models.length > 1 ? (
+				<div className="rounded-lg border border-border p-5">
+					<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+						Default Model
+					</Label>
+					<select
+						value={form.defaultModel}
+						onChange={(e) =>
+							setForm((prev) => ({ ...prev, defaultModel: e.target.value }))
+						}
+						className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+					>
+						{form.models.map((model) => (
+							<option key={model} value={model}>
+								{model}
+							</option>
+						))}
+					</select>
+				</div>
+			) : null}
+
+			<div className="rounded-lg border border-border p-5">
+				<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+					API Key (Optional)
+				</Label>
+				<div className="relative">
+					<input
+						type={showApiKey ? "text" : "password"}
+						value={form.apiKey}
+						onChange={(e) =>
+							setForm((prev) => ({ ...prev, apiKey: e.target.value }))
+						}
+						placeholder="sk-..."
+						className="w-full rounded-lg border border-border bg-input px-3 py-2 pr-20 font-mono text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+					/>
+					<div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+						<Button
+							onClick={() => setShowApiKey(!showApiKey)}
+							variant="ghost"
+							className="rounded-md p-1 transition-colors"
+							aria-label={showApiKey ? "Hide API key" : "Show API key"}
+						>
+							{showApiKey ? (
+								<EyeOff className="h-4 w-4" />
+							) : (
+								<Eye className="h-4 w-4" />
+							)}
+						</Button>
+						<Button
+							onClick={() => navigator.clipboard.writeText(form.apiKey)}
+							variant="ghost"
+							className="rounded-md p-1 transition-colors"
+							aria-label="Copy API key"
+						>
+							<Copy className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			</div>
+
+			<div className="rounded-lg border border-border p-5">
+				<Label className="mb-3 block text-xs font-medium text-muted-foreground">
+					Capabilities
+				</Label>
+				<div className="flex flex-wrap gap-2">
+					{CAPABILITY_OPTIONS.map((cap) => (
+						<Button
+							key={cap}
+							onClick={() => toggleCapability(cap)}
+							className={cn(
+								"rounded-lg border px-3 py-1.5 text-xs font-medium transition-all",
+								form.capabilities.includes(cap)
+									? "border-primary/40 bg-primary/10 text-primary"
+									: "border-border bg-card text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground",
+							)}
+						>
+							{cap.replace(/-/g, " ")}
+						</Button>
+					))}
+				</div>
+			</div>
+
+			<div className="rounded-lg border border-border overflow-hidden">
+				<Button
+					onClick={() => setShowAdvanced(!showAdvanced)}
+					className="flex w-full items-center justify-between px-5 py-4 text-sm font-medium transition-colors text-foreground/40"
+					variant="ghost"
+				>
+					Advanced Settings
+					<ChevronDown
+						className={cn(
+							"h-4 w-4 text-muted-foreground transition-transform",
+							showAdvanced && "rotate-180",
+						)}
+					/>
+				</Button>
+
+				{showAdvanced ? (
+					<div className="border-t border-border px-5 py-5 flex flex-col gap-5">
+						<div>
+							<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+								Timeout (ms)
+							</Label>
+							<input
+								type="number"
+								value={form.timeoutMs}
+								onChange={(e) =>
+									setForm((prev) => ({
+										...prev,
+										timeoutMs: e.target.value,
+									}))
+								}
+								placeholder="30000"
+								className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+							/>
+						</div>
+
+						<div>
+							<Label className="mb-2 block text-xs font-medium text-muted-foreground">
+								Custom Headers
+							</Label>
+							<div className="flex flex-col gap-2">
+								{Object.entries(form.headers).map(([key, value], idx) => (
+									<div key={key} className="flex items-center gap-2">
+										<input
+											type="text"
+											value={key}
+											onChange={(e) =>
+												updateHeaderKey(key, e.target.value, idx)
+											}
+											placeholder="Header name"
+											className="flex-1 rounded-lg border border-border bg-input px-3 py-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+										/>
+										<input
+											type="text"
+											value={value}
+											onChange={(e) => updateHeaderValue(key, e.target.value)}
+											placeholder="Value"
+											className="flex-1 rounded-lg border border-border bg-input px-3 py-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+										/>
+										<Button
+											onClick={() => removeHeader(key)}
+											className="rounded-md p-2 text-muted-foreground hover:text-destructive transition-colors"
+											aria-label="Remove header"
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									</div>
+								))}
+								<Button
+									onClick={addHeader}
+									className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium hover:text-foreground transition-colors w-fit"
+								>
+									<Plus className="h-3 w-3" />
+									Add Header
+								</Button>
+							</div>
+						</div>
+					</div>
+				) : null}
+			</div>
+
+			{error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+			<div className="flex items-center justify-end gap-3 pt-2">
+				<Button
+					onClick={onBack}
+					className="rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-surface-hover hover:text-foreground"
+				>
+					Cancel
+				</Button>
+				<Button
+					onClick={() => void handleSave()}
+					disabled={!canSave || saving}
+					className={cn(
+						"rounded-lg px-4 py-2 text-sm font-medium",
+						canSave && !saving
+							? "bg-primary hover:bg-primary/90"
+							: "bg-muted cursor-not-allowed text-foreground",
+					)}
+				>
+					{saving ? "Saving..." : "Add Provider"}
+				</Button>
+			</div>
+		</div>
+	);
+
+	if (variant === "dialog") {
+		return content;
+	}
+
 	return (
 		<PageFrame contentClassName="max-w-4xl">
 			<PageHeader
@@ -192,289 +479,12 @@ export function AddProviderContent({
 						className="rounded-md p-1.5"
 						aria-label="Back to providers"
 					>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowLeft className="size-4" />
 						Providers
 					</Button>
 				}
 			/>
-
-			<div className="flex flex-col gap-6">
-				<div className="rounded-lg border border-border p-5">
-					<h3 className="mb-4 text-sm font-semibold text-foreground">
-						OpenAI-Compatible Provider
-					</h3>
-					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<div>
-							<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-								Provider ID
-							</Label>
-							<input
-								type="text"
-								value={form.providerId}
-								onChange={(e) =>
-									setForm((prev) => ({ ...prev, providerId: e.target.value }))
-								}
-								placeholder="my-provider"
-								className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-							/>
-							<p className="mt-1.5 text-xs text-muted-foreground">
-								Lowercase ID used in provider registry.
-							</p>
-							{duplicateProviderId ? (
-								<p className="mt-1 text-xs text-destructive">
-									This provider ID already exists.
-								</p>
-							) : null}
-						</div>
-						<div>
-							<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-								Provider Name
-							</Label>
-							<input
-								type="text"
-								value={form.name}
-								onChange={(e) =>
-									setForm((prev) => ({ ...prev, name: e.target.value }))
-								}
-								placeholder="My Provider"
-								className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-							/>
-						</div>
-					</div>
-				</div>
-
-				<div className="rounded-lg border border-border p-5">
-					<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-						Base URL
-					</Label>
-					<input
-						type="url"
-						value={form.baseUrl}
-						onChange={(e) =>
-							setForm((prev) => ({ ...prev, baseUrl: e.target.value }))
-						}
-						placeholder="https://api.example.com/v1"
-						className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-					/>
-				</div>
-
-				<div className="rounded-lg border border-border p-5">
-					<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-						Model Source URL (Optional)
-					</Label>
-					<input
-						type="url"
-						value={form.modelsSourceUrl}
-						onChange={(e) =>
-							setForm((prev) => ({
-								...prev,
-								modelsSourceUrl: e.target.value,
-							}))
-						}
-						placeholder="https://api.example.com/v1/models"
-						className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-					/>
-					<p className="mt-1.5 text-xs text-muted-foreground">
-						Supported JSON: OpenAI `/models` shape with a `data` array, or a
-						direct model array.
-					</p>
-				</div>
-
-				<div className="rounded-lg border border-border p-5">
-					<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-						Models
-					</Label>
-					<ModelIdInput models={form.models} onChange={updateModels} />
-					<p className="mt-1.5 text-xs text-muted-foreground">
-						Add at least one model or set a Model Source URL.
-					</p>
-				</div>
-
-				{form.models.length > 1 ? (
-					<div className="rounded-lg border border-border p-5">
-						<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-							Default Model
-						</Label>
-						<select
-							value={form.defaultModel}
-							onChange={(e) =>
-								setForm((prev) => ({ ...prev, defaultModel: e.target.value }))
-							}
-							className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
-						>
-							{form.models.map((model) => (
-								<option key={model} value={model}>
-									{model}
-								</option>
-							))}
-						</select>
-					</div>
-				) : null}
-
-				<div className="rounded-lg border border-border p-5">
-					<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-						API Key (Optional)
-					</Label>
-					<div className="relative">
-						<input
-							type={showApiKey ? "text" : "password"}
-							value={form.apiKey}
-							onChange={(e) =>
-								setForm((prev) => ({ ...prev, apiKey: e.target.value }))
-							}
-							placeholder="sk-..."
-							className="w-full rounded-lg border border-border bg-input px-3 py-2 pr-20 font-mono text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-						/>
-						<div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-							<Button
-								onClick={() => setShowApiKey(!showApiKey)}
-								variant="ghost"
-								className="rounded-md p-1 transition-colors"
-								aria-label={showApiKey ? "Hide API key" : "Show API key"}
-							>
-								{showApiKey ? (
-									<EyeOff className="h-4 w-4" />
-								) : (
-									<Eye className="h-4 w-4" />
-								)}
-							</Button>
-							<Button
-								onClick={() => navigator.clipboard.writeText(form.apiKey)}
-								variant="ghost"
-								className="rounded-md p-1 transition-colors"
-								aria-label="Copy API key"
-							>
-								<Copy className="h-4 w-4" />
-							</Button>
-						</div>
-					</div>
-				</div>
-
-				<div className="rounded-lg border border-border p-5">
-					<Label className="mb-3 block text-xs font-medium text-muted-foreground">
-						Capabilities
-					</Label>
-					<div className="flex flex-wrap gap-2">
-						{CAPABILITY_OPTIONS.map((cap) => (
-							<Button
-								key={cap}
-								onClick={() => toggleCapability(cap)}
-								className={cn(
-									"rounded-lg border px-3 py-1.5 text-xs font-medium transition-all",
-									form.capabilities.includes(cap)
-										? "border-primary/40 bg-primary/10 text-primary"
-										: "border-border bg-card text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground",
-								)}
-							>
-								{cap.replace(/-/g, " ")}
-							</Button>
-						))}
-					</div>
-				</div>
-
-				<div className="rounded-lg border border-border overflow-hidden">
-					<Button
-						onClick={() => setShowAdvanced(!showAdvanced)}
-						className="flex w-full items-center justify-between px-5 py-4 text-sm font-medium transition-colors text-foreground/40"
-						variant="ghost"
-					>
-						Advanced Settings
-						<ChevronDown
-							className={cn(
-								"h-4 w-4 text-muted-foreground transition-transform",
-								showAdvanced && "rotate-180",
-							)}
-						/>
-					</Button>
-
-					{showAdvanced ? (
-						<div className="border-t border-border px-5 py-5 flex flex-col gap-5">
-							<div>
-								<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-									Timeout (ms)
-								</Label>
-								<input
-									type="number"
-									value={form.timeoutMs}
-									onChange={(e) =>
-										setForm((prev) => ({
-											...prev,
-											timeoutMs: e.target.value,
-										}))
-									}
-									placeholder="30000"
-									className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-								/>
-							</div>
-
-							<div>
-								<Label className="mb-2 block text-xs font-medium text-muted-foreground">
-									Custom Headers
-								</Label>
-								<div className="flex flex-col gap-2">
-									{Object.entries(form.headers).map(([key, value], idx) => (
-										<div key={key} className="flex items-center gap-2">
-											<input
-												type="text"
-												value={key}
-												onChange={(e) =>
-													updateHeaderKey(key, e.target.value, idx)
-												}
-												placeholder="Header name"
-												className="flex-1 rounded-lg border border-border bg-input px-3 py-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-											/>
-											<input
-												type="text"
-												value={value}
-												onChange={(e) => updateHeaderValue(key, e.target.value)}
-												placeholder="Value"
-												className="flex-1 rounded-lg border border-border bg-input px-3 py-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-											/>
-											<Button
-												onClick={() => removeHeader(key)}
-												className="rounded-md p-2 text-muted-foreground hover:text-destructive transition-colors"
-												aria-label="Remove header"
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									))}
-									<Button
-										onClick={addHeader}
-										className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium hover:text-foreground transition-colors w-fit"
-									>
-										<Plus className="h-3 w-3" />
-										Add Header
-									</Button>
-								</div>
-							</div>
-						</div>
-					) : null}
-				</div>
-
-				{error ? <p className="text-sm text-destructive">{error}</p> : null}
-
-				<div className="flex items-center justify-end gap-3 pt-2">
-					<Button
-						onClick={onBack}
-						className="rounded-lg border border-border px-4 py-2 text-sm font-medium hover:bg-surface-hover hover:text-foreground"
-					>
-						Cancel
-					</Button>
-					<Button
-						onClick={() => void handleSave()}
-						disabled={!canSave || saving}
-						className={cn(
-							"rounded-lg px-4 py-2 text-sm font-medium",
-							canSave && !saving
-								? "bg-primary hover:bg-primary/90"
-								: "bg-muted cursor-not-allowed text-foreground",
-						)}
-					>
-						{saving ? "Saving..." : "Add Provider"}
-					</Button>
-				</div>
-			</div>
+			{content}
 		</PageFrame>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Store } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { desktopClient } from "@/lib/desktop-client";
@@ -10,25 +9,33 @@ import { CustomizationSectionView } from "./extensions-view";
 import { McpServersContent } from "./mcp-view";
 
 /**
- * Unified Plugins hub: one page for everything installed (plugins, MCP
- * servers, skills) with sub-tabs and live counts. The "Browse Marketplace"
- * button navigates to the dedicated Marketplace settings page.
+ * Unified Customize hub: one page for everything that extends Cline —
+ * skills, MCP servers, plugins, rules, hooks, and tools — as sub-tabs with
+ * live counts. Tabs with a marketplace catalog (skills, MCP, plugins) show
+ * installed items followed by an inline browsable marketplace section, so
+ * there is no separate Marketplace page.
  */
 
-type PluginsHubTab = "plugins" | "mcp" | "skills";
+type CustomizeTab = "skills" | "mcp" | "plugins" | "rules" | "hooks" | "tools";
 
-const HUB_TABS: { id: PluginsHubTab; label: string }[] = [
-	{ id: "plugins", label: "Plugins" },
-	{ id: "mcp", label: "MCP" },
+const CUSTOMIZE_TABS: { id: CustomizeTab; label: string }[] = [
 	{ id: "skills", label: "Skills" },
+	{ id: "mcp", label: "MCP" },
+	{ id: "plugins", label: "Plugins" },
+	{ id: "rules", label: "Rules" },
+	{ id: "hooks", label: "Hooks" },
+	{ id: "tools", label: "Tools" },
 ];
 
-type HubCounts = Partial<Record<PluginsHubTab, number>>;
+type TabCounts = Partial<Record<CustomizeTab, number>>;
 
 type HubInventoryResponse = {
 	plugins?: unknown[];
 	skills?: unknown[];
 	workflows?: unknown[];
+	rules?: unknown[];
+	hooks?: unknown[];
+	tools?: unknown[];
 	mcp?: { servers?: unknown[] };
 };
 
@@ -36,13 +43,9 @@ function asCount(value: unknown): number {
 	return Array.isArray(value) ? value.length : 0;
 }
 
-export function PluginsHubView({
-	onOpenMarketplace,
-}: {
-	onOpenMarketplace?: () => void;
-}) {
-	const [tab, setTab] = useState<PluginsHubTab>("plugins");
-	const [counts, setCounts] = useState<HubCounts>({});
+export function CustomizeView() {
+	const [tab, setTab] = useState<CustomizeTab>("skills");
+	const [counts, setCounts] = useState<TabCounts>({});
 
 	const refreshCounts = useCallback(async () => {
 		const inventory = await desktopClient
@@ -52,9 +55,12 @@ export function PluginsHubView({
 			return;
 		}
 		setCounts({
-			plugins: asCount(inventory.plugins),
 			skills: asCount(inventory.skills) + asCount(inventory.workflows),
 			mcp: asCount(inventory.mcp?.servers),
+			plugins: asCount(inventory.plugins),
+			rules: asCount(inventory.rules),
+			hooks: asCount(inventory.hooks),
+			tools: asCount(inventory.tools),
 		});
 	}, []);
 
@@ -72,22 +78,14 @@ export function PluginsHubView({
 	return (
 		<PageFrame>
 			<PageHeader
-				description="Manage installed plugins, MCP servers, and skills. Browse the marketplace to install more."
-				title="Plugins"
-				actions={
-					onOpenMarketplace ? (
-						<Button onClick={onOpenMarketplace} type="button" variant="outline">
-							<Store className="size-4" />
-							Browse Marketplace
-						</Button>
-					) : undefined
-				}
+				description="Extend what Cline can do and change how it works. Manage what's installed and browse the marketplace for more options."
+				title="Customize"
 			/>
 
 			<div className="mb-6 flex items-center gap-0 border-b border-border">
-				{HUB_TABS.map((hubTab) => {
-					const count = counts[hubTab.id];
-					const active = tab === hubTab.id;
+				{CUSTOMIZE_TABS.map((customizeTab) => {
+					const count = counts[customizeTab.id];
+					const active = tab === customizeTab.id;
 					return (
 						<Button
 							aria-current={active ? "page" : undefined}
@@ -97,12 +95,12 @@ export function PluginsHubView({
 									? "text-foreground"
 									: "text-muted-foreground hover:text-foreground",
 							)}
-							key={hubTab.id}
-							onClick={() => setTab(hubTab.id)}
+							key={customizeTab.id}
+							onClick={() => setTab(customizeTab.id)}
 							type="button"
 							variant="ghost"
 						>
-							{hubTab.label}
+							{customizeTab.label}
 							{typeof count === "number" ? (
 								<span
 									className={cn(
@@ -123,26 +121,44 @@ export function PluginsHubView({
 				})}
 			</div>
 
-			{tab === "plugins" ? (
+			{tab === "skills" ? (
 				<CustomizationSectionView
-					catalogPrimitive="plugin"
+					catalogPrimitive="skill"
 					chrome="embedded"
-					marketplaceVariant="installed"
+					marketplaceVariant="full"
 					onInventoryChanged={handleInventoryChanged}
-					section="Plugins"
+					section="Skills"
 				/>
 			) : tab === "mcp" ? (
 				<McpServersContent
 					chrome="embedded"
 					onInventoryChanged={handleInventoryChanged}
 				/>
+			) : tab === "plugins" ? (
+				<CustomizationSectionView
+					catalogPrimitive="plugin"
+					chrome="embedded"
+					marketplaceVariant="full"
+					onInventoryChanged={handleInventoryChanged}
+					section="Plugins"
+				/>
+			) : tab === "rules" ? (
+				<CustomizationSectionView
+					chrome="embedded"
+					onInventoryChanged={handleInventoryChanged}
+					section="Rules"
+				/>
+			) : tab === "hooks" ? (
+				<CustomizationSectionView
+					chrome="embedded"
+					onInventoryChanged={handleInventoryChanged}
+					section="Hooks"
+				/>
 			) : (
 				<CustomizationSectionView
-					catalogPrimitive="skill"
 					chrome="embedded"
-					marketplaceVariant="installed"
 					onInventoryChanged={handleInventoryChanged}
-					section="Skills"
+					section="Tools"
 				/>
 			)}
 		</PageFrame>

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -7,6 +7,7 @@ import {
 	FileText,
 	MoreVertical,
 	Play,
+	Puzzle,
 	RefreshCw,
 	Server,
 	Trash2,
@@ -907,25 +908,23 @@ export function CustomizationSectionView({
 		);
 	};
 
-	const renderLocalActionRow = (target: LocalUninstallTarget) => {
+	// Sized and styled to match the Install/Uninstall button on marketplace
+	// entry cards so installed rows and browse rows read as one list.
+	const renderLocalActionButton = (target: LocalUninstallTarget) => {
 		const uninstalling = localUninstallingKeys.has(target.key);
 		return (
-			<div className="flex flex-wrap items-center justify-between gap-3">
-				<div className="min-h-5 text-xs text-muted-foreground">
-					{renderLocalActionMessage(target.key)}
-				</div>
-				<Button
-					disabled={uninstalling}
-					onClick={() => {
-						void uninstallLocalPrimitive(target);
-					}}
-					type="button"
-					variant="destructive"
-				>
-					{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
-					{uninstalling ? "Uninstalling..." : "Uninstall"}
-				</Button>
-			</div>
+			<Button
+				disabled={uninstalling}
+				onClick={() => {
+					void uninstallLocalPrimitive(target);
+				}}
+				size="xs"
+				type="button"
+				variant="destructive"
+			>
+				{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
+				{uninstalling ? "Uninstalling..." : "Uninstall"}
+			</Button>
 		);
 	};
 
@@ -973,14 +972,26 @@ export function CustomizationSectionView({
 	) => {
 		const key = `${item.type}:${item.path}`;
 		return (
-			<div key={key} className="rounded-lg border border-border px-5 py-4">
-				<div className="flex items-center gap-3">
+			<div
+				key={key}
+				className="relative grid min-w-0 gap-2 rounded-lg border bg-card p-4"
+			>
+				<div className="absolute top-4 right-4">
+					{renderLocalActionButton({
+						key,
+						type: item.type,
+						id: item.id,
+						name: item.name,
+						path: item.path,
+					})}
+				</div>
+				<div className="flex min-w-0 items-center gap-2 pr-28">
 					{item.type === "workflow" ? (
 						<Play className="h-4 w-4 shrink-0 text-primary" />
 					) : (
 						<Zap className="h-4 w-4 shrink-0 text-primary" />
 					)}
-					<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+					<h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
 						{item.name}
 					</h3>
 					<ScopeBadge scope={item.scope} />
@@ -993,26 +1004,16 @@ export function CustomizationSectionView({
 						</Badge>
 					) : null}
 				</div>
-				<p className="mt-2 ml-7 text-xs text-muted-foreground">
+				<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 					{item.description?.trim() || previewText(item.instructions)}
 				</p>
-				<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
+				<p className="truncate text-xs font-mono text-muted-foreground">
 					{item.path}
 				</p>
 				{context?.matchedEntries?.length ? (
-					<div className="mt-2 ml-7">
-						<MarketplaceEntrySetupDetails entries={context.matchedEntries} />
-					</div>
+					<MarketplaceEntrySetupDetails entries={context.matchedEntries} />
 				) : null}
-				<div className="mt-3">
-					{renderLocalActionRow({
-						key,
-						type: item.type,
-						id: item.id,
-						name: item.name,
-						path: item.path,
-					})}
-				</div>
+				{renderLocalActionMessage(key)}
 			</div>
 		);
 	};
@@ -1049,12 +1050,10 @@ export function CustomizationSectionView({
 			},
 		].filter((group) => group.items.length > 0);
 		return (
-			<details
-				key={plugin.path}
-				className="rounded-lg border border-border px-5 py-4"
-			>
-				<summary className="flex cursor-pointer list-none items-center gap-3">
-					<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+			<details key={plugin.path} className="rounded-lg border bg-card p-4">
+				<summary className="flex cursor-pointer list-none items-center gap-2">
+					<Puzzle className="h-4 w-4 shrink-0 text-primary" />
+					<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 						{plugin.name}
 					</h3>
 					<ScopeBadge scope={scope} />
@@ -1142,11 +1141,19 @@ export function CustomizationSectionView({
 		return (
 			<div
 				key={server.name}
-				className="rounded-lg border border-border px-5 py-4"
+				className="relative grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 			>
-				<div className="flex items-center gap-3">
+				<div className="absolute top-4 right-4">
+					{renderLocalActionButton({
+						key,
+						type: "mcp",
+						id: server.name,
+						name: server.name,
+					})}
+				</div>
+				<div className="flex min-w-0 items-center gap-2 pr-28">
 					<Server className="h-4 w-4 shrink-0 text-primary" />
-					<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+					<h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
 						{server.name}
 					</h3>
 					<ScopeBadge scope="Global" />
@@ -1158,11 +1165,13 @@ export function CustomizationSectionView({
 							Marketplace
 						</Badge>
 					) : null}
-					<span className="text-xs text-muted-foreground">
-						{server.disabled ? "Disabled" : "Enabled"}
-					</span>
+					{server.disabled ? (
+						<Badge variant="outline" className="shrink-0 text-muted-foreground">
+							Disabled
+						</Badge>
+					) : null}
 				</div>
-				<p className="mt-2 ml-7 text-xs text-muted-foreground">
+				<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 					{server.url ??
 						([server.command, ...(server.args ?? [])]
 							.filter(Boolean)
@@ -1170,23 +1179,14 @@ export function CustomizationSectionView({
 							"No launch command configured.")}
 				</p>
 				{mcp.settingsPath ? (
-					<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
+					<p className="truncate text-xs font-mono text-muted-foreground">
 						{mcp.settingsPath}
 					</p>
 				) : null}
 				{context?.matchedEntries?.length ? (
-					<div className="mt-2 ml-7">
-						<MarketplaceEntrySetupDetails entries={context.matchedEntries} />
-					</div>
+					<MarketplaceEntrySetupDetails entries={context.matchedEntries} />
 				) : null}
-				<div className="mt-3">
-					{renderLocalActionRow({
-						key,
-						type: "mcp",
-						id: server.name,
-						name: server.name,
-					})}
-				</div>
+				{renderLocalActionMessage(key)}
 			</div>
 		);
 	};
@@ -1313,11 +1313,6 @@ export function CustomizationSectionView({
 
 			{activeTab === "Rules" && (
 				<div>
-					<p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-						Enabled rules discovered from configured workspace/global
-						directories.
-					</p>
-
 					<div className="grid gap-3">
 						<div className="flex items-center justify-between gap-3">
 							<h3 className="text-base font-semibold text-foreground">
@@ -1331,19 +1326,19 @@ export function CustomizationSectionView({
 							{scopedRules.map(({ rule, scope }) => (
 								<div
 									key={rule.path}
-									className="rounded-lg border border-border px-4 py-3"
+									className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 								>
-									<div className="flex items-center gap-3">
-										<FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-										<span className="flex-1 text-sm font-medium text-foreground">
+									<div className="flex min-w-0 items-center gap-2">
+										<FileText className="h-4 w-4 shrink-0 text-primary" />
+										<span className="min-w-0 truncate text-sm font-semibold text-foreground">
 											{rule.name}
 										</span>
 										<ScopeBadge scope={scope} />
 									</div>
-									<p className="mt-2 text-xs text-muted-foreground">
+									<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 										{previewText(rule.instructions)}
 									</p>
-									<p className="mt-1 text-xs font-mono text-muted-foreground">
+									<p className="truncate text-xs font-mono text-muted-foreground">
 										{rule.path}
 									</p>
 								</div>
@@ -1360,9 +1355,6 @@ export function CustomizationSectionView({
 
 			{activeTab === "Hooks" && (
 				<div>
-					<p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-						Hook config files from workspace and global hook directories.
-					</p>
 					{hookExecutionLoading && hookExecutionSessionId && (
 						<p className="mb-4 text-xs text-muted-foreground">
 							Execution status is based on hook events in session{" "}
@@ -1383,43 +1375,47 @@ export function CustomizationSectionView({
 							{scopedHooks.map(({ hook, scope }) => (
 								<div
 									key={hook.path}
-									className="rounded-lg border border-border px-4 py-3"
+									className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 								>
-									<div className="flex items-center gap-3">
-										<Code className="h-4 w-4 shrink-0 text-muted-foreground" />
-										<span className="flex-1 text-sm font-mono text-foreground">
+									<div className="flex min-w-0 items-center gap-2">
+										<Code className="h-4 w-4 shrink-0 text-primary" />
+										<span className="min-w-0 truncate text-sm font-semibold text-foreground">
 											{hook.fileName}
 										</span>
 										<ScopeBadge scope={scope} />
 										{hook.hookEventName && (
-											<div className="flex items-center gap-2">
-												<span className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground">
+											<>
+												<Badge
+													variant="outline"
+													className="shrink-0 text-muted-foreground"
+												>
 													{hook.hookEventName}
-												</span>
+												</Badge>
 												{(() => {
 													const stats =
 														hookExecutionByEvent[hook.hookEventName];
 													const executed = (stats?.count ?? 0) > 0;
 													return (
-														<span
+														<Badge
+															variant="outline"
 															className={cn(
-																"rounded border px-2 py-0.5 text-xs",
+																"shrink-0",
 																executed
 																	? "border-emerald-400/50 text-emerald-600 dark:text-emerald-400"
-																	: "border-border text-muted-foreground",
+																	: "text-muted-foreground",
 															)}
 														>
 															{executed
 																? `${stats?.count ?? 0} executed`
 																: "never executed"}
-														</span>
+														</Badge>
 													);
 												})()}
-											</div>
+											</>
 										)}
 									</div>
 									{hook.hookEventName ? (
-										<p className="mt-1 text-xs text-muted-foreground">
+										<p className="text-xs leading-5 text-muted-foreground">
 											Last run:{" "}
 											{formatExecutionTs(
 												hookExecutionByEvent[hook.hookEventName]?.lastTs ??
@@ -1427,7 +1423,7 @@ export function CustomizationSectionView({
 											)}
 										</p>
 									) : null}
-									<p className="mt-1 text-xs font-mono text-muted-foreground">
+									<p className="truncate text-xs font-mono text-muted-foreground">
 										{hook.path}
 									</p>
 								</div>
@@ -1659,27 +1655,27 @@ export function CustomizationSectionView({
 
 			{activeTab === "Tools" && (
 				<div>
-					<p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-						Builtin tool groups and plugin-contributed tools available to the
-						runtime.
-					</p>
-
-					<div className="mb-6">
-						<h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							Builtin Tools
-						</h3>
-						<div className="flex flex-col gap-3">
+					<div className="mb-6 grid gap-3">
+						<div className="flex items-center justify-between gap-3">
+							<h3 className="text-base font-semibold text-foreground">
+								Builtin Tools
+							</h3>
+							<span className="text-sm text-muted-foreground">
+								{builtinTools.length}
+							</span>
+						</div>
+						<div className="flex flex-col gap-2">
 							{builtinTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
 										<div
 											key={tool.id}
-											className="rounded-lg border border-border px-5 py-4"
+											className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 										>
-											<div className="flex items-center gap-3">
+											<div className="flex min-w-0 items-center gap-2">
 												<Wrench className="h-4 w-4 shrink-0 text-primary" />
-												<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+												<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 													{tool.name}
 												</h3>
 												<span className="text-xs text-muted-foreground">
@@ -1694,12 +1690,12 @@ export function CustomizationSectionView({
 													aria-label={`Toggle ${tool.name}`}
 												/>
 											</div>
-											<p className="mt-2 ml-7 text-xs text-muted-foreground">
+											<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
 											{!!tool.headlessToolNames?.length && (
-												<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
+												<p className="truncate text-xs font-mono text-muted-foreground">
 													{tool.headlessToolNames.join(", ")}
 												</p>
 											)}
@@ -1715,28 +1711,36 @@ export function CustomizationSectionView({
 						</div>
 					</div>
 
-					<div>
-						<h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							Plugin Tools
-						</h3>
-						<div className="flex flex-col gap-3">
+					<div className="grid gap-3">
+						<div className="flex items-center justify-between gap-3">
+							<h3 className="text-base font-semibold text-foreground">
+								Plugin Tools
+							</h3>
+							<span className="text-sm text-muted-foreground">
+								{pluginTools.length}
+							</span>
+						</div>
+						<div className="flex flex-col gap-2">
 							{pluginTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
 										<div
 											key={tool.id}
-											className="rounded-lg border border-border px-5 py-4"
+											className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 										>
-											<div className="flex items-center gap-3">
+											<div className="flex min-w-0 items-center gap-2">
 												<Wrench className="h-4 w-4 shrink-0 text-primary" />
-												<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+												<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 													{tool.name}
 												</h3>
 												{tool.pluginName && (
-													<span className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground">
-														plugin: {tool.pluginName}
-													</span>
+													<Badge
+														variant="outline"
+														className="shrink-0 text-muted-foreground"
+													>
+														{tool.pluginName}
+													</Badge>
 												)}
 												<span className="text-xs text-muted-foreground">
 													{tool.enabled ? "Enabled" : "Disabled"}
@@ -1750,12 +1754,12 @@ export function CustomizationSectionView({
 													aria-label={`Toggle ${tool.name}`}
 												/>
 											</div>
-											<p className="mt-2 ml-7 text-xs text-muted-foreground">
+											<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
 											{tool.path && (
-												<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
+												<p className="truncate text-xs font-mono text-muted-foreground">
 													{tool.path}
 												</p>
 											)}

--- a/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
@@ -20,6 +20,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Collapsible,
@@ -623,9 +624,9 @@ export function McpServersContent({
 		return (
 			<div
 				key={server.name}
-				className="group relative rounded-lg border border-border px-5 py-4 hover:bg-surface-hover"
+				className="group relative rounded-lg border bg-card p-4 transition-colors hover:bg-surface-hover-lighter"
 			>
-				<div className="flex items-center gap-3">
+				<div className="flex min-w-0 items-center gap-2">
 					<Circle
 						className={cn(
 							"h-2.5 w-2.5 shrink-0",
@@ -634,17 +635,17 @@ export function McpServersContent({
 								: "fill-primary text-primary",
 						)}
 					/>
-					<h3 className="text-sm font-semibold text-foreground">
+					<h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
 						{server.name}
 					</h3>
-					<span className="rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground">
+					<Badge variant="outline" className="shrink-0 text-muted-foreground">
 						{TRANSPORT_TYPE_LABELS[server.transportType] ??
 							server.transportType}
-					</span>
+					</Badge>
 					{context?.matchedEntries?.length ? (
-						<span className="rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground">
+						<Badge variant="outline" className="shrink-0 text-muted-foreground">
 							Marketplace
-						</span>
+						</Badge>
 					) : null}
 					<div className="flex-1" />
 					{renderServerToggle(server)}
@@ -813,7 +814,7 @@ export function McpServersContent({
 				installedItems={installedItems}
 				onInstalledItemsChanged={() => refreshServers()}
 				primitive="mcp"
-				variant={chrome === "embedded" ? "installed" : "full"}
+				variant="full"
 			/>
 			<Dialog
 				open={editorOpen}

--- a/apps/examples/desktop-app/webview/components/views/settings/notification-settings.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/notification-settings.tsx
@@ -83,11 +83,7 @@ export function NotificationSettings() {
 			<span className="shrink-0 text-xs font-medium text-muted-foreground">
 				Allowed by system
 			</span>
-		) : permission === "unsupported" ? (
-			<span className="shrink-0 text-xs text-muted-foreground">
-				Available in the desktop app
-			</span>
-		) : permission === null ? (
+		) : permission === "unsupported" ? null : permission === null ? (
 			<span className="shrink-0 text-xs text-muted-foreground">Checking…</span>
 		) : (
 			<Button
@@ -101,9 +97,13 @@ export function NotificationSettings() {
 			</Button>
 		);
 
+	// One settings section: a top-level header row like the other General
+	// settings, with the per-event matrix nested in a card so its rows read
+	// as children of "Desktop notifications" rather than as siblings of
+	// top-level settings like Dark mode.
 	return (
-		<>
-			<div className="flex items-center justify-between gap-5 border-b py-4 max-[720px]:flex-col max-[720px]:items-stretch">
+		<div className="border-b py-4">
+			<div className="flex items-center justify-between gap-5 max-[720px]:flex-col max-[720px]:items-stretch">
 				<div className="flex flex-col gap-1">
 					<p className="text-base font-semibold text-foreground">
 						Desktop notifications
@@ -120,7 +120,7 @@ export function NotificationSettings() {
 				</div>
 				{permissionControl}
 			</div>
-			<div className="border-b">
+			<div className="mt-4 rounded-lg border bg-card px-4">
 				<div className="grid grid-cols-[minmax(0,1fr)_5rem_4rem] items-center gap-3 border-b py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
 					<span>Event</span>
 					<span className="text-center">Notify</span>
@@ -165,6 +165,6 @@ export function NotificationSettings() {
 					);
 				})}
 			</div>
-		</>
+		</div>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -36,7 +36,10 @@ import {
 	type ProviderAuthKind,
 } from "@/lib/provider-connection";
 import { getProviderApiKeyUrl } from "@/lib/provider-key-urls";
-import { loadProviderModels, supportsAudio } from "@/lib/provider-model-catalog";
+import {
+	loadProviderModels,
+	supportsAudio,
+} from "@/lib/provider-model-catalog";
 import type {
 	Provider,
 	ProviderConfigField,
@@ -45,6 +48,13 @@ import type {
 	ProviderSettingsUpdate,
 } from "@/lib/provider-schema";
 import { cn } from "@/lib/utils";
+
+// Inputs nested inside a composed bordered box (icon + input + buttons in
+// one rounded frame) must strip the Input component's own chrome — border,
+// dark-mode bg tint, shadow, focus ring — or the inner field reads as a
+// mismatched second box inside the frame.
+const EMBEDDED_INPUT_CLASS =
+	"h-7 flex-1 border-0 bg-transparent px-0 text-sm shadow-none outline-none placeholder:text-muted-foreground dark:bg-transparent focus-visible:ring-0";
 
 const FAVORITE_MODELS_STORAGE_KEY = "cline.favorite-provider-models.v1";
 
@@ -327,7 +337,7 @@ export function ProviderListContent({
 						<Search className="size-4 shrink-0 text-muted-foreground" />
 						<Input
 							aria-label="Search model providers"
-							className="h-7 border-0 bg-transparent px-0 text-sm"
+							className={EMBEDDED_INPUT_CLASS}
 							onChange={(event) => setProviderSearch(event.target.value)}
 							placeholder="Search providers"
 							value={providerSearch}
@@ -456,7 +466,7 @@ function ConfigFieldRow({
 						<LinkIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
 					) : null}
 					<Input
-						className="h-7 flex-1 border-0 bg-transparent px-0 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+						className={EMBEDDED_INPUT_CLASS}
 						onBlur={() => onCommit(valueText)}
 						onChange={(event) => onDraftChange(event.target.value)}
 						placeholder={field.placeholder}
@@ -831,7 +841,9 @@ export function ProviderDetailContent({
 									/>
 								</Button>
 								{manualKeyExpanded ? (
-									<div className="mt-1">{renderConfigFieldRow(apiKeyField)}</div>
+									<div className="mt-1">
+										{renderConfigFieldRow(apiKeyField)}
+									</div>
 								) : null}
 							</div>
 						) : null}
@@ -877,7 +889,9 @@ export function ProviderDetailContent({
 		) : (
 			<section className={cn("mb-8", isPanel ? "max-w-none" : "max-w-344")}>
 				{configFields.length > 0 ? (
-					<div className="flex flex-col">{configFields.map(renderConfigFieldRow)}</div>
+					<div className="flex flex-col">
+						{configFields.map(renderConfigFieldRow)}
+					</div>
 				) : null}
 				<div className="mt-4 flex items-center justify-between gap-4">
 					{connected ? (
@@ -901,8 +915,8 @@ export function ProviderDetailContent({
 						<>
 							<p className="text-xs text-muted-foreground">
 								Saving an API key configures this provider automatically. Use
-								Connect if it reads credentials from your environment or a
-								local endpoint.
+								Connect if it reads credentials from your environment or a local
+								endpoint.
 							</p>
 							{onConnect ? (
 								<Button
@@ -929,22 +943,18 @@ export function ProviderDetailContent({
 					isPanel ? "px-6" : "px-18 max-[1200px]:px-8",
 				)}
 			>
-				{/* Back + title */}
+				{/* Back + title (the panel variant is always open, so no close button) */}
 				<div className="mb-8 flex items-center gap-3">
-					<Button
-						aria-label={
-							isPanel ? "Close provider details" : "Back to providers"
-						}
-						className="rounded-md p-1.5 text-muted-foreground hover:bg-surface-hover hover:text-foreground "
-						onClick={onBack}
-						variant="ghost"
-					>
-						{isPanel ? (
-							<X className="h-4 w-4" />
-						) : (
-							<ArrowLeft className="h-4 w-4" />
-						)}
-					</Button>
+					{isPanel ? null : (
+						<Button
+							aria-label="Back to providers"
+							className="rounded-md p-1.5 text-muted-foreground hover:bg-surface-hover hover:text-foreground "
+							onClick={onBack}
+							variant="ghost"
+						>
+							<ArrowLeft className="size-4" />
+						</Button>
+					)}
 					<h1
 						className={cn(
 							"min-w-0 flex-1 truncate font-semibold leading-[1.15] text-foreground",
@@ -1041,11 +1051,11 @@ export function ProviderDetailContent({
 					) : null}
 					{modelList.length > 0 ? (
 						<div className="space-y-3">
-							<div className="mx-4 mt-4 flex items-center gap-2 rounded border border-border bg-background px-3 py-2">
+							<div className="mx-4 mt-4 flex h-9 items-center gap-2 rounded border bg-background px-3">
 								<Search className="size-4 shrink-0 text-muted-foreground" />
 								<Input
 									aria-label="Search models"
-									className="h-7 flex-1 border-0 text-sm text-foreground placeholder:text-muted-foreground"
+									className={EMBEDDED_INPUT_CLASS}
 									onChange={(event) =>
 										setModelSearchState({
 											providerId: provider.id,
@@ -1058,7 +1068,7 @@ export function ProviderDetailContent({
 								/>
 							</div>
 							{filteredModelList.length > 0 ? (
-								<div className="max-h-125 overflow-y-scroll border-t">
+								<div className="border-t">
 									{filteredModelList.map((model) => (
 										<div
 											className="group flex min-h-16 items-center gap-3 border-b px-4 py-3 hover:bg-surface-hover-lighter"

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -1115,8 +1115,8 @@ export function RoutineSchedulesContent({
 	return (
 		<PageFrame>
 			<PageHeader
-				description="Scheduled jobs are run through the hub."
-				title="Schedules"
+				description="Run agents on cron schedules for recurring automations like daily summaries and code reviews."
+				title="Schedule"
 				meta={<CommandBadge>cline schedule</CommandBadge>}
 				actions={
 					<>

--- a/apps/examples/desktop-app/webview/components/views/settings/sections.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/sections.ts
@@ -14,17 +14,10 @@ const ALL_SETTINGS_SECTIONS = [
 	"Account",
 ] as const;
 
-// Mirrors the Cline Hub dashboard's Customizations nav group. Plugins is the
-// unified hub for installed plugins, MCP servers, and skills; Marketplace is
-// the full catalog page for installing more.
-const ALL_CUSTOMIZATION_SECTIONS = [
-	"Plugins",
-	"Marketplace",
-	"Hooks",
-	"Rules",
-	"Agents",
-	"Tools",
-] as const;
+// Customize is the unified hub for everything that extends Cline — skills,
+// MCP servers, plugins, rules, hooks, and tools — each as a sub-tab with
+// inline marketplace browsing where a catalog exists.
+const ALL_CUSTOMIZATION_SECTIONS = ["Customize"] as const;
 
 export type SettingsSection =
 	| (typeof ALL_SETTINGS_SECTIONS)[number]
@@ -32,10 +25,7 @@ export type SettingsSection =
 
 // Temporarily hidden from the sidebar. The views and routes still exist —
 // remove a section from this set to surface it again.
-const HIDDEN_SECTIONS: ReadonlySet<SettingsSection> = new Set([
-	"Channels",
-	"Agents",
-]);
+const HIDDEN_SECTIONS: ReadonlySet<SettingsSection> = new Set(["Channels"]);
 
 export const SETTINGS_SECTIONS = ALL_SETTINGS_SECTIONS.filter(
 	(section) => !HIDDEN_SECTIONS.has(section),

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -3,6 +3,13 @@ import { Minus, Plus, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { isBetaVersion, productNameForVersion } from "@/lib/app-channel";
@@ -25,7 +32,10 @@ import {
 } from "@/lib/app-icon";
 import { desktopClient } from "@/lib/desktop-client";
 import { resetOnboarding } from "@/lib/onboarding";
-import { getProviderAuthKind } from "@/lib/provider-connection";
+import {
+	getProviderAuthKind,
+	isProviderConnected,
+} from "@/lib/provider-connection";
 import {
 	fetchProviderCatalog,
 	invalidateProviderCatalogCache,
@@ -49,17 +59,12 @@ import {
 	setStoredHubTheme,
 } from "@/lib/theme";
 import { cn } from "@/lib/utils";
-import { MarketplaceView } from "../marketplace-view";
 import { PageFrame, PageHeader } from "../page-layout";
 import { AccountView } from "./account-view";
 import { AddProviderContent, type AddProviderPayload } from "./add-provider";
 import { ChannelsContent } from "./channels-view";
-import {
-	CustomizationSectionView,
-	invalidateExtensionInventoryCache,
-} from "./extensions-view";
+import { CustomizeView } from "./customize-view";
 import { NotificationSettings } from "./notification-settings";
-import { PluginsHubView } from "./plugins-hub-view";
 import {
 	ProviderDetailContent,
 	ProviderListContent,
@@ -384,8 +389,15 @@ export function SettingsView({
 		[loadProviderModels],
 	);
 
-	const selectedProvider = selectedProviderId
-		? (providers.find((p) => p.id === selectedProviderId) ?? null)
+	// The detail panel is always open: with no explicit selection, default to
+	// the first connected provider (the one in use), then the first provider.
+	const effectiveSelectedProviderId =
+		selectedProviderId ??
+		providers.find(isProviderConnected)?.id ??
+		providers[0]?.id ??
+		null;
+	const selectedProvider = effectiveSelectedProviderId
+		? (providers.find((p) => p.id === effectiveSelectedProviderId) ?? null)
 		: null;
 
 	const usesOAuth = (provider: Provider) =>
@@ -430,14 +442,14 @@ export function SettingsView({
 	};
 
 	useEffect(() => {
-		if (!selectedProviderId) {
+		if (!effectiveSelectedProviderId) {
 			return;
 		}
 		const timeoutId = window.setTimeout(() => {
-			void loadProviderModels(selectedProviderId);
+			void loadProviderModels(effectiveSelectedProviderId);
 		}, 0);
 		return () => window.clearTimeout(timeoutId);
-	}, [loadProviderModels, selectedProviderId]);
+	}, [loadProviderModels, effectiveSelectedProviderId]);
 
 	const backToProviderList = () => {
 		onNavigateSection("Models");
@@ -469,17 +481,36 @@ export function SettingsView({
 
 	const openAddProvider = () => {
 		onNavigateSection("Models");
-		setSelectedProviderId(null);
 		setAddingProvider(true);
 	};
 
-	const providerContent = addingProvider ? (
-		<AddProviderContent
-			existingProviderIds={providers.map((provider) => provider.id)}
-			onBack={backToProviderList}
-			onSave={saveNewProvider}
-		/>
-	) : providersLoading ? (
+	const addProviderDialog = (
+		<Dialog
+			onOpenChange={(open) => {
+				if (!open) {
+					setAddingProvider(false);
+				}
+			}}
+			open={addingProvider}
+		>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+				<DialogHeader>
+					<DialogTitle>Add Provider</DialogTitle>
+					<DialogDescription>
+						Add an OpenAI-compatible provider and choose its available models.
+					</DialogDescription>
+				</DialogHeader>
+				<AddProviderContent
+					existingProviderIds={providers.map((provider) => provider.id)}
+					onBack={() => setAddingProvider(false)}
+					onSave={saveNewProvider}
+					variant="dialog"
+				/>
+			</DialogContent>
+		</Dialog>
+	);
+
+	const providerContent = providersLoading ? (
 		<div className="flex h-full items-center justify-center">
 			<p className="text-sm text-muted-foreground">Loading providers...</p>
 		</div>
@@ -491,13 +522,18 @@ export function SettingsView({
 		</div>
 	) : selectedProvider ? (
 		<div className="grid h-full grid-cols-[minmax(24rem,0.95fr)_minmax(28rem,1.05fr)] overflow-hidden max-[1100px]:grid-cols-1 max-[1100px]:grid-rows-[minmax(24rem,0.9fr)_minmax(26rem,1fr)]">
-			<ProviderListContent
-				onAddProvider={openAddProvider}
-				onConfigure={openProviderDetail}
-				providers={providers}
-				selectedProviderId={selectedProvider.id}
-				variant="panel"
-			/>
+			{/* min-h-0/min-w-0: grid items default to min-size auto, which lets
+			    the pane grow past its track and leaves the inner ScrollArea with
+			    nothing to scroll. */}
+			<div className="min-h-0 min-w-0 overflow-hidden">
+				<ProviderListContent
+					onAddProvider={openAddProvider}
+					onConfigure={openProviderDetail}
+					providers={providers}
+					selectedProviderId={selectedProvider.id}
+					variant="panel"
+				/>
+			</div>
 			<aside className="min-h-0 overflow-hidden border-l bg-background max-[1100px]:border-l-0 max-[1100px]:border-t">
 				<ProviderDetailContent
 					key={`${selectedProvider.id}:${detailResetToken}`}
@@ -532,28 +568,16 @@ export function SettingsView({
 
 	const content =
 		activeNav === "Models" ? (
-			providerContent
+			<>
+				{providerContent}
+				{addProviderDialog}
+			</>
 		) : activeNav === "Voice" ? (
 			<VoiceInputContent
 				onOpenModelProviders={() => onNavigateSection("Models")}
 			/>
-		) : activeNav === "Plugins" ? (
-			<PluginsHubView
-				onOpenMarketplace={() => onNavigateSection("Marketplace")}
-			/>
-		) : activeNav === "Marketplace" ? (
-			<MarketplaceView
-				onInstalledItemsChanged={invalidateExtensionInventoryCache}
-				variant="directory"
-			/>
-		) : activeNav === "Hooks" ? (
-			<CustomizationSectionView section="Hooks" />
-		) : activeNav === "Rules" ? (
-			<CustomizationSectionView section="Rules" />
-		) : activeNav === "Agents" ? (
-			<CustomizationSectionView section="Agents" />
-		) : activeNav === "Tools" ? (
-			<CustomizationSectionView section="Tools" />
+		) : activeNav === "Customize" ? (
+			<CustomizeView />
 		) : activeNav === "Channels" ? (
 			<ChannelsContent />
 		) : activeNav === "Schedules" ? (

--- a/apps/examples/desktop-app/webview/lib/prompt-input-focus.ts
+++ b/apps/examples/desktop-app/webview/lib/prompt-input-focus.ts
@@ -1,0 +1,24 @@
+/**
+ * Tiny cross-tree signal for focusing the chat prompt input. The sidebar's
+ * "New" action lives far from the chat pane, so instead of threading a focus
+ * callback through the whole component chain it dispatches a window event
+ * that the mounted prompt input listens for.
+ */
+
+const FOCUS_PROMPT_INPUT_EVENT = "cline:focus-prompt-input";
+
+export function requestPromptInputFocus(): void {
+	if (typeof window === "undefined") {
+		return;
+	}
+	// Deferred so a focus request issued alongside a navigation (e.g. the New
+	// button remounting the chat pane) reaches the freshly mounted input.
+	window.setTimeout(() => {
+		window.dispatchEvent(new Event(FOCUS_PROMPT_INPUT_EVENT));
+	}, 0);
+}
+
+export function subscribeToPromptInputFocus(listener: () => void): () => void {
+	window.addEventListener(FOCUS_PROMPT_INPUT_EVENT, listener);
+	return () => window.removeEventListener(FOCUS_PROMPT_INPUT_EVENT, listener);
+}


### PR DESCRIPTION
### Related Issue

N/A — internal desktop-app UX/design pass.

### Description

Big desktop-app UX pass across the Customize/settings surface, the sidebar, and the chat composer. Everything here came out of hands-on dogfooding of the browser dev build; the theme throughout is consolidation and consistency.

#### Customize hub (replaces Plugins + Marketplace pages)

The old layout had a Plugins page (with Plugins/MCP/Skills sub-tabs), a dedicated Marketplace page, and separate Hooks/Rules/Tools sidebar entries. All of that is now one **Customize** page with six tabs — **Skills, MCP, Plugins, Rules, Hooks, Tools** — each with live counts from the inventory call. Tabs that have a marketplace catalog (skills/MCP/plugins) render **Installed** followed by an inline **Browse** section, CLI-hub style, so you install right where you manage things and the item hops up into Installed. The `MarketplaceView` plumbing for this already existed (`variant="full"` vs `"installed"`); the hub just never used it. The standalone Marketplace settings page is gone (`MarketplaceView`'s now-unreachable `directory` variant is left in place to keep the diff focused).

`SettingsSection` collapsed accordingly: the customization group is a single `"Customize"` entry, which simplified the settings sidebar nav to a divider + one row.

#### Installed-card / browse-card consistency

Installed rows and browse rows looked like two different apps: different backgrounds, paddings, badge styles, and a bottom-row full-size destructive Uninstall vs the browse cards' compact top-right button. Installed cards now mirror the browse-card anatomy exactly — `bg-card p-4` containers, absolute top-right `xs` Uninstall (header reserves `pr-28`), truncating semibold titles with badges inline after the name, `text-primary` icons, real `Badge` components instead of ad-hoc bordered spans, un-indented `line-clamp-2` descriptions. Rules/Hooks/Tools rows got the same card language, and their intro paragraphs (which duplicated the page description two lines above) are gone.

Two genuine bugs surfaced during this:

- **`xs` buttons collapsed to 12×12 when they contained an icon.** The `xs` size still carried `has-[>svg]:size-3` from an old iteration where xs *was* a 12px micro-button. Any xs button with an svg child (i.e. Uninstall with its trash icon) imploded, while Install (text-only) rendered normally — the original "install and uninstall buttons are different sizes" report. Fixed to a `has-[>svg]:px-2` padding tweak; the only consumers of this size are the marketplace action buttons (onboarding's `size="xs"` comes from `@cline/ui`, a different component).
- **Icons inside buttons silently shrink.** The Button base has `[&_svg:not([class*='size-'])]:size-3`, which beats `h-4 w-4` on specificity — this is why the provider-panel close X looked comically small. Anything icon-in-button needs `size-*` classes.

#### Sidebar overhaul

- **Always grouped by project** — the sort toggle is gone, and so are the Pinned/Scheduled/Tasks category sections along with the time-mode paging machinery (including the page-fill effect and its failure-halt ref). Pinned sessions lead their project group (pinned-by-recency, then rest-by-recency — falls out of concatenating pinned first since `groupThreadsByProject` preserves insertion order). Scheduled sessions get an inline clock icon where the pin lives; pin+clock render together, and the status dot coexists with both.
- **One font size** (`text-sm`) across the list: titles, timestamps, project headers, show-more buttons, empty states. Gotcha: `sidebarText`'s `text-sm` was losing to the default size variant's `text-base` in twMerge (cva emits size classes after variant classes) — hence `!text-sm`, same trick `sidebarItem` already used.
- **Scroll fade** under the Sessions header (gradient overlay, fades in via `onScrollCapture` tracking the viewport's scrollTop) instead of rows hard-clipping.
- **Hover card closes on scroll** — Radix HoverCards get no pointer events while scrolling, so the session-detail popup used to float over moving content. The open state is lifted to the sidebar (`hoverCardThreadId`) and any list scroll clears it.
- **Min width** raised 224→260px (stored widths clamp on load). The real clip culprit was also fixed: the per-project "Show more in {project}" button's `whitespace-nowrap` label forced the list wider than the sidebar at narrow widths, pushing timestamps out of view — it truncates now.
- **Navigation**: the top rows are New / Schedule / Customize. Schedules+Customize are hidden from the expanded settings nav (the rows cover them; still present when collapsed since collapsed mode has no action rows). The gear always opens **General** (it used to resume the last section, so it "opened Customize"). The **New** row highlights (`aria-current`) while the fresh not-yet-started task page shows, hands off to the session row once the task starts, and focuses the prompt input — via a tiny window-event signal (`lib/prompt-input-focus.ts`) because the sidebar and the composer textarea live in distant subtrees; the request defers a tick so it lands after the chat pane remounts.

#### Models page

- The provider detail panel is **always open** — no X, no empty state. Defaults to the first connected provider, falling back to the first in the catalog. This also killed the layout shift on selection: the page used to swap between a full-width `page` variant and a narrower `panel` variant (title jumped 3xl→2xl too).
- **Unscrollable list fix**: classic grid trap — grid items default to `min-height/width: auto`, so the list pane grew past its track inside the `overflow-hidden` grid and its inner ScrollArea had nothing to scroll. A `min-h-0 min-w-0 overflow-hidden` wrapper cell fixes it; both panes scroll independently now.
- **Add Provider is a dialog** (`AddProviderContent` gained a `variant="dialog"` rendering just the form body; the page variant is untouched). Saving still selects the new provider in the panel.
- **Embedded input consistency**: the `Input` component's own `dark:bg-input/30` tint + border + shadow + focus ring survived inside the composed search boxes (the dark-mode bg is a `dark:` variant, so a plain `bg-transparent` override doesn't touch it in twMerge). One shared `EMBEDDED_INPUT_CLASS` strips all of it — applied to the provider search, model search, and detail-panel fields. The model search box also matches the provider search frame now (it had `py-2` + the input's default `px-3`, so it was taller with double-indented text).
- The model list flows with the page instead of a `max-h-125` inner scroller.

#### Other pages

- **Account** uses the shared `PageFrame`/`PageHeader`: left-aligned, `text-3xl` title like every other page (was centered `max-w-3xl` with a `text-2xl` h2), Sign Out in the header actions slot.
- **General → Desktop notifications** is one coherent section: header row + the Event/Notify/Sound matrix nested in a `rounded-lg border bg-card` inset, instead of the event rows rendering as structural peers of Dark mode/Font size. The "Available in the desktop app" unsupported-permission label is removed.
- **Schedule** retitled from "Schedules" with a real description ("Run agents on cron schedules for recurring automations…"); Customize's description no longer parrots the tab names sitting right under it.

#### Chat composer

The voice dictation button only renders once a voice model is configured (Settings → Voice). The unconfigured state used to show the mic and deep-link to voice settings on click; that path is removed (the `onOpenVoiceInputSettings` prop type is kept so restoring the deep-link is trivial).

### Test Procedure

- Full webview unit suite: **577 tests pass** (`bunx vitest run webview`). Rewrote the sidebar tests that covered the removed sections/sort machinery into tests for the new behavior (clock icon incl. pin+clock combo, pinned-leads-project-group, always-project grouping with scoped expansion, explicit-click-only history loading, New-row highlight, gear-opens-General). The 9 voice transcription tests were briefly skipped while the mic was hidden outright, then re-enabled once the button became conditional — they configure a voice model in setup, so they exercise the rendered path.
- `tsc --noEmit` on the webview: the repo has a pre-existing baseline of type errors in unrelated test files; this PR doesn't add any (and removes two — stray `onNewThread` props in sidebar tests).
- Biome clean on all touched files.
- Manually exercised throughout in the container browser dev stack (Next.js UI + Bun sidecar, hot reload) while iterating with Saoud reviewing each change live in the browser.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Iterated live against the running dev build rather than captured — happy to add before/afters if useful for review.

### Additional Notes

- Intermediate commits in this branch are grouped by theme rather than strict buildability (the `SettingsSection` union change threads through sidebar + settings files that live in different commits); the branch head is fully green.
- `MarketplaceView` still supports its now-unreachable `directory` variant internally — left in to keep the diff focused; can strip in a follow-up if preferred.
