### PR TITLE
feat(desktop): hover trash button on sidebar session rows

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -319,6 +319,48 @@ describe("AgentSidebar session organization", () => {
 		expect(sessionIsVisible("gamma session 1")).toBe(true);
 	});
 
+	it("deletes a session through the row's hover trash button", async () => {
+		const deleteThread = vi.fn(async () => undefined);
+		const sessionHistory = makeSessionHistory([makeThread("alpha", 1)], vi.fn());
+		(sessionHistory as { deleteThread: unknown }).deleteThread = deleteThread;
+
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={sessionHistory}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		// The trash affordance is a sibling of the row button (buttons cannot
+		// nest) and opens the same confirmation dialog as the context menu.
+		const deleteButton = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Delete alpha session 1"]',
+		);
+		expect(deleteButton).not.toBeNull();
+		expect(deleteButton?.closest("button")).toBe(deleteButton);
+		await click(deleteButton as HTMLButtonElement);
+
+		const confirm = await vi.waitFor(() => {
+			const button = [...document.body.querySelectorAll("button")].find(
+				(candidate) => candidate.textContent === "Delete",
+			);
+			expect(button).toBeDefined();
+			return button as HTMLButtonElement;
+		});
+		expect(document.body.textContent).toContain("Delete session?");
+		await click(confirm);
+		expect(deleteThread).toHaveBeenCalledWith("alpha-1");
+	});
+
 	it("pins sessions to the top of their project group in project sort", async () => {
 		const pinned = { ...makeThread("alpha", 3), pinned: true };
 		const threads = [makeThread("alpha", 1), makeThread("alpha", 2), pinned];

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -1442,41 +1442,65 @@ function ThreadItem({
 			>
 				<ContextMenuTrigger asChild>
 					<HoverCardTrigger asChild>
-						<button
-							className={cn(
-								"group grid h-8 w-full max-w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 overflow-hidden rounded-md px-2 text-left text-sm font-normal",
-								isActive
-									? "bg-surface-hover text-sidebar-foreground"
-									: "text-sidebar-foreground/80 hover:bg-surface-hover",
-							)}
-							disabled={pending}
-							onClick={onClick}
-							type="button"
-						>
-							<span className="flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
-								{thread.isScheduled ? (
-									<Clock3
-										aria-label="Scheduled"
-										className="size-3 shrink-0 text-muted-foreground"
-									/>
-								) : null}
-								<span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
-									{title}
+						{/* The delete affordance is a sibling of the row button
+						    (buttons cannot nest), overlaid where the timestamp
+						    sits; group/row hover swaps the two and keeps the
+						    row's hover background while the pointer is on the
+						    trash button. */}
+						<div className="group/row relative min-w-0">
+							<button
+								className={cn(
+									"group grid h-8 w-full max-w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 overflow-hidden rounded-md px-2 text-left text-sm font-normal",
+									isActive
+										? "bg-surface-hover text-sidebar-foreground"
+										: "text-sidebar-foreground/80 group-hover/row:bg-surface-hover",
+								)}
+								disabled={pending}
+								onClick={onClick}
+								type="button"
+							>
+								<span className="flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
+									{thread.isScheduled ? (
+										<Clock3
+											aria-label="Scheduled"
+											className="size-3 shrink-0 text-muted-foreground"
+										/>
+									) : null}
+									<span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
+										{title}
+									</span>
 								</span>
-							</span>
-							<span className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
-								{statusDotClass ? (
-									<span
-										aria-hidden="true"
-										className={cn("size-1.5 rounded-full", statusDotClass)}
-									/>
-								) : null}
-								{thread.pinned ? (
-									<Pin aria-label="Pinned" className="size-3 fill-current" />
-								) : null}
-								<span>{thread.time}</span>
-							</span>
-						</button>
+								<span className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
+									{statusDotClass ? (
+										<span
+											aria-hidden="true"
+											className={cn("size-1.5 rounded-full", statusDotClass)}
+										/>
+									) : null}
+									{thread.pinned ? (
+										<Pin aria-label="Pinned" className="size-3 fill-current" />
+									) : null}
+									<span className="group-hover/row:invisible">
+										{thread.time}
+									</span>
+								</span>
+							</button>
+							<Button
+								aria-label={`Delete ${title}`}
+								className="absolute top-1/2 right-1 size-6 -translate-y-1/2 justify-center px-0 text-muted-foreground opacity-0 group-hover/row:opacity-100 hover:text-destructive focus-visible:opacity-100"
+								disabled={pending}
+								onClick={(event) => {
+									event.stopPropagation();
+									onDelete();
+								}}
+								size="icon"
+								title="Delete session"
+								type="button"
+								variant="ghost"
+							>
+								<Trash2 className="size-3.5" />
+							</Button>
+						</div>
 					</HoverCardTrigger>
 				</ContextMenuTrigger>
 				<HoverCardContent


### PR DESCRIPTION
### Related Issue

Small desktop UX follow-up in the sidebar-sessions series (#13570, #13573).

### Description

Session rows in the sidebar get a hover-revealed delete affordance: a trash icon on the right side of the row that opens the existing delete confirmation dialog (the same one the row's context menu Delete uses — nothing new in the deletion flow itself, just a discoverable entry point).

Implementation notes, since the obvious version is invalid HTML:

- The session row is a `<button>`, and buttons cannot nest. The trash is therefore an absolutely positioned **sibling** of the row button inside a `group/row` wrapper div, overlaid where the timestamp sits. Radix's `ContextMenuTrigger`/`HoverCardTrigger` (`asChild`) now attach to the wrapper instead of the row button — hover-card and context-menu behavior are unchanged since both are pointer-driven and React's focus events bubble.
- On row hover: the timestamp turns invisible, the trash fades in (`opacity-0 group-hover/row:opacity-100`, plus `focus-visible:opacity-100` so keyboard focus reveals it too). The row's hover background moved from the button's own `:hover` to `group-hover/row:` so the highlight holds while the pointer is on the trash button itself.
- The trash click `stopPropagation()`s so it never also opens the session, and it disables alongside the row while a rename/delete is pending.
- Deleting still requires confirming the existing "Delete session?" dialog — a stray hover-click can't destroy history.

### Test Procedure

- New test drives the full path: trash button present with a per-session aria-label, verified to be a standalone button (not nested inside the row button), click → confirmation dialog appears → confirm → `deleteThread` called with the right session id.
- Full webview suite: **587 tests, 55 files, passing**; the existing sidebar tests (row lookup helpers, hover-card behavior, context-menu delete) all pass unchanged against the restructured row.
- `bunx biome check` clean; `bunx tsc --noEmit -p webview/tsconfig.json` at the pre-existing 63-error baseline.
- Verified live in the browser dev stack: hover shows the trash where the timestamp was, highlight holds over the trash, confirm dialog flows as before.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Iterated live in the browser dev stack; happy to attach before/afters on request.

### Additional Notes

The delete affordance intentionally reuses `requestDeleteThread` → confirm dialog rather than deleting immediately; if we ever want one-click delete with undo-toast semantics instead, that's a separate design conversation.
