### PR TITLE
fix(vscode): thread task id into hook runner creation so execution telemetry fires

### DIFF
--- a/apps/vscode/src/sdk/hooks-adapter.test.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.test.ts
@@ -1,0 +1,97 @@
+// Hook-execution telemetry only fires when the adapter passes a task id into
+// HookFactory.create (StdioHookRunner gates every captureHookExecution on it),
+// so these tests pin the id threading at every adapter call site.
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { buildAgentHooks } from "./hooks-adapter"
+
+const mocks = vi.hoisted(() => ({
+	create: vi.fn(),
+}))
+
+vi.mock("@/core/hooks/hook-factory", () => ({
+	HookFactory: class {
+		create = mocks.create
+	},
+}))
+
+function makeRunner() {
+	return {
+		isNoOp: false,
+		run: vi.fn(async () => ({ cancel: false, contextModification: "", errorMessage: "" })),
+	}
+}
+
+const snapshot = {
+	conversationId: "conv-1",
+	runId: "run-1",
+	agentId: "agent-1",
+	messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+} as never
+
+const stateManager = { getGlobalSettingsKey: vi.fn(() => true) } as never
+
+describe("hooks-adapter task id threading", () => {
+	let runner: ReturnType<typeof makeRunner>
+
+	beforeEach(() => {
+		mocks.create.mockReset()
+		runner = makeRunner()
+		mocks.create.mockResolvedValue(runner)
+	})
+
+	it("passes the task id and tool name when creating the PreToolUse runner", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.beforeTool?.({ toolCall: { toolName: "read_file" }, input: { path: "a.ts" }, snapshot } as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("PreToolUse", "conv-1", "read_file")
+		expect(runner.run).toHaveBeenCalledWith(expect.objectContaining({ taskId: "conv-1" }))
+	})
+
+	it("passes the task id and tool name when creating the PostToolUse runner", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.afterTool?.({
+			toolCall: { toolName: "write_file" },
+			input: {},
+			result: { output: "ok", isError: false },
+			durationMs: 5,
+			snapshot,
+		} as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("PostToolUse", "conv-1", "write_file")
+		expect(runner.run).toHaveBeenCalledWith(expect.objectContaining({ taskId: "conv-1" }))
+	})
+
+	it("passes the task id when creating the TaskStart and UserPromptSubmit runners", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.beforeRun?.({ snapshot } as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("TaskStart", "conv-1")
+		expect(mocks.create).toHaveBeenCalledWith("UserPromptSubmit", "conv-1")
+	})
+
+	it("passes the task id when creating the TaskComplete runner", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.afterRun?.({ snapshot, result: { status: "completed", outputText: "done" } } as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("TaskComplete", "conv-1")
+	})
+
+	it("passes the task id when creating the TaskCancel runner", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.afterRun?.({ snapshot, result: { status: "aborted", outputText: "" } } as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("TaskCancel", "conv-1")
+	})
+
+	it("falls back to the run id when the snapshot has no conversation id", async () => {
+		const hooks = buildAgentHooks(stateManager)
+		await hooks.beforeTool?.({
+			toolCall: { toolName: "read_file" },
+			input: {},
+			snapshot: { ...(snapshot as object), conversationId: undefined },
+		} as never)
+
+		expect(mocks.create).toHaveBeenCalledWith("PreToolUse", "run-1", "read_file")
+	})
+})

--- a/apps/vscode/src/sdk/hooks-adapter.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.ts
@@ -123,19 +123,20 @@ export function buildAgentHooks(
 					return undefined
 				}
 
+				const taskId = taskIdFromSnapshot(ctx.snapshot)
+				const toolName = ctx.toolCall.toolName
 				const factory = createFactory()
-				const runner = await factory.create("PreToolUse")
+				const runner = await factory.create("PreToolUse", taskId, toolName)
 				if (runner.isNoOp) {
 					return undefined
 				}
 
-				const toolName = ctx.toolCall.toolName
 				const runningMsg = buildHookStatusMessage({ hookName: "PreToolUse", toolName, status: "running" })
 				runningTs = runningMsg.ts
 				emitHookMessage?.(runningMsg)
 
 				const result = await runner.run({
-					taskId: taskIdFromSnapshot(ctx.snapshot),
+					taskId,
 					preToolUse: {
 						toolName,
 						parameters: toStringRecord(ctx.input),
@@ -182,19 +183,20 @@ export function buildAgentHooks(
 					return undefined
 				}
 
+				const taskId = taskIdFromSnapshot(ctx.snapshot)
+				const toolName = ctx.toolCall.toolName
 				const factory = createFactory()
-				const runner = await factory.create("PostToolUse")
+				const runner = await factory.create("PostToolUse", taskId, toolName)
 				if (runner.isNoOp) {
 					return undefined
 				}
 
-				const toolName = ctx.toolCall.toolName
 				const runningMsg = buildHookStatusMessage({ hookName: "PostToolUse", toolName, status: "running" })
 				runningTs = runningMsg.ts
 				emitHookMessage?.(runningMsg)
 
 				const result = await runner.run({
-					taskId: taskIdFromSnapshot(ctx.snapshot),
+					taskId,
 					postToolUse: {
 						toolName,
 						parameters: toStringRecord(ctx.input),
@@ -253,13 +255,13 @@ export function buildAgentHooks(
 					return
 				}
 
+				const taskId = taskIdFromSnapshot(ctx.snapshot)
 				const factory = createFactory()
-				const runner = await factory.create(hookName)
+				const runner = await factory.create(hookName, taskId)
 				if (runner.isNoOp) {
 					return
 				}
 
-				const taskId = taskIdFromSnapshot(ctx.snapshot)
 				const runningMsg = buildHookStatusMessage({ hookName, status: "running" })
 				runningTs = runningMsg.ts
 				emitHookMessage?.(runningMsg)
@@ -313,8 +315,9 @@ async function runTaskStart(
 			return undefined
 		}
 
+		const taskId = taskIdFromSnapshot(ctx.snapshot)
 		const factory = createFactory()
-		const runner = await factory.create("TaskStart")
+		const runner = await factory.create("TaskStart", taskId)
 		if (runner.isNoOp) {
 			return undefined
 		}
@@ -323,7 +326,6 @@ async function runTaskStart(
 		runningTs = runningMsg.ts
 		emitHookMessage?.(runningMsg)
 
-		const taskId = taskIdFromSnapshot(ctx.snapshot)
 		const result = await runner.run({
 			taskId,
 			taskStart: {
@@ -362,8 +364,9 @@ async function runUserPromptSubmit(
 			return undefined
 		}
 
+		const taskId = taskIdFromSnapshot(ctx.snapshot)
 		const factory = createFactory()
-		const runner = await factory.create("UserPromptSubmit")
+		const runner = await factory.create("UserPromptSubmit", taskId)
 		if (runner.isNoOp) {
 			return undefined
 		}
@@ -373,7 +376,7 @@ async function runUserPromptSubmit(
 		emitHookMessage?.(runningMsg)
 
 		const result = await runner.run({
-			taskId: taskIdFromSnapshot(ctx.snapshot),
+			taskId,
 			userPromptSubmit: {
 				prompt: latestUserPrompt(ctx),
 				attachments: [],


### PR DESCRIPTION
## Problem

The next VS Code extension emits zero `hooks.execution` telemetry events. `apps/vscode/src/sdk/hooks-adapter.ts` created every hook runner via `factory.create(hookName)` without a task id, and `StdioHookRunner` gates all of its `captureHookExecution` calls on `if (taskId)` — so execution telemetry silently never fired.

ClickHouse confirms it's a telemetry gap, not absent usage (last 30 days): `hooks.execution` has 285/227 distinct users (global/workspace) on `extension_variant=legacy` and **zero rows on next**, while `hooks.discovery_completed` fires fine on next (429 users). This blinds rollout monitoring of hook execution health on the variant being rolled to 100%.

Tracked in [CLINE-3013](https://linear.app/cline-bot/issue/CLINE-3013).

## Fix

- Pass the task id (resolved by the existing `taskIdFromSnapshot`, conversationId → runId → agentId) into `factory.create(...)` at all five adapter call sites: `beforeTool`, `afterTool`, `afterRun` (TaskComplete/TaskCancel), and the two `beforeRun` paths (TaskStart, UserPromptSubmit). `create(hookName, taskId, toolName)` already accepted these params.
- The tool hooks also pass the tool name so the telemetry's `toolName` property is populated, matching legacy.
- Each site hoists the `taskId`/`toolName` computation above the `create` call and reuses the same const in `runner.run`, so the id given to the factory and the one in the hook input can't diverge.

## Tests

- New `apps/vscode/src/sdk/hooks-adapter.test.ts` — the adapter had no test file, which is how this shipped silently. Pins the id threading at every call site, including the runId fallback.
- Full apps/vscode vitest run: 90 files / 1165 tests pass; full bun unit suite (includes all hooks suites): 73 files / 1074 tests pass; `tsc --noEmit` clean.

## Verification after rollout

Once released, `hooks.execution` rows for `extension_variant=next` should appear in ClickHouse (`otel.otel_logs`) within a release cycle.