### PR TITLE
Fix scheduled tasks disappearing after desktop app updates

### DIFF
--- a/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
+++ b/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
@@ -124,6 +124,21 @@ describe("CronReconciler", () => {
 		);
 	});
 
+	it("still removes deleted file specs that spoof the hub-schedule source", async () => {
+		writeSpec(
+			"impostor.cron.md",
+			`---\nid: impostor\nworkspaceRoot: /ws\nschedule: "0 9 * * *"\nsource: hub-schedule\n---\nBody`,
+		);
+		await reconciler.reconcileAll();
+		const spec = requireValue(store.getSpecBySourcePath("impostor.cron.md"));
+		expect(spec.source).toBe("hub-schedule");
+
+		rmSync(join(cronDir, "impostor.cron.md"));
+		const summary = await reconciler.reconcileAll();
+		expect(summary.removed).toBe(1);
+		expect(requireValue(store.getSpec(spec.specId)).removed).toBe(true);
+	});
+
 	it("cancels queued runs when spec is removed", async () => {
 		writeSpec("cleanup.md", `---\nid: cleanup\nworkspaceRoot: /ws\n---\nBody`);
 		await reconciler.reconcileAll();

--- a/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
+++ b/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
@@ -139,6 +139,23 @@ describe("CronReconciler", () => {
 		expect(requireValue(store.getSpec(spec.specId)).removed).toBe(true);
 	});
 
+	it("still removes deleted spoofing files inside a physical hub/schedules directory", async () => {
+		writeSpec(
+			"hub/schedules/nested-impostor.cron.md",
+			`---\nid: nested-impostor\nworkspaceRoot: /ws\nschedule: "0 9 * * *"\nsource: hub-schedule\n---\nBody`,
+		);
+		await reconciler.reconcileAll();
+		const spec = requireValue(
+			store.getSpecBySourcePath("hub/schedules/nested-impostor.cron.md"),
+		);
+		expect(spec.source).toBe("hub-schedule");
+
+		rmSync(join(cronDir, "hub/schedules/nested-impostor.cron.md"));
+		const summary = await reconciler.reconcileAll();
+		expect(summary.removed).toBe(1);
+		expect(requireValue(store.getSpec(spec.specId)).removed).toBe(true);
+	});
+
 	it("cancels queued runs when spec is removed", async () => {
 		writeSpec("cleanup.md", `---\nid: cleanup\nworkspaceRoot: /ws\n---\nBody`);
 		await reconciler.reconcileAll();

--- a/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
+++ b/sdk/packages/core/src/cron/specs/cron-reconciler.test.ts
@@ -103,6 +103,27 @@ describe("CronReconciler", () => {
 		expect(all[0]?.removed).toBe(true);
 	});
 
+	it("does not remove hub-managed schedules with virtual source paths", async () => {
+		const created = store.createHubSchedule({
+			name: "Daily digest",
+			cronPattern: "0 9 * * *",
+			prompt: "Summarize the day",
+			workspaceRoot: "/ws",
+		});
+
+		// Simulates hub startup (e.g. after an app update) with no cron spec
+		// files on disk: DB-native hub schedules must survive reconciliation.
+		const summary = await reconciler.reconcileAll();
+		expect(summary.removed).toBe(0);
+
+		const schedule = requireValue(store.getSpec(created.specId));
+		expect(schedule.removed).toBe(false);
+		expect(schedule.enabled).toBe(true);
+		expect(store.listHubSchedules().map((s) => s.specId)).toContain(
+			created.specId,
+		);
+	});
+
 	it("cancels queued runs when spec is removed", async () => {
 		writeSpec("cleanup.md", `---\nid: cleanup\nworkspaceRoot: /ws\n---\nBody`);
 		await reconciler.reconcileAll();

--- a/sdk/packages/core/src/cron/specs/cron-reconciler.ts
+++ b/sdk/packages/core/src/cron/specs/cron-reconciler.ts
@@ -6,10 +6,11 @@ import {
 	resolveCronSpecsDir,
 } from "@cline/shared/storage";
 import { getNextCronTime } from "../schedule/scheduler";
-import type {
-	CronSpecRecord,
-	SqliteCronStore,
-	UpsertSpecResult,
+import {
+	type CronSpecRecord,
+	isHubManagedSpec,
+	type SqliteCronStore,
+	type UpsertSpecResult,
 } from "../store/sqlite-cron-store";
 import { type ParseCronSpecInput, parseCronSpecFile } from "./cron-spec-parser";
 
@@ -133,7 +134,7 @@ export class CronReconciler {
 			// Hub-managed schedules live only in cron.db with a virtual
 			// sourcePath (`hub/schedules/<id>.cron.md`) that never exists on
 			// disk — they must not be treated as deleted spec files.
-			if (spec.source === "hub-schedule") continue;
+			if (isHubManagedSpec(spec)) continue;
 			if (!seenPaths.has(spec.sourcePath)) {
 				this.handleFileDeleted(spec);
 				summary.removed += 1;

--- a/sdk/packages/core/src/cron/specs/cron-reconciler.ts
+++ b/sdk/packages/core/src/cron/specs/cron-reconciler.ts
@@ -130,6 +130,10 @@ export class CronReconciler {
 			limit: 10_000,
 		});
 		for (const spec of existing) {
+			// Hub-managed schedules live only in cron.db with a virtual
+			// sourcePath (`hub/schedules/<id>.cron.md`) that never exists on
+			// disk — they must not be treated as deleted spec files.
+			if (spec.source === "hub-schedule") continue;
 			if (!seenPaths.has(spec.sourcePath)) {
 				this.handleFileDeleted(spec);
 				summary.removed += 1;

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
@@ -364,8 +364,25 @@ function filenameStemFromPath(sourcePath: string): string {
 		.replace(/\.md$/, "");
 }
 
+const HUB_SCHEDULE_SOURCE_PATH_PREFIX = "hub/schedules/";
+
 function hubScheduleSourcePath(scheduleId: string): string {
-	return `hub/schedules/${scheduleId}.cron.md`;
+	return `${HUB_SCHEDULE_SOURCE_PATH_PREFIX}${scheduleId}.cron.md`;
+}
+
+/**
+ * DB-native hub schedules (created via the schedule tools/UI) live only in
+ * cron.db under a virtual sourcePath that never exists on disk. File-backed
+ * specs can spoof `source: hub-schedule` in frontmatter but keep their real
+ * relative sourcePath, so both markers are required to identify one.
+ */
+export function isHubManagedSpec(
+	spec: Pick<CronSpecRecord, "source" | "sourcePath">,
+): boolean {
+	return (
+		spec.source === "hub-schedule" &&
+		spec.sourcePath.startsWith(HUB_SCHEDULE_SOURCE_PATH_PREFIX)
+	);
 }
 
 function hubScheduleMetadata(

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
@@ -373,15 +373,18 @@ function hubScheduleSourcePath(scheduleId: string): string {
 /**
  * DB-native hub schedules (created via the schedule tools/UI) live only in
  * cron.db under a virtual sourcePath that never exists on disk. File-backed
- * specs can spoof `source: hub-schedule` in frontmatter but keep their real
- * relative sourcePath, so both markers are required to identify one.
+ * specs can spoof `source: hub-schedule` in frontmatter — even inside a
+ * physical `hub/schedules/` directory — but reconciliation always records
+ * their source file's mtime, which DB-native rows never have. All three
+ * markers are required to identify a DB-native hub schedule.
  */
 export function isHubManagedSpec(
-	spec: Pick<CronSpecRecord, "source" | "sourcePath">,
+	spec: Pick<CronSpecRecord, "source" | "sourcePath" | "sourceMtimeMs">,
 ): boolean {
 	return (
 		spec.source === "hub-schedule" &&
-		spec.sourcePath.startsWith(HUB_SCHEDULE_SOURCE_PATH_PREFIX)
+		spec.sourcePath.startsWith(HUB_SCHEDULE_SOURCE_PATH_PREFIX) &&
+		spec.sourceMtimeMs === undefined
 	);
 }
 


### PR DESCRIPTION
### Related Issue

User report: every time the desktop app updates, all scheduled tasks are gone and the Schedules view shows "No schedules yet".

Related to #13613, which fixed the workspace-scoping half of this symptom (schedule hub commands were scoped to the connection's registered workspace, so the desktop Schedules page hid schedules from other workspace folders while they kept running). This PR fixes a second, independent bug where a hub daemon restart actually soft-deletes hub-managed schedules, so they disappear from the page and stop running.

### Description

Schedules created from the desktop UI or by agents are hub-managed: they live only in `~/.cline/data/db/cron.db` with a virtual `source_path` of `hub/schedules/<id>.cron.md` (marked `source = 'hub-schedule'`) and never exist as files on disk.

`CronReconciler.reconcileAll()` scans the cron specs directory for spec files and then marks every non-removed spec whose `source_path` was not found on disk as `removed = 1` (and disables it, cancelling queued runs). Since hub-managed schedules have virtual paths, reconciliation flags all of them as deleted files and soft-deletes them.

The hub daemon entry always passes `cronOptions`, so `CronService.start()` runs `reconcileAll()` on every detached hub daemon startup. On normal app relaunches the running daemon is reused and nothing reconciles; an app update retires the old-build daemon and starts a fresh one, which wipes every hub-managed schedule. Any other full daemon restart (reboot, crash) or a file deletion under the cron specs dir (the watcher triggers a full reconcile) does the same.

The fix skips `source = 'hub-schedule'` specs in the reconciler's removal pass, which is the same marker the report writer, schedule service, and cron runner already use to identify DB-native schedules. File-backed spec removal behavior is unchanged.

Note on recovery: schedules already lost by affected users cannot be safely auto-restored. Explicit deletion via the UI and the reconciler wipe both write the identical `removed = 1` state, so there is no way to tell them apart in existing databases.

### Test Procedure

End-to-end against a real detached hub daemon (`cline schedule create` + `cline hub ensure` with an isolated `CLINE_DIR`):

- Unfixed code: created a hub schedule, then started the detached daemon. The row in `cron.db` flipped to `removed = 1, enabled = 0` during daemon startup, i.e. the schedule disappears and would no longer run.
- Fixed code: created another schedule and restarted the daemon (fresh pid confirmed). The row stayed `removed = 0, enabled = 1` after startup reconciliation, while the previously wiped row stayed wiped.

Automated coverage:

- Added a regression test that creates a hub schedule via `store.createHubSchedule()` and runs `reconcileAll()` with no spec files on disk. Before the fix it fails with `summary.removed = 1`; after the fix the schedule survives, stays enabled, and is still returned by `listHubSchedules()`.
- All 89 cron tests in `@cline/core` pass, including existing tests covering file-backed spec removal.
- Full `@cline/core` unit suite: 2084 passed, 1 failed. The failure is the known cloud-env artifact in `workspace-manifest.test.ts` (git `insteadOf` remote rewriting), unrelated to this change.
- `bun -F @cline/core typecheck` and Biome checks pass on the changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend-only change. Real-daemon evidence, unfixed code (row wiped by daemon startup):

```
[
 { "source_path": "hub/schedules/sched_2de41....cron.md", "source": "hub-schedule", "removed": 1, "enabled": 0 }
]
```

Fixed code (new schedule survives an identical daemon restart):

```
[
 { "title": "Daily digest", "source": "hub-schedule", "removed": 1, "enabled": 0 },   <- wiped earlier by unfixed daemon
 { "title": "Survivor",     "source": "hub-schedule", "removed": 0, "enabled": 1 }    <- survives with fix
]
```

### Additional Notes

The fix is in `sdk/packages/core/src/cron/specs/cron-reconciler.ts` and applies to every host that runs the hub cron service, not just the desktop app.