### PR TITLE
fix(cli): respect CLINE_SESSION_BACKEND_MODE in interactive mode

### DIFF
--- a/apps/cli/src/runtime/interactive/session-runtime.test.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.test.ts
@@ -242,6 +242,18 @@ describe("createInteractiveSessionRuntime", () => {
 		subscribeToPendingPromptEventsMock.mockReturnValue(() => {});
 	});
 
+	it("defers backend selection to CLINE_SESSION_BACKEND_MODE", async () => {
+		vi.stubEnv("CLINE_SESSION_BACKEND_MODE", "local");
+		try {
+			const runtime = await makeRuntime(makeManager());
+			await runtime.ensureReady();
+			expect(createCliCoreMock).toHaveBeenCalledTimes(1);
+			expect(createCliCoreMock.mock.calls[0][0]?.backendMode).toBeUndefined();
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
 	it("manual compact updates the active session sidecar without restarting", async () => {
 		const sessionId = "sess-active";
 		const messages = [

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -143,14 +143,13 @@ export function createInteractiveSessionRuntime(input: {
 			return sessionManager;
 		}
 		const manager = await createCliCore({
-			// Interactive startup must never wait for a detached hub daemon to boot.
-			// `auto` uses an already-compatible hub when one is immediately available,
-			// but falls back to the local runtime while the hub is prewarmed in the
-			// background. Forcing `hub` here routes through `ensureCompatibleLocalHubUrl`,
-			// which can poll for up to the hub startup timeout before the TUI is usable.
-			// Yolo and sandbox modes must stay fully local and must not prewarm or reuse
-			// the shared daemon hub.
-			backendMode: "auto",
+			// Backend selection is deferred to ClineCore, which honors
+			// CLINE_SESSION_BACKEND_MODE and otherwise defaults to `auto`: use an
+			// already-compatible hub when one is immediately available, but fall back
+			// to the local runtime while the hub is prewarmed in the background.
+			// Never force `hub` here — `ensureCompatibleLocalHubUrl` can poll for up
+			// to the hub startup timeout before the TUI is usable. Yolo and sandbox
+			// modes stay fully local via `forceLocalBackend` below.
 			forceLocalBackend:
 				input.config.mode === "yolo" || input.config.sandbox === true,
 			capabilities: {


### PR DESCRIPTION
## Root cause

`createInteractiveSessionRuntime` hardcoded `backendMode: "auto"` when calling `createCliCore`. In `createCliCore`, an explicit `backendMode` is forwarded to `ClineCore.create`, and `resolveConfiguredBackendMode` only consults `CLINE_SESSION_BACKEND_MODE` when `options.backendMode` is absent. Because the interactive path always passed `"auto"`, the env var was never read, and interactive sessions prewarmed/connected to a detached hub daemon even with `CLINE_SESSION_BACKEND_MODE=local` (#13631).

The non-interactive (`run-agent`) and ACP entry points already omit `backendMode`, so they honored the env var — only interactive was inconsistent.

## Change

Drop the hardcoded `backendMode: "auto"` in `session-runtime.ts` and defer to `ClineCore`'s env-managed resolution, which honors `CLINE_SESSION_BACKEND_MODE` and otherwise defaults to `"auto"`.

Default behavior is unchanged:
- Env var unset → resolved mode is still `"auto"` (use a compatible hub if immediately available, else local while the hub prewarms).
- Interactive startup still never forces `"hub"`, so it cannot block on `ensureCompatibleLocalHubUrl` polling.
- Yolo/sandbox modes stay fully local via `forceLocalBackend`.

## Validation

- New unit test: with `CLINE_SESSION_BACKEND_MODE=local`, `createCliCore` is called without a `backendMode` override (failed with `expected 'auto' to be undefined` before the fix, passes after).
- `vitest run` (apps/cli): 137 files, 1166 tests, all pass.
- `biome format`/`biome lint` on changed files: clean.

Fixes #13631