### PR TITLE
chore(desktop): suppress useSemanticElements on the styled radio option

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
@@ -270,6 +270,7 @@ export function VoiceInputContent({
 											defaultTranscriptionModel(selectedEntry.models)?.id ===
 											model.id;
 										return (
+											// biome-ignore lint/a11y/useSemanticElements: custom-styled radio option; a native input would need a full restyle
 											<button
 												aria-checked={isSelected}
 												className={cn(


### PR DESCRIPTION
## What

`Quality Checks` is currently red on `main`: biome's `lint/a11y/useSemanticElements` errors (error severity) on the `role="radio"` custom-styled model-option button introduced in #13531 (`voice-input-view.tsx`), so `bun run lint` fails repo-wide and every PR rebased onto current `main` fails CI.

This suppresses the diagnostic with the repo's established inline-ignore pattern (as in `sessions-view.tsx`): the option is a deliberately styled `<button>` inside a `role="radiogroup"` list, and the view's tests select it via `[role="radio"]`; switching to a native `<input type="radio">` would need a full restyle and is a call for the feature's owner.

Comment-only change — no behavior difference.

## Verification

- `bun run lint`: 0 errors (was 1).
- `voice-input-view.test.tsx`: 5/5 pass.

First hit on #13513 via the branch auto-rebase; that PR temporarily carries the same one-liner, which will fall away as patch-identical on its next rebase once this merges.
