### PR TITLE
feat(vscode): recognize SCX.ai provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.test.ts
@@ -57,6 +57,7 @@ describe("parseProviderId", () => {
 		parseProviderId("xiaomi")
 		parseProviderId("tencent-tokenhub")
 		parseProviderId("chutes")
+		parseProviderId("scx-ai")
 
 		expect(warnSpy).not.toHaveBeenCalled()
 	})
@@ -74,6 +75,7 @@ describe("isKnownProviderId", () => {
 		expect(isKnownProviderId(parseProviderId("xiaomi"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("tencent-tokenhub"))).toBe(true)
 		expect(isKnownProviderId(parseProviderId("chutes"))).toBe(true)
+		expect(isKnownProviderId(parseProviderId("scx-ai"))).toBe(true)
 	})
 
 	it("returns false for a custom provider id", () => {

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -59,6 +59,7 @@ const KNOWN_API_PROVIDERS = {
 	xiaomi: true,
 	"tencent-tokenhub": true,
 	chutes: true,
+	"scx-ai": true,
 	"cline-pass": true,
 } satisfies Record<ApiProvider, true>
 

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -52,6 +52,7 @@ export type ApiProvider =
 	| "xiaomi"
 	| "tencent-tokenhub"
 	| "chutes"
+	| "scx-ai"
 
 export const DEFAULT_API_PROVIDER = "openrouter" as ApiProvider
 

--- a/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
+++ b/apps/vscode/src/shared/proto-conversions/models/api-configuration-conversion.test.ts
@@ -4,7 +4,7 @@ import { convertApiConfigurationToProto, convertProtoToApiConfiguration } from "
 
 describe("api configuration provider conversion", () => {
 	it("round-trips SDK provider ids added after the legacy enum list", () => {
-		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "chutes", "zai-coding-plan"]
+		const providers: ApiProvider[] = ["poolside", "v0", "xiaomi", "tencent-tokenhub", "chutes", "scx-ai", "zai-coding-plan"]
 
 		for (const provider of providers) {
 			const proto = convertApiConfigurationToProto({

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -74,6 +74,7 @@ describe("providerSettingsRegistry", () => {
 			["nousResearch", "NousResearch", undefined],
 			["poolside", "Poolside", undefined],
 			["sambanova", "SambaNova", "https://docs.sambanova.ai/cloud/docs/get-started/overview"],
+			["scx-ai", "SCX.ai", "https://platform.scx.ai"],
 			["tencent-tokenhub", "Tencent TokenHub", "https://cloud.tencent.com/document/product/1823/130050"],
 			["vercel-ai-gateway", "Vercel AI Gateway", "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai"],
 			["v0", "Vercel v0", undefined],

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -107,6 +107,9 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	chutes: {
 		signupUrl: "https://chutes.ai/app/api",
 	},
+	"scx-ai": {
+		signupUrl: "https://platform.scx.ai",
+	},
 	"zai-coding-plan": {},
 }
 
@@ -169,6 +172,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	xiaomi: "Xiaomi",
 	"tencent-tokenhub": "Tencent TokenHub",
 	chutes: "Chutes",
+	"scx-ai": "SCX.ai",
 	"zai-coding-plan": "Z.AI Coding Plan",
 } as const
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — this follows the same limited-scope pattern as the merged provider-recognition PRs #12068 (Chutes) and #12028 (Tencent TokenHub).

### Description

`scx-ai` (SCX.ai, https://platform.scx.ai/docs) is already part of the generated models.dev catalog on `main` — its provider spec lives in `sdk/packages/llms/src/providers/providers.generated.ts` (base URL `https://api.scx.ai/v1`, `SCX_API_KEY`, default model `Qwen3.8-Max`) and its four models are in `catalog.generated.ts`, so it already appears in the settings provider dropdown via the SDK catalog listing.

However, the VS Code extension still treats it as an unknown/custom provider:

- `parseProviderId` logs `Unknown provider id "scx-ai". Treating as a custom provider.` because it is missing from `KNOWN_API_PROVIDERS` / the `ApiProvider` union.
- The settings view renders the raw OpenAI-compatible custom form instead of the curated generic provider form, so users don't get the API key + signup link + generated-catalog model picker experience that other recognized models.dev providers get.

This PR adds the remaining recognition wiring only — exactly what #12068 did for Chutes:

- `apps/vscode/src/shared/api.ts`: add `"scx-ai"` to the `ApiProvider` union
- `apps/vscode/src/sdk/model-catalog/provider-id.ts`: add it to `KNOWN_API_PROVIDERS`
- `apps/vscode/webview-ui/.../providerSettingsRegistry.ts`: generic settings presentation (name "SCX.ai", signup URL)
- matching test updates in the three companion test files

No handwritten provider spec is added anywhere — the models.dev-generated spec (https://models.dev) remains the single source of truth for base URL, models, pricing, and limits, so this does not fall under the "superseded by generated provider specs" scope that closed earlier handwritten provider PRs.

### Test Procedure

- `apps/vscode`: `bunx vitest run src/sdk/model-catalog src/shared` — 13 files, 163 tests passed (includes the updated `provider-id.test.ts` and `api-configuration-conversion.test.ts` round-trip test)
- `apps/vscode/webview-ui`: `bunx vitest run src/components/settings` — 18 files, 160 tests passed (includes the updated `providerSettingsRegistry.test.ts`, which asserts the generic fallback resolves `scx-ai` → "SCX.ai" with its signup URL)
- `bun run check-types` (extension + webview tsc) — clean; the `satisfies Record<ApiProvider, true>` exhaustiveness check enforces the union/known-list stay in sync
- `bun run lint` (biome + proto lint) — clean

What could break: provider id round-tripping over proto and settings-form selection. Both are covered by the updated tests above; `scx-ai` is lowercase already, so `parseProviderId` normalization is a no-op.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Disclosure: I work with SCX.ai (SouthernCrossAI). Provider metadata is sourced exclusively from the models.dev `scx-ai` entry already merged into this repo's generated catalog.
