### PR TITLE
fix(cli): enforce timeout during initial one-shot turn

### DIFF
--- a/apps/cli/src/runtime/run-agent.test.ts
+++ b/apps/cli/src/runtime/run-agent.test.ts
@@ -167,7 +167,78 @@ describe("runAgent", () => {
 
 	afterEach(() => {
 		process.exitCode = originalExitCode;
+		vi.useRealTimers();
 		vi.clearAllMocks();
+	});
+
+	it("times out while the initial one-shot turn is still running", async () => {
+		vi.useFakeTimers();
+		const startedAt = new Date("2026-03-22T00:00:00.000Z");
+		const endedAt = new Date("2026-03-22T00:00:01.100Z");
+		let abortCount = 0;
+		let resolveStart: ((value: unknown) => void) | undefined;
+		sessionManagerMocks.start.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveStart = resolve;
+				}),
+		);
+		sessionManagerMocks.abort.mockImplementation(async (sessionId: string) => {
+			abortCount += 1;
+			if (abortCount === 2) {
+				resolveStart?.({
+					sessionId,
+					manifest: { session_id: sessionId },
+					result: {
+						text: "aborted",
+						usage: {
+							inputTokens: 0,
+							outputTokens: 0,
+							cacheReadTokens: 0,
+							cacheWriteTokens: 0,
+							totalCost: undefined,
+						},
+						messages: [],
+						toolCalls: [],
+						iterations: 0,
+						finishReason: "aborted",
+						model: { id: "test", provider: "test", info: {} },
+						startedAt,
+						endedAt,
+						durationMs: 1100,
+					},
+				});
+			}
+		});
+
+		const { runAgent } = await import("./run-agent");
+		const runPromise = runAgent("test prompt", {
+			cwd: process.cwd(),
+			enableAgentTeams: false,
+			enableSpawnAgent: false,
+			enableTools: [],
+			execution: { maxConsecutiveMistakes: 3 },
+			logger: undefined,
+			mode: "yolo",
+			modelId: "test",
+			outputMode: "text",
+			providerId: "test",
+			systemPrompt: "system",
+			thinking: false,
+			timeoutSeconds: 1,
+			toolPolicies: { "*": { autoApprove: true } },
+			verbose: false,
+			workspaceRoot: process.cwd(),
+		} as never);
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(sessionManagerMocks.start).toHaveBeenCalledOnce();
+		await vi.advanceTimersByTimeAsync(1100);
+		await runPromise;
+
+		expect(sessionManagerMocks.abort).toHaveBeenCalledTimes(2);
+		expect(outputMocks.writeErr).toHaveBeenCalledWith("run timed out after 1s");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("starts the session with normalized user input", async () => {

--- a/apps/cli/src/runtime/run-agent.ts
+++ b/apps/cli/src/runtime/run-agent.ts
@@ -221,6 +221,19 @@ export async function runAgent(
 	let abortRequested = false;
 	let timedOut = false;
 	let activeSessionId: string | undefined;
+	let sessionStartPending = false;
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	let timeoutAbortRetryId: ReturnType<typeof setTimeout> | undefined;
+	const timeoutMs =
+		typeof config.timeoutSeconds === "number" &&
+		Number.isFinite(config.timeoutSeconds) &&
+		config.timeoutSeconds > 0
+			? config.timeoutSeconds * 1000
+			: undefined;
+	const clearRunTimeout = () => {
+		if (timeoutId) clearTimeout(timeoutId);
+		if (timeoutAbortRetryId) clearTimeout(timeoutAbortRetryId);
+	};
 
 	const abortAll = () => {
 		if (abortRequested) return false;
@@ -231,6 +244,18 @@ export async function runAgent(
 				.catch(() => {});
 		}
 		return true;
+	};
+	const retryTimedOutStartAbort = async () => {
+		if (!timedOut || !sessionStartPending) return;
+		await sessionManager
+			.abort(plannedSessionId, new Error("Run-agent runtime abort requested"))
+			.catch(() => {});
+		if (timedOut && sessionStartPending) {
+			timeoutAbortRetryId = setTimeout(
+				() => void retryTimedOutStartAbort(),
+				100,
+			);
+		}
 	};
 	setActiveRuntimeAbort(abortAll);
 
@@ -280,6 +305,20 @@ export async function runAgent(
 		} = await buildUserInputMessage(prompt, userInstructionService, {
 			mode: config.mode,
 		});
+		activeSessionId = plannedSessionId;
+		sessionStartPending = true;
+		timeoutId = timeoutMs
+			? setTimeout(() => {
+					timedOut = true;
+					abortAll();
+					if (sessionStartPending) {
+						timeoutAbortRetryId = setTimeout(
+							() => void retryTimedOutStartAbort(),
+							100,
+						);
+					}
+				}, timeoutMs)
+			: undefined;
 		const started = await sessionManager.start({
 			source: SessionSource.CLI,
 			config: {
@@ -305,28 +344,13 @@ export async function runAgent(
 				onTeamRestored: () => emitTeamRestored(config),
 			},
 		});
+		sessionStartPending = false;
+		if (timeoutAbortRetryId) clearTimeout(timeoutAbortRetryId);
 
 		activeSessionId = started.sessionId;
 		setActiveCliSession({
 			manifest: started.manifest,
 		});
-
-		// Schedule timeout abort if configured.
-		const timeoutMs =
-			typeof config.timeoutSeconds === "number" &&
-			Number.isFinite(config.timeoutSeconds) &&
-			config.timeoutSeconds > 0
-				? config.timeoutSeconds * 1000
-				: undefined;
-		const timeoutId = timeoutMs
-			? setTimeout(() => {
-					timedOut = true;
-					abortAll();
-				}, timeoutMs)
-			: undefined;
-		const clearRunTimeout = () => {
-			if (timeoutId) clearTimeout(timeoutId);
-		};
 
 		// When start() already ran the first turn (non-interactive with prompt),
 		// the session is finalized before start() returns. Use that result
@@ -417,11 +441,17 @@ export async function runAgent(
 		);
 		process.exitCode = 0;
 	} catch (err) {
-		const message = formatCliErrorMessage(err, { modelId: config.modelId });
-		logCliError(config.logger, "CLI task run failed", { error: err });
-		writeErr(message);
+		if (timedOut) {
+			writeErr(`run timed out after ${config.timeoutSeconds}s`);
+		} else {
+			const message = formatCliErrorMessage(err, { modelId: config.modelId });
+			logCliError(config.logger, "CLI task run failed", { error: err });
+			writeErr(message);
+		}
 		process.exitCode = 1;
 	} finally {
+		sessionStartPending = false;
+		clearRunTimeout();
 		await cleanupRuntime();
 	}
 }


### PR DESCRIPTION
### Description

In one-shot CLI runs, `sessionManager.start()` executes the initial turn before returning. The timeout was scheduled only after `start()` completed, so `--timeout` could not stop a long-running initial turn.

This PR:

- starts the timeout before `sessionManager.start()`
- aborts using the planned session ID
- retries abort while session registration is still pending
- reports timeout errors consistently
- adds regression coverage for delayed session registration

### Test Procedure

Run:

```bash
bun --cwd apps/cli test:unit src/runtime/run-agent.test.ts
bun --cwd apps/cli typecheck
bun biome check apps/cli/src/runtime/run-agent.ts apps/cli/src/runtime/run-agent.test.ts
```

Results:

- 18 unit tests passed
- CLI typecheck passed
- Biome checks passed

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor Changes
- [ ] Cosmetic Changes
- [ ] Documentation update
- [ ] Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single bug fix
- [x] Relevant tests are passing and changed files are formatted and linted
- [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable — CLI runtime behavior only.

### Additional Notes

No breaking changes.
