### PR TITLE
feat(desktop): configure static MCP OAuth clients

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -90,6 +90,7 @@ import {
 import {
 	ensureMcpSettingsFile,
 	readMcpServersResponse,
+	resolveMcpOAuthClientUpdate,
 	shouldProbeMcpServerAfterUpsert,
 } from "./mcp";
 import {
@@ -250,6 +251,21 @@ function readProviderSettingsUpdate(
 		: {};
 }
 
+function mcpRemoteHeadersIdentity(headers: unknown): string {
+	if (headers === undefined) {
+		return "omitted";
+	}
+	if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+		return "invalid";
+	}
+	const entries = Object.entries(headers);
+	if (entries.some(([, value]) => typeof value !== "string")) {
+		return "invalid";
+	}
+	entries.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+	return `present:${JSON.stringify(entries)}`;
+}
+
 /**
  * Transport type + URL a server record actually points at, tolerating both
  * the nested `transport` shape and legacy flat fields (mirrors
@@ -260,7 +276,7 @@ function mcpTransportIdentity(name: string, record: JsonRecord): string {
 		const resolved = parseMcpServerRegistration(name, record).transport;
 		return resolved.type === "stdio"
 			? "stdio\u0000"
-			: `${resolved.type}\u0000${resolved.url}`;
+			: `${resolved.type}\u0000${resolved.url}\u0000${mcpRemoteHeadersIdentity(resolved.headers)}`;
 	} catch {
 		// Preserve a best-effort identity for malformed entries so the editor can
 		// still repair them without requiring the entire settings file to parse.
@@ -281,7 +297,11 @@ function mcpTransportIdentity(name: string, record: JsonRecord): string {
 	const rawType = transport?.type ?? record.transportType ?? record.type;
 	const type = String(rawType ?? (url ? "sse" : "stdio")).trim();
 	const normalizedType = type === "http" ? "streamableHttp" : type;
-	return `${normalizedType}\u0000${url}`;
+	const headers =
+		transport && Object.hasOwn(transport, "headers")
+			? transport.headers
+			: record.headers;
+	return `${normalizedType}\u0000${url}\u0000${mcpRemoteHeadersIdentity(headers)}`;
 }
 
 function removePathIfExists(
@@ -2142,6 +2162,11 @@ export async function handleCommand(
 		).trim();
 		const requestedDisabled = Boolean(input.disabled);
 		const isRemote = transportType !== "stdio";
+		if (!isRemote && input.oauthClient != null) {
+			throw new Error(
+				"OAuth clients are only supported for remote MCP servers",
+			);
+		}
 		const next: JsonRecord =
 			transportType === "stdio"
 				? {
@@ -2175,10 +2200,12 @@ export async function handleCommand(
 				const existingName =
 					previousName && servers[previousName] ? previousName : name;
 				const existing = servers[existingName];
+				let existingRecord: JsonRecord | undefined;
 				let existingTransportIdentity: string | undefined;
 				let existingWasEnabled = false;
 				if (existing && typeof existing === "object") {
 					const record = existing as JsonRecord;
+					existingRecord = record;
 					existingTransportIdentity = mcpTransportIdentity(
 						existingName,
 						record,
@@ -2188,16 +2215,26 @@ export async function handleCommand(
 				const nextTransportIdentity = mcpTransportIdentity(name, next);
 				const transportIdentityUnchanged =
 					existingTransportIdentity === nextTransportIdentity;
+				const { oauthClient, oauthClientUnchanged } =
+					resolveMcpOAuthClientUpdate({
+						requestedOAuthClient: input.oauthClient,
+						existingOAuthClient: existingRecord?.oauthClient,
+						transportIdentityUnchanged,
+					});
 				const shouldProbe = shouldProbeMcpServerAfterUpsert({
 					isRemote,
 					requestedDisabled,
 					existingWasEnabled,
 					transportIdentityUnchanged,
+					oauthClientUnchanged,
 				});
 				const upserted: JsonRecord = {
 					...next,
 					disabled: requestedDisabled || shouldProbe,
 				};
+				if (oauthClient !== undefined) {
+					upserted.oauthClient = oauthClient;
+				}
 				if (existing && typeof existing === "object") {
 					const record = existing as JsonRecord;
 					if (
@@ -2206,14 +2243,14 @@ export async function handleCommand(
 					) {
 						upserted.metadata = record.metadata;
 					}
-					// OAuth tokens were issued for a specific endpoint; carrying them
-					// onto an edited transport or URL would send the old server's
-					// credentials to a different endpoint.
-					if (record.oauth !== undefined && transportIdentityUnchanged) {
+					// OAuth state is bound to both endpoint and client identity. Never
+					// carry tokens or discovery state across either kind of change.
+					if (
+						record.oauth !== undefined &&
+						transportIdentityUnchanged &&
+						oauthClientUnchanged
+					) {
 						upserted.oauth = record.oauth;
-					}
-					if (record.oauthClient !== undefined && transportIdentityUnchanged) {
-						upserted.oauthClient = record.oauthClient;
 					}
 				}
 				if (previousName && previousName !== name) {

--- a/apps/examples/desktop-app/sidecar/mcp.test.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { handleCommand } from "./commands";
 import {
 	buildMcpServersResponse,
+	resolveMcpOAuthClientUpdate,
 	shouldProbeMcpServerAfterUpsert,
 } from "./mcp";
 import type { JsonRecord, SidecarContext } from "./types";
@@ -33,6 +34,11 @@ describe("desktop MCP settings", () => {
 					command: "npx",
 					args: ["-y", "mcp-remote", "https://mcp.linear.app/mcp"],
 					disabled: true,
+					oauthClient: {
+						clientId: "desktop-client",
+						clientSecret: "must-not-leave-the-sidecar",
+						allowedScopes: ["search:read.public", "channels:history"],
+					},
 					oauth: {
 						authorizationRequired: true,
 						lastError: "OAuth authorization required",
@@ -49,6 +55,11 @@ describe("desktop MCP settings", () => {
 			transportType: "streamableHttp",
 			url: "https://mcp.linear.app/mcp",
 			disabled: true,
+			oauthClient: {
+				clientId: "desktop-client",
+				hasClientSecret: true,
+				allowedScopes: ["channels:history", "search:read.public"],
+			},
 			oauthStatus: {
 				authorizationRequired: true,
 				lastError: "OAuth authorization required",
@@ -60,6 +71,9 @@ describe("desktop MCP settings", () => {
 		});
 		expect(String(servers[1]?.configurationError)).toContain(
 			'Invalid MCP server "broken"',
+		);
+		expect(JSON.stringify(response)).not.toContain(
+			"must-not-leave-the-sidecar",
 		);
 	});
 
@@ -80,6 +94,492 @@ describe("desktop MCP settings", () => {
 				transportIdentityUnchanged: false,
 			}),
 		).toBe(true);
+		expect(
+			shouldProbeMcpServerAfterUpsert({
+				isRemote: true,
+				requestedDisabled: false,
+				existingWasEnabled: true,
+				transportIdentityUnchanged: true,
+				oauthClientUnchanged: false,
+			}),
+		).toBe(true);
+	});
+
+	it("validates requests to preserve a redacted OAuth client secret", () => {
+		expect(() =>
+			resolveMcpOAuthClientUpdate({
+				requestedOAuthClient: {
+					clientId: "replacement-client",
+					preserveClientSecret: true,
+				},
+				existingOAuthClient: {
+					clientId: "desktop-client",
+					clientSecret: "saved-secret",
+				},
+				transportIdentityUnchanged: true,
+			}),
+		).toThrow("cannot be preserved for this client ID");
+		expect(() =>
+			resolveMcpOAuthClientUpdate({
+				requestedOAuthClient: {
+					clientId: "desktop-client",
+					preserveClientSecret: true,
+				},
+				existingOAuthClient: {
+					clientId: "desktop-client",
+					clientSecret: "saved-secret",
+				},
+				transportIdentityUnchanged: false,
+			}),
+		).toThrow("server transport, URL, or headers");
+	});
+
+	it("fails closed on malformed or unknown OAuth scope policy input", () => {
+		const base = {
+			clientId: "desktop-client",
+			allowedScopes: ["channels:history"],
+		};
+		for (const requestedOAuthClient of [
+			{ ...base, allowedScopes: [] },
+			{ ...base, allowedScopes: ["channels:history", "channels:history"] },
+			{ ...base, allowedScopes: ["channels:history chat:write"] },
+			{ ...base, allowedScopes: "channels:history" },
+			{ ...base, unexpected: true },
+		]) {
+			expect(() =>
+				resolveMcpOAuthClientUpdate({
+					requestedOAuthClient,
+					existingOAuthClient: undefined,
+					transportIdentityUnchanged: false,
+				}),
+			).toThrow();
+		}
+	});
+
+	it("preserves a saved OAuth client secret and its current OAuth state", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "desktop-mcp-oauth-"));
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		try {
+			await writeFile(
+				settingsPath,
+				JSON.stringify({
+					mcpServers: {
+						slack: {
+							transport: {
+								type: "streamableHttp",
+								url: "https://mcp.slack.com/mcp",
+							},
+							disabled: true,
+							oauthClient: {
+								clientId: "desktop-client",
+								clientSecret: "saved-secret",
+								allowedScopes: ["search:read.public", "channels:history"],
+							},
+							oauth: {
+								tokens: { access_token: "saved-token" },
+							},
+						},
+					},
+				}),
+				"utf8",
+			);
+
+			const response = (await handleCommand(
+				createContext(tempRoot),
+				"upsert_mcp_server",
+				{
+					input: {
+						name: "slack",
+						previousName: "slack",
+						transportType: "streamableHttp",
+						url: "https://mcp.slack.com/mcp",
+						disabled: true,
+						oauthClient: {
+							clientId: "desktop-client",
+							preserveClientSecret: true,
+						},
+					},
+				},
+			)) as JsonRecord;
+			expect(response.servers).toEqual([
+				expect.objectContaining({
+					name: "slack",
+					oauthClient: {
+						clientId: "desktop-client",
+						hasClientSecret: true,
+						allowedScopes: ["channels:history", "search:read.public"],
+					},
+				}),
+			]);
+			expect(JSON.stringify(response)).not.toContain("saved-secret");
+			expect(JSON.stringify(response)).not.toContain("saved-token");
+
+			const written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.slack.oauthClient).toEqual({
+				clientId: "desktop-client",
+				clientSecret: "saved-secret",
+				allowedScopes: ["search:read.public", "channels:history"],
+			});
+			expect(written.mcpServers.slack.oauth).toEqual({
+				tokens: { access_token: "saved-token" },
+			});
+		} finally {
+			if (previousSettingsPath === undefined) {
+				delete process.env.CLINE_MCP_SETTINGS_PATH;
+			} else {
+				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+			}
+			await rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("canonicalizes scope edits and invalidates OAuth state only for policy changes", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "desktop-mcp-scopes-"));
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		try {
+			const writeScopedServer = async () =>
+				writeFile(
+					settingsPath,
+					JSON.stringify({
+						mcpServers: {
+							slack: {
+								transport: {
+									type: "streamableHttp",
+									url: "https://mcp.slack.com/mcp",
+								},
+								disabled: true,
+								oauthClient: {
+									clientId: "desktop-client",
+									clientSecret: "saved-secret",
+									allowedScopes: ["search:read.public", "channels:history"],
+								},
+								oauth: {
+									tokens: { access_token: "saved-token" },
+								},
+							},
+						},
+					}),
+					"utf8",
+				);
+
+			await writeScopedServer();
+			await handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+				input: {
+					name: "slack",
+					previousName: "slack",
+					transportType: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+					disabled: true,
+					oauthClient: {
+						clientId: "desktop-client",
+						preserveClientSecret: true,
+						allowedScopes: ["channels:history", "search:read.public"],
+					},
+				},
+			});
+			let written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.slack.oauthClient.allowedScopes).toEqual([
+				"channels:history",
+				"search:read.public",
+			]);
+			expect(written.mcpServers.slack.oauth).toEqual({
+				tokens: { access_token: "saved-token" },
+			});
+
+			await writeScopedServer();
+			await handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+				input: {
+					name: "slack",
+					previousName: "slack",
+					transportType: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+					disabled: true,
+					oauthClient: {
+						clientId: "desktop-client",
+						preserveClientSecret: true,
+						allowedScopes: ["channels:history"],
+					},
+				},
+			});
+			written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.slack.oauthClient).toEqual({
+				clientId: "desktop-client",
+				clientSecret: "saved-secret",
+				allowedScopes: ["channels:history"],
+			});
+			expect(written.mcpServers.slack.oauth).toBeUndefined();
+			expect(
+				shouldProbeMcpServerAfterUpsert({
+					isRemote: true,
+					requestedDisabled: false,
+					existingWasEnabled: true,
+					transportIdentityUnchanged: true,
+					oauthClientUnchanged: false,
+				}),
+			).toBe(true);
+
+			await writeScopedServer();
+			await handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+				input: {
+					name: "slack",
+					previousName: "slack",
+					transportType: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+					disabled: true,
+					oauthClient: {
+						clientId: "desktop-client",
+						preserveClientSecret: true,
+						allowedScopes: null,
+					},
+				},
+			});
+			written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.slack.oauthClient).toEqual({
+				clientId: "desktop-client",
+				clientSecret: "saved-secret",
+			});
+			expect(written.mcpServers.slack.oauth).toBeUndefined();
+		} finally {
+			if (previousSettingsPath === undefined) {
+				delete process.env.CLINE_MCP_SETTINGS_PATH;
+			} else {
+				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+			}
+			await rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("binds OAuth state and saved secrets to canonical remote headers", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "desktop-mcp-headers-"));
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		const originalHeaders = {
+			Authorization: "Bearer fixed-test-header",
+			"X-Tenant": "one",
+		};
+		const reorderedHeaders = {
+			"X-Tenant": "one",
+			Authorization: "Bearer fixed-test-header",
+		};
+		const changedHeaders = {
+			Authorization: "Bearer fixed-test-header",
+			"X-Tenant": "two",
+		};
+		const writeServer = async () =>
+			writeFile(
+				settingsPath,
+				JSON.stringify({
+					mcpServers: {
+						proxied: {
+							transport: {
+								type: "streamableHttp",
+								url: "http://127.0.0.1:1/mcp",
+								headers: originalHeaders,
+							},
+							disabled: false,
+							oauthClient: {
+								clientId: "desktop-client",
+								clientSecret: "saved-secret",
+							},
+							oauth: {
+								clientInformation: {
+									client_id: "desktop-client",
+									client_secret: "saved-secret",
+								},
+								tokens: { access_token: "saved-token" },
+							},
+						},
+					},
+				}),
+				"utf8",
+			);
+		try {
+			await writeServer();
+			await handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+				input: {
+					name: "proxied",
+					previousName: "proxied",
+					transportType: "streamableHttp",
+					url: "http://127.0.0.1:1/mcp",
+					headers: reorderedHeaders,
+					disabled: false,
+					oauthClient: {
+						clientId: "desktop-client",
+						preserveClientSecret: true,
+						allowedScopes: null,
+					},
+				},
+			});
+			let written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.proxied.disabled).toBe(false);
+			expect(written.mcpServers.proxied.oauthClient.clientSecret).toBe(
+				"saved-secret",
+			);
+			expect(written.mcpServers.proxied.oauth.tokens.access_token).toBe(
+				"saved-token",
+			);
+
+			await writeServer();
+			await expect(
+				handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+					input: {
+						name: "proxied",
+						previousName: "proxied",
+						transportType: "streamableHttp",
+						url: "http://127.0.0.1:1/mcp",
+						headers: changedHeaders,
+						disabled: false,
+						oauthClient: {
+							clientId: "desktop-client",
+							preserveClientSecret: true,
+							allowedScopes: null,
+						},
+					},
+				}),
+			).rejects.toThrow("server transport, URL, or headers");
+			written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.proxied.transport.headers).toEqual(
+				originalHeaders,
+			);
+			expect(written.mcpServers.proxied.oauth.tokens.access_token).toBe(
+				"saved-token",
+			);
+
+			await writeServer();
+			const response = (await handleCommand(
+				createContext(tempRoot),
+				"upsert_mcp_server",
+				{
+					input: {
+						name: "proxied",
+						previousName: "proxied",
+						transportType: "streamableHttp",
+						url: "http://127.0.0.1:1/mcp",
+						headers: changedHeaders,
+						disabled: false,
+						oauthClient: {
+							clientId: "desktop-client",
+							allowedScopes: null,
+						},
+					},
+				},
+			)) as JsonRecord;
+			const server = (response.servers as JsonRecord[]).find(
+				(candidate) => candidate.name === "proxied",
+			);
+			expect(server).toMatchObject({
+				disabled: true,
+				oauthClient: {
+					clientId: "desktop-client",
+					hasClientSecret: false,
+				},
+			});
+			expect(
+				typeof (server?.oauthStatus as JsonRecord | undefined)?.lastError,
+			).toBe("string");
+			written = JSON.parse(await readFile(settingsPath, "utf8"));
+			expect(written.mcpServers.proxied.disabled).toBe(true);
+			expect(written.mcpServers.proxied.transport.headers).toEqual(
+				changedHeaders,
+			);
+			expect(written.mcpServers.proxied.oauthClient).toEqual({
+				clientId: "desktop-client",
+			});
+			expect(written.mcpServers.proxied.oauth?.tokens).toBeUndefined();
+		} finally {
+			if (previousSettingsPath === undefined) {
+				delete process.env.CLINE_MCP_SETTINGS_PATH;
+			} else {
+				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+			}
+			await rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates OAuth state when the OAuth client changes or clears", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "desktop-mcp-oauth-"));
+		const settingsPath = join(tempRoot, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		try {
+			const cases = [
+				{
+					name: "replace client and secret",
+					oauthClient: {
+						clientId: "replacement-client",
+						clientSecret: "replacement-secret",
+					},
+					expected: {
+						clientId: "replacement-client",
+						clientSecret: "replacement-secret",
+					},
+				},
+				{
+					name: "clear only the secret",
+					oauthClient: { clientId: "desktop-client" },
+					expected: { clientId: "desktop-client" },
+				},
+				{
+					name: "clear the client",
+					oauthClient: null,
+					expected: undefined,
+				},
+			] as const;
+
+			for (const testCase of cases) {
+				await writeFile(
+					settingsPath,
+					JSON.stringify({
+						mcpServers: {
+							slack: {
+								transport: {
+									type: "streamableHttp",
+									url: "https://mcp.slack.com/mcp",
+								},
+								disabled: true,
+								oauthClient: {
+									clientId: "desktop-client",
+									clientSecret: "saved-secret",
+								},
+								oauth: {
+									tokens: { access_token: "saved-token" },
+								},
+							},
+						},
+					}),
+					"utf8",
+				);
+
+				await handleCommand(createContext(tempRoot), "upsert_mcp_server", {
+					input: {
+						name: "slack",
+						previousName: "slack",
+						transportType: "streamableHttp",
+						url: "https://mcp.slack.com/mcp",
+						disabled: true,
+						oauthClient: testCase.oauthClient,
+					},
+				});
+
+				const written = JSON.parse(await readFile(settingsPath, "utf8"));
+				expect(written.mcpServers.slack.oauthClient, testCase.name).toEqual(
+					testCase.expected,
+				);
+				expect(written.mcpServers.slack.oauth, testCase.name).toBeUndefined();
+			}
+		} finally {
+			if (previousSettingsPath === undefined) {
+				delete process.env.CLINE_MCP_SETTINGS_PATH;
+			} else {
+				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+			}
+			await rm(tempRoot, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps an unchanged enabled remote server enabled when saving metadata", async () => {

--- a/apps/examples/desktop-app/sidecar/mcp.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.ts
@@ -7,16 +7,282 @@ import {
 import { resolveMcpSettingsPath } from "@cline/shared/storage";
 import type { JsonRecord } from "./types";
 
+interface StoredMcpOAuthClient {
+	clientId: string;
+	clientSecret?: string;
+	allowedScopes?: string[];
+}
+
+// RFC 6749 section 3.3 scope-token: printable ASCII excluding DQUOTE and "\\".
+const MCP_OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
+export interface McpOAuthClientUpdate {
+	oauthClient: unknown;
+	oauthClientUnchanged: boolean;
+}
+
+function parseMcpOAuthAllowedScopes(
+	value: unknown,
+	canonicalize: boolean,
+): string[] | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!Array.isArray(value)) {
+		throw new Error("OAuth allowedScopes must be an array");
+	}
+	if (value.length === 0) {
+		throw new Error("OAuth allowedScopes must contain at least one scope");
+	}
+	const scopes: string[] = [];
+	const seen = new Set<string>();
+	for (const scope of value) {
+		if (
+			typeof scope !== "string" ||
+			!MCP_OAUTH_SCOPE_TOKEN_PATTERN.test(scope)
+		) {
+			throw new Error(
+				"OAuth allowedScopes entries must be valid RFC 6749 scope tokens without whitespace",
+			);
+		}
+		if (seen.has(scope)) {
+			throw new Error(`Duplicate OAuth scope: ${scope}`);
+		}
+		seen.add(scope);
+		scopes.push(scope);
+	}
+	return canonicalize ? scopes.sort() : scopes;
+}
+
+function readStoredMcpOAuthClient(value: unknown): StoredMcpOAuthClient | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return null;
+	}
+	const record = value as JsonRecord;
+	if (typeof record.clientId !== "string" || record.clientId.length === 0) {
+		return null;
+	}
+	if (
+		record.clientSecret !== undefined &&
+		(typeof record.clientSecret !== "string" ||
+			record.clientSecret.length === 0)
+	) {
+		return null;
+	}
+	let allowedScopes: string[] | undefined;
+	try {
+		allowedScopes = parseMcpOAuthAllowedScopes(record.allowedScopes, false);
+	} catch {
+		return null;
+	}
+	return {
+		clientId: record.clientId,
+		...(typeof record.clientSecret === "string"
+			? { clientSecret: record.clientSecret }
+			: {}),
+		...(allowedScopes ? { allowedScopes } : {}),
+	};
+}
+
+function mcpOAuthScopePoliciesEqual(
+	left: readonly string[] | undefined,
+	right: readonly string[] | undefined,
+): boolean {
+	if (left === undefined || right === undefined) {
+		return left === right;
+	}
+	if (left.length !== right.length) {
+		return false;
+	}
+	const leftSorted = [...left].sort();
+	const rightSorted = [...right].sort();
+	return leftSorted.every((scope, index) => scope === rightSorted[index]);
+}
+
+function mcpOAuthClientsEqual(left: unknown, right: unknown): boolean {
+	if (left === undefined || right === undefined) {
+		return left === right;
+	}
+	const leftClient = readStoredMcpOAuthClient(left);
+	const rightClient = readStoredMcpOAuthClient(right);
+	return Boolean(
+		leftClient &&
+			rightClient &&
+			leftClient.clientId === rightClient.clientId &&
+			leftClient.clientSecret === rightClient.clientSecret &&
+			mcpOAuthScopePoliciesEqual(
+				leftClient.allowedScopes,
+				rightClient.allowedScopes,
+			),
+	);
+}
+
+/**
+ * Resolve the editor's redacted OAuth-client update into the persisted shape.
+ * An omitted update preserves compatible existing settings for older callers;
+ * null clears them; and preserveClientSecret keeps a secret that was never sent
+ * to the webview.
+ */
+export function resolveMcpOAuthClientUpdate(options: {
+	requestedOAuthClient: unknown;
+	existingOAuthClient: unknown;
+	transportIdentityUnchanged: boolean;
+}): McpOAuthClientUpdate {
+	const {
+		requestedOAuthClient,
+		existingOAuthClient,
+		transportIdentityUnchanged,
+	} = options;
+	if (requestedOAuthClient === undefined) {
+		const oauthClient = transportIdentityUnchanged
+			? existingOAuthClient
+			: undefined;
+		return {
+			oauthClient,
+			oauthClientUnchanged: transportIdentityUnchanged
+				? true
+				: existingOAuthClient === undefined,
+		};
+	}
+	if (requestedOAuthClient === null) {
+		return {
+			oauthClient: undefined,
+			oauthClientUnchanged: existingOAuthClient === undefined,
+		};
+	}
+	if (
+		typeof requestedOAuthClient !== "object" ||
+		Array.isArray(requestedOAuthClient)
+	) {
+		throw new Error("oauthClient must be an object or null");
+	}
+
+	const requested = requestedOAuthClient as JsonRecord;
+	const allowedKeys = new Set([
+		"clientId",
+		"clientSecret",
+		"preserveClientSecret",
+		"allowedScopes",
+	]);
+	const unknownKey = Object.keys(requested).find(
+		(key) => !allowedKeys.has(key),
+	);
+	if (unknownKey) {
+		throw new Error(`unknown oauthClient field: ${unknownKey}`);
+	}
+	if (typeof requested.clientId !== "string" || !requested.clientId.trim()) {
+		throw new Error("OAuth client ID is required");
+	}
+	if (
+		requested.clientSecret !== undefined &&
+		(typeof requested.clientSecret !== "string" ||
+			requested.clientSecret.length === 0)
+	) {
+		throw new Error("OAuth client secret must be a non-empty string");
+	}
+	if (
+		requested.preserveClientSecret !== undefined &&
+		typeof requested.preserveClientSecret !== "boolean"
+	) {
+		throw new Error("preserveClientSecret must be a boolean");
+	}
+	if (
+		requested.preserveClientSecret === true &&
+		requested.clientSecret !== undefined
+	) {
+		throw new Error(
+			"OAuth client secret cannot be replaced and preserved at the same time",
+		);
+	}
+
+	const clientId = requested.clientId.trim();
+	const existing = readStoredMcpOAuthClient(existingOAuthClient);
+	const existingRecord =
+		existingOAuthClient &&
+		typeof existingOAuthClient === "object" &&
+		!Array.isArray(existingOAuthClient)
+			? (existingOAuthClient as JsonRecord)
+			: undefined;
+	const existingHasAllowedScopes =
+		existingRecord !== undefined &&
+		Object.hasOwn(existingRecord, "allowedScopes") &&
+		existingRecord.allowedScopes !== undefined;
+	let existingAllowedScopes: string[] | undefined;
+	if (existingHasAllowedScopes) {
+		try {
+			existingAllowedScopes = parseMcpOAuthAllowedScopes(
+				existingRecord?.allowedScopes,
+				false,
+			);
+		} catch {
+			if (requested.allowedScopes === undefined) {
+				throw new Error(
+					"The existing OAuth allowedScopes policy is invalid; replace or clear it explicitly",
+				);
+			}
+		}
+	}
+	let allowedScopes: string[] | undefined;
+	if (requested.allowedScopes === null) {
+		allowedScopes = undefined;
+	} else if (requested.allowedScopes !== undefined) {
+		allowedScopes = parseMcpOAuthAllowedScopes(requested.allowedScopes, true);
+	} else if (existingAllowedScopes) {
+		if (!transportIdentityUnchanged || existingRecord?.clientId !== clientId) {
+			throw new Error(
+				"Specify allowedScopes when changing an OAuth client's server endpoint or client ID",
+			);
+		}
+		// Older callers do not know about scope policy. Preserve the existing
+		// validated order losslessly unless the policy is explicitly edited.
+		allowedScopes = [...existingAllowedScopes];
+	}
+	let clientSecret: string | undefined;
+	if (requested.preserveClientSecret === true) {
+		if (!transportIdentityUnchanged) {
+			throw new Error(
+				"Re-enter the OAuth client secret after changing the server transport, URL, or headers",
+			);
+		}
+		if (!existing?.clientSecret || existing.clientId !== clientId) {
+			throw new Error(
+				"The saved OAuth client secret cannot be preserved for this client ID",
+			);
+		}
+		clientSecret = existing.clientSecret;
+	} else if (typeof requested.clientSecret === "string") {
+		clientSecret = requested.clientSecret;
+	}
+
+	const oauthClient: StoredMcpOAuthClient = {
+		clientId,
+		...(clientSecret !== undefined ? { clientSecret } : {}),
+		...(allowedScopes ? { allowedScopes } : {}),
+	};
+	return {
+		oauthClient,
+		oauthClientUnchanged: mcpOAuthClientsEqual(
+			existingOAuthClient,
+			oauthClient,
+		),
+	};
+}
+
 export function shouldProbeMcpServerAfterUpsert(options: {
 	isRemote: boolean;
 	requestedDisabled: boolean;
 	existingWasEnabled: boolean;
 	transportIdentityUnchanged: boolean;
+	oauthClientUnchanged?: boolean;
 }): boolean {
 	return (
 		options.isRemote &&
 		!options.requestedDisabled &&
-		!(options.existingWasEnabled && options.transportIdentityUnchanged)
+		!(
+			options.existingWasEnabled &&
+			options.transportIdentityUnchanged &&
+			options.oauthClientUnchanged !== false
+		)
 	);
 }
 
@@ -133,6 +399,18 @@ export function buildMcpServersResponse(
 						? record.headers
 						: undefined,
 			metadata: registration?.metadata ?? record.metadata,
+			oauthClient: registration?.oauthClient
+				? {
+						clientId: registration.oauthClient.clientId,
+						hasClientSecret:
+							typeof registration.oauthClient.clientSecret === "string",
+						...(registration.oauthClient.allowedScopes
+							? {
+									allowedScopes: [...registration.oauthClient.allowedScopes],
+								}
+							: {}),
+					}
+				: undefined,
 			...(configurationError ? { configurationError } : {}),
 			oauthStatus: oauthStatus
 				? {

--- a/apps/examples/desktop-app/webview/components/views/settings/mcp-oauth-form.test.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/mcp-oauth-form.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildMcpOAuthClientUpsert,
+	createMcpOAuthClientFormFields,
+	MCP_OAUTH_REDIRECT_URIS,
+	parseMcpOAuthAllowedScopesText,
+} from "./mcp-oauth-form";
+
+describe("MCP OAuth client form", () => {
+	it("lists every local redirect URI in core bind order", () => {
+		expect(MCP_OAUTH_REDIRECT_URIS).toEqual([
+			"http://127.0.0.1:1456/mcp/oauth/callback",
+			"http://127.0.0.1:1457/mcp/oauth/callback",
+			"http://127.0.0.1:1458/mcp/oauth/callback",
+		]);
+	});
+
+	it("preserves a saved secret without exposing it to the form", () => {
+		const form = createMcpOAuthClientFormFields({
+			clientId: "desktop-client",
+			hasClientSecret: true,
+		});
+
+		expect(form.clientSecret).toBe("");
+		expect(buildMcpOAuthClientUpsert(form)).toEqual({
+			clientId: "desktop-client",
+			preserveClientSecret: true,
+			allowedScopes: null,
+		});
+	});
+
+	it("replaces, clears, or removes the OAuth client explicitly", () => {
+		const existing = createMcpOAuthClientFormFields({
+			clientId: "desktop-client",
+			hasClientSecret: true,
+		});
+
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				clientSecret: "replacement-secret",
+			}),
+		).toEqual({
+			clientId: "desktop-client",
+			clientSecret: "replacement-secret",
+			allowedScopes: null,
+		});
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				preserveSavedClientSecret: false,
+			}),
+		).toEqual({ clientId: "desktop-client", allowedScopes: null });
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				clientId: "",
+			}),
+		).toBeNull();
+	});
+
+	it("does not carry a saved secret to a different client ID", () => {
+		const existing = createMcpOAuthClientFormFields({
+			clientId: "desktop-client",
+			hasClientSecret: true,
+		});
+
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				clientId: "replacement-client",
+			}),
+		).toEqual({ clientId: "replacement-client", allowedScopes: null });
+	});
+
+	it("does not carry a saved secret to a different server endpoint", () => {
+		const existing = createMcpOAuthClientFormFields(
+			{
+				clientId: "desktop-client",
+				hasClientSecret: true,
+			},
+			"https://mcp.slack.com/mcp",
+		);
+
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				serverUrl: "https://example.com/mcp",
+			}),
+		).toEqual({ clientId: "desktop-client", allowedScopes: null });
+	});
+
+	it("does not carry a saved secret to a different remote transport", () => {
+		const existing = createMcpOAuthClientFormFields(
+			{
+				clientId: "desktop-client",
+				hasClientSecret: true,
+			},
+			"https://mcp.slack.com/mcp",
+			"streamableHttp",
+		);
+
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				transportType: "sse",
+			}),
+		).toEqual({ clientId: "desktop-client", allowedScopes: null });
+	});
+
+	it("binds saved-secret preservation to canonical remote headers", () => {
+		const existing = createMcpOAuthClientFormFields(
+			{
+				clientId: "desktop-client",
+				hasClientSecret: true,
+			},
+			"https://mcp.example.com/mcp",
+			"streamableHttp",
+			{ Authorization: "Bearer fixed", "X-Tenant": "one" },
+		);
+
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				headers: { "X-Tenant": "one", Authorization: "Bearer fixed" },
+			}),
+		).toEqual({
+			clientId: "desktop-client",
+			preserveClientSecret: true,
+			allowedScopes: null,
+		});
+		expect(
+			buildMcpOAuthClientUpsert({
+				...existing,
+				headers: { Authorization: "Bearer fixed", "X-Tenant": "two" },
+			}),
+		).toEqual({ clientId: "desktop-client", allowedScopes: null });
+	});
+
+	it("requires a client ID before accepting a client secret", () => {
+		expect(() =>
+			buildMcpOAuthClientUpsert({
+				...createMcpOAuthClientFormFields(),
+				clientSecret: "orphaned-secret",
+			}),
+		).toThrow("OAuth client ID is required");
+	});
+
+	it("surfaces and canonicalizes an allowed-scope maximum", () => {
+		const form = createMcpOAuthClientFormFields({
+			clientId: "desktop-client",
+			hasClientSecret: false,
+			allowedScopes: ["search:read.public", "channels:history"],
+		});
+
+		expect(form.allowedScopesText).toBe("search:read.public\nchannels:history");
+		expect(buildMcpOAuthClientUpsert(form)).toEqual({
+			clientId: "desktop-client",
+			allowedScopes: ["channels:history", "search:read.public"],
+		});
+	});
+
+	it("fails closed on duplicate, whitespace, and invalid scope input", () => {
+		expect(() =>
+			parseMcpOAuthAllowedScopesText("channels:history\nchannels:history"),
+		).toThrow("Duplicate OAuth scope");
+		expect(() =>
+			parseMcpOAuthAllowedScopesText("channels:history chat:write"),
+		).toThrow("without whitespace");
+		expect(() => parseMcpOAuthAllowedScopesText(" channels:history")).toThrow(
+			"without surrounding whitespace",
+		);
+		expect(() => parseMcpOAuthAllowedScopesText('channels:"history')).toThrow(
+			"valid RFC 6749 scope tokens",
+		);
+		expect(() => parseMcpOAuthAllowedScopesText("channels:history\n")).toThrow(
+			"exactly one token per line",
+		);
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/mcp-oauth-form.ts
+++ b/apps/examples/desktop-app/webview/components/views/settings/mcp-oauth-form.ts
@@ -1,0 +1,141 @@
+export interface McpOAuthClientSummary {
+	clientId: string;
+	hasClientSecret: boolean;
+	allowedScopes?: string[];
+}
+
+export interface McpOAuthClientUpsert {
+	clientId: string;
+	clientSecret?: string;
+	preserveClientSecret?: boolean;
+	allowedScopes: string[] | null;
+}
+
+export interface McpOAuthClientFormFields {
+	clientId: string;
+	clientSecret: string;
+	originalClientId: string;
+	hasSavedClientSecret: boolean;
+	preserveSavedClientSecret: boolean;
+	allowedScopesText: string;
+	serverUrl: string;
+	originalServerUrl: string;
+	transportType: string;
+	originalTransportType: string;
+	headers?: Record<string, string>;
+	originalHeaders?: Record<string, string>;
+}
+
+// RFC 6749 section 3.3 scope-token: printable ASCII excluding DQUOTE and "\\".
+const MCP_OAUTH_SCOPE_TOKEN_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
+export const MCP_OAUTH_REDIRECT_URIS = [1456, 1457, 1458].map(
+	(port) => `http://127.0.0.1:${port}/mcp/oauth/callback`,
+);
+
+export function createMcpOAuthClientFormFields(
+	existing?: McpOAuthClientSummary,
+	serverUrl = "",
+	transportType = "streamableHttp",
+	headers?: Record<string, string>,
+): McpOAuthClientFormFields {
+	return {
+		clientId: existing?.clientId ?? "",
+		clientSecret: "",
+		originalClientId: existing?.clientId ?? "",
+		hasSavedClientSecret: existing?.hasClientSecret ?? false,
+		preserveSavedClientSecret: existing?.hasClientSecret ?? false,
+		allowedScopesText: existing?.allowedScopes?.join("\n") ?? "",
+		serverUrl,
+		originalServerUrl: serverUrl,
+		transportType,
+		originalTransportType: transportType,
+		headers: headers ? { ...headers } : undefined,
+		originalHeaders: headers ? { ...headers } : undefined,
+	};
+}
+
+function mcpRemoteHeadersIdentity(
+	headers: Record<string, string> | undefined,
+): string {
+	if (headers === undefined) {
+		return "omitted";
+	}
+	const entries = Object.entries(headers).sort(([left], [right]) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+	return `present:${JSON.stringify(entries)}`;
+}
+
+export function isMcpOAuthClientIdentityUnchanged(
+	form: McpOAuthClientFormFields,
+): boolean {
+	return (
+		form.clientId.trim() === form.originalClientId &&
+		form.serverUrl.trim() === form.originalServerUrl &&
+		form.transportType === form.originalTransportType &&
+		mcpRemoteHeadersIdentity(form.headers) ===
+			mcpRemoteHeadersIdentity(form.originalHeaders)
+	);
+}
+
+export function parseMcpOAuthAllowedScopesText(
+	text: string,
+): string[] | undefined {
+	if (text.length === 0) {
+		return undefined;
+	}
+	const scopes = text.split(/\r?\n/);
+	const seen = new Set<string>();
+	for (const scope of scopes) {
+		if (!scope || scope !== scope.trim()) {
+			throw new Error(
+				"OAuth scopes must contain exactly one token per line without surrounding whitespace.",
+			);
+		}
+		if (!MCP_OAUTH_SCOPE_TOKEN_PATTERN.test(scope)) {
+			throw new Error(
+				"OAuth scopes must be valid RFC 6749 scope tokens without whitespace, quotes, or backslashes.",
+			);
+		}
+		if (seen.has(scope)) {
+			throw new Error(`Duplicate OAuth scope: ${scope}`);
+		}
+		seen.add(scope);
+	}
+	return scopes.sort();
+}
+
+export function buildMcpOAuthClientUpsert(
+	form: McpOAuthClientFormFields,
+): McpOAuthClientUpsert | null {
+	const clientId = form.clientId.trim();
+	if (!clientId) {
+		if (
+			!form.originalClientId &&
+			(form.clientSecret.length > 0 || form.allowedScopesText.length > 0)
+		) {
+			throw new Error(
+				"OAuth client ID is required when a secret or scope policy is provided.",
+			);
+		}
+		return null;
+	}
+	const allowedScopes = parseMcpOAuthAllowedScopesText(form.allowedScopesText);
+	if (form.clientSecret.length > 0) {
+		return {
+			clientId,
+			clientSecret: form.clientSecret,
+			allowedScopes: allowedScopes ?? null,
+		};
+	}
+	const canPreserveSecret =
+		form.hasSavedClientSecret &&
+		form.preserveSavedClientSecret &&
+		isMcpOAuthClientIdentityUnchanged(form);
+	return {
+		clientId,
+		...(canPreserveSecret ? { preserveClientSecret: true } : {}),
+		allowedScopes: allowedScopes ?? null,
+	};
+}

--- a/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
@@ -57,6 +57,14 @@ import {
 } from "../marketplace-view";
 import { CommandBadge, PageFrame, PageHeader } from "../page-layout";
 import { subscribeToExtensionInventoryInvalidation } from "./extensions-view";
+import {
+	buildMcpOAuthClientUpsert,
+	createMcpOAuthClientFormFields,
+	isMcpOAuthClientIdentityUnchanged,
+	MCP_OAUTH_REDIRECT_URIS,
+	type McpOAuthClientSummary,
+	type McpOAuthClientUpsert,
+} from "./mcp-oauth-form";
 
 type McpTransportType = "stdio" | "sse" | "streamableHttp";
 
@@ -83,6 +91,7 @@ interface McpServer {
 	url?: string;
 	headers?: Record<string, string>;
 	metadata?: unknown;
+	oauthClient?: McpOAuthClientSummary;
 	configurationError?: string;
 	oauthStatus?: {
 		supported: boolean;
@@ -111,6 +120,7 @@ interface McpServerUpsertInput {
 	headers?: Record<string, string>;
 	disabled?: boolean;
 	metadata?: unknown;
+	oauthClient?: McpOAuthClientUpsert | null;
 }
 
 type McpServerFormState = {
@@ -125,6 +135,15 @@ type McpServerFormState = {
 	headersText: string;
 	disabled: boolean;
 	metadataText: string;
+	oauthClientId: string;
+	oauthClientSecret: string;
+	originalOauthClientId: string;
+	hasSavedOauthClientSecret: boolean;
+	preserveSavedOauthClientSecret: boolean;
+	oauthAllowedScopesText: string;
+	originalOauthServerUrl: string;
+	originalOauthTransportType: McpTransportType;
+	originalOauthHeaders?: Record<string, string>;
 };
 
 function splitCsv(text: string): string[] {
@@ -189,6 +208,12 @@ function createEnvEntries(
 }
 
 function createServerFormState(existing?: McpServer): McpServerFormState {
+	const oauthClient = createMcpOAuthClientFormFields(
+		existing?.oauthClient,
+		existing?.url ?? "",
+		existing?.transportType ?? "streamableHttp",
+		existing?.headers,
+	);
 	return {
 		name: existing?.name ?? "",
 		previousName: existing?.name ?? "",
@@ -204,6 +229,16 @@ function createServerFormState(existing?: McpServer): McpServerFormState {
 			existing?.metadata === undefined
 				? ""
 				: JSON.stringify(existing.metadata, null, 2),
+		oauthClientId: oauthClient.clientId,
+		oauthClientSecret: oauthClient.clientSecret,
+		originalOauthClientId: oauthClient.originalClientId,
+		hasSavedOauthClientSecret: oauthClient.hasSavedClientSecret,
+		preserveSavedOauthClientSecret: oauthClient.preserveSavedClientSecret,
+		oauthAllowedScopesText: oauthClient.allowedScopesText,
+		originalOauthServerUrl: oauthClient.originalServerUrl,
+		originalOauthTransportType:
+			oauthClient.originalTransportType as McpTransportType,
+		originalOauthHeaders: oauthClient.originalHeaders,
 	};
 }
 
@@ -428,6 +463,7 @@ export function McpServersContent({
 				env: Object.keys(env).length > 0 ? env : undefined,
 				disabled: form.disabled,
 				metadata,
+				oauthClient: null,
 			} satisfies McpServerUpsertInput;
 		}
 		const url = form.url.trim();
@@ -442,6 +478,20 @@ export function McpServersContent({
 			headers: parseKeyValuePairs(form.headersText),
 			disabled: form.disabled,
 			metadata,
+			oauthClient: buildMcpOAuthClientUpsert({
+				clientId: form.oauthClientId,
+				clientSecret: form.oauthClientSecret,
+				originalClientId: form.originalOauthClientId,
+				hasSavedClientSecret: form.hasSavedOauthClientSecret,
+				preserveSavedClientSecret: form.preserveSavedOauthClientSecret,
+				allowedScopesText: form.oauthAllowedScopesText,
+				serverUrl: form.url,
+				originalServerUrl: form.originalOauthServerUrl,
+				transportType: form.transportType,
+				originalTransportType: form.originalOauthTransportType,
+				headers: parseKeyValuePairs(form.headersText),
+				originalHeaders: form.originalOauthHeaders,
+			}),
 		} satisfies McpServerUpsertInput;
 	}, []);
 
@@ -463,12 +513,18 @@ export function McpServersContent({
 		setEditorOpen(true);
 	};
 
+	const closeEditorDialog = () => {
+		setEditorOpen(false);
+		setFormState(createServerFormState());
+		setFormErrorMessage(null);
+	};
+
 	const handleSaveServer = async () => {
 		setFormErrorMessage(null);
 		try {
 			const input = buildServerInput(formState);
 			await upsertServer(input);
-			setEditorOpen(false);
+			closeEditorDialog();
 		} catch (error) {
 			setFormErrorMessage(
 				error instanceof Error ? error.message : String(error),
@@ -502,6 +558,20 @@ export function McpServersContent({
 			),
 		[servers],
 	);
+	const savedOauthSecretMatchesIdentity = isMcpOAuthClientIdentityUnchanged({
+		clientId: formState.oauthClientId,
+		clientSecret: formState.oauthClientSecret,
+		originalClientId: formState.originalOauthClientId,
+		hasSavedClientSecret: formState.hasSavedOauthClientSecret,
+		preserveSavedClientSecret: formState.preserveSavedOauthClientSecret,
+		allowedScopesText: formState.oauthAllowedScopesText,
+		serverUrl: formState.url,
+		originalServerUrl: formState.originalOauthServerUrl,
+		transportType: formState.transportType,
+		originalTransportType: formState.originalOauthTransportType,
+		headers: parseKeyValuePairs(formState.headersText),
+		originalHeaders: formState.originalOauthHeaders,
+	});
 
 	const updateEnvEntry = (
 		id: string,
@@ -599,6 +669,19 @@ export function McpServersContent({
 					<span className="text-muted-foreground/70">URL:</span> {server.url}
 				</p>
 			)}
+			{server.oauthClient && (
+				<p>
+					<span className="text-muted-foreground/70">OAuth client:</span>{" "}
+					{server.oauthClient.clientId}
+					{server.oauthClient.hasClientSecret ? " · secret saved" : ""}
+				</p>
+			)}
+			{server.oauthClient?.allowedScopes?.length ? (
+				<p>
+					<span className="text-muted-foreground/70">OAuth scope maximum:</span>{" "}
+					{server.oauthClient.allowedScopes.join(", ")}
+				</p>
+			) : null}
 			{server.env && Object.keys(server.env).length > 0 && (
 				<p>
 					<span className="text-muted-foreground/70">Env:</span>{" "}
@@ -822,10 +905,8 @@ export function McpServersContent({
 			<Dialog
 				open={editorOpen}
 				onOpenChange={(open) => {
-					setEditorOpen(open);
-					if (!open) {
-						setFormErrorMessage(null);
-					}
+					if (open) setEditorOpen(true);
+					else closeEditorDialog();
 				}}
 			>
 				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
@@ -1025,6 +1106,132 @@ export function McpServersContent({
 										placeholder="Authorization=Bearer token"
 									/>
 								</div>
+								<div className="grid gap-3 rounded-md border border-border px-3 py-3">
+									<div className="grid gap-1">
+										<p className="text-sm font-medium text-foreground">
+											OAuth client
+										</p>
+										<p className="text-xs text-muted-foreground">
+											Optional pre-registered client credentials for servers
+											that do not support dynamic client registration.
+										</p>
+									</div>
+									<div className="grid gap-2">
+										<p className="text-sm font-medium text-foreground">
+											Redirect URIs
+										</p>
+										<p className="text-xs text-muted-foreground">
+											Register all three redirect URIs with the OAuth provider.
+											Cline uses the first available local port.
+										</p>
+										<div className="grid gap-1 rounded-md bg-muted/40 px-3 py-2">
+											{MCP_OAUTH_REDIRECT_URIS.map((redirectUri) => (
+												<code
+													className="select-all break-all font-mono text-xs text-foreground"
+													key={redirectUri}
+												>
+													{redirectUri}
+												</code>
+											))}
+										</div>
+									</div>
+									<div className="grid gap-2">
+										<Label htmlFor="mcp-oauth-client-id">Client ID</Label>
+										<Input
+											id="mcp-oauth-client-id"
+											value={formState.oauthClientId}
+											onChange={(event) => {
+												setFormState((current) => ({
+													...current,
+													oauthClientId: event.target.value,
+												}));
+											}}
+											placeholder="OAuth client ID"
+										/>
+									</div>
+									<div className="grid gap-2">
+										<Label htmlFor="mcp-oauth-client-secret">
+											Client secret (optional)
+										</Label>
+										<Input
+											autoComplete="off"
+											id="mcp-oauth-client-secret"
+											type="password"
+											value={formState.oauthClientSecret}
+											onChange={(event) => {
+												setFormState((current) => ({
+													...current,
+													oauthClientSecret: event.target.value,
+												}));
+											}}
+											placeholder={
+												formState.hasSavedOauthClientSecret &&
+												savedOauthSecretMatchesIdentity
+													? "Saved; leave blank to keep it"
+													: formState.hasSavedOauthClientSecret
+														? "Re-enter for the changed client, transport, URL, or headers"
+														: "OAuth client secret"
+											}
+										/>
+										<p className="text-xs text-muted-foreground">
+											Saved locally in the MCP settings file and not displayed
+											again after this dialog closes.
+										</p>
+									</div>
+									<div className="grid gap-2">
+										<Label htmlFor="mcp-oauth-allowed-scopes">
+											Allowed scopes (optional)
+										</Label>
+										<Textarea
+											id="mcp-oauth-allowed-scopes"
+											value={formState.oauthAllowedScopesText}
+											onChange={(event) =>
+												setFormState((current) => ({
+													...current,
+													oauthAllowedScopesText: event.target.value,
+												}))
+											}
+											placeholder={"channels:history\nsearch:read.public"}
+										/>
+										<p className="text-xs text-muted-foreground">
+											One RFC 6749 scope token per line. This is the maximum the
+											client may request or accept. Leave blank for no local
+											scope maximum.
+										</p>
+									</div>
+									{formState.hasSavedOauthClientSecret ? (
+										<div className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
+											<div>
+												<p className="text-sm font-medium text-foreground">
+													Keep saved client secret
+												</p>
+												<p className="text-xs text-muted-foreground">
+													{savedOauthSecretMatchesIdentity
+														? "Turn this off to remove the saved secret."
+														: "Re-enter the secret after changing the client ID, server transport, URL, or headers."}
+												</p>
+											</div>
+											<Switch
+												aria-label="Keep saved OAuth client secret"
+												checked={
+													formState.preserveSavedOauthClientSecret &&
+													formState.oauthClientSecret.length === 0 &&
+													savedOauthSecretMatchesIdentity
+												}
+												disabled={
+													formState.oauthClientSecret.length > 0 ||
+													!savedOauthSecretMatchesIdentity
+												}
+												onCheckedChange={(preserve) =>
+													setFormState((current) => ({
+														...current,
+														preserveSavedOauthClientSecret: preserve,
+													}))
+												}
+											/>
+										</div>
+									) : null}
+								</div>
 								<div className="grid gap-2">
 									<Label>Transport</Label>
 									<Select
@@ -1132,7 +1339,7 @@ export function McpServersContent({
 					<DialogFooter>
 						<Button
 							variant="outline"
-							onClick={() => setEditorOpen(false)}
+							onClick={closeEditorDialog}
 							disabled={busyServerName !== null}
 						>
 							Cancel


### PR DESCRIPTION
## Summary

- adds Desktop fields for a pre-registered MCP OAuth client ID, optional secret, and explicit allowed-scope maximum
- never returns a stored client secret to the webview; it exposes only client ID, scope policy, and `hasClientSecret`
- implements explicit preserve, replace, clear-secret, and clear-client semantics
- invalidates OAuth state and reprobes when client identity, URL, transport, headers, or scope policy changes
- includes all three exact loopback redirect URIs required when registering a desktop OAuth client
- keeps remote header identity exact and order-insensitive so credentials cannot cross logical upstreams behind one URL

## Stack

Depends on [#13673](https://github.com/cline/cline/pull/13673). That base must merge first because this UI edits and persists `oauthClient.allowedScopes`.

## Motivation

Cline Core already supports pre-registered MCP OAuth clients, but Desktop exposes only endpoint configuration. Servers such as Slack reject dynamic client registration, leaving Desktop's Connect action unable to authorize even when an organization has an approved internal OAuth app.

## Validation

- Desktop focused Vitest suite: 19/19 passed
- Desktop typecheck passed
- full Desktop production build passed (optimized Next.js webview and native sidecar binary)
- Core base suite: 54/54 passed
- full SDK build passed
- Biome passed for every changed file
- `git diff --check` passed
- independent security review found no remaining P0-P2 issues

## Residual follow-up

The callback URI constants are duplicated between Core and the Desktop display helper. The current values are exact and tested, but a future cleanup should publish a shared pure contract to prevent drift.

## Side effects

No MCP provider was contacted and no live Cline settings file was modified.
