### PR TITLE
fix: stop showing cost estimates for subscription-billed providers

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/catalog.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/catalog.test.ts
@@ -554,6 +554,30 @@ describe("ProviderCatalog Phase 3.5 listProviders", () => {
 		expect(mocks.listLocalProviders).toHaveBeenCalledWith(expect.anything(), { isClinePassEnabled: true })
 	})
 
+	it("passes the SDK's subscription usage-cost display through to listings", async () => {
+		const { createProviderCatalog } = await import("./catalog")
+		mocks.listLocalProviders.mockResolvedValue({
+			providers: [
+				{
+					id: "openai-codex",
+					name: "OpenAI ChatGPT Subscription",
+					authDescription: "OpenAI ChatGPT subscription access uses an OAuth device code flow.",
+					protocol: "openai-responses",
+					client: "openai-codex",
+					defaultModelId: "gpt-5.4",
+					source: "system",
+				},
+			],
+		})
+		const providerId = parseProviderId("openai-codex")
+		const catalog = createProviderCatalog(makeReader({ providerId }))
+
+		const listings = await catalog.listProviders()
+
+		expect(listings).toHaveLength(1)
+		expect(listings[0].usageCostDisplay).toBe("subscription")
+	})
+
 	it("caches provider listings per catalog instance without reading provider config", async () => {
 		const { createProviderCatalog } = await import("./catalog")
 		mocks.listLocalProviders.mockResolvedValue({

--- a/apps/vscode/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -92,9 +92,10 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	// Local providers report no cost; the openai-compatible provider can
 	// report cost only when the user has supplied both prices. For every
 	// other provider, the SDK is the source of truth for whether to render
-	// per-task cost: providers with `metadata.usageCostDisplay` set to
-	// "hide" or "subscription" (e.g. ClinePass, ChatGPT Plus/Pro
-	// subscription) are filtered out here. This
+	// per-task cost: any `metadata.usageCostDisplay` other than "show" —
+	// "hide", or "subscription" for flat-rate providers like ClinePass and
+	// ChatGPT Plus/Pro where the computed figure would be an API-rate
+	// estimate rather than a real charge — suppresses the cost here. This
 	// mirrors the CLI's `shouldShowCliUsageCost` consumer and removes the
 	// previous extension-side hard-coded "openai-codex" check.
 	const usageCostDisplay = useProviderUsageCostDisplay(modeFields.apiProvider)
@@ -106,7 +107,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 		(modeFields.apiProvider !== "vscode-lm" &&
 			modeFields.apiProvider !== "ollama" &&
 			modeFields.apiProvider !== "lmstudio" &&
-			usageCostDisplay !== "hide")
+			usageCostDisplay === "show")
 
 	// Event handlers
 	const toggleTaskExpanded = useCallback(() => setIsTaskExpanded(!isTaskExpanded), [setIsTaskExpanded, isTaskExpanded])

--- a/apps/vscode/webview-ui/src/components/settings/common/ModelInfoView.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/common/ModelInfoView.tsx
@@ -178,8 +178,8 @@ interface ModelInfoViewProps {
 	/**
 	 * Suppress the per-token pricing display (compact input/output row, cache
 	 * pricing in Advanced, and tiered pricing). Set this for providers whose
-	 * billing is subscription-based or otherwise not per-token, mirroring the
-	 * SDK's `ProviderInfo.metadata.usageCostDisplay = "hide"` signal (see
+	 * billing is subscription-based or otherwise not per-token — any
+	 * `ProviderInfo.metadata.usageCostDisplay` other than `"show"` (see
 	 * `resolveProviderUsageCostDisplay` in `@cline/llms`).
 	 */
 	hideUsageCost?: boolean

--- a/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -4,6 +4,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useProviderConfig } from "@/hooks/useProviderConfig"
 import { useProviderModelSelection } from "@/hooks/useProviderModelSelection"
 import { useProviderModels } from "@/hooks/useProviderModels"
+import { useProviderUsageCostDisplay } from "@/hooks/useProviderUsageCostDisplay"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { ModelSelector } from "../common/ModelSelector"
@@ -27,6 +28,9 @@ export const ClaudeCodeProvider = ({ showModelOptions, isPopup, currentMode }: C
 	const { handleFieldChange } = useApiConfigurationHandlers()
 	const providerId = "claude-code"
 	const { models, defaultModelId } = useProviderModels(providerId)
+	// The models reuse Anthropic API pricing metadata, but usage is billed
+	// through the Claude subscription — suppress the per-token price rows.
+	const hideUsageCost = useProviderUsageCostDisplay(providerId) !== "show"
 	const { config, write, commitSelection } = useProviderConfig(providerId)
 	const { selectedModelId, selectedModelInfo, commitModelSelection } = useProviderModelSelection(providerId, currentMode, {
 		models,
@@ -99,7 +103,12 @@ export const ClaudeCodeProvider = ({ showModelOptions, isPopup, currentMode }: C
 						/>
 					)}
 
-					<ModelInfoView isPopup={isPopup} modelInfo={selectedModelInfo} selectedModelId={selectedModelId} />
+					<ModelInfoView
+						hideUsageCost={hideUsageCost}
+						isPopup={isPopup}
+						modelInfo={selectedModelInfo}
+						selectedModelId={selectedModelId}
+					/>
 				</>
 			)}
 		</div>

--- a/apps/vscode/webview-ui/src/hooks/useDynamicProviderSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useDynamicProviderSelection.ts
@@ -45,7 +45,7 @@ export function useDynamicProviderSelection(
 	apiConfiguration: ApiConfiguration | undefined,
 	mode: Mode,
 ): DynamicProviderSelection {
-	const hideUsageCost = useProviderUsageCostDisplay(providerId) === "hide"
+	const hideUsageCost = useProviderUsageCostDisplay(providerId) !== "show"
 	return useMemo(() => {
 		const fields = readFields(apiConfiguration, mode)
 		const fallbackInfo = FALLBACK_INFO_BY_PROVIDER[providerId] ?? openAiModelInfoSafeDefaults

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
@@ -37,4 +37,10 @@ describe("useProviderUsageCostDisplay", () => {
 		expect(renderHook(() => useProviderUsageCostDisplay("anthropic")).result.current).toBe("show")
 		expect(renderHook(() => useProviderUsageCostDisplay(undefined)).result.current).toBe("show")
 	})
+
+	it("returns unknown while listings have not arrived", () => {
+		withListings([])
+		const { result } = renderHook(() => useProviderUsageCostDisplay("cline-pass"))
+		expect(result.current).toBe("unknown")
+	})
 })

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.test.ts
@@ -19,13 +19,13 @@ function withListings(providers: Array<{ id: string; usageCostDisplay: string }>
 }
 
 describe("useProviderUsageCostDisplay", () => {
-	it("hides cost for providers the SDK marks as subscription", () => {
+	it("returns the subscription mark for subscription-billed providers", () => {
 		withListings([{ id: "cline-pass", usageCostDisplay: "subscription" }])
 		const { result } = renderHook(() => useProviderUsageCostDisplay("cline-pass"))
-		expect(result.current).toBe("hide")
+		expect(result.current).toBe("subscription")
 	})
 
-	it("hides cost for providers the SDK marks as hide", () => {
+	it("returns hide for providers the SDK marks as hide", () => {
 		withListings([{ id: "some-provider", usageCostDisplay: "hide" }])
 		const { result } = renderHook(() => useProviderUsageCostDisplay("some-provider"))
 		expect(result.current).toBe("hide")

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
@@ -1,6 +1,14 @@
 import { useMemo } from "react"
 import { useProviderListings } from "./useProviderListings"
 
+export type UsageCostDisplay = "show" | "hide" | "subscription"
+
+const USAGE_COST_DISPLAYS: readonly UsageCostDisplay[] = ["show", "hide", "subscription"]
+
+function isUsageCostDisplay(value: string | undefined): value is UsageCostDisplay {
+	return !!value && USAGE_COST_DISPLAYS.includes(value as UsageCostDisplay)
+}
+
 /**
  * Surfaces the SDK's `usageCostDisplay` decision for a single provider
  * id. The decision originates in the `@cline/llms` SDK (see
@@ -8,26 +16,29 @@ import { useProviderListings } from "./useProviderListings"
  * `apps/vscode/src/sdk/model-catalog/catalog.ts`) and is propagated
  * through the `ProviderListing.usage_cost_display` gRPC field.
  *
- * Returns `"hide"` when the SDK reports `"hide"` or `"subscription"` —
- * either way per-token / total cost displays should be suppressed
- * (matches the CLI's `shouldShowCliUsageCost`, which only shows cost
- * for `"show"`). Falls back to `"show"` while the listings are still
- * loading or for any provider the SDK does not explicitly mark — the
- * same default policy the SDK and CLI use.
+ * Returns `"hide"` when cost is unknowable or meaningless for the
+ * provider, and `"subscription"` when usage is billed through a
+ * flat-rate subscription (e.g. ChatGPT Plus/Pro, ClinePass) — in that
+ * case any computed dollar figure is a per-token API-rate estimate, not
+ * an actual charge. Cost displays must render only for `"show"`, which
+ * matches the CLI's `shouldShowCliUsageCost` consumer. Falls back to
+ * `"show"` while the listings are still loading or for any provider the
+ * SDK does not explicitly mark — the same default policy the SDK and
+ * CLI use.
  *
- * Webview consumers must pass the returned value into
- * `ModelInfoView.hideUsageCost` (and equivalent cost-display sites)
- * rather than re-deriving it. If a new provider needs to suppress cost,
- * set `metadata.usageCostDisplay = "hide"` in the SDK provider builtin;
+ * Webview consumers must derive cost visibility from the returned value
+ * (`=== "show"`, or `ModelInfoView.hideUsageCost`) rather than
+ * re-deriving it per provider. If a new provider needs to suppress
+ * cost, set `metadata.usageCostDisplay` in the SDK provider builtin;
  * the webview picks it up without any change here.
  */
-export function useProviderUsageCostDisplay(providerId: string | undefined): "show" | "hide" {
+export function useProviderUsageCostDisplay(providerId: string | undefined): UsageCostDisplay {
 	const { providers } = useProviderListings()
 	return useMemo(() => {
 		if (!providerId) {
 			return "show"
 		}
-		const listing = providers.find((p) => p.id === providerId)
-		return listing?.usageCostDisplay === "hide" || listing?.usageCostDisplay === "subscription" ? "hide" : "show"
+		const value = providers.find((p) => p.id === providerId)?.usageCostDisplay
+		return isUsageCostDisplay(value) ? value : "show"
 	}, [providers, providerId])
 }

--- a/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
+++ b/apps/vscode/webview-ui/src/hooks/useProviderUsageCostDisplay.ts
@@ -21,10 +21,15 @@ function isUsageCostDisplay(value: string | undefined): value is UsageCostDispla
  * flat-rate subscription (e.g. ChatGPT Plus/Pro, ClinePass) — in that
  * case any computed dollar figure is a per-token API-rate estimate, not
  * an actual charge. Cost displays must render only for `"show"`, which
- * matches the CLI's `shouldShowCliUsageCost` consumer. Falls back to
- * `"show"` while the listings are still loading or for any provider the
- * SDK does not explicitly mark — the same default policy the SDK and
- * CLI use.
+ * matches the CLI's `shouldShowCliUsageCost` consumer.
+ *
+ * Returns `"unknown"` until the listings have arrived (and if the
+ * listing request failed). Rendering cost in that window would flash a
+ * dollar estimate at subscription users — the exact display this hook
+ * exists to suppress — so consumers treat `"unknown"` like any other
+ * non-`"show"` value and render nothing. Once listings are present, a
+ * provider the SDK does not explicitly mark falls back to `"show"`,
+ * the same default policy the SDK and CLI use.
  *
  * Webview consumers must derive cost visibility from the returned value
  * (`=== "show"`, or `ModelInfoView.hideUsageCost`) rather than
@@ -32,11 +37,16 @@ function isUsageCostDisplay(value: string | undefined): value is UsageCostDispla
  * cost, set `metadata.usageCostDisplay` in the SDK provider builtin;
  * the webview picks it up without any change here.
  */
-export function useProviderUsageCostDisplay(providerId: string | undefined): UsageCostDisplay {
+export function useProviderUsageCostDisplay(providerId: string | undefined): UsageCostDisplay | "unknown" {
 	const { providers } = useProviderListings()
 	return useMemo(() => {
 		if (!providerId) {
 			return "show"
+		}
+		// Listings are never legitimately empty (builtin providers always
+		// exist), so an empty array means "not loaded yet" or "load failed".
+		if (providers.length === 0) {
+			return "unknown"
 		}
 		const value = providers.find((p) => p.id === providerId)?.usageCostDisplay
 		return isUsageCostDisplay(value) ? value : "show"

--- a/apps/vscode/webview-ui/src/hooks/useStaticProviderSelection.ts
+++ b/apps/vscode/webview-ui/src/hooks/useStaticProviderSelection.ts
@@ -44,7 +44,7 @@ export function useStaticProviderSelection(
 	hideUsageCost: boolean
 } {
 	const { models, defaultModelId } = useProviderModels(providerId)
-	const hideUsageCost = useProviderUsageCostDisplay(providerId) === "hide"
+	const hideUsageCost = useProviderUsageCostDisplay(providerId) !== "show"
 
 	const fallbackSavedModelId =
 		currentMode === "plan" ? apiConfiguration?.planModeApiModelId : apiConfiguration?.actModeApiModelId

--- a/sdk/packages/llms/src/providers/billing.test.ts
+++ b/sdk/packages/llms/src/providers/billing.test.ts
@@ -17,6 +17,11 @@ describe("provider usage cost display", () => {
 		expect(shouldShowProviderUsageCost("openai-codex-cli")).toBe(false);
 	});
 
+	it("hides usage cost for the Claude Code subscription provider", () => {
+		expect(resolveProviderUsageCostDisplay("claude-code")).toBe("subscription");
+		expect(shouldShowProviderUsageCost("claude-code")).toBe(false);
+	});
+
 	it("shows usage cost by default for usage-billed providers", () => {
 		expect(resolveProviderUsageCostDisplay("openai-native")).toBe("show");
 		expect(resolveProviderUsageCostDisplay("anthropic")).toBe("show");

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1160,6 +1160,12 @@ const BUILTIN_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		modelsFactory: buildClaudeCodeModels,
 		defaults: { baseUrl: "" },
 		configFields: [],
+		// Claude Code is typically authenticated with a Pro/Max subscription,
+		// where any dollar figure would be an API-rate estimate rather than a
+		// real charge. The CLI does report a cost when it runs on API-key
+		// billing, but the provider cannot tell the two apart from here, so
+		// prefer not showing a number over showing a misleading one.
+		metadata: { usageCostDisplay: "subscription" },
 	},
 	{
 		id: "gemini",


### PR DESCRIPTION
Fixes [ENG-2471](https://linear.app/cline-bot/issue/ENG-2471/subscription-providers-chatgpt-clinepass-claude-code-show-api-rate) — reported on [Reddit](https://www.reddit.com/r/CLine/comments/1vxwsfp/cline_showing_a_cost_when_using_my_chatgpt/): a user on the ChatGPT-subscription provider sees a `$` cost on every task and thinks they're being charged on top of their subscription.

## Problem

Subscription-billed providers (`openai-codex`, `openai-codex-cli`, ClinePass) are already marked `metadata.usageCostDisplay = "subscription"` in the SDK, and the CLI honors that mark, but the figures still reached the VS Code webview as displayable costs — all computed from API-rate catalog pricing, none of it an actual charge.

> **Rebase note:** #13515 landed on main mid-review and fixed the host side (pass the SDK's value through the catalog listing) plus a binary hide at the webview hook. This PR is rebased on top of it and now carries what main still lacks, below.

## Changes

**Commit 1 — keep the tri-state in the webview (fix)**
- `useProviderUsageCostDisplay` returns the full `"show" | "hide" | "subscription"` union instead of collapsing `"subscription"` into `"hide"`, preserving the semantic distinction (e.g. for a future "included in subscription" label). Cost renders only when the value is `"show"`, matching the CLI's `shouldShowCliUsageCost` policy: the TaskHeader gate flips from `!== "hide"` to `=== "show"`, and `useStaticProviderSelection` / `useDynamicProviderSelection` derive `hideUsageCost` from `!== "show"`. The hook unit test from #13515 is updated to the tri-state expectations, and a catalog test pins the `"subscription"` pass-through for `openai-codex`.

**Commit 2 — mark Claude Code as subscription-billed (feat)**
- The `claude-code` provider (Claude Pro/Max) reuses Anthropic API pricing metadata, so it had the same problem. It now sets `usageCostDisplay = "subscription"`, and its settings card passes `hideUsageCost` through to `ModelInfoView`.
- Caveat: the Claude Code CLI can also run on API-key billing, where a real cost exists. The provider can't distinguish the two, so this prefers showing no number over a misleading one.

**Commit 3 — suppress cost while listings load (fix)**
- While the `ListProviders` request is in flight (or after it fails), the hook had no listing to consult and fell back to `"show"`, flashing the API-rate estimate at subscription users on every chat-view mount. It now returns `"unknown"` whenever listings are absent; consumers already render cost only for `"show"`, so the window is suppressed with no consumer changes.

## Known gap (follow-up, out of scope)

Task history rows (`HistoryViewItem`, `HistoryPreview` — including the history entries shown in an empty chat view) render the stored `totalCost`, and `HistoryItem` doesn't record which provider ran the task, so past-task estimates remain visible in history. Hiding those needs provider plumbed into history items.

## Testing

- Hook unit tests cover all three values plus the `"unknown"` loading state; catalog listing test pins `"subscription"` pass-through for `openai-codex`; new billing test pins `claude-code` as subscription.
- `apps/vscode` vitest (model-catalog + controller/models): 200 passed; full webview suite: 446 passed; `@cline/llms` provider suite: 691 passed.
- `check-types` (extension + webview) and biome clean.
