### PR TITLE
fix(vscode): stop pinning DeepSeek model count in catalog smoke test

### DIFF
--- a/apps/vscode/src/core/controller/models/__tests__/providerCatalogSmoke.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/providerCatalogSmoke.test.ts
@@ -62,7 +62,9 @@ describe("provider model catalog backend smoke", () => {
 		})
 		expect(models.ok).toBe(true)
 		expect(models.requestId).toBe("smoke-request")
-		expect(Object.keys(models.models).length).toBeGreaterThanOrEqual(4)
+		// Don't pin an exact count: the generated catalog is refreshed regularly
+		// and DeepSeek's lineup changes (e.g. the v4 refresh shrank it to 3).
+		expect(Object.keys(models.models).length).toBeGreaterThan(0)
 
 		const modelId = models.defaultModelId || Object.keys(models.models)[0]
 		expect(modelId).toBeTruthy()


### PR DESCRIPTION
### Related Issue

None. Fixes the `ext-vscode-test` failure that has been red on `main` since the SDK v0.0.80 model catalog refresh (first failing commit 4c8cd9835, e.g. https://github.com/cline/cline/actions/runs/32952978724).

### Description

`providerCatalogSmoke.test.ts` asserted that the native DeepSeek provider resolves at least 4 models. The regenerated model catalog replaced DeepSeek's legacy `deepseek-chat` / `deepseek-reasoner` ids with the v4 family, and after dated snapshots (`-0813`, `-0731`) are deduped into their parents, the provider now resolves 3 models (`deepseek-v4-flash-vision-exp`, `deepseek-v4-pro`, `deepseek-v4-flash`), so the assertion fails.

The count threshold is not what the smoke test is for. Its real coverage is that providers list, DeepSeek models resolve, a default model exists, and a committed selection round-trips through the config store. Pinning an exact model count just re-breaks the suite on every catalog refresh, so the assertion now only requires a non-empty model list.

### Test Procedure

- Rebuilt the SDK (`bun run build:sdk`) on current `main` so the test runs against the refreshed catalog, reproduced the CI failure locally (expected 3 to be greater than or equal to 4), then verified the fix makes the test pass.
- Ran the full extension vitest suite (the same step CI runs): 89 files, 1162 tests, all passing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable (test-only change).

### Additional Notes

The shipped extension v4.1.16 was built from a green commit before the refresh, so nothing broken went out; this only unblocks `main` CI for the next release.