### PR TITLE
feat(ui): share attachment drop zone

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ImagePlus, Loader2 } from "lucide-react";
+import { AttachmentDropZone } from "@cline/ui";
+import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import {
 	useCallback,
@@ -637,8 +638,6 @@ function ChatThreadPane({
 		promptInputRef.current = value;
 	}, []);
 	const [pendingAttachments, setPendingAttachments] = useState<File[]>([]);
-	const [isDraggingFiles, setIsDraggingFiles] = useState(false);
-	const dragDepthRef = useRef(0);
 	const [showDiffView, setShowDiffView] = useState(false);
 	const [deletingSession, setDeletingSession] = useState(false);
 	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -1288,52 +1287,6 @@ function ChatThreadPane({
 		});
 	}, []);
 
-	// Drag-and-drop file attachments. Requires `dragDropEnabled: false` on the
-	// Tauri window — otherwise the native shell swallows OS file drags and these
-	// HTML5 events never fire.
-	const handleDragEnter = useCallback((event: React.DragEvent) => {
-		if (!event.dataTransfer.types.includes("Files")) {
-			return;
-		}
-		event.preventDefault();
-		dragDepthRef.current += 1;
-		setIsDraggingFiles(true);
-	}, []);
-
-	const handleDragOver = useCallback((event: React.DragEvent) => {
-		if (!event.dataTransfer.types.includes("Files")) {
-			return;
-		}
-		event.preventDefault();
-		event.dataTransfer.dropEffect = "copy";
-	}, []);
-
-	const handleDragLeave = useCallback((event: React.DragEvent) => {
-		if (!event.dataTransfer.types.includes("Files")) {
-			return;
-		}
-		dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-		if (dragDepthRef.current === 0) {
-			setIsDraggingFiles(false);
-		}
-	}, []);
-
-	const handleDrop = useCallback(
-		(event: React.DragEvent) => {
-			if (!event.dataTransfer.types.includes("Files")) {
-				return;
-			}
-			event.preventDefault();
-			dragDepthRef.current = 0;
-			setIsDraggingFiles(false);
-			const files = Array.from(event.dataTransfer.files);
-			if (files.length > 0) {
-				handleAttachFiles(files);
-			}
-		},
-		[handleAttachFiles],
-	);
-
 	const attachmentList = useMemo(
 		() =>
 			pendingAttachments.map((file, index) => ({
@@ -1589,31 +1542,15 @@ function ChatThreadPane({
 
 	return (
 		<WorkspaceProvider value={workspaceContextValue}>
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: Drag-and-drop target only; the paperclip button is the accessible attach path. */}
-			<div
+			{/* Requires `dragDropEnabled: false` on the Tauri window so the native shell does not swallow OS file drags. */}
+			<AttachmentDropZone
 				className={
 					isWelcomeState
-						? "relative grid h-full min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden"
-						: "relative grid h-full min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto] overflow-hidden"
+						? "grid h-full min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden"
+						: "grid h-full min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto] overflow-hidden"
 				}
-				onDragEnter={handleDragEnter}
-				onDragLeave={handleDragLeave}
-				onDragOver={handleDragOver}
-				onDrop={handleDrop}
+				onAttachFiles={handleAttachFiles}
 			>
-				{isDraggingFiles ? (
-					<div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-						<div className="flex flex-col items-center gap-2 rounded-xl border-2 border-dashed border-primary/60 bg-card px-10 py-8 shadow-lg">
-							<ImagePlus className="h-8 w-8 text-primary" />
-							<p className="text-sm font-medium text-foreground">
-								Drop to attach
-							</p>
-							<p className="text-xs text-muted-foreground">
-								Screenshots and files will be added to your next message
-							</p>
-						</div>
-					</div>
-				) : null}
 				{!isWelcomeState ? (
 					<WindowTitleBarContent>
 						<div className="cline-view-enter z-20 border-b border-border/70 bg-background/85 backdrop-blur-sm">
@@ -1688,7 +1625,7 @@ function ChatThreadPane({
 					onOpenSession={onOpenSessionById}
 					onSwitchGitBranch={switchGitBranch}
 				/>
-			</div>
+			</AttachmentDropZone>
 			<AlertDialog
 				open={deleteConfirmOpen}
 				onOpenChange={(open) => {

--- a/bun.lock
+++ b/bun.lock
@@ -747,7 +747,7 @@
     },
     "sdk/packages/ui": {
       "name": "@cline/ui",
-      "version": "0.2.0-next.7",
+      "version": "0.2.0-next.8",
       "dependencies": {
         "@cline/shared": "workspace:*",
         "@radix-ui/react-slot": "1.2.4",

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -27,7 +27,7 @@ Use `@cline/ui@next` only for deliberate previews. Monorepo consumers use
 
 | Import | Contents | Runtime requirement |
 | --- | --- | --- |
-| `@cline/ui` | Button, icon-button, attachment drop-zone, agent ask-question, approval-card, Aurora, hero-heading, prompt-queue, quick-action, search-combobox, and session-status React primitives | React 18.3 or 19 and Tailwind v4 |
+| `@cline/ui` | Reusable React primitives exported from [`components/index.ts`](./components/index.ts) | React 18.3 or 19 and Tailwind v4 |
 | `@cline/ui/components.css` | Styles, namespaced Tailwind mappings, and source registration for the root React primitives | Tailwind v4 and theme tokens |
 | `@cline/ui/theme/palette.css` | Cline-owned light/dark solid and alpha color scales | CSS |
 | `@cline/ui/theme/tokens.css` | Light/dark custom properties only | CSS |
@@ -45,18 +45,6 @@ for a host-specific status palette.
 
 `SearchCombobox` provides a searchable selector for repository and model lists.
 Its in-place panel requires ancestors that do not clip overflow.
-
-`AttachmentDropZone` wraps an existing attachment surface and passes dropped
-`File` objects to the host for validation and storage. It owns the shared drag
-overlay and cancels native file-drop behavior while disabled.
-
-```tsx
-import { AttachmentDropZone } from "@cline/ui";
-
-<AttachmentDropZone disabled={disabled} onAttachFiles={addFiles}>
-	<Composer />
-</AttachmentDropZone>;
-```
 
 Import `components.css` after Tailwind and either token entry point. It
 registers package-namespaced mappings and the packaged component sources so

--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -27,7 +27,7 @@ Use `@cline/ui@next` only for deliberate previews. Monorepo consumers use
 
 | Import | Contents | Runtime requirement |
 | --- | --- | --- |
-| `@cline/ui` | Button, icon-button, agent ask-question, approval-card, Aurora, hero-heading, prompt-queue, quick-action, search-combobox, and session-status React primitives | React 18.3 or 19 and Tailwind v4 |
+| `@cline/ui` | Button, icon-button, attachment drop-zone, agent ask-question, approval-card, Aurora, hero-heading, prompt-queue, quick-action, search-combobox, and session-status React primitives | React 18.3 or 19 and Tailwind v4 |
 | `@cline/ui/components.css` | Styles, namespaced Tailwind mappings, and source registration for the root React primitives | Tailwind v4 and theme tokens |
 | `@cline/ui/theme/palette.css` | Cline-owned light/dark solid and alpha color scales | CSS |
 | `@cline/ui/theme/tokens.css` | Light/dark custom properties only | CSS |
@@ -45,6 +45,18 @@ for a host-specific status palette.
 
 `SearchCombobox` provides a searchable selector for repository and model lists.
 Its in-place panel requires ancestors that do not clip overflow.
+
+`AttachmentDropZone` wraps an existing attachment surface and passes dropped
+`File` objects to the host for validation and storage. It owns the shared drag
+overlay and cancels native file-drop behavior while disabled.
+
+```tsx
+import { AttachmentDropZone } from "@cline/ui";
+
+<AttachmentDropZone disabled={disabled} onAttachFiles={addFiles}>
+	<Composer />
+</AttachmentDropZone>;
+```
 
 Import `components.css` after Tailwind and either token entry point. It
 registers package-namespaced mappings and the packaged component sources so

--- a/sdk/packages/ui/components/attachment-drop-zone.tsx
+++ b/sdk/packages/ui/components/attachment-drop-zone.tsx
@@ -80,8 +80,9 @@ export const AttachmentDropZone = forwardRef<
 
 		const handleDragEnter = useCallback(
 			(event: React.DragEvent<HTMLDivElement>) => {
-				if (disabled || !includesFiles(event)) return;
+				if (!includesFiles(event)) return;
 				event.preventDefault();
+				if (disabled) return;
 				dragDepthRef.current += 1;
 				setIsDraggingFiles(true);
 			},
@@ -90,9 +91,9 @@ export const AttachmentDropZone = forwardRef<
 
 		const handleDragOver = useCallback(
 			(event: React.DragEvent<HTMLDivElement>) => {
-				if (disabled || !includesFiles(event)) return;
+				if (!includesFiles(event)) return;
 				event.preventDefault();
-				event.dataTransfer.dropEffect = "copy";
+				event.dataTransfer.dropEffect = disabled ? "none" : "copy";
 			},
 			[disabled],
 		);
@@ -108,10 +109,11 @@ export const AttachmentDropZone = forwardRef<
 
 		const handleDrop = useCallback(
 			(event: React.DragEvent<HTMLDivElement>) => {
-				if (disabled || !includesFiles(event)) return;
+				if (!includesFiles(event)) return;
 				event.preventDefault();
 				dragDepthRef.current = 0;
 				setIsDraggingFiles(false);
+				if (disabled) return;
 				const files = Array.from(event.dataTransfer.files);
 				if (files.length > 0) onAttachFiles(files);
 			},

--- a/sdk/packages/ui/components/attachment-drop-zone.tsx
+++ b/sdk/packages/ui/components/attachment-drop-zone.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { clsx } from "clsx";
+import {
+	forwardRef,
+	type HTMLAttributes,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+export interface AttachmentDropZoneProps
+	extends Omit<
+		HTMLAttributes<HTMLDivElement>,
+		"onDragEnter" | "onDragLeave" | "onDragOver" | "onDrop"
+	> {
+	children: ReactNode;
+	description?: ReactNode;
+	disabled?: boolean;
+	label?: ReactNode;
+	onAttachFiles: (files: File[]) => void;
+}
+
+function includesFiles(event: React.DragEvent<HTMLDivElement>): boolean {
+	return event.dataTransfer.types.includes("Files");
+}
+
+function ImagePlusIcon() {
+	return (
+		<svg
+			aria-hidden="true"
+			className="size-8 text-cline-ui-primary"
+			fill="none"
+			stroke="currentColor"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth="2"
+			viewBox="0 0 24 24"
+		>
+			<path d="M16 5h6" />
+			<path d="M19 2v6" />
+			<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7" />
+			<circle cx="9" cy="9" r="2" />
+			<path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+		</svg>
+	);
+}
+
+/**
+ * Adds OS file drag-and-drop to an existing attachment surface.
+ *
+ * The consumer remains responsible for validating and storing the dropped files.
+ */
+export const AttachmentDropZone = forwardRef<
+	HTMLDivElement,
+	AttachmentDropZoneProps
+>(
+	(
+		{
+			children,
+			className,
+			description = "Screenshots and files will be added to your next message",
+			disabled = false,
+			label = "Drop to attach",
+			onAttachFiles,
+			...props
+		},
+		ref,
+	) => {
+		const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+		const dragDepthRef = useRef(0);
+
+		useEffect(() => {
+			if (!disabled) return;
+			dragDepthRef.current = 0;
+			setIsDraggingFiles(false);
+		}, [disabled]);
+
+		const handleDragEnter = useCallback(
+			(event: React.DragEvent<HTMLDivElement>) => {
+				if (disabled || !includesFiles(event)) return;
+				event.preventDefault();
+				dragDepthRef.current += 1;
+				setIsDraggingFiles(true);
+			},
+			[disabled],
+		);
+
+		const handleDragOver = useCallback(
+			(event: React.DragEvent<HTMLDivElement>) => {
+				if (disabled || !includesFiles(event)) return;
+				event.preventDefault();
+				event.dataTransfer.dropEffect = "copy";
+			},
+			[disabled],
+		);
+
+		const handleDragLeave = useCallback(
+			(event: React.DragEvent<HTMLDivElement>) => {
+				if (disabled || !includesFiles(event)) return;
+				dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+				if (dragDepthRef.current === 0) setIsDraggingFiles(false);
+			},
+			[disabled],
+		);
+
+		const handleDrop = useCallback(
+			(event: React.DragEvent<HTMLDivElement>) => {
+				if (disabled || !includesFiles(event)) return;
+				event.preventDefault();
+				dragDepthRef.current = 0;
+				setIsDraggingFiles(false);
+				const files = Array.from(event.dataTransfer.files);
+				if (files.length > 0) onAttachFiles(files);
+			},
+			[disabled, onAttachFiles],
+		);
+
+		return (
+			// biome-ignore lint/a11y/noStaticElementInteractions: The drop zone augments the consumer's accessible file picker.
+			<div
+				{...props}
+				className={clsx("cline-ui-attachment-drop-zone relative", className)}
+				data-dragging-files={isDraggingFiles || undefined}
+				data-slot="attachment-drop-zone"
+				onDragEnter={handleDragEnter}
+				onDragLeave={handleDragLeave}
+				onDragOver={handleDragOver}
+				onDrop={handleDrop}
+				ref={ref}
+			>
+				{isDraggingFiles ? (
+					<div className="cline-ui-attachment-drop-zone__overlay pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-cline-ui-background/80 backdrop-blur-sm">
+						<div className="cline-ui-attachment-drop-zone__panel flex flex-col items-center gap-2 rounded-cline-ui-xl border-2 border-cline-ui-primary/60 border-dashed bg-cline-ui-card px-10 py-8 shadow-lg">
+							<ImagePlusIcon />
+							<p className="font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm">
+								{label}
+							</p>
+							<p className="text-cline-ui-muted-foreground text-cline-ui-xs">
+								{description}
+							</p>
+						</div>
+					</div>
+				) : null}
+				{children}
+			</div>
+		);
+	},
+);
+AttachmentDropZone.displayName = "AttachmentDropZone";

--- a/sdk/packages/ui/components/attachment-drop-zone.tsx
+++ b/sdk/packages/ui/components/attachment-drop-zone.tsx
@@ -124,7 +124,7 @@ export const AttachmentDropZone = forwardRef<
 			// biome-ignore lint/a11y/noStaticElementInteractions: The drop zone augments the consumer's accessible file picker.
 			<div
 				{...props}
-				className={clsx("cline-ui-attachment-drop-zone relative", className)}
+				className={clsx("relative", className)}
 				data-dragging-files={isDraggingFiles || undefined}
 				data-slot="attachment-drop-zone"
 				onDragEnter={handleDragEnter}
@@ -134,8 +134,8 @@ export const AttachmentDropZone = forwardRef<
 				ref={ref}
 			>
 				{isDraggingFiles ? (
-					<div className="cline-ui-attachment-drop-zone__overlay pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-cline-ui-background/80 backdrop-blur-sm">
-						<div className="cline-ui-attachment-drop-zone__panel flex flex-col items-center gap-2 rounded-cline-ui-xl border-2 border-cline-ui-primary/60 border-dashed bg-cline-ui-card px-10 py-8 shadow-lg">
+					<div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-cline-ui-background/80 backdrop-blur-sm">
+						<div className="flex flex-col items-center gap-2 rounded-cline-ui-xl border-2 border-cline-ui-primary/60 border-dashed bg-cline-ui-card px-10 py-8 shadow-lg">
 							<ImagePlusIcon />
 							<p className="font-cline-ui-medium text-cline-ui-foreground text-cline-ui-sm">
 								{label}

--- a/sdk/packages/ui/components/index.ts
+++ b/sdk/packages/ui/components/index.ts
@@ -27,6 +27,10 @@ export {
 	type AgentWelcomeHeroLayout,
 	type AgentWelcomeHeroProps,
 } from "./agent-welcome-hero.js";
+export {
+	AttachmentDropZone,
+	type AttachmentDropZoneProps,
+} from "./attachment-drop-zone.js";
 export { Badge, type BadgeProps } from "./badge.js";
 export {
 	Button,

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cline/ui",
-	"version": "0.2.0-next.7",
+	"version": "0.2.0-next.8",
 	"description": "Shared Cline web theme and reusable agent UI components",
 	"repository": {
 		"type": "git",

--- a/sdk/packages/ui/package.json
+++ b/sdk/packages/ui/package.json
@@ -47,6 +47,7 @@
 	},
 	"files": [
 		"components.css",
+		"components/attachment-drop-zone.tsx",
 		"components/badge.tsx",
 		"components/button.tsx",
 		"components/generated-media.tsx",

--- a/sdk/packages/ui/scripts/smoke-package.ts
+++ b/sdk/packages/ui/scripts/smoke-package.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import {
 	AgentAskQuestion,
 	AgentApprovalCard,
+	AttachmentDropZone,
 	AgentAurora,
 	AgentHeroHeading,
 	AgentWelcomeHero,
@@ -64,6 +65,7 @@ if (typeof ToolFileDiff !== "function") {
 }
 if (
 	!AgentApprovalCard ||
+	!AttachmentDropZone ||
 	!AgentAskQuestion ||
 	!AgentAurora ||
 	!AgentHeroHeading ||
@@ -169,6 +171,9 @@ async function verifyTailwindContract(
 		"focus-visible:outline-3",
 		"min-h-8",
 		"resize-none",
+		"backdrop-blur-sm",
+		"border-dashed",
+		"pointer-events-none",
 	]) {
 		expectCandidate(css, candidate);
 	}

--- a/sdk/packages/ui/tests/attachment-drop-zone.test.tsx
+++ b/sdk/packages/ui/tests/attachment-drop-zone.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AttachmentDropZone } from "../components/index.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+});
+
+async function render(node: ReactNode) {
+	await act(async () => root.render(node));
+}
+
+function dispatchDrag(
+	target: Element,
+	type: string,
+	files: File[] = [],
+	types: string[] = ["Files"],
+) {
+	const event = new Event(type, { bubbles: true, cancelable: true });
+	const dataTransfer = { dropEffect: "none", files, types };
+	Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+	target.dispatchEvent(event);
+	return { dataTransfer, event };
+}
+
+describe("AttachmentDropZone", () => {
+	it("keeps the overlay open across nested drag targets and attaches on drop", async () => {
+		const onAttachFiles = vi.fn();
+		await render(
+			<AttachmentDropZone onAttachFiles={onAttachFiles}>
+				<div data-testid="child">Composer</div>
+			</AttachmentDropZone>,
+		);
+
+		const zone = container.firstElementChild as HTMLElement;
+		const child = container.querySelector(
+			'[data-testid="child"]',
+		) as HTMLElement;
+		const file = new File(["image"], "screenshot.png", {
+			type: "image/png",
+		});
+
+		await act(async () => {
+			dispatchDrag(zone, "dragenter");
+			dispatchDrag(child, "dragenter");
+			dispatchDrag(child, "dragleave");
+		});
+		expect(zone.dataset.draggingFiles).toBe("true");
+		expect(container.textContent).toContain("Drop to attach");
+
+		let dragOver: ReturnType<typeof dispatchDrag> | undefined;
+		await act(async () => {
+			dragOver = dispatchDrag(child, "dragover");
+		});
+		expect(dragOver?.dataTransfer.dropEffect).toBe("copy");
+		expect(dragOver?.event.defaultPrevented).toBe(true);
+
+		await act(async () => {
+			dispatchDrag(child, "drop", [file]);
+		});
+		expect(onAttachFiles).toHaveBeenCalledWith([file]);
+		expect(zone.dataset.draggingFiles).toBeUndefined();
+	});
+
+	it("ignores non-file and disabled drags", async () => {
+		const onAttachFiles = vi.fn();
+		await render(
+			<AttachmentDropZone disabled onAttachFiles={onAttachFiles}>
+				Composer
+			</AttachmentDropZone>,
+		);
+		const zone = container.firstElementChild as HTMLElement;
+
+		await act(async () => {
+			dispatchDrag(zone, "dragenter", [], ["text/plain"]);
+			dispatchDrag(zone, "drop", [new File(["x"], "file.txt")]);
+		});
+
+		expect(zone.dataset.draggingFiles).toBeUndefined();
+		expect(onAttachFiles).not.toHaveBeenCalled();
+	});
+
+	it("supports consumer-specific overlay copy", async () => {
+		await render(
+			<AttachmentDropZone
+				description="Images will be added to your next message"
+				label="Drop image to attach"
+				onAttachFiles={() => {}}
+			>
+				Composer
+			</AttachmentDropZone>,
+		);
+		const zone = container.firstElementChild as HTMLElement;
+
+		await act(async () => {
+			dispatchDrag(zone, "dragenter");
+		});
+
+		expect(container.textContent).toContain("Drop image to attach");
+		expect(container.textContent).toContain(
+			"Images will be added to your next message",
+		);
+	});
+});

--- a/sdk/packages/ui/tests/attachment-drop-zone.test.tsx
+++ b/sdk/packages/ui/tests/attachment-drop-zone.test.tsx
@@ -85,13 +85,21 @@ describe("AttachmentDropZone", () => {
 		);
 		const zone = container.firstElementChild as HTMLElement;
 
+		let nonFileDrag: ReturnType<typeof dispatchDrag> | undefined;
+		let disabledDragOver: ReturnType<typeof dispatchDrag> | undefined;
+		let disabledDrop: ReturnType<typeof dispatchDrag> | undefined;
 		await act(async () => {
-			dispatchDrag(zone, "dragenter", [], ["text/plain"]);
-			dispatchDrag(zone, "drop", [new File(["x"], "file.txt")]);
+			nonFileDrag = dispatchDrag(zone, "dragenter", [], ["text/plain"]);
+			disabledDragOver = dispatchDrag(zone, "dragover");
+			disabledDrop = dispatchDrag(zone, "drop", [new File(["x"], "file.txt")]);
 		});
 
 		expect(zone.dataset.draggingFiles).toBeUndefined();
 		expect(onAttachFiles).not.toHaveBeenCalled();
+		expect(nonFileDrag?.event.defaultPrevented).toBe(false);
+		expect(disabledDragOver?.event.defaultPrevented).toBe(true);
+		expect(disabledDragOver?.dataTransfer.dropEffect).toBe("none");
+		expect(disabledDrop?.event.defaultPrevented).toBe(true);
 	});
 
 	it("supports consumer-specific overlay copy", async () => {


### PR DESCRIPTION
### Related Issue

**Consumer:** https://github.com/cline/core-platform/pull/3290

### Description

Adds a focused AttachmentDropZone primitive to @cline/ui and switches the Cline desktop chat surface to consume it. The shared component owns file-drag detection, nested drag state, the copy cursor, and the standard overlay; consumers continue to own validation and attachment storage.

This gives Desktop and Core Platform one drag-and-drop interaction without coupling their different attachment contracts.

### Test Procedure

- @cline/ui: 148 tests passed
- @cline/ui: typecheck and build passed
- packed-package smoke test passed with Bun/React 19 and npm/Node/React 18
- Desktop app typecheck passed
- verified the Tauri window keeps dragDropEnabled disabled so OS file drags reach the webview

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Refactor Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Relevant tests are passing and changed files are formatted
- [x] I have reviewed contributor guidelines

### Screenshots

Desktop interaction reference:

<img width="1503" height="967" alt="Attachment drag overlay" src="https://github.com/user-attachments/assets/bd4c9fd1-2d72-4bb0-8d70-c8c19e453f6d" />

### Additional Notes

Publishing a new @cline/ui version is intentionally outside this PR. Core Platform can switch from its temporary local wrapper after the shared package is released.