### PR TITLE
Remove box shadow from chat message actions hover row

### DIFF
--- a/sdk/packages/ui/components/agent-chat/agent-chat.css
+++ b/sdk/packages/ui/components/agent-chat/agent-chat.css
@@ -161,7 +161,6 @@
 		border-radius: var(--radius);
 		background: color-mix(in oklab, var(--background) 92%, transparent);
 		backdrop-filter: blur(4px);
-		box-shadow: 0 1px 3px rgb(0 0 0 / 0.1);
 		pointer-events: none;
 		opacity: 0;
 	}


### PR DESCRIPTION
### Related Issue

N/A (small cosmetic fix)

### Description

The copy/fork/timestamp action row that appears on hover under each chat message had a `box-shadow` that was visibly distracting in light mode. This removes the shadow from `.cline-chat-message-actions` in the shared `@cline/ui` agent-chat styles, so the desktop app and any other consumers of the library pick up the flat look. The translucent background and backdrop blur are kept so the row still reads cleanly over content that follows it.

### Test Procedure

Ran the `@cline/ui` Storybook (Agent chat / Primitives, Complete Conversation story) in light mode, hovered the assistant message, and captured the action row before and after. Also confirmed via computed styles that `box-shadow` resolves to `none` after the change.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (shadow under the hover action row, light mode):

![Before: action row with shadow](https://cursor.com/artifacts/c/art-2387832c-9af6-4aab-9f6e-db0e97dbe676)

After (flat, no shadow):

![After: action row without shadow](https://cursor.com/artifacts/c/art-3e8271da-f18e-4434-8c53-ca634ed4af83)

### Additional Notes

One-line CSS deletion in `sdk/packages/ui/components/agent-chat/agent-chat.css`.