### PR TITLE
fix: discover global rules at ~/Cline/Rules so they reach the system prompt

### DIFF
--- a/sdk/packages/shared/src/storage/paths.test.ts
+++ b/sdk/packages/shared/src/storage/paths.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	AGENT_CONFIG_DIRECTORY_NAME,
@@ -204,6 +204,12 @@ describe("storage path resolution", () => {
 			expect.arrayContaining([
 				resolveGlobalAgentsRulesPath(),
 				join("/tmp/home", ".cline", RULES_CONFIG_DIRECTORY_NAME),
+				// xdg-user-dir's unconfigured Documents fallback (cline/cline#13542)
+				join(
+					dirname(dirname(resolveGlobalAgentsRulesPath())),
+					"Cline",
+					"Rules",
+				),
 			]),
 		);
 		expect(resolveRulesConfigSearchPaths()).not.toContain(

--- a/sdk/packages/shared/src/storage/paths.ts
+++ b/sdk/packages/shared/src/storage/paths.ts
@@ -514,6 +514,11 @@ export function resolveRulesConfigSearchPaths(
 		...wsPaths,
 		resolveGlobalAgentsRulesPath(),
 		join(resolveClineDir(), RULES_CONFIG_DIRECTORY_NAME),
+		// The VS Code Rules tab resolves Documents via `xdg-user-dir DOCUMENTS`,
+		// which prints bare $HOME when unconfigured (WSL/headless), putting
+		// global rules at ~/Cline/Rules instead of ~/Documents/Cline/Rules
+		// (cline/cline#13542).
+		join(HOME_DIR, "Cline", "Rules"),
 		resolveDocumentsExtensionPath("Rules"),
 	]);
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #13542

### Description

Global rules shown in the Rules tab never reached the model's system prompt on some setups (notably WSL/headless Linux).

The Rules tab resolves the Documents folder by shelling out to `xdg-user-dir DOCUMENTS`, which prints bare `$HOME` when no user-dirs config exists (the default on WSL and headless installs). So the UI reads and writes global rules at `~/Cline/Rules`. The SDK's rule discovery search paths only covered `~/Documents/Cline/Rules`, so rules created through the UI were shown in the Rules tab but never scanned into the session's rule watcher, and never injected into the prompt.

Fix: add the missing `~/Cline/Rules` path to `resolveRulesConfigSearchPaths` in `@cline/shared`. 2 files, +12/-1.

### Test Procedure

- Unit test: `paths.test.ts` asserts the new path is in the rules search list.
- `bun -F @cline/shared test` (369 pass), SDK typecheck, and the extension's `check-types` and `bun run test:unit` against the rebuilt dist, all green.
- Live repro in a VS Code Extension Development Host on Linux with `xdg-user-dir` resolving to `$HOME` (the reporter's WSL condition): created a global rule containing a marker token via the Rules tab (file lands at `~/Cline/Rules/team-standards.md`), started a task asking the model to list its rules without tools. Before the fix the model saw no rules; with the fix it replies "The custom rule is 'team-standards', which contains the token RULE_TOKEN_73X". Verified the token exists nowhere else on disk, so it could only have reached the prompt through the new search path.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Known gaps intentionally left out of scope to keep this minimal: Windows Documents redirection (e.g. OneDrive Known Folder Move, where the UI writes under `~/OneDrive/Documents/Cline/Rules`) is not covered, and Rules tab enable/disable toggles still do not affect the prompt in the next extension (the SDK's enablement mechanism is frontmatter `disabled: true`). Related open PR #13485 addresses configured-XDG resolution on Linux; this change covers the unconfigured fallback case the reporter hit.