### PR TITLE
fix: sync session manifest provider after mid-task provider switch

### DIFF
--- a/apps/vscode/src/sdk/sdk-provider-change-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-provider-change-coordinator.test.ts
@@ -132,6 +132,40 @@ describe("SdkProviderChangeCoordinator", () => {
 		await vi.waitFor(() => expect(options.sessions.replaceActiveSession).toHaveBeenCalledTimes(2))
 	})
 
+	it("syncs the session manifest connection after the restart", async () => {
+		const activeSession = makeActiveSession()
+		const { coordinator } = makeCoordinator({ activeSession })
+
+		await coordinator.restartActiveSessionForProviderChange()
+
+		expect(activeSession.sdkHost.updateSessionConnection).toHaveBeenCalledWith("new-session", {
+			providerId: "deepseek",
+			modelId: "deepseek-v4-flash",
+		})
+	})
+
+	it("tolerates a host without updateSessionConnection", async () => {
+		const activeSession = makeActiveSession()
+		activeSession.sdkHost.updateSessionConnection = undefined as never
+		const { coordinator, options } = makeCoordinator({ activeSession })
+
+		await coordinator.restartActiveSessionForProviderChange()
+
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
+		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("keeps the restart successful when the manifest sync fails", async () => {
+		const activeSession = makeActiveSession()
+		activeSession.sdkHost.updateSessionConnection.mockRejectedValue(new Error("sync failed"))
+		const { coordinator, options } = makeCoordinator({ activeSession })
+
+		await coordinator.restartActiveSessionForProviderChange()
+
+		expect(options.messages.appendAndEmit).not.toHaveBeenCalled()
+		expect(options.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
 	it("emits an error message when restart fails", async () => {
 		const activeSession = makeActiveSession()
 		const { coordinator, options } = makeCoordinator({ activeSession })
@@ -226,6 +260,7 @@ function makeActiveSession(input: { isRunning?: boolean } = {}) {
 			send: vi.fn(),
 			stop: vi.fn().mockResolvedValue(undefined),
 			dispose: vi.fn().mockResolvedValue(undefined),
+			updateSessionConnection: vi.fn().mockResolvedValue(undefined),
 		},
 		unsubscribe: vi.fn(),
 		startResult: { sessionId: "old-session" },

--- a/apps/vscode/src/sdk/sdk-provider-change-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-provider-change-coordinator.ts
@@ -103,6 +103,15 @@ export class SdkProviderChangeCoordinator {
 				task.taskId = startResult.sessionId
 			}
 
+			// A same-ID restart resumes the existing on-disk session manifest
+			// wholesale, so the record still names the provider the task
+			// started with. Sync the connection label after the restarted
+			// runtime is live (the CLI does the same after its restart) so
+			// session history reflects the provider/model that will handle
+			// subsequent turns. Failure here leaves only a stale history
+			// label; the restart itself already succeeded.
+			await this.syncSessionManifestConnection(startResult.sessionId, config)
+
 			await this.options.postStateToWebview()
 			Logger.log(`[SdkController] Session restarted for provider change: ${oldSessionId} -> ${startResult.sessionId}`)
 		} catch (error) {
@@ -122,6 +131,27 @@ export class SdkProviderChangeCoordinator {
 				{ type: "status", payload: { sessionId: oldSessionId, status: "error" } },
 			)
 			await this.options.postStateToWebview()
+		}
+	}
+
+	private async syncSessionManifestConnection(sessionId: string, config: SessionConfig): Promise<void> {
+		if (!config.providerId) {
+			return
+		}
+		const session = this.options.sessions.getActiveSession()
+		if (!session?.sdkHost.updateSessionConnection) {
+			return
+		}
+		try {
+			await session.sdkHost.updateSessionConnection(sessionId, {
+				providerId: config.providerId,
+				...(config.modelId ? { modelId: config.modelId } : {}),
+			})
+		} catch (error) {
+			Logger.warn(
+				`[SdkController] Failed to sync session manifest connection after provider change for ${sessionId}:`,
+				error,
+			)
 		}
 	}
 

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -1,4 +1,5 @@
 import type {
+	ClineCore,
 	ClineCoreListHistoryOptions,
 	ClineCoreStartInput,
 	CompareCheckpointInput,
@@ -21,6 +22,9 @@ import type {
 	StartSessionResult,
 } from "@cline/core"
 import type { AgentResult } from "@cline/shared"
+
+/** Connection fields updatable on a live session. Not exported by @cline/core; derived the same way the CLI does. */
+export type SessionConnectionUpdate = Parameters<ClineCore["updateSessionConnection"]>[1]
 
 export interface SdkSessionHost {
 	readonly runtimeAddress: string | undefined
@@ -60,6 +64,12 @@ export interface SdkSessionHost {
 	pendingPrompts(action: "delete", input: PendingPromptsDeleteInput): Promise<PendingPromptMutationResult>
 	subscribe(listener: (event: CoreSessionEvent) => void): () => void
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void>
+	/**
+	 * Updates provider/model connection options for subsequent turns in an
+	 * active session, and syncs the persisted session manifest so history
+	 * reflects the connection the session is now using.
+	 */
+	updateSessionConnection?(sessionId: string, updates: SessionConnectionUpdate): Promise<void>
 }
 
 export type SdkInitialMessages = NonNullable<StartSessionInput["initialMessages"]>

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -45,7 +45,7 @@ import { getDistinctId } from "@/services/logging/distinctId"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
 import type { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
-import type { SdkSessionHost } from "./session-host"
+import type { SdkSessionHost, SessionConnectionUpdate } from "./session-host"
 import { createVscodeExtraTools } from "./vscode-runtime-builder"
 import { getEffectiveTerminalExecutionMode } from "./vscode-terminal-execution-mode"
 
@@ -110,6 +110,9 @@ export class VscodeSessionHost implements SdkSessionHost {
 	}
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void> {
 		return this.inner.updateSessionModel(sessionId, modelId)
+	}
+	updateSessionConnection?(sessionId: string, updates: SessionConnectionUpdate): Promise<void> {
+		return this.inner.updateSessionConnection(sessionId, updates)
 	}
 
 	static async create(options: VscodeSessionHostOptions): Promise<VscodeSessionHost> {

--- a/apps/vscode/src/test/e2e/provider-switch.test.ts
+++ b/apps/vscode/src/test/e2e/provider-switch.test.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { expect } from "@playwright/test"
+import { E2ETestHelper, e2e } from "./utils/helpers"
+
+function readSessionManifests(clineDir: string): Array<{ id: string; provider: string }> {
+	const sessionsDir = path.join(clineDir, "data", "sessions")
+	try {
+		return readdirSync(sessionsDir).map((id) => {
+			const record = JSON.parse(readFileSync(path.join(sessionsDir, id, `${id}.json`), "utf8"))
+			return { id, provider: record.provider }
+		})
+	} catch {
+		return []
+	}
+}
+
+// A mid-task provider switch restarts the session under the same id, and the
+// SDK's resume path reuses the existing on-disk manifest wholesale — so
+// without the coordinator's post-restart connection sync, the record keeps
+// the provider the task STARTED with forever, and everything keyed on it
+// (history cost display, session listings) reports the wrong provider.
+e2e("Provider switch - mid-task switch updates the session manifest", async ({ app, page, helper, server: _server }, testInfo) => {
+	testInfo.setTimeout(120_000)
+	const clineDir = (await app.evaluate(() => process.env.CLINE_DIR)) as string
+	expect(clineDir).toBeTruthy()
+
+	await E2ETestHelper.openClineSidebar(page)
+	const sidebar = await helper.getSidebar(page)
+	await helper.signin(sidebar)
+
+	// Run a task on the mock cline provider and let the turn complete.
+	const inputbox = sidebar.getByTestId("chat-input")
+	await inputbox.fill("Hello, Cline!")
+	await sidebar.getByTestId("send-button").click()
+	await expect(sidebar.getByText("mock Cline API response")).toBeVisible()
+
+	// The persisted session record starts out on the cline provider.
+	await expect.poll(() => readSessionManifests(clineDir).map((s) => s.provider)).toContain("cline")
+	const before = readSessionManifests(clineDir)
+
+	// Switch to OpenRouter mid-task via the settings view (the chat
+	// model-picker button opens it).
+	await sidebar.getByRole("button", { name: /^cline:/ }).click({ delay: 100 })
+	const providerSelectorInput = sidebar.getByTestId("provider-selector-input")
+	await expect(providerSelectorInput).toBeVisible()
+	await providerSelectorInput.click({ delay: 100 })
+	await sidebar.getByTestId("provider-option-openrouter").click({ delay: 100 })
+	await sidebar.getByRole("textbox", { name: "OpenRouter API Key" }).fill("test-api-key")
+	await sidebar.getByRole("button", { name: "Done" }).click({ delay: 100 })
+
+	// The switch committed: the model-picker relabels.
+	await expect(sidebar.getByRole("button", { name: /^openrouter/ })).toBeVisible({ timeout: 10_000 })
+
+	// The SAME session's manifest re-labels to the new provider once the
+	// idle restart and its connection sync have run.
+	await expect
+		.poll(() => readSessionManifests(clineDir).map((s) => s.provider), { timeout: 30_000 })
+		.toContain("openrouter")
+	const after = readSessionManifests(clineDir)
+	expect(after.map((s) => s.id)).toEqual(before.map((s) => s.id))
+})


### PR DESCRIPTION
Fixes [ENG-2486](https://linear.app/cline-bot/issue/ENG-2486/vs-code-mid-task-provider-switch-never-updates-the-session-manifests) — found while live-verifying #13562 and discussed on that PR's review thread.

## Problem

A mid-task provider change in VS Code restarts the session under the same id (`sdk-provider-change-coordinator` → `replaceActiveSession`). The SDK treats that start as a resume and reuses the existing on-disk manifest wholesale (`manifest = existingManifest` in `local-runtime-host.ts`), and no later write can correct it — `PersistedSessionUpdateInput` has no provider field. Net effect: the persisted session record names the provider the task **started** with, forever. Everything keyed on the record reports the wrong provider after a switch — most visibly the history cost-display policy from #13562 (a task that started on a subscription provider and switched to API billing hides a partly-real cost).

The CLI has the same restart mechanics but already compensates: after its same-id restart it calls `updateSessionConnection` to sync the manifest ("so session history reflects the provider/model that will handle subsequent turns" — `run-interactive.ts`). VS Code was missing that call.

## Change

- Expose the SDK's `updateSessionConnection` through `SdkSessionHost` / `VscodeSessionHost` (type derived from `ClineCore`, the same way the CLI does — it isn't exported from `@cline/core`).
- After a successful provider-change restart, the coordinator syncs the new provider/model to the session manifest. Best-effort: a failure only leaves a stale history label, so it logs a warning instead of taking the restart-failed error path.

## Testing

- **e2e (real VS Code)**: new `provider-switch.test.ts` runs a task on the mock `cline` provider, switches to OpenRouter mid-task through the settings UI, and asserts the same session's on-disk manifest re-labels to `openrouter`. This spec reproduced the bug verbatim before the fix (manifest stayed `cline` indefinitely) and passes with it.
- Coordinator unit tests: sync called with the restarted session's provider/model; hosts without the optional method tolerated; sync failure doesn't disturb the successful restart (12 passed).
- Extension typecheck and biome clean. Full e2e suite: all specs pass except `codex-oauth.test.ts`, which fails identically with and without this change on a real developer machine — its sign-in click opens the actual logged-in browser, whose real OAuth redirect races the spec's simulated one. Unrelated subsystem (from the Codex sign-in toast work); not touched here.

## Note

The residual limitation stands regardless of this fix: a task that ran on multiple providers has one aggregate `totalCost`, so any single provider tag classifies its history cost display approximately. This PR makes the tag match the CLI's semantics (most recent provider) instead of silently diverging (original provider).
