### PR TITLE
feat(cli): manage Agent Plugins through the Hub

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## 3.0.60
 
+- The config screen now separates Cline Plugins from Agent Plugins discovered by the Hub. Agent Plugins can be enabled or disabled with Space; the Hub persists the state and their skills and MCP servers follow it when the interactive runtime is rebuilt
 - Fixed the background hub process ballooning in memory during long sessions — session status updates were broadcasting a full copy of the conversation transcript to every connected client, which on a large task could grow the process to tens of gigabytes. Upgrading retires the running hub so the fix takes effect on the next command
 - New files are now created with your platform's native line endings
 - Fixed the codebase search tool crashing on files that contain a single enormous line

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -19,6 +19,7 @@ import {
 import { readFileSyncStrippingUtf8Bom } from "@cline/shared/node";
 import { Command } from "commander";
 import { getToolCatalog } from "../runtime/tools";
+import { createCliCore } from "../session/session";
 import { loadInteractiveConfigData } from "../tui/interactive-config";
 import type { CliOutputMode } from "../utils/types";
 
@@ -423,8 +424,20 @@ async function loadInteractiveConfigDataForCommand(
 	cwd: string,
 ): Promise<Awaited<ReturnType<typeof loadInteractiveConfigData>>> {
 	const userInstructionService = createConfigUserInstructionService(cwd);
+	const core = await createCliCore({
+		backendMode: "auto",
+		cwd,
+		workspaceRoot: cwd,
+	});
 	try {
-		await userInstructionService.start();
+		const [, agentPluginSettings] = await Promise.all([
+			userInstructionService.start(),
+			core.settings.list({
+				cwd,
+				workspaceRoot: cwd,
+				includePluginTools: true,
+			}),
+		]);
 		return await loadInteractiveConfigData({
 			userInstructionService,
 			cwd,
@@ -432,9 +445,11 @@ async function loadInteractiveConfigDataForCommand(
 			availabilityContext: {
 				mode: "act",
 			},
+			agentPluginSettings,
 		});
 	} finally {
 		userInstructionService.stop();
+		await core.dispose("cli_config_command_complete");
 	}
 }
 

--- a/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -17,6 +17,7 @@ import {
 import {
 	applyPluginFailures,
 	type InteractiveConfigItem,
+	isToggleableInteractiveConfigItem,
 } from "../../tui/interactive-config";
 import type { Config } from "../../utils/types";
 import { createInteractiveConfigDataLoader } from "./config-data";
@@ -112,6 +113,172 @@ describe("interactive config data loader", () => {
 		);
 		return pluginPath;
 	}
+
+	it("merges the hub-owned Agent Plugin inventory into the config view", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-agent-plugin-"));
+		tempRoots.push(tempRoot);
+		const pluginRoot = "/remote/home/.agents/plugins/portable-review";
+		const calls: unknown[] = [];
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+			loadCoreSettings: async (input) => {
+				calls.push(input);
+				return {
+					workflows: [],
+					rules: [],
+					tools: [],
+					plugins: [
+						{
+							id: "agent-plugin:portable-review",
+							name: "portable-review",
+							path: pluginRoot,
+							kind: "plugin",
+							source: "global-plugin",
+							enabled: true,
+							toggleable: true,
+							agentPlugin: true,
+						},
+					],
+					skills: [
+						{
+							id: "portable-review:review",
+							name: "review",
+							path: `${pluginRoot}/skills/review/SKILL.md`,
+							kind: "skill",
+							source: "global-plugin",
+							enabled: true,
+							toggleable: false,
+							agentPlugin: true,
+							pluginName: "portable-review",
+							pluginPath: pluginRoot,
+						},
+					],
+					mcp: [
+						{
+							id: "portable-review.docs",
+							name: "portable-review.docs",
+							path: `${pluginRoot}/mcp.json`,
+							kind: "mcp",
+							source: "global-plugin",
+							enabled: true,
+							toggleable: false,
+							agentPlugin: true,
+							pluginName: "portable-review",
+							pluginPath: pluginRoot,
+						},
+					],
+				};
+			},
+		});
+
+		const data = await loader.loadConfigData({ includePluginTools: false });
+
+		expect(calls).toEqual([
+			expect.objectContaining({
+				includePluginTools: false,
+			}),
+		]);
+		expect(data.plugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "portable-review",
+					agentPlugin: true,
+					toggleable: true,
+					deletable: false,
+				}),
+			]),
+		);
+		const skill = data.skills.find(
+			(item) => item.id === "portable-review:review",
+		);
+		expect(skill).toMatchObject({
+			pluginName: "portable-review",
+			agentPlugin: true,
+		});
+		expect(skill && isToggleableInteractiveConfigItem(skill)).toBe(false);
+		expect(data.mcp).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "portable-review.docs" }),
+			]),
+		);
+	});
+
+	it("toggles Agent Plugins through the hub without mutating client settings", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-agent-toggle-"));
+		tempRoots.push(tempRoot);
+		const globalSettingsPath = join(tempRoot, "global-settings.json");
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = globalSettingsPath;
+		const pluginRoot = "/hub/home/.agents/plugins/portable-review";
+		const toggleCalls: unknown[] = [];
+		const loader = createInteractiveConfigDataLoader({
+			config: {
+				...createConfig(tempRoot),
+				agentPluginPaths: ["./portable-review"],
+			},
+			toggleCoreSettings: async (input) => {
+				toggleCalls.push(input);
+				return {
+					changedTypes: ["plugins", "skills", "mcp"],
+					snapshot: {
+						workflows: [],
+						rules: [],
+						tools: [],
+						skills: [],
+						mcp: [],
+						plugins: [
+							{
+								id: "agent-plugin:portable-review",
+								name: "portable-review",
+								path: pluginRoot,
+								kind: "plugin",
+								source: "global-plugin",
+								enabled: false,
+								toggleable: true,
+								agentPlugin: true,
+							},
+						],
+					},
+				};
+			},
+		});
+
+		const data = await loader.onToggleConfigItem(
+			{
+				id: "agent-plugin:portable-review",
+				name: "portable-review",
+				path: pluginRoot,
+				kind: "plugin",
+				source: "global-plugin",
+				enabled: true,
+				toggleable: true,
+				deletable: false,
+				agentPlugin: true,
+			},
+			{ includePluginTools: false },
+		);
+
+		expect(toggleCalls).toEqual([
+			expect.objectContaining({
+				type: "plugins",
+				id: "agent-plugin:portable-review",
+				path: pluginRoot,
+				name: "portable-review",
+				enabled: false,
+				agentPluginPaths: ["./portable-review"],
+				includePluginTools: false,
+			}),
+		]);
+		expect(data?.plugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "portable-review",
+					enabled: false,
+					agentPlugin: true,
+				}),
+			]),
+		);
+		await expect(readFile(globalSettingsPath, "utf8")).rejects.toThrow();
+	});
 
 	it("toggles a skill item to the opposite enabled state and refreshes before reload", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));

--- a/apps/cli/src/runtime/interactive/config-data.ts
+++ b/apps/cli/src/runtime/interactive/config-data.ts
@@ -1,4 +1,8 @@
 import {
+	type CoreSettingsListInput,
+	type CoreSettingsMutationResult,
+	type CoreSettingsSnapshot,
+	type CoreSettingsToggleInput,
 	createCoreSettingsService,
 	disablePluginMcpServersInSettings,
 	setDisabledPlugin,
@@ -10,6 +14,7 @@ import {
 import {
 	type InteractiveConfigData,
 	type InteractiveConfigItem,
+	isToggleableInteractiveConfigItem,
 	type LoadInteractiveConfigDataOptions,
 	loadInteractiveConfigData,
 } from "../../tui/interactive-config";
@@ -18,6 +23,12 @@ import type { Config } from "../../utils/types";
 export function createInteractiveConfigDataLoader(input: {
 	config: Config;
 	userInstructionService?: UserInstructionConfigService;
+	loadCoreSettings?: (
+		input: CoreSettingsListInput,
+	) => Promise<CoreSettingsSnapshot>;
+	toggleCoreSettings?: (
+		input: CoreSettingsToggleInput,
+	) => Promise<CoreSettingsMutationResult>;
 }) {
 	const workspaceRoot = () =>
 		input.config.workspaceRoot?.trim() || input.config.cwd;
@@ -28,16 +39,36 @@ export function createInteractiveConfigDataLoader(input: {
 		enableSpawnAgent: input.config.enableSpawnAgent,
 		enableAgentTeams: input.config.enableAgentTeams,
 	});
-	const loadConfigData = async (
+	const buildSettingsInput = (
 		options: LoadInteractiveConfigDataOptions = {},
-	): Promise<InteractiveConfigData> =>
-		await loadInteractiveConfigData({
+	): CoreSettingsListInput => ({
+		cwd: input.config.cwd,
+		workspaceRoot: workspaceRoot(),
+		availabilityContext: availabilityContext(),
+		agentPluginPaths: input.config.agentPluginPaths,
+		includePluginTools: options.includePluginTools,
+	});
+	const buildConfigData = async (
+		options: LoadInteractiveConfigDataOptions,
+		agentPluginSettings: CoreSettingsSnapshot | undefined,
+	): Promise<InteractiveConfigData> => {
+		return await loadInteractiveConfigData({
 			userInstructionService: input.userInstructionService,
 			cwd: input.config.cwd,
 			workspaceRoot: workspaceRoot(),
 			availabilityContext: availabilityContext(),
 			includePluginTools: options.includePluginTools,
+			agentPluginSettings,
 		});
+	};
+	const loadConfigData = async (
+		options: LoadInteractiveConfigDataOptions = {},
+	): Promise<InteractiveConfigData> => {
+		const agentPluginSettings = await input
+			.loadCoreSettings?.(buildSettingsInput(options))
+			.catch(() => undefined);
+		return await buildConfigData(options, agentPluginSettings);
+	};
 
 	const refreshUserInstructionConfigs = async (): Promise<void> => {
 		const service = input.userInstructionService;
@@ -55,6 +86,9 @@ export function createInteractiveConfigDataLoader(input: {
 		item: InteractiveConfigItem,
 		options: LoadInteractiveConfigDataOptions = {},
 	): Promise<InteractiveConfigData | undefined> => {
+		if (!isToggleableInteractiveConfigItem(item)) {
+			return undefined;
+		}
 		const settings = createCoreSettingsService();
 		if (item.kind === "skill" && typeof item.enabled === "boolean") {
 			await settings.toggle({
@@ -72,6 +106,22 @@ export function createInteractiveConfigDataLoader(input: {
 		}
 
 		if (item.kind === "plugin" && typeof item.enabled === "boolean") {
+			if (item.agentPlugin === true) {
+				if (!input.toggleCoreSettings) {
+					throw new Error(
+						"Agent Plugin settings require a connected Cline Hub.",
+					);
+				}
+				const result = await input.toggleCoreSettings({
+					...buildSettingsInput(options),
+					type: "plugins",
+					id: item.id,
+					path: item.path,
+					name: item.name,
+					enabled: !item.enabled,
+				});
+				return await buildConfigData(options, result.snapshot);
+			}
 			if (item.enabled) {
 				disablePluginMcpServersInSettings({ pluginPaths: [item.path] });
 				setDisabledPlugin(item.path, true);
@@ -150,7 +200,11 @@ export function createInteractiveConfigDataLoader(input: {
 		item: InteractiveConfigItem,
 		options: LoadInteractiveConfigDataOptions = {},
 	): Promise<InteractiveConfigData | undefined> => {
-		if (item.kind !== "plugin") {
+		if (
+			item.kind !== "plugin" ||
+			item.agentPlugin === true ||
+			item.deletable === false
+		) {
 			return undefined;
 		}
 		await uninstallPlugin({

--- a/apps/cli/src/runtime/interactive/session-runtime.ts
+++ b/apps/cli/src/runtime/interactive/session-runtime.ts
@@ -2,6 +2,10 @@ import {
 	type AgentEvent,
 	type AgentHooks,
 	type CheckpointEntry,
+	type CoreSettingsListInput,
+	type CoreSettingsMutationResult,
+	type CoreSettingsSnapshot,
+	type CoreSettingsToggleInput,
 	createSessionCompactionState,
 	isSessionNotFoundError,
 	type PendingPromptMutationResult,
@@ -297,6 +301,19 @@ export function createInteractiveSessionRuntime(input: {
 			throw error;
 		});
 		return await startupPromise;
+	};
+
+	const listCoreSettings = async (
+		settingsInput: CoreSettingsListInput,
+	): Promise<CoreSettingsSnapshot> => {
+		const manager = await ensureSessionManager();
+		return await manager.settings.list(settingsInput);
+	};
+	const toggleCoreSettings = async (
+		settingsInput: CoreSettingsToggleInput,
+	): Promise<CoreSettingsMutationResult> => {
+		const manager = await ensureSessionManager();
+		return await manager.settings.toggle(settingsInput);
 	};
 
 	const readCurrentMessages = async (): Promise<CurrentMessagesRead> => {
@@ -883,6 +900,8 @@ export function createInteractiveSessionRuntime(input: {
 
 	return {
 		ensureReady,
+		listCoreSettings,
+		toggleCoreSettings,
 		sendCurrentTurn,
 		updatePendingPrompt,
 		getAccumulatedUsage,

--- a/apps/cli/src/runtime/run-interactive.ts
+++ b/apps/cli/src/runtime/run-interactive.ts
@@ -200,10 +200,6 @@ export async function runInteractive(
 	let pluginChatCommandHostPromise:
 		| Promise<InteractiveSlashCommand[]>
 		| undefined;
-	const configDataLoader = createInteractiveConfigDataLoader({
-		config,
-		userInstructionService,
-	});
 	const ensurePluginChatCommandHost = async (): Promise<
 		InteractiveSlashCommand[]
 	> => {
@@ -301,6 +297,12 @@ export async function runInteractive(
 		onPendingPromptSubmitted: (event) => {
 			uiEvents.emit("pending-prompt-submitted", event);
 		},
+	});
+	const configDataLoader = createInteractiveConfigDataLoader({
+		config,
+		userInstructionService,
+		loadCoreSettings: sessionRuntime.listCoreSettings,
+		toggleCoreSettings: sessionRuntime.toggleCoreSettings,
 	});
 	let modeChangePromise: Promise<void> | undefined;
 	let modeChangeTarget: "plan" | "act" | undefined;

--- a/apps/cli/src/tui/components/dialogs/config-dialogs-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs-helpers.ts
@@ -47,7 +47,10 @@ export function shouldCloseExtDetailForKey(keyName: string): boolean {
 
 export function shouldToggleExtDetailForKey(
 	keyName: string,
-	item: Pick<InteractiveConfigItem, "kind" | "source" | "enabled">,
+	item: Pick<
+		InteractiveConfigItem,
+		"kind" | "source" | "enabled" | "pluginName" | "toggleable"
+	>,
 ): boolean {
 	return (
 		keyName === "space" &&
@@ -57,7 +60,10 @@ export function shouldToggleExtDetailForKey(
 }
 
 export function getExtDetailFooterText(
-	item: Pick<InteractiveConfigItem, "kind" | "source" | "enabled">,
+	item: Pick<
+		InteractiveConfigItem,
+		"kind" | "source" | "enabled" | "pluginName" | "toggleable"
+	>,
 ): string {
 	return typeof item.enabled === "boolean" &&
 		isToggleableInteractiveConfigItem(item)

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -9,6 +9,8 @@ import {
 } from "node:path";
 import {
 	type BuiltinToolAvailabilityContext,
+	type CoreSettingsItem,
+	type CoreSettingsSnapshot,
 	DEFAULT_MCP_CONNECT_TIMEOUT_MS,
 	discoverPluginModulePaths,
 	getPluginDisplayName,
@@ -80,6 +82,12 @@ export interface InteractiveConfigItem {
 		| "global-plugin"
 		| "workspace-plugin";
 	description?: string;
+	/** True when the hub discovered this through agent-plugins.org. */
+	agentPlugin?: boolean;
+	/** Explicitly overrides the default toggle policy for this item. */
+	toggleable?: boolean;
+	/** Explicitly overrides the default delete policy for this item. */
+	deletable?: boolean;
 }
 
 export interface InteractiveConfigData {
@@ -100,8 +108,14 @@ export interface LoadInteractiveConfigDataOptions {
 }
 
 export function isToggleableInteractiveConfigItem(
-	item: Pick<InteractiveConfigItem, "kind" | "source" | "pluginName">,
+	item: Pick<
+		InteractiveConfigItem,
+		"kind" | "source" | "pluginName" | "toggleable"
+	>,
 ): boolean {
+	if (item.toggleable !== undefined) {
+		return item.toggleable;
+	}
 	if (item.kind === "mcp") {
 		return !item.pluginName;
 	}
@@ -324,12 +338,53 @@ export function applyPluginFailures(
 	}
 }
 
+function toAgentPluginInteractiveItem(
+	item: CoreSettingsItem,
+): InteractiveConfigItem {
+	return {
+		id: item.id,
+		name: item.name,
+		path: item.path,
+		enabled: item.enabled,
+		kind: item.kind,
+		source: item.source,
+		description: item.description,
+		pluginName: item.pluginName,
+		pluginPath: item.pluginPath,
+		loadError: item.loadError,
+		agentPlugin: true,
+		toggleable: item.toggleable ?? false,
+		deletable: false,
+		...(item.kind === "plugin" ? { configKind: "plugin" as const } : {}),
+	};
+}
+
+function appendAgentPluginSnapshotItems(
+	target: InteractiveConfigItem[],
+	items: readonly CoreSettingsItem[],
+): void {
+	const existing = new Set(
+		target.map((item) => `${item.kind}\0${item.id}\0${item.path}`),
+	);
+	for (const item of items) {
+		if (item.agentPlugin !== true) {
+			continue;
+		}
+		const key = `${item.kind}\0${item.id}\0${item.path}`;
+		if (!existing.has(key)) {
+			target.push(toAgentPluginInteractiveItem(item));
+			existing.add(key);
+		}
+	}
+}
+
 export async function loadInteractiveConfigData(input: {
 	userInstructionService?: UserInstructionConfigService;
 	cwd: string;
 	workspaceRoot: string;
 	availabilityContext?: BuiltinToolAvailabilityContext;
 	includePluginTools?: boolean;
+	agentPluginSettings?: CoreSettingsSnapshot;
 }): Promise<InteractiveConfigData> {
 	const workflows: InteractiveConfigItem[] = [];
 	const rules: InteractiveConfigItem[] = [];
@@ -518,14 +573,23 @@ export async function loadInteractiveConfigData(input: {
 		}
 	}
 
+	if (input.agentPluginSettings) {
+		appendAgentPluginSnapshotItems(plugins, input.agentPluginSettings.plugins);
+		appendAgentPluginSnapshotItems(skills, input.agentPluginSettings.skills);
+		appendAgentPluginSnapshotItems(mcp, input.agentPluginSettings.mcp);
+	}
+
+	const existsLocallyOrComesFromHub = (item: InteractiveConfigItem) =>
+		item.agentPlugin === true || existsSync(item.path);
+
 	return {
-		workflows: toSorted(workflows.filter((item) => existsSync(item.path))),
-		rules: toSorted(rules.filter((item) => existsSync(item.path))),
-		skills: toSorted(skills.filter((item) => existsSync(item.path))),
-		hooks: toSorted(hooks.filter((item) => existsSync(item.path))),
-		agents: toSorted(agents.filter((item) => existsSync(item.path))),
-		plugins: toSorted(plugins.filter((item) => existsSync(item.path))),
-		mcp: toSorted(mcp.filter((item) => existsSync(item.path))),
+		workflows: toSorted(workflows.filter(existsLocallyOrComesFromHub)),
+		rules: toSorted(rules.filter(existsLocallyOrComesFromHub)),
+		skills: toSorted(skills.filter(existsLocallyOrComesFromHub)),
+		hooks: toSorted(hooks.filter(existsLocallyOrComesFromHub)),
+		agents: toSorted(agents.filter(existsLocallyOrComesFromHub)),
+		plugins: toSorted(plugins.filter(existsLocallyOrComesFromHub)),
+		mcp: toSorted(mcp.filter(existsLocallyOrComesFromHub)),
 		tools: toSorted(tools),
 		workflowSlashCommands,
 		pluginDiagnosticsLoaded: input.includePluginTools !== false,

--- a/apps/cli/src/tui/views/config-view-helpers.ts
+++ b/apps/cli/src/tui/views/config-view-helpers.ts
@@ -128,12 +128,61 @@ export function resolveActiveConfigItems(
 	}
 }
 
+export interface ConfigPluginSection {
+	label: string;
+	items: InteractiveConfigItem[];
+}
+
+export function getConfigPluginSections(
+	items: readonly InteractiveConfigItem[],
+): ConfigPluginSection[] {
+	const clinePlugins = items.filter((item) => item.agentPlugin !== true);
+	const agentPlugins = items.filter((item) => item.agentPlugin === true);
+	return [
+		...(clinePlugins.length > 0
+			? [
+					{
+						label: `Cline Plugins (${clinePlugins.length})`,
+						items: clinePlugins,
+					},
+				]
+			: []),
+		...(agentPlugins.length > 0
+			? [
+					{
+						label: `Agent Plugins (${agentPlugins.length})`,
+						items: agentPlugins,
+					},
+				]
+			: []),
+	];
+}
+
+export function getConfigTabCountHeading(
+	tab: InteractiveConfigTab,
+	itemCount: number,
+): string | undefined {
+	return tab === "plugins" ? undefined : `${toTabLabel(tab)} (${itemCount})`;
+}
+
+export function shouldRenderConfigItemAsEnabled(
+	item: InteractiveConfigItem,
+	enabledState: "enabled" | "disabled" | "partial",
+): boolean {
+	return (
+		enabledState === "enabled" &&
+		(isToggleableInteractiveConfigItem(item) || item.agentPlugin === true)
+	);
+}
+
 export function isToggleableConfigItem(item: InteractiveConfigItem): boolean {
 	return isToggleableInteractiveConfigItem(item);
 }
 
 export function isDeletableConfigItem(item: InteractiveConfigItem): boolean {
-	return item.kind === "plugin";
+	return (
+		item.deletable ?? (item.kind === "plugin" && item.agentPlugin !== true)
+	);
 }
 
 export function resolveConfigItemSelectAction(

--- a/apps/cli/src/tui/views/config-view.test.ts
+++ b/apps/cli/src/tui/views/config-view.test.ts
@@ -5,11 +5,16 @@ import {
 	getAdjacentConfigTab,
 	getConfigFooterText,
 	getConfigItemDisplayName,
+	getConfigPluginSections,
+	getConfigTabCountHeading,
+	isDeletableConfigItem,
 	isInlineConfigAction,
 	isToggleableConfigItem,
+	resolveConfigItemDeleteAction,
 	resolveConfigItemSelectAction,
 	resolveConfigItemToggleAction,
 	resolveInitialConfigTab,
+	shouldRenderConfigItemAsEnabled,
 } from "./config-view-helpers";
 
 function createItem(
@@ -69,6 +74,65 @@ describe("config view helpers", () => {
 				}),
 			),
 		).toBe(false);
+	});
+
+	it("lets users toggle hub-discovered Agent Plugins without deleting them", () => {
+		const plugin = createItem({
+			kind: "plugin",
+			agentPlugin: true,
+			toggleable: true,
+			deletable: false,
+			source: "global-plugin",
+		});
+
+		expect(isToggleableConfigItem(plugin)).toBe(true);
+		expect(isDeletableConfigItem(plugin)).toBe(false);
+		expect(resolveConfigItemToggleAction(plugin)).toEqual({
+			kind: "toggle-item",
+			item: plugin,
+		});
+		expect(resolveConfigItemDeleteAction(plugin)).toBeUndefined();
+		expect(resolveConfigItemSelectAction(plugin)).toEqual({
+			kind: "toggle-item",
+			item: plugin,
+		});
+	});
+
+	it("separates Cline and Agent Plugins into labeled sections", () => {
+		const clinePlugin = createItem({
+			kind: "plugin",
+			name: "cline-plugin",
+			source: "workspace-plugin",
+		});
+		const agentPlugin = createItem({
+			kind: "plugin",
+			name: "portable-plugin",
+			source: "global-plugin",
+			agentPlugin: true,
+		});
+
+		expect(getConfigPluginSections([clinePlugin, agentPlugin])).toEqual([
+			{ label: "Cline Plugins (1)", items: [clinePlugin] },
+			{ label: "Agent Plugins (1)", items: [agentPlugin] },
+		]);
+	});
+
+	it("uses section counts instead of a combined Plugins heading", () => {
+		expect(getConfigTabCountHeading("plugins", 10)).toBeUndefined();
+		expect(getConfigTabCountHeading("skills", 20)).toBe("Skills (20)");
+	});
+
+	it("renders a loaded Agent Plugin as enabled", () => {
+		const agentPlugin = createItem({
+			kind: "plugin",
+			agentPlugin: true,
+			toggleable: true,
+		});
+
+		expect(shouldRenderConfigItemAsEnabled(agentPlugin, "enabled")).toBe(true);
+		expect(shouldRenderConfigItemAsEnabled(agentPlugin, "disabled")).toBe(
+			false,
+		);
 	});
 
 	it("resolves Enter/Tab on a skill row to details", () => {

--- a/apps/cli/src/tui/views/config-view.tsx
+++ b/apps/cli/src/tui/views/config-view.tsx
@@ -25,6 +25,8 @@ import {
 	getAdjacentConfigTab,
 	getConfigFooterText,
 	getConfigItemDisplayName,
+	getConfigPluginSections,
+	getConfigTabCountHeading,
 	getConfigTabs,
 	getPluginDiagnosticsLoadingText,
 	isInlineConfigAction,
@@ -34,6 +36,7 @@ import {
 	resolveConfigItemSelectAction,
 	resolveConfigItemToggleAction,
 	resolveInitialConfigTab,
+	shouldRenderConfigItemAsEnabled,
 	toTabLabel,
 } from "./config-view-helpers";
 
@@ -298,6 +301,16 @@ function appendSkillRows(
 	}
 }
 
+function appendPluginRows(
+	rows: ConfigRow[],
+	items: InteractiveConfigItem[],
+): void {
+	for (const section of getConfigPluginSections(items)) {
+		rows.push({ kind: "head", label: section.label });
+		appendExtRows(rows, section.items);
+	}
+}
+
 function withOptimisticToggle(
 	data: InteractiveConfigData,
 	item: InteractiveConfigItem,
@@ -477,10 +490,13 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			r.push({ kind: "toggle", id: "verbose", label: "Verbose" });
 		} else {
 			const activeItems = resolveActiveConfigItems(configData, activeTab);
-			r.push({
-				kind: "head",
-				label: `${toTabLabel(activeTab)} (${activeItems.length})`,
-			});
+			const countHeading = getConfigTabCountHeading(
+				activeTab,
+				activeItems.length,
+			);
+			if (countHeading) {
+				r.push({ kind: "head", label: countHeading });
+			}
 
 			if (activeItems.length === 0 && !pluginToolsLoading) {
 				r.push({
@@ -504,6 +520,21 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 				}
 			} else if (activeTab === "skills") {
 				appendSkillRows(r, activeItems);
+			} else if (activeTab === "plugins") {
+				appendPluginRows(r, activeItems);
+				if (pluginToolsLoading) {
+					const loadingText = getPluginDiagnosticsLoadingText(activeTab);
+					r.push({
+						kind: "detail",
+						text: loadingText ?? "Loading plugin diagnostics...",
+					});
+				}
+				if (pluginToolsError) {
+					r.push({
+						kind: "detail",
+						text: pluginToolsError,
+					});
+				}
 			} else {
 				for (const item of activeItems) {
 					r.push({
@@ -521,19 +552,6 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 										lastError: item.loadError,
 									})
 								: getPluginLoadErrorLabel(item),
-					});
-				}
-				if (activeTab === "plugins" && pluginToolsLoading) {
-					const loadingText = getPluginDiagnosticsLoadingText(activeTab);
-					r.push({
-						kind: "detail",
-						text: loadingText ?? "Loading plugin diagnostics...",
-					});
-				}
-				if (activeTab === "plugins" && pluginToolsError) {
-					r.push({
-						kind: "detail",
-						text: pluginToolsError,
 					});
 				}
 			}
@@ -871,11 +889,10 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 											: "○ "
 								: "";
 						const rightLabel = row.rightLabel ?? "";
-						const toggleable = isToggleableConfigItem(row.item);
 						const prefix = " ".repeat(row.indent ?? 0);
 						const rowColor = row.item.loadError
 							? "red"
-							: toggleable && enabledState === "enabled"
+							: shouldRenderConfigItemAsEnabled(row.item, enabledState)
 								? palette.success
 								: enabledState === "partial"
 									? "yellow"


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This stacked PR adds the CLI client integration for the Hub-managed Agent Plugins capability introduced by #13652.

- Reads Agent Plugin inventory and enabled state from the Hub settings API.
- Displays separate `Cline Plugins` and `Agent Plugins` sections in the config view.
- Lets users enable or disable Agent Plugins through the Hub instead of maintaining client-local state.
- Refreshes plugin and skill data after Hub settings changes so the CLI reflects the authoritative state.
- Keeps Agent Plugins distinct from uninstallable Cline marketplace plugins.

### Test Procedure

1. Ran the focused config data and config view suites: 2 files and 41 tests passed.
2. Ran `bun run typecheck` from `apps/cli`.
3. Ran the production CLI build with `bun run build` from `apps/cli`.
4. Previously verified the interactive flow with Tuistory: the installed Agent Plugin rendered enabled, Space disabled it through the Hub, its contributed skill disappeared, the manifest name persisted in Hub global settings, and re-enabling restored both the plugin and skill.

The primary risks are incorrect section grouping, stale Hub-backed state, and toggles mutating client-local state. The focused tests cover projection and interaction behavior, while the live TUI verification exercises the end-to-end Hub mutation path.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


git clone https://github.com/agentplugins/agent-plugins-example into your ~/.agents/plugins directory and then start CLI from this branch with `bun run cli config` and confirms the skills from the agent plugin are showing up in Skills, and the agent plugin is showing up in Plugins:

<img width="979" height="536" alt="Screenshot 2026-08-27 at 7 28 29 PM" src="https://github.com/user-attachments/assets/0689233e-8e95-44f1-8a32-0ee03d28e43f" />

<img width="989" height="570" alt="Screenshot 2026-08-27 at 7 28 21 PM" src="https://github.com/user-attachments/assets/4e49a6de-81b7-425d-8c89-5e531542a9c7" />


### Additional Notes

- This PR is stacked on #13652 and intentionally targets `bee/agent-plugins-support`.
- Its diff is limited to 11 files under `apps/cli`.
- Merge #13652 first; this PR can then be retargeted to `main` if GitHub does not update the base automatically.
- No matching GitHub issue was found, so the Related Issue placeholder remains for maintainers to replace with the approved issue or discussion.
