### PR TITLE
fix: sanitize stored API keys and make provider credential rejections actionable

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -315,7 +315,15 @@ export class Controller {
 		// completion row (plan → yellow plan box, act → green completion box).
 		this.messageTranslatorState = new MessageTranslatorState(
 			undefined,
-			() => this.getActiveProviderId(),
+			// Provider backing the active turn — error reshaping branches on it
+			// (BYOK credential guidance vs the cline sign-in card). Prefer the
+			// active session's start metadata over the current settings
+			// selection: a provider/mode switch made while a turn is in flight
+			// changes the settings selection immediately, but the failing turn
+			// still belongs to the session's provider. Provider switches always
+			// start a new session, so start metadata never goes stale the way
+			// a mid-task model-only switch does for models below.
+			() => this.getSessionProviderId() ?? this.getActiveProviderId(),
 			() => (this.stateManager.getGlobalSettingsKey("mode") === "plan" ? "plan" : "act"),
 			() => this.lastKnownWorkspaceRoot,
 			// Model backing the active turn — lets error reshaping recognize

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -29,7 +29,7 @@
 import type { CoreSessionEvent } from "@cline/core"
 import { PATCH_MARKERS, projectSessionMessagesForDisplay } from "@cline/core"
 import type { MessageWithMetadata as SdkMessage } from "@cline/llms"
-import { type AgentEvent, formatDisplayUserInput } from "@cline/shared"
+import { type AgentEvent, formatDisplayUserInput, type ProviderErrorClass } from "@cline/shared"
 import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
 import type {
 	ClineApiReqInfo,
@@ -45,10 +45,11 @@ import type {
 } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import * as path from "path"
+import { isClineManagedProvider } from "@/shared/utils/cline"
 import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { CLINE_FREE_PROMOTION_ENDED_ERROR_CODE, isClineFreePromotionEndedMessage } from "../services/error/ClineError"
 import { MessageIdMinter } from "./message-id-minter"
-import { describeMissingCredentialError } from "./provider-credential-error"
+import { describeCredentialRejectedError, describeMissingCredentialError } from "./provider-credential-error"
 import { extractPersistedHookContextChips, isSyntheticSdkUserMessage, isSyntheticUserPrompt } from "./sdk-user-message-mapping"
 import { isDeniedToolApprovalMistake, isKnownToolApprovalDenial } from "./tool-approval-denial"
 
@@ -1931,7 +1932,12 @@ function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): 
 			// `code: "insufficient_credits"`). We try to reshape it into the
 			// ClineError-serialized format the webview expects so that ErrorRow
 			// can render the correct UI (Buy Credits button, etc.).
-			const errorPayload = reshapeErrorForWebview(event.error, state.activeProviderId(), state.activeModelId())
+			const errorPayload = reshapeErrorForWebview(
+				event.error,
+				state.activeProviderId(),
+				state.activeModelId(),
+				event.errorClass,
+			)
 
 			// Emit an api_req_started with streamingFailedMessage so the
 			// RequestStartRow renders the error via ErrorRow. This replaces
@@ -2637,6 +2643,7 @@ export function reshapeErrorForWebview(
 	error: { message?: string; status?: number; code?: string },
 	providerId?: string,
 	modelId?: string,
+	errorClass?: ProviderErrorClass,
 ): string {
 	// The ClineError-JSON branches below are cline-provider flows (balance,
 	// spend limit), so "cline" stays their fallback id. The missing-credential
@@ -2668,6 +2675,18 @@ export function reshapeErrorForWebview(
 	const vertexGlobalRegionMessage = describeVertexGlobalRegionError(rawMessage, providerId)
 	if (vertexGlobalRegionMessage) {
 		return vertexGlobalRegionMessage
+	}
+
+	// A BYOK provider rejected the configured credentials (llms classified the
+	// HTTP 401/403 while the typed error was still available). Raw provider
+	// bodies here are dead ends — e.g. Mistral's `{"detail":"Invalid API Key"}`
+	// is identical for a wrong, empty, or wrong-scope key — so point the user
+	// at the key configuration instead. Cline-account providers keep the JSON
+	// path below (the webview renders their auth failures as a sign-in card),
+	// and so does an *unknown* provider id: rewriting without knowing the
+	// provider could suppress that sign-in card for a cline-account failure.
+	if (errorClass === "auth" && providerId !== undefined && !isClineManagedProvider(providerId)) {
+		return describeCredentialRejectedError(rawMessage, providerId)
 	}
 
 	// Try to extract structured error info from the error message.

--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -184,6 +184,37 @@ describe("createProviderConfigStore", () => {
 		expect(store.read(providerId).baseUrl).toBeUndefined()
 	})
 
+	// Pasted API keys can carry invisible clipboard artifacts (surrounding
+	// whitespace, newlines, zero-width characters). The masked key field hides
+	// them from the user and the provider rejects the key with a 401 that
+	// looks identical to a genuinely wrong key, so the write boundary must
+	// strip them before the value reaches either backing store.
+	it("sanitizes pasted API keys before writing to both stores", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("mistral")
+
+		store.write(providerId, { apiKey: " \u200b\ufeffmistral-key\u200d \n" })
+
+		expect(mocks.getApiConfiguration().mistralApiKey).toBe("mistral-key")
+		expect(mocks.getSavedProviderSettings("mistral")).toEqual({ provider: "mistral", apiKey: "mistral-key" })
+		expect(store.read(providerId).apiKey).toBe("mistral-key")
+	})
+
+	it("treats a whitespace-only API key as a clear", async () => {
+		const { createProviderConfigStore } = await import("./store")
+		mocks.setProviderSettings({ mistral: { provider: "mistral", apiKey: "existing-key" } })
+		mocks.setApiConfiguration({ mistralApiKey: "existing-key" })
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("mistral")
+
+		store.write(providerId, { apiKey: " \n " })
+
+		expect(mocks.getApiConfiguration().mistralApiKey).toBeUndefined()
+		expect(mocks.getSavedProviderSettings("mistral")).toEqual({ provider: "mistral" })
+		expect(store.read(providerId).apiKey).toBeUndefined()
+	})
+
 	// Changing the regional API line in the settings UI goes through
 	// store.write. It must land in providers.json (the CLI and desktop app
 	// bake the regional base URL from its stored apiLine) AND mirror to the

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -161,6 +161,21 @@ function patchStringValue(value: string | null | undefined): string | undefined 
 	return patched === "" ? undefined : patched
 }
 
+/**
+ * API keys are opaque pasted tokens. Clipboards smuggle in control and
+ * invisible formatting characters (newlines, zero-width spaces, BOM,
+ * direction marks) that make the provider reject the key with a 401 that is
+ * indistinguishable from a genuinely wrong key — while the field's masked
+ * rendering hides the corruption from the user. Strip those characters and
+ * surrounding whitespace before the value reaches either backing store.
+ */
+function sanitizeApiKeyPatch(patch: ProviderConfigPatch): ProviderConfigPatch {
+	if (!("apiKey" in patch) || typeof patch.apiKey !== "string") {
+		return patch
+	}
+	return { ...patch, apiKey: patch.apiKey.replace(/[\p{Cc}\p{Cf}]/gu, "").trim() }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -918,8 +933,9 @@ export function createProviderConfigStore(): ProviderConfigStore {
 		},
 
 		write(providerId: ProviderId, patch: ProviderConfigPatch): EffectiveProviderConfig {
-			writeStateFields(providerId, patch)
-			writeProviderSettingsFields(providerId, patch)
+			const sanitizedPatch = sanitizeApiKeyPatch(patch)
+			writeStateFields(providerId, sanitizedPatch)
+			writeProviderSettingsFields(providerId, sanitizedPatch)
 			const config = this.read(providerId)
 			emit({ kind: "fields", providerId, config })
 			return config

--- a/apps/vscode/src/sdk/provider-credential-error.test.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.test.ts
@@ -51,13 +51,57 @@ describe("reshapeErrorForWebview - missing credentials", () => {
 		)
 	})
 
-	it("passes an invalid-key error through unchanged", () => {
+	it("passes an invalid-key error through unchanged when unclassified", () => {
 		expect(reshapeErrorForWebview({ message: "Invalid API key" }, "openai")).toBe("Invalid API key")
 	})
 
 	it("does not blame the cline provider when the active provider id is unknown", () => {
 		expect(reshapeErrorForWebview({ message: "Missing Authorization header" })).toBe(
 			"Missing API key for the active provider. Add credentials in Settings, or switch providers.",
+		)
+	})
+})
+
+describe("reshapeErrorForWebview - rejected credentials (errorClass auth)", () => {
+	it("rewrites a classified 401 into actionable guidance and keeps the provider body", () => {
+		const reshaped = reshapeErrorForWebview(
+			{ message: '{"detail":"Invalid API Key"}' },
+			"mistral",
+			"mistral-large-2512",
+			"auth",
+		)
+		expect(reshaped).toBe(
+			'Provider "mistral" rejected the configured credentials. Re-enter the API key in Settings → API Configuration (checking it is the right kind of key for this provider), or switch providers.\n\nProvider response: {"detail":"Invalid API Key"}',
+		)
+	})
+
+	it("keeps the cline provider on the JSON path so the webview renders the sign-in card", () => {
+		const reshaped = reshapeErrorForWebview(
+			{ message: '{"status":401,"message":"Unauthorized"}' },
+			"cline",
+			undefined,
+			"auth",
+		)
+		expect(reshaped).toBe('{"status":401,"message":"Unauthorized"}')
+	})
+
+	it("keeps cline-pass on the JSON path as well", () => {
+		const reshaped = reshapeErrorForWebview(
+			{ message: '{"status":401,"message":"Unauthorized"}' },
+			"cline-pass",
+			undefined,
+			"auth",
+		)
+		expect(reshaped).toBe('{"status":401,"message":"Unauthorized"}')
+	})
+
+	it("does not rewrite unclassified errors", () => {
+		expect(reshapeErrorForWebview({ message: "boom" }, "mistral", undefined, "unknown")).toBe("boom")
+	})
+
+	it("does not rewrite when the provider id is unknown, so a cline-account sign-in card is never suppressed", () => {
+		expect(reshapeErrorForWebview({ message: '{"status":401,"message":"Unauthorized"}' }, undefined, undefined, "auth")).toBe(
+			'{"status":401,"message":"Unauthorized"}',
 		)
 	})
 })

--- a/apps/vscode/src/sdk/provider-credential-error.ts
+++ b/apps/vscode/src/sdk/provider-credential-error.ts
@@ -9,3 +9,18 @@ export function describeMissingCredentialError(rawMessage: string, providerId?: 
 	const subject = providerId ? `Missing API key for provider "${providerId}".` : "Missing API key for the active provider."
 	return `${subject} Add credentials in Settings, or switch providers.`
 }
+
+/**
+ * Actionable text for a credential rejection (HTTP 401/403) from a BYOK
+ * provider. The provider's raw body is appended because it is the only
+ * provider-specific diagnostic the user has — but alone it is a dead end
+ * (e.g. Mistral answers an identical `{"detail":"Invalid API Key"}` for a
+ * wrong, empty, or wrong-scope key).
+ */
+export function describeCredentialRejectedError(rawMessage: string, providerId: string): string {
+	const subject = `Provider "${providerId}" rejected the configured credentials.`
+	const guidance =
+		"Re-enter the API key in Settings → API Configuration (checking it is the right kind of key for this provider), or switch providers."
+	const detail = rawMessage.trim()
+	return detail ? `${subject} ${guidance}\n\nProvider response: ${detail}` : `${subject} ${guidance}`
+}

--- a/sdk/packages/llms/src/providers/error-classification.test.ts
+++ b/sdk/packages/llms/src/providers/error-classification.test.ts
@@ -110,6 +110,72 @@ describe("classifyProviderError", () => {
 		});
 	});
 
+	describe("auth", () => {
+		it("classifies a structural 401 payload", () => {
+			expect(
+				classifyProviderError({
+					statusCode: 401,
+					message: "invalid x-api-key",
+				}),
+			).toBe("auth");
+		});
+
+		it("classifies a structural 403 payload", () => {
+			expect(classifyProviderError({ status: 403, message: "Forbidden" })).toBe(
+				"auth",
+			);
+		});
+
+		it("classifies a typed APICallError 401 (Mistral invalid-key shape)", () => {
+			expect(
+				classifyProviderError(
+					new APICallError({
+						message: "Invalid API Key",
+						url: "https://api.mistral.ai/v1/chat/completions",
+						requestBodyValues: {},
+						statusCode: 401,
+						responseBody: JSON.stringify({ detail: "Invalid API Key" }),
+					}),
+				),
+			).toBe("auth");
+		});
+
+		it("treats the typed statusCode as authoritative: 401 wins over context wording", () => {
+			expect(
+				classifyProviderError(
+					new APICallError({
+						message: "Unauthorized",
+						url: "https://api.example.com/v1/chat/completions",
+						requestBodyValues: {},
+						statusCode: 401,
+						responseBody: JSON.stringify({
+							error: { message: "context length exceeded" },
+						}),
+					}),
+				),
+			).toBe("auth");
+		});
+
+		it("unwraps a RetryError whose final attempt was a 401", () => {
+			const last = new APICallError({
+				message: "Unauthorized",
+				url: "https://api.example.com/v1/chat/completions",
+				requestBodyValues: {},
+				statusCode: 401,
+				responseBody: JSON.stringify({ detail: "Invalid API Key" }),
+			});
+			expect(
+				classifyProviderError(
+					new RetryError({
+						message: "Failed after 2 attempts",
+						reason: "errorNotRetryable",
+						errors: [last],
+					}),
+				),
+			).toBe("auth");
+		});
+	});
+
 	describe("unknown", () => {
 		it("vetoes token-per-minute rate limits despite token wording", () => {
 			expect(
@@ -141,12 +207,11 @@ describe("classifyProviderError", () => {
 			).toBe("unknown");
 		});
 
-		it("leaves auth errors unclassified", () => {
+		it("leaves auth wording without an HTTP status unclassified", () => {
+			// Status-only policy: provider bodies can quote "unauthorized"
+			// without the request having been an auth failure.
 			expect(
-				classifyProviderError({
-					statusCode: 401,
-					message: "invalid x-api-key",
-				}),
+				classifyProviderError(new Error("Unauthorized: check your key")),
 			).toBe("unknown");
 		});
 

--- a/sdk/packages/llms/src/providers/error-classification.ts
+++ b/sdk/packages/llms/src/providers/error-classification.ts
@@ -35,6 +35,13 @@ const RATE_LIMIT_PATTERNS = [/rate[\s_-]?limit/i, /per[\s_-]?minute\b/i];
 /** Overflow rejections arrive as invalid-request-family statuses. */
 const CONTEXT_WINDOW_STATUSES = new Set([400, 413, 422]);
 const RATE_LIMIT_STATUS = 429;
+/**
+ * Credential rejections. Status-only on purpose: matching message text
+ * ("unauthorized", "forbidden") would misfire on provider bodies that merely
+ * quote such words, and every provider that rejects credentials does say so
+ * in the HTTP layer.
+ */
+const AUTH_STATUSES = new Set([401, 403]);
 
 const MAX_WALK_DEPTH = 8;
 
@@ -156,6 +163,10 @@ function verdictFromSignals(signals: ErrorSignals): ProviderErrorClass {
 		return "context_window_exceeded";
 	}
 
+	if ([...signals.statuses].some((status) => AUTH_STATUSES.has(status))) {
+		return "auth";
+	}
+
 	if (signals.statuses.has(RATE_LIMIT_STATUS)) {
 		return "unknown";
 	}
@@ -236,6 +247,9 @@ function classifyTypedError(
 		// out-votes the HTTP layer. Absent a statusCode, the payload decides.
 		const status =
 			typeof error.statusCode === "number" ? error.statusCode : undefined;
+		if (status !== undefined && AUTH_STATUSES.has(status)) {
+			return "auth";
+		}
 		if (status !== undefined && !CONTEXT_WINDOW_STATUSES.has(status)) {
 			return "unknown";
 		}
@@ -249,13 +263,14 @@ function classifyTypedError(
 	}
 	if (TypeValidationError.isInstance(error)) {
 		// `value` holds the payload that failed validation — for gateway
-		// streams, the upstream provider rejection.
+		// streams, the upstream provider rejection. Only a definitive verdict
+		// counts; "unknown" defers to the caller's structural walk.
 		const verdict = verdictFromSignals(collectSignalsFrom([error.value]));
-		return verdict === "context_window_exceeded" ? verdict : undefined;
+		return verdict !== "unknown" ? verdict : undefined;
 	}
 	if (AISDKError.isInstance(error)) {
 		const verdict = classifyTypedError(error.cause, depth + 1);
-		return verdict === "context_window_exceeded" ? verdict : undefined;
+		return verdict !== undefined && verdict !== "unknown" ? verdict : undefined;
 	}
 	return undefined;
 }

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -266,9 +266,12 @@ export type AgentModelFinishReason =
  * Coarse classification of a provider error, derived from the raw provider
  * error object before it is flattened into a display string. Shared by the
  * runtime's recovery policy and telemetry (`error_class`). Extend with new
- * classes (auth, rate_limit, billing, ...) as consumers need them.
+ * classes (rate_limit, billing, ...) as consumers need them.
+ *
+ * `auth`: the provider rejected the request's credentials (HTTP 401/403) —
+ * hosts should point the user at their API key configuration.
  */
-export type ProviderErrorClass = "context_window_exceeded" | "unknown";
+export type ProviderErrorClass = "context_window_exceeded" | "auth" | "unknown";
 
 export type AgentModelEvent =
 	| { type: "text-delta"; text: string }


### PR DESCRIPTION
Follow-up to the investigation in #13288 ([CLINE-2982](https://linear.app/cline-bot/issue/CLINE-2982/mistral-invalid-api-key)): a user's valid-looking key was rejected with a raw `401 {"detail":"Invalid API Key"}`, and both the raw error and the masked key field gave them nothing to act on. Both transport paths were verified byte-correct on the wire, so the fixes target the two generic gaps: silently storing a corrupted key, and surfacing credential rejections as dead-end raw bodies.

Two provider-agnostic changes, one commit each:

### 1. Sanitize pasted API keys at the settings write boundary

Clipboards smuggle control and invisible formatting characters (newlines, zero-width spaces, BOM) into pasted keys. The masked field hides the corruption, and the provider rejects the key with a 401 indistinguishable from a genuinely wrong key. The provider config store now strips those characters and surrounding whitespace once in its write path, so both backing stores (legacy state secrets and providers.json) receive the clean value. A whitespace-only value now clears the key.

### 2. Classify provider 401/403 as `auth` errors and surface actionable guidance

Adds an `"auth"` member to `ProviderErrorClass` (the type's doc comment already invited it), assigned in the llms error classifier when the HTTP layer reports 401/403 — status-only on purpose, since provider bodies can quote words like "unauthorized" without the request being an auth failure. The class rides the existing `errorClass` plumbing, so all hosts receive it with no new wiring.

The VS Code chat surface then rewrites classified credential rejections from BYOK providers into:

> Provider "mistral" rejected the configured credentials. Re-enter the API key in Settings → API Configuration (checking it is the right kind of key for this provider), or switch providers.
>
> Provider response: {"detail":"Invalid API Key"}

Cline-account providers (`cline`, `cline-pass`) keep the existing JSON path so the webview still renders their auth failures as a sign-in card.

### Testing

- New unit tests: key sanitization round-trips in `store.test.ts`, `auth` classification table in `error-classification.test.ts` (typed `APICallError`, structural payloads, `RetryError` unwrap, status-authoritative over message wording), reshape branch in `provider-credential-error.test.ts` (including the cline/cline-pass carve-out and the no-classification pass-through).
- Full `apps/vscode` sdk-layer suite (68 files / 1082 tests), `@cline/llms`, and `@cline/agents` suites green; `tsc --noEmit` clean.

### Out of scope

- The preflight/send-error path (`onSendError`) bypasses the reshape function and still shows raw text; it only fires before streaming starts and can pick up the same classification in a follow-up.
- Settings-time credential validation (catching a bad key at save, not first message) is the durable fix for the whole category — tracked separately.
