### PR TITLE
fix(desktop): unblock sdk-test lint on the voice-input model picker

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/voice-input-view.tsx
@@ -270,6 +270,7 @@ export function VoiceInputContent({
 											defaultTranscriptionModel(selectedEntry.models)?.id ===
 											model.id;
 										return (
+											// biome-ignore lint/a11y/useSemanticElements: the model picker is a styled radiogroup of buttons; aria-checked + role convey the semantics, and an <input type="radio"> would need a full restyle.
 											<button
 												aria-checked={isSelected}
 												className={cn(


### PR DESCRIPTION
The `sdk-test` Quality Checks job (`biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/`) fails on every PR touching those paths since #13531: the voice-input model picker's `role="radio"` buttons trip `lint/a11y/useSemanticElements` at error level. The workflow is PR-triggered only, so main shows green while all sdk-path PRs are red (hit on #13524).

One-line `biome-ignore` with justification: the picker is a styled radiogroup of buttons carrying `aria-checked`/`role`, and converting to `<input type="radio">` needs a restyle that belongs with the desktop settings work, not a lint unblock.

Verified: `bunx biome lint sdk/ apps/cli/ apps/cline-hub/ apps/examples/` exits 0 with this change (37 warnings/25 infos pre-existing, zero errors).