### PR TITLE
feat(mcp): enforce configured OAuth scope policy

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/client-url.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client-url.test.ts
@@ -205,4 +205,60 @@ describe("SDK URL MCP client authorization persistence", () => {
 			lastError: "SSE error: Non-200 status code (404)",
 		});
 	});
+
+	it("fails before network use when a persisted token exceeds its scope policy", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-client-url-"));
+		tempRoots.push(tempRoot);
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const transport = {
+			type: "streamableHttp" as const,
+			url: "https://mcp.example.test",
+		};
+		const oauthClient = {
+			clientId: "cline-internal-client",
+			allowedScopes: ["channels:history"],
+		};
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				mcpServers: {
+					linear: {
+						transport,
+						oauthClient,
+						oauth: {
+							clientInformation: {
+								client_id: "cline-internal-client",
+							},
+							scopePolicy: ["channels:history"],
+							tokens: {
+								access_token: "over-scoped-token",
+								token_type: "bearer",
+								scope: "channels:history chat:write",
+							},
+						},
+					},
+				},
+			}),
+			"utf8",
+		);
+		const fetch = vi.fn<typeof globalThis.fetch>();
+		const client = await createDefaultMcpServerClientFactory({
+			settingsPath,
+			fetch,
+		})({
+			name: "linear",
+			transport,
+			oauthClient,
+		});
+
+		await expect(client.connect()).rejects.toThrow(/chat:write/);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(
+			listMcpServerOAuthStatuses({ filePath: settingsPath })[0],
+		).toMatchObject({
+			oauthConfigured: false,
+			authorizationRequired: false,
+			lastError: expect.stringContaining("chat:write"),
+		});
+	});
 });

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -613,17 +613,18 @@ class SdkUrlMcpClient implements McpServerClient {
 			clientInformation: createMcpOAuthClientInformation(
 				this.registration.oauthClient,
 			),
+			allowedScopes: this.registration.oauthClient?.allowedScopes,
 		});
 		this.authContext = authContext;
-		// A normal connection may consume/refresh existing credentials, but it
-		// must not initiate a new interactive OAuth flow. Without stored tokens,
-		// omit the provider so the MCP SDK reports UnauthorizedError immediately;
-		// the host can then render an explicit authorization action.
-		const oauthProvider = (await authContext.provider.tokens())
-			? authContext.provider
-			: undefined;
 		let client: Client | undefined;
 		try {
+			// A normal connection may consume/refresh existing credentials, but it
+			// must not initiate a new interactive OAuth flow. Without stored tokens,
+			// omit the provider so the MCP SDK reports UnauthorizedError immediately;
+			// the host can then render an explicit authorization action.
+			const oauthProvider = (await authContext.provider.tokens())
+				? authContext.provider
+				: undefined;
 			client = new Client({
 				name: this.options.clientName?.trim() || "@cline/core",
 				version: this.options.clientVersion?.trim() || "0.0.0",
@@ -752,6 +753,7 @@ class SdkUrlMcpClient implements McpServerClient {
 				clientInformation: createMcpOAuthClientInformation(
 					this.registration.oauthClient,
 				),
+				allowedScopes: this.registration.oauthClient?.allowedScopes,
 			});
 		const effectiveError = augmentMcpTimeoutError(
 			error,

--- a/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.test.ts
@@ -1,4 +1,5 @@
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	readdirSync,
@@ -99,6 +100,48 @@ describe("mcp config loader", () => {
 				oauth: undefined,
 			},
 		]);
+	});
+
+	it("validates and canonicalizes pre-registered OAuth scope policies", () => {
+		const registration = parseMcpServerRegistration("slack", {
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.slack.com/mcp",
+			},
+			oauthClient: {
+				clientId: "cline-internal-client",
+				allowedScopes: ["search:read.public", "channels:history"],
+			},
+		});
+
+		expect(registration.oauthClient?.allowedScopes).toEqual([
+			"channels:history",
+			"search:read.public",
+		]);
+		expect(() =>
+			parseMcpServerRegistration("slack", {
+				transport: {
+					type: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+				},
+				oauthClient: {
+					clientId: "cline-internal-client",
+					allowedScopes: ["channels:history", "channels:history"],
+				},
+			}),
+		).toThrow(/Invalid MCP server/);
+		expect(() =>
+			parseMcpServerRegistration("slack", {
+				transport: {
+					type: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+				},
+				oauthClient: {
+					clientId: "cline-internal-client",
+					allowedScopes: ["channels:history chat:write"],
+				},
+			}),
+		).toThrow(/Invalid MCP server/);
 	});
 
 	it("parses per-server timeout (seconds) in nested and legacy formats", async () => {
@@ -546,6 +589,73 @@ describe("mcp config loader", () => {
 		expect(written.mcpServers.linear.oauth?.lastAuthenticatedAt).toBe(123);
 	});
 
+	it("does not report tokens as configured outside their bound scope policy", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
+		tempRoots.push(tempRoot);
+		const filePath = join(tempRoot, "cline_mcp_settings.json");
+		const server = {
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.slack.com/mcp",
+			},
+			oauthClient: {
+				clientId: "cline-internal-client",
+				allowedScopes: ["channels:history"],
+			},
+			oauth: {
+				clientInformation: { client_id: "cline-internal-client" },
+				tokens: {
+					access_token: "stored-token",
+					token_type: "Bearer",
+					scope: "channels:history",
+				},
+			},
+		};
+		await writeFile(
+			filePath,
+			JSON.stringify({ mcpServers: { slack: server } }),
+			"utf8",
+		);
+
+		expect(listMcpServerOAuthStatuses({ filePath })[0]?.oauthConfigured).toBe(
+			false,
+		);
+		const policyBoundServer = {
+			...server,
+			oauth: {
+				...server.oauth,
+				scopePolicy: ["channels:history"],
+			},
+		};
+		await writeFile(
+			filePath,
+			JSON.stringify({ mcpServers: { slack: policyBoundServer } }),
+			"utf8",
+		);
+		expect(listMcpServerOAuthStatuses({ filePath })[0]?.oauthConfigured).toBe(
+			true,
+		);
+
+		const overScopedServer = {
+			...policyBoundServer,
+			oauth: {
+				...policyBoundServer.oauth,
+				tokens: {
+					...policyBoundServer.oauth.tokens,
+					scope: "channels:history chat:write",
+				},
+			},
+		};
+		await writeFile(
+			filePath,
+			JSON.stringify({ mcpServers: { slack: overScopedServer } }),
+			"utf8",
+		);
+		expect(listMcpServerOAuthStatuses({ filePath })[0]?.oauthConfigured).toBe(
+			false,
+		);
+	});
+
 	it("rejects inherited server names when updating oauth state", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-config-loader-"));
 		tempRoots.push(tempRoot);
@@ -866,6 +976,54 @@ describe("updateMcpSettingsFile (async acquisition)", () => {
 		const written = JSON.parse(await readFile(filePath, "utf8"));
 		expect(Object.keys(written.mcpServers)).toEqual(["docs"]);
 	});
+
+	it.skipIf(process.platform === "win32")(
+		"creates settings privately even under a permissive umask",
+		async () => {
+			const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-mode-"));
+			tempRoots.push(tempRoot);
+			const filePath = join(tempRoot, "cline_mcp_settings.json");
+			const previousUmask = process.umask(0);
+			try {
+				updateMcpSettingsFileSync(filePath, (settings) => {
+					const servers = settings.mcpServers as Record<string, unknown>;
+					servers.docs = { transport: { type: "stdio", command: "node" } };
+				});
+			} finally {
+				process.umask(previousUmask);
+			}
+
+			expect(statSync(filePath).mode & 0o777).toBe(0o600);
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"restricts permissive existing modes and preserves stricter owner modes",
+		async () => {
+			const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-mode-"));
+			tempRoots.push(tempRoot);
+			for (const [existingMode, expectedMode] of [
+				[0o644, 0o600],
+				[0o640, 0o600],
+				[0o600, 0o600],
+				[0o400, 0o400],
+			] as const) {
+				const filePath = join(
+					tempRoot,
+					`cline_mcp_settings_${existingMode.toString(8)}.json`,
+				);
+				await writeFile(filePath, JSON.stringify({ mcpServers: {} }), "utf8");
+				chmodSync(filePath, existingMode);
+
+				updateMcpSettingsFileSync(filePath, (settings) => {
+					const servers = settings.mcpServers as Record<string, unknown>;
+					servers.docs = { transport: { type: "stdio", command: "node" } };
+				});
+
+				expect(statSync(filePath).mode & 0o777).toBe(expectedMode);
+			}
+		},
+	);
 
 	it("reclaims a stale lock directory on the async path", async () => {
 		const filePath = await makeSettingsFile();

--- a/sdk/packages/core/src/extensions/mcp/config-loader.ts
+++ b/sdk/packages/core/src/extensions/mcp/config-loader.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	readFileSync,
@@ -19,6 +20,12 @@ import {
 } from "@cline/shared";
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import { z } from "zod";
+import {
+	areMcpOAuthScopePoliciesEqual,
+	assertMcpOAuthScopesAllowed,
+	MCP_OAUTH_SCOPE_TOKEN_PATTERN,
+	normalizeMcpOAuthAllowedScopes,
+} from "./oauth-scope-policy";
 import { resolveNativeMcpTransport } from "./remote-proxy";
 import type {
 	McpManager,
@@ -30,6 +37,25 @@ import type {
 
 const stringRecordSchema = z.record(z.string(), z.string());
 const metadataSchema = z.record(z.string(), z.unknown());
+const oauthAllowedScopesSchema = z
+	.array(
+		z
+			.string()
+			.regex(
+				MCP_OAUTH_SCOPE_TOKEN_PATTERN,
+				"OAuth scopes must be valid RFC 6749 scope tokens",
+			),
+	)
+	.min(1)
+	.superRefine((scopes, context) => {
+		if (new Set(scopes).size !== scopes.length) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "OAuth allowedScopes must not contain duplicates",
+			});
+		}
+	})
+	.transform((scopes) => [...scopes].sort());
 
 // Preserve omission and malformed values for the stdio initialize budget.
 // Finite numbers clamp through the shared resolver without rejecting otherwise
@@ -45,6 +71,7 @@ const oauthStateSchema = z
 	.object({
 		clientInformation: z.record(z.string(), z.unknown()).optional(),
 		tokens: z.record(z.string(), z.unknown()).optional(),
+		scopePolicy: oauthAllowedScopesSchema.optional(),
 		codeVerifier: z.string().optional(),
 		discoveryState: z.record(z.string(), z.unknown()).optional(),
 		redirectUrl: z.string().url().optional(),
@@ -57,6 +84,7 @@ const oauthClientSchema = z
 	.object({
 		clientId: z.string().min(1),
 		clientSecret: z.string().min(1).optional(),
+		allowedScopes: oauthAllowedScopesSchema.optional(),
 	})
 	.strip();
 
@@ -293,6 +321,33 @@ export function resolveDefaultMcpSettingsPath(): string {
 	return resolveMcpSettingsPath();
 }
 
+const PRIVATE_SETTINGS_FILE_MODE = 0o600;
+
+function privateSettingsFileMode(filePath: string): number {
+	try {
+		const existingMode = statSync(filePath).mode & 0o777;
+		if (process.platform === "win32") {
+			// Windows chmod only controls the coarse read-only attribute; preserve a
+			// read-only file without claiming that 0600 replaces user-profile ACLs.
+			return existingMode & 0o200 ? PRIVATE_SETTINGS_FILE_MODE : 0o400;
+		}
+		// Never carry group/other or execute permissions forward, and never add an
+		// owner permission that a deliberately stricter existing file omitted.
+		return existingMode & PRIVATE_SETTINGS_FILE_MODE;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return PRIVATE_SETTINGS_FILE_MODE;
+		}
+		throw error;
+	}
+}
+
+function applySettingsFileMode(filePath: string, mode: number): void {
+	// POSIX enforces the full mask. Windows uses this call only to preserve the
+	// read-only attribute; the enclosing user-profile ACL remains authoritative.
+	chmodSync(filePath, mode);
+}
+
 /**
  * Atomically write the MCP settings file using a temp file + rename.
  *
@@ -305,14 +360,25 @@ export function resolveDefaultMcpSettingsPath(): string {
  */
 function atomicWriteSettingsFile(filePath: string, contents: string): void {
 	mkdirSync(dirname(filePath), { recursive: true });
+	const finalMode = privateSettingsFileMode(filePath);
 	const tempPath = `${filePath}.tmp.${process.pid}.${Date.now()}.${Math.random()
 		.toString(36)
 		.slice(2)}`;
 	try {
-		writeFileSync(tempPath, contents, { encoding: "utf8", flag: "wx" });
+		writeFileSync(tempPath, contents, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: PRIVATE_SETTINGS_FILE_MODE,
+		});
+		applySettingsFileMode(tempPath, finalMode);
 		renameSync(tempPath, filePath);
+		// The temp file already carried this mode. Re-apply after rename as a
+		// defensive check against platform/filesystem rename behavior.
+		applySettingsFileMode(filePath, finalMode);
 	} catch (error) {
 		try {
+			// A preserved read-only mode can otherwise block cleanup on Windows.
+			applySettingsFileMode(tempPath, PRIVATE_SETTINGS_FILE_MODE);
 			unlinkSync(tempPath);
 		} catch {
 			// Best-effort cleanup of the temp file.
@@ -708,6 +774,9 @@ export function normalizeMcpServerOAuthState(
 			? { clientInformation: value.clientInformation }
 			: {}),
 		...(value.tokens ? { tokens: value.tokens } : {}),
+		...(value.scopePolicy?.length
+			? { scopePolicy: normalizeMcpOAuthAllowedScopes(value.scopePolicy) }
+			: {}),
 		...(value.codeVerifier ? { codeVerifier: value.codeVerifier } : {}),
 		...(value.discoveryState ? { discoveryState: value.discoveryState } : {}),
 		...(value.redirectUrl ? { redirectUrl: value.redirectUrl } : {}),
@@ -871,7 +940,11 @@ function buildOAuthStateMutator(
 			const expectedClient = options.expectedOAuthClient ?? undefined;
 			if (
 				currentClient?.clientId !== expectedClient?.clientId ||
-				currentClient?.clientSecret !== expectedClient?.clientSecret
+				currentClient?.clientSecret !== expectedClient?.clientSecret ||
+				!areMcpOAuthScopePoliciesEqual(
+					currentClient?.allowedScopes,
+					expectedClient?.allowedScopes,
+				)
 			) {
 				throw new McpOAuthClientChangedError(serverName);
 			}
@@ -946,9 +1019,25 @@ export function getMcpServerOAuthStatus(
 			tokenClientInformation?.client_secret ===
 				registration.oauthClient.clientSecret
 		: true;
+	const tokensMatchScopePolicy = areMcpOAuthScopePoliciesEqual(
+		registration.oauthClient?.allowedScopes,
+		registration.oauth?.scopePolicy,
+	);
+	let tokenScopesAllowed = true;
+	try {
+		assertMcpOAuthScopesAllowed(
+			registration.oauth?.tokens?.scope,
+			registration.oauthClient?.allowedScopes,
+			"persisted token",
+		);
+	} catch {
+		tokenScopesAllowed = false;
+	}
 	const oauthConfigured =
 		oauthSupported &&
 		tokensMatchConfiguredClient &&
+		tokensMatchScopePolicy &&
+		tokenScopesAllowed &&
 		typeof accessToken === "string" &&
 		accessToken.trim().length > 0;
 	return {

--- a/sdk/packages/core/src/extensions/mcp/index.ts
+++ b/sdk/packages/core/src/extensions/mcp/index.ts
@@ -46,6 +46,7 @@ export type {
 	McpOAuthProviderContext,
 } from "./oauth";
 export { authorizeMcpServerOAuth } from "./oauth";
+export { McpOAuthScopePolicyError } from "./oauth-scope-policy";
 export type { PluginMcpServerResolution } from "./plugin-server-registration";
 export {
 	normalizePluginMcpServerRegistration,

--- a/sdk/packages/core/src/extensions/mcp/oauth-scope-policy.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth-scope-policy.test.ts
@@ -1,0 +1,196 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { describe, expect, it, vi } from "vitest";
+import { createMcpSdkTransport } from "./oauth";
+import {
+	createMcpOAuthScopePolicyFetch,
+	McpOAuthScopePolicyError,
+	normalizeMcpOAuthAllowedScopes,
+} from "./oauth-scope-policy";
+
+describe("MCP OAuth scope policy", () => {
+	it("canonicalizes valid policies and rejects malformed or duplicate scopes", () => {
+		expect(
+			normalizeMcpOAuthAllowedScopes([
+				"search:read.public",
+				"channels:history",
+			]),
+		).toEqual(["channels:history", "search:read.public"]);
+		expect(() => normalizeMcpOAuthAllowedScopes([])).toThrow(
+			McpOAuthScopePolicyError,
+		);
+		expect(() =>
+			normalizeMcpOAuthAllowedScopes(["channels:history", "channels:history"]),
+		).toThrow(/Duplicate/);
+		expect(() =>
+			normalizeMcpOAuthAllowedScopes(["channels:history chat:write"]),
+		).toThrow(/Invalid/);
+	});
+
+	it("injects the configured maximum when a Bearer challenge omits scope", async () => {
+		const baseFetch = vi.fn(
+			async () =>
+				new Response("authorization required", {
+					status: 401,
+					headers: {
+						"WWW-Authenticate":
+							'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"',
+					},
+				}),
+		);
+		const policyFetch = createMcpOAuthScopePolicyFetch(baseFetch, [
+			"search:read.public",
+			"channels:history",
+		]);
+		if (!policyFetch) {
+			throw new Error("Expected a policy fetch wrapper.");
+		}
+
+		const response = await policyFetch("https://mcp.example.test/mcp");
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer scope="channels:history search:read.public", resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"',
+		);
+		await expect(response.text()).resolves.toBe("authorization required");
+	});
+
+	it("rejects authorization and upscope challenges outside the policy", async () => {
+		const authorizeFetch = createMcpOAuthScopePolicyFetch(
+			async () =>
+				new Response(null, {
+					status: 401,
+					headers: {
+						"WWW-Authenticate": 'Bearer scope="channels:history chat:write"',
+					},
+				}),
+			["channels:history"],
+		);
+		const upscopeFetch = createMcpOAuthScopePolicyFetch(
+			async () =>
+				new Response(null, {
+					status: 403,
+					headers: {
+						"WWW-Authenticate":
+							'Bearer error="insufficient_scope", scope="chat:write"',
+					},
+				}),
+			["channels:history"],
+		);
+
+		await expect(
+			authorizeFetch?.("https://mcp.example.test/mcp"),
+		).rejects.toThrow(/chat:write/);
+		await expect(
+			upscopeFetch?.("https://mcp.example.test/mcp"),
+		).rejects.toThrow(/chat:write/);
+	});
+
+	it("preserves the existing fetch path when no policy is configured", () => {
+		const baseFetch = vi.fn<typeof fetch>();
+		expect(createMcpOAuthScopePolicyFetch(baseFetch, undefined)).toBe(
+			baseFetch,
+		);
+	});
+
+	it("overrides broad protected-resource metadata in the SDK authorization URL", async () => {
+		let authorizationUrl: URL | undefined;
+		let codeVerifier: string | undefined;
+		const provider: OAuthClientProvider = {
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientMetadata: {
+				client_name: "Cline",
+				redirect_uris: ["http://127.0.0.1:1456/mcp/oauth/callback"],
+				grant_types: ["authorization_code", "refresh_token"],
+				response_types: ["code"],
+				token_endpoint_auth_method: "none",
+				scope: "channels:history",
+			},
+			clientInformation: () => ({ client_id: "cline-internal-client" }),
+			tokens: () => undefined,
+			saveTokens: () => undefined,
+			redirectToAuthorization: (url) => {
+				authorizationUrl = url;
+			},
+			saveCodeVerifier: (value) => {
+				codeVerifier = value;
+			},
+			codeVerifier: () => {
+				if (!codeVerifier) {
+					throw new Error("Missing test code verifier.");
+				}
+				return codeVerifier;
+			},
+		};
+		const fetch = vi.fn(async (input: string | URL) => {
+			const url = new URL(input);
+			if (url.href === "https://mcp.example.test/mcp") {
+				return new Response(null, {
+					status: 401,
+					headers: {
+						"WWW-Authenticate":
+							'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"',
+					},
+				});
+			}
+			if (
+				url.href ===
+				"https://mcp.example.test/.well-known/oauth-protected-resource"
+			) {
+				return Response.json({
+					resource: "https://mcp.example.test/mcp",
+					authorization_servers: ["https://auth.example.test"],
+					scopes_supported: ["channels:history", "chat:write"],
+				});
+			}
+			if (
+				url.href ===
+				"https://auth.example.test/.well-known/oauth-authorization-server"
+			) {
+				return Response.json({
+					issuer: "https://auth.example.test",
+					authorization_endpoint: "https://auth.example.test/authorize",
+					token_endpoint: "https://auth.example.test/token",
+					response_types_supported: ["code"],
+					grant_types_supported: ["authorization_code", "refresh_token"],
+					code_challenge_methods_supported: ["S256"],
+					token_endpoint_auth_methods_supported: ["none"],
+				});
+			}
+			return new Response(null, { status: 404 });
+		});
+		const transport = createMcpSdkTransport({
+			registration: {
+				name: "slack",
+				transport: {
+					type: "streamableHttp",
+					url: "https://mcp.example.test/mcp",
+				},
+				oauthClient: {
+					clientId: "cline-internal-client",
+					allowedScopes: ["channels:history"],
+				},
+			},
+			oauthProvider: provider,
+			fetch,
+		});
+
+		try {
+			await expect(
+				transport.send({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "initialize",
+					params: {
+						protocolVersion: "2025-06-18",
+						capabilities: {},
+						clientInfo: { name: "test", version: "0.0.0" },
+					},
+				}),
+			).rejects.toBeInstanceOf(UnauthorizedError);
+			expect(authorizationUrl?.searchParams.get("scope")).toBe(
+				"channels:history",
+			);
+		} finally {
+			await transport.close();
+		}
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/oauth-scope-policy.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth-scope-policy.ts
@@ -1,0 +1,188 @@
+import { extractWWWAuthenticateParams } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+// RFC 6749 section 3.3 scope-token: printable ASCII excluding DQUOTE and "\\".
+export const MCP_OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
+export class McpOAuthScopePolicyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "McpOAuthScopePolicyError";
+	}
+}
+
+export function isMcpOAuthScopeToken(value: string): boolean {
+	return MCP_OAUTH_SCOPE_TOKEN_PATTERN.test(value);
+}
+
+/**
+ * Returns one canonical policy representation for config comparisons, state
+ * binding, authorization requests, and persisted-token checks.
+ */
+export function normalizeMcpOAuthAllowedScopes(
+	allowedScopes: readonly string[] | undefined,
+): string[] | undefined {
+	if (allowedScopes === undefined) {
+		return undefined;
+	}
+	if (allowedScopes.length === 0) {
+		throw new McpOAuthScopePolicyError(
+			"MCP OAuth allowedScopes must contain at least one scope.",
+		);
+	}
+	const unique = new Set<string>();
+	for (const scope of allowedScopes) {
+		if (!isMcpOAuthScopeToken(scope)) {
+			throw new McpOAuthScopePolicyError(
+				`Invalid MCP OAuth scope token: ${JSON.stringify(scope)}.`,
+			);
+		}
+		if (unique.has(scope)) {
+			throw new McpOAuthScopePolicyError(
+				`Duplicate MCP OAuth scope in allowedScopes: ${JSON.stringify(scope)}.`,
+			);
+		}
+		unique.add(scope);
+	}
+	return [...unique].sort();
+}
+
+export function areMcpOAuthScopePoliciesEqual(
+	left: readonly string[] | undefined,
+	right: readonly string[] | undefined,
+): boolean {
+	if (left === undefined || right === undefined) {
+		return left === right;
+	}
+	if (left.length !== right.length) {
+		return false;
+	}
+	const leftSorted = [...left].sort();
+	const rightSorted = [...right].sort();
+	return leftSorted.every((scope, index) => scope === rightSorted[index]);
+}
+
+function parseScopeValue(scopeValue: string, source: string): string[] {
+	const scopes = scopeValue.trim().split(/\s+/).filter(Boolean);
+	if (
+		scopes.length === 0 ||
+		scopes.some((scope) => !isMcpOAuthScopeToken(scope))
+	) {
+		throw new McpOAuthScopePolicyError(
+			`MCP OAuth ${source} contains an invalid scope value.`,
+		);
+	}
+	return scopes;
+}
+
+/** Rejects any requested or granted scope outside the configured maximum. */
+export function assertMcpOAuthScopesAllowed(
+	scopeValue: unknown,
+	allowedScopes: readonly string[] | undefined,
+	source: string,
+): void {
+	if (scopeValue === undefined || allowedScopes === undefined) {
+		return;
+	}
+	if (typeof scopeValue !== "string") {
+		throw new McpOAuthScopePolicyError(
+			`MCP OAuth ${source} contains a non-string scope value.`,
+		);
+	}
+	const normalized = normalizeMcpOAuthAllowedScopes(allowedScopes);
+	if (!normalized) {
+		return;
+	}
+	const allowed = new Set(normalized);
+	const outsidePolicy = parseScopeValue(scopeValue, source).filter(
+		(scope) => !allowed.has(scope),
+	);
+	if (outsidePolicy.length > 0) {
+		throw new McpOAuthScopePolicyError(
+			`MCP OAuth ${source} requested scopes outside allowedScopes: ${outsidePolicy.sort().join(", ")}.`,
+		);
+	}
+}
+
+function responseWithScopeChallenge(
+	response: Response,
+	header: string | null,
+	policyScope: string,
+): Response {
+	const headers = new Headers(response.headers);
+	const bearerParameters = header
+		? header
+				.trim()
+				.replace(/^Bearer\s*/i, "")
+				.trim()
+		: "";
+	headers.set(
+		"WWW-Authenticate",
+		`Bearer scope="${policyScope}"${bearerParameters ? `, ${bearerParameters}` : ""}`,
+	);
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+}
+
+/**
+ * Constrains the MCP SDK's scope selection strategy without depending on its
+ * private transport fields. The SDK gives an explicit Bearer challenge scope
+ * precedence over broad protected-resource metadata, so a missing scope is
+ * normalized to the configured policy and an explicit upscope is rejected.
+ */
+export function createMcpOAuthScopePolicyFetch(
+	baseFetch: FetchLike | undefined,
+	allowedScopes: readonly string[] | undefined,
+): FetchLike | undefined {
+	const normalized = normalizeMcpOAuthAllowedScopes(allowedScopes);
+	if (!normalized) {
+		return baseFetch;
+	}
+	const fetchFn = baseFetch ?? globalThis.fetch;
+	const policyScope = normalized.join(" ");
+
+	return async (url, init) => {
+		const response = await fetchFn(url, init);
+		if (response.status !== 401 && response.status !== 403) {
+			return response;
+		}
+
+		const header = response.headers.get("WWW-Authenticate");
+		if (header && !/^\s*Bearer(?:\s+|$)/i.test(header)) {
+			if (response.status === 401) {
+				await response.body?.cancel().catch(() => undefined);
+				throw new McpOAuthScopePolicyError(
+					"MCP OAuth scope policy cannot authorize a non-Bearer challenge.",
+				);
+			}
+			return response;
+		}
+
+		const { scope, error } = extractWWWAuthenticateParams(response);
+		const declaresScope =
+			header !== null && /(?:^|[,\s])scope\s*=/i.test(header);
+		if (declaresScope && !scope) {
+			await response.body?.cancel().catch(() => undefined);
+			throw new McpOAuthScopePolicyError(
+				"MCP OAuth WWW-Authenticate challenge contains an invalid scope parameter.",
+			);
+		}
+		if (scope) {
+			try {
+				assertMcpOAuthScopesAllowed(scope, normalized, "challenge");
+			} catch (policyError) {
+				await response.body?.cancel().catch(() => undefined);
+				throw policyError;
+			}
+			return response;
+		}
+
+		if (response.status === 401 || error === "insufficient_scope") {
+			return responseWithScopeChallenge(response, header, policyScope);
+		}
+		return response;
+	};
+}

--- a/sdk/packages/core/src/extensions/mcp/oauth.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth.test.ts
@@ -15,6 +15,7 @@ import {
 	createMcpSdkTransport,
 	isMcpUnauthorizedError,
 } from "./oauth";
+import { McpOAuthScopePolicyError } from "./oauth-scope-policy";
 
 describe("mcp oauth", () => {
 	const tempRoots: string[] = [];
@@ -31,6 +32,7 @@ describe("mcp oauth", () => {
 	async function createSettingsFile(oauthClient?: {
 		clientId: string;
 		clientSecret?: string;
+		allowedScopes?: string[];
 	}): Promise<string> {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-mcp-oauth-"));
 		tempRoots.push(tempRoot);
@@ -173,6 +175,108 @@ describe("mcp oauth", () => {
 		expect(await changedSecret.provider.tokens()).toBeUndefined();
 	});
 
+	it("binds persisted tokens and client metadata to the configured scope policy", async () => {
+		const settingsPath = await createSettingsFile({
+			clientId: "client-a",
+			allowedScopes: ["search:read.public", "channels:history"],
+		});
+		const context = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+			allowedScopes: ["search:read.public", "channels:history"],
+		});
+
+		expect(context.provider.clientMetadata.scope).toBe(
+			"channels:history search:read.public",
+		);
+		await context.provider.saveTokens({
+			access_token: "policy-bound-token",
+			token_type: "bearer",
+			scope: "channels:history",
+		});
+		expect((await context.provider.tokens())?.access_token).toBe(
+			"policy-bound-token",
+		);
+
+		const written = JSON.parse(await readFile(settingsPath, "utf8"));
+		expect(written.mcpServers.linear.oauth.scopePolicy).toEqual([
+			"channels:history",
+			"search:read.public",
+		]);
+
+		const changedPolicy = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+			allowedScopes: ["channels:history"],
+		});
+		expect(await changedPolicy.provider.tokens()).toBeUndefined();
+	});
+
+	it("invalidates policy-bound tokens when the configured policy is removed", async () => {
+		const settingsPath = await createSettingsFile({
+			clientId: "client-a",
+			allowedScopes: ["channels:history"],
+		});
+		const scopedContext = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+			allowedScopes: ["channels:history"],
+		});
+		await scopedContext.provider.saveTokens({
+			access_token: "policy-bound-token",
+			token_type: "bearer",
+			scope: "channels:history",
+		});
+		await updateMcpSettingsFile(settingsPath, (settings) => {
+			const servers = settings.mcpServers as Record<string, unknown>;
+			const linear = servers.linear as Record<string, unknown>;
+			linear.oauthClient = { clientId: "client-a" };
+		});
+
+		const unscopedContext = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+		});
+		expect(await unscopedContext.provider.tokens()).toBeUndefined();
+		await unscopedContext.resetInteractiveState();
+
+		const written = JSON.parse(await readFile(settingsPath, "utf8"));
+		expect(written.mcpServers.linear.oauth.tokens).toBeUndefined();
+		expect(written.mcpServers.linear.oauth.scopePolicy).toBeUndefined();
+	});
+
+	it("rejects token responses that grant scopes outside the configured policy", async () => {
+		const settingsPath = await createSettingsFile({
+			clientId: "client-a",
+			allowedScopes: ["channels:history"],
+		});
+		const context = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+			allowedScopes: ["channels:history"],
+		});
+
+		await expect(
+			context.provider.saveTokens({
+				access_token: "over-scoped-token",
+				token_type: "bearer",
+				scope: "channels:history chat:write",
+			}),
+		).rejects.toBeInstanceOf(McpOAuthScopePolicyError);
+		const written = JSON.parse(await readFile(settingsPath, "utf8"));
+		expect(written.mcpServers.linear.oauth).toBeUndefined();
+	});
+
 	it("merges updates with the latest OAuth state read under the settings lock", async () => {
 		const settingsPath = await createSettingsFile();
 		const context = createMcpOAuthProviderContext({
@@ -238,6 +342,41 @@ describe("mcp oauth", () => {
 			clientId: "client-b",
 			clientSecret: "secret-b",
 		});
+		expect(written.mcpServers.linear.oauth).toBeUndefined();
+	});
+
+	it("rejects tokens from a callback after the configured scope policy changes", async () => {
+		const settingsPath = await createSettingsFile({
+			clientId: "client-a",
+			allowedScopes: ["channels:history"],
+		});
+		const context = createMcpOAuthProviderContext({
+			settingsPath,
+			serverName: "linear",
+			redirectUrl: "http://127.0.0.1:1456/mcp/oauth/callback",
+			clientInformation: { client_id: "client-a" },
+			allowedScopes: ["channels:history"],
+		});
+		await context.resetInteractiveState();
+
+		await updateMcpSettingsFile(settingsPath, (settings) => {
+			const servers = settings.mcpServers as Record<string, unknown>;
+			const linear = servers.linear as Record<string, unknown>;
+			linear.oauthClient = {
+				clientId: "client-a",
+				allowedScopes: ["search:read.public"],
+			};
+			delete linear.oauth;
+		});
+
+		await expect(
+			context.provider.saveTokens({
+				access_token: "stale-access-token",
+				token_type: "bearer",
+				scope: "channels:history",
+			}),
+		).rejects.toBeInstanceOf(McpOAuthClientChangedError);
+		const written = JSON.parse(await readFile(settingsPath, "utf8"));
 		expect(written.mcpServers.linear.oauth).toBeUndefined();
 	});
 

--- a/sdk/packages/core/src/extensions/mcp/oauth.ts
+++ b/sdk/packages/core/src/extensions/mcp/oauth.ts
@@ -28,6 +28,12 @@ import {
 	resolveDefaultMcpSettingsPath,
 	updateMcpServerOAuthStateAsync,
 } from "./config-loader";
+import {
+	areMcpOAuthScopePoliciesEqual,
+	assertMcpOAuthScopesAllowed,
+	createMcpOAuthScopePolicyFetch,
+	normalizeMcpOAuthAllowedScopes,
+} from "./oauth-scope-policy";
 import { augmentMcpTimeoutError, resolveMcpRequestTimeoutMs } from "./timeout";
 import type {
 	McpServerOAuthClientConfig,
@@ -49,6 +55,7 @@ export interface CreateMcpOAuthProviderContextOptions {
 	redirectUrl: string;
 	onAuthorizationUrl?: (url: string) => void | Promise<void>;
 	clientInformation?: OAuthClientInformationMixed;
+	allowedScopes?: readonly string[];
 }
 
 export interface McpOAuthProviderContext {
@@ -95,13 +102,17 @@ function toErrorMessage(error: unknown): string {
 	return String(error);
 }
 
-function createOAuthClientMetadata(redirectUrl: string): OAuthClientMetadata {
+function createOAuthClientMetadata(
+	redirectUrl: string,
+	allowedScopes: readonly string[] | undefined,
+): OAuthClientMetadata {
 	return {
 		client_name: "Cline",
 		redirect_uris: [redirectUrl],
 		grant_types: ["authorization_code", "refresh_token"],
 		response_types: ["code"],
 		token_endpoint_auth_method: "none",
+		...(allowedScopes ? { scope: allowedScopes.join(" ") } : {}),
 	};
 }
 
@@ -144,6 +155,7 @@ function assertOAuthClientUnchanged(
 export function createMcpOAuthProviderContext(
 	options: CreateMcpOAuthProviderContextOptions,
 ): McpOAuthProviderContext {
+	const allowedScopes = normalizeMcpOAuthAllowedScopes(options.allowedScopes);
 	let state: McpServerOAuthState = {};
 	try {
 		state =
@@ -164,6 +176,7 @@ export function createMcpOAuthProviderContext(
 				...(options.clientInformation.client_secret
 					? { clientSecret: options.clientInformation.client_secret }
 					: {}),
+				...(allowedScopes ? { allowedScopes } : {}),
 			}
 		: null;
 
@@ -196,6 +209,7 @@ export function createMcpOAuthProviderContext(
 		get clientMetadata() {
 			return createOAuthClientMetadata(
 				state.redirectUrl ?? options.redirectUrl,
+				allowedScopes,
 			);
 		},
 		state: () => {
@@ -221,22 +235,42 @@ export function createMcpOAuthProviderContext(
 					...current,
 					clientInformation: clientInformation as Record<string, unknown>,
 					...(clientChanged
-						? { tokens: undefined, lastAuthenticatedAt: undefined }
+						? {
+								tokens: undefined,
+								scopePolicy: undefined,
+								lastAuthenticatedAt: undefined,
+							}
 						: {}),
 					redirectUrl: options.redirectUrl,
 					lastError: undefined,
 				};
 			});
 		},
-		tokens: () =>
-			currentClientInformation()?.client_id &&
-			isSameOAuthClient(
-				state.clientInformation as OAuthClientInformationMixed | undefined,
-				currentClientInformation(),
-			)
-				? (state.tokens as OAuthTokens | undefined)
-				: undefined,
+		tokens: () => {
+			const tokens = state.tokens as OAuthTokens | undefined;
+			if (
+				!currentClientInformation()?.client_id ||
+				!isSameOAuthClient(
+					state.clientInformation as OAuthClientInformationMixed | undefined,
+					currentClientInformation(),
+				) ||
+				!areMcpOAuthScopePoliciesEqual(allowedScopes, state.scopePolicy)
+			) {
+				return undefined;
+			}
+			assertMcpOAuthScopesAllowed(
+				tokens?.scope,
+				allowedScopes,
+				"persisted token",
+			);
+			return tokens;
+		},
 		saveTokens: async (tokens) => {
+			assertMcpOAuthScopesAllowed(
+				tokens.scope,
+				allowedScopes,
+				"token response",
+			);
 			const lastAuthenticatedAt = Date.now();
 			const clientInformation = currentClientInformation();
 			if (!clientInformation?.client_id) {
@@ -256,6 +290,7 @@ export function createMcpOAuthProviderContext(
 				return {
 					...current,
 					tokens: tokens as Record<string, unknown>,
+					scopePolicy: allowedScopes ? [...allowedScopes] : undefined,
 					clientInformation: clientInformation as Record<string, unknown>,
 					redirectUrl: options.redirectUrl,
 					lastError: undefined,
@@ -312,6 +347,7 @@ export function createMcpOAuthProviderContext(
 					...(scope === "tokens"
 						? {
 								tokens: undefined,
+								scopePolicy: undefined,
 								lastAuthenticatedAt: undefined,
 							}
 						: {}),
@@ -355,6 +391,10 @@ export function createMcpOAuthProviderContext(
 							| undefined,
 						configuredClientInformation,
 					);
+				const scopePolicyChanged = !areMcpOAuthScopePoliciesEqual(
+					allowedScopes,
+					current.scopePolicy,
+				);
 				return {
 					...current,
 					...(configuredClientInformation
@@ -365,9 +405,10 @@ export function createMcpOAuthProviderContext(
 								>,
 							}
 						: {}),
-					...(configuredClientChanged
+					...(configuredClientChanged || scopePolicyChanged
 						? { tokens: undefined, lastAuthenticatedAt: undefined }
 						: {}),
+					scopePolicy: allowedScopes ? [...allowedScopes] : undefined,
 					codeVerifier: undefined,
 					discoveryState: undefined,
 					lastError: undefined,
@@ -422,14 +463,20 @@ export function createMcpSdkTransport(input: {
 				headers: transport.headers,
 			}
 		: undefined;
+	const oauthFetch = input.oauthProvider
+		? createMcpOAuthScopePolicyFetch(
+				input.fetch,
+				input.registration.oauthClient?.allowedScopes,
+			)
+		: input.fetch;
 	// The upstream transports only surface a typed UnauthorizedError for a 401
 	// when an OAuth provider is present. For passive connections without stored
 	// tokens, translate the response at the fetch boundary so callers can show
 	// an explicit sign-in action without starting discovery/registration/PKCE.
 	const transportFetch: FetchLike | undefined = input.oauthProvider
-		? input.fetch
+		? oauthFetch
 		: async (url, init) => {
-				const response = await (input.fetch ?? globalThis.fetch)(url, init);
+				const response = await (oauthFetch ?? globalThis.fetch)(url, init);
 				if (response.status === 401) {
 					await response.body?.cancel().catch(() => undefined);
 					throw new UnauthorizedError("MCP server requires authorization");
@@ -445,7 +492,7 @@ export function createMcpSdkTransport(input: {
 			// passed-through 401 fails the connection with an SseError carrying
 			// the HTTP code that isMcpUnauthorizedError recognizes.
 			eventSourceInit: {
-				fetch: (url, init) => (input.fetch ?? globalThis.fetch)(url, init),
+				fetch: (url, init) => (oauthFetch ?? globalThis.fetch)(url, init),
 			},
 			fetch: transportFetch,
 		});
@@ -548,6 +595,7 @@ export async function authorizeMcpServerOAuth(
 		clientInformation: createMcpOAuthClientInformation(
 			registration.oauthClient,
 		),
+		allowedScopes: registration.oauthClient?.allowedScopes,
 		onAuthorizationUrl: async (url) => {
 			await options.openUrl?.(url);
 		},

--- a/sdk/packages/core/src/extensions/mcp/types.ts
+++ b/sdk/packages/core/src/extensions/mcp/types.ts
@@ -64,6 +64,8 @@ export type McpServerTransportConfig =
 export interface McpServerOAuthState {
 	clientInformation?: Record<string, unknown>;
 	tokens?: Record<string, unknown>;
+	/** Scope policy that the persisted token set was issued under. */
+	scopePolicy?: string[];
 	codeVerifier?: string;
 	discoveryState?: Record<string, unknown>;
 	redirectUrl?: string;
@@ -75,6 +77,8 @@ export interface McpServerOAuthState {
 export interface McpServerOAuthClientConfig {
 	clientId: string;
 	clientSecret?: string;
+	/** Maximum OAuth scopes this pre-registered client may request or accept. */
+	allowedScopes?: string[];
 }
 
 export interface McpServerRegistration {

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -306,6 +306,7 @@ export {
 	type McpManager,
 	type McpManagerOptions,
 	McpOAuthClientChangedError,
+	McpOAuthScopePolicyError,
 	type McpServerClient,
 	type McpServerClientFactory,
 	type McpServerOAuthClientConfig,


### PR DESCRIPTION
## Summary

- adds an optional per-server `oauthClient.allowedScopes` maximum for pre-registered MCP OAuth clients
- constrains missing-scope Bearer challenges to that maximum so broad protected-resource metadata cannot widen the authorization request
- rejects explicit challenge, token-response, persisted-token, and stale-callback scopes outside policy
- binds cached OAuth state to the canonical scope policy and invalidates it when the policy is added, changed, or removed
- makes atomic MCP settings writes private (`0600` or stricter on POSIX) now that the file may contain OAuth client secrets and tokens

## Motivation

Slack's hosted MCP server requires a pre-registered client and advertises both read and write scopes in protected-resource metadata. Cline already supports fixed client IDs, but without an explicit maximum the MCP SDK can select the provider's broad advertised catalog. A read-only engineering workflow needs the host to constrain that request before browser consent.

## Compatibility

- Omitting `allowedScopes` preserves existing behavior.
- Empty, duplicate, whitespace-containing, and malformed scope lists fail configuration validation.
- Existing no-policy tokens remain valid only when no policy was previously bound.
- OAuth token responses may legally omit `scope`; in that case OAuth defines the grant as the requested scope, which this change has already constrained.

## Validation

- Core focused Vitest suite: 54/54 passed
- `@cline/core` typecheck and smoke typecheck passed
- full SDK build passed
- Biome passed for every changed file
- `git diff --check` passed
- independent security review found no remaining P0-P2 issues

The full Core suite was also sampled: 2,047 passed, 74 failed, and 29 skipped. Observed failures were environment-only in the restricted worktree (loopback bind `EPERM`, denied writes to live `~/.cline` paths/read-only SQLite, and git-signing configuration), not scope-policy assertions.

## Side effects

No MCP provider was contacted and no live Cline settings file was modified.

Follow-up Desktop configuration is stacked in [#13674](https://github.com/cline/cline/pull/13674).
