### PR TITLE
feat(desktop): scheduled sessions UX — unified details dialog, run-now handoff, hidden steering, stuck-thinking fix

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -852,6 +852,24 @@ describe("ChatMessages tool disclosures", () => {
 		);
 	});
 
+	it("shows a genuine user prompt that happens to start with [SYSTEM]", async () => {
+		await renderMessages([
+			{
+				id: "user-prompt",
+				sessionId: "session-1",
+				role: "user",
+				content: "[SYSTEM] is a prefix I typed myself, explain it",
+				createdAt: 1,
+			},
+		]);
+
+		// Only injected reminders (userRunSpan 0) are steering; a person's
+		// own prompt stays visible.
+		expect(container.textContent).toContain(
+			"is a prefix I typed myself, explain it",
+		);
+	});
+
 	it("keeps steering notes hidden inside the expanded work block", async () => {
 		await renderMessages([
 			{

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -823,6 +823,89 @@ describe("ChatMessages tool disclosures", () => {
 		expect(writeText).toHaveBeenCalledWith("Original prompt");
 	});
 
+	it("hides runtime steering notes from the transcript", async () => {
+		await renderMessages([
+			{
+				id: "user-prompt",
+				sessionId: "session-1",
+				role: "user",
+				content: "tell me the current time",
+				createdAt: 1,
+			},
+			{
+				id: "steer-1",
+				sessionId: "session-1",
+				role: "user",
+				content:
+					"[SYSTEM] This run is not complete until you call one of these terminal completion tools: submit_and_exit.",
+				createdAt: 2,
+				meta: { userRunSpan: 0 },
+			},
+		]);
+
+		// Steering nudges are machinery talking to the model — not rendered
+		// at all, and never as a user bubble.
+		expect(container.textContent).toContain("tell me the current time");
+		expect(container.textContent).not.toContain("[SYSTEM]");
+		expect(container.textContent).not.toContain(
+			"This run is not complete until you call",
+		);
+	});
+
+	it("keeps steering notes hidden inside the expanded work block", async () => {
+		await renderMessages([
+			{
+				id: "user-prompt",
+				sessionId: "session-1",
+				role: "user",
+				content: "tell me the current time",
+				createdAt: 1,
+			},
+			{
+				id: "steer-1",
+				sessionId: "session-1",
+				role: "user",
+				content: "[SYSTEM] This run is not complete until you finish.",
+				createdAt: 2,
+				meta: { userRunSpan: 0 },
+			},
+			{
+				id: "tool-1",
+				sessionId: "session-1",
+				role: "tool",
+				content: JSON.stringify({
+					toolName: "run_commands",
+					input: {},
+					result: {},
+				}),
+				createdAt: 3,
+			},
+			{
+				id: "answer",
+				sessionId: "session-1",
+				role: "assistant",
+				content: "It is 12:28 PM PT.",
+				createdAt: 4,
+			},
+		]);
+
+		// The steering note is working-rows machinery grouped with the run,
+		// and stays hidden even when the work block is expanded.
+		expect(container.textContent).toContain("It is 12:28 PM PT.");
+		expect(container.textContent).not.toContain(
+			"This run is not complete until you finish.",
+		);
+
+		const trigger = [
+			...container.querySelectorAll<HTMLButtonElement>("button"),
+		].find((button) => button.textContent?.includes("Worked"));
+		expect(trigger).toBeDefined();
+		await act(async () => trigger?.click());
+		expect(container.textContent).not.toContain(
+			"This run is not complete until you finish.",
+		);
+	});
+
 	it("counts folded system-displayed runs before an editable user message", async () => {
 		const onEditMessage = vi.fn(async () => undefined);
 		await renderMessages(
@@ -1641,17 +1724,18 @@ describe("ChatMessages work collapse", () => {
 		expect(container.querySelectorAll(".cline-chat-tool")).toHaveLength(2);
 	});
 
-	it.each(["cancelled", "failed", "error"] as const)(
-		"keeps an interrupted run's rows visible even with partial trailing text (%s)",
-		async (status) => {
-			// Stop can land mid-answer, leaving partial assistant text after the
-			// tool calls; the run still must not fold into a summary.
-			await renderMessages(completedRun, { status });
+	it.each([
+		"cancelled",
+		"failed",
+		"error",
+	] as const)("keeps an interrupted run's rows visible even with partial trailing text (%s)", async (status) => {
+		// Stop can land mid-answer, leaving partial assistant text after the
+		// tool calls; the run still must not fold into a summary.
+		await renderMessages(completedRun, { status });
 
-			expect(container.querySelector(".cline-chat-work")).toBeNull();
-			expect(container.querySelectorAll(".cline-chat-tool")).toHaveLength(2);
-		},
-	);
+		expect(container.querySelector(".cline-chat-work")).toBeNull();
+		expect(container.querySelectorAll(".cline-chat-tool")).toHaveLength(2);
+	});
 });
 
 describe("ChatMessages thinking indicator", () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
@@ -39,6 +39,10 @@ export type ChatRenderItem =
 export function isSystemSteeringMessage(message: ChatMessage): boolean {
 	return (
 		message.role === "user" &&
+		// Injected reminders carry userRunSpan 0 (they are not user turns);
+		// requiring it keeps a person's genuine prompt that happens to start
+		// with "[SYSTEM]" visible and turn-counted.
+		message.meta?.userRunSpan === 0 &&
 		message.content.trimStart().startsWith("[SYSTEM]")
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
@@ -29,6 +29,20 @@ export type ChatRenderItem =
 			items: ChatRenderItem[];
 	  };
 
+/**
+ * Runtime steering notes injected into the conversation as user-role
+ * messages (completion-tool reminders, team-obligation nudges). They are
+ * machinery talking to the model, not the person talking, so the transcript
+ * renders them as subtle system rows and folds them into the run's working
+ * span instead of showing user bubbles.
+ */
+export function isSystemSteeringMessage(message: ChatMessage): boolean {
+	return (
+		message.role === "user" &&
+		message.content.trimStart().startsWith("[SYSTEM]")
+	);
+}
+
 export function hasMessageReasoning(message: ChatMessage): boolean {
 	return Boolean(message.reasoning?.trim() || message.reasoningRedacted);
 }
@@ -66,7 +80,8 @@ export function buildUserRunCountMap(
 
 	for (const message of messages) {
 		const userRunSpan =
-			message.meta?.userRunSpan ?? (message.role === "user" ? 1 : 0);
+			message.meta?.userRunSpan ??
+			(message.role === "user" && !isSystemSteeringMessage(message) ? 1 : 0);
 		const storedRunCount =
 			message.meta?.runCount ?? message.meta?.checkpoint?.runCount;
 		if (storedRunCount !== undefined) {
@@ -119,8 +134,9 @@ export type CollapseWorkOptions = {
  */
 function isCollapsibleWorkItem(item: ChatRenderItem): boolean {
 	if (item.type === "tools") return true;
+	if (item.type !== "message") return false;
+	if (isSystemSteeringMessage(item.message)) return true;
 	return (
-		item.type === "message" &&
 		item.message.role === "assistant" &&
 		!item.message.images?.length &&
 		!item.message.media?.length
@@ -177,7 +193,11 @@ export function collapseCompletedWork(
 	let lastUserIndex = -1;
 	for (let index = items.length - 1; index >= 0; index--) {
 		const item = items[index];
-		if (item.type === "message" && item.message.role === "user") {
+		if (
+			item.type === "message" &&
+			item.message.role === "user" &&
+			!isSystemSteeringMessage(item.message)
+		) {
 			lastUserIndex = index;
 			break;
 		}
@@ -195,7 +215,9 @@ export function collapseCompletedWork(
 		// message is the run's answer and stays visible below the summary.
 		const last = span.at(-1);
 		const answer =
-			last?.type === "message" && last.message.content.trim()
+			last?.type === "message" &&
+			last.message.role === "assistant" &&
+			last.message.content.trim()
 				? last
 				: undefined;
 		// A span is settled once a later user message exists. The trailing span

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/message-bubble.tsx
@@ -27,6 +27,7 @@ import type {
 import { cn } from "@/lib/utils";
 import { MemoizedMarkdown } from "../../../ui/markdown";
 import { formatChatMessageContent } from "../message-content";
+import { isSystemSteeringMessage } from "./group-messages";
 import { ReasoningBlock } from "./reasoning-block";
 
 function AssistantImageCarousel({
@@ -217,6 +218,14 @@ export const MessageBubble = memo(function MessageBubble({
 	const isUser = message.role === "user";
 	const isError = message.role === "error";
 	const checkpoint = message.meta?.checkpoint;
+	// Runtime steering notes (completion nudges in scheduled/automation runs,
+	// team-obligation reminders) are user-role messages the machinery sends to
+	// the model, not something the person said or needs to read — hide them
+	// from the transcript entirely. Grouping still treats them as working-row
+	// machinery (never a turn boundary, an answer, or a run-count increment).
+	if (isSystemSteeringMessage(message)) {
+		return null;
+	}
 	const displayContent = formatChatMessageContent(
 		message.role,
 		message.content,

--- a/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/welcome-workspace-controls.tsx
@@ -12,8 +12,8 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
 import { scrollCurrentOptionIntoView } from "@/lib/scroll-current-option";
+import { cn } from "@/lib/utils";
 import {
 	looksLikeFolderPath,
 	normalizeWorkspacePath,
@@ -399,9 +399,9 @@ function BranchPicker({
 							</div>
 						) : (
 							<div
-							className="flex max-h-56 flex-col gap-0.5 overflow-y-auto"
-							ref={branchListRef}
-						>
+								className="flex max-h-56 flex-col gap-0.5 overflow-y-auto"
+								ref={branchListRef}
+							>
 								{filteredBranches.length === 0 ? (
 									<div className="px-2 py-2 text-xs text-muted-foreground">
 										No branches found

--- a/apps/examples/desktop-app/webview/components/views/chat/workspace-selector.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/workspace-selector.tsx
@@ -358,7 +358,10 @@ export function WorkspaceSelector({
 											</span>
 										</Button>
 									)}
-									<div ref={workspaceListRef} className="flex flex-col gap-0.5 max-h-28 overflow-y-auto">
+									<div
+										ref={workspaceListRef}
+										className="flex flex-col gap-0.5 max-h-28 overflow-y-auto"
+									>
 										{filteredWorkspaces.length === 0 ? (
 											<div className="px-2 py-2 text-xs text-muted-foreground">
 												{looksLikeFolderPath(search)
@@ -459,7 +462,10 @@ export function WorkspaceSelector({
 										<div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
 											Branches
 										</div>
-										<div ref={branchListRef} className="flex flex-col gap-0.5 max-h-36 overflow-y-auto">
+										<div
+											ref={branchListRef}
+											className="flex flex-col gap-0.5 max-h-36 overflow-y-auto"
+										>
 											{filteredBranches.length === 0 ? (
 												<div className="px-2 py-2 text-xs text-muted-foreground">
 													No branches found

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -840,6 +840,18 @@ export function RoutineSchedulesContent({
 			}>("trigger_routine_schedule", {
 				schedule_id: schedule.scheduleId,
 			});
+			// A reply without an execution means no run was enqueued (the
+			// schedule may have been disabled or deleted since the page
+			// loaded) — say so instead of confirming a start.
+			if (!reply?.execution) {
+				toast({
+					title: "Run not started",
+					description: `"${schedule.name}" did not queue a run — the schedule may be disabled or deleted.`,
+					variant: "destructive",
+				});
+				await refreshSchedules({ force: true, showLoading: false });
+				return;
+			}
 			toast({
 				title: "Run started",
 				description: `"${schedule.name}" was queued to run now.`,
@@ -851,8 +863,8 @@ export function RoutineSchedulesContent({
 			// Only ever follow the execution the trigger itself named; matching
 			// "the schedule's newest execution" could open a previous run's
 			// session when the trigger failed to enqueue one.
-			const executionId = reply?.execution?.executionId ?? null;
-			let sessionId = reply?.execution?.sessionId?.trim() || null;
+			const executionId = reply.execution.executionId ?? null;
+			let sessionId = reply.execution.sessionId?.trim() || null;
 			const deadline = Date.now() + 15_000;
 			while (
 				!sessionId &&

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -7,6 +7,7 @@ import {
 } from "@cline/shared/browser";
 import {
 	CheckCircle2,
+	ChevronDown,
 	Circle,
 	Clock3,
 	ExternalLink,
@@ -63,7 +64,6 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import {
 	Tooltip,
@@ -527,6 +527,15 @@ export function RoutineSchedulesContent({
 	// rejected synchronously — two rapid clicks can both fire before React
 	// re-renders the disabled state, and state alone can't distinguish them.
 	const busyScheduleIdsRef = useRef<Set<string>>(new Set());
+	// Guards the run-now follow-up: an auto-navigation into the started
+	// session should not fire from a page the user already left.
+	const mountedRef = useRef(true);
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
 	const beginScheduleAction = (scheduleId: string): boolean => {
 		if (busyScheduleIdsRef.current.has(scheduleId)) {
 			return false;
@@ -550,6 +559,7 @@ export function RoutineSchedulesContent({
 			return next;
 		});
 	};
+	const [showAllViewingRuns, setShowAllViewingRuns] = useState(false);
 	const [viewingSchedule, setViewingSchedule] =
 		useState<RoutineSchedule | null>(null);
 	const [schedulePendingDelete, setSchedulePendingDelete] =
@@ -773,6 +783,7 @@ export function RoutineSchedulesContent({
 					lastExecutions,
 					fetchedAt: now,
 				};
+				return response;
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
@@ -824,17 +835,46 @@ export function RoutineSchedulesContent({
 		setScheduleTriggering(schedule.scheduleId, true);
 		setErrorMessage(null);
 		try {
-			await desktopClient.invoke("trigger_routine_schedule", {
+			const reply = await desktopClient.invoke<{
+				execution?: RoutineExecution | null;
+			}>("trigger_routine_schedule", {
 				schedule_id: schedule.scheduleId,
 			});
 			toast({
 				title: "Run started",
 				description: `"${schedule.name}" was queued to run now.`,
 			});
-			await refreshSchedules({ force: true, showLoading: false });
-			window.setTimeout(() => {
-				void refreshSchedules({ force: true, showLoading: false });
-			}, 1_000);
+			// The trigger queues the run and returns before the runner starts
+			// the agent session, so the session id usually is not attached
+			// yet. Poll the overview (which also keeps the page's run status
+			// fresh) until it appears, then jump into the session.
+			const executionId = reply?.execution?.executionId ?? null;
+			let sessionId = reply?.execution?.sessionId?.trim() || null;
+			const deadline = Date.now() + 15_000;
+			while (!sessionId && mountedRef.current && Date.now() < deadline) {
+				const overview = await refreshSchedules({
+					force: true,
+					showLoading: false,
+				});
+				const executions = [
+					...(overview?.activeExecutions ?? []),
+					...(overview?.lastExecutions ?? []),
+				];
+				// Without an execution id from the trigger reply, fall back to
+				// the newest execution recorded for this schedule.
+				const match = executions.find((execution) =>
+					executionId
+						? execution.executionId === executionId
+						: execution.scheduleId === schedule.scheduleId,
+				);
+				sessionId = match?.sessionId?.trim() || null;
+				if (!sessionId) {
+					await new Promise((resolve) => window.setTimeout(resolve, 1_000));
+				}
+			}
+			if (sessionId && mountedRef.current) {
+				await onOpenSession?.(sessionId);
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			setErrorMessage(message);
@@ -1092,6 +1132,13 @@ export function RoutineSchedulesContent({
 		);
 	}, [schedules]);
 
+	// Collapse the runs list back to the recent-three preview whenever a
+	// different schedule's details are opened.
+	const viewingScheduleId = viewingSchedule?.scheduleId ?? null;
+	// biome-ignore lint/correctness/useExhaustiveDependencies: viewingScheduleId is the reset trigger, not a value the effect reads
+	useEffect(() => {
+		setShowAllViewingRuns(false);
+	}, [viewingScheduleId]);
 	const viewingExecutions = useMemo(() => {
 		if (!viewingSchedule) {
 			return [];
@@ -1423,131 +1470,121 @@ export function RoutineSchedulesContent({
 					}
 				}}
 			>
-				<DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+				<DialogContent
+					aria-describedby={undefined}
+					className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+				>
 					<DialogHeader>
 						<DialogTitle>{viewingSchedule?.name ?? "Schedule"}</DialogTitle>
-						<DialogDescription>
-							Full configuration for this schedule.
-						</DialogDescription>
 					</DialogHeader>
 					{viewingSchedule && (
-						<Tabs className="min-h-0 flex-1" defaultValue="overview">
-							<TabsList>
-								<TabsTrigger value="overview">Overview</TabsTrigger>
-								<TabsTrigger value="runs">
-									Runs
-									{viewingExecutions.length > 0 && (
-										<span className="ml-1 text-xs text-muted-foreground">
-											{viewingExecutions.length}
-										</span>
-									)}
-								</TabsTrigger>
-							</TabsList>
-							<TabsContent
-								className="mt-4 flex min-h-0 flex-1 flex-col gap-3"
-								value="overview"
-							>
-								<div className="grid grid-cols-1 gap-1.5 text-xs sm:grid-cols-2">
-									<p>
-										<span className="text-muted-foreground/70">Schedule:</span>{" "}
-										{formatScheduleTrigger(viewingSchedule)}
-									</p>
-									<p>
-										<span className="text-muted-foreground/70">Mode:</span>{" "}
-										{viewingSchedule.mode}
-									</p>
-									<p>
-										<span className="text-muted-foreground/70">Model:</span>{" "}
-										{formatScheduleModel(viewingSchedule)}
-									</p>
-									<p>
-										<span className="text-muted-foreground/70">Enabled:</span>{" "}
-										{viewingSchedule.enabled ? "yes" : "no"}
-									</p>
-									<p>
-										<span className="text-muted-foreground/70">Last run:</span>{" "}
-										{formatDateTime(viewingSchedule.lastRunAt)}
-									</p>
-									<p>
-										<span className="text-muted-foreground/70">Next run:</span>{" "}
-										{formatDateTime(viewingSchedule.nextRunAt)}
-									</p>
+						<div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+							<div className="grid grid-cols-1 gap-1.5 text-xs sm:grid-cols-2">
+								<p>
+									<span className="text-muted-foreground/70">Schedule:</span>{" "}
+									{formatScheduleTrigger(viewingSchedule)}
+								</p>
+								<p>
+									<span className="text-muted-foreground/70">Mode:</span>{" "}
+									{viewingSchedule.mode}
+								</p>
+								<p>
+									<span className="text-muted-foreground/70">Model:</span>{" "}
+									{formatScheduleModel(viewingSchedule)}
+								</p>
+								<p>
+									<span className="text-muted-foreground/70">Enabled:</span>{" "}
+									{viewingSchedule.enabled ? "yes" : "no"}
+								</p>
+								<p>
+									<span className="text-muted-foreground/70">Last run:</span>{" "}
+									{formatDateTime(viewingSchedule.lastRunAt)}
+								</p>
+								<p>
+									<span className="text-muted-foreground/70">Next run:</span>{" "}
+									{formatDateTime(viewingSchedule.nextRunAt)}
+								</p>
+							</div>
+							{/* The JSON block scrolls internally past its cap so it
+								    cannot push the runs below it out of easy reach. */}
+							<pre className="max-h-64 shrink-0 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
+								{JSON.stringify(viewingSchedule, null, 2)}
+							</pre>
+							<div className="mt-1 flex items-center justify-between">
+								<h3 className="text-sm font-semibold">Runs</h3>
+								<span className="text-xs text-muted-foreground">
+									{viewingExecutions.length} result
+									{viewingExecutions.length === 1 ? "" : "s"}
+								</span>
+							</div>
+							{viewingExecutions.length === 0 ? (
+								<div className="rounded-lg border border-border px-3 py-6 text-center text-sm text-muted-foreground">
+									No runs yet.
 								</div>
-								{/* The JSON block absorbs the overflow so the dialog
-								    itself never scrolls: min-h-0 lets it shrink to the
-								    space the capped dialog leaves, and it scrolls
-								    internally past that. */}
-								<pre className="min-h-0 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
-									{JSON.stringify(viewingSchedule, null, 2)}
-								</pre>
-							</TabsContent>
-							<TabsContent
-								className="mt-4 min-h-0 flex-1 overflow-y-auto"
-								value="runs"
-							>
-								<div className="mb-2 flex items-center justify-between">
-									<h3 className="text-sm font-semibold">Runs</h3>
-									<span className="text-xs text-muted-foreground">
-										{viewingExecutions.length} result
-										{viewingExecutions.length === 1 ? "" : "s"}
-									</span>
-								</div>
-								{viewingExecutions.length === 0 ? (
-									<div className="rounded-lg border border-border px-3 py-6 text-center text-sm text-muted-foreground">
-										No runs yet.
-									</div>
-								) : (
-									<div className="overflow-hidden rounded-lg border border-border">
-										{viewingExecutions.map((execution) => {
-											const status = execution.status?.toLowerCase() ?? "";
-											const succeeded = ["success", "completed"].includes(
-												status,
-											);
-											const failed = ["failed", "timeout", "aborted"].includes(
-												status,
-											);
-											return (
-												<button
-													className="group flex w-full items-center gap-3 border-b border-border px-3 py-3 text-left text-sm transition-colors last:border-b-0 hover:bg-surface-hover disabled:cursor-default disabled:hover:bg-transparent"
-													disabled={!execution.sessionId || !onOpenSession}
-													key={execution.executionId}
-													onClick={() => {
-														if (execution.sessionId) {
-															void onOpenSession?.(execution.sessionId);
-														}
-													}}
-													type="button"
-												>
-													{succeeded ? (
-														<CheckCircle2 className="size-4 shrink-0 text-emerald-500" />
-													) : failed ? (
-														<XCircle className="size-4 shrink-0 text-destructive" />
-													) : (
-														<Clock3 className="size-4 shrink-0 text-muted-foreground" />
-													)}
-													<span className="min-w-0 flex-1">
-														<span className="block truncate font-medium capitalize">
-															{execution.status || "Unknown result"}
+							) : (
+								<div className="overflow-hidden rounded-lg border border-border">
+									{(showAllViewingRuns
+										? viewingExecutions
+										: viewingExecutions.slice(0, 3)
+									).map((execution) => {
+										const status = execution.status?.toLowerCase() ?? "";
+										const succeeded = ["success", "completed"].includes(status);
+										const failed = ["failed", "timeout", "aborted"].includes(
+											status,
+										);
+										return (
+											<button
+												className="group flex w-full items-center gap-3 border-b border-border px-3 py-3 text-left text-sm transition-colors last:border-b-0 hover:bg-surface-hover disabled:cursor-default disabled:hover:bg-transparent"
+												disabled={!execution.sessionId || !onOpenSession}
+												key={execution.executionId}
+												onClick={() => {
+													if (execution.sessionId) {
+														void onOpenSession?.(execution.sessionId);
+													}
+												}}
+												type="button"
+											>
+												{succeeded ? (
+													<CheckCircle2 className="size-4 shrink-0 text-emerald-500" />
+												) : failed ? (
+													<XCircle className="size-4 shrink-0 text-destructive" />
+												) : (
+													<Clock3 className="size-4 shrink-0 text-muted-foreground" />
+												)}
+												<span className="min-w-0 flex-1">
+													<span className="block truncate font-medium capitalize">
+														{execution.status || "Unknown result"}
+													</span>
+													{execution.errorMessage && (
+														<span className="block truncate text-xs text-destructive">
+															{execution.errorMessage}
 														</span>
-														{execution.errorMessage && (
-															<span className="block truncate text-xs text-destructive">
-																{execution.errorMessage}
-															</span>
-														)}
-													</span>
-													<span className="shrink-0 text-xs text-muted-foreground">
-														{formatExecutionTimestamp(execution)}
-													</span>
-													{execution.sessionId && onOpenSession && (
-														<ExternalLink className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
 													)}
-												</button>
-											);
-										})}
-									</div>
-								)}
-							</TabsContent>
-						</Tabs>
+												</span>
+												<span className="shrink-0 text-xs text-muted-foreground">
+													{formatExecutionTimestamp(execution)}
+												</span>
+												{execution.sessionId && onOpenSession && (
+													<ExternalLink className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+												)}
+											</button>
+										);
+									})}
+								</div>
+							)}
+							{!showAllViewingRuns && viewingExecutions.length > 3 ? (
+								<Button
+									className="self-start text-muted-foreground"
+									onClick={() => setShowAllViewingRuns(true)}
+									size="sm"
+									type="button"
+									variant="ghost"
+								>
+									Show all {viewingExecutions.length} runs
+									<ChevronDown className="size-3.5" />
+								</Button>
+							) : null}
+						</div>
 					)}
 				</DialogContent>
 			</Dialog>

--- a/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/routine-view.tsx
@@ -848,10 +848,18 @@ export function RoutineSchedulesContent({
 			// the agent session, so the session id usually is not attached
 			// yet. Poll the overview (which also keeps the page's run status
 			// fresh) until it appears, then jump into the session.
+			// Only ever follow the execution the trigger itself named; matching
+			// "the schedule's newest execution" could open a previous run's
+			// session when the trigger failed to enqueue one.
 			const executionId = reply?.execution?.executionId ?? null;
 			let sessionId = reply?.execution?.sessionId?.trim() || null;
 			const deadline = Date.now() + 15_000;
-			while (!sessionId && mountedRef.current && Date.now() < deadline) {
+			while (
+				!sessionId &&
+				executionId &&
+				mountedRef.current &&
+				Date.now() < deadline
+			) {
 				const overview = await refreshSchedules({
 					force: true,
 					showLoading: false,
@@ -860,12 +868,8 @@ export function RoutineSchedulesContent({
 					...(overview?.activeExecutions ?? []),
 					...(overview?.lastExecutions ?? []),
 				];
-				// Without an execution id from the trigger reply, fall back to
-				// the newest execution recorded for this schedule.
-				const match = executions.find((execution) =>
-					executionId
-						? execution.executionId === executionId
-						: execution.scheduleId === schedule.scheduleId,
+				const match = executions.find(
+					(execution) => execution.executionId === executionId,
 				);
 				sessionId = match?.sessionId?.trim() || null;
 				if (!sessionId) {

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -55,36 +55,28 @@ describe("resolveCredentialError", () => {
 });
 
 describe("inferHydratedChatStatus", () => {
-	const user = (createdAt: number) => ({
-		id: "u",
-		sessionId: "s",
-		role: "user" as const,
-		content: "prompt",
-		createdAt,
-	});
-	const assistant = (createdAt: number) => ({
-		id: "a",
-		sessionId: "s",
-		role: "assistant" as const,
-		content: "It is 12:28 PM PT.",
-		createdAt,
-	});
-
-	it("treats an assistant-answered running record as completed once stale", () => {
-		// A record stuck on "running" whose transcript went quiet long ago is
-		// a session that died without a status flip.
-		expect(inferHydratedChatStatus("running", [user(1), assistant(2)])).toBe(
-			"completed",
-		);
-	});
-
-	it("trusts a running record while the transcript is recently active", () => {
-		// Scheduled runs narrate between tool calls: a snapshot can genuinely
-		// end on assistant text mid-run. Flipping it to completed would hide
-		// the working indicator and disarm the stale-stream poll.
-		const now = Date.now();
+	it("treats an assistant-answered running record as completed", () => {
+		// The stale-record heuristic: a "running" record whose transcript
+		// ends on an assistant answer is read as a session that died without
+		// a status flip. (The stale-stream poll deliberately bypasses this
+		// via mapSessionRecordStatus — see use-chat-session.)
 		expect(
-			inferHydratedChatStatus("running", [user(now - 5_000), assistant(now)]),
-		).toBe("running");
+			inferHydratedChatStatus("running", [
+				{
+					id: "u",
+					sessionId: "s",
+					role: "user",
+					content: "prompt",
+					createdAt: 1,
+				},
+				{
+					id: "a",
+					sessionId: "s",
+					role: "assistant",
+					content: "answer",
+					createdAt: 2,
+				},
+			]),
+		).toBe("completed");
 	});
 });

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
-import { resolveCredentialError } from "./helpers";
+import { inferHydratedChatStatus, resolveCredentialError } from "./helpers";
 
 function makeConfig(overrides: Partial<ChatSessionConfig>): ChatSessionConfig {
 	return {
@@ -51,5 +51,40 @@ describe("resolveCredentialError", () => {
 		expect(
 			resolveCredentialError(makeConfig({ provider: "Cline-Pass" })),
 		).toBeNull();
+	});
+});
+
+describe("inferHydratedChatStatus", () => {
+	const user = (createdAt: number) => ({
+		id: "u",
+		sessionId: "s",
+		role: "user" as const,
+		content: "prompt",
+		createdAt,
+	});
+	const assistant = (createdAt: number) => ({
+		id: "a",
+		sessionId: "s",
+		role: "assistant" as const,
+		content: "It is 12:28 PM PT.",
+		createdAt,
+	});
+
+	it("treats an assistant-answered running record as completed once stale", () => {
+		// A record stuck on "running" whose transcript went quiet long ago is
+		// a session that died without a status flip.
+		expect(inferHydratedChatStatus("running", [user(1), assistant(2)])).toBe(
+			"completed",
+		);
+	});
+
+	it("trusts a running record while the transcript is recently active", () => {
+		// Scheduled runs narrate between tool calls: a snapshot can genuinely
+		// end on assistant text mid-run. Flipping it to completed would hide
+		// the working indicator and disarm the stale-stream poll.
+		const now = Date.now();
+		expect(
+			inferHydratedChatStatus("running", [user(now - 5_000), assistant(now)]),
+		).toBe("running");
 	});
 });

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -194,6 +194,11 @@ function mapHistoryStatusToChatStatus(
 	}
 }
 
+// How fresh the newest message must be for a "running" session record to be
+// trusted over the assistant-answered-last staleness heuristic below. Agent
+// turns (model latency plus tool runs) fit comfortably inside this.
+const RUNNING_RECORD_TRUSTED_ACTIVITY_MS = 2 * 60 * 1000;
+
 export function inferHydratedChatStatus(
 	fallback: SessionHistoryStatus,
 	messages: ChatMessage[],
@@ -215,7 +220,23 @@ export function inferHydratedChatStatus(
 	}
 	if (fallback === "running") {
 		const lastMeaningful = meaningfulMessages[meaningfulMessages.length - 1];
-		if (lastMeaningful?.role === "assistant") {
+		// A "running" record whose transcript ends on an assistant answer is
+		// usually a session that died without a status flip — but only when
+		// the transcript has actually gone quiet. Scheduled/automation runs
+		// narrate between tool calls, so a snapshot can genuinely end on
+		// assistant text mid-run; flipping those to completed hides the
+		// working indicator and disarms the stale-stream poll that would
+		// have delivered the rest of the run.
+		const newestTimestamp = messages.reduce(
+			(newest, message) =>
+				Number.isFinite(message.createdAt) && message.createdAt > newest
+					? message.createdAt
+					: newest,
+			0,
+		);
+		const recentlyActive =
+			Date.now() - newestTimestamp < RUNNING_RECORD_TRUSTED_ACTIVITY_MS;
+		if (lastMeaningful?.role === "assistant" && !recentlyActive) {
 			return "completed";
 		}
 	}

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -194,11 +194,6 @@ function mapHistoryStatusToChatStatus(
 	}
 }
 
-// How fresh the newest message must be for a "running" session record to be
-// trusted over the assistant-answered-last staleness heuristic below. Agent
-// turns (model latency plus tool runs) fit comfortably inside this.
-const RUNNING_RECORD_TRUSTED_ACTIVITY_MS = 2 * 60 * 1000;
-
 export function inferHydratedChatStatus(
 	fallback: SessionHistoryStatus,
 	messages: ChatMessage[],
@@ -220,25 +215,22 @@ export function inferHydratedChatStatus(
 	}
 	if (fallback === "running") {
 		const lastMeaningful = meaningfulMessages[meaningfulMessages.length - 1];
-		// A "running" record whose transcript ends on an assistant answer is
-		// usually a session that died without a status flip — but only when
-		// the transcript has actually gone quiet. Scheduled/automation runs
-		// narrate between tool calls, so a snapshot can genuinely end on
-		// assistant text mid-run; flipping those to completed hides the
-		// working indicator and disarms the stale-stream poll that would
-		// have delivered the rest of the run.
-		const newestTimestamp = messages.reduce(
-			(newest, message) =>
-				Number.isFinite(message.createdAt) && message.createdAt > newest
-					? message.createdAt
-					: newest,
-			0,
-		);
-		const recentlyActive =
-			Date.now() - newestTimestamp < RUNNING_RECORD_TRUSTED_ACTIVITY_MS;
-		if (lastMeaningful?.role === "assistant" && !recentlyActive) {
+		if (lastMeaningful?.role === "assistant") {
 			return "completed";
 		}
 	}
 	return mapHistoryStatusToChatStatus(fallback);
+}
+
+/**
+ * The session record's status mapped verbatim — no transcript inference. For
+ * callers observing a session whose record is actively maintained by the
+ * executing host (the stale-stream poll), the record is the authority;
+ * inferHydratedChatStatus's stale-record heuristic would misread a mid-run
+ * snapshot that happens to end on assistant narration as a finished session.
+ */
+export function mapSessionRecordStatus(
+	status: SessionHistoryStatus,
+): ChatSessionStatus {
+	return mapHistoryStatusToChatStatus(status);
 }

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -255,6 +255,94 @@ describe("useChatSession", () => {
 		expect(current.status).toBe("completed");
 	});
 
+	it("keeps the stale-stream poll inert while a local turn is in flight", async () => {
+		// Regression: the fallback poll replaced an optimistic user bubble
+		// (raw prompt) with its canonical envelope-wrapped twin, desyncing
+		// the rekey bookkeeping so the stream appended a duplicate bubble.
+		const hydratedSessionId = "session-local-turn";
+		let readCount = 0;
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "read_session_messages") {
+					readCount += 1;
+					return [
+						{
+							id: "history-user",
+							sessionId: hydratedSessionId,
+							role: "user",
+							content: "earlier prompt",
+							createdAt: 1,
+						},
+					];
+				}
+				if (command === "get_discovered_session") {
+					return { sessionId: hydratedSessionId, status: "running" };
+				}
+				if (command === "read_session_hooks") return [];
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "attach" || request?.action === "start") {
+						return {
+							sessionId: hydratedSessionId,
+							status: "idle",
+							provider: "cline",
+							model: "test-model",
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					if (request?.action === "send") {
+						// Keep the send unresolved: the local turn stays in
+						// flight for the whole test.
+						return await new Promise(() => {});
+					}
+					return { promptsInQueue: [] };
+				}
+				return [];
+			},
+		);
+
+		vi.useFakeTimers();
+		try {
+			await act(async () => {
+				await current.hydrateSession({
+					sessionId: hydratedSessionId,
+					status: "idle",
+					provider: "cline",
+					model: "test-model",
+					cwd: "/workspace/cline",
+					workspaceRoot: "/workspace/cline",
+					startedAt: "2026-08-12T00:00:00.000Z",
+				});
+			});
+			const readsAfterHydration = readCount;
+
+			await act(async () => {
+				void current.sendPrompt("what time is it");
+				await Promise.resolve();
+			});
+			expect(current.status).toBe("starting");
+			expect(
+				current.messages.filter((m) => m.content === "what time is it"),
+			).toHaveLength(1);
+
+			// Model produces nothing for a long quiet window; the poll must
+			// not fire while the local turn is unsettled.
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(10_000);
+			});
+			expect(readCount).toBe(readsAfterHydration);
+			expect(
+				current.messages.filter((m) => m.content === "what time is it"),
+			).toHaveLength(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("routes command updates after attaching to an in-flight tool call", async () => {
 		const hydratedSessionId = "session-in-flight-command";
 		invokeMock.mockImplementation(

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -171,6 +171,7 @@ describe("useChatSession", () => {
 		// this client; the transcript must still settle without a remount.
 		const hydratedSessionId = "session-dead-stream";
 		let readCount = 0;
+		let recordReads = 0;
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {
 				if (command === "get_process_context") {
@@ -201,7 +202,14 @@ describe("useChatSession", () => {
 							];
 				}
 				if (command === "get_discovered_session") {
-					return { sessionId: hydratedSessionId, status: "completed" };
+					recordReads += 1;
+					// Still running on the first poll — the snapshot already
+					// ends on assistant narration, which must NOT read as
+					// finished while the record says running.
+					return {
+						sessionId: hydratedSessionId,
+						status: recordReads === 1 ? "running" : "completed",
+					};
 				}
 				if (command === "read_session_hooks") return [];
 				if (command === "chat_session_command") {
@@ -240,18 +248,24 @@ describe("useChatSession", () => {
 			expect(current.status).toBe("running");
 			expect(current.messages).toHaveLength(1);
 
-			// No chat_event chunks arrive. The fallback poll re-reads canonical
-			// history and the session record, surfacing the answer and settling
-			// the stuck thinking state.
+			// No chat_event chunks arrive. The first poll surfaces the
+			// narration mid-run; the record still says running, and the
+			// record — not transcript shape — decides the status.
 			await act(async () => {
-				await vi.advanceTimersByTimeAsync(6_500);
+				await vi.advanceTimersByTimeAsync(3_100);
+			});
+			expect(current.messages).toHaveLength(2);
+			expect(current.messages[1]?.content).toBe("It is 12:28 PM PT.");
+			expect(current.status).toBe("running");
+
+			// The record flips to completed; the next poll mirrors it.
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(3_100);
 			});
 		} finally {
 			vi.useRealTimers();
 		}
 
-		expect(current.messages).toHaveLength(2);
-		expect(current.messages[1]?.content).toBe("It is 12:28 PM PT.");
 		expect(current.status).toBe("completed");
 	});
 

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -166,6 +166,95 @@ describe("useChatSession", () => {
 		});
 	});
 
+	it("heals a running attached session with a dead event stream by polling history", async () => {
+		// Scheduled runs can execute on a host whose live events never reach
+		// this client; the transcript must still settle without a remount.
+		const hydratedSessionId = "session-dead-stream";
+		let readCount = 0;
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "read_session_messages") {
+					readCount += 1;
+					const base = [
+						{
+							id: "history-user",
+							sessionId: hydratedSessionId,
+							role: "user",
+							content: "tell me the current time",
+							createdAt: 1,
+						},
+					];
+					return readCount === 1
+						? base
+						: [
+								...base,
+								{
+									id: "history-answer",
+									sessionId: hydratedSessionId,
+									role: "assistant",
+									content: "It is 12:28 PM PT.",
+									createdAt: 2,
+								},
+							];
+				}
+				if (command === "get_discovered_session") {
+					return { sessionId: hydratedSessionId, status: "completed" };
+				}
+				if (command === "read_session_hooks") return [];
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "attach") {
+						return {
+							sessionId: hydratedSessionId,
+							status: "running",
+							provider: "cline",
+							model: "test-model",
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					return { promptsInQueue: [] };
+				}
+				return [];
+			},
+		);
+
+		// Fake timers must be active before hydration so the fallback's
+		// interval registers on the fake clock.
+		vi.useFakeTimers();
+		try {
+			await act(async () => {
+				await current.hydrateSession({
+					sessionId: hydratedSessionId,
+					status: "running",
+					provider: "cline",
+					model: "test-model",
+					cwd: "/workspace/cline",
+					workspaceRoot: "/workspace/cline",
+					startedAt: "2026-08-12T00:00:00.000Z",
+				});
+			});
+			expect(current.status).toBe("running");
+			expect(current.messages).toHaveLength(1);
+
+			// No chat_event chunks arrive. The fallback poll re-reads canonical
+			// history and the session record, surfacing the answer and settling
+			// the stuck thinking state.
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(6_500);
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+
+		expect(current.messages).toHaveLength(2);
+		expect(current.messages[1]?.content).toBe("It is 12:28 PM PT.");
+		expect(current.status).toBe("completed");
+	});
+
 	it("routes command updates after attaching to an in-flight tool call", async () => {
 		const hydratedSessionId = "session-in-flight-command";
 		invokeMock.mockImplementation(

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -91,6 +91,12 @@ const BUSY_STATUSES = new Set<ChatSessionStatus>([
 	"stopping",
 ]);
 
+// Stale-stream fallback cadence for attached sessions (see the polling
+// effect below): only poll after the live stream has been quiet this long,
+// and re-check at this interval while it stays quiet.
+const STALE_STREAM_QUIET_MS = 5_000;
+const STALE_STREAM_POLL_INTERVAL_MS = 3_000;
+
 type PendingToolOutput = {
 	text: string;
 	truncated: boolean;
@@ -382,6 +388,9 @@ export function useChatSession() {
 	>([]);
 	const [promptsInQueue, setPromptsInQueue] = useState<PromptInQueue[]>([]);
 	const messagesRef = useRef<ChatMessage[]>([]);
+	// When the last chat_event chunk for the active session arrived. The
+	// stale-stream fallback below only polls while this stays quiet.
+	const lastLiveChunkAtRef = useRef(0);
 	const promptsInQueueRef = useRef<PromptInQueue[]>([]);
 	const liveToolMessageIdsRef = useRef<Record<string, string>>({});
 	const pendingToolOutputRef = useRef(new Map<string, PendingToolOutput>());
@@ -1224,6 +1233,7 @@ export function useChatSession() {
 			if (!listeningSessionId || payload.sessionId !== listeningSessionId) {
 				return;
 			}
+			lastLiveChunkAtRef.current = Date.now();
 			if (abortedRef.current) {
 				return;
 			}
@@ -1799,6 +1809,98 @@ export function useChatSession() {
 			unsubscribeEnded();
 		};
 	}, [clearLiveToolRefs, finalizeSettledTurn]);
+
+	// ---- Stale-stream fallback for attached sessions ----
+	// Scheduled/automation runs execute on a session host whose events are
+	// not projected through the hub's live pipeline (and with several hub
+	// daemons sharing cron.db, a different daemon can claim the run
+	// entirely), so an attached session can sit at "running" with a dead
+	// event stream — stuck on the thinking shimmer until a remount re-reads
+	// history. While an attached session is busy and the stream is quiet,
+	// poll canonical history and the session record so the transcript and
+	// status heal in place. A locally driven turn keeps chunks flowing, so
+	// the quiet-window guard keeps this fallback out of the way there.
+	useEffect(() => {
+		if (!sessionId || hydratedHistorySessionId !== sessionId) {
+			return;
+		}
+		if (!BUSY_STATUSES.has(status)) {
+			return;
+		}
+		let cancelled = false;
+		let polling = false;
+		const poll = async () => {
+			if (cancelled || polling) {
+				return;
+			}
+			if (Date.now() - lastLiveChunkAtRef.current < STALE_STREAM_QUIET_MS) {
+				return;
+			}
+			// An assistant bubble mid-stream means the live pipeline works;
+			// canonical history could lag behind it.
+			if (activeAssistantMessageIdRef.current) {
+				return;
+			}
+			polling = true;
+			try {
+				const pollStartedAt = Date.now();
+				const [historyMessages, record] = await Promise.all([
+					desktopClient
+						.invoke<ChatMessage[]>("read_session_messages", {
+							sessionId,
+							maxMessages: MAX_MESSAGES,
+						})
+						.catch(() => null),
+					desktopClient
+						.invoke<{ status?: string } | null>("get_discovered_session", {
+							sessionId,
+						})
+						.catch(() => null),
+				]);
+				if (
+					cancelled ||
+					activeSessionIdRef.current !== sessionId ||
+					// The live stream resumed while the poll was in flight; its
+					// state is fresher than the snapshot we just read.
+					Date.now() - lastLiveChunkAtRef.current < STALE_STREAM_QUIET_MS ||
+					activeAssistantMessageIdRef.current
+				) {
+					return;
+				}
+				if (Array.isArray(historyMessages) && historyMessages.length > 0) {
+					setMessages(
+						mergeHydratedMessagesWithLive({
+							hydrated: historyMessages,
+							current: messagesRef.current,
+							sessionId,
+							hydrationStartedAt: pollStartedAt,
+						}),
+					);
+				}
+				const nextStatus = record?.status?.trim();
+				if (nextStatus) {
+					setStatus(
+						inferHydratedChatStatus(
+							nextStatus as SessionHistoryStatus,
+							Array.isArray(historyMessages) && historyMessages.length > 0
+								? historyMessages
+								: messagesRef.current,
+						),
+					);
+				}
+			} finally {
+				polling = false;
+			}
+		};
+		const interval = window.setInterval(
+			() => void poll(),
+			STALE_STREAM_POLL_INTERVAL_MS,
+		);
+		return () => {
+			cancelled = true;
+			window.clearInterval(interval);
+		};
+	}, [hydratedHistorySessionId, sessionId, status]);
 
 	// ---- Shared: start a new session via RPC ----
 

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -11,6 +11,7 @@ import {
 	extractAssistantTurnDataFromRpcMessages,
 	inferHydratedChatStatus,
 	makeId,
+	mapSessionRecordStatus,
 	normalizeRuntimeConfig,
 	resolveCredentialError,
 } from "@/hooks/chat-session/helpers";
@@ -1899,16 +1900,15 @@ export function useChatSession() {
 					liveToolInputsRef.current = liveToolState.inputs;
 					setMessages(mergedMessages);
 				}
+				// The record is the authority here: the sessions this poll
+				// serves have a live host maintaining their record, and it
+				// flips to a terminal status when the run ends. Transcript
+				// inference (inferHydratedChatStatus) would misread a mid-run
+				// snapshot ending on assistant narration as finished, hiding
+				// the working indicator and disarming this poll.
 				const nextStatus = record?.status?.trim();
 				if (nextStatus) {
-					setStatus(
-						inferHydratedChatStatus(
-							nextStatus as SessionHistoryStatus,
-							Array.isArray(historyMessages) && historyMessages.length > 0
-								? historyMessages
-								: messagesRef.current,
-						),
-					);
+					setStatus(mapSessionRecordStatus(nextStatus as SessionHistoryStatus));
 				}
 			} finally {
 				polling = false;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -1841,6 +1841,20 @@ export function useChatSession() {
 			if (activeAssistantMessageIdRef.current) {
 				return;
 			}
+			// A locally driven turn is in flight (submit/queue bumps the epoch;
+			// settling closes it). Its optimistic user bubble carries the raw
+			// prompt while canonical history stores it wrapped in a
+			// user_input envelope, so replacing state mid-turn desyncs the
+			// rekey bookkeeping and the stream then appends a duplicate
+			// bubble. The fallback exists for externally driven runs
+			// (schedules, other clients) — stay inert until the local turn
+			// settles.
+			if (
+				turnEpochRef.current !== turnSettledEpochRef.current ||
+				outstandingOptimisticUserIdsRef.current.size > 0
+			) {
+				return;
+			}
 			polling = true;
 			try {
 				const pollStartedAt = Date.now();
@@ -1860,22 +1874,30 @@ export function useChatSession() {
 				if (
 					cancelled ||
 					activeSessionIdRef.current !== sessionId ||
-					// The live stream resumed while the poll was in flight; its
-					// state is fresher than the snapshot we just read.
+					// The live stream resumed (or a local turn started) while
+					// the poll was in flight; live state is fresher than the
+					// snapshot we just read.
 					Date.now() - lastLiveChunkAtRef.current < STALE_STREAM_QUIET_MS ||
-					activeAssistantMessageIdRef.current
+					activeAssistantMessageIdRef.current ||
+					turnEpochRef.current !== turnSettledEpochRef.current ||
+					outstandingOptimisticUserIdsRef.current.size > 0
 				) {
 					return;
 				}
 				if (Array.isArray(historyMessages) && historyMessages.length > 0) {
-					setMessages(
-						mergeHydratedMessagesWithLive({
-							hydrated: historyMessages,
-							current: messagesRef.current,
-							sessionId,
-							hydrationStartedAt: pollStartedAt,
-						}),
-					);
+					const mergedMessages = mergeHydratedMessagesWithLive({
+						hydrated: historyMessages,
+						current: messagesRef.current,
+						sessionId,
+						hydrationStartedAt: pollStartedAt,
+					});
+					// Same as hydration: canonical rows may have replaced live
+					// tool rows, so rebuild the tool routing keys or later
+					// tool events would append instead of updating in place.
+					const liveToolState = deriveLiveToolState(mergedMessages);
+					liveToolMessageIdsRef.current = liveToolState.messageIds;
+					liveToolInputsRef.current = liveToolState.inputs;
+					setMessages(mergedMessages);
 				}
 				const nextStatus = record?.status?.trim();
 				if (nextStatus) {
@@ -2844,6 +2866,10 @@ export function useChatSession() {
 			activeSessionIdRef.current = session.sessionId;
 			activeAssistantMessageIdRef.current = null;
 			setActiveAssistantMessageId(null);
+			// A freshly hydrated session has no local turn in flight; without
+			// this the mount defaults (epoch 0, settled -1) read as an open
+			// turn and keep the stale-stream fallback inert forever.
+			turnSettledEpochRef.current = turnEpochRef.current;
 			setHydratedHistorySessionId(session.sessionId);
 			setPendingToolApprovals([]);
 			setPendingAskQuestions([]);


### PR DESCRIPTION
### Related Issue

Follow-up desktop UX round after #13570, focused on the scheduled-sessions experience. The live-streaming gap discovered along the way is tracked as [ENG-2474](https://linear.app/cline-bot/issue/ENG-2474/wire-scheduled-runs-into-the-hubs-live-session-pipeline-live-streaming).

### Description

Four commits, all about making scheduled runs feel like a first-class part of the app instead of machinery leaking through the UI.

#### 1. Schedule details dialog: one view, runs inline, run-now opens the session

- The details dialog drops the Overview/Runs tabs for a single scrollable column: meta grid → configuration JSON → **Runs**. The JSON `<pre>` is capped (`max-h-64`, internal scroll) so a large schedule object can't crowd the runs out of reach; the Runs section shows the **3 most recent** with a ghost "Show all N runs" expander that resets whenever a different schedule's details open. The "Full configuration for this schedule." subtext is gone — and since Radix warns on a description-less dialog, the content passes `aria-describedby={undefined}`.
- **Run now** hands you into the session it starts. Non-obvious part: the sidecar's trigger command deliberately queues with `wait: false` and returns *before* the runner attaches a session id (the blocking path would outlive the webview's request timeout). So after the "Run started" toast, the handler polls the schedule overview once a second for up to 15s until the triggered execution (matched by execution id, falling back to the schedule's newest execution) reports a `sessionId`, then calls `onOpenSession`. The poll goes through `refreshSchedules` — which now returns the fetched overview — so it doubles as keeping the page's run status live while you wait, and a mounted-ref guard prevents auto-navigation if you've already left the page.

#### 2. `[SYSTEM]` steering messages hidden from transcripts

Scheduled/automation runs inject user-role steering messages every iteration (`[SYSTEM] This run is not complete until you call one of these terminal completion tools: submit_and_exit…` — from `agent-runtime.ts`'s completion policy; there's also a team-obligations variant). The chat view rendered these as **user bubbles**, as if the person had typed them — a scheduled session transcript was mostly steering noise on the right-hand side.

They're machinery talking to the model, so the transcript now hides them entirely (`MessageBubble` returns `null`). The important part is that grouping still accounts for them via one `isSystemSteeringMessage` predicate (user role + `[SYSTEM]` prefix — these messages carry `userRunSpan: 0` in metadata, but the predicate doesn't depend on it surviving the pipeline):

- they collapse into the run's work span like tool calls and thinking traces,
- they are never a turn boundary for the collapse logic,
- they can never be mistaken for a run's "answer" (answer detection now requires assistant role),
- they never advance the run count even when metadata is missing — so checkpoint/edit run numbering stays correct.

A finished scheduled session now reads: prompt → "Worked for…" summary → answer. (We iterated here: the first pass rendered them as subtle "System" chip rows; hiding them fully was the right call.)

#### 3. Stuck-thinking fix: history polling for attached sessions with dead event streams

The reproducible bug: open a scheduled session while (or right after) it runs → the view sits on the thinking shimmer forever; switch away and back → everything appears instantly.

**Root cause (core, not fixed here):** the hub daemon executes scheduled runs through `createLocalHubScheduleRuntimeHandlers()`, which builds its own **private** `LocalRuntimeHost` — while the hub server only projects live events from **its own** session host (`this.sessionHost.subscribe → projectSessionEvent` in `hub-server-transport.ts`). So `session.attach` succeeds but no assistant/tool/status events ever flow for scheduled sessions; the remount "fix" worked because it re-reads history from the shared sqlite store. Verified against a real scheduled run (cron run completed, `cron.db` row links the session, pid-matched the session manifest to the executing daemon). On top of that, multiple hub daemons share `cron.db` and whichever claims a run executes it — so a run claimed by a *different* daemon is invisible to this hub's live pipeline no matter what. The proper rewiring (which also unlocks live steering into running scheduled sessions) is ENG-2474.

**The client-side heal (covers every case, including the wrong-daemon one):** while an attached history session reports a busy status and no `chat_event` chunk has arrived for 5s — and no assistant bubble is mid-stream — `use-chat-session` polls every 3s: re-reads canonical history (merged through the same `mergeHydratedMessagesWithLive` dedupe path hydration uses, so live rows aren't clobbered) and the session record's status via `get_discovered_session`, settling the transcript and the thinking indicator in place. Locally driven turns keep chunks flowing, so the quiet-window guard keeps the fallback inert for normal interactive use.

This also very likely explains a user report we couldn't repro (scheduled session showing only right-side messages and no agent work at all): same defect observed mid-run, before assistant/tool messages had persisted. Worth watching whether that complaint recurs after this ships.

One honest caveat observed while testing: with a slow provider, a scheduled session can legitimately sit on the shimmer for the length of the model's first turn (~39s observed with `deepseek-v4-pro`) because until ENG-2474 lands the view can only surface what's persisted to disk. That's the indicator telling the truth, not this bug.

#### 4. Formatting chore

Two workspace-selector files landed on main unformatted and got picked up by a `biome --write` pass over `components/views/chat`; committed separately to keep the real diffs clean.

### Test Procedure

- `bunx vitest run` in `apps/examples/desktop-app/webview`: **583 tests, 55 files, all passing.** New coverage: steering messages render nothing at all (while real prompts still show), steering stays hidden even inside an expanded work block, and a dead-stream test that hydrates a running attached session with no live events and (under fake timers — they must be installed *before* hydration or the poll interval registers on the real clock) advances past the quiet window to assert the transcript and status heal to completed.
- `bunx biome check` clean on touched files (3 pre-existing `noArrayIndexKey` infos in untouched files); `bunx tsc --noEmit -p webview/tsconfig.json` at the pre-existing 63-error baseline.
- Exercised live against real schedules in the dev stack, including the stuck-thinking repro (heals in ≤ ~8s worst case: 5s quiet window + 3s poll tick) and run-now → auto-open into the started session.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Iterated live in the browser dev stack; happy to attach before/afters on request.

### Additional Notes

- The polling fallback is intentionally the *desktop* answer; ENG-2474 (assigned) is the core answer — unifying the schedule runtime's session host with the hub's projected host so scheduled sessions stream for real and can be steered. The two compose: even after ENG-2474, the fallback still covers runs claimed by a different daemon sharing `cron.db`.
- Related provenance bug noted in ENG-2474: scheduled sessions persist `sessionHistoryOrigin: {mode: "user"}` without the `hub-schedule` trigger despite the stamping code in `runtime-handlers.ts`/`automation.ts`. The sidebar no longer depends on the stamp (it matches schedule-execution session ids), but on-disk provenance is wrong.
- The run-now poll holds the schedule row's busy/spinner state until the session handoff completes (or the 15s deadline passes) — deliberate feedback, capped so a stuck runner can't wedge the row.
