### PR TITLE
fix(cli): honor configured interactive backend mode

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -242,6 +242,33 @@ describe("createInteractiveSessionRuntime", () => {
 		subscribeToPendingPromptEventsMock.mockReturnValue(() => {});
 	});
 
+	it("lets core select the backend for ordinary interactive sessions", async () => {
+		const runtime = await makeRuntime(makeManager());
+
+		await runtime.ensureReady();
+
+		expect(createCliCoreMock).toHaveBeenCalledWith(
+			expect.objectContaining({ forceLocalBackend: false }),
+		);
+		expect(createCliCoreMock).toHaveBeenCalledWith(
+			expect.not.objectContaining({ backendMode: expect.anything() }),
+		);
+	});
+
+	it.each([
+		["yolo", { mode: "yolo" }],
+		["sandbox", { sandbox: true }],
+	] as const)("forces the local backend for %s interactive sessions", async (_mode, overrides) => {
+		const config: Config = { ...createConfig(), ...overrides };
+		const runtime = await makeRuntime(makeManager(), { config });
+
+		await runtime.ensureReady();
+
+		expect(createCliCoreMock).toHaveBeenCalledWith(
+			expect.objectContaining({ forceLocalBackend: true }),
+		);
+	});
+
 	it("manual compact updates the active session sidecar without restarting", async () => {
 		const sessionId = "sess-active";
 		const messages = [

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -143,14 +143,9 @@ export function createInteractiveSessionRuntime(input: {
 			return sessionManager;
 		}
 		const manager = await createCliCore({
-			// Interactive startup must never wait for a detached hub daemon to boot.
-			// `auto` uses an already-compatible hub when one is immediately available,
-			// but falls back to the local runtime while the hub is prewarmed in the
-			// background. Forcing `hub` here routes through `ensureCompatibleLocalHubUrl`,
-			// which can poll for up to the hub startup timeout before the TUI is usable.
-			// Yolo and sandbox modes must stay fully local and must not prewarm or reuse
-			// the shared daemon hub.
-			backendMode: "auto",
+			// Core owns backend selection. Without an environment override it defaults to
+			// non-blocking `auto` behavior, while configured environment modes are honored.
+			// Yolo and sandbox modes must stay fully local.
 			forceLocalBackend:
 				input.config.mode === "yolo" || input.config.sandbox === true,
 			capabilities: {

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -320,7 +320,7 @@ different process.
 ### Interactive CLI Startup
 
 1. `apps/cli` owns OpenTUI startup and must render the first frame without waiting for detached hub startup.
-2. Interactive sessions use `backendMode: "auto"` so an already-compatible hub can be reused immediately, while a missing hub is only prewarmed in the background and the TUI falls back to a local runtime for responsiveness.
+2. Interactive sessions delegate backend selection to core; absent an environment override, core defaults to the same non-blocking `auto` behavior so an already-compatible hub can be reused immediately while the TUI falls back to a local runtime for responsiveness.
 3. Hub-required flows such as `cline hub`, schedules, connectors, and `--zen` may still call the explicit ensure path because those commands require a live hub before proceeding.
 4. Resume hydration is deferred until after `renderOpenTui()` so loading previous messages cannot block initial TUI paint.
 5. Any future CLI/TUI startup work should follow the same rule: daemon startup, discovery polling, provider catalog refreshes, file indexing, and resume reads must be background or user-action gated unless a command explicitly requires their result before output.


### PR DESCRIPTION
### Related Issue

**Issue:** #13631

### Description

Interactive Cline always supplied `backendMode: "auto"`, which took precedence over the documented `CLINE_SESSION_BACKEND_MODE` and `CLINE_VCR` overrides. As a result, `CLINE_SESSION_BACKEND_MODE=local` could still discover or prewarm a detached Hub.

This change delegates backend selection to core, where the existing resolver honors environment overrides and still defaults to non-blocking `auto` behavior when no override is configured. Yolo and sandbox sessions retain their stronger local override.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes CLI backend selection without altering the UI.

### Additional Notes

The upstream GitHub Actions workflows currently require maintainer approval before they can run for this fork.
