### PR TITLE
fix(sdk): inject TaskStart/UserPromptSubmit contextModification into the conversation

### DIFF
--- a/apps/vscode/src/sdk/hooks-adapter.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.ts
@@ -13,6 +13,7 @@
 
 import type {
 	AgentAfterToolContext,
+	AgentBeforeRunResult,
 	AgentBeforeToolContext,
 	AgentHooks,
 	AgentRunLifecycleContext,
@@ -52,6 +53,21 @@ function mapStopControl(hookOutput: {
 		stop: true,
 		reason,
 	}
+}
+
+function mapBeforeRunResult(hookOutput: {
+	cancel?: boolean
+	errorMessage?: string
+	contextModification?: string
+}): AgentBeforeRunResult | undefined {
+	const stopControl = mapStopControl(hookOutput)
+	if (stopControl) {
+		return stopControl
+	}
+	// Non-cancelling lifecycle hooks surface contextModification as context the
+	// runtime injects into the conversation before the run's input messages.
+	const appendContext = hookOutput.contextModification?.trim()
+	return appendContext ? { appendContext } : undefined
 }
 
 function taskIdFromSnapshot(snapshot: AgentRunLifecycleContext["snapshot"]): string {
@@ -106,12 +122,19 @@ export function buildAgentHooks(
 	const createFactory = () => new HookFactory({ sessionWorkspaceRoot })
 
 	return {
-		async beforeRun(ctx: AgentRunLifecycleContext): Promise<AgentStopControl | undefined> {
-			const taskStartControl = await runTaskStart(ctx, hooksEnabled, createFactory, emitHookMessage)
-			if (taskStartControl) {
-				return taskStartControl
+		async beforeRun(ctx: AgentRunLifecycleContext): Promise<AgentBeforeRunResult | undefined> {
+			const taskStartResult = await runTaskStart(ctx, hooksEnabled, createFactory, emitHookMessage)
+			if (taskStartResult?.stop) {
+				return taskStartResult
 			}
-			return runUserPromptSubmit(ctx, hooksEnabled, createFactory, emitHookMessage)
+			const userPromptSubmitResult = await runUserPromptSubmit(ctx, hooksEnabled, createFactory, emitHookMessage)
+			if (userPromptSubmitResult?.stop) {
+				return userPromptSubmitResult
+			}
+			const appendContext = [taskStartResult?.appendContext, userPromptSubmitResult?.appendContext]
+				.filter((context): context is string => !!context)
+				.join("\n\n")
+			return appendContext ? { appendContext } : undefined
 		},
 
 		async beforeTool(
@@ -306,7 +329,7 @@ async function runTaskStart(
 	hooksEnabled: () => boolean,
 	createFactory: () => HookFactory,
 	emitHookMessage?: HookMessageEmitter,
-): Promise<AgentStopControl | undefined> {
+): Promise<AgentBeforeRunResult | undefined> {
 	let runningTs: number | undefined
 	try {
 		if (!hooksEnabled()) {
@@ -342,7 +365,7 @@ async function runTaskStart(
 				ts: runningTs,
 			}),
 		)
-		return mapStopControl(result)
+		return mapBeforeRunResult(result)
 	} catch (error) {
 		emitHookMessage?.(buildHookStatusMessage({ hookName: "TaskStart", status: "failed", ts: runningTs }))
 		Logger.error("[HooksAdapter] beforeRun (TaskStart) hook failed:", error)
@@ -355,7 +378,7 @@ async function runUserPromptSubmit(
 	hooksEnabled: () => boolean,
 	createFactory: () => HookFactory,
 	emitHookMessage?: HookMessageEmitter,
-): Promise<AgentStopControl | undefined> {
+): Promise<AgentBeforeRunResult | undefined> {
 	let runningTs: number | undefined
 	try {
 		if (!hooksEnabled()) {
@@ -387,7 +410,7 @@ async function runUserPromptSubmit(
 				ts: runningTs,
 			}),
 		)
-		return mapStopControl(result)
+		return mapBeforeRunResult(result)
 	} catch (error) {
 		emitHookMessage?.(buildHookStatusMessage({ hookName: "UserPromptSubmit", status: "failed", ts: runningTs }))
 		Logger.error("[HooksAdapter] beforeRun (UserPromptSubmit) hook failed:", error)

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1633,6 +1633,56 @@ describe("AgentRuntime", () => {
 		expect(runtime.snapshot().status).toBe("completed");
 	});
 
+	it("injects beforeRun appendContext as a hook_context message", async () => {
+		const model = new ScriptedModel([
+			(request) => {
+				// The context block is injected before the run's input message, so
+				// the model sees it on the first request.
+				const inputMessage = request.messages.at(-1);
+				expect(inputMessage?.role).toBe("user");
+				expect(inputMessage?.content[0]).toMatchObject({
+					type: "text",
+					text: "Start",
+				});
+				const contextMessage = request.messages.at(-2);
+				expect(contextMessage?.role).toBe("user");
+				expect(contextMessage?.content[0]).toMatchObject({
+					type: "text",
+					text: '<hook_context source="beforeRun">\nlifecycle hook context\n</hook_context>',
+				});
+				return [
+					{ type: "text-delta", text: "ok" },
+					{ type: "finish", reason: "stop" },
+				];
+			},
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			hooks: {
+				beforeRun: async () => ({ appendContext: "lifecycle hook context" }),
+			},
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		const hookContextMessage = result.messages.find(
+			(message) =>
+				message.role === "user" &&
+				message.content.some(
+					(part) =>
+						part.type === "text" && (part.text ?? "").includes("<hook_context"),
+				),
+		);
+		expect(hookContextMessage).toBeDefined();
+		// Hidden from user-facing transcripts (live and replayed) while still
+		// sent to the model, like tool hook context and compaction summaries.
+		expect(hookContextMessage?.metadata).toMatchObject({
+			displayRole: "system",
+			userRunSpan: 0,
+		});
+	});
+
 	it("annotates assistant messages with per-turn metrics and model info", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -12,6 +12,7 @@ import type {
 	AgentModel,
 	AgentModelEvent,
 	AgentModelFinishReason,
+	AgentBeforeRunResult,
 	AgentModelRequest,
 	AgentModelToolActivity,
 	AgentRunResult,
@@ -359,6 +360,14 @@ function formatHookContextBlock(
 	const toolCallId = sanitizeHookAttribute(toolCall.toolCallId);
 	const body = text.trim().replace(/<(\/?)hook_context/gi, "<\\$1hook_context");
 	return `<hook_context source="${source}" tool_name="${toolName}" tool_call_id="${toolCallId}">\n${body}\n</hook_context>`;
+}
+
+function formatLifecycleHookContextBlock(source: string, text: string): string {
+	// Embedded hook_context tags (opening and closing) are neutralized so
+	// lifecycle hook output cannot corrupt or spoof the block markup,
+	// mirroring the tool hook context handling.
+	const body = text.trim().replace(/<(\/?)hook_context/gi, "<\\$1hook_context");
+	return `<hook_context source="${source}">\n${body}\n</hook_context>`;
 }
 
 function cloneMessages(messages: readonly AgentMessage[]): AgentMessage[] {
@@ -937,11 +946,34 @@ export class AgentRuntime {
 	}
 
 	private async callBeforeRunHooks(): Promise<void> {
+		const pendingContexts: string[] = [];
 		for (const hook of this.hooks.beforeRun) {
 			const control = (await hook({
 				snapshot: this.snapshot(),
-			})) as AgentStopControl | undefined;
+			})) as AgentBeforeRunResult | undefined;
+			if (control?.appendContext?.trim()) {
+				pendingContexts.push(
+					formatLifecycleHookContextBlock("beforeRun", control.appendContext),
+				);
+			}
 			this.applyStopControl(control);
+		}
+		if (pendingContexts.length > 0) {
+			const hookContextText = pendingContexts.join("\n\n");
+			// displayRole "system" keeps the injected block out of user-facing
+			// transcripts (live and replayed) while it still reaches the model,
+			// mirroring how tool hook context is handled.
+			const hookContextMessage = createMessage(
+				"user",
+				[{ type: "text", text: hookContextText }],
+				{ userRunSpan: 0, displayRole: "system" },
+			);
+			this.state.messages.push(hookContextMessage);
+			await this.emit({
+				type: "message-added",
+				snapshot: this.snapshot(),
+				message: hookContextMessage,
+			});
 		}
 	}
 

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -333,6 +333,16 @@ export interface AgentModel {
 // Hook contexts
 // =============================================================================
 
+export interface AgentBeforeRunResult extends AgentStopControl {
+	/**
+	 * Text to inject into the conversation as hook context (e.g. a lifecycle
+	 * hook's `contextModification`). Injected as a `<hook_context>` user
+	 * message before the run's input messages, so the model sees it on the
+	 * first request.
+	 */
+	appendContext?: string;
+}
+
 export interface AgentBeforeModelContext {
 	snapshot: AgentRuntimeStateSnapshot;
 	request: AgentModelRequest;
@@ -417,7 +427,10 @@ export interface AgentRunLifecycleContext {
 export interface AgentRuntimeHooks {
 	beforeRun?: (
 		context: AgentRunLifecycleContext,
-	) => AgentStopControl | undefined | Promise<AgentStopControl | undefined>;
+	) =>
+		| AgentBeforeRunResult
+		| undefined
+		| Promise<AgentBeforeRunResult | undefined>;
 	afterRun?: (
 		context: AgentRunLifecycleContext & { result: AgentRunResult },
 	) => void | Promise<void>;


### PR DESCRIPTION
## Problem

Closes #13554

`TaskStart` and `UserPromptSubmit` hooks can return `contextModification` to add context to the conversation. The VS Code adapter (\`apps/vscode/src/sdk/hooks-adapter.ts\`) only mapped the hooks' cancel output to \`AgentStopControl\`, so for any non-cancelling hook the \`contextModification\` string was silently discarded — the documented behavior never happened in the SDK runtime.

## Change

- \`AgentBeforeRunResult\` (new, extends \`AgentStopControl\`) adds \`appendContext\`, and \`AgentRuntimeHooks.beforeRun\` now returns it.
- \`AgentRuntime.callBeforeRunHooks\` collects \`appendContext\` across hooks and injects it as a \`<hook_context source="beforeRun">\` user message **before** the run's input messages, so the model sees it on the first request. The message carries \`{ userRunSpan: 0, displayRole: "system" }\`, keeping it out of user-facing transcripts (live and replayed) — the same treatment tool hook context and compaction summaries already get. Embedded \`hook_context\` tags in hook output are neutralized, mirroring the tool-hook path.
- The adapter's \`runTaskStart\`/\`runUserPromptSubmit\` now surface non-cancelling \`contextModification\` as \`appendContext\`; \`beforeRun\` still returns early on a cancel control, otherwise merges both hooks' context. Cancelling hooks are unchanged (\`contextModification\` stays the fallback stop reason, never injected).

## Validation

- New runtime test \`injects beforeRun appendContext as a hook_context message\` — verified RED on the old code (no context injected), GREEN with the fix; asserts the block precedes the input message in the first model request and lands in the transcript with \`displayRole: "system"\`.
- \`agent-runtime\` suite: 65/65 pass; \`agent-runtime.provider-form\`: 8/8 pass.
- \`bun run build:sdk\` clean; typecheck on \`@cline/shared\`, \`@cline/agents\`, \`@cline/core\` clean; biome format/lint clean on changed files.