### PR TITLE
fix(vscode): avoid chat view render crash on malformed api_req payloads

### DIFF
--- a/apps/vscode/src/shared/combineApiRequests.test.ts
+++ b/apps/vscode/src/shared/combineApiRequests.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "bun:test"
+import { strict as assert } from "node:assert"
+import type { ClineMessage } from "./ExtensionMessage"
+import { combineApiRequests } from "./combineApiRequests"
+
+function started(ts: number, text: string) {
+	return { ts, type: "say", say: "api_req_started", text } as ClineMessage
+}
+
+function finished(ts: number, text: string) {
+	return { ts, type: "say", say: "api_req_finished", text } as ClineMessage
+}
+
+describe("combineApiRequests", () => {
+	it("merges a started request with its following finished payload", () => {
+		const messages: ClineMessage[] = [
+			started(1, JSON.stringify({ request: "GET /api/data" })),
+			finished(2, JSON.stringify({ cost: 0.005, tokensIn: 10, tokensOut: 5 })),
+		]
+
+		const combined = combineApiRequests(messages)
+
+		assert.equal(combined.length, 1)
+		assert.equal(combined[0]?.say, "api_req_started")
+		assert.deepEqual(JSON.parse(combined[0]?.text ?? "{}"), {
+			request: "GET /api/data",
+			cost: 0.005,
+			tokensIn: 10,
+			tokensOut: 5,
+		})
+	})
+
+	it("keeps an api_req_started without a matching finished payload", () => {
+		const messages: ClineMessage[] = [started(1, JSON.stringify({ request: "A" }))]
+
+		const combined = combineApiRequests(messages)
+
+		assert.equal(combined.length, 1)
+		assert.deepEqual(JSON.parse(combined[0]?.text ?? "{}"), { request: "A" })
+	})
+
+	it("does not throw on a malformed api_req_started payload and keeps the row", () => {
+		const messages: ClineMessage[] = [
+			started(1, "{not-json"),
+			{ ts: 2, type: "say", say: "text", text: "hello" } as ClineMessage,
+		]
+
+		const combined = combineApiRequests(messages)
+
+		assert.equal(combined[0]?.text, "{not-json")
+		assert.equal(combined[1]?.text, "hello")
+	})
+
+	it("does not throw on a malformed api_req_finished payload", () => {
+		const messages: ClineMessage[] = [
+			started(1, JSON.stringify({ request: "A", cost: 0.1 })),
+			finished(2, "{not-json"),
+		]
+
+		const combined = combineApiRequests(messages)
+
+		// Pair is still consumed; the started row survives with its own payload.
+		assert.equal(combined.length, 1)
+		assert.deepEqual(JSON.parse(combined[0]?.text ?? "{}"), { request: "A", cost: 0.1 })
+	})
+})

--- a/apps/vscode/src/shared/combineApiRequests.ts
+++ b/apps/vscode/src/shared/combineApiRequests.ts
@@ -23,12 +23,29 @@ export function combineApiRequests(messages: ClineMessage[]): ClineMessage[] {
 
 	for (let i = 0; i < messages.length; i++) {
 		if (messages[i].type === "say" && messages[i].say === "api_req_started") {
-			const startedRequest = JSON.parse(messages[i].text || "{}")
+			// Malformed payloads are tolerated everywhere else that reads this row
+			// (see messageUtils, RequestStartRow, getApiMetrics) because this runs
+			// inside the render pipeline. A JSON.parse throw here would crash the
+			// whole chat view, so degrade to keeping the original row instead.
+			let startedRequest: Record<string, unknown>
+			try {
+				startedRequest = JSON.parse(messages[i].text || "{}")
+			} catch {
+				continue
+			}
+
 			let j = i + 1
 
 			while (j < messages.length) {
 				if (messages[j].type === "say" && messages[j].say === "api_req_finished") {
-					const finishedRequest = JSON.parse(messages[j].text || "{}")
+					let finishedRequest: Record<string, unknown>
+					try {
+						finishedRequest = JSON.parse(messages[j].text || "{}")
+					} catch {
+						// Unparseable finish payload — nothing to merge, keep the
+						// started row as-is but still consume the pair.
+						finishedRequest = {}
+					}
 					const combinedRequest = {
 						...startedRequest,
 						...finishedRequest,


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #13561

### Description

`combineApiRequests()` in `apps/vscode/src/shared/combineApiRequests.ts` parses the `text` JSON of `api_req_started` / `api_req_finished` messages **without** a `try/catch`. This function runs inside the chat render pipeline (`ChatView.tsx` calls it inside a `useMemo`), so a single malformed payload throws during render and blanks the entire chat view.

Every other reader of these rows already tolerates malformed payloads:

- `messageUtils.ts` — catches, "keep on parse error to be safe"
- `RequestStartRow.tsx`, `ToolGroupRenderer.tsx` — `try/catch`
- `getApiMetrics.ts` / `getLastApiReqTotalTokens` — `try/catch`

`combineApiRequests` was the unchecked exception. This fix brings it in line with the rest of the codebase:

- An unparseable `api_req_started` row is kept as-is (`continue`) instead of throwing.
- An unparseable `api_req_finished` row is merged as an empty object, so the started/finished pair is still consumed without crashing.

### Test Procedure

- Reviewed every other reader of `api_req_started`/`api_req_finished` to confirm `try/catch` is the established pattern and that this code path runs during render.
- Added unit tests in `apps/vscode/src/shared/combineApiRequests.test.ts` (bun:test, matching the existing `getApiMetrics.test.ts` style) covering:
  1. Normal merge of started + finished payloads (unchanged behavior).
  2. A started row with no matching finished row is preserved.
  3. A malformed `api_req_started` payload does not throw and the row is preserved.
  4. A malformed `api_req_finished` payload does not throw and the pair is consumed.

Good payloads behave exactly as before; the well-formed merge path is unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend/UI-crash-safety change; no visual change.

### Additional Notes

I was not able to run the full `bun test` suite locally in the environment where I prepared this change, and I did not add a CHANGELOG entry (per repo convention, maintainers handle changelog curation during release).
