### PR TITLE
fix(llms): Cline provider models from the live catalog

### DIFF
--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -418,6 +418,69 @@ describe("addLocalProvider – model ID parsing via modelsSourceUrl", () => {
 		expect(models.map((m) => m.id).sort()).toEqual(["llama3.1", "qwen3:8b"]);
 	});
 
+	it("merges live Cline models into the registered catalog", async () => {
+		const liveModelId = "vendor/live-cline-model";
+		const fetchMock = vi.fn(async (url: string) => {
+			if (url === "https://models.dev/api.json") {
+				return new Response(
+					JSON.stringify({
+						openrouter: {
+							models: {
+								[liveModelId]: {
+									name: "Live Cline Model",
+									tool_call: true,
+									reasoning: true,
+									limit: {
+										context: 256_000,
+										input: 200_000,
+										output: 32_000,
+									},
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+
+			return new Response(
+				JSON.stringify({
+					recommended: [
+						{
+							id: liveModelId,
+							name: liveModelId,
+							description: "Fresh from the live catalog",
+							tags: ["NEW"],
+						},
+					],
+					free: [],
+					clinePass: [],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { models } = await getLocalProviderModels("cline");
+
+		// models.dev and the recommended feed populate the live catalog; the
+		// recommended feed is fetched once more for the featured-tier overlay.
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(models.find((model) => model.id === liveModelId)).toMatchObject({
+			id: liveModelId,
+			name: "Live Cline Model",
+			supportsReasoning: true,
+			description: "Fresh from the live catalog",
+			featured: { tier: "recommended", rank: 0, tags: ["NEW"] },
+		});
+	});
+
 	it("uses only live ClinePass models when live models are found", async () => {
 		const fetchMock = vi.fn(async (url: string) => {
 			if (url === "https://models.dev/api.json") {
@@ -1191,6 +1254,15 @@ describe("audio transcription", () => {
 
 describe("models.json model overlays", () => {
 	it("loads model-only entries for built-in providers", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({}), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			),
+		);
 		const dir = mkdtempSync(
 			path.join(os.tmpdir(), "local-provider-overlay-test-"),
 		);

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -157,16 +157,21 @@ async function resolveProviderModelMap(
 	providerId: string,
 	config?: ProviderConfig,
 ): Promise<Record<string, ModelInfo>> {
-	const registeredModels = await LlmsModels.getModelsForProvider(providerId);
+	const [registeredModels, registeredModelOverrides] = await Promise.all([
+		LlmsModels.getModelsForProvider(providerId),
+		LlmsModels.getModelOverridesForProvider(providerId),
+	]);
+	const shouldLoadLiveCatalog =
+		providerId === CLINE_PROVIDER_ID || providerId === CLINE_PASS_PROVIDER_ID;
 	const isClinePass = providerId === CLINE_PASS_PROVIDER_ID;
-	if (!config && !isClinePass) {
+	if (!config && !shouldLoadLiveCatalog) {
 		return registeredModels;
 	}
 
 	const resolved = await resolveProviderConfig(
 		providerId,
 		{
-			loadLatestOnInit: isClinePass,
+			loadLatestOnInit: shouldLoadLiveCatalog,
 			loadPrivateOnAuth: true,
 			failOnError: false,
 		},
@@ -184,6 +189,7 @@ async function resolveProviderModelMap(
 		? {
 				...registeredModels,
 				...resolved.knownModels,
+				...registeredModelOverrides,
 			}
 		: registeredModels;
 }

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -15,6 +15,7 @@ export {
 	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,
+	getModelOverridesForProvider,
 	getModelsForProvider,
 	getProvider,
 	getProviderCollection,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -20,6 +20,7 @@ export {
 	getAllProviders,
 	getGeneratedModelsForProvider,
 	getGeneratedProviderModels,
+	getModelOverridesForProvider,
 	getModelsForProvider,
 	getProvider,
 	getProviderCollection,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -28,6 +28,7 @@ export type {
 } from "./providers/model-registry";
 export {
 	getAllProviders,
+	getModelOverridesForProvider,
 	getModelsForProvider,
 	getProvider,
 	getProviderCollection,

--- a/sdk/packages/llms/src/providers/model-registry.test.ts
+++ b/sdk/packages/llms/src/providers/model-registry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	getModelOverridesForProvider,
 	getModelsForProvider,
 	registerModel,
 	registerProvider,
@@ -71,5 +72,19 @@ describe("getModelsForProvider", () => {
 		expect(
 			Object.keys(await getModelsForProvider(PROVIDER_ID, { filter: "chat" })),
 		).toEqual(["legacy", "chat", "mixed"]);
+	});
+
+	it("exposes runtime model overrides without the bundled provider models", async () => {
+		registerModel("anthropic", "custom-claude", {
+			id: "custom-claude",
+			name: "Custom Claude",
+		});
+
+		await expect(getModelOverridesForProvider("anthropic")).resolves.toEqual({
+			"custom-claude": {
+				id: "custom-claude",
+				name: "Custom Claude",
+			},
+		});
 	});
 });

--- a/sdk/packages/llms/src/providers/model-registry.ts
+++ b/sdk/packages/llms/src/providers/model-registry.ts
@@ -90,6 +90,21 @@ export async function getModelsForProvider(
 	);
 }
 
+/**
+ * Returns only models explicitly registered at runtime, excluding the bundled
+ * provider collection. These overrides must remain highest-precedence when a
+ * caller merges the registry with a freshly fetched catalog.
+ */
+export async function getModelOverridesForProvider(
+	providerId: string,
+): Promise<Record<string, ModelInfo>> {
+	const providerModels = CUSTOM_PROVIDERS.get(providerId)?.models ?? {};
+	const customModels = CUSTOM_MODELS.get(providerId);
+	return customModels
+		? { ...providerModels, ...Object.fromEntries(customModels) }
+		: { ...providerModels };
+}
+
 export async function getAllProviders(): Promise<ProviderInfo[]> {
 	return getProviderIds()
 		.map((id) => getProviderFromCache(id)?.provider)


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The desktop refreshes the active provider's model list at startup, but the shared provider resolver enabled the live catalog only for ClinePass. The Cline provider therefore remained on its bundled catalog; its live recommendation feed could decorate existing entries but could not surface newly published models.

This change loads the live catalog for both `cline` and `cline-pass`, including when no provider configuration has been saved. Live metadata is merged into Cline's registered catalog while explicit runtime and `models.json` model overrides retain highest precedence.

The LLM registry now exposes those explicit overrides separately so callers can preserve them when merging a fresh remote catalog.

### Test Procedure

- Rebuilt all SDK packages with `bun run build:sdk`.
- Ran the focused Core provider suite: 82 tests passed.
- Ran the complete LLM suite: 738 tests passed and 4 skipped.
- Ran the desktop app TypeScript check with `bun run typecheck`.
- Ran Biome checks over all seven changed files.
- Added regression coverage proving a model available only in the live catalog appears for Cline with live metadata and recommendation tiering, while local model overrides remain authoritative.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Desktop app has glm 5.3 shows up as free

<img width="1012" height="649" alt="image" src="https://github.com/user-attachments/assets/f524b454-9f77-46c7-a8eb-0fbb7cd7a144" />

### Additional Notes

The existing live-catalog cache behavior is unchanged: cold startup fetches current data, and subsequent resolutions reuse the in-memory catalog for its configured TTL.

The complete Core unit suite was also attempted, but the unrelated hub UI-event tests could not acquire the local Hub instance lock while a live Hub was running. The affected provider suites pass independently.
