### PR TITLE
fix(sdk): don't log out Codex/OCA users when token refresh fails transiently

### DIFF
--- a/sdk/packages/core/src/auth/codex.test.ts
+++ b/sdk/packages/core/src/auth/codex.test.ts
@@ -128,12 +128,27 @@ describe("auth/codex token lifecycle", () => {
 			),
 		);
 
+		const capture = vi.fn();
 		const current = createCredentials({ expires: 150_000 });
 		const result = await getValidOpenAICodexCredentials(current, {
 			refreshBufferMs: 60_000,
 			retryableTokenGraceMs: 30_000,
+			telemetry: { capture } as never,
 		});
 		expect(result).toBe(current);
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "user.auth_refresh_soft_failure",
+				properties: expect.objectContaining({
+					provider: "openai-codex",
+					status: 500,
+					tokenExpired: false,
+				}),
+			}),
+		);
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "user.auth_logged_out" }),
+		);
 		nowSpy.mockRestore();
 	});
 
@@ -152,44 +167,6 @@ describe("auth/codex token lifecycle", () => {
 		await expect(refreshOpenAICodexToken("refresh")).rejects.toThrow(
 			"Failed to refresh OpenAI Codex token",
 		);
-	});
-
-	it("keeps current credentials and captures a soft failure on transient refresh error while the token is still usable", async () => {
-		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							error: "server_error",
-							error_description: "temporary issue",
-						}),
-						{ status: 500, headers: { "Content-Type": "application/json" } },
-					),
-			),
-		);
-
-		const capture = vi.fn();
-		const current = createCredentials({ expires: 200_000 });
-		const result = await getValidOpenAICodexCredentials(current, {
-			telemetry: { capture } as never,
-		});
-		expect(result).toBe(current);
-		expect(capture).toHaveBeenCalledWith(
-			expect.objectContaining({
-				event: "user.auth_refresh_soft_failure",
-				properties: expect.objectContaining({
-					provider: "openai-codex",
-					status: 500,
-					tokenExpired: false,
-				}),
-			}),
-		);
-		expect(capture).not.toHaveBeenCalledWith(
-			expect.objectContaining({ event: "user.auth_logged_out" }),
-		);
-		nowSpy.mockRestore();
 	});
 
 	it("throws on transient refresh error when the token is already expired", async () => {

--- a/sdk/packages/core/src/auth/codex.test.ts
+++ b/sdk/packages/core/src/auth/codex.test.ts
@@ -153,4 +153,113 @@ describe("auth/codex token lifecycle", () => {
 			"Failed to refresh OpenAI Codex token",
 		);
 	});
+
+	it("keeps current credentials and captures a soft failure on transient refresh error while the token is still usable", async () => {
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							error: "server_error",
+							error_description: "temporary issue",
+						}),
+						{ status: 500, headers: { "Content-Type": "application/json" } },
+					),
+			),
+		);
+
+		const capture = vi.fn();
+		const current = createCredentials({ expires: 200_000 });
+		const result = await getValidOpenAICodexCredentials(current, {
+			telemetry: { capture } as never,
+		});
+		expect(result).toBe(current);
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "user.auth_refresh_soft_failure",
+				properties: expect.objectContaining({
+					provider: "openai-codex",
+					status: 500,
+					tokenExpired: false,
+				}),
+			}),
+		);
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "user.auth_logged_out" }),
+		);
+		nowSpy.mockRestore();
+	});
+
+	it("throws on transient refresh error when the token is already expired", async () => {
+		// A server error landing after expiry is NOT an invalid grant; returning
+		// null here is what turned an outage blip into a forced
+		// "requires re-authentication" stop.
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							error: "server_error",
+							error_description: "temporary issue",
+						}),
+						{ status: 500, headers: { "Content-Type": "application/json" } },
+					),
+			),
+		);
+
+		const capture = vi.fn();
+		await expect(
+			getValidOpenAICodexCredentials(createCredentials({ expires: 90_000 }), {
+				telemetry: { capture } as never,
+			}),
+		).rejects.toThrow("Token refresh failed: 500");
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "user.auth_refresh_soft_failure",
+				properties: expect.objectContaining({
+					provider: "openai-codex",
+					status: 500,
+					tokenExpired: true,
+				}),
+			}),
+		);
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "user.auth_logged_out" }),
+		);
+		nowSpy.mockRestore();
+	});
+
+	it("throws on a network-level refresh failure when the token is already expired", async () => {
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new TypeError("fetch failed");
+			}),
+		);
+
+		const capture = vi.fn();
+		await expect(
+			getValidOpenAICodexCredentials(createCredentials({ expires: 90_000 }), {
+				telemetry: { capture } as never,
+			}),
+		).rejects.toThrow("Failed to refresh OpenAI Codex token");
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "user.auth_refresh_soft_failure",
+				properties: expect.objectContaining({
+					provider: "openai-codex",
+					tokenExpired: true,
+				}),
+			}),
+		);
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "user.auth_logged_out" }),
+		);
+		nowSpy.mockRestore();
+	});
 });

--- a/sdk/packages/core/src/auth/codex.ts
+++ b/sdk/packages/core/src/auth/codex.ts
@@ -448,25 +448,20 @@ export async function getValidOpenAICodexCredentials(
 			);
 			return null;
 		}
-		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {
-			// Keep the current token on transient refresh failures while it
-			// still has usable life left.
-			captureAuthRefreshSoftFailure(options?.telemetry, "openai-codex", {
-				...failureDetails,
-				tokenExpired: false,
-			});
-			return currentCredentials;
-		}
-		// Transient failure with an already-expired token: rethrow instead of
-		// returning null. A null from this function means the refresh token was
-		// REJECTED (re-auth required); a network blip or server error that
-		// happens to land after expiry must not be mistaken for that — callers
-		// turn null into a forced "requires re-authentication" stop even though
-		// the very next refresh attempt would likely succeed.
+		const tokenExpired =
+			currentCredentials.expires - Date.now() <= retryableTokenGraceMs;
 		captureAuthRefreshSoftFailure(options?.telemetry, "openai-codex", {
 			...failureDetails,
-			tokenExpired: true,
+			tokenExpired,
 		});
+		if (!tokenExpired) {
+			return currentCredentials;
+		}
+		// Rethrow instead of returning null. A null from this function means the
+		// refresh token was REJECTED (re-auth required); a network blip or server
+		// error that happens to land after expiry must not be mistaken for that —
+		// callers turn null into a forced "requires re-authentication" stop even
+		// though the very next refresh attempt would likely succeed.
 		throw error;
 	}
 }

--- a/sdk/packages/core/src/auth/codex.ts
+++ b/sdk/packages/core/src/auth/codex.ts
@@ -10,6 +10,7 @@ import { nanoid } from "nanoid";
 import {
 	captureAuthFailed,
 	captureAuthLoggedOut,
+	captureAuthRefreshSoftFailure,
 	captureAuthStarted,
 	captureAuthSucceeded,
 	identifyAccount,
@@ -423,16 +424,49 @@ export async function getValidOpenAICodexCredentials(
 		);
 		return refreshed;
 	} catch (error) {
+		const failureDetails = {
+			status:
+				error instanceof OpenAICodexOAuthTokenError ? error.status : undefined,
+			errorCode:
+				error instanceof OpenAICodexOAuthTokenError
+					? error.errorCode
+					: undefined,
+			errorName: error instanceof Error ? error.name : undefined,
+		};
 		if (
 			error instanceof OpenAICodexOAuthTokenError &&
 			error.isLikelyInvalidGrant()
 		) {
-			captureAuthLoggedOut(options?.telemetry, "openai-codex", "invalid_grant");
+			captureAuthLoggedOut(
+				options?.telemetry,
+				"openai-codex",
+				"invalid_grant",
+				{
+					status: error.status,
+					errorCode: error.errorCode,
+				},
+			);
 			return null;
 		}
 		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {
+			// Keep the current token on transient refresh failures while it
+			// still has usable life left.
+			captureAuthRefreshSoftFailure(options?.telemetry, "openai-codex", {
+				...failureDetails,
+				tokenExpired: false,
+			});
 			return currentCredentials;
 		}
-		return null;
+		// Transient failure with an already-expired token: rethrow instead of
+		// returning null. A null from this function means the refresh token was
+		// REJECTED (re-auth required); a network blip or server error that
+		// happens to land after expiry must not be mistaken for that — callers
+		// turn null into a forced "requires re-authentication" stop even though
+		// the very next refresh attempt would likely succeed.
+		captureAuthRefreshSoftFailure(options?.telemetry, "openai-codex", {
+			...failureDetails,
+			tokenExpired: true,
+		});
+		throw error;
 	}
 }

--- a/sdk/packages/core/src/auth/oca.test.ts
+++ b/sdk/packages/core/src/auth/oca.test.ts
@@ -213,6 +213,77 @@ describe("auth/oca getValidOcaCredentials", () => {
 		nowSpy.mockRestore();
 	});
 
+	it("throws on transient refresh error when the token is already expired", async () => {
+		// A server error landing after expiry is NOT an invalid grant; returning
+		// null here is what turned an outage blip into a forced
+		// "requires re-authentication" stop.
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+		const fetchMock = vi
+			.fn()
+			.mockImplementationOnce(
+				async () =>
+					new Response(
+						JSON.stringify({
+							token_endpoint: "https://idcs.expired/oauth2/v1/token",
+						}),
+						{
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						},
+					),
+			)
+			.mockImplementationOnce(
+				async () =>
+					new Response(
+						JSON.stringify({
+							error: "server_error",
+							error_description: "temporary issue",
+						}),
+						{
+							status: 500,
+							headers: { "Content-Type": "application/json" },
+						},
+					),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const capture = vi.fn();
+		await expect(
+			getValidOcaCredentials(
+				createCredentials({ expires: 90_000 }),
+				{
+					refreshBufferMs: 60_000,
+					retryableTokenGraceMs: 30_000,
+					telemetry: { capture } as never,
+				},
+				{
+					config: {
+						internal: {
+							clientId: "client-3",
+							idcsUrl: "https://idcs.expired",
+							scopes: "openid offline_access",
+							baseUrl: "https://oca.example.com",
+						},
+					},
+				},
+			),
+		).rejects.toThrow("Token refresh failed: 500");
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "user.auth_refresh_soft_failure",
+				properties: expect.objectContaining({
+					provider: "oca",
+					status: 500,
+					tokenExpired: true,
+				}),
+			}),
+		);
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "user.auth_logged_out" }),
+		);
+		nowSpy.mockRestore();
+	});
+
 	it("re-discovers token endpoint shortly after discovery fallback errors", async () => {
 		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
 		const fetchMock = vi

--- a/sdk/packages/core/src/auth/oca.ts
+++ b/sdk/packages/core/src/auth/oca.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import {
 	captureAuthFailed,
 	captureAuthLoggedOut,
+	captureAuthRefreshSoftFailure,
 	captureAuthStarted,
 	captureAuthSucceeded,
 	identifyAccount,
@@ -512,13 +513,39 @@ export async function getValidOcaCredentials(
 	try {
 		return await refreshOcaToken(currentCredentials, providerOptions);
 	} catch (error) {
+		const telemetry = providerOptions?.telemetry ?? options?.telemetry;
+		const failureDetails = {
+			status: error instanceof OcaOAuthTokenError ? error.status : undefined,
+			errorCode:
+				error instanceof OcaOAuthTokenError ? error.errorCode : undefined,
+			errorName: error instanceof Error ? error.name : undefined,
+		};
 		if (error instanceof OcaOAuthTokenError && error.isLikelyInvalidGrant()) {
-			captureAuthLoggedOut(providerOptions?.telemetry, "oca", "invalid_grant");
+			captureAuthLoggedOut(telemetry, "oca", "invalid_grant", {
+				status: error.status,
+				errorCode: error.errorCode,
+			});
 			return null;
 		}
 		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {
+			// Keep the current token on transient refresh failures while it
+			// still has usable life left.
+			captureAuthRefreshSoftFailure(telemetry, "oca", {
+				...failureDetails,
+				tokenExpired: false,
+			});
 			return currentCredentials;
 		}
-		return null;
+		// Transient failure with an already-expired token: rethrow instead of
+		// returning null. A null from this function means the refresh token was
+		// REJECTED (re-auth required); a network blip or server error that
+		// happens to land after expiry must not be mistaken for that — callers
+		// turn null into a forced "requires re-authentication" stop even though
+		// the very next refresh attempt would likely succeed.
+		captureAuthRefreshSoftFailure(telemetry, "oca", {
+			...failureDetails,
+			tokenExpired: true,
+		});
+		throw error;
 	}
 }

--- a/sdk/packages/core/src/auth/oca.ts
+++ b/sdk/packages/core/src/auth/oca.ts
@@ -527,25 +527,20 @@ export async function getValidOcaCredentials(
 			});
 			return null;
 		}
-		if (currentCredentials.expires - Date.now() > retryableTokenGraceMs) {
-			// Keep the current token on transient refresh failures while it
-			// still has usable life left.
-			captureAuthRefreshSoftFailure(telemetry, "oca", {
-				...failureDetails,
-				tokenExpired: false,
-			});
-			return currentCredentials;
-		}
-		// Transient failure with an already-expired token: rethrow instead of
-		// returning null. A null from this function means the refresh token was
-		// REJECTED (re-auth required); a network blip or server error that
-		// happens to land after expiry must not be mistaken for that — callers
-		// turn null into a forced "requires re-authentication" stop even though
-		// the very next refresh attempt would likely succeed.
+		const tokenExpired =
+			currentCredentials.expires - Date.now() <= retryableTokenGraceMs;
 		captureAuthRefreshSoftFailure(telemetry, "oca", {
 			...failureDetails,
-			tokenExpired: true,
+			tokenExpired,
 		});
+		if (!tokenExpired) {
+			return currentCredentials;
+		}
+		// Rethrow instead of returning null. A null from this function means the
+		// refresh token was REJECTED (re-auth required); a network blip or server
+		// error that happens to land after expiry must not be mistaken for that —
+		// callers turn null into a forced "requires re-authentication" stop even
+		// though the very next refresh attempt would likely succeed.
 		throw error;
 	}
 }


### PR DESCRIPTION
### Related Issue

Partial fix for #13535 ([CLINE-3059](https://linear.app/cline-bot/issue/CLINE-3059/cline-not-working-with-gpt)): tasks on `openai-codex` models "start thinking, then silently stop with Retry" while settings still show the user signed in.

### Description

Telemetry traced #13535 to one error: **"openai-codex requires re-authentication."** — ~90 users in the last 3 days, all GPT models, steadily present since late July. It fires whenever `getValidOpenAICodexCredentials` returns `null`, and today that happens not only on a genuine `invalid_grant` but on **any transient refresh failure** (network error, timeout, OpenAI 5xx) once the access token is past its 30-second grace window — e.g. the first request after the machine wakes from sleep. One bad refresh attempt becomes a forced logout even though the refresh token is perfectly valid and the next attempt would succeed.

The `cline` provider had this exact bug and was fixed in #12255; `openai-codex` and `oca` never got the port. This PR ports it:

- `getValidOpenAICodexCredentials` / `getValidOcaCredentials` now **rethrow** transient failures with an expired token instead of returning `null`. `null` is reserved for a genuinely rejected refresh token (re-auth required).
- Both providers emit `user.auth_refresh_soft_failure` on transient failures — the "prevented logout" counter the cline provider already reports (~12k events/day there), so we can watch codex/oca numbers post-release.
- The genuine `invalid_grant` logout event now carries `status`/`errorCode` details, matching cline.

Not in scope (follow-ups): surfacing a signed-out state + sign-in CTA in the extension UI when re-auth genuinely is required, and the cross-process refresh-token rotation race (PR #11148 addresses that; currently stale/conflicting).

### Test Procedure

- New unit tests mirror the #12255 cline tests: transient 500 with usable token → keeps current credentials + soft-failure event; transient 500 with expired token → throws + soft-failure event, no `user.auth_logged_out`; network-level failure with expired token → throws; `invalid_grant` → still returns `null` + logout event.
- All 63 `src/auth` tests pass; all 330 `src/runtime` (token manager / orchestration) tests pass; `@cline/core` typecheck clean; biome clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

For affected users the practical change: instead of a dead-end "requires re-authentication" stop (with settings still claiming they're signed in), a transient refresh failure now surfaces as an honest one-shot refresh error whose Retry actually works — and spurious logouts stop occurring at all.