### PR TITLE
Gate GitHub onboarding rollout on desktop experimental

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands-settings.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-settings.test.ts
@@ -57,6 +57,10 @@ describe("desktop settings commands", () => {
 		).resolves.toEqual({ cloudSessionsEnabled: false });
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
 			cloudAgents: false,
+			flags: {
+				"code-onboarding-github": false,
+				"ext-cline-pass": false,
+			},
 		});
 	});
 
@@ -89,6 +93,10 @@ describe("desktop settings commands", () => {
 		]);
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
 			cloudAgents: true,
+			flags: {
+				"code-onboarding-github": false,
+				"ext-cline-pass": false,
+			},
 		});
 
 		await handleCommand(ctx, "set_cloud_sessions_enabled", {
@@ -106,6 +114,10 @@ describe("desktop settings commands", () => {
 
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
 			cloudAgents: true,
+			flags: {
+				"code-onboarding-github": false,
+				"ext-cline-pass": false,
+			},
 		});
 		// The toggle's stored value is reported as-is; the override only
 		// affects the effective gate.

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1909,9 +1909,6 @@ export async function handleCommand(
 			},
 		};
 	}
-	if (command === "get_feature_flags") {
-		return { cloudAgents: isCloudAgentsEnabled() };
-	}
 	if (command === "list_cloud_repositories") {
 		return await getCloudSessionManager(ctx).listRepositories();
 	}
@@ -2748,10 +2745,11 @@ export async function handleCommand(
 	// distinct ID it reports telemetry with. The client just reads the
 	// resolved values.
 	if (command === "get_feature_flags") {
-		return await refreshDesktopFeatureFlags({
+		const snapshot = await refreshDesktopFeatureFlags({
 			logger: ctx.logger,
 			telemetry: ctx.telemetry,
 		});
+		return { ...snapshot, cloudAgents: isCloudAgentsEnabled() };
 	}
 
 	// ── Connector channels ─────────────────────────────────────────────

--- a/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.test.tsx
@@ -9,13 +9,21 @@ import {
 	parseModelSelectionStorage,
 } from "@/lib/model-selection";
 import type { Provider } from "@/lib/provider-schema";
-import { OnboardingView, sortProvidersForApiKeySetup } from "./onboarding-view";
+import {
+	GITHUB_ONBOARDING_FEATURE_FLAG,
+	OnboardingView,
+	sortProvidersForApiKeySetup,
+} from "./onboarding-view";
 
 const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
 vi.mock("@/lib/desktop-client", () => ({
 	desktopClient: { invoke },
 	openExternalUrl: vi.fn(),
 }));
+
+const GITHUB_STEP_ENABLED_FLAGS = {
+	flags: { [GITHUB_ONBOARDING_FEATURE_FLAG]: true },
+};
 
 class StorageStub implements Storage {
 	readonly #values = new Map<string, string>();
@@ -140,6 +148,9 @@ describe("OnboardingView", () => {
 					],
 					settingsPath: "/tmp/providers.json",
 				};
+			}
+			if (command === "get_feature_flags") {
+				return GITHUB_STEP_ENABLED_FLAGS;
 			}
 			return {};
 		});
@@ -375,6 +386,9 @@ describe("OnboardingView", () => {
 			if (command === "list_provider_catalog") {
 				return { providers: [makeProvider()], settingsPath: "/tmp/p.json" };
 			}
+			if (command === "get_feature_flags") {
+				return GITHUB_STEP_ENABLED_FLAGS;
+			}
 			return {};
 		});
 		await render();
@@ -420,6 +434,9 @@ describe("OnboardingView", () => {
 			if (command === "list_provider_catalog") {
 				return { providers: [makeProvider()], settingsPath: "/tmp/p.json" };
 			}
+			if (command === "get_feature_flags") {
+				return GITHUB_STEP_ENABLED_FLAGS;
+			}
 			return {};
 		});
 		await render();
@@ -429,6 +446,28 @@ describe("OnboardingView", () => {
 		await act(async () => {
 			buttonByText("Continue").click();
 		});
+		expect(container.textContent).not.toContain("Connect GitHub");
+		expect(container.textContent).toContain("You're all set");
+	});
+
+	it("bypasses the GitHub step when the rollout flag is off", async () => {
+		invoke.mockImplementation(async (command: string) => {
+			if (command === "cline_account") {
+				return { email: "dev@example.com", displayName: "Dev" };
+			}
+			if (command === "list_provider_catalog") {
+				return { providers: [makeProvider()], settingsPath: "/tmp/p.json" };
+			}
+			return {};
+		});
+		await render();
+		await act(async () => {
+			buttonByText("Get started").click();
+		});
+		await act(async () => {
+			buttonByText("Continue").click();
+		});
+		expect(invoke).toHaveBeenCalledWith("get_feature_flags");
 		expect(container.textContent).not.toContain("Connect GitHub");
 		expect(container.textContent).toContain("You're all set");
 	});

--- a/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
@@ -24,6 +24,7 @@ import { WelcomeHero } from "@/components/views/chat/welcome-hero";
 import { GitHubConnectStep } from "@/components/views/onboarding/onboarding-github-step";
 import { useAccount } from "@/contexts/account-context";
 import { OAUTH_MANAGED_PROVIDERS } from "@/hooks/chat-session/constants";
+import { isFeatureEnabled, useFeatureFlags } from "@/hooks/use-feature-flags";
 import { isClineAccountNotAuthenticatedResult } from "@/lib/cline-account-state";
 import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import {
@@ -42,6 +43,8 @@ import type { Provider } from "@/lib/provider-schema";
 import { cn } from "@/lib/utils";
 
 const CREATE_ACCOUNT_URL = "https://app.cline.bot";
+
+export const GITHUB_ONBOARDING_FEATURE_FLAG = "code-onboarding-github";
 
 export type OnboardingStep = "welcome" | "connect" | "github" | "done";
 
@@ -870,6 +873,11 @@ export function OnboardingView({
 	const [connection, setConnection] = useState<OnboardingConnection | null>(
 		null,
 	);
+	const { flags } = useFeatureFlags();
+	const githubStepEnabled = isFeatureEnabled(
+		flags,
+		GITHUB_ONBOARDING_FEATURE_FLAG,
+	);
 
 	return (
 		<div className="relative h-full w-full overflow-y-auto bg-background">
@@ -896,8 +904,12 @@ export function OnboardingView({
 						onConnected={(nextConnection) => {
 							setConnection(nextConnection);
 							// The GitHub integration lives on the Cline account, so the
-							// step only applies when one is connected.
-							setStep(nextConnection.kind === "cline" ? "github" : "done");
+							// step only applies when one is connected and included in the rollout.
+							setStep(
+								nextConnection.kind === "cline" && githubStepEnabled
+									? "github"
+									: "done",
+							);
 						}}
 						onSkip={onComplete}
 					/>

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.test.ts
@@ -117,7 +117,7 @@ describe("FeatureFlagsService", () => {
 		writeFileSync(
 			cacheFilePath,
 			`${JSON.stringify({
-				version: 1,
+				version: 2,
 				updatedAt: Date.now(),
 				userId: "user-1",
 				flagsPayload: {
@@ -163,7 +163,7 @@ describe("FeatureFlagsService", () => {
 			};
 		};
 		expect(cache).toMatchObject({
-			version: 1,
+			version: 2,
 			updatedAt: Date.now(),
 			userId: "user-1",
 			flagsPayload: {

--- a/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
+++ b/sdk/packages/core/src/services/feature-flags/FeatureFlagsService.ts
@@ -17,7 +17,7 @@ import { CORE_TELEMETRY_EVENTS } from "../..";
 
 const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_PERSISTENT_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-const FEATURE_FLAGS_CACHE_FILE_VERSION = 1;
+const FEATURE_FLAGS_CACHE_FILE_VERSION = 2;
 
 type CacheInfo = {
 	updateTime: number;

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -1,6 +1,8 @@
 export const FeatureFlag = {
 	/** Enables ClinePass provider/model list exposure in supported clients. */
 	CLINE_PASS: "ext-cline-pass",
+	/** Shows the GitHub integration step in the desktop app. */
+	CODE_ONBOARDING_GITHUB: "code-onboarding-github",
 } as const;
 
 export type KnownFeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -62,6 +64,7 @@ export const FeatureFlagDefaultValue: Partial<
 	Record<FeatureFlag, FeatureFlagPayload | undefined>
 > = {
 	[FeatureFlag.CLINE_PASS]: false,
+	[FeatureFlag.CODE_ONBOARDING_GITHUB]: false,
 };
 
 export const FEATURE_FLAGS: readonly FeatureFlag[] = Object.values(FeatureFlag);


### PR DESCRIPTION
## Summary

- register `code-onboarding-github` with a disabled default
- show the existing GitHub onboarding step only for enabled Cline-account rollouts
- invalidate the prior feature-flag cache schema so the new flag is evaluated promptly
- cover enabled and disabled onboarding paths

This is the narrow delta from #13225 needed by `desktop-experimental`; the underlying GitHub integration flow is already present on that branch.

## Testing

- `bun x vitest run webview/components/views/onboarding/onboarding-view.test.tsx --config vitest.config.ts`
- `bun x vitest run src/services/feature-flags/FeatureFlagsService.test.ts --config vitest.config.ts`
- `bun -F @cline/shared typecheck`
- `bun -F @cline/core typecheck`
- `bun run typecheck` (`apps/examples/desktop-app`)
- `bun run build` (`apps/examples/desktop-app`)
- Biome check on all changed files