### PR TITLE
feat(cli): add OpenAI Fast mode

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -259,6 +259,7 @@ Schedules can route results back to chat surfaces with `--delivery-adapter`, `--
 | `--hooks-dir <path>` | Additional hooks directory hint for runtime hook injection |
 | `--acp` | ACP (Agent Client Protocol) mode |
 | `--thinking [none\|low\|medium\|high\|xhigh]` | Model thinking level when supported. Defaults to `medium` when the flag is provided without a level; thinking is off when the flag is omitted. |
+| `--fast` | Use OpenAI Fast mode with the OpenAI or ChatGPT subscription provider. Fast mode has higher per-token pricing. |
 | `--compaction <agentic\|basic\|off>` | Context compaction mode. Defaults to `agentic`; use `basic` for local truncation or `off` to disable. |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting (default: `3`) |
 | `--json` | Output NDJSON instead of styled text |

--- a/apps/cli/src/cli.e2e.test.ts
+++ b/apps/cli/src/cli.e2e.test.ts
@@ -126,6 +126,7 @@ describe("cli e2e", () => {
 		expect(asText(result.stdout)).toContain("--auto-approve [value]");
 		expect(asText(result.stdout)).toContain("--data-dir");
 		expect(asText(result.stdout)).toContain("--thinking [level]");
+		expect(asText(result.stdout)).toContain("--fast");
 		expect(asText(result.stdout)).not.toContain("--reasoning-effort");
 		expect(asText(result.stdout)).not.toContain("--act");
 		expect(asText(result.stdout)).toContain("Show current configuration");

--- a/apps/cli/src/commands/program.ts
+++ b/apps/cli/src/commands/program.ts
@@ -35,6 +35,10 @@ export function addRootOptions(cmd: Command): Command {
 				"--thinking <level>",
 				"Set reasoning effort: none|low|medium|high|xhigh. Bare --thinking uses medium; omitted leaves provider default.",
 			)
+			.option(
+				"--fast",
+				"Use OpenAI Fast mode with OpenAI or ChatGPT subscription providers (higher per-token cost)",
+			)
 			.option("--compaction <mode>", CLI_COMPACTION_MODE_OPTION_DESCRIPTION)
 			.option(
 				"-i, --tui",
@@ -138,6 +142,7 @@ export function commanderToParsedArgs(program: Command): ParsedArgs {
 		acpMode: !!opts.acp,
 		thinking: false,
 		reasoningEffort: undefined,
+		fast: !!opts.fast,
 		defaultToolAutoApprove: true,
 		id: opts.id,
 	};

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1514,6 +1514,50 @@ describe("runCli lightweight command dispatch", () => {
 		);
 	});
 
+	it("enables OpenAI Fast mode when --fast is provided", async () => {
+		mockState.runAgentCalls = 0;
+		runtimeMocks.runAgent.mockClear();
+
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "--fast", "say hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(mockState.runAgentCalls).toBe(1);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"say hello",
+			expect.objectContaining({
+				serviceTier: "fast",
+			}),
+			expect.anything(),
+		);
+		expect(providerSettingsMocks.saveProviderSettings).toHaveBeenCalled();
+		const persistedSettings =
+			providerSettingsMocks.saveProviderSettings.mock.calls.at(-1)?.[0];
+		expect(persistedSettings).not.toHaveProperty("serviceTier");
+	});
+
+	it("leaves the service tier unset when --fast is omitted", async () => {
+		mockState.runAgentCalls = 0;
+		runtimeMocks.runAgent.mockClear();
+
+		forcePromptModeInput();
+		process.argv = ["bun", "src/index.ts", "say hello"];
+
+		const { runCli } = await import("./main");
+
+		await expect(runCli()).resolves.toBeUndefined();
+		expect(mockState.runAgentCalls).toBe(1);
+		expect(runtimeMocks.runAgent).toHaveBeenCalledWith(
+			"say hello",
+			expect.objectContaining({
+				serviceTier: undefined,
+			}),
+			expect.anything(),
+		);
+	});
+
 	it("leaves thinking unset when --thinking is not provided", async () => {
 		mockState.runAgentCalls = 0;
 		runtimeMocks.runAgent.mockClear();

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1077,6 +1077,7 @@ export async function runCli(): Promise<void> {
 			verbose: args.verbose,
 			thinking: resolvedReasoning.thinking,
 			reasoningEffort: resolvedReasoning.reasoningEffort,
+			serviceTier: args.fast ? "fast" : undefined,
 			outputMode: args.outputMode,
 			mode: effectiveMode,
 			logger: loggerAdapter.core,

--- a/apps/cli/src/tests/flags.test.ts
+++ b/apps/cli/src/tests/flags.test.ts
@@ -30,6 +30,8 @@ test.describe("root flag descriptions", () => {
 			"Set reasoning effort:",
 			"Bare --thinking uses medium",
 			"omitted leaves provider default",
+			"Use OpenAI Fast mode with OpenAI or ChatGPT subscription providers",
+			"higher per-token cost",
 			"consecutive mistakes",
 			"Output messages as JSON",
 			"Check for updates and install if available",

--- a/apps/cli/src/utils/types.ts
+++ b/apps/cli/src/utils/types.ts
@@ -80,6 +80,7 @@ export interface ParsedArgs {
 	thinkingExplicitlySet?: boolean;
 	reasoningEffort?: CliReasoningEffort;
 	invalidThinkingLevel?: string;
+	fast: boolean;
 	compactionMode?: CliCompactionMode;
 	invalidCompactionMode?: string;
 	invalidAutoApprove?: string;

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -413,6 +413,36 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards the OpenAI service tier to gateway provider options", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openai-native",
+				modelId: "gpt-5.6-sol",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "openai-native",
+					modelId: "gpt-5.6-sol",
+					serviceTier: "fast",
+				},
+			},
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "openai-native",
+						options: expect.objectContaining({ serviceTier: "fast" }),
+					}),
+				],
+			}),
+		);
+	});
+
 	it("projects providers.json contextWindow (maxInputTokens) onto the selected gateway model", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -38,6 +38,7 @@ function buildGatewayProviderOptions(
 	const options: Record<string, unknown> = {
 		region: config.region,
 		apiLine: config.apiLine,
+		serviceTier: config.serviceTier,
 		openRouterProviderSorting: config.openRouterProviderSorting,
 		modelCatalog: config.modelCatalog,
 	};

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.test.ts
@@ -80,6 +80,35 @@ describe("prepareLocalRuntimeBootstrap", () => {
 		});
 	});
 
+	it("applies the session OpenAI service tier to provider config", async () => {
+		const { prepareLocalRuntimeBootstrap } = await import(
+			"./local-runtime-bootstrap"
+		);
+		const input = createStartInput() as ReturnType<typeof createStartInput> & {
+			config: ReturnType<typeof createStartInput>["config"] & {
+				serviceTier?: "fast";
+			};
+		};
+		input.config.providerId = "openai-native";
+		input.config.modelId = "gpt-5.6-sol";
+		input.config.serviceTier = "fast";
+
+		const bootstrap = await prepareLocalRuntimeBootstrap({
+			input,
+			sessionId: "sess-fast-mode",
+			providerSettingsManager: createProviderSettingsManager() as never,
+			defaultTelemetry: undefined,
+			defaultToolPolicies: undefined,
+			onPluginEvent: () => {},
+			onTeamEvent: () => {},
+			createSpawnTool,
+			readSessionMetadata: async () => undefined,
+			writeSessionMetadata: async () => {},
+		});
+
+		expect(bootstrap.providerConfig.serviceTier).toBe("fast");
+	});
+
 	it("lets stored provider model catalog settings override hub defaults", async () => {
 		const { prepareLocalRuntimeBootstrap } = await import(
 			"./local-runtime-bootstrap"

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -196,6 +196,7 @@ function buildProviderConfig(
 	const providerConfig: ProviderConfig = {
 		...toProviderConfig(settings),
 		...(sessionProviderConfig ?? {}),
+		serviceTier: config.serviceTier ?? sessionProviderConfig?.serviceTier,
 	};
 	if (resolvedHeaders) {
 		providerConfig.headers = resolvedHeaders;

--- a/sdk/packages/core/src/types/config.ts
+++ b/sdk/packages/core/src/types/config.ts
@@ -49,6 +49,10 @@ export interface CoreModelConfig {
 	 * Sampling temperature per API call.
 	 */
 	temperature?: number;
+	/**
+	 * OpenAI request service tier.
+	 */
+	serviceTier?: ProviderConfig["serviceTier"];
 }
 
 export interface CoreRuntimeFeatures {

--- a/sdk/packages/llms/src/providers/config.ts
+++ b/sdk/packages/llms/src/providers/config.ts
@@ -114,6 +114,8 @@ export interface ModelConfig {
 	modelInfo?: ModelInfo;
 	/** Known models for this provider with their info */
 	knownModels?: Record<string, ModelInfo>;
+	/** OpenAI request service tier. */
+	serviceTier?: "fast";
 }
 
 /**

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -4814,6 +4814,37 @@ describe("sdk-gateway", () => {
 		expect(call?.providerOptions?.openaiCodex).not.toHaveProperty("truncation");
 	});
 
+	it.each([
+		"openai-native",
+		"openai-codex",
+	])("passes OpenAI Fast mode through provider options for %s", async (providerId) => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId, options: { serviceTier: "fast" } }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId,
+				modelId: "gpt-5.6-sol",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					openai: expect.objectContaining({ serviceTier: "fast" }),
+				}),
+			}),
+		);
+	});
+
 	it("passes object JSON schemas unchanged to the OpenAI Codex tool adapter", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.ts
+++ b/sdk/packages/llms/src/providers/gateway.ts
@@ -360,6 +360,11 @@ export class DefaultGateway implements Gateway {
 				...request,
 				modelId: resolved.model.id,
 				providerId: resolved.provider.id,
+				serviceTier:
+					request.serviceTier ??
+					(providerRecord.config.options?.serviceTier === "fast"
+						? "fast"
+						: undefined),
 				maxTokens,
 				defaultedMaxTokens:
 					maxTokens !== undefined && !isPositiveFiniteNumber(request.maxTokens),

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -118,6 +118,7 @@ function makeRequest(overrides: RequestOverrides): GatewayStreamRequest {
 		systemPrompt: overrides.systemPrompt,
 		temperature: overrides.temperature,
 		maxTokens: overrides.maxTokens,
+		serviceTier: overrides.serviceTier,
 		reasoning: overrides.reasoning,
 		signal: overrides.signal,
 		tools: overrides.tools,
@@ -2284,6 +2285,40 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 			expect.objectContaining({ store: false }),
 		);
 		expect(result.openaiCodex).not.toHaveProperty("truncation");
+	});
+
+	it.each([
+		"openai-native",
+		"openai-codex",
+	])("emits OpenAI Fast mode for %s", (providerId) => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId,
+				modelId: "gpt-5.6-sol",
+				serviceTier: "fast",
+			}),
+			makeContext({ providerId, modelId: "gpt-5.6-sol" }),
+		);
+
+		expect(result.openai).toEqual(
+			expect.objectContaining({ serviceTier: "fast" }),
+		);
+	});
+
+	it("does not emit OpenAI Fast mode for non-OpenAI providers", () => {
+		for (const { providerId, modelId } of [
+			{ providerId: "anthropic", modelId: "claude-sonnet-4-6" },
+			{ providerId: "openai", modelId: "gpt-5.6-sol" },
+			{ providerId: "custom-openai-adapter", modelId: "gpt-5.6-sol" },
+		]) {
+			const result = composeAiSdkProviderOptions(
+				makeRequest({ providerId, modelId, serviceTier: "fast" }),
+				makeContext({ providerId, modelId }),
+				"openai",
+			);
+
+			expect(result.openai).not.toHaveProperty("serviceTier");
+		}
 	});
 
 	it("keeps portable OpenAI Codex effort out of every provider bucket", () => {

--- a/sdk/packages/llms/src/providers/routing/provider-options.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.ts
@@ -51,6 +51,16 @@ function buildBaseProviderOptionsPatch(
 	};
 }
 
+function buildOpenAIServiceTierPatch(
+	request: GatewayStreamRequest,
+): ProviderOptionsPatch | undefined {
+	return request.serviceTier === "fast" &&
+		(request.providerId === "openai-native" ||
+			request.providerId === "openai-codex")
+		? { openai: { serviceTier: "fast" } }
+		: undefined;
+}
+
 /**
  * Compose AI SDK `providerOptions` from named provider/model-family rules.
  *
@@ -109,5 +119,6 @@ export function composeAiSdkProviderOptions(
 	return mergeProviderOptionPatches([
 		buildBaseProviderOptionsPatch(compatibleOptions, anthropicOptions),
 		...buildProviderOptionRulePatches(matchedRules, buildInput),
+		buildOpenAIServiceTierPatch(normalizedRequest),
 	]);
 }

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -244,6 +244,8 @@ export interface GatewayStreamRequest {
 	 */
 	defaultedMaxTokens?: boolean;
 	metadata?: Record<string, unknown>;
+	/** OpenAI request service tier. */
+	serviceTier?: "fast";
 	reasoning?: {
 		enabled?: boolean;
 		effort?: ReasoningEffort;


### PR DESCRIPTION
﻿## Summary

- add an opt-in `--fast` CLI flag for OpenAI and ChatGPT subscription providers
- propagate the session-only service tier through Core and the LLM gateway
- send `providerOptions.openai.serviceTier = "fast"` only for `openai-native` and `openai-codex`
- keep the billing-affecting choice out of persisted provider settings
- document the higher per-token pricing and add CLI/Core/gateway coverage

Closes #13615

## Test plan

- [x] `bun -F @cline/cli test:unit -- main.test.ts` (84 tests)
- [x] `bun -F @cline/llms test -- src/providers/routing/provider-options.test.ts src/providers/gateway.test.ts` (281 tests)
- [x] `bun -F @cline/core test:unit -- src/services/llms/handler-factory.test.ts src/services/local-runtime-bootstrap.test.ts` (35 tests)
- [x] `bun -F @cline/shared typecheck`
- [x] `bun -F @cline/llms typecheck`
- [x] `bun -F @cline/core typecheck`
- [x] `bun -F @cline/cli typecheck`
- [x] `bun run build:sdk`
- [x] `bun -F @cline/cli build`
- [x] Biome check on all changed files
- [x] source CLI `--help` smoke test

## Notes

OpenAI renamed Priority processing to Fast mode on July 30, 2026. The OpenAI Responses request value used here is `service_tier: "fast"`. Unsupported models or accounts surface the provider error rather than silently changing model or reasoning settings.
