### PR TITLE
fix: hide history cost estimates for subscription-billed tasks

### DIFF
--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -110,6 +110,9 @@ message TaskItem {
   int32 cache_reads = 10;
   string model_id = 11;
   bool is_legacy = 12;
+  // Provider id the task ran on. Empty for tasks recorded before this
+  // field existed and for legacy imports; consumers show cost in that case.
+  string api_provider = 13;
 }
 
 // Request for ask response operation

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -2042,6 +2042,7 @@ export class Controller {
 				cacheWrites: metadataNumber(metadata, "cacheWrites") ?? 0,
 				cacheReads: metadataNumber(metadata, "cacheReads") ?? 0,
 				modelId: item.model || metadataString(metadata, "modelId") || "",
+				apiProvider: item.provider ?? "",
 				isLegacy:
 					metadataBoolean(metadata, "legacyTask") === true ||
 					metadataBoolean(metadata, "migratedFromLegacyTask") === true,
@@ -2066,6 +2067,7 @@ export class Controller {
 					cacheWrites: 0,
 					cacheReads: 0,
 					modelId: this.task.api?.getModel?.().id ?? "",
+					apiProvider: "",
 					isLegacy: false,
 				})
 			}

--- a/apps/vscode/src/sdk/sdk-task-history.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.test.ts
@@ -116,6 +116,7 @@ describe("SdkTaskHistory", () => {
 			totalCost: 0.01,
 			isFavorited: true,
 			modelId: "claude-test",
+			apiProvider: "anthropic",
 			cwdOnTaskInitialization: "/repo",
 		})
 		expect(result.ts).toBeGreaterThan(0)

--- a/apps/vscode/src/sdk/sdk-task-history.ts
+++ b/apps/vscode/src/sdk/sdk-task-history.ts
@@ -114,7 +114,7 @@ function historyItemToSessionHistoryRecord(item: HistoryItem): SessionHistoryRec
 		exitCode: 0,
 		status: "completed",
 		interactive: true,
-		provider: "",
+		provider: item.apiProvider ?? "",
 		model: item.modelId ?? "",
 		cwd: item.cwdOnTaskInitialization ?? "",
 		workspaceRoot: item.cwdOnTaskInitialization ?? "",
@@ -189,6 +189,7 @@ export function sessionHistoryRecordToHistoryItem(item: SessionHistoryRecord): H
 		size: metadataNumber(metadata, "size"),
 		isFavorited: metadataBoolean(metadata, "isFavorited") ?? metadataBoolean(metadata, "is_favorited") ?? false,
 		modelId: item.model || metadataString(metadata, "modelId") || "",
+		apiProvider: item.provider || undefined,
 		cwdOnTaskInitialization: item.cwd ?? item.workspaceRoot,
 		isLegacy:
 			metadataBoolean(metadata, "legacyTask") === true || metadataBoolean(metadata, "migratedFromLegacyTask") === true,

--- a/apps/vscode/src/shared/HistoryItem.ts
+++ b/apps/vscode/src/shared/HistoryItem.ts
@@ -15,5 +15,12 @@ export type HistoryItem = {
 	isFavorited?: boolean
 
 	modelId?: string
+	/**
+	 * Provider id the task ran on (from the SDK session record). Absent for
+	 * tasks recorded before this field existed and for legacy imports —
+	 * cost-display consumers treat an absent provider as "show", since
+	 * there is nothing to key suppression on.
+	 */
+	apiProvider?: string
 	isLegacy?: boolean
 }

--- a/apps/vscode/src/test/e2e/history.test.ts
+++ b/apps/vscode/src/test/e2e/history.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { expect } from "@playwright/test"
+import { E2ETestHelper, e2e } from "./utils/helpers"
+
+/**
+ * Seeds an SDK session history record the way a completed task persists it
+ * (~/.cline/data/sessions/<id>/<id>.json, snake_case on disk). `provider` is
+ * the field the cost-display suppression keys on.
+ */
+function seedSessionRecord(
+	clineDir: string,
+	options: { id: string; provider: string; title: string; totalCost: number; ts: number },
+): void {
+	const { id, provider, title, totalCost, ts } = options
+	const startedAt = new Date(ts).toISOString()
+	const sessionDir = path.join(clineDir, "data", "sessions", id)
+	mkdirSync(sessionDir, { recursive: true })
+	writeFileSync(
+		path.join(sessionDir, `${id}.json`),
+		JSON.stringify({
+			version: 1,
+			session_id: id,
+			source: "vscode",
+			pid: 1,
+			started_at: startedAt,
+			ended_at: startedAt,
+			exit_code: 0,
+			status: "completed",
+			interactive: true,
+			provider,
+			model: "test-model",
+			cwd: "/tmp/e2e-history",
+			workspace_root: "/tmp/e2e-history",
+			enable_tools: true,
+			enable_spawn: false,
+			enable_teams: false,
+			prompt: title,
+			metadata: {
+				title,
+				isFavorited: false,
+				size: 1024,
+				totalCost,
+				tokensIn: 100,
+				tokensOut: 50,
+				cacheWrites: 0,
+				cacheReads: 0,
+				modelId: "test-model",
+				legacyTask: false,
+			},
+			updated_at: startedAt,
+		}),
+	)
+	writeFileSync(path.join(sessionDir, `${id}.messages.json`), "[]")
+}
+
+e2e("History - hides cost estimates for subscription-billed tasks", async ({ app, page, helper, server: _server }) => {
+	// Seed history BEFORE the webview loads so its first state fetch sees the
+	// records (the extension caches history metadata for ~10s).
+	const clineDir = await app.evaluate(() => process.env.CLINE_DIR)
+	expect(clineDir).toBeTruthy()
+
+	const now = Date.now()
+	// openai-codex is marked usageCostDisplay = "subscription" in the SDK; its
+	// stored totalCost is an API-rate estimate, not a real charge.
+	seedSessionRecord(clineDir as string, {
+		id: `${now - 1000}_subtask`,
+		provider: "openai-codex",
+		title: "Subscription billed e2e task",
+		totalCost: 0.4242,
+		ts: now - 1000,
+	})
+	// anthropic is usage-billed; its cost must keep rendering.
+	seedSessionRecord(clineDir as string, {
+		id: `${now - 2000}_apitask`,
+		provider: "anthropic",
+		title: "Usage billed e2e task",
+		totalCost: 0.1337,
+		ts: now - 2000,
+	})
+
+	await E2ETestHelper.openClineSidebar(page)
+	const sidebar = await helper.getSidebar(page)
+	await helper.signin(sidebar)
+
+	// Recent-task chips in the empty chat view (HistoryPreview)
+	await expect(sidebar.getByText("Recent")).toBeVisible()
+	await expect(sidebar.getByText("Subscription billed e2e task")).toBeVisible()
+	await expect(sidebar.getByText("Usage billed e2e task")).toBeVisible()
+	await expect(sidebar.getByText("$0.13")).toBeVisible()
+	await expect(sidebar.getByText("$0.42")).not.toBeVisible()
+
+	// Full history page (HistoryView) — scope to the virtualized list, since
+	// the HistoryPreview beneath still holds matching task titles.
+	await sidebar.getByRole("button", { name: "View all history" }).click()
+	const historyList = sidebar.getByTestId("virtuoso-item-list")
+	await expect(historyList.getByText("Subscription billed e2e task")).toBeVisible()
+	await expect(historyList.getByText("Usage billed e2e task")).toBeVisible()
+	await expect(historyList.getByText("$0.1337")).toBeVisible()
+	await expect(historyList.getByText("$0.4242")).not.toBeVisible()
+})

--- a/apps/vscode/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryPreview.tsx
@@ -1,6 +1,7 @@
 import { StringRequest } from "@shared/proto/cline/common"
 import { memo } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { useUsageCostVisibility } from "@/hooks/useUsageCostVisibility"
 import { TaskServiceClient } from "@/services/grpc-client"
 
 type HistoryPreviewProps = {
@@ -9,6 +10,7 @@ type HistoryPreviewProps = {
 
 const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 	const { taskHistory } = useExtensionState()
+	const isCostVisible = useUsageCostVisibility()
 	const handleHistorySelect = (id: string) => {
 		TaskServiceClient.showTaskWithId(StringRequest.create({ value: id })).catch((error) =>
 			console.error("Error showing task:", error),
@@ -165,7 +167,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 									</div>
 									<div className="history-meta-stack">
 										<span className="history-date">{formatDate(item.ts)}</span>
-										{item.totalCost != null && (
+										{item.totalCost != null && isCostVisible(item.apiProvider) && (
 											<span className="history-cost-chip">${item.totalCost.toFixed(2)}</span>
 										)}
 									</div>

--- a/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react"
 import { memo, useCallback, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { useUsageCostVisibility } from "@/hooks/useUsageCostVisibility"
 import { cn } from "@/lib/utils"
 import { TaskServiceClient } from "@/services/grpc-client"
 import { formatLargeNumber, formatSize } from "@/utils/format"
@@ -37,6 +38,7 @@ const HistoryViewItem = ({
 	selectedItems,
 }: HistoryViewItemProps) => {
 	const [expanded, setExpanded] = useState(false)
+	const isCostVisible = useUsageCostVisibility()
 
 	const isFavoritedItem = useMemo(
 		() => pendingFavoriteToggles[item.id] ?? item.isFavorited,
@@ -145,7 +147,9 @@ const HistoryViewItem = ({
 					<div className="flex items-center justify-between w-full">
 						<div className="text-description text-xs uppercase">{formatDate(item.ts)}</div>
 						<div className="self-end flex items-center text-xs">
-							<span className="text-description">${item.totalCost?.toFixed(4) ?? 0}</span>
+							{isCostVisible(item.apiProvider) && (
+								<span className="text-description">${item.totalCost?.toFixed(4) ?? 0}</span>
+							)}
 							{expanded ? (
 								<ChevronsDownUpIcon className="text-description" />
 							) : (

--- a/apps/vscode/webview-ui/src/hooks/useUsageCostVisibility.test.ts
+++ b/apps/vscode/webview-ui/src/hooks/useUsageCostVisibility.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { useProviderListings } from "./useProviderListings"
+import { useUsageCostVisibility } from "./useUsageCostVisibility"
+
+vi.mock("./useProviderListings", () => ({
+	useProviderListings: vi.fn(),
+}))
+
+const mockUseProviderListings = vi.mocked(useProviderListings)
+
+function withListings(providers: Array<{ id: string; usageCostDisplay: string }>) {
+	mockUseProviderListings.mockReturnValue({
+		providers,
+		isLoading: false,
+		error: undefined,
+		refresh: vi.fn(),
+	} as unknown as ReturnType<typeof useProviderListings>)
+}
+
+function renderPredicate() {
+	return renderHook(() => useUsageCostVisibility()).result.current
+}
+
+describe("useUsageCostVisibility", () => {
+	it("hides cost for rows whose provider is subscription-billed or marked hide", () => {
+		withListings([
+			{ id: "cline-pass", usageCostDisplay: "subscription" },
+			{ id: "some-provider", usageCostDisplay: "hide" },
+		])
+		const isCostVisible = renderPredicate()
+		expect(isCostVisible("cline-pass")).toBe(false)
+		expect(isCostVisible("some-provider")).toBe(false)
+	})
+
+	it("shows cost for providers marked show and for providers absent from the listings", () => {
+		withListings([{ id: "openrouter", usageCostDisplay: "show" }])
+		const isCostVisible = renderPredicate()
+		expect(isCostVisible("openrouter")).toBe(true)
+		expect(isCostVisible("anthropic")).toBe(true)
+	})
+
+	it("shows cost for rows that recorded no provider", () => {
+		withListings([{ id: "cline-pass", usageCostDisplay: "subscription" }])
+		const isCostVisible = renderPredicate()
+		expect(isCostVisible(undefined)).toBe(true)
+		expect(isCostVisible("")).toBe(true)
+	})
+
+	it("hides cost while listings have not arrived", () => {
+		withListings([])
+		const isCostVisible = renderPredicate()
+		expect(isCostVisible("cline-pass")).toBe(false)
+		expect(isCostVisible("anthropic")).toBe(false)
+	})
+})

--- a/apps/vscode/webview-ui/src/hooks/useUsageCostVisibility.ts
+++ b/apps/vscode/webview-ui/src/hooks/useUsageCostVisibility.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react"
+import { useProviderListings } from "./useProviderListings"
+
+/**
+ * Returns a predicate deciding whether a history row's stored dollar cost
+ * may be shown, keyed by the provider id recorded on the row
+ * (`HistoryItem.apiProvider` / `TaskItem.api_provider`).
+ *
+ * A row's stored `totalCost` is an API-rate estimate; for providers the
+ * SDK marks with `metadata.usageCostDisplay` other than `"show"` (e.g.
+ * subscription-billed ChatGPT Plus/Pro, ClinePass, Claude Code) it is not
+ * a real charge, so history surfaces must not render it. This is the
+ * per-row counterpart of `useProviderUsageCostDisplay`, which decides for
+ * a single provider; history lists mix providers, hence the predicate.
+ *
+ * Decision table:
+ * - No provider recorded on the row (tasks predating the field, legacy
+ *   imports) → show; there is nothing to key suppression on.
+ * - Listings not loaded yet (or the request failed) → hide; rendering in
+ *   that window would flash estimates at subscription users.
+ * - Provider absent from the listings, or marked `"show"` → show; the
+ *   same default policy the SDK and CLI use.
+ */
+export function useUsageCostVisibility(): (providerId: string | undefined) => boolean {
+	const { providers } = useProviderListings()
+	return useCallback(
+		(providerId: string | undefined) => {
+			if (!providerId) {
+				return true
+			}
+			// Listings are never legitimately empty (builtin providers always
+			// exist), so an empty array means "not loaded yet" or "load failed".
+			if (providers.length === 0) {
+				return false
+			}
+			const listing = providers.find((p) => p.id === providerId)
+			return !listing || !listing.usageCostDisplay || listing.usageCostDisplay === "show"
+		},
+		[providers],
+	)
+}


### PR DESCRIPTION
Fixes [ENG-2472](https://linear.app/cline-bot/issue/ENG-2472/history-surfaces-still-show-cost-estimates-for-subscription-billed) — the history follow-up raised on #13552: history surfaces still render the stored `$` cost estimate for subscription-billed tasks (ChatGPT Plus/Pro, ClinePass, Claude Code), where the figure is an API-rate estimate, not a real charge.

## Problem

Two surfaces render a task's stored `totalCost` regardless of provider:
- **History page** (`HistoryViewItem`) — `$X.XXXX` on every row
- **Recent-task chips** in an empty chat view (`HistoryPreview`) — a `$` chip per task

The per-provider suppression from #13515 / #13552 can't reach them because a history row doesn't know its provider: `HistoryItem` and the `TaskItem` proto carry `modelId` but not the provider id, and `modelId` isn't a safe proxy (`gpt-5.4` could be the OpenAI API *or* the ChatGPT subscription).

## Changes

- **Plumb the provider through.** The SDK session records already persist `provider` (the CLI's history view keys its per-row cost hiding on it); the VS Code mappers just dropped it. `sessionHistoryRecordToHistoryItem` now maps it to a new `HistoryItem.apiProvider`, and `getTaskHistory` fills a new `TaskItem.api_provider` proto field (plain string, field 13). The legacy round-trip (`historyItemToSessionHistoryRecord`) writes it back instead of hard-coding `""`.
- **Suppress per row.** New `useUsageCostVisibility` hook returns a predicate keyed by the row's provider id — history lists mix providers, so this is the per-row counterpart of `useProviderUsageCostDisplay`. Both render sites hide the `$` when the provider's `usageCostDisplay` isn't `"show"`, and while provider listings haven't loaded (no estimate flashes during the load window).

## Deliberate behavior

- **Rows without a recorded provider keep showing the stored value** — tasks recorded before this field existed and legacy imports have nothing to key suppression on. Their estimates age out naturally as new tasks record the provider.
- `totalCost` is still computed and stored for subscription tasks (same as the CLI); suppression stays a display-layer decision. The "sort by most expensive" option keeps working off stored values.

## Testing

- **Live e2e (real VS Code via Playwright)**: new `history.test.ts` seeds SDK session records (an `openai-codex` subscription task and an `anthropic` usage-billed task) into the isolated `CLINE_DIR` before the webview loads, then asserts both surfaces render the `$` only for the usage-billed task. This exercises the exact boundaries unit tests stub: on-disk records reaching `getTaskHistory` with `provider` populated, and the listings delivering the subscription mark to the webview. Full e2e suite green (9 passed, 2 Windows-only skips).

- `useUsageCostVisibility` unit tests: subscription/hide suppression, show + unlisted-provider defaults, no-provider rows, and the listings-not-loaded window.
- `sdk-task-history` mapping test extended to pin `apiProvider`.
- Full webview suite: 449 passed; extension + webview typecheck and biome clean.

Independent of #13552 (based on `main`); the two compose without conflicts.

