### PR TITLE
feat(desktop): manage Agent Plugins through the Hub

### DIFF
--- a/apps/examples/desktop-app/CHANGELOG.md
+++ b/apps/examples/desktop-app/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ## 0.0.20
 
+- Customize now separates Cline Plugins from Agent Plugins discovered by the Hub. Agent Plugin switches use Hub-managed enablement, contributed skills appear in the Skills inventory, and connected desktop views refresh when Hub settings change
 - Cline Desktop now ships on Windows: releases include a code-signed x64 installer, and installed apps auto-update on the same feed macOS does
 - Windows shell fixes: background processes (the sidecar, git) no longer pop visible console windows; updates now download in the background and install when you restart the app; the MCP settings path falls back to `USERPROFILE` when `HOME` is unset
 - Tool results that return images — screenshots from browser or MCP tools — now render as inline images you can click to expand, with a carousel for stepping through multiple images, instead of raw base64 text

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1036,6 +1036,34 @@ async function listUserInstructionConfigs(
 	} finally {
 		userInstructionService.stop();
 	}
+	const knownSkillPaths = new Set(
+		skills.flatMap((skill) => {
+			if (!skill || typeof skill !== "object") return [];
+			const path = (skill as JsonRecord).path;
+			return typeof path === "string" ? [path] : [];
+		}),
+	);
+	for (const skill of hubSettings.skills) {
+		if (
+			skill.agentPlugin !== true ||
+			skill.enabled === false ||
+			knownSkillPaths.has(skill.path)
+		) {
+			continue;
+		}
+		skills.push({
+			id: skill.id,
+			name: skill.name,
+			description: skill.description,
+			instructions: "",
+			path: skill.path,
+			enabled: true,
+			source: skill.source,
+			agentPlugin: true,
+			pluginName: skill.pluginName,
+		});
+		knownSkillPaths.add(skill.path);
+	}
 
 	const disabledTools = new Set(readGlobalSettings().disabledTools ?? []);
 	// Pin spawn/teams availability so this listing matches the hub's
@@ -1055,9 +1083,15 @@ async function listUserInstructionConfigs(
 		runtimeCommands,
 		agents: loadAgents(),
 		plugins: hubSettings.plugins.map((plugin) => ({
+			id: plugin.id,
 			name: plugin.name,
 			path: plugin.path,
 			enabled: plugin.enabled !== false,
+			source: plugin.source,
+			toggleable: plugin.toggleable === true,
+			agentPlugin: plugin.agentPlugin === true,
+			description: plugin.description,
+			loadError: plugin.loadError,
 			contributions: plugin.contributions,
 		})),
 		tools: [

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1193,6 +1193,33 @@ describe("Code sidecar runtime capabilities", () => {
 			},
 		]);
 	});
+
+	it("forwards Hub settings changes so open desktop views can refresh", async () => {
+		const { createSidecarContext, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() } as never);
+
+		handleHubLiveEvent(ctx, {
+			event: "settings.changed",
+			payload: {
+				types: ["plugins", "skills", "mcp"],
+			},
+		});
+
+		expect(readEvents(ctx)).toEqual([
+			{
+				type: "event",
+				event: {
+					name: "settings.changed",
+					payload: {
+						types: ["plugins", "skills", "mcp"],
+					},
+				},
+			},
+		]);
+	});
 });
 
 describe("disposeSidecarContext attachment cleanup", () => {

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -811,6 +811,10 @@ export function handleHubLiveEvent(
 		});
 		return;
 	}
+	if (event.event === "settings.changed") {
+		sendEvent(ctx, event.event, event.payload ?? {});
+		return;
+	}
 
 	const sessionId = typeof event.sessionId === "string" ? event.sessionId : "";
 	if (!sessionId) {

--- a/apps/examples/desktop-app/sidecar/marketplace.test.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.test.ts
@@ -187,4 +187,19 @@ describe("official plugin install detection", () => {
 		);
 		expect(populated.installedKeys).toEqual(["plugin:goal"]);
 	});
+
+	it("does not match portable Agent Plugins to Cline marketplace entries", () => {
+		const result = listMarketplaceInstalledEntries({ entries: [GOAL_ENTRY] }, {
+			plugins: [
+				{
+					id: "agent-plugin:goal",
+					name: "goal",
+					path: "/home/user/.agents/plugins/goal",
+					agentPlugin: true,
+				},
+			],
+		} as JsonRecord);
+
+		expect(result.installedKeys).toEqual([]);
+	});
 });

--- a/apps/examples/desktop-app/sidecar/marketplace.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.ts
@@ -714,6 +714,7 @@ function hasMatchingInventoryItem(
 	return items.some((item) => {
 		if (!item || typeof item !== "object") return false;
 		const record = item as JsonRecord;
+		if (record.agentPlugin === true) return false;
 		const values = [
 			typeof record.name === "string" ? record.name : undefined,
 			typeof record.id === "string" ? record.id : undefined,

--- a/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/ui/button";
 import { desktopClient } from "@/lib/desktop-client";
 import { cn } from "@/lib/utils";
 import { PageFrame, PageHeader } from "../page-layout";
-import { CustomizationSectionView } from "./extensions-view";
+import {
+	CustomizationSectionView,
+	invalidateExtensionInventoryCache,
+} from "./extensions-view";
 import { McpServersContent } from "./mcp-view";
 
 /**
@@ -74,6 +77,15 @@ export function CustomizeView({
 		}, 0);
 		return () => window.clearTimeout(timeoutId);
 	}, [refreshCounts]);
+
+	useEffect(
+		() =>
+			desktopClient.subscribe("settings.changed", () => {
+				invalidateExtensionInventoryCache();
+				void refreshCounts();
+			}),
+		[refreshCounts],
+	);
 
 	const handleInventoryChanged = useCallback(() => {
 		void refreshCounts();

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CustomizationSectionView,
+	invalidateExtensionInventoryCache,
+} from "./extensions-view";
+
+const { fetchMarketplaceCatalog, invoke } = vi.hoisted(() => ({
+	fetchMarketplaceCatalog: vi.fn(),
+	invoke: vi.fn(),
+}));
+
+vi.mock("@/lib/desktop-client", () => ({
+	desktopClient: { invoke },
+	openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/marketplace", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/lib/marketplace")>()),
+	fetchMarketplaceCatalog,
+}));
+
+const EMPTY_CATALOG = {
+	version: 1,
+	counts: { total: 0, plugins: 0, skills: 0, mcps: 0 },
+	tags: [],
+	entries: [],
+};
+
+const AGENT_PLUGIN = {
+	id: "agent-plugin:/Users/test/.agents/plugins/example",
+	name: "agent-plugins-example",
+	path: "/Users/test/.agents/plugins/example",
+	enabled: true,
+	source: "agent-plugin",
+	toggleable: true,
+	agentPlugin: true,
+	contributions: {
+		inspectionStatus: "available",
+		capabilities: ["skills"],
+		tools: [],
+		skills: ["example-skill"],
+		rules: [],
+		hooks: [],
+		commands: [],
+		mcpServers: [],
+		providers: [],
+	},
+};
+
+const AGENT_PLUGIN_SKILL = {
+	name: "example-skill",
+	description: "A skill contributed by an Agent Plugin.",
+	instructions: "",
+	path: "/Users/test/.agents/plugins/example/skills/example-skill/SKILL.md",
+	agentPlugin: true,
+	pluginName: "agent-plugins-example",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	invalidateExtensionInventoryCache();
+	fetchMarketplaceCatalog.mockReset();
+	fetchMarketplaceCatalog.mockResolvedValue(EMPTY_CATALOG);
+	invoke.mockReset();
+	invoke.mockImplementation((command: string) => {
+		if (command === "list_marketplace_installed_entries") {
+			return Promise.resolve({ installedKeys: [] });
+		}
+		if (command === "list_user_instruction_configs") {
+			return Promise.resolve({
+				workspaceRoot: "/workspace",
+				rules: [],
+				workflows: [],
+				skills: [AGENT_PLUGIN_SKILL],
+				agents: [],
+				plugins: [AGENT_PLUGIN],
+				tools: [],
+				hooks: [],
+				mcp: { servers: [] },
+				warnings: [],
+			});
+		}
+		return Promise.reject(new Error(`Unexpected command: ${command}`));
+	});
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+	invalidateExtensionInventoryCache();
+});
+
+describe("CustomizationSectionView Agent Plugin inventory", () => {
+	it("shows Hub-managed Agent Plugins in the installed Plugins view", async () => {
+		await act(async () => {
+			root.render(
+				<CustomizationSectionView
+					catalogPrimitive="plugin"
+					chrome="embedded"
+					marketplaceVariant="installed"
+					section="Plugins"
+				/>,
+			);
+		});
+
+		await vi.waitFor(() => {
+			expect(container.textContent).toContain("agent-plugins-example");
+			expect(container.textContent).toContain("Agent Plugin");
+		});
+	});
+
+	it("shows Agent Plugin skills in the installed Skills view", async () => {
+		await act(async () => {
+			root.render(
+				<CustomizationSectionView
+					catalogPrimitive="skill"
+					chrome="embedded"
+					marketplaceVariant="installed"
+					section="Skills"
+				/>,
+			);
+		});
+
+		await vi.waitFor(() => {
+			expect(container.textContent).toContain("example-skill");
+			expect(container.textContent).toContain("Agent Plugin");
+		});
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -84,6 +84,8 @@ type SkillItem = {
 	description?: string;
 	instructions: string;
 	path: string;
+	agentPlugin?: boolean;
+	pluginName?: string;
 };
 
 type CommandItem = {
@@ -94,6 +96,8 @@ type CommandItem = {
 	instructions: string;
 	path: string;
 	scope: ItemScope;
+	agentPlugin?: boolean;
+	pluginName?: string;
 };
 
 type ItemScope = "Global" | "Project";
@@ -104,9 +108,15 @@ type AgentItem = {
 };
 
 type PluginItem = {
+	id: string;
 	name: string;
 	path: string;
 	enabled: boolean;
+	source?: string;
+	toggleable?: boolean;
+	agentPlugin?: boolean;
+	description?: string;
+	loadError?: string;
 	contributions?: PluginContributions;
 };
 
@@ -774,6 +784,8 @@ export function CustomizationSectionView({
 			instructions: skill.instructions,
 			path: skill.path,
 			scope: getPathScope(skill.path, workspaceRoot),
+			agentPlugin: skill.agentPlugin,
+			pluginName: skill.pluginName,
 		}));
 		return [...workflowItems, ...skillItems].sort((a, b) =>
 			a.name.localeCompare(b.name),
@@ -825,9 +837,11 @@ export function CustomizationSectionView({
 		for (const plugin of plugins) {
 			const normalized = normalizePath(plugin.path);
 			if (
-				normalizedRoot &&
-				normalized.startsWith(`${normalizedRoot}/`) &&
-				normalized.includes("/.cline/plugins")
+				plugin.source === "workspace-plugin" ||
+				(normalizedRoot &&
+					normalized.startsWith(`${normalizedRoot}/`) &&
+					(normalized.includes("/.cline/plugins") ||
+						normalized.includes("/.agents/plugins")))
 			) {
 				project.push(plugin);
 			} else {
@@ -871,6 +885,14 @@ export function CustomizationSectionView({
 			})),
 		],
 		[globalPlugins, projectPlugins],
+	);
+	const clinePlugins = useMemo(
+		() => scopedPlugins.filter(({ plugin }) => plugin.agentPlugin !== true),
+		[scopedPlugins],
+	);
+	const agentPlugins = useMemo(
+		() => scopedPlugins.filter(({ plugin }) => plugin.agentPlugin === true),
+		[scopedPlugins],
 	);
 
 	const scopedRules = useMemo(
@@ -976,15 +998,17 @@ export function CustomizationSectionView({
 				key={key}
 				className="relative grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 			>
-				<div className="absolute top-4 right-4">
-					{renderLocalActionButton({
-						key,
-						type: item.type,
-						id: item.id,
-						name: item.name,
-						path: item.path,
-					})}
-				</div>
+				{item.agentPlugin !== true ? (
+					<div className="absolute top-4 right-4">
+						{renderLocalActionButton({
+							key,
+							type: item.type,
+							id: item.id,
+							name: item.name,
+							path: item.path,
+						})}
+					</div>
+				) : null}
 				<div className="flex min-w-0 items-center gap-2 pr-28">
 					{item.type === "workflow" ? (
 						<Play className="h-4 w-4 shrink-0 text-primary" />
@@ -998,6 +1022,11 @@ export function CustomizationSectionView({
 					<Badge variant="outline" className="shrink-0 text-muted-foreground">
 						{item.type}
 					</Badge>
+					{item.agentPlugin === true ? (
+						<Badge variant="outline" className="shrink-0 text-muted-foreground">
+							Agent Plugin
+						</Badge>
+					) : null}
 					{context?.matchedEntries?.length ? (
 						<Badge variant="outline" className="shrink-0 text-muted-foreground">
 							Marketplace
@@ -1057,6 +1086,9 @@ export function CustomizationSectionView({
 						{plugin.name}
 					</h3>
 					<ScopeBadge scope={scope} />
+					<Badge variant="outline" className="shrink-0 text-muted-foreground">
+						{plugin.agentPlugin === true ? "Agent Plugin" : "Cline Plugin"}
+					</Badge>
 					{context?.matchedEntries?.length ? (
 						<Badge variant="outline" className="shrink-0 text-muted-foreground">
 							Marketplace
@@ -1071,18 +1103,33 @@ export function CustomizationSectionView({
 							void setPluginEnabled(plugin);
 						}}
 						onClick={(event) => event.stopPropagation()}
-						disabled={togglingPluginPaths.has(plugin.path)}
+						disabled={
+							plugin.toggleable === false ||
+							togglingPluginPaths.has(plugin.path)
+						}
 						aria-label={`Toggle ${plugin.name}`}
 					/>
-					{renderPluginMenu({
-						key,
-						type: "plugin",
-						id: plugin.name,
-						name: plugin.name,
-						path: plugin.path,
-					})}
+					{plugin.agentPlugin !== true
+						? renderPluginMenu({
+								key,
+								type: "plugin",
+								id: plugin.name,
+								name: plugin.name,
+								path: plugin.path,
+							})
+						: null}
 				</summary>
 				<div className="mt-3">
+					{plugin.description?.trim() ? (
+						<p className="mb-2 whitespace-pre-line text-xs text-muted-foreground">
+							{plugin.description}
+						</p>
+					) : null}
+					{plugin.loadError?.trim() ? (
+						<p className="mb-2 whitespace-pre-line text-xs text-destructive">
+							{plugin.loadError}
+						</p>
+					) : null}
 					{plugin.contributions?.inspectionStatus === "disabled" ? (
 						<p className="mb-2 text-xs text-muted-foreground">
 							Enable this plugin to inspect its dynamic contributions.
@@ -1193,19 +1240,21 @@ export function CustomizationSectionView({
 
 	const installedCatalogLocalItems =
 		catalogPrimitive === "skill"
-			? commandItems.map(
-					(item): MarketplaceLocalInstalledItem => ({
-						key: `${item.type}:${item.path}`,
-						matchValues: getLocalMarketplaceMatchValues(
-							item.id,
-							item.name,
-							item.path,
-						),
-						render: (context) => renderSkillCard(item, context),
-					}),
-				)
+			? commandItems
+					.filter((item) => item.agentPlugin !== true)
+					.map(
+						(item): MarketplaceLocalInstalledItem => ({
+							key: `${item.type}:${item.path}`,
+							matchValues: getLocalMarketplaceMatchValues(
+								item.id,
+								item.name,
+								item.path,
+							),
+							render: (context) => renderSkillCard(item, context),
+						}),
+					)
 			: catalogPrimitive === "plugin"
-				? scopedPlugins.map(
+				? clinePlugins.map(
 						(item): MarketplaceLocalInstalledItem => ({
 							key: item.plugin.path,
 							matchValues: getLocalMarketplaceMatchValues(
@@ -1520,68 +1569,19 @@ export function CustomizationSectionView({
 			{activeTab === "Plugins" && !catalogPrimitive && (
 				<div>
 					<p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-						Plugins discovered from workspace and global plugin directories.
+						Cline and portable Agent Plugins discovered by the shared Hub.
+						Changes apply when a session is rebuilt or started.
 					</p>
 
 					<div className="mb-6">
 						<h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							Global Plugins
+							Cline Plugins ({clinePlugins.length})
 						</h3>
 						<div className="flex flex-col gap-3">
-							{globalPlugins.map((plugin) => (
-								<div
-									key={plugin.path}
-									className="rounded-lg border border-border px-5 py-4"
-								>
-									<div className="flex items-center gap-3">
-										<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
-											{plugin.name}
-										</h3>
-										<span className="text-xs text-muted-foreground">
-											{plugin.enabled ? "Enabled" : "Disabled"}
-										</span>
-										<Switch
-											checked={plugin.enabled}
-											onCheckedChange={() => {
-												void setPluginEnabled(plugin);
-											}}
-											disabled={togglingPluginPaths.has(plugin.path)}
-											aria-label={`Toggle ${plugin.name}`}
-										/>
-									</div>
-									<div className="mt-3 ml-7 flex max-h-56 flex-col gap-2 overflow-y-auto">
-										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
-											(tool) => {
-												return (
-													<div
-														key={tool.id}
-														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-													>
-														<div className="min-w-0">
-															<p className="text-xs font-medium text-foreground">
-																{tool.name}
-															</p>
-															<p className="text-xs text-muted-foreground">
-																{tool.description?.trim() ||
-																	"No description available."}
-															</p>
-														</div>
-													</div>
-												);
-											},
-										)}
-										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
-											0 && (
-											<p className="text-xs text-muted-foreground">
-												No plugin tools found.
-											</p>
-										)}
-									</div>
-								</div>
-							))}
-							{globalPlugins.length === 0 && (
+							{clinePlugins.map((plugin) => renderPluginCard(plugin))}
+							{clinePlugins.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No global plugins found.
+									No Cline Plugins found.
 								</p>
 							)}
 						</div>
@@ -1589,63 +1589,13 @@ export function CustomizationSectionView({
 
 					<div>
 						<h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-							Project Plugins
+							Agent Plugins ({agentPlugins.length})
 						</h3>
 						<div className="flex flex-col gap-3">
-							{projectPlugins.map((plugin) => (
-								<div
-									key={plugin.path}
-									className="rounded-lg border border-border px-5 py-4"
-								>
-									<div className="flex items-center gap-3">
-										<h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
-											{plugin.name}
-										</h3>
-										<span className="text-xs text-muted-foreground">
-											{plugin.enabled ? "Enabled" : "Disabled"}
-										</span>
-										<Switch
-											checked={plugin.enabled}
-											onCheckedChange={() => {
-												void setPluginEnabled(plugin);
-											}}
-											disabled={togglingPluginPaths.has(plugin.path)}
-											aria-label={`Toggle ${plugin.name}`}
-										/>
-									</div>
-									<div className="mt-3 ml-7 flex max-h-56 flex-col gap-2 overflow-y-auto">
-										{(pluginToolsByPluginKey.get(plugin.path) ?? []).map(
-											(tool) => {
-												return (
-													<div
-														key={tool.id}
-														className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2"
-													>
-														<div className="min-w-0">
-															<p className="text-xs font-medium text-foreground">
-																{tool.name}
-															</p>
-															<p className="text-xs text-muted-foreground">
-																{tool.description?.trim() ||
-																	"No description available."}
-															</p>
-														</div>
-													</div>
-												);
-											},
-										)}
-										{(pluginToolsByPluginKey.get(plugin.path)?.length ?? 0) ===
-											0 && (
-											<p className="text-xs text-muted-foreground">
-												No plugin tools found.
-											</p>
-										)}
-									</div>
-								</div>
-							))}
-							{projectPlugins.length === 0 && (
+							{agentPlugins.map((plugin) => renderPluginCard(plugin))}
+							{agentPlugins.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No project plugins found.
+									No Agent Plugins found.
 								</p>
 							)}
 						</div>

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -1240,21 +1240,19 @@ export function CustomizationSectionView({
 
 	const installedCatalogLocalItems =
 		catalogPrimitive === "skill"
-			? commandItems
-					.filter((item) => item.agentPlugin !== true)
-					.map(
-						(item): MarketplaceLocalInstalledItem => ({
-							key: `${item.type}:${item.path}`,
-							matchValues: getLocalMarketplaceMatchValues(
-								item.id,
-								item.name,
-								item.path,
-							),
-							render: (context) => renderSkillCard(item, context),
-						}),
-					)
+			? commandItems.map(
+					(item): MarketplaceLocalInstalledItem => ({
+						key: `${item.type}:${item.path}`,
+						matchValues: getLocalMarketplaceMatchValues(
+							item.id,
+							item.name,
+							item.path,
+						),
+						render: (context) => renderSkillCard(item, context),
+					}),
+				)
 			: catalogPrimitive === "plugin"
-				? clinePlugins.map(
+				? scopedPlugins.map(
 						(item): MarketplaceLocalInstalledItem => ({
 							key: item.plugin.path,
 							matchValues: getLocalMarketplaceMatchValues(


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This stacked PR adds the Desktop client integration for the Hub-managed Agent Plugins capability introduced by #13652.

- Reads Agent Plugin inventory and enabled state from the Hub settings API.
- Displays Agent Plugins separately from Cline marketplace plugins in Desktop settings.
- Lets users enable or disable Agent Plugins through the Hub instead of maintaining client-local state.
- Refreshes plugin and skill inventories when Hub settings change.
- Prevents portable Agent Plugins from being sent through the Cline marketplace uninstall path.

### Test Procedure

1. Ran the focused sidecar context and marketplace suites: 2 files and 37 tests passed.
2. Ran `bun run typecheck` from `apps/examples/desktop-app`.
3. Ran the production Desktop build with `bun run build`, including the optimized Next.js webview and compiled sidecar binary.

The primary risks are stale Hub-backed inventories, incorrect enabled-state projection, and treating Agent Plugins as marketplace packages. Focused tests cover settings events, inventory mapping, and uninstall routing; typecheck and the production build validate both sidecar and webview integration.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

git clone https://github.com/agentplugins/agent-plugins-example into your ~/.agents/plugins directory.
In desktop app starting from this branch, confirms the agent plugin is showing up in following screen in Customize view:

Plugins

<img width="1446" height="931" alt="image" src="https://github.com/user-attachments/assets/17339213-2d45-4d89-ab2d-da968b244095" />

Skills

<img width="1459" height="939" alt="image" src="https://github.com/user-attachments/assets/d7510882-c1fc-4619-9461-a556336834c6" />

### Additional Notes

- This PR is stacked on #13652 and intentionally targets `bee/agent-plugins-support`.
- Its diff is limited to 8 files under `apps/examples/desktop-app`.
- Merge #13652 first; this PR can then be retargeted to `main` if GitHub does not update the base automatically.
- No matching GitHub issue was found, so the Related Issue placeholder remains for maintainers to replace with the approved issue or discussion.
