### PR TITLE
feat(core): anchor agent-created schedules in the user's .cline schedules home

### DIFF
--- a/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
+++ b/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
@@ -28,6 +28,7 @@ describe("Hub agenda task vertical slice", () => {
 		// the Cline dir at the test root so that home stays inside this test.
 		const clineHome = join(root, "cline-home");
 		mkdirSync(clineHome);
+		const previousClineDir = process.env.CLINE_DIR;
 		process.env.CLINE_DIR = clineHome;
 		const sessions = new Map<string, Record<string, unknown>>();
 		let capturedStart: StartSessionInput | undefined;
@@ -415,7 +416,11 @@ describe("Hub agenda task vertical slice", () => {
 			});
 			expect(startSession).toHaveBeenCalledTimes(1);
 		} finally {
-			delete process.env.CLINE_DIR;
+			if (previousClineDir === undefined) {
+				delete process.env.CLINE_DIR;
+			} else {
+				process.env.CLINE_DIR = previousClineDir;
+			}
 			await transport.stop();
 		}
 	});

--- a/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
+++ b/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
@@ -24,6 +24,11 @@ describe("Hub agenda task vertical slice", () => {
 		const chatWorkspace = join(root, "chat-workspace");
 		mkdirSync(chatWorkspace);
 		const canonicalChatWorkspace = realpathSync.native(chatWorkspace);
+		// Agent-created schedules anchor in the ~/.cline/schedules home; point
+		// the Cline dir at the test root so that home stays inside this test.
+		const clineHome = join(root, "cline-home");
+		mkdirSync(clineHome);
+		process.env.CLINE_DIR = clineHome;
 		const sessions = new Map<string, Record<string, unknown>>();
 		let capturedStart: StartSessionInput | undefined;
 		let requestToolApproval:
@@ -234,12 +239,18 @@ describe("Hub agenda task vertical slice", () => {
 					iteration: 2,
 				},
 			);
+			// Agent-created schedules anchor in the user's schedules home, not
+			// the chat workspace that created them.
+			expect((scheduled as { error?: unknown })?.error).toBeUndefined();
+			const canonicalSchedulesHome = realpathSync.native(
+				join(clineHome, "schedules"),
+			);
 			expect(scheduled).toMatchObject({
 				ok: true,
 				kind: "scheduled",
 				schedule: {
 					name: "Review task output",
-					workspaceRoot: canonicalChatWorkspace,
+					workspaceRoot: canonicalSchedulesHome,
 					timezone: "America/Los_Angeles",
 					createdBy: "agent:task-agent",
 				},
@@ -268,8 +279,8 @@ describe("Hub agenda task vertical slice", () => {
 					clientType: "test-client",
 					transport: "native",
 					workspaceContext: {
-						workspaceRoot: canonicalChatWorkspace,
-						cwd: canonicalChatWorkspace,
+						workspaceRoot: canonicalSchedulesHome,
+						cwd: canonicalSchedulesHome,
 					},
 				},
 			});
@@ -278,7 +289,26 @@ describe("Hub agenda task vertical slice", () => {
 					version: "v1",
 					command: "schedule.list",
 					clientId: "schedule-client",
-					payload: { workspaceRoot: canonicalChatWorkspace },
+					payload: { workspaceRoot: canonicalSchedulesHome },
+				},
+				{
+					clientId: "schedule-client",
+					workspaceContext: {
+						workspaceRoot: canonicalSchedulesHome,
+						cwd: canonicalSchedulesHome,
+					},
+				},
+			);
+			expect(listedSchedules.payload?.schedules).toEqual([
+				expect.objectContaining({ name: "Review task output" }),
+			]);
+			// A client scoped to the chat workspace no longer owns the
+			// agent-created schedule.
+			const chatScopedSchedules = await transport.handleCommand(
+				{
+					version: "v1",
+					command: "schedule.list",
+					clientId: "schedule-client",
 				},
 				{
 					clientId: "schedule-client",
@@ -288,9 +318,7 @@ describe("Hub agenda task vertical slice", () => {
 					},
 				},
 			);
-			expect(listedSchedules.payload?.schedules).toEqual([
-				expect.objectContaining({ name: "Review task output" }),
-			]);
+			expect(chatScopedSchedules.payload?.schedules).toEqual([]);
 
 			await vi.waitFor(async () => {
 				const listed = await transport.handleCommand({
@@ -387,6 +415,7 @@ describe("Hub agenda task vertical slice", () => {
 			});
 			expect(startSession).toHaveBeenCalledTimes(1);
 		} finally {
+			delete process.env.CLINE_DIR;
 			await transport.stop();
 		}
 	});

--- a/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
+++ b/sdk/packages/core/src/hub/server/agenda-task-hub.test.ts
@@ -6,7 +6,7 @@ import type {
 	ToolApprovalRequest,
 	ToolApprovalResult,
 } from "@cline/shared";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 
 vi.mock("@ai-sdk/provider-utils", () => ({
 	createProviderDefinedToolFactory: vi.fn(() => vi.fn()),
@@ -26,10 +26,19 @@ describe("Hub agenda task vertical slice", () => {
 		const canonicalChatWorkspace = realpathSync.native(chatWorkspace);
 		// Agent-created schedules anchor in the ~/.cline/schedules home; point
 		// the Cline dir at the test root so that home stays inside this test.
+		// Restore via onTestFinished so an early throw (before the try below)
+		// cannot leave the override behind for later tests in this worker.
 		const clineHome = join(root, "cline-home");
 		mkdirSync(clineHome);
 		const previousClineDir = process.env.CLINE_DIR;
 		process.env.CLINE_DIR = clineHome;
+		onTestFinished(() => {
+			if (previousClineDir === undefined) {
+				delete process.env.CLINE_DIR;
+			} else {
+				process.env.CLINE_DIR = previousClineDir;
+			}
+		});
 		const sessions = new Map<string, Record<string, unknown>>();
 		let capturedStart: StartSessionInput | undefined;
 		let requestToolApproval:
@@ -416,11 +425,6 @@ describe("Hub agenda task vertical slice", () => {
 			});
 			expect(startSession).toHaveBeenCalledTimes(1);
 		} finally {
-			if (previousClineDir === undefined) {
-				delete process.env.CLINE_DIR;
-			} else {
-				process.env.CLINE_DIR = previousClineDir;
-			}
 			await transport.stop();
 		}
 	});

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -27,6 +27,7 @@ import type {
 	RuntimeHost,
 } from "../../runtime/host/runtime-host";
 import { SqliteSessionStore } from "../../services/storage/sqlite-session-store";
+import { ensureAgentSchedulesWorkspace } from "../../services/workspace/agent-schedules-workspace";
 import { withSessionHistoryOriginMetadata } from "../../session/history-origin";
 import { CoreSessionService } from "../../session/services/session-service";
 import {
@@ -376,9 +377,14 @@ export class HubServerTransport implements NativeHubTransport {
 					resolveSessionDefaults: async (sessionId) => {
 						const session = await this.sessionHost.getSession(sessionId);
 						if (!session) return undefined;
+						// Agent-created schedules are user-level routines: anchor
+						// them (and run their unattended sessions) in the stable
+						// ~/.cline/schedules home instead of whichever chat
+						// workspace created them, so they survive chat cleanup and
+						// every chat manages the same set. Prompts must carry
+						// absolute paths to any project they operate on.
 						return {
-							workspaceRoot: session.workspaceRoot,
-							cwd: session.cwd,
+							workspaceRoot: await ensureAgentSchedulesWorkspace(),
 							modelSelection: {
 								providerId: session.provider,
 								modelId: session.model,

--- a/sdk/packages/core/src/services/workspace/agent-schedules-workspace.ts
+++ b/sdk/packages/core/src/services/workspace/agent-schedules-workspace.ts
@@ -1,0 +1,15 @@
+import { mkdir } from "node:fs/promises";
+import { resolveAgentSchedulesDir } from "@cline/shared/storage";
+
+/**
+ * Ensure the home workspace for agent-created schedules exists and return its
+ * path. Agent-created schedules are user-level routines: they anchor (and
+ * their unattended sessions run) in `~/.cline/schedules/` instead of
+ * inheriting whichever chat workspace happened to create them, so they
+ * survive chat cleanup and stay in one predictable scope.
+ */
+export async function ensureAgentSchedulesWorkspace(): Promise<string> {
+	const schedulesHome = resolveAgentSchedulesDir();
+	await mkdir(schedulesHome, { recursive: true, mode: 0o700 });
+	return schedulesHome;
+}

--- a/sdk/packages/core/src/services/workspace/index.ts
+++ b/sdk/packages/core/src/services/workspace/index.ts
@@ -1,3 +1,4 @@
+export { ensureAgentSchedulesWorkspace } from "./agent-schedules-workspace";
 export { ensureChatWorkspace } from "./chat-workspace";
 export type { FastFileIndexOptions } from "./file-indexer";
 export { getFileIndex, prewarmFileIndex } from "./file-indexer";

--- a/sdk/packages/core/src/tasks/task-tool.ts
+++ b/sdk/packages/core/src/tasks/task-tool.ts
@@ -25,6 +25,7 @@ Use the \`tasks\` tool to manage durable Todo items and explicitly requested sch
 - "Remind me" is ambiguous: ask whether the user wants a reviewed Todo note or an agent to execute work at that time when intent is unclear.
 - Never create both kinds for the same request unless the user explicitly requests both. Check existing items before creating a likely duplicate.
 - Todo instructions and scheduled prompts must be self-contained. Include the goal, constraints, relevant project context, and expected output.
+- Scheduled sessions run in the user's schedules home workspace, not this conversation's folder. Include absolute paths in the scheduled \`prompt\` for any project files or repositories the work must touch.
 - Never approve or start a Todo yourself. Only mutate schedules from an interactive user session, and only update, pause, resume, delete, or run one immediately when the user asks.`;
 
 /** Guidance used while the Todo kind is disabled and only schedules remain. */
@@ -34,7 +35,7 @@ Use the \`tasks\` tool only when the user explicitly asks Cline to execute work 
 
 - One-time schedules require an exact future ISO 8601 \`run_at\` with an offset or Z. Recurring schedules require a five-field \`cron_pattern\` and may include an IANA \`timezone\`.
 - Never create a schedule proactively. Check existing schedules before creating a likely duplicate.
-- Make the scheduled \`prompt\` self-contained because it runs in a new unattended session. Include the goal, constraints, relevant project context, and expected output.
+- Make the scheduled \`prompt\` self-contained because it runs in a new unattended session in the user's schedules home workspace, not this conversation's folder. Include the goal, constraints, expected output, and absolute paths for any project files or repositories the work must touch.
 - Only update, pause, resume, delete, or run a schedule immediately when the user asks for that action.`;
 
 const TodoRequestSchema = TodoTaskInputSchema.extend({

--- a/sdk/packages/shared/src/storage/index.ts
+++ b/sdk/packages/shared/src/storage/index.ts
@@ -19,6 +19,7 @@ export {
 	type ResolveTaskSpecsDirOptions,
 	RULES_CONFIG_DIRECTORY_NAME,
 	resolveAgentConfigSearchPaths,
+	resolveAgentSchedulesDir,
 	resolveAgentsConfigDirPath,
 	resolveChatWorkspacePath,
 	resolveClineDataDir,

--- a/sdk/packages/shared/src/storage/paths.ts
+++ b/sdk/packages/shared/src/storage/paths.ts
@@ -269,6 +269,16 @@ export interface ResolveTaskSpecsDirOptions {
 	workspaceRoot?: string;
 }
 
+/**
+ * Home workspace for agent-created schedules: `~/.cline/schedules/`.
+ * Agent-created schedules are user-level routines, so they anchor here (and
+ * their unattended sessions run here) instead of inheriting whichever chat
+ * workspace happened to create them.
+ */
+export function resolveAgentSchedulesDir(): string {
+	return join(resolveClineDir(), "schedules");
+}
+
 /** Global file-backed agenda tasks: `~/.cline/tasks/`. */
 export function resolveGlobalTaskSpecsDir(): string {
 	return join(resolveClineDir(), "tasks");


### PR DESCRIPTION
## Problem

When an agent creates a scheduled task via the `tasks` tool, the schedule inherits `workspaceRoot`/`cwd` from whichever workspace folder the chat session happened to run in. That scatters user-level routines across chat and project folders:

- they're invisible to any workspace-scoped listing outside that folder (the root cause behind #13613 and #13633),
- they're tied to folders that may be ephemeral or cleaned up, and
- each chat's `tasks` tool scopes `list`/duplicate-checks to its own folder, so agents in different chats can't see (or dedupe against) each other's schedules.

## Change

Agent-created schedules now anchor in a stable user-level home, **`~/.cline/schedules/`**:

- New `resolveAgentSchedulesDir()` in `@cline/shared/storage` and `ensureAgentSchedulesWorkspace()` in core (mirrors `ensureChatWorkspace`).
- The hub transport's scheduled-task `resolveSessionDefaults` returns that home instead of the session's workspace, so agent-created schedules are created, listed, scoped, and executed there — one predictable set across every chat.
- The tasks-tool system-prompt rules now tell the agent that scheduled sessions run in the schedules home, so the scheduled `prompt` must carry absolute paths to any project files or repositories the work touches.

Out of scope, unchanged:
- Schedules created with an explicit workspace (CLI `schedule create --workspace`, desktop routine wizard) keep their chosen workspace.
- Existing schedule rows are not migrated; they remain visible through the all-workspaces listing paths (#13613 desktop, #13633 CLI).

## Trade-off to review

A scheduled session no longer starts in the project the chat was in — repo-touching scheduled work must name absolute paths in its prompt (the prompt rule now says so, and self-contained prompts were already required). In exchange, the agent tool sees one consistent schedule set everywhere, and user routines stop depending on the lifetime of a chat folder.

## Test plan

- Updated the hub vertical-slice test: agent-created schedule's `workspaceRoot` is the canonical `$CLINE_DIR/schedules` home; a client scoped to that home lists it; a client scoped to the chat workspace no longer does. Verified the test fails with the transport change reverted.
- `vitest run src/tasks src/cron src/hub/server/agenda-task-hub.test.ts` — 134 tests pass.
- `tsc --noEmit` on shared and core, `biome check` on all touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)