### PR TITLE
fix(desktop): make the Tauri shell work on Windows

### DIFF
--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -112,6 +112,12 @@ struct UpdateState {
     // concurrently and the later one can overwrite a freshly staged "ready"
     // with "idle"/"error" decided from its stale pre-await snapshot.
     cycle: tokio::sync::Mutex<()>,
+    // Windows only: the downloaded-but-not-installed update. On Windows,
+    // Update::install launches the NSIS installer and std::process::exit(0)s
+    // immediately, so installation must wait for the user-initiated restart
+    // instead of running inside the background cycle like it does on macOS.
+    #[cfg(windows)]
+    pending_install: Mutex<Option<(tauri_plugin_updater::Update, Vec<u8>)>>,
 }
 
 impl UpdateState {
@@ -224,8 +230,26 @@ async fn check_and_install_update(app: &tauri::AppHandle, state: &UpdateState) {
                 return;
             }
             set_update_status(app, state, "downloading", Some(version.clone()), None);
+            // macOS: install right away — it only swaps the .app on disk and
+            // the running app keeps going until the user restarts. Windows:
+            // download only, because install() launches the NSIS installer
+            // and exits the process on the spot; the staged bytes are
+            // installed by restart_to_apply_update instead.
+            #[cfg(not(windows))]
             match update.download_and_install(|_, _| {}, || {}).await {
                 Ok(()) => set_update_status(app, state, "ready", Some(version), None),
+                Err(error) => {
+                    set_update_status(app, state, "error", Some(version), Some(error.to_string()))
+                }
+            }
+            #[cfg(windows)]
+            match update.download(|_, _| {}, || {}).await {
+                Ok(bytes) => {
+                    if let Ok(mut pending) = state.pending_install.lock() {
+                        *pending = Some((update, bytes));
+                    }
+                    set_update_status(app, state, "ready", Some(version), None);
+                }
                 Err(error) => {
                     set_update_status(app, state, "error", Some(version), Some(error.to_string()))
                 }
@@ -285,8 +309,15 @@ impl DesktopBackendState {
                 // exits itself, finishing session persistence as an orphan.
                 #[cfg(unix)]
                 let _ = Command::new("kill").arg(child.id().to_string()).status();
+                // Windows has no SIGTERM equivalent, so terminate outright.
+                // Reap the child too: TerminateProcess is quick, and the
+                // update-restart path needs the sidecar exe's file lock
+                // released before the NSIS installer replaces it.
                 #[cfg(not(unix))]
-                let _ = child.kill();
+                {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
             }
             *process_guard = None;
         }
@@ -314,13 +345,29 @@ struct DesktopBackendReadyLine {
     mode: Option<String>,
 }
 
+/// The release binary is a GUI-subsystem app (no console), so on Windows
+/// every console-subsystem child (git, cmd, the sidecar) would otherwise
+/// allocate its own visible console window. Piped stdio does not prevent
+/// that; only CREATE_NO_WINDOW does.
+#[cfg(windows)]
+fn hide_console_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn hide_console_window(_command: &mut Command) {}
+
 fn resolve_workspace_root(launch_cwd: &str) -> String {
-    let output = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .arg("-C")
         .arg(launch_cwd)
         .arg("rev-parse")
-        .arg("--show-toplevel")
-        .output();
+        .arg("--show-toplevel");
+    hide_console_window(&mut command);
+    let output = command.output();
 
     match output {
         Ok(result) if result.status.success() => {
@@ -438,7 +485,9 @@ fn spawn_desktop_backend_process(context: &AppContext) -> Result<Child, String> 
     command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    hide_console_window(&mut command);
+    command
         .spawn()
         .map_err(|e| format!("failed to start desktop backend sidecar: {e}"))
 }
@@ -561,7 +610,11 @@ fn resolve_mcp_settings_path() -> Result<PathBuf, String> {
             return Ok(PathBuf::from(trimmed));
         }
     }
-    let home = std::env::var("HOME").map_err(|_| "HOME is not set".to_string())?;
+    // USERPROFILE is the Windows equivalent of HOME (and what the sidecar's
+    // homedir() resolves there); HOME is usually unset on Windows.
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| "neither HOME nor USERPROFILE is set".to_string())?;
     Ok(PathBuf::from(home)
         .join(".cline")
         .join("data")
@@ -585,8 +638,10 @@ fn open_path_with_default_app(path: &Path) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         let path_arg = path.to_string_lossy().to_string();
-        let status = Command::new("cmd")
-            .args(["/C", "start", "", &path_arg])
+        let mut command = Command::new("cmd");
+        command.args(["/C", "start", "", &path_arg]);
+        hide_console_window(&mut command);
+        let status = command
             .status()
             .map_err(|e| format!("failed to open path: {e}"))?;
         if status.success() {
@@ -673,10 +728,30 @@ fn get_update_status(update_state: State<'_, Arc<UpdateState>>) -> UpdateStatus 
 fn restart_to_apply_update(
     app: tauri::AppHandle,
     backend_state: State<'_, Arc<DesktopBackendState>>,
+    update_state: State<'_, Arc<UpdateState>>,
 ) {
-    // restart() never returns, so the run-loop Exit handler does not get a
-    // chance to stop the sidecar; shut it down explicitly first.
+    // Neither restart() nor install() returns, so the run-loop Exit handler
+    // does not get a chance to stop the sidecar; shut it down explicitly
+    // first. On Windows this also releases the sidecar exe's file lock,
+    // which the NSIS installer needs in order to replace it.
     backend_state.stop();
+    // Windows: install the bytes staged by the background cycle. install()
+    // launches the NSIS installer (which relaunches the app when done) and
+    // exits this process, so it only returns on failure — fall through to a
+    // plain restart of the current version in that case.
+    #[cfg(windows)]
+    if let Some((update, bytes)) = update_state
+        .pending_install
+        .lock()
+        .ok()
+        .and_then(|mut pending| pending.take())
+    {
+        if let Err(error) = update.install(bytes) {
+            eprintln!("[updater] failed to launch the update installer: {error}");
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = update_state;
     app.restart();
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (follow-up to #13607, which added Windows desktop publishing)

### Description

#13607 wired up Windows build publishing for the desktop app, but the app itself has never been built or run on Windows (the Windows publish job merged after desktop-v0.0.19 was tagged, so it has never executed). An audit of the Tauri shell found four Windows-specific problems, all in `src-tauri/src/main.rs`:

1. The background updater would abruptly kill the app. `run_update_loop` calls `download_and_install` automatically (10s after launch, then every 2h). On macOS that just stages the new `.app` and the app keeps running until the user restarts. On Windows, `tauri-plugin-updater`'s `install()` launches the NSIS installer via `ShellExecuteW` and calls `std::process::exit(0)` immediately, bypassing the `RunEvent::Exit` handler. So the window would vanish mid-session as soon as any newer version existed, the sidecar would be orphaned, and the orphan's file lock on `code-sidecar.exe` would break the install. The background cycle now downloads only on Windows and stages the bytes in `UpdateState`; `restart_to_apply_update` stops the sidecar and then installs them (NSIS relaunches the app when done). macOS behavior is unchanged.

2. Visible console windows. The release binary is a GUI-subsystem app, and it spawned console-subsystem children (the sidecar, `git rev-parse`, `cmd /C start`) with plain `std::process::Command`, so each would allocate its own visible console: a persistent empty console for the sidecar's whole lifetime plus flashes for git and file-open. All spawn sites now go through a `hide_console_window` helper that sets `CREATE_NO_WINDOW` on Windows.

3. "Open MCP settings" was broken. `resolve_mcp_settings_path` read the `HOME` env var, which is normally unset on Windows, so the command failed with "HOME is not set". It now falls back to `USERPROFILE`, matching what the sidecar's `homedir()` resolves.

4. The Windows hard-kill in `DesktopBackendState::stop()` now also reaps the child with `wait()`, so the sidecar exe's file lock is released before the NSIS installer replaces it during the update-restart flow.

### Test Procedure

There is no Windows CI or hardware for this app yet, so verification was done by compiling for the Windows target plus the existing suite:

- `cargo check` passes for both the host target and `x86_64-pc-windows-gnu` (cross-checked with mingw-w64; this compiles all the `#[cfg(windows)]` code including the new updater staging path). Only warning is the pre-existing dead-code warning for the macOS-only zoom menu variants.
- All 9 existing `cargo test` unit tests pass.
- The plugin behavior the fix is built around was verified directly in the `tauri-plugin-updater` 2.10.1 source: `install()` on Windows ends in `std::process::exit(0)`, and its `on_before_exit` hook only runs `cleanup_before_exit`, which never fires the app's `RunEvent::Exit` handler.
- The sidecar cross-compiles to a Windows exe with `bun build --compile --target=bun-windows-x64` (unchanged by this PR, verified as part of the audit).

Worth a real run on a Windows machine before the first Windows release: toast notifications (the NSIS-registered AppUserModelID must match the `app_id` handed to notify-rust) and the full update cycle.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable: Rust-only changes to the desktop shell, with no Windows hardware available to run the app. Compile evidence is in the Test Procedure section.

### Additional Notes

Known remaining Windows issues deliberately left out of this PR to keep it reviewable: the cosmetic double title bar (`titleBarStyle: "Overlay"` and `hiddenTitle` are macOS-only, so Windows shows the native title bar above the app's own title-bar row), and quit on Windows still hard-kills the sidecar rather than giving it a graceful shutdown window (Windows has no SIGTERM; doing this properly needs a real shutdown channel to the sidecar).