### PR TITLE
fix(hub): terminate subscribers whose websocket send buffer exceeds a cap

### DIFF
--- a/sdk/packages/core/src/hub/server/browser-websocket.test.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.test.ts
@@ -84,6 +84,68 @@ describe("BrowserWebSocketHubAdapter", () => {
 		}
 	});
 
+	it("terminates a subscriber whose send buffer exceeds the backpressure cap", async () => {
+		let capturedListener: ((envelope: HubEventEnvelope) => void) | undefined;
+		const transport = {
+			command: vi.fn(),
+			subscribe: vi.fn(
+				(_clientId: string, listener: (envelope: HubEventEnvelope) => void) => {
+					capturedListener = listener;
+					return () => {
+						capturedListener = undefined;
+					};
+				},
+			),
+		};
+		const socket = createSocket();
+		const backpressured = socket as typeof socket & {
+			bufferedAmount?: number;
+			terminate?: () => void;
+		};
+		backpressured.bufferedAmount = 0;
+		const terminate = vi.fn(() => socket.emitClose());
+		backpressured.terminate = terminate;
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			new BrowserWebSocketHubAdapter(transport).attach(backpressured);
+			socket.emitMessage(
+				JSON.stringify({
+					kind: "stream.subscribe",
+					clientId: "slow-client",
+				}),
+			);
+			await vi.waitFor(() => {
+				expect(capturedListener).toBeDefined();
+			});
+
+			const envelope = (id: string): HubEventEnvelope =>
+				({
+					version: "v1",
+					event: "session.updated",
+					eventId: id,
+					timestamp: 1,
+					payload: {},
+				}) as unknown as HubEventEnvelope;
+
+			// Draining socket: frames flow normally.
+			capturedListener?.(envelope("evt-1"));
+			expect(socket.sent).toHaveLength(1);
+
+			// Send buffer past the cap: the frame is dropped and the socket is
+			// torn down instead of buffering forever.
+			backpressured.bufferedAmount = 65 * 1024 * 1024;
+			capturedListener?.(envelope("evt-2"));
+			expect(terminate).toHaveBeenCalledTimes(1);
+			expect(socket.sent).toHaveLength(1);
+			// The close handler released the subscription; nothing further is
+			// delivered or sent on the dead connection.
+			expect(capturedListener).toBeUndefined();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("binds client identity to the Hub-authorized workspace", async () => {
 		const transport = {
 			command: vi.fn(
@@ -466,7 +528,10 @@ describe("BrowserWebSocketHubAdapter", () => {
 		);
 
 		const deadline = Date.now() + 2_000;
-		while (transport.replayEventsAfter.mock.calls.length < 2 && Date.now() < deadline) {
+		while (
+			transport.replayEventsAfter.mock.calls.length < 2 &&
+			Date.now() < deadline
+		) {
 			await new Promise((r) => setTimeout(r, 5));
 		}
 		// Let the buffered-flush finally-block run past the last replay page.
@@ -616,8 +681,7 @@ describe("BrowserWebSocketHubAdapter", () => {
 			.map((entry) => JSON.parse(entry))
 			.filter(
 				(frame) =>
-					frame.kind === "event" &&
-					frame.envelope.eventId === "hevt_reissued",
+					frame.kind === "event" && frame.envelope.eventId === "hevt_reissued",
 			);
 		expect(delivered).toHaveLength(2);
 	});

--- a/sdk/packages/core/src/hub/server/browser-websocket.ts
+++ b/sdk/packages/core/src/hub/server/browser-websocket.ts
@@ -29,8 +29,31 @@ const HUB_EVENT_REPLAY_PAGE_SIZE = 200;
  */
 const HUB_EVENT_REPLAY_MAX_PAGES = 1_000;
 
+/**
+ * Kick threshold for a subscriber that stopped draining its socket. Frames
+ * are queued in process memory by `socket.send`, so an unread backlog grows
+ * the Hub without bound (observed as a 25GB hub process feeding a stalled
+ * client). Past this ceiling the connection is terminated; the client's
+ * auto-reconnect resubscribes with its `sinceSequence` cursor and the durable
+ * event log replays everything it missed, so the kick is lossless within the
+ * log's retention window.
+ */
+const MAX_SOCKET_BUFFERED_BYTES = 64 * 1024 * 1024;
+
 export interface BrowserHubSocketLike {
 	send(data: string): void;
+	/**
+	 * Bytes queued in the socket's send buffer, when the underlying transport
+	 * exposes it. Used to detect subscribers that stopped draining; sockets
+	 * that cannot report it are exempt from the backpressure cap.
+	 */
+	readonly bufferedAmount?: number;
+	/**
+	 * Immediately tear the connection down without a close handshake. A close
+	 * frame would queue behind the very backlog that triggered the kick, so
+	 * graceful close is useless here.
+	 */
+	terminate?(): void;
 	addEventListener(
 		type: "message",
 		listener: (event: { data: string }) => void,
@@ -121,8 +144,47 @@ export class BrowserWebSocketHubAdapter {
 		const registeredClientIds = new Set<string>();
 		let authority: HubConnectionAuthority | undefined;
 		let closed = false;
+		// Set on a backpressure kick: terminate() tears the transport down
+		// asynchronously, so this gates sends (and repeat kicks) in the window
+		// before the close event lands.
+		let kicked = false;
 
 		const sendFrame = (frame: HubTransportFrame): void => {
+			if (closed || kicked) {
+				return;
+			}
+			const bufferedAmount = socket.bufferedAmount;
+			if (
+				typeof bufferedAmount === "number" &&
+				bufferedAmount > MAX_SOCKET_BUFFERED_BYTES
+			) {
+				kicked = true;
+				// The peer stopped reading: every additional frame is retained
+				// in this process until the socket drains, which it clearly is
+				// not doing. Cut the connection instead of buffering forever —
+				// reconnect + cursor replay makes this lossless for the client.
+				logHubMessage("warn", "socket.backpressure_kick", {
+					bufferedAmount,
+					maxBufferedBytes: MAX_SOCKET_BUFFERED_BYTES,
+					droppedFrameKind: frame.kind,
+				});
+				captureSdkError(this.telemetry, {
+					component: "core",
+					operation: "hub.websocket_backpressure_kick",
+					error: new Error(
+						`hub socket send buffer exceeded ${MAX_SOCKET_BUFFERED_BYTES} bytes (${bufferedAmount})`,
+					),
+					severity: "warn",
+					handled: true,
+					context: { bufferedAmount },
+				});
+				try {
+					socket.terminate?.();
+				} catch {
+					// The close listener still runs; nothing else to do.
+				}
+				return;
+			}
 			try {
 				socket.send(JSON.stringify(frame));
 			} catch (error) {

--- a/sdk/packages/core/src/hub/server/hub-websocket-server.ts
+++ b/sdk/packages/core/src/hub/server/hub-websocket-server.ts
@@ -56,6 +56,7 @@ export { HubServerTransport } from "./hub-server-transport";
 
 type NodeWebSocketLike = {
 	send(data: string): void;
+	readonly bufferedAmount?: number;
 	on(event: "message", listener: (data: unknown) => void): void;
 	on(event: "close", listener: () => void): void;
 	on(event: "pong", listener: () => void): void;
@@ -94,6 +95,12 @@ function wrapWsSocket(socket: NodeWebSocketLike) {
 	return {
 		send(data: string): void {
 			socket.send(data);
+		},
+		get bufferedAmount(): number | undefined {
+			return socket.bufferedAmount;
+		},
+		terminate(): void {
+			socket.terminate?.();
 		},
 		addEventListener(
 			type: "message" | "close",


### PR DESCRIPTION
### Related Issue

Same incident as #13587 (25GB cline process on a 16GB Mac, CLI 3.0.58): the structural half of the fix. **Draft on purpose** — the strip PR is the tonight hotfix; this one is being handed off for a proper look at the design questions below before it merges.

### Description

#### The hole

`sendFrame` in `hub/server/browser-websocket.ts` is `socket.send(JSON.stringify(frame))`, unconditionally. `ws`'s `send()` never blocks — a frame the peer isn't reading is queued in **this process's memory** (`bufferedAmount`). So any subscriber that stops draining — a machine deep in swap, a SIGSTOPped/App-Napped process, a laptop mid-sleep-wake — makes the hub retain every subsequent frame, forever. Nothing anywhere in the hub checks `bufferedAmount`.

Measured on main with a repro harness (stub hub + slow consumer doing 150ms of work per 30ms event): `bufferedAmount` reached **5.3GB in 40 seconds**, heapUsed tracking it 1:1 and surviving `Bun.gc(true)`. The transcript-stripping hotfix makes frames small, so this stops being a fast OOM — but the queue is still unbounded, and any future fat event (or just enough small ones against a wedged client) reopens the hole.

#### The fix

Cap the per-socket send buffer at **64MiB**. Past the cap, drop the frame and `terminate()` the connection — *not* `close()`, because a graceful close frame would queue behind the very backlog that triggered the kick and never arrive.

Why kicking is safe: this is exactly the failure mode the durable event log was built for. The client's `NodeHubClient` auto-reconnects and resubscribes with its `sinceSequence` cursor; the hub replays everything it missed from the log. Disconnect never implies data loss (within the log's retention window), which turns "buffer forever" into "cut the cord and let replay catch them up". Verified live: with the cap, the slow-consumer repro fires the kick repeatedly (33 kicks in 45s), the hub's heap oscillates *under* the cap instead of growing without bound, and the client keeps reconnecting and consuming events throughout — no stall, no loss.

Mechanics:
- `BrowserHubSocketLike` gains optional `bufferedAmount` / `terminate()`; the node `ws` wrapper in `hub-websocket-server.ts` forwards both. That wrapper is the **only** production attach site, so every real hub socket is covered; a socket that can't report `bufferedAmount` is exempt (no behavior change).
- A `kicked` flag gates sends between `terminate()` and the (async) close event, so the kick fires once — the existing `onClose` cleanup then releases subscriptions and unregisters clients exactly as if the peer had vanished.
- The kick logs `socket.backpressure_kick` (with the observed `bufferedAmount`) and captures a handled `hub.websocket_backpressure_kick` sdk-error so we can see it firing in the wild.

#### Open questions for whoever picks this up

1. **Threshold.** 64MiB is "clearly wedged" territory once events are slim, and matches the event log's size cap (a kicked client can always replay at least a full log window). But it's a judgment call — should it scale with event size, or be time-based (buffer not draining for N seconds) instead of size-based?
2. **Kick vs. drop-subscription.** Terminating the socket also kills in-flight command replies for that client. A softer option is dropping only the stream subscription and letting the command channel live. I went with terminate because a connection 64MiB behind is not meaningfully alive, and reconnect/replay is the well-tested path — but reasonable people could disagree.
3. **Replay-window math.** The kick is lossless only within the log's retention (64MB / 200k rows / 7d). After the strip PR events are small, so this is thousands of events of headroom — but a client kicked *and* offline past retention silently loses events (same as any long-disconnected client today). Worth confirming that's acceptable.
4. **The replay `buffered[]` array.** During cursor replay, live events buffer in an in-process array before the flush. It's bounded by replay duration, and the cap indirectly limits it, but it's the same pattern one layer up — worth a look while in here.
5. **Sleep/wake behavior on macOS.** The original incident involved 19h with presumable sleep cycles. A slept client's socket sits at high `bufferedAmount` until the TCP stack gives up; with this PR the hub kicks it on the next event instead of buffering. That's the intent, but it means every laptop sleep becomes a reconnect+replay on wake — should be invisible, worth a sanity check in the desktop app.

### Test Procedure

- New test in `browser-websocket.test.ts`: a subscribed socket under the cap sends normally; past the cap the frame is dropped, `terminate()` fires exactly once, and the close-path cleanup releases the subscription.
- `browser-websocket`, `hub-websocket-server`, `replay-wire`, `ensure-retire` suites green (21 tests).
- Live repro validation as above (33 kicks, bounded heap, client keeps consuming via reconnect+replay).
