### PR TITLE
fix(core): let desktop Schedules page manage schedules across workspaces

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -612,11 +612,19 @@ async function handleRoutineScheduleCommand(
 	args?: Record<string, unknown>,
 ): Promise<unknown> {
 	const hubClient = await ensureSharedHubClient(ctx);
+	// The Schedules page manages schedules across every workspace, while this
+	// hub connection is registered with the app launch directory (which is
+	// meaningless — e.g. "/" for a Finder-launched production app). Opt out of
+	// connection-workspace confinement so agent- and project-created schedules
+	// stay visible and manageable, and creates honor the user-picked workspace.
 	const clientCommand = async (
 		hubCommand: string,
 		payload?: Record<string, unknown>,
 	) => {
-		const reply = await hubClient.command(hubCommand as never, payload);
+		const reply = await hubClient.command(hubCommand as never, {
+			...payload,
+			allWorkspaces: true,
+		});
 		if (!reply.ok) {
 			throw new Error(
 				reply.error?.message ?? `hub command failed: ${hubCommand}`,

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -928,8 +928,12 @@ describe("Code sidecar runtime capabilities", () => {
 		).resolves.toEqual({
 			schedule: { scheduleId: "schedule-1", enabled: false },
 		});
+		// allWorkspaces lifts the hub's connection-workspace confinement: the
+		// Schedules page manages schedules regardless of the launch directory
+		// this sidecar's hub client happens to be registered with.
 		expect(hubCommandMock).toHaveBeenCalledWith("schedule.disable", {
 			scheduleId: "schedule-1",
+			allWorkspaces: true,
 		});
 	});
 

--- a/sdk/packages/core/src/cron/service/schedule-command-service.ts
+++ b/sdk/packages/core/src/cron/service/schedule-command-service.ts
@@ -12,18 +12,32 @@ import type { HubScheduleService } from "./schedule-service";
 interface ScheduleCommandScope {
 	workspaceRoot: string;
 	cwd: string;
+	/**
+	 * Explicit per-command opt-out of connection-workspace confinement,
+	 * requested via `payload.allWorkspaces`. User-driven surfaces that manage
+	 * schedules across every workspace (e.g. the desktop Schedules page, whose
+	 * connection workspace is just the app launch directory) set this; scoped
+	 * clients such as the CLI and the agent tasks tool never do.
+	 */
+	allWorkspaces: boolean;
 }
 
-function scopedCwd(
-	scope: ScheduleCommandScope,
-	value: unknown,
-): string | undefined {
+function scopedCwd(workspaceRoot: string, value: unknown): string | undefined {
 	if (typeof value !== "string" || !value.trim()) return undefined;
-	const cwd = resolve(scope.workspaceRoot, value);
-	if (!pathWithin(scope.workspaceRoot, cwd)) {
+	const cwd = resolve(workspaceRoot, value);
+	if (!pathWithin(workspaceRoot, cwd)) {
 		throw new Error("schedule cwd is outside the client workspace scope");
 	}
 	return cwd;
+}
+
+function requestedWorkspaceRoot(
+	payload: Record<string, unknown>,
+): string | undefined {
+	return typeof payload.workspaceRoot === "string" &&
+		payload.workspaceRoot.trim()
+		? resolve(payload.workspaceRoot.trim())
+		: undefined;
 }
 
 function pathWithin(workspaceRoot: string, candidate: string): boolean {
@@ -64,7 +78,7 @@ export class HubScheduleCommandService {
 		authority?: HubConnectionAuthority,
 	): Promise<HubReplyEnvelope> {
 		try {
-			const scope = this.resolveScope(authority);
+			const scope = this.resolveScope(authority, envelope.payload);
 			switch (envelope.command) {
 				case "schedule.create":
 					return okReply(envelope, {
@@ -86,20 +100,24 @@ export class HubScheduleCommandService {
 							tags: Array.isArray(envelope.payload?.tags)
 								? (envelope.payload?.tags as string[])
 								: undefined,
-							workspaceRoot: scope.workspaceRoot,
+							workspaceRoot: scope.allWorkspaces
+								? undefined
+								: scope.workspaceRoot,
 						}),
 					});
 				case "schedule.get":
 					return okReply(envelope, {
 						schedule: this.requireScopedSchedule(envelope, scope),
 					});
-				case "schedule.update":
+				case "schedule.update": {
+					const schedule = this.requireScopedSchedule(envelope, scope);
 					return okReply(envelope, {
 						schedule: this.schedules.updateSchedule(
-							this.requireScopedSchedule(envelope, scope).scheduleId,
-							this.toUpdateInput(envelope.payload ?? {}, scope),
+							schedule.scheduleId,
+							this.toUpdateInput(envelope.payload ?? {}, scope, schedule),
 						),
 					});
+				}
 				case "schedule.delete":
 					return okReply(envelope, {
 						deleted: this.schedules.deleteSchedule(
@@ -140,23 +158,29 @@ export class HubScheduleCommandService {
 						),
 					});
 				case "schedule.active": {
+					const executions = this.schedules.getActiveExecutions();
+					if (scope.allWorkspaces) {
+						return okReply(envelope, { executions });
+					}
 					const scheduleIds = this.scopedScheduleIds(scope);
 					return okReply(envelope, {
-						executions: this.schedules
-							.getActiveExecutions()
-							.filter((execution) => scheduleIds.has(execution.scheduleId)),
+						executions: executions.filter((execution) =>
+							scheduleIds.has(execution.scheduleId),
+						),
 					});
 				}
 				case "schedule.upcoming": {
+					const runs = this.schedules.getUpcomingRuns(
+						typeof envelope.payload?.limit === "number"
+							? envelope.payload.limit
+							: undefined,
+					);
+					if (scope.allWorkspaces) {
+						return okReply(envelope, { runs });
+					}
 					const scheduleIds = this.scopedScheduleIds(scope);
 					return okReply(envelope, {
-						runs: this.schedules
-							.getUpcomingRuns(
-								typeof envelope.payload?.limit === "number"
-									? envelope.payload.limit
-									: undefined,
-							)
-							.filter((run) => scheduleIds.has(run.scheduleId)),
+						runs: runs.filter((run) => scheduleIds.has(run.scheduleId)),
 					});
 				}
 				default:
@@ -177,6 +201,7 @@ export class HubScheduleCommandService {
 
 	private resolveScope(
 		authority: HubConnectionAuthority | undefined,
+		payload: Record<string, unknown> | undefined,
 	): ScheduleCommandScope {
 		const context = authority?.workspaceContext;
 		if (!authority?.clientId || !context?.workspaceRoot?.trim()) {
@@ -189,7 +214,11 @@ export class HubScheduleCommandService {
 		if (!pathWithin(workspaceRoot, cwd)) {
 			throw new Error("client cwd is outside its workspace scope");
 		}
-		return { workspaceRoot, cwd };
+		return {
+			workspaceRoot,
+			cwd,
+			allWorkspaces: payload?.allWorkspaces === true,
+		};
 	}
 
 	private requireScopedSchedule(
@@ -200,7 +229,11 @@ export class HubScheduleCommandService {
 		const schedule = scheduleId
 			? this.schedules.getSchedule(scheduleId)
 			: undefined;
-		if (!schedule || resolve(schedule.workspaceRoot) !== scope.workspaceRoot) {
+		if (
+			!schedule ||
+			(!scope.allWorkspaces &&
+				resolve(schedule.workspaceRoot) !== scope.workspaceRoot)
+		) {
 			throw new Error("schedule does not exist in this workspace");
 		}
 		return schedule;
@@ -225,20 +258,24 @@ export class HubScheduleCommandService {
 		if (requestedScheduleId) {
 			this.requireScopedSchedule(envelope, scope);
 		}
+		const executions = this.schedules.listScheduleExecutions({
+			scheduleId: requestedScheduleId,
+			status:
+				typeof envelope.payload?.status === "string"
+					? (envelope.payload.status as never)
+					: undefined,
+			limit:
+				typeof envelope.payload?.limit === "number"
+					? envelope.payload.limit
+					: undefined,
+		});
+		if (scope.allWorkspaces) {
+			return executions;
+		}
 		const scheduleIds = this.scopedScheduleIds(scope);
-		return this.schedules
-			.listScheduleExecutions({
-				scheduleId: requestedScheduleId,
-				status:
-					typeof envelope.payload?.status === "string"
-						? (envelope.payload.status as never)
-						: undefined,
-				limit:
-					typeof envelope.payload?.limit === "number"
-						? envelope.payload.limit
-						: undefined,
-			})
-			.filter((execution) => scheduleIds.has(execution.scheduleId));
+		return executions.filter((execution) =>
+			scheduleIds.has(execution.scheduleId),
+		);
 	}
 
 	private toCreateInput(
@@ -257,18 +294,25 @@ export class HubScheduleCommandService {
 							modelId: String(payload.model),
 						}
 					: undefined;
+		const workspaceRoot = scope.allWorkspaces
+			? (requestedWorkspaceRoot(payload) ?? scope.workspaceRoot)
+			: scope.workspaceRoot;
+		const { allWorkspaces: _allWorkspaces, ...rest } = payload;
 		return {
-			...(payload as unknown as HubScheduleCreateInput),
+			...(rest as unknown as HubScheduleCreateInput),
 			modelSelection,
 			mode,
-			workspaceRoot: scope.workspaceRoot,
-			cwd: scopedCwd(scope, payload.cwd) ?? scope.cwd,
+			workspaceRoot,
+			cwd:
+				scopedCwd(workspaceRoot, payload.cwd) ??
+				(workspaceRoot === scope.workspaceRoot ? scope.cwd : workspaceRoot),
 		};
 	}
 
 	private toUpdateInput(
 		payload: Record<string, unknown>,
 		scope: ScheduleCommandScope,
+		schedule: { workspaceRoot: string },
 	): HubScheduleUpdateInput {
 		const mode = readHubScheduleMode(payload);
 		const modelSelection =
@@ -283,17 +327,24 @@ export class HubScheduleCommandService {
 							modelId: typeof payload.model === "string" ? payload.model : "",
 						}
 					: undefined;
+		const workspaceRoot = scope.allWorkspaces
+			? (requestedWorkspaceRoot(payload) ?? resolve(schedule.workspaceRoot))
+			: scope.workspaceRoot;
+		const { allWorkspaces: _allWorkspaces, ...rest } = payload;
 		return {
-			...(payload as unknown as HubScheduleUpdateInput),
+			...(rest as unknown as HubScheduleUpdateInput),
 			modelSelection,
 			...(mode === undefined ? {} : { mode }),
-			workspaceRoot: scope.workspaceRoot,
+			workspaceRoot,
 			...(Object.hasOwn(payload, "cwd")
 				? {
 						cwd:
 							payload.cwd === null
-								? scope.workspaceRoot
-								: (scopedCwd(scope, payload.cwd) ?? scope.cwd),
+								? workspaceRoot
+								: (scopedCwd(workspaceRoot, payload.cwd) ??
+									(workspaceRoot === scope.workspaceRoot
+										? scope.cwd
+										: workspaceRoot)),
 					}
 				: {}),
 		};

--- a/sdk/packages/core/src/cron/service/schedule-service.test.ts
+++ b/sdk/packages/core/src/cron/service/schedule-service.test.ts
@@ -500,4 +500,143 @@ describe("HubScheduleService", () => {
 			}
 		},
 	);
+
+	sqliteIt(
+		"lets allWorkspaces commands cross the connection workspace scope",
+		async () => {
+			const dbPath = await createTempDbPath();
+			cleanupPaths.push(dbPath);
+			const service = new HubScheduleService({
+				dbPath,
+				specs: { cronSpecsDir: join(dirname(dbPath), "cron") },
+				runtimeHandlers: {
+					startSession: vi.fn(async () => ({ sessionId: "session-3" })),
+					sendSession: vi.fn(async () => ({ result: { text: "done" } })),
+					abortSession: vi.fn(async () => ({ applied: true })),
+					stopSession: vi.fn(async () => ({ applied: true })),
+				},
+			});
+			try {
+				const commands = new HubScheduleCommandService(service);
+				// Mirrors the production desktop app: the sidecar's hub client is
+				// registered with the app launch directory, not the workspace the
+				// schedules actually belong to.
+				const launchDirAuthority = {
+					clientId: "desktop-observer",
+					workspaceContext: { workspaceRoot: "/", cwd: "/" },
+				};
+				const projectRoot = resolve("/workspace");
+
+				const agentCreated = service.createSchedule({
+					name: "Agent routine",
+					cronPattern: "0 9 * * *",
+					prompt: "Created by an agent session",
+					workspaceRoot: projectRoot,
+					cwd: projectRoot,
+				});
+
+				const scopedList = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.list",
+						clientId: "desktop-observer",
+						payload: { limit: 10 },
+					},
+					launchDirAuthority,
+				);
+				expect(scopedList.ok).toBe(true);
+				expect(scopedList.payload?.schedules).toEqual([]);
+
+				const globalList = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.list",
+						clientId: "desktop-observer",
+						payload: { limit: 10, allWorkspaces: true },
+					},
+					launchDirAuthority,
+				);
+				expect(globalList.ok).toBe(true);
+				expect(
+					(globalList.payload?.schedules as Array<{ scheduleId: string }>).map(
+						(schedule) => schedule.scheduleId,
+					),
+				).toContain(agentCreated.scheduleId);
+
+				const scopedGet = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.get",
+						clientId: "desktop-observer",
+						payload: { scheduleId: agentCreated.scheduleId },
+					},
+					launchDirAuthority,
+				);
+				expect(scopedGet.ok).toBe(false);
+
+				const globalDisable = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.disable",
+						clientId: "desktop-observer",
+						payload: {
+							scheduleId: agentCreated.scheduleId,
+							allWorkspaces: true,
+						},
+					},
+					launchDirAuthority,
+				);
+				expect(globalDisable.ok).toBe(true);
+				expect(globalDisable.payload?.schedule).toMatchObject({
+					enabled: false,
+				});
+
+				const globalUpdate = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.update",
+						clientId: "desktop-observer",
+						payload: {
+							scheduleId: agentCreated.scheduleId,
+							name: "Renamed by desktop",
+							allWorkspaces: true,
+						},
+					},
+					launchDirAuthority,
+				);
+				expect(globalUpdate.ok).toBe(true);
+				// An all-workspaces update keeps the schedule in its own
+				// workspace instead of pulling it into the connection scope.
+				expect(globalUpdate.payload?.schedule).toMatchObject({
+					name: "Renamed by desktop",
+					workspaceRoot: projectRoot,
+				});
+
+				const globalCreate = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.create",
+						clientId: "desktop-observer",
+						payload: {
+							name: "Desktop routine",
+							cronPattern: "30 8 * * *",
+							prompt: "Created from the Schedules page",
+							workspaceRoot: projectRoot,
+							allWorkspaces: true,
+						},
+					},
+					launchDirAuthority,
+				);
+				expect(globalCreate.ok).toBe(true);
+				// The user-picked workspace is honored instead of being forced
+				// to the connection's launch-directory scope.
+				expect(globalCreate.payload?.schedule).toMatchObject({
+					workspaceRoot: projectRoot,
+					cwd: projectRoot,
+				});
+			} finally {
+				await service.dispose();
+			}
+		},
+	);
 });


### PR DESCRIPTION
### Related Issue

Production user report: schedules created by the agent (and schedules that existed before updating the app) never show up on the desktop app's Schedules page.

### Description

Since #13331 (shipped in desktop v0.0.15), every hub schedule command is pinned to the workspace root that the client connection registered. That regressed the production desktop app:

- The Tauri app launched from Finder/Dock has cwd `/`, `git rev-parse --show-toplevel` fails, so the sidecar registers its hub clients with workspace root `/` (`main.rs` `resolve_workspace_root`, `sidecar/paths.ts` `resolveWorkspaceRoot`).
- `schedule.list` filters `workspace_root = '/'` exactly, which matches nothing. Agent-created schedules are stored under the chat session's workspace (project folder or `~/.cline/data/workspaces/chat`), and pre-v0.0.15 schedules kept their real workspace roots, so the Schedules page always renders empty. The rows are all still in `~/.cline/data/db/cron.db`.
- `schedule.create` silently overwrites the user-picked Workspace field with `/`, so schedules created from the page would run at `/`.

Dev builds never reproduce this because `bun run dev` runs from the repo, so the sidecar's connection scope and the tested session workspace are both the repo root and the filter happens to match.

The fix keeps connection-workspace confinement as the default (CLI and the agent `tasks` tool are intentionally scoped and unchanged) and adds an explicit per-command `allWorkspaces` opt-out in `HubScheduleCommandService`. The desktop sidecar's routine schedule commands opt out, since the Schedules page is a cross-workspace management surface: listing spans all workspaces, mutations can address any schedule, and create/update honor the explicit `workspaceRoot` the desktop already sends (the user-picked Workspace field) instead of stomping it with the connection scope. Since token-authorized clients may already self-register any workspace root, this does not weaken a security boundary; the agent-facing scoping in `schedule-tool.ts` is untouched.

### Test Procedure

- New unit test in `schedule-service.test.ts` mirroring production: a client registered at `/` sees an empty scoped list, sees the project-workspace schedule with `allWorkspaces: true`, can pause/update it without pulling it into `/`, and creates honor the requested workspace root. Existing scoping tests (foreign get rejected, spoofed create forced into scope) still pass unchanged.
- End-to-end repro against a real hub daemon: sidecar started with cwd `/` (production launch condition), schedule created by a project-scoped hub client; `list_routine_schedules` over the sidecar websocket returns the schedule after the fix, while a raw scoped `schedule.list` from the `/`-registered connection still returns empty (the pre-fix behavior):

```
CREATED sched_2c772ce4-... workspaceRoot= /tmp/demo-project
SCOPED LIST (old desktop behavior) contains schedule: false (0 schedules)
SIDECAR list_routine_schedules (fixed Schedules page) contains schedule: true name="E2E agent-created schedule" workspaceRoot=/tmp/demo-project
```

- Manual UI check in the headless webview against the cwd-`/` sidecar: the Schedules page lists the agent-created, project-scoped schedule (screenshot below).
- `bun -F @cline/core` cron + hub server suites: 29 files / 241 tests pass; `@cline/core` typecheck passes; desktop sidecar tests (27) and desktop `typecheck` pass.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The Schedules page (webview served against a sidecar launched from cwd `/`, the production condition) showing an agent-created schedule that lives in `/tmp/demo-project`:

![Schedules page listing an agent-created project-scoped schedule](https://cursor.com/artifacts/c/art-5f6cf11f-38c4-4df8-8fae-5fec595cb73e)

### Additional Notes

The agenda task commands (`HubAgendaTaskCommandService`) have the same connection-workspace confinement, so workspace-scoped todos created by agents are likely also invisible in the production desktop sidebar. Left out of this PR to keep it focused; can follow up.