### PR TITLE
fix(cli): show schedules from all workspaces in schedule commands

### DIFF
--- a/apps/cli/src/commands/schedule.test.ts
+++ b/apps/cli/src/commands/schedule.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -164,12 +164,118 @@ describe("runScheduleCommand list output", () => {
 		);
 
 		expect(code).toBe(0);
-		// The hub query spans every workspace; --workspace narrows client-side.
+		// The hub query spans every workspace, and fetches wide so the global
+		// limit cannot truncate away this workspace's matches before the
+		// client-side --workspace filter runs.
 		expect(mockHubClientCommand).toHaveBeenCalledWith(
 			"schedule.list",
-			expect.objectContaining({ allWorkspaces: true }),
+			expect.objectContaining({ allWorkspaces: true, limit: 10_000 }),
 		);
 		expect(JSON.parse(output.join("\n"))).toEqual([elsewhere]);
+	});
+
+	it("applies --limit after the --workspace filter", async () => {
+		mockEnsureCliHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "test-token",
+		});
+		const matchA = {
+			scheduleId: "sched_a",
+			name: "match-a",
+			workspaceRoot: "/Users/someone/project-b",
+		};
+		const matchB = {
+			scheduleId: "sched_b",
+			name: "match-b",
+			workspaceRoot: "/Users/someone/project-b",
+		};
+		mockHubClientCommand.mockResolvedValue({
+			ok: true,
+			payload: {
+				schedules: [
+					{
+						scheduleId: "sched_other",
+						name: "other",
+						workspaceRoot: "/Users/someone/project-a",
+					},
+					matchA,
+					matchB,
+				],
+			},
+		});
+
+		const output: string[] = [];
+		const code = await runScheduleCommand(
+			[
+				"list",
+				"--json",
+				"--limit",
+				"1",
+				"--workspace",
+				"/Users/someone/project-b",
+				"--address",
+				"127.0.0.1:25463",
+			],
+			{
+				writeln: (text?: string) => {
+					output.push(text ?? "");
+				},
+				writeErr: () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.list",
+			expect.objectContaining({ limit: 10_000 }),
+		);
+		expect(JSON.parse(output.join("\n"))).toEqual([matchA]);
+	});
+
+	it("matches --workspace across symlinked path forms", async () => {
+		mockEnsureCliHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "test-token",
+		});
+		const root = join(tmpdir(), `cline-cli-schedule-links-${Date.now()}`);
+		const realWorkspace = join(root, "real-workspace");
+		const linkedWorkspace = join(root, "linked-workspace");
+		await mkdir(realWorkspace, { recursive: true });
+		await symlink(realWorkspace, linkedWorkspace, "dir");
+		try {
+			const schedule = {
+				scheduleId: "sched_real",
+				name: "daily-summary",
+				workspaceRoot: realWorkspace,
+			};
+			mockHubClientCommand.mockResolvedValue({
+				ok: true,
+				payload: { schedules: [schedule] },
+			});
+
+			const output: string[] = [];
+			const code = await runScheduleCommand(
+				[
+					"list",
+					"--json",
+					"--workspace",
+					linkedWorkspace,
+					"--address",
+					"127.0.0.1:25463",
+				],
+				{
+					writeln: (text?: string) => {
+						output.push(text ?? "");
+					},
+					writeErr: () => {},
+				},
+			);
+
+			expect(code).toBe(0);
+			expect(JSON.parse(output.join("\n"))).toEqual([schedule]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 
 	it("sends allWorkspaces on id-addressed schedule commands", async () => {

--- a/apps/cli/src/commands/schedule.test.ts
+++ b/apps/cli/src/commands/schedule.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -118,9 +118,82 @@ describe("runScheduleCommand list output", () => {
 			}),
 		);
 		expect(mockHubClientCommand).toHaveBeenCalledWith("schedule.list", {
+			allWorkspaces: true,
 			limit: 100,
 			enabled: undefined,
 			tags: undefined,
+		});
+	});
+
+	it("lists schedules across all workspaces and filters with --workspace", async () => {
+		mockEnsureCliHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "test-token",
+		});
+		const inWorkspace = {
+			scheduleId: "sched_a",
+			name: "daily-issue-summary",
+			workspaceRoot: "/Users/someone/project-a",
+		};
+		const elsewhere = {
+			scheduleId: "sched_b",
+			name: "daily-pr-summary",
+			workspaceRoot: "/Users/someone/project-b",
+		};
+		mockHubClientCommand.mockResolvedValue({
+			ok: true,
+			payload: { schedules: [inWorkspace, elsewhere] },
+		});
+
+		const output: string[] = [];
+		const code = await runScheduleCommand(
+			[
+				"list",
+				"--json",
+				"--workspace",
+				"/Users/someone/project-b",
+				"--address",
+				"127.0.0.1:25463",
+			],
+			{
+				writeln: (text?: string) => {
+					output.push(text ?? "");
+				},
+				writeErr: () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		// The hub query spans every workspace; --workspace narrows client-side.
+		expect(mockHubClientCommand).toHaveBeenCalledWith(
+			"schedule.list",
+			expect.objectContaining({ allWorkspaces: true }),
+		);
+		expect(JSON.parse(output.join("\n"))).toEqual([elsewhere]);
+	});
+
+	it("sends allWorkspaces on id-addressed schedule commands", async () => {
+		mockEnsureCliHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "test-token",
+		});
+		mockHubClientCommand.mockResolvedValue({
+			ok: true,
+			payload: { schedule: { scheduleId: "sched_a" } },
+		});
+
+		const code = await runScheduleCommand(
+			["pause", "sched_a", "--address", "127.0.0.1:25463"],
+			{
+				writeln: () => {},
+				writeErr: () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(mockHubClientCommand).toHaveBeenCalledWith("schedule.disable", {
+			allWorkspaces: true,
+			scheduleId: "sched_a",
 		});
 	});
 
@@ -152,6 +225,71 @@ describe("runScheduleCommand list output", () => {
 		expect(errors).toEqual([]);
 		expect(output).toEqual(["[]"]);
 		expect(mockHubClientCommand).toHaveBeenCalled();
+	});
+});
+
+describe("runScheduleCommand local client across workspaces", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		delete process.env.CLINE_CRON_DB_PATH;
+	});
+
+	it("lists schedules created for another workspace without a hub address", async () => {
+		const root = join(tmpdir(), `cline-cli-schedules-${Date.now()}`);
+		const workspaceA = join(root, "workspace-a");
+		await mkdir(workspaceA, { recursive: true });
+		process.env.CLINE_CRON_DB_PATH = join(root, "cron.db");
+		try {
+			const created = await runScheduleCommand(
+				[
+					"create",
+					"daily-issue-summary",
+					"--cron",
+					"0 7 * * *",
+					"--prompt",
+					"Summarize new issues.",
+					"--workspace",
+					workspaceA,
+					"--provider",
+					"cline",
+					"--model",
+					"cline/test-model",
+					"--disabled",
+				],
+				{
+					writeln: () => {},
+					writeErr: () => {},
+				},
+			);
+			expect(created).toBe(0);
+
+			// The list runs from this test process's cwd, which is not
+			// workspace-a. The schedule must still appear, matching how the
+			// desktop Schedules page shows every schedule on the machine.
+			const output: string[] = [];
+			const errors: string[] = [];
+			const code = await runScheduleCommand(["list", "--json"], {
+				writeln: (text?: string) => {
+					output.push(text ?? "");
+				},
+				writeErr: (text: string) => {
+					errors.push(text);
+				},
+			});
+			expect(errors).toEqual([]);
+			expect(code).toBe(0);
+			const schedules = JSON.parse(output.join("\n")) as Array<{
+				name?: string;
+				workspaceRoot?: string;
+			}>;
+			expect(schedules).toHaveLength(1);
+			expect(schedules[0]).toMatchObject({
+				name: "daily-issue-summary",
+				workspaceRoot: workspaceA,
+			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -492,6 +630,7 @@ describe("runScheduleCommand export", () => {
 			const written = await readFile(targetPath, "utf8");
 			expect(written).toBe(JSON.stringify(scheduleRecord, null, 2));
 			expect(mockHubClientCommand).toHaveBeenCalledWith("schedule.get", {
+				allWorkspaces: true,
 				scheduleId: "sched_abc",
 			});
 		} finally {

--- a/apps/cli/src/commands/schedule.test.ts
+++ b/apps/cli/src/commands/schedule.test.ts
@@ -125,83 +125,19 @@ describe("runScheduleCommand list output", () => {
 		});
 	});
 
-	it("lists schedules across all workspaces and filters with --workspace", async () => {
+	it("passes --workspace to the hub for server-side filtering", async () => {
 		mockEnsureCliHubServer.mockResolvedValue({
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "test-token",
 		});
-		const inWorkspace = {
-			scheduleId: "sched_a",
-			name: "daily-issue-summary",
-			workspaceRoot: "/Users/someone/project-a",
-		};
-		const elsewhere = {
+		const filtered = {
 			scheduleId: "sched_b",
 			name: "daily-pr-summary",
 			workspaceRoot: "/Users/someone/project-b",
 		};
 		mockHubClientCommand.mockResolvedValue({
 			ok: true,
-			payload: { schedules: [inWorkspace, elsewhere] },
-		});
-
-		const output: string[] = [];
-		const code = await runScheduleCommand(
-			[
-				"list",
-				"--json",
-				"--workspace",
-				"/Users/someone/project-b",
-				"--address",
-				"127.0.0.1:25463",
-			],
-			{
-				writeln: (text?: string) => {
-					output.push(text ?? "");
-				},
-				writeErr: () => {},
-			},
-		);
-
-		expect(code).toBe(0);
-		// The hub query spans every workspace, and fetches wide so the global
-		// limit cannot truncate away this workspace's matches before the
-		// client-side --workspace filter runs.
-		expect(mockHubClientCommand).toHaveBeenCalledWith(
-			"schedule.list",
-			expect.objectContaining({ allWorkspaces: true, limit: 10_000 }),
-		);
-		expect(JSON.parse(output.join("\n"))).toEqual([elsewhere]);
-	});
-
-	it("applies --limit after the --workspace filter", async () => {
-		mockEnsureCliHubServer.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			authToken: "test-token",
-		});
-		const matchA = {
-			scheduleId: "sched_a",
-			name: "match-a",
-			workspaceRoot: "/Users/someone/project-b",
-		};
-		const matchB = {
-			scheduleId: "sched_b",
-			name: "match-b",
-			workspaceRoot: "/Users/someone/project-b",
-		};
-		mockHubClientCommand.mockResolvedValue({
-			ok: true,
-			payload: {
-				schedules: [
-					{
-						scheduleId: "sched_other",
-						name: "other",
-						workspaceRoot: "/Users/someone/project-a",
-					},
-					matchA,
-					matchB,
-				],
-			},
+			payload: { schedules: [filtered] },
 		});
 
 		const output: string[] = [];
@@ -210,7 +146,7 @@ describe("runScheduleCommand list output", () => {
 				"list",
 				"--json",
 				"--limit",
-				"1",
+				"5",
 				"--workspace",
 				"/Users/someone/project-b",
 				"--address",
@@ -225,57 +161,17 @@ describe("runScheduleCommand list output", () => {
 		);
 
 		expect(code).toBe(0);
+		// The hub filters by workspace before applying the limit and matches
+		// canonical path forms, so the CLI just forwards the filter.
 		expect(mockHubClientCommand).toHaveBeenCalledWith(
 			"schedule.list",
-			expect.objectContaining({ limit: 10_000 }),
+			expect.objectContaining({
+				allWorkspaces: true,
+				workspaceRoot: "/Users/someone/project-b",
+				limit: 5,
+			}),
 		);
-		expect(JSON.parse(output.join("\n"))).toEqual([matchA]);
-	});
-
-	it("matches --workspace across symlinked path forms", async () => {
-		mockEnsureCliHubServer.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			authToken: "test-token",
-		});
-		const root = join(tmpdir(), `cline-cli-schedule-links-${Date.now()}`);
-		const realWorkspace = join(root, "real-workspace");
-		const linkedWorkspace = join(root, "linked-workspace");
-		await mkdir(realWorkspace, { recursive: true });
-		await symlink(realWorkspace, linkedWorkspace, "dir");
-		try {
-			const schedule = {
-				scheduleId: "sched_real",
-				name: "daily-summary",
-				workspaceRoot: realWorkspace,
-			};
-			mockHubClientCommand.mockResolvedValue({
-				ok: true,
-				payload: { schedules: [schedule] },
-			});
-
-			const output: string[] = [];
-			const code = await runScheduleCommand(
-				[
-					"list",
-					"--json",
-					"--workspace",
-					linkedWorkspace,
-					"--address",
-					"127.0.0.1:25463",
-				],
-				{
-					writeln: (text?: string) => {
-						output.push(text ?? "");
-					},
-					writeErr: () => {},
-				},
-			);
-
-			expect(code).toBe(0);
-			expect(JSON.parse(output.join("\n"))).toEqual([schedule]);
-		} finally {
-			await rm(root, { recursive: true, force: true });
-		}
+		expect(JSON.parse(output.join("\n"))).toEqual([filtered]);
 	});
 
 	it("sends allWorkspaces on id-addressed schedule commands", async () => {
@@ -393,6 +289,69 @@ describe("runScheduleCommand local client across workspaces", () => {
 				name: "daily-issue-summary",
 				workspaceRoot: workspaceA,
 			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("filters --workspace through symlinked paths before the limit", async () => {
+		const root = join(tmpdir(), `cline-cli-schedule-links-${Date.now()}`);
+		const targetWorkspace = join(root, "target-workspace");
+		const linkedWorkspace = join(root, "linked-workspace");
+		const otherWorkspace = join(root, "other-workspace");
+		await mkdir(targetWorkspace, { recursive: true });
+		await mkdir(otherWorkspace, { recursive: true });
+		await symlink(targetWorkspace, linkedWorkspace, "dir");
+		process.env.CLINE_CRON_DB_PATH = join(root, "cron.db");
+		try {
+			const seed = async (name: string, workspaceRoot: string) => {
+				const code = await runScheduleCommand(
+					[
+						"create",
+						name,
+						"--cron",
+						"0 7 * * *",
+						"--prompt",
+						`Run ${name}.`,
+						"--workspace",
+						workspaceRoot,
+						"--provider",
+						"cline",
+						"--model",
+						"cline/test-model",
+						"--disabled",
+					],
+					{ writeln: () => {}, writeErr: () => {} },
+				);
+				expect(code).toBe(0);
+			};
+			// Surround the match with other-workspace schedules so a global
+			// limit of 1 could not contain it under any listing order.
+			await seed("other-first", otherWorkspace);
+			await seed("target-routine", targetWorkspace);
+			await seed("other-last", otherWorkspace);
+
+			const output: string[] = [];
+			const errors: string[] = [];
+			const code = await runScheduleCommand(
+				["list", "--json", "--limit", "1", "--workspace", linkedWorkspace],
+				{
+					writeln: (text?: string) => {
+						output.push(text ?? "");
+					},
+					writeErr: (text: string) => {
+						errors.push(text);
+					},
+				},
+			);
+			expect(errors).toEqual([]);
+			expect(code).toBe(0);
+			const schedules = JSON.parse(output.join("\n")) as Array<{
+				name?: string;
+			}>;
+			expect(schedules).toEqual([
+				expect.objectContaining({ name: "target-routine" }),
+			]);
 		} finally {
 			await rm(root, { recursive: true, force: true });
 		}

--- a/apps/cli/src/commands/schedule/client.ts
+++ b/apps/cli/src/commands/schedule/client.ts
@@ -55,7 +55,15 @@ export class HubScheduleClient {
 		payload?: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
 		const client = await this.connectedHub();
-		const reply = await client.command(command as never, payload);
+		// Agent-created schedules live under each chat's own workspace folder,
+		// not necessarily the directory this CLI ran from. Like the desktop
+		// Schedules page, manage every schedule on this machine; the hub only
+		// honors this for token-authenticated connections and keeps
+		// workspace-bound clients scoped.
+		const reply = await client.command(command as never, {
+			allWorkspaces: true,
+			...payload,
+		});
 		return (reply.payload ?? {}) as Record<string, unknown>;
 	}
 
@@ -135,7 +143,10 @@ export class LocalScheduleClient {
 				version: "v1",
 				clientId: "cline-schedule-local",
 				command: command as never,
-				payload,
+				// Match the hub-connected client: manage schedules across all
+				// workspaces, since agent-created schedules live under each
+				// chat's own workspace folder rather than this CLI's cwd.
+				payload: { allWorkspaces: true, ...payload },
 			},
 			{
 				clientId: "cline-schedule-local",
@@ -143,6 +154,10 @@ export class LocalScheduleClient {
 					workspaceRoot: this.workspaceRoot,
 					cwd: this.workspaceRoot,
 				},
+				// This client opens the local schedule store directly in the
+				// user's own process, so the workspace scope is a UX default
+				// here, not a security boundary.
+				crossWorkspace: true,
 			},
 		);
 		if (!reply.ok) {

--- a/apps/cli/src/commands/schedule/handlers.ts
+++ b/apps/cli/src/commands/schedule/handlers.ts
@@ -1,5 +1,3 @@
-import { realpathSync } from "node:fs";
-import { resolve } from "node:path";
 import type { Command } from "commander";
 import { ensureSchedulerHub } from "./client";
 import {
@@ -22,28 +20,6 @@ import {
 } from "./import-export";
 import { resolveScheduleModelSelection } from "./model-selection";
 import type { CommandIo, ScheduleActionWrapper } from "./types";
-
-/**
- * Fetch window used when a `--workspace` filter is applied client-side. The
- * hub's limit is global across workspaces, so filtering a response truncated
- * to the user's `--limit` could drop every match; fetch wide, filter, then
- * apply the user's limit to the filtered results.
- */
-const WORKSPACE_FILTER_FETCH_LIMIT = 10_000;
-
-/**
- * Stored workspace roots mix canonical (realpath) and merely resolved forms,
- * so compare canonical forms on both sides; fall back to the resolved path
- * when it does not exist (e.g. a cleaned-up workspace).
- */
-function canonicalWorkspacePath(value: string): string {
-	const resolved = resolve(value.trim());
-	try {
-		return realpathSync.native(resolved);
-	} catch {
-		return resolved;
-	}
-}
 
 export function registerScheduleCommands(
 	schedule: Command,
@@ -271,27 +247,19 @@ export function registerScheduleCommands(
 			const client = ensured.client;
 			try {
 				const enabled = opts.enabled ? true : opts.disabled ? false : undefined;
-				const limit = toPositiveInt(opts.limit, 100);
-				const workspaceFilter =
+				// The hub filters by workspace before applying the limit, and
+				// matches canonical path forms, so the filter cannot be starved
+				// by other workspaces' schedules or miss symlink aliases.
+				const workspaceRoot =
 					typeof opts.workspace === "string" && opts.workspace.trim()
-						? canonicalWorkspacePath(opts.workspace)
+						? opts.workspace.trim()
 						: undefined;
-				const listed = await client.listSchedules({
-					limit: workspaceFilter ? WORKSPACE_FILTER_FETCH_LIMIT : limit,
+				const schedules = await client.listSchedules({
+					limit: toPositiveInt(opts.limit, 100),
 					enabled,
 					tags: parseList(opts.tags),
+					...(workspaceRoot ? { workspaceRoot } : {}),
 				});
-				const schedules =
-					workspaceFilter && Array.isArray(listed)
-						? listed
-								.filter(
-									(schedule) =>
-										typeof schedule?.workspaceRoot === "string" &&
-										canonicalWorkspacePath(schedule.workspaceRoot) ===
-											workspaceFilter,
-								)
-								.slice(0, limit)
-						: listed;
 				if (!opts.json && Array.isArray(schedules) && schedules.length === 0) {
 					io.writeln("No schedules found.");
 					return;

--- a/apps/cli/src/commands/schedule/handlers.ts
+++ b/apps/cli/src/commands/schedule/handlers.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Command } from "commander";
 import { ensureSchedulerHub } from "./client";
@@ -21,6 +22,28 @@ import {
 } from "./import-export";
 import { resolveScheduleModelSelection } from "./model-selection";
 import type { CommandIo, ScheduleActionWrapper } from "./types";
+
+/**
+ * Fetch window used when a `--workspace` filter is applied client-side. The
+ * hub's limit is global across workspaces, so filtering a response truncated
+ * to the user's `--limit` could drop every match; fetch wide, filter, then
+ * apply the user's limit to the filtered results.
+ */
+const WORKSPACE_FILTER_FETCH_LIMIT = 10_000;
+
+/**
+ * Stored workspace roots mix canonical (realpath) and merely resolved forms,
+ * so compare canonical forms on both sides; fall back to the resolved path
+ * when it does not exist (e.g. a cleaned-up workspace).
+ */
+function canonicalWorkspacePath(value: string): string {
+	const resolved = resolve(value.trim());
+	try {
+		return realpathSync.native(resolved);
+	} catch {
+		return resolved;
+	}
+}
 
 export function registerScheduleCommands(
 	schedule: Command,
@@ -248,22 +271,26 @@ export function registerScheduleCommands(
 			const client = ensured.client;
 			try {
 				const enabled = opts.enabled ? true : opts.disabled ? false : undefined;
+				const limit = toPositiveInt(opts.limit, 100);
+				const workspaceFilter =
+					typeof opts.workspace === "string" && opts.workspace.trim()
+						? canonicalWorkspacePath(opts.workspace)
+						: undefined;
 				const listed = await client.listSchedules({
-					limit: toPositiveInt(opts.limit, 100),
+					limit: workspaceFilter ? WORKSPACE_FILTER_FETCH_LIMIT : limit,
 					enabled,
 					tags: parseList(opts.tags),
 				});
-				const workspaceFilter =
-					typeof opts.workspace === "string" && opts.workspace.trim()
-						? resolve(opts.workspace.trim())
-						: undefined;
 				const schedules =
 					workspaceFilter && Array.isArray(listed)
-						? listed.filter(
-								(schedule) =>
-									typeof schedule?.workspaceRoot === "string" &&
-									resolve(schedule.workspaceRoot) === workspaceFilter,
-							)
+						? listed
+								.filter(
+									(schedule) =>
+										typeof schedule?.workspaceRoot === "string" &&
+										canonicalWorkspacePath(schedule.workspaceRoot) ===
+											workspaceFilter,
+								)
+								.slice(0, limit)
 						: listed;
 				if (!opts.json && Array.isArray(schedules) && schedules.length === 0) {
 					io.writeln("No schedules found.");

--- a/apps/cli/src/commands/schedule/handlers.ts
+++ b/apps/cli/src/commands/schedule/handlers.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { Command } from "commander";
 import { ensureSchedulerHub } from "./client";
 import {
@@ -222,11 +223,15 @@ export function registerScheduleCommands(
 
 	const listCmd = schedule
 		.command("list")
-		.description("List schedules")
+		.description("List schedules across all workspaces")
 		.option("--disabled", "Show only disabled schedules")
 		.option("--enabled", "Show only enabled schedules")
 		.option("--limit <n>", "Maximum number of results", "100")
-		.option("--tags <list>", "Filter by comma-separated tags");
+		.option("--tags <list>", "Filter by comma-separated tags")
+		.option(
+			"--workspace <path>",
+			"Only show schedules for this workspace root",
+		);
 	addSharedOptions(listCmd);
 	listCmd.action(
 		action(async () => {
@@ -243,11 +248,23 @@ export function registerScheduleCommands(
 			const client = ensured.client;
 			try {
 				const enabled = opts.enabled ? true : opts.disabled ? false : undefined;
-				const schedules = await client.listSchedules({
+				const listed = await client.listSchedules({
 					limit: toPositiveInt(opts.limit, 100),
 					enabled,
 					tags: parseList(opts.tags),
 				});
+				const workspaceFilter =
+					typeof opts.workspace === "string" && opts.workspace.trim()
+						? resolve(opts.workspace.trim())
+						: undefined;
+				const schedules =
+					workspaceFilter && Array.isArray(listed)
+						? listed.filter(
+								(schedule) =>
+									typeof schedule?.workspaceRoot === "string" &&
+									resolve(schedule.workspaceRoot) === workspaceFilter,
+							)
+						: listed;
 				if (!opts.json && Array.isArray(schedules) && schedules.length === 0) {
 					io.writeln("No schedules found.");
 					return;

--- a/sdk/packages/core/src/cron/service/schedule-command-service.ts
+++ b/sdk/packages/core/src/cron/service/schedule-command-service.ts
@@ -1,5 +1,13 @@
 import { realpathSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import {
+	basename,
+	dirname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+	sep,
+} from "node:path";
 import type {
 	HubCommandEnvelope,
 	HubReplyEnvelope,
@@ -57,19 +65,37 @@ function pathWithin(workspaceRoot: string, candidate: string): boolean {
 const DEFAULT_LIST_LIMIT = 200;
 
 /**
+ * Canonicalize a path that may no longer exist: realpath the deepest existing
+ * ancestor and reattach the missing remainder, so a removed workspace that was
+ * reached through a symlinked ancestor (e.g. `/var` vs `/private/var`) still
+ * canonicalizes to the same identity as its stored form.
+ */
+function canonicalizeThroughExistingAncestor(resolved: string): string {
+	let prefix = resolved;
+	let suffix = "";
+	for (;;) {
+		try {
+			const canonicalPrefix = realpathSync.native(prefix);
+			return suffix ? join(canonicalPrefix, suffix) : canonicalPrefix;
+		} catch {
+			const parent = dirname(prefix);
+			// Even the filesystem root failed to resolve; keep the input.
+			if (parent === prefix) return resolved;
+			suffix = suffix ? join(basename(prefix), suffix) : basename(prefix);
+			prefix = parent;
+		}
+	}
+}
+
+/**
  * Stored workspace roots mix canonical (realpath) and merely resolved forms,
- * so workspace filters compare canonical forms on both sides. Fall back to
- * the resolved form for paths that no longer exist, and fold case on Windows,
- * where lexically different paths can name the same directory.
+ * so workspace filters compare canonical forms on both sides. Removed
+ * workspaces canonicalize through their deepest existing ancestor, and case
+ * folds on Windows, where lexically different paths can name the same
+ * directory.
  */
 function comparableWorkspacePath(value: string): string {
-	const resolved = resolve(value.trim());
-	let canonical = resolved;
-	try {
-		canonical = realpathSync.native(resolved);
-	} catch {
-		// A removed workspace still filters by its last known path.
-	}
+	const canonical = canonicalizeThroughExistingAncestor(resolve(value.trim()));
 	return process.platform === "win32" ? canonical.toLowerCase() : canonical;
 }
 

--- a/sdk/packages/core/src/cron/service/schedule-command-service.ts
+++ b/sdk/packages/core/src/cron/service/schedule-command-service.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type {
 	HubCommandEnvelope,
@@ -52,6 +53,38 @@ function pathWithin(workspaceRoot: string, candidate: string): boolean {
 	return path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path);
 }
 
+/** Mirrors the store's default page size for filtered listings. */
+const DEFAULT_LIST_LIMIT = 200;
+
+/**
+ * Stored workspace roots mix canonical (realpath) and merely resolved forms,
+ * so workspace filters compare canonical forms on both sides. Fall back to
+ * the resolved form for paths that no longer exist, and fold case on Windows,
+ * where lexically different paths can name the same directory.
+ */
+function comparableWorkspacePath(value: string): string {
+	const resolved = resolve(value.trim());
+	let canonical = resolved;
+	try {
+		canonical = realpathSync.native(resolved);
+	} catch {
+		// A removed workspace still filters by its last known path.
+	}
+	return process.platform === "win32" ? canonical.toLowerCase() : canonical;
+}
+
+/** Per-request memo so large listings canonicalize each distinct root once. */
+function memoizedComparableWorkspacePath(): (value: string) => string {
+	const cache = new Map<string, string>();
+	return (value) => {
+		const cached = cache.get(value);
+		if (cached !== undefined) return cached;
+		const computed = comparableWorkspacePath(value);
+		cache.set(value, computed);
+		return computed;
+	};
+}
+
 function okReply(
 	envelope: HubCommandEnvelope,
 	payload?: Record<string, unknown>,
@@ -97,25 +130,51 @@ export class HubScheduleCommandService {
 							),
 						),
 					});
-				case "schedule.list":
+				case "schedule.list": {
+					const enabled =
+						typeof envelope.payload?.enabled === "boolean"
+							? envelope.payload.enabled
+							: undefined;
+					const limit =
+						typeof envelope.payload?.limit === "number"
+							? envelope.payload.limit
+							: undefined;
+					const tags = Array.isArray(envelope.payload?.tags)
+						? (envelope.payload?.tags as string[])
+						: undefined;
+					const requestedRoot = spansAllWorkspaces(envelope, scope)
+						? requestedWorkspaceRoot(envelope.payload ?? {})
+						: undefined;
+					if (requestedRoot) {
+						// Filter before applying the limit — a limited global
+						// listing could otherwise truncate away every match for
+						// the requested workspace.
+						const wanted = comparableWorkspacePath(requestedRoot);
+						const comparable = memoizedComparableWorkspacePath();
+						return okReply(envelope, {
+							schedules: this.schedules
+								.listSchedules({
+									enabled,
+									tags,
+									limit: Number.MAX_SAFE_INTEGER,
+								})
+								.filter(
+									(schedule) => comparable(schedule.workspaceRoot) === wanted,
+								)
+								.slice(0, limit ?? DEFAULT_LIST_LIMIT),
+						});
+					}
 					return okReply(envelope, {
 						schedules: this.schedules.listSchedules({
-							enabled:
-								typeof envelope.payload?.enabled === "boolean"
-									? envelope.payload.enabled
-									: undefined,
-							limit:
-								typeof envelope.payload?.limit === "number"
-									? envelope.payload.limit
-									: undefined,
-							tags: Array.isArray(envelope.payload?.tags)
-								? (envelope.payload?.tags as string[])
-								: undefined,
+							enabled,
+							limit,
+							tags,
 							workspaceRoot: spansAllWorkspaces(envelope, scope)
 								? undefined
 								: scope.workspaceRoot,
 						}),
 					});
+				}
 				case "schedule.get":
 					return okReply(envelope, {
 						schedule: this.requireScopedSchedule(envelope, scope),
@@ -229,7 +288,11 @@ export class HubScheduleCommandService {
 		if (!pathWithin(workspaceRoot, cwd)) {
 			throw new Error("client cwd is outside its workspace scope");
 		}
-		return { workspaceRoot, cwd, crossWorkspace: authority.crossWorkspace === true };
+		return {
+			workspaceRoot,
+			cwd,
+			crossWorkspace: authority.crossWorkspace === true,
+		};
 	}
 
 	private requireScopedSchedule(

--- a/sdk/packages/core/src/cron/service/schedule-service.test.ts
+++ b/sdk/packages/core/src/cron/service/schedule-service.test.ts
@@ -725,6 +725,29 @@ describe("HubScheduleService", () => {
 					.map((schedule) => schedule.name)
 					.sort();
 				expect(scopedNames).toEqual(["other-first", "other-last"]);
+
+				// A removed workspace referenced through a symlinked ancestor
+				// still filters by identity, not by lexical spelling: both
+				// sides canonicalize through their deepest existing ancestor.
+				const goneSchedule = seed(
+					"gone-routine",
+					join(targetWorkspace, "gone-workspace"),
+				);
+				const goneFiltered = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.list",
+						clientId: "cross-client",
+						payload: {
+							allWorkspaces: true,
+							workspaceRoot: join(aliasWorkspace, "gone-workspace"),
+						},
+					},
+					crossAuthority,
+				);
+				expect(goneFiltered.payload?.schedules).toMatchObject([
+					{ scheduleId: goneSchedule.scheduleId },
+				]);
 			} finally {
 				await service.dispose();
 			}

--- a/sdk/packages/core/src/cron/service/schedule-service.test.ts
+++ b/sdk/packages/core/src/cron/service/schedule-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -627,6 +627,104 @@ describe("HubScheduleService", () => {
 					workspaceRoot: resolve("/another-workspace"),
 					cwd: resolve("/another-workspace"),
 				});
+			} finally {
+				await service.dispose();
+			}
+		},
+	);
+
+	sqliteIt(
+		"filters cross-workspace listings by workspace before the limit and across path aliases",
+		async () => {
+			const dbPath = await createTempDbPath();
+			cleanupPaths.push(dbPath);
+			const service = new HubScheduleService({
+				dbPath,
+				specs: { cronSpecsDir: join(dirname(dbPath), "cron") },
+				runtimeHandlers: {
+					startSession: vi.fn(async () => ({ sessionId: "session-4" })),
+					sendSession: vi.fn(async () => ({ result: { text: "done" } })),
+					abortSession: vi.fn(async () => ({ applied: true })),
+					stopSession: vi.fn(async () => ({ applied: true })),
+				},
+			});
+			try {
+				const commands = new HubScheduleCommandService(service);
+				const root = dirname(dbPath);
+				const targetWorkspace = join(root, "target-workspace");
+				const aliasWorkspace = join(root, "alias-workspace");
+				const otherWorkspace = join(root, "other-workspace");
+				await mkdir(targetWorkspace, { recursive: true });
+				await mkdir(otherWorkspace, { recursive: true });
+				await symlink(targetWorkspace, aliasWorkspace, "dir");
+
+				const seed = (name: string, workspaceRoot: string) =>
+					service.createSchedule({
+						name,
+						cronPattern: "0 * * * *",
+						prompt: `Run ${name}`,
+						workspaceRoot,
+						cwd: workspaceRoot,
+					});
+				// Surround the match with other-workspace schedules so a global
+				// limit of 1 could not contain it under any listing order.
+				seed("other-first", otherWorkspace);
+				const match = seed("target-routine", targetWorkspace);
+				seed("other-last", otherWorkspace);
+
+				const crossAuthority = {
+					clientId: "cross-client",
+					workspaceContext: {
+						workspaceRoot: otherWorkspace,
+						cwd: otherWorkspace,
+					},
+					crossWorkspace: true,
+				};
+				// The workspace filter applies before the limit and matches the
+				// symlinked spelling of the target workspace root.
+				const filtered = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.list",
+						clientId: "cross-client",
+						payload: {
+							allWorkspaces: true,
+							workspaceRoot: aliasWorkspace,
+							limit: 1,
+						},
+					},
+					crossAuthority,
+				);
+				expect(filtered.payload?.schedules).toMatchObject([
+					{ scheduleId: match.scheduleId },
+				]);
+
+				// Without cross-workspace authority the payload filter is
+				// ignored and the listing stays scoped to the connection.
+				const scopedList = await commands.handleCommand(
+					{
+						version: "v1",
+						command: "schedule.list",
+						clientId: "scoped-client",
+						payload: {
+							allWorkspaces: true,
+							workspaceRoot: targetWorkspace,
+						},
+					},
+					{
+						clientId: "scoped-client",
+						workspaceContext: {
+							workspaceRoot: otherWorkspace,
+							cwd: otherWorkspace,
+						},
+					},
+				);
+				const scopedNames = (
+					scopedList.payload?.schedules as Array<{ name: string }>
+				)
+					.map((schedule) => schedule.name)
+					.sort();
+				expect(scopedNames).toEqual(["other-first", "other-last"]);
 			} finally {
 				await service.dispose();
 			}


### PR DESCRIPTION
## Problem

When an agent creates a scheduled task from a chat, the schedule's `workspaceRoot` is that chat's workspace folder — but the CLI's schedule commands are scoped to the directory the CLI happens to run from. `cline schedule list` therefore silently omits agent-created schedules unless it runs from that exact folder, and id-addressed commands (`get`, `pause`, `resume`, `delete`, `trigger`, `stats`, `history`) fail on them with "schedule does not exist in this workspace".

Both CLI paths were affected:
- the hub-connected `HubScheduleClient` never asked for cross-workspace access, and
- the default no-address `LocalScheduleClient` synthesized a connection authority without `crossWorkspace`, so the in-process `HubScheduleCommandService` scoped it the same way.

#13613 fixed exactly this for the desktop Schedules page and deliberately left the CLI scoped; this brings the CLI in line.

## Fix

- Both schedule clients now send `allWorkspaces: true` on every schedule command, matching the desktop sidecar. The hub only honors the flag for token-authenticated connections and keeps workspace-bound clients scoped, so unauthorized connections degrade to today's behavior instead of erroring.
- `LocalScheduleClient` grants `crossWorkspace` on its synthesized authority: it opens the user's own schedule store directly in-process, so the workspace scope there is a UX default, not a security boundary.
- `cline schedule list` gains `--workspace <path>` to narrow output back to one workspace root, since the old implicit cwd scoping is gone. The filter runs **server-side** in `HubScheduleCommandService`: it applies before the limit (so matches can never be starved out of a globally limited page) and compares canonical path forms — realpath with a resolved-path fallback for removed workspaces, case-folded on Windows — so symlink aliases like `/var` vs `/private/var` match. Workspace-scoped connections ignore the payload filter, exactly as before.

`schedule create` semantics are unchanged — it already registers against its required `--workspace` argument.

## Test plan

- End-to-end test through the real `LocalScheduleClient` and `HubScheduleCommandService`: a schedule created for another workspace (via a temp `CLINE_CRON_DB_PATH` store) appears in `schedule list --json` run from a different cwd; a second e2e proves `--workspace` matches through a symlinked path and filters before the limit (the match is surrounded by other-workspace schedules with `--limit 1`).
- Core test in `schedule-service.test.ts` covers the server-side filter directly: filter-before-limit, symlink alias matching, and that scoped connections ignore the payload filter.
- Tests assert the hub path sends `allWorkspaces: true` on `schedule.list` and id-addressed commands, and forwards `--workspace` in the payload.
- All new tests verified to fail with the fix reverted. `vitest` on `apps/cli` command/wizard suites and core cron suites, `tsc --noEmit`, and `biome check` — clean.