### PR TITLE
fix(hub): stop shipping full transcripts inside broadcast hub events

### DIFF
--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -1238,6 +1238,85 @@ describe("HubServerTransport boundaries", () => {
 		expect(updateSessionCompactionState).not.toHaveBeenCalled();
 	});
 
+	it("strips snapshot.messages from published events but keeps them in replies", async () => {
+		const transcript = [
+			{ role: "user", content: [{ type: "text", text: "hello" }] },
+			{ role: "assistant", content: [{ type: "text", text: "world" }] },
+		];
+		let capturedSessionListener:
+			| ((event: Record<string, unknown>) => void)
+			| undefined;
+		const transport = createTransport({
+			sessionHost: {
+				subscribe: vi.fn(
+					(listener: (event: Record<string, unknown>) => void) => {
+						capturedSessionListener = listener;
+						return () => {};
+					},
+				),
+				updateSession: vi.fn().mockResolvedValue({ updated: true }),
+				readSessionMessages: vi.fn().mockResolvedValue(transcript),
+			},
+		});
+		const ctx = getContext(transport);
+		const events: HubEventEnvelope[] = [];
+		ensureSessionState(ctx, "session-1", "owner-client", "creator");
+		transport.subscribe("owner-client", (event) => events.push(event));
+
+		// A snapshot-only persistence update from the session host: the
+		// published session.updated must keep the snapshot's status but drop
+		// the transcript.
+		capturedSessionListener?.({
+			type: "session_snapshot",
+			payload: {
+				sessionId: "session-1",
+				snapshot: {
+					version: 1,
+					sessionId: "session-1",
+					status: "idle",
+					messages: transcript,
+				},
+			},
+		});
+		await vi.waitFor(() => {
+			expect(events.some((event) => event.event === "session.updated")).toBe(
+				true,
+			);
+		});
+		const snapshotOnly = events.find(
+			(event) => event.event === "session.updated",
+		);
+		const snapshotOnlyPayload = snapshotOnly?.payload?.snapshot as Record<
+			string,
+			unknown
+		>;
+		expect(snapshotOnlyPayload.status).toBe("idle");
+		expect(snapshotOnlyPayload).not.toHaveProperty("messages");
+
+		// A session.update command: the published event is stripped the same
+		// way, while the command reply keeps the full snapshot (replies are
+		// request-scoped, not broadcast).
+		events.length = 0;
+		const reply = await transport.handleCommand({
+			version: "v1",
+			requestId: "req-update-strip",
+			command: "session.update",
+			clientId: "owner-client",
+			sessionId: "session-1",
+			payload: { metadata: { title: "renamed" } },
+		});
+		const replySnapshot = reply.payload?.snapshot as Record<string, unknown>;
+		expect(replySnapshot.messages).toEqual(transcript);
+		const updated = events.find((event) => event.event === "session.updated");
+		expect(updated).toBeDefined();
+		const updatedSnapshot = updated?.payload?.snapshot as Record<
+			string,
+			unknown
+		>;
+		expect(updatedSnapshot).not.toHaveProperty("messages");
+		expect(updatedSnapshot.status).toBe("completed");
+	});
+
 	it("publishes session updates after successful compaction sidecar updates", async () => {
 		const state = createSessionCompactionState({
 			sourceMessages: [{ role: "user", content: "source" }],

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -462,7 +462,12 @@ describe("HubServerTransport boundaries", () => {
 		});
 
 		expect(snapshotReply.payload).toHaveProperty("snapshot");
-		expect(readSessionMessages).toHaveBeenCalledWith("session-1");
+		// Snapshots are state notifications: even when requested they never
+		// carry (or read) the transcript — that's session.messages' job.
+		expect(readSessionMessages).not.toHaveBeenCalled();
+		expect(
+			snapshotReply.payload?.snapshot as Record<string, unknown>,
+		).not.toHaveProperty("messages");
 	});
 
 	it("keeps interactive approval requests pending until a response arrives", async () => {
@@ -1238,7 +1243,7 @@ describe("HubServerTransport boundaries", () => {
 		expect(updateSessionCompactionState).not.toHaveBeenCalled();
 	});
 
-	it("strips snapshot.messages from published events but keeps them in replies", async () => {
+	it("never captures the transcript into event or reply snapshots", async () => {
 		const transcript = [
 			{ role: "user", content: [{ type: "text", text: "hello" }] },
 			{ role: "assistant", content: [{ type: "text", text: "world" }] },
@@ -1246,6 +1251,7 @@ describe("HubServerTransport boundaries", () => {
 		let capturedSessionListener:
 			| ((event: Record<string, unknown>) => void)
 			| undefined;
+		const readSessionMessages = vi.fn().mockResolvedValue(transcript);
 		const transport = createTransport({
 			sessionHost: {
 				subscribe: vi.fn(
@@ -1255,7 +1261,7 @@ describe("HubServerTransport boundaries", () => {
 					},
 				),
 				updateSession: vi.fn().mockResolvedValue({ updated: true }),
-				readSessionMessages: vi.fn().mockResolvedValue(transcript),
+				readSessionMessages,
 			},
 		});
 		const ctx = getContext(transport);
@@ -1263,50 +1269,41 @@ describe("HubServerTransport boundaries", () => {
 		ensureSessionState(ctx, "session-1", "owner-client", "creator");
 		transport.subscribe("owner-client", (event) => events.push(event));
 
-		// A snapshot-only persistence update from the session host: the
-		// published session.updated must keep the snapshot's status but drop
-		// the transcript.
+		// A status change projects a session.updated whose snapshot carries
+		// state (status, usage, ...) but never the conversation — the session
+		// host's transcript must not even be read for it.
 		capturedSessionListener?.({
-			type: "session_snapshot",
-			payload: {
-				sessionId: "session-1",
-				snapshot: {
-					version: 1,
-					sessionId: "session-1",
-					status: "idle",
-					messages: transcript,
-				},
-			},
+			type: "status",
+			payload: { sessionId: "session-1", status: "running" },
 		});
 		await vi.waitFor(() => {
 			expect(events.some((event) => event.event === "session.updated")).toBe(
 				true,
 			);
 		});
-		const snapshotOnly = events.find(
+		const statusEvent = events.find(
 			(event) => event.event === "session.updated",
 		);
-		const snapshotOnlyPayload = snapshotOnly?.payload?.snapshot as Record<
+		const statusSnapshot = statusEvent?.payload?.snapshot as Record<
 			string,
 			unknown
 		>;
-		expect(snapshotOnlyPayload.status).toBe("idle");
-		expect(snapshotOnlyPayload).not.toHaveProperty("messages");
+		expect(statusSnapshot.status).toBe("completed");
+		expect(statusSnapshot).not.toHaveProperty("messages");
 
-		// A session.update command: the published event is stripped the same
-		// way, while the command reply keeps the full snapshot (replies are
-		// request-scoped, not broadcast).
+		// A session.update command: neither the published event nor the reply
+		// snapshot contains messages (clients fetch them via session.messages).
 		events.length = 0;
 		const reply = await transport.handleCommand({
 			version: "v1",
-			requestId: "req-update-strip",
+			requestId: "req-update-no-transcript",
 			command: "session.update",
 			clientId: "owner-client",
 			sessionId: "session-1",
 			payload: { metadata: { title: "renamed" } },
 		});
 		const replySnapshot = reply.payload?.snapshot as Record<string, unknown>;
-		expect(replySnapshot.messages).toEqual(transcript);
+		expect(replySnapshot).not.toHaveProperty("messages");
 		const updated = events.find((event) => event.event === "session.updated");
 		expect(updated).toBeDefined();
 		const updatedSnapshot = updated?.payload?.snapshot as Record<
@@ -1315,6 +1312,7 @@ describe("HubServerTransport boundaries", () => {
 		>;
 		expect(updatedSnapshot).not.toHaveProperty("messages");
 		expect(updatedSnapshot.status).toBe("completed");
+		expect(readSessionMessages).not.toHaveBeenCalled();
 	});
 
 	it("publishes session updates after successful compaction sidecar updates", async () => {

--- a/sdk/packages/core/src/hub/server/handlers/context.ts
+++ b/sdk/packages/core/src/hub/server/handlers/context.ts
@@ -185,6 +185,15 @@ export async function readHubSessionRecord(
 	);
 }
 
+/**
+ * Builds the snapshot that rides on hub events and command replies. It is a
+ * state notification — status, usage, model, workspace, checkpoint — and
+ * deliberately does NOT read the transcript: `snapshot.messages` here would
+ * put the entire conversation on every status flip, for every subscriber,
+ * and into the durable event log (observed in the wild as a 25GB hub process
+ * feeding a slow reader). Anything that needs messages fetches them with the
+ * `session.messages` command.
+ */
 export async function readCoreSessionSnapshot(
 	ctx: HubTransportContext,
 	sessionId: string,
@@ -193,15 +202,9 @@ export async function readCoreSessionSnapshot(
 	if (!session) {
 		return undefined;
 	}
-	const [messages, usageSummary] = await Promise.all([
-		typeof ctx.sessionHost.readSessionMessages === "function"
-			? ctx.sessionHost.readSessionMessages(sessionId)
-			: [],
-		ctx.sessionHost.getAccumulatedUsage?.(sessionId),
-	]);
+	const usageSummary = await ctx.sessionHost.getAccumulatedUsage?.(sessionId);
 	return createCoreSessionSnapshot({
 		session,
-		messages,
 		usage: usageSummary?.usage,
 		aggregateUsage: usageSummary?.aggregateUsage,
 	});

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -1115,6 +1115,14 @@ export class HubServerTransport implements NativeHubTransport {
 	}
 
 	private publish(event: HubEventEnvelope): void {
+		// Events are broadcast state notifications, not transcript transport:
+		// no consumer reads `snapshot.messages` off an event (they fetch via
+		// the `session.messages` command instead), but a full transcript here
+		// multiplies every status flip into megabytes per subscriber — enough
+		// to swamp the event log and, for a slow reader, balloon the socket
+		// send queue until the process OOMs. Strip messages before the event
+		// becomes durable so live fan-out and cursor replay stay identical.
+		event = stripSnapshotMessagesFromEvent(event);
 		// Durability before delivery: append to the event log and fan out the
 		// sequence-stamped envelope, so live listeners and replaying clients
 		// observe identical frames and the cursor is always meaningful.
@@ -1155,6 +1163,32 @@ export class HubServerTransport implements NativeHubTransport {
 			}
 		}
 	}
+}
+
+/**
+ * Drops the (potentially multi-megabyte) `snapshot.messages` transcript from
+ * an outward-bound event envelope, keeping every other snapshot field
+ * (status, usage, model, workspace, checkpoint, ...) intact. Command replies
+ * are untouched — only the broadcast stream is slimmed.
+ */
+function stripSnapshotMessagesFromEvent(
+	event: HubEventEnvelope,
+): HubEventEnvelope {
+	const payload = event.payload;
+	const snapshot = payload?.snapshot;
+	if (
+		!snapshot ||
+		typeof snapshot !== "object" ||
+		Array.isArray(snapshot) ||
+		!("messages" in snapshot)
+	) {
+		return event;
+	}
+	const { messages: _messages, ...slimSnapshot } = snapshot as Record<
+		string,
+		unknown
+	>;
+	return { ...event, payload: { ...payload, snapshot: slimSnapshot } };
 }
 
 function shouldCaptureHubReplyError(code: string): boolean {

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -1115,14 +1115,6 @@ export class HubServerTransport implements NativeHubTransport {
 	}
 
 	private publish(event: HubEventEnvelope): void {
-		// Events are broadcast state notifications, not transcript transport:
-		// no consumer reads `snapshot.messages` off an event (they fetch via
-		// the `session.messages` command instead), but a full transcript here
-		// multiplies every status flip into megabytes per subscriber — enough
-		// to swamp the event log and, for a slow reader, balloon the socket
-		// send queue until the process OOMs. Strip messages before the event
-		// becomes durable so live fan-out and cursor replay stay identical.
-		event = stripSnapshotMessagesFromEvent(event);
 		// Durability before delivery: append to the event log and fan out the
 		// sequence-stamped envelope, so live listeners and replaying clients
 		// observe identical frames and the cursor is always meaningful.
@@ -1163,32 +1155,6 @@ export class HubServerTransport implements NativeHubTransport {
 			}
 		}
 	}
-}
-
-/**
- * Drops the (potentially multi-megabyte) `snapshot.messages` transcript from
- * an outward-bound event envelope, keeping every other snapshot field
- * (status, usage, model, workspace, checkpoint, ...) intact. Command replies
- * are untouched — only the broadcast stream is slimmed.
- */
-function stripSnapshotMessagesFromEvent(
-	event: HubEventEnvelope,
-): HubEventEnvelope {
-	const payload = event.payload;
-	const snapshot = payload?.snapshot;
-	if (
-		!snapshot ||
-		typeof snapshot !== "object" ||
-		Array.isArray(snapshot) ||
-		!("messages" in snapshot)
-	) {
-		return event;
-	}
-	const { messages: _messages, ...slimSnapshot } = snapshot as Record<
-		string,
-		unknown
-	>;
-	return { ...event, payload: { ...payload, snapshot: slimSnapshot } };
 }
 
 function shouldCaptureHubReplyError(code: string): boolean {

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -2603,6 +2603,11 @@ export class LocalRuntimeHost implements RuntimeHost {
 		});
 	}
 
+	// The emitted snapshot is a state notification (status, usage, workspace,
+	// checkpoint) and deliberately omits the transcript: emitStatus fires this
+	// on every status flip, so including messages would re-read and broadcast
+	// the entire conversation each time. Consumers that need messages read
+	// them explicitly via readSessionMessages / the session.messages command.
 	private async emitSessionSnapshot(sessionId: string): Promise<void> {
 		const session = await this.getSession(sessionId);
 		if (!session) return;
@@ -2612,7 +2617,6 @@ export class LocalRuntimeHost implements RuntimeHost {
 				sessionId,
 				snapshot: createCoreSessionSnapshot({
 					session,
-					messages: await this.readSessionMessages(sessionId),
 					usage: this.usageBySession.get(sessionId),
 					aggregateUsage: this.aggregateUsageBySession.get(sessionId),
 				}),


### PR DESCRIPTION
### Related Issue

Community report (no issue filed): a user on CLI **3.0.58** hit a **25GB** cline process (35.5GB across five cline processes) on a 16GB Mac after ~19h of an ordinary interactive session — three sessions totaling just **7.5MB on disk**. Their arithmetic was right: `25GB ÷ 6.79MB-per-transcript ≈ 3,700` retained transcript copies.

### Description

#### What's wrong

Snapshots that ride on hub events and command replies captured the session's **entire message transcript**:
- `emitSessionSnapshot` in `local-runtime-host.ts` re-read *all* messages from disk on **every status flip** just to emit a `session_snapshot` state event.
- `readCoreSessionSnapshot` (`hub/server/handlers/context.ts`) did the same for every `session.updated` / `session.created` / `session.detached` / `run.started` event and their command replies.

So every status transition put the whole conversation on the wire (per subscriber), into the durable event log, and — the lethal part — into the hub's websocket send queue, which has no backpressure check (`socket.send(JSON.stringify(frame))`, fixed separately in #13588). A subscriber that drains slower than events arrive makes the hub retain one full-transcript frame per event, forever.

Reproduced against main (== 3.0.58) with a stub hub + slow consumer: hub `bufferedAmount` hit **5.3GB in 40 seconds**, heapUsed tracking it 1:1 and surviving forced `Bun.gc(true)`; the slow client itself stayed flat (~500MB) — the sender is the process that balloons. Repro gotcha: payload *shape* matters — a transcript of a few giant strings never triggers it, the same bytes as thousands of small structured messages (realistic transcripts) do, because parsing ~200k objects per frame is what makes the consumer slow.

#### The fix

Don't capture the transcript into these snapshots **at all**. A snapshot is a state notification — status, usage, model, workspace, capabilities, checkpoint — and every field except `messages` is preserved. I audited the entire repo before removing it: **no consumer reads `snapshot.messages`** from any event or any reply (desktop sidecar reads only `session.status`; `HubRuntimeHost` uses `artifacts.messagesPath`, usage, and status; the vscode example treats these events as list-refresh triggers). Anything that needs messages already fetches them via the `session.messages` command.

Deliberately untouched: checkpoint-restore (`session-versioning-service.ts`) still builds its message-bearing snapshots, and restore replies keep carrying messages in their own dedicated `messages` field — that's a user-initiated, request-scoped transcript operation, not a broadcast.

Side benefit: `emitStatus` no longer does a full-transcript disk read + JSON clone per status change — that was pure wasted I/O/CPU even when nothing was stalled.

Note this changes the (optional) `messages` field's presence in `session_snapshot` core events for SDK `ClineCore.subscribe` consumers and in reply snapshots — intentionally; grep found zero readers.

#### First attempt, for the record

The first commit on this branch stripped `snapshot.messages` centrally in `HubServerTransport.publish()`. That kept replies fat and still paid the read+clone cost per event — the follow-up commit removes it and fixes the sources instead.

### Test Procedure

- New `boundary.test.ts` test: a `status` core event and a `session.update` command publish `session.updated` with status intact and **no** `messages` — and `readSessionMessages` is never even called. Reply snapshots equally transcript-free.
- Updated the "lightweight session list/get" test: `session.get` with `includeSnapshot` no longer reads the transcript either.
- Full affected suites green: boundary, hub-event-log, replay-wire, ui-events, hub-runtime-host, runtime/host (203 tests).
- Live validation with the repro harness: the slow-consumer scenario that ballooned the hub to 4.4GB heapUsed in 40s holds flat at ~120MB after 500+ events.
- `tsc -b sdk/packages/core` clean apart from a pre-existing unused-import error in `hub-upgrades.test.ts` that exists on main; biome clean.
