### PR TITLE
test(vscode): prevent E2E worker teardown hangs

### DIFF
--- a/apps/vscode/src/test/e2e/utils/helpers.ts
+++ b/apps/vscode/src/test/e2e/utils/helpers.ts
@@ -420,10 +420,7 @@ export const e2e = test
 						TEMP_PROFILE: "true",
 						E2E_TEST: "true",
 						CLINE_ENVIRONMENT: "local",
-						// OAuth tests intentionally open auth URLs. Capture those URLs in
-						// the isolated test profile instead of launching a real browser;
-						// browser processes outlive VS Code on Linux and keep Playwright's
-						// worker from shutting down cleanly.
+						// Prevent OAuth E2E from launching a browser that can outlive VS Code on Linux.
 						CLINE_CAPTURE_BROWSER: "true",
 						CLINE_DIR: clineTestDir, // Isolate test data from user's ~/.cline
 						CLINE_DATA_DIR: clineDataDir, // Keep SDK/shared storage off the user's real Cline data dir

--- a/apps/vscode/src/test/e2e/utils/helpers.ts
+++ b/apps/vscode/src/test/e2e/utils/helpers.ts
@@ -420,6 +420,11 @@ export const e2e = test
 						TEMP_PROFILE: "true",
 						E2E_TEST: "true",
 						CLINE_ENVIRONMENT: "local",
+						// OAuth tests intentionally open auth URLs. Capture those URLs in
+						// the isolated test profile instead of launching a real browser;
+						// browser processes outlive VS Code on Linux and keep Playwright's
+						// worker from shutting down cleanly.
+						CLINE_CAPTURE_BROWSER: "true",
 						CLINE_DIR: clineTestDir, // Isolate test data from user's ~/.cline
 						CLINE_DATA_DIR: clineDataDir, // Keep SDK/shared storage off the user's real Cline data dir
 						GRPC_RECORDER_FILE_NAME: E2ETestHelper.generateTestFileName(testInfo.title, testInfo.project.name),


### PR DESCRIPTION
## Summary

- capture external browser URLs inside the isolated E2E profile
- prevent OAuth tests from launching a browser process that outlives VS Code on Linux

## Why this started now

#13537 merged on August 27 and added the first driven VS Code E2E coverage for the Codex OAuth flow. Its port-free case clicks the real sign-in path, which calls `openExternal` and launches the system browser. Earlier E2E suites did not exercise this external-browser path.

The merge workflow was cancelled by a subsequent push, so the regression was initially hidden. The following completed Ubuntu runs consistently hit the same teardown failure on `main` and across 11 PRs based on the affected commits.

## Root cause

On Ubuntu, the browser process launched during OAuth can outlive the Electron app. The assertions still pass, but Playwright cannot finish closing the Electron worker and eventually reports `Worker teardown timeout of 60000ms exceeded`.

## Fix

Set the existing `CLINE_CAPTURE_BROWSER` test-harness mode in the shared E2E launch fixture. Calls to `openExternal` are captured inside the isolated test profile instead of starting an unmanaged external process. This preserves the OAuth flow under test while making the external-browser boundary deterministic.

## Verification

- `bunx playwright test src/test/e2e/codex-oauth.test.ts` — passed
- `bunx playwright test` — 11 passed, 2 Windows-only tests skipped, clean worker shutdown
- GitHub Actions `e2e (ubuntu)` — passed on this PR after repeatedly failing with the teardown signature before the change