### PR TITLE
fix(desktop): keep Stop available for running child agents

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1510,6 +1510,7 @@ function ChatThreadPane({
 	const composer = (
 		<ChatInputBar
 			attachments={attachmentList}
+			hasRunningAgents={agentActivity.running > 0}
 			onAbort={handleAbort}
 			onAttachFiles={handleAttachFiles}
 			onListGitBranches={listGitBranches}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -152,15 +152,21 @@ function deferred<T>() {
 }
 
 async function renderVoiceComposer({
+	hasRunningAgents = false,
+	onAbort = vi.fn(),
 	onPromptInputChange = vi.fn(),
 	onSend = vi.fn(),
 	prompt = "",
 	promptVersion = 0,
+	status = "idle",
 }: {
+	hasRunningAgents?: boolean;
+	onAbort?: ReturnType<typeof vi.fn>;
 	onPromptInputChange?: ReturnType<typeof vi.fn>;
 	onSend?: ReturnType<typeof vi.fn>;
 	prompt?: string;
 	promptVersion?: number;
+	status?: ChatSessionStatus;
 } = {}) {
 	await act(async () => {
 		root.render(
@@ -168,9 +174,10 @@ async function renderVoiceComposer({
 				<ChatInputBar
 					attachments={[]}
 					gitBranch="main"
+					hasRunningAgents={hasRunningAgents}
 					mode="act"
 					model="test-model"
-					onAbort={vi.fn()}
+					onAbort={onAbort}
 					onAttachFiles={vi.fn()}
 					onEditPromptInQueue={vi.fn()}
 					onListGitBranches={vi.fn(async () => ({
@@ -191,7 +198,7 @@ async function renderVoiceComposer({
 					promptsInQueue={[]}
 					provider="cline"
 					reasoningEffort="low"
-					status="idle"
+					status={status}
 					summary={{ toolCalls: 0, tokensIn: 0, tokensOut: 0 }}
 					thinking
 				/>
@@ -202,6 +209,23 @@ async function renderVoiceComposer({
 }
 
 describe("ChatInputBar", () => {
+	it("allows a parent session with a running child agent to be stopped", async () => {
+		const onAbort = vi.fn();
+		await renderVoiceComposer({
+			hasRunningAgents: true,
+			onAbort,
+			status: "idle",
+		});
+
+		const stopButton = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Stop agent"]',
+		);
+		expect(stopButton).not.toBeNull();
+
+		await act(async () => stopButton?.click());
+		expect(onAbort).toHaveBeenCalledOnce();
+	});
+
 	it("builds slash commands from both workflows and skills", () => {
 		expect(
 			buildUserInstructionSlashCommands({

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -279,6 +279,7 @@ export type PromptDraft = {
 type ChatInputBarProps = {
 	variant?: "conversation" | "welcome";
 	status: ChatSessionStatus;
+	hasRunningAgents?: boolean;
 	provider: string;
 	model: string;
 	modelContextWindow?: number;
@@ -322,6 +323,7 @@ type ChatInputBarProps = {
 function ChatInputBarImpl({
 	variant = "conversation",
 	status,
+	hasRunningAgents = false,
 	provider,
 	model,
 	modelContextWindow,
@@ -416,7 +418,8 @@ function ChatInputBarImpl({
 	}, [promptDraft, setPromptInput]);
 	const isBusy =
 		status === "starting" || status === "running" || status === "stopping";
-	const canAbort = status === "running" || status === "stopping";
+	const canAbort =
+		status === "running" || status === "stopping" || hasRunningAgents;
 	const hasDraft = promptInput.trim().length > 0 || attachments.length > 0;
 	const [speechInputActive, setSpeechInputActive] = useState(false);
 	const speechInputActiveRef = useRef(false);

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -104,6 +104,137 @@ describe("useChatSession", () => {
 		expect(current.status).toBe(parentStatus);
 	});
 
+	it("reconciles a running tool row after an aborted send settles", async () => {
+		const sessionId = "session-aborted-tool";
+		let resolveActiveSend!: (value: unknown) => void;
+		let resolveQueuedSend!: (value: unknown) => void;
+		const activeSendResponse = new Promise((resolve) => {
+			resolveActiveSend = resolve;
+		});
+		const queuedSendResponse = new Promise((resolve) => {
+			resolveQueuedSend = resolve;
+		});
+		let sendCount = 0;
+		const canonicalMessages = [
+			{
+				id: "history-user",
+				sessionId,
+				role: "user",
+				content: "spawn a subagent",
+				createdAt: 1,
+			},
+			{
+				id: "history-assistant",
+				sessionId,
+				role: "assistant",
+				content: "",
+				createdAt: 2,
+			},
+			{
+				id: "history-tool",
+				sessionId,
+				role: "tool",
+				content: JSON.stringify({
+					toolName: "spawn_agent",
+					input: { task: "sleep" },
+					result: { finishReason: "aborted" },
+					isError: false,
+				}),
+				createdAt: 3,
+				meta: {
+					toolName: "spawn_agent",
+					toolCallId: "call-spawn",
+					hookEventName: "history_tool_result",
+				},
+			},
+		];
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return {
+						cwd: "/workspace/cline",
+						workspaceRoot: "/workspace/cline",
+					};
+				}
+				if (command === "read_session_messages") return canonicalMessages;
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "start") {
+						return {
+							sessionId,
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					if (request?.action === "send") {
+						sendCount += 1;
+						return await (sendCount === 1
+							? activeSendResponse
+							: queuedSendResponse);
+					}
+					if (request?.action === "abort") return { sessionId, ok: true };
+				}
+				return [];
+			},
+		);
+
+		await act(async () => current.start(current.config));
+		const chatEventHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_event",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(chatEventHandler).toBeDefined();
+
+		let activeSendTask!: Promise<void>;
+		let queuedSendTask!: Promise<void>;
+		await act(async () => {
+			activeSendTask = current.sendPrompt("spawn a subagent");
+			await Promise.resolve();
+			chatEventHandler?.({
+				sessionId,
+				stream: "chat_tool_call_start",
+				chunk: JSON.stringify({
+					toolCallId: "call-spawn",
+					toolName: "spawn_agent",
+					input: { task: "sleep" },
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+			queuedSendTask = current.sendPrompt("report when finished");
+			await Promise.resolve();
+		});
+		expect(
+			current.messages.find((message) => message.role === "tool")?.meta
+				?.hookEventName,
+		).toBe("tool_call_start");
+
+		await act(async () => current.abort());
+		await act(async () => {
+			resolveActiveSend({ ok: true, result: { finishReason: "aborted" } });
+			await activeSendTask;
+			await new Promise((resolve) => setTimeout(resolve, 300));
+		});
+		expect(
+			current.messages.find((message) => message.role === "tool")?.meta
+				?.hookEventName,
+		).toBe("tool_call_start");
+
+		await act(async () => {
+			resolveQueuedSend({ ok: true, queued: true, promptsInQueue: [] });
+			await queuedSendTask;
+			await new Promise((resolve) => setTimeout(resolve, 300));
+		});
+
+		expect(current.status).toBe("cancelled");
+		const toolMessage = current.messages.find(
+			(message) => message.role === "tool",
+		);
+		expect(toolMessage?.meta?.hookEventName).toBe("history_tool_result");
+		expect(JSON.parse(toolMessage?.content ?? "{}").result).toEqual({
+			finishReason: "aborted",
+		});
+	});
+
 	it("caps command output while preserving the newest tail", () => {
 		const result = appendCappedCommandOutput(
 			"head\n",

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -79,18 +79,9 @@ afterEach(async () => {
 });
 
 describe("useChatSession", () => {
-	it.each([
-		"idle",
-		"completed",
-	] as const)("restores a %s parent when aborting its child fails", async (parentStatus) => {
+	it("restores an idle parent when aborting its child fails", async () => {
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {
-				if (command === "get_process_context") {
-					return {
-						cwd: "/workspace/cline",
-						workspaceRoot: "/workspace/cline",
-					};
-				}
 				if (command === "chat_session_command") {
 					const request = args?.request as { action?: string } | undefined;
 					if (request?.action === "start") {
@@ -108,58 +99,13 @@ describe("useChatSession", () => {
 		const statusHandler = handlerFor("chat_session_status");
 
 		await act(async () => {
-			statusHandler?.({ sessionId: current.sessionId, status: parentStatus });
+			statusHandler({ sessionId: current.sessionId, status: "idle" });
 		});
-		expect(current.status).toBe(parentStatus);
+		expect(current.status).toBe("idle");
 
 		await act(async () => current.abort());
 
-		expect(current.status).toBe(parentStatus);
-	});
-
-	it("preserves an authoritative status received while a failed abort is pending", async () => {
-		const abortResponse = deferred<unknown>();
-		invokeMock.mockImplementation(
-			async (command: string, args?: Record<string, unknown>) => {
-				if (command === "get_process_context") {
-					return {
-						cwd: "/workspace/cline",
-						workspaceRoot: "/workspace/cline",
-					};
-				}
-				if (command === "chat_session_command") {
-					const request = args?.request as { action?: string } | undefined;
-					if (request?.action === "start") {
-						return { sessionId: "session-abort-race" };
-					}
-					if (request?.action === "abort") {
-						return await abortResponse.promise;
-					}
-				}
-				return [];
-			},
-		);
-
-		await act(async () => current.start(current.config));
-		const statusHandler = handlerFor("chat_session_status");
-
-		let abortTask!: Promise<void>;
-		await act(async () => {
-			abortTask = current.abort();
-			await Promise.resolve();
-		});
-		expect(current.status).toBe("stopping");
-
-		await act(async () => {
-			statusHandler?.({ sessionId: current.sessionId, status: "failed" });
-		});
-		expect(current.status).toBe("failed");
-
-		await act(async () => {
-			abortResponse.resolve({ ok: false });
-			await abortTask;
-		});
-		expect(current.status).toBe("failed");
+		expect(current.status).toBe("idle");
 	});
 
 	it("preserves authoritative completion across abort races", async () => {
@@ -170,12 +116,6 @@ describe("useChatSession", () => {
 			const sendResponse = deferred<unknown>();
 			invokeMock.mockImplementation(
 				async (command: string, args?: Record<string, unknown>) => {
-					if (command === "get_process_context") {
-						return {
-							cwd: "/workspace/cline",
-							workspaceRoot: "/workspace/cline",
-						};
-					}
 					if (command === "chat_session_command") {
 						const request = args?.request as { action?: string } | undefined;
 						if (request?.action === "start") return { sessionId };
@@ -248,68 +188,10 @@ describe("useChatSession", () => {
 		}
 	});
 
-	it("restores the prior status when a failed abort outlasts the local timeout", async () => {
-		vi.useFakeTimers();
-		try {
-			const abortResponse = deferred<unknown>();
-			invokeMock.mockImplementation(
-				async (command: string, args?: Record<string, unknown>) => {
-					if (command === "get_process_context") {
-						return {
-							cwd: "/workspace/cline",
-							workspaceRoot: "/workspace/cline",
-						};
-					}
-					if (command === "chat_session_command") {
-						const request = args?.request as { action?: string } | undefined;
-						if (request?.action === "start") {
-							return { sessionId: "session-abort-timeout" };
-						}
-						if (request?.action === "abort") {
-							return await abortResponse.promise;
-						}
-					}
-					return [];
-				},
-			);
-
-			await act(async () => current.start(current.config));
-			const statusHandler = handlerFor("chat_session_status");
-			await act(async () => {
-				statusHandler?.({ sessionId: current.sessionId, status: "completed" });
-			});
-
-			let abortTask!: Promise<void>;
-			await act(async () => {
-				abortTask = current.abort();
-				await Promise.resolve();
-				await vi.advanceTimersByTimeAsync(2000);
-			});
-			expect(current.status).toBe("cancelled");
-
-			await act(async () => {
-				abortResponse.resolve({ ok: false });
-				await abortTask;
-			});
-			expect(current.status).toBe("completed");
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
 	it("reconciles a running tool row after an aborted send settles", async () => {
 		const sessionId = "session-aborted-tool";
-		const activeSendResponse = deferred<unknown>();
-		const queuedSendResponse = deferred<unknown>();
-		let sendCount = 0;
+		const sendResponse = deferred<unknown>();
 		const canonicalMessages = [
-			{
-				id: "history-user",
-				sessionId,
-				role: "user",
-				content: "spawn a subagent",
-				createdAt: 1,
-			},
 			{
 				id: "history-assistant",
 				sessionId,
@@ -337,27 +219,14 @@ describe("useChatSession", () => {
 		];
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {
-				if (command === "get_process_context") {
-					return {
-						cwd: "/workspace/cline",
-						workspaceRoot: "/workspace/cline",
-					};
-				}
 				if (command === "read_session_messages") return canonicalMessages;
 				if (command === "chat_session_command") {
 					const request = args?.request as { action?: string } | undefined;
 					if (request?.action === "start") {
-						return {
-							sessionId,
-							cwd: "/workspace/cline",
-							workspaceRoot: "/workspace/cline",
-						};
+						return { sessionId };
 					}
 					if (request?.action === "send") {
-						sendCount += 1;
-						return await (sendCount === 1
-							? activeSendResponse.promise
-							: queuedSendResponse.promise);
+						return await sendResponse.promise;
 					}
 					if (request?.action === "abort") return { sessionId, ok: true };
 				}
@@ -368,10 +237,9 @@ describe("useChatSession", () => {
 		await act(async () => current.start(current.config));
 		const chatEventHandler = handlerFor("chat_event");
 
-		let activeSendTask!: Promise<void>;
-		let queuedSendTask!: Promise<void>;
+		let sendTask!: Promise<void>;
 		await act(async () => {
-			activeSendTask = current.sendPrompt("spawn a subagent");
+			sendTask = current.sendPrompt("spawn a subagent");
 			await Promise.resolve();
 			chatEventHandler?.({
 				sessionId,
@@ -384,8 +252,6 @@ describe("useChatSession", () => {
 				ts: Date.now(),
 				index: 1,
 			});
-			queuedSendTask = current.sendPrompt("report when finished");
-			await Promise.resolve();
 		});
 		expect(
 			current.messages.find((message) => message.role === "tool")?.meta
@@ -394,25 +260,11 @@ describe("useChatSession", () => {
 
 		await act(async () => current.abort());
 		await act(async () => {
-			activeSendResponse.resolve({
+			sendResponse.resolve({
 				ok: true,
 				result: { finishReason: "aborted" },
 			});
-			await activeSendTask;
-			await new Promise((resolve) => setTimeout(resolve, 300));
-		});
-		expect(
-			current.messages.find((message) => message.role === "tool")?.meta
-				?.hookEventName,
-		).toBe("tool_call_start");
-
-		await act(async () => {
-			queuedSendResponse.resolve({
-				ok: true,
-				queued: true,
-				promptsInQueue: [],
-			});
-			await queuedSendTask;
+			await sendTask;
 			await new Promise((resolve) => setTimeout(resolve, 300));
 		});
 

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -63,6 +63,47 @@ afterEach(async () => {
 });
 
 describe("useChatSession", () => {
+	it.each([
+		"idle",
+		"completed",
+	] as const)("restores a %s parent when aborting its child fails", async (parentStatus) => {
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return {
+						cwd: "/workspace/cline",
+						workspaceRoot: "/workspace/cline",
+					};
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "start") {
+						return { sessionId: "session-child-abort" };
+					}
+					if (request?.action === "abort") {
+						return { ok: false };
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => current.start(current.config));
+		const statusHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_session_status",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(statusHandler).toBeDefined();
+
+		await act(async () => {
+			statusHandler?.({ sessionId: current.sessionId, status: parentStatus });
+		});
+		expect(current.status).toBe(parentStatus);
+
+		await act(async () => current.abort());
+
+		expect(current.status).toBe(parentStatus);
+	});
+
 	it("caps command output while preserving the newest tail", () => {
 		const result = appendCappedCommandOutput(
 			"head\n",

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -104,6 +104,171 @@ describe("useChatSession", () => {
 		expect(current.status).toBe(parentStatus);
 	});
 
+	it("preserves an authoritative status received while a failed abort is pending", async () => {
+		let resolveAbort!: (value: unknown) => void;
+		const abortResponse = new Promise((resolve) => {
+			resolveAbort = resolve;
+		});
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return {
+						cwd: "/workspace/cline",
+						workspaceRoot: "/workspace/cline",
+					};
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "start") {
+						return { sessionId: "session-abort-race" };
+					}
+					if (request?.action === "abort") {
+						return await abortResponse;
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => current.start(current.config));
+		const statusHandler = subscribeMock.mock.calls.find(
+			([eventName]) => eventName === "chat_session_status",
+		)?.[1] as ((payload: unknown) => void) | undefined;
+		expect(statusHandler).toBeDefined();
+
+		let abortTask!: Promise<void>;
+		await act(async () => {
+			abortTask = current.abort();
+			await Promise.resolve();
+		});
+		expect(current.status).toBe("stopping");
+
+		await act(async () => {
+			statusHandler?.({ sessionId: current.sessionId, status: "failed" });
+		});
+		expect(current.status).toBe("failed");
+
+		await act(async () => {
+			resolveAbort({ ok: false });
+			await abortTask;
+		});
+		expect(current.status).toBe("failed");
+	});
+
+	it("keeps chat_done authoritative past the abort timeout and failure", async () => {
+		vi.useFakeTimers();
+		try {
+			const sessionId = "session-abort-chat-done";
+			let resolveAbort!: (value: unknown) => void;
+			const abortResponse = new Promise((resolve) => {
+				resolveAbort = resolve;
+			});
+			invokeMock.mockImplementation(
+				async (command: string, args?: Record<string, unknown>) => {
+					if (command === "get_process_context") {
+						return {
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					if (command === "chat_session_command") {
+						const request = args?.request as { action?: string } | undefined;
+						if (request?.action === "start") return { sessionId };
+						if (request?.action === "abort") return await abortResponse;
+					}
+					return [];
+				},
+			);
+
+			await act(async () => current.start(current.config));
+			const chatEventHandler = subscribeMock.mock.calls.find(
+				([eventName]) => eventName === "chat_event",
+			)?.[1] as ((payload: unknown) => void) | undefined;
+			expect(chatEventHandler).toBeDefined();
+
+			let abortTask!: Promise<void>;
+			await act(async () => {
+				abortTask = current.abort();
+				await Promise.resolve();
+				chatEventHandler?.({
+					sessionId,
+					stream: "chat_done",
+					chunk: JSON.stringify({ reason: "completed" }),
+					ts: Date.now(),
+					index: 1,
+				});
+			});
+			expect(current.status).toBe("completed");
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			expect(current.status).toBe("completed");
+
+			await act(async () => {
+				resolveAbort({ ok: false });
+				await abortTask;
+			});
+			expect(current.status).toBe("completed");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("restores the prior status when a failed abort outlasts the local timeout", async () => {
+		vi.useFakeTimers();
+		try {
+			let resolveAbort!: (value: unknown) => void;
+			const abortResponse = new Promise((resolve) => {
+				resolveAbort = resolve;
+			});
+			invokeMock.mockImplementation(
+				async (command: string, args?: Record<string, unknown>) => {
+					if (command === "get_process_context") {
+						return {
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+					if (command === "chat_session_command") {
+						const request = args?.request as { action?: string } | undefined;
+						if (request?.action === "start") {
+							return { sessionId: "session-abort-timeout" };
+						}
+						if (request?.action === "abort") {
+							return await abortResponse;
+						}
+					}
+					return [];
+				},
+			);
+
+			await act(async () => current.start(current.config));
+			const statusHandler = subscribeMock.mock.calls.find(
+				([eventName]) => eventName === "chat_session_status",
+			)?.[1] as ((payload: unknown) => void) | undefined;
+			await act(async () => {
+				statusHandler?.({ sessionId: current.sessionId, status: "completed" });
+			});
+
+			let abortTask!: Promise<void>;
+			await act(async () => {
+				abortTask = current.abort();
+				await Promise.resolve();
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			expect(current.status).toBe("cancelled");
+
+			await act(async () => {
+				resolveAbort({ ok: false });
+				await abortTask;
+			});
+			expect(current.status).toBe("completed");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("reconciles a running tool row after an aborted send settles", async () => {
 		const sessionId = "session-aborted-tool";
 		let resolveActiveSend!: (value: unknown) => void;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -113,6 +113,7 @@ describe("useChatSession", () => {
 		try {
 			const sessionId = "session-abort-chat-done";
 			const abortResponse = deferred<unknown>();
+			const pendingResponse = deferred<unknown>();
 			const sendResponse = deferred<unknown>();
 			invokeMock.mockImplementation(
 				async (command: string, args?: Record<string, unknown>) => {
@@ -124,6 +125,9 @@ describe("useChatSession", () => {
 						}
 						if (request?.action === "abort") {
 							return await abortResponse.promise;
+						}
+						if (request?.action === "pending_prompts") {
+							return await pendingResponse.promise;
 						}
 					}
 					return [];
@@ -143,6 +147,17 @@ describe("useChatSession", () => {
 				for (let i = 0; i < 5; i += 1) await Promise.resolve();
 			});
 
+			await act(async () => {
+				chatEventHandler({
+					sessionId,
+					stream: "chat_done",
+					chunk: JSON.stringify({ reason: "completed" }),
+					ts: Date.now(),
+					index: 1,
+				});
+			});
+			expect(current.status).toBe("running");
+
 			let abortTask!: Promise<void>;
 			await act(async () => {
 				abortTask = current.abort();
@@ -152,18 +167,21 @@ describe("useChatSession", () => {
 
 			await act(async () => {
 				statusHandler({ sessionId, status: "running" });
-				await vi.advanceTimersByTimeAsync(2000);
 			});
-			expect(current.status).toBe("cancelled");
+			expect(current.status).toBe("stopping");
 
 			await act(async () => {
-				chatEventHandler({
+				pendingResponse.resolve({
 					sessionId,
-					stream: "chat_done",
-					chunk: JSON.stringify({ reason: "completed" }),
-					ts: Date.now(),
-					index: 1,
+					ok: true,
+					promptsInQueue: [],
 				});
+				for (let i = 0; i < 5; i += 1) await Promise.resolve();
+			});
+			expect(current.status).toBe("completed");
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			expect(current.status).toBe("completed");
 

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -39,6 +39,22 @@ function HookHarness() {
 	return null;
 }
 
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
+}
+
+function handlerFor(eventName: string): (payload: unknown) => void {
+	const handler = subscribeMock.mock.calls.find(
+		([subscribedEvent]) => subscribedEvent === eventName,
+	)?.[1];
+	expect(handler).toBeDefined();
+	return handler as (payload: unknown) => void;
+}
+
 beforeEach(async () => {
 	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 	window.localStorage.clear();
@@ -89,10 +105,7 @@ describe("useChatSession", () => {
 		);
 
 		await act(async () => current.start(current.config));
-		const statusHandler = subscribeMock.mock.calls.find(
-			([eventName]) => eventName === "chat_session_status",
-		)?.[1] as ((payload: unknown) => void) | undefined;
-		expect(statusHandler).toBeDefined();
+		const statusHandler = handlerFor("chat_session_status");
 
 		await act(async () => {
 			statusHandler?.({ sessionId: current.sessionId, status: parentStatus });
@@ -105,10 +118,7 @@ describe("useChatSession", () => {
 	});
 
 	it("preserves an authoritative status received while a failed abort is pending", async () => {
-		let resolveAbort!: (value: unknown) => void;
-		const abortResponse = new Promise((resolve) => {
-			resolveAbort = resolve;
-		});
+		const abortResponse = deferred<unknown>();
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {
 				if (command === "get_process_context") {
@@ -123,7 +133,7 @@ describe("useChatSession", () => {
 						return { sessionId: "session-abort-race" };
 					}
 					if (request?.action === "abort") {
-						return await abortResponse;
+						return await abortResponse.promise;
 					}
 				}
 				return [];
@@ -131,10 +141,7 @@ describe("useChatSession", () => {
 		);
 
 		await act(async () => current.start(current.config));
-		const statusHandler = subscribeMock.mock.calls.find(
-			([eventName]) => eventName === "chat_session_status",
-		)?.[1] as ((payload: unknown) => void) | undefined;
-		expect(statusHandler).toBeDefined();
+		const statusHandler = handlerFor("chat_session_status");
 
 		let abortTask!: Promise<void>;
 		await act(async () => {
@@ -149,20 +156,18 @@ describe("useChatSession", () => {
 		expect(current.status).toBe("failed");
 
 		await act(async () => {
-			resolveAbort({ ok: false });
+			abortResponse.resolve({ ok: false });
 			await abortTask;
 		});
 		expect(current.status).toBe("failed");
 	});
 
-	it("keeps chat_done authoritative past the abort timeout and failure", async () => {
+	it("preserves authoritative completion across abort races", async () => {
 		vi.useFakeTimers();
 		try {
 			const sessionId = "session-abort-chat-done";
-			let resolveAbort!: (value: unknown) => void;
-			const abortResponse = new Promise((resolve) => {
-				resolveAbort = resolve;
-			});
+			const abortResponse = deferred<unknown>();
+			const sendResponse = deferred<unknown>();
 			invokeMock.mockImplementation(
 				async (command: string, args?: Record<string, unknown>) => {
 					if (command === "get_process_context") {
@@ -174,23 +179,49 @@ describe("useChatSession", () => {
 					if (command === "chat_session_command") {
 						const request = args?.request as { action?: string } | undefined;
 						if (request?.action === "start") return { sessionId };
-						if (request?.action === "abort") return await abortResponse;
+						if (request?.action === "send") {
+							return await sendResponse.promise;
+						}
+						if (request?.action === "abort") {
+							return await abortResponse.promise;
+						}
 					}
 					return [];
 				},
 			);
 
 			await act(async () => current.start(current.config));
-			const chatEventHandler = subscribeMock.mock.calls.find(
-				([eventName]) => eventName === "chat_event",
-			)?.[1] as ((payload: unknown) => void) | undefined;
-			expect(chatEventHandler).toBeDefined();
+			const chatEventHandler = handlerFor("chat_event");
+			const queueHandler = handlerFor("prompts_in_queue_state");
+			const statusHandler = handlerFor("chat_session_status");
+
+			await act(async () => {
+				statusHandler({ sessionId, status: "running" });
+			});
+			let sendTask!: Promise<void>;
+			await act(async () => {
+				sendTask = current.sendPrompt("queued follow-up");
+				for (let i = 0; i < 5; i += 1) await Promise.resolve();
+			});
 
 			let abortTask!: Promise<void>;
 			await act(async () => {
 				abortTask = current.abort();
 				await Promise.resolve();
-				chatEventHandler?.({
+			});
+			expect(current.status).toBe("stopping");
+
+			await act(async () => {
+				statusHandler({ sessionId, status: "running" });
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			expect(current.status).toBe("cancelled");
+
+			await act(async () => {
+				queueHandler({ sessionId, items: [] });
+			});
+			await act(async () => {
+				chatEventHandler({
 					sessionId,
 					stream: "chat_done",
 					chunk: JSON.stringify({ reason: "completed" }),
@@ -201,12 +232,18 @@ describe("useChatSession", () => {
 			expect(current.status).toBe("completed");
 
 			await act(async () => {
-				await vi.advanceTimersByTimeAsync(2000);
+				sendResponse.resolve({
+					sessionId,
+					ok: true,
+					queued: true,
+					promptsInQueue: [],
+				});
+				await sendTask;
 			});
 			expect(current.status).toBe("completed");
 
 			await act(async () => {
-				resolveAbort({ ok: false });
+				abortResponse.resolve({ ok: false });
 				await abortTask;
 			});
 			expect(current.status).toBe("completed");
@@ -218,10 +255,7 @@ describe("useChatSession", () => {
 	it("restores the prior status when a failed abort outlasts the local timeout", async () => {
 		vi.useFakeTimers();
 		try {
-			let resolveAbort!: (value: unknown) => void;
-			const abortResponse = new Promise((resolve) => {
-				resolveAbort = resolve;
-			});
+			const abortResponse = deferred<unknown>();
 			invokeMock.mockImplementation(
 				async (command: string, args?: Record<string, unknown>) => {
 					if (command === "get_process_context") {
@@ -236,7 +270,7 @@ describe("useChatSession", () => {
 							return { sessionId: "session-abort-timeout" };
 						}
 						if (request?.action === "abort") {
-							return await abortResponse;
+							return await abortResponse.promise;
 						}
 					}
 					return [];
@@ -244,9 +278,7 @@ describe("useChatSession", () => {
 			);
 
 			await act(async () => current.start(current.config));
-			const statusHandler = subscribeMock.mock.calls.find(
-				([eventName]) => eventName === "chat_session_status",
-			)?.[1] as ((payload: unknown) => void) | undefined;
+			const statusHandler = handlerFor("chat_session_status");
 			await act(async () => {
 				statusHandler?.({ sessionId: current.sessionId, status: "completed" });
 			});
@@ -260,7 +292,7 @@ describe("useChatSession", () => {
 			expect(current.status).toBe("cancelled");
 
 			await act(async () => {
-				resolveAbort({ ok: false });
+				abortResponse.resolve({ ok: false });
 				await abortTask;
 			});
 			expect(current.status).toBe("completed");
@@ -271,14 +303,8 @@ describe("useChatSession", () => {
 
 	it("reconciles a running tool row after an aborted send settles", async () => {
 		const sessionId = "session-aborted-tool";
-		let resolveActiveSend!: (value: unknown) => void;
-		let resolveQueuedSend!: (value: unknown) => void;
-		const activeSendResponse = new Promise((resolve) => {
-			resolveActiveSend = resolve;
-		});
-		const queuedSendResponse = new Promise((resolve) => {
-			resolveQueuedSend = resolve;
-		});
+		const activeSendResponse = deferred<unknown>();
+		const queuedSendResponse = deferred<unknown>();
 		let sendCount = 0;
 		const canonicalMessages = [
 			{
@@ -334,8 +360,8 @@ describe("useChatSession", () => {
 					if (request?.action === "send") {
 						sendCount += 1;
 						return await (sendCount === 1
-							? activeSendResponse
-							: queuedSendResponse);
+							? activeSendResponse.promise
+							: queuedSendResponse.promise);
 					}
 					if (request?.action === "abort") return { sessionId, ok: true };
 				}
@@ -344,10 +370,7 @@ describe("useChatSession", () => {
 		);
 
 		await act(async () => current.start(current.config));
-		const chatEventHandler = subscribeMock.mock.calls.find(
-			([eventName]) => eventName === "chat_event",
-		)?.[1] as ((payload: unknown) => void) | undefined;
-		expect(chatEventHandler).toBeDefined();
+		const chatEventHandler = handlerFor("chat_event");
 
 		let activeSendTask!: Promise<void>;
 		let queuedSendTask!: Promise<void>;
@@ -375,7 +398,10 @@ describe("useChatSession", () => {
 
 		await act(async () => current.abort());
 		await act(async () => {
-			resolveActiveSend({ ok: true, result: { finishReason: "aborted" } });
+			activeSendResponse.resolve({
+				ok: true,
+				result: { finishReason: "aborted" },
+			});
 			await activeSendTask;
 			await new Promise((resolve) => setTimeout(resolve, 300));
 		});
@@ -385,7 +411,11 @@ describe("useChatSession", () => {
 		).toBe("tool_call_start");
 
 		await act(async () => {
-			resolveQueuedSend({ ok: true, queued: true, promptsInQueue: [] });
+			queuedSendResponse.resolve({
+				ok: true,
+				queued: true,
+				promptsInQueue: [],
+			});
 			await queuedSendTask;
 			await new Promise((resolve) => setTimeout(resolve, 300));
 		});

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -192,7 +192,6 @@ describe("useChatSession", () => {
 
 			await act(async () => current.start(current.config));
 			const chatEventHandler = handlerFor("chat_event");
-			const queueHandler = handlerFor("prompts_in_queue_state");
 			const statusHandler = handlerFor("chat_session_status");
 
 			await act(async () => {
@@ -217,9 +216,6 @@ describe("useChatSession", () => {
 			});
 			expect(current.status).toBe("cancelled");
 
-			await act(async () => {
-				queueHandler({ sessionId, items: [] });
-			});
 			await act(async () => {
 				chatEventHandler({
 					sessionId,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -428,9 +428,10 @@ export function useChatSession() {
 	// trail chat_done; when no new turn has started since the turn settled
 	// (epoch unchanged), such a "running" must not reopen the turn.
 	const turnSettledEpochRef = useRef(-1);
-	// Server-projected status changes supersede any local status captured before
-	// an in-flight abort request.
+	// Runtime status changes supersede local status captured by an abort.
 	const authoritativeStatusRevisionRef = useRef(0);
+	// Snapshot used to keep a late send response from overwriting a newer status.
+	const abortStatusRevisionRef = useRef(0);
 	// Last error-level core log per session, used to explain failed turns.
 	const lastCoreErrorBySessionRef = useRef<Record<string, string>>({});
 	const [chatTransportState, setChatTransportState] =
@@ -1777,7 +1778,8 @@ export function useChatSession() {
 				// equals the settled epoch a "running" here can only be stale.
 				if (
 					nextStatus === "running" &&
-					turnEpochRef.current === turnSettledEpochRef.current
+					(abortedRef.current ||
+						turnEpochRef.current === turnSettledEpochRef.current)
 				) {
 					return;
 				}
@@ -1914,8 +1916,14 @@ export function useChatSession() {
 				// the working indicator and disarming this poll.
 				const nextStatus = record?.status?.trim();
 				if (nextStatus) {
+					const mappedStatus = mapSessionRecordStatus(
+						nextStatus as SessionHistoryStatus,
+					);
+					if (abortedRef.current && mappedStatus === "running") {
+						return;
+					}
 					authoritativeStatusRevisionRef.current += 1;
-					setStatus(mapSessionRecordStatus(nextStatus as SessionHistoryStatus));
+					setStatus(mappedStatus);
 				}
 			} finally {
 				polling = false;
@@ -2250,15 +2258,22 @@ export function useChatSession() {
 				return;
 			}
 			let abortedReconcileEpoch: number | undefined;
+			const settleAbortedSend = () => {
+				if (!abortedRef.current) return false;
+				if (
+					authoritativeStatusRevisionRef.current ===
+					abortStatusRevisionRef.current
+				) {
+					abortedReconcileEpoch = turnEpochRef.current;
+					turnSettledEpochRef.current = turnEpochRef.current;
+					setStatus("cancelled");
+				}
+				return true;
+			};
 			try {
 				const payload = await sendTask;
 				if (payload.ok && payload.queued) {
-					if (abortedRef.current) {
-						abortedReconcileEpoch = turnEpochRef.current;
-						turnSettledEpochRef.current = turnEpochRef.current;
-						setStatus("cancelled");
-						return;
-					}
+					if (settleAbortedSend()) return;
 					if (turnEpochRef.current !== turnEpochAtDispatch) {
 						// The runtime already started consuming a queued prompt
 						// (chat_queued_prompt_start bumped the epoch) while this
@@ -2278,12 +2293,7 @@ export function useChatSession() {
 
 				const result = payload.result as ChatApiResult | undefined;
 				applyPromptsInQueue(payload.promptsInQueue);
-				if (abortedRef.current) {
-					abortedReconcileEpoch = turnEpochRef.current;
-					turnSettledEpochRef.current = turnEpochRef.current;
-					setStatus("cancelled");
-					return;
-				}
+				if (settleAbortedSend()) return;
 				// On a failed run the runtime reports the error string in
 				// result.text — it is not assistant content and must not be
 				// rendered as an assistant bubble (canonical rehydration would
@@ -2580,10 +2590,8 @@ export function useChatSession() {
 				const hasQueuedFollowUps =
 					Array.isArray(payload.promptsInQueue) &&
 					payload.promptsInQueue.length > 0;
-				if (abortedRef.current) {
-					turnSettledEpochRef.current = turnEpochRef.current;
-					setStatus("cancelled");
-				} else if (result?.finishReason === "error") {
+				if (settleAbortedSend()) return;
+				if (result?.finishReason === "error") {
 					// On a failed run result.text is the runtime's error string
 					// (never assistant content — see isErrorResult above), so it
 					// is the best failure detail available. The reporter dedupes
@@ -2609,11 +2617,7 @@ export function useChatSession() {
 				}
 				void refreshSessionDiffSummary(activeSessionId);
 			} catch (err) {
-				if (abortedRef.current) {
-					abortedReconcileEpoch = turnEpochRef.current;
-					setStatus("cancelled");
-					return;
-				}
+				if (settleAbortedSend()) return;
 				if (optimisticQueuedPromptId) {
 					setPromptsInQueue((prev) =>
 						prev.filter((item) => item.id !== optimisticQueuedPromptId),
@@ -2767,6 +2771,7 @@ export function useChatSession() {
 		const fallbackStatus: ChatSessionStatus =
 			status === "stopping" ? "running" : status;
 		const statusRevisionAtAbort = authoritativeStatusRevisionRef.current;
+		abortStatusRevisionRef.current = statusRevisionAtAbort;
 		const restoreFallbackStatus = () => {
 			abortedRef.current = false;
 			clearAbortFallbackTimeout();

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -737,6 +737,7 @@ export function useChatSession() {
 					setPromptsInQueue(items);
 					if (items.length === 0) {
 						turnSettledEpochRef.current = turnEpochRef.current;
+						authoritativeStatusRevisionRef.current += 1;
 						setStatus((current) =>
 							current === "running" ? "completed" : current,
 						);

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -428,6 +428,9 @@ export function useChatSession() {
 	// trail chat_done; when no new turn has started since the turn settled
 	// (epoch unchanged), such a "running" must not reopen the turn.
 	const turnSettledEpochRef = useRef(-1);
+	// Server-projected status changes supersede any local status captured before
+	// an in-flight abort request.
+	const authoritativeStatusRevisionRef = useRef(0);
 	// Last error-level core log per session, used to explain failed turns.
 	const lastCoreErrorBySessionRef = useRef<Record<string, string>>({});
 	const [chatTransportState, setChatTransportState] =
@@ -1235,7 +1238,7 @@ export function useChatSession() {
 				return;
 			}
 			lastLiveChunkAtRef.current = Date.now();
-			if (abortedRef.current) {
+			if (abortedRef.current && payload.stream !== "chat_done") {
 				return;
 			}
 
@@ -1622,6 +1625,7 @@ export function useChatSession() {
 					verifyQueueStillBusy(listeningSessionId);
 				} else {
 					turnSettledEpochRef.current = turnEpochRef.current;
+					authoritativeStatusRevisionRef.current += 1;
 					finalizeSettledTurn(listeningSessionId);
 				}
 				return;
@@ -1777,6 +1781,7 @@ export function useChatSession() {
 				) {
 					return;
 				}
+				authoritativeStatusRevisionRef.current += 1;
 				setStatus(nextStatus as ChatSessionStatus);
 			},
 		);
@@ -1801,6 +1806,7 @@ export function useChatSession() {
 				setActiveAssistantMessageId(null);
 				clearLiveToolRefs();
 				turnSettledEpochRef.current = turnEpochRef.current;
+				authoritativeStatusRevisionRef.current += 1;
 				setStatus((record.reason?.trim() || "idle") as ChatSessionStatus);
 				finalizeSettledTurn(targetSessionId);
 			},
@@ -1908,6 +1914,7 @@ export function useChatSession() {
 				// the working indicator and disarming this poll.
 				const nextStatus = record?.status?.trim();
 				if (nextStatus) {
+					authoritativeStatusRevisionRef.current += 1;
 					setStatus(mapSessionRecordStatus(nextStatus as SessionHistoryStatus));
 				}
 			} finally {
@@ -2759,11 +2766,26 @@ export function useChatSession() {
 		if (!sessionId) return;
 		const fallbackStatus: ChatSessionStatus =
 			status === "stopping" ? "running" : status;
+		const statusRevisionAtAbort = authoritativeStatusRevisionRef.current;
+		const restoreFallbackStatus = () => {
+			abortedRef.current = false;
+			clearAbortFallbackTimeout();
+			if (
+				activeSessionIdRef.current === sessionId &&
+				authoritativeStatusRevisionRef.current === statusRevisionAtAbort
+			) {
+				setStatus(fallbackStatus);
+			}
+		};
 		abortedRef.current = true;
 		setStatus("stopping");
 		clearAbortFallbackTimeout();
 		abortFallbackTimeoutRef.current = setTimeout(() => {
-			if (abortedRef.current) {
+			if (
+				abortedRef.current &&
+				activeSessionIdRef.current === sessionId &&
+				authoritativeStatusRevisionRef.current === statusRevisionAtAbort
+			) {
 				setStatus("cancelled");
 			}
 			abortFallbackTimeoutRef.current = null;
@@ -2771,14 +2793,10 @@ export function useChatSession() {
 		try {
 			const response = await postSession({ action: "abort", sessionId });
 			if (!response.ok) {
-				abortedRef.current = false;
-				clearAbortFallbackTimeout();
-				setStatus(fallbackStatus);
+				restoreFallbackStatus();
 			}
 		} catch {
-			abortedRef.current = false;
-			clearAbortFallbackTimeout();
-			setStatus(fallbackStatus);
+			restoreFallbackStatus();
 		}
 	}, [clearAbortFallbackTimeout, postSession, sessionId, status]);
 

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -739,7 +739,9 @@ export function useChatSession() {
 						turnSettledEpochRef.current = turnEpochRef.current;
 						authoritativeStatusRevisionRef.current += 1;
 						setStatus((current) =>
-							current === "running" ? "completed" : current,
+							current === "running" || current === "stopping"
+								? "completed"
+								: current,
 						);
 						finalizeSettledTurn(sid);
 					}

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -2242,9 +2242,16 @@ export function useChatSession() {
 				finishPromptSubmission();
 				return;
 			}
+			let abortedReconcileEpoch: number | undefined;
 			try {
 				const payload = await sendTask;
 				if (payload.ok && payload.queued) {
+					if (abortedRef.current) {
+						abortedReconcileEpoch = turnEpochRef.current;
+						turnSettledEpochRef.current = turnEpochRef.current;
+						setStatus("cancelled");
+						return;
+					}
 					if (turnEpochRef.current !== turnEpochAtDispatch) {
 						// The runtime already started consuming a queued prompt
 						// (chat_queued_prompt_start bumped the epoch) while this
@@ -2258,11 +2265,6 @@ export function useChatSession() {
 						return;
 					}
 					applyPromptsInQueue(payload.promptsInQueue);
-					if (abortedRef.current) {
-						turnSettledEpochRef.current = turnEpochRef.current;
-						setStatus("cancelled");
-						return;
-					}
 					setStatus("running");
 					return;
 				}
@@ -2270,6 +2272,7 @@ export function useChatSession() {
 				const result = payload.result as ChatApiResult | undefined;
 				applyPromptsInQueue(payload.promptsInQueue);
 				if (abortedRef.current) {
+					abortedReconcileEpoch = turnEpochRef.current;
 					turnSettledEpochRef.current = turnEpochRef.current;
 					setStatus("cancelled");
 					return;
@@ -2600,6 +2603,7 @@ export function useChatSession() {
 				void refreshSessionDiffSummary(activeSessionId);
 			} catch (err) {
 				if (abortedRef.current) {
+					abortedReconcileEpoch = turnEpochRef.current;
 					setStatus("cancelled");
 					return;
 				}
@@ -2617,6 +2621,13 @@ export function useChatSession() {
 					clearLiveToolRefs();
 				}
 				finishPromptSubmission();
+				if (
+					abortedReconcileEpoch !== undefined &&
+					activeSessionIdRef.current === activeSessionId &&
+					turnEpochRef.current === abortedReconcileEpoch
+				) {
+					finalizeSettledTurn(activeSessionId);
+				}
 			}
 		},
 		[
@@ -2627,6 +2638,7 @@ export function useChatSession() {
 			clearAbortFallbackTimeout,
 			clearLiveToolRefs,
 			config,
+			finalizeSettledTurn,
 			hydratedHistorySessionId,
 			materializeToolMessagesFromResult,
 			refreshSessionDiffSummary,

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -2745,6 +2745,8 @@ export function useChatSession() {
 
 	const abort = useCallback(async () => {
 		if (!sessionId) return;
+		const fallbackStatus: ChatSessionStatus =
+			status === "stopping" ? "running" : status;
 		abortedRef.current = true;
 		setStatus("stopping");
 		clearAbortFallbackTimeout();
@@ -2759,14 +2761,14 @@ export function useChatSession() {
 			if (!response.ok) {
 				abortedRef.current = false;
 				clearAbortFallbackTimeout();
-				setStatus("running");
+				setStatus(fallbackStatus);
 			}
 		} catch {
 			abortedRef.current = false;
 			clearAbortFallbackTimeout();
-			setStatus("running");
+			setStatus(fallbackStatus);
 		}
-	}, [clearAbortFallbackTimeout, postSession, sessionId]);
+	}, [clearAbortFallbackTimeout, postSession, sessionId, status]);
 
 	const proceedWhileRunning = useCallback(
 		async (targetSessionId: string, toolCallId?: string) => {

--- a/apps/examples/desktop-app/webview/hooks/use-session-agents.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-agents.test.tsx
@@ -403,6 +403,22 @@ describe("useSessionAgents", () => {
 		}
 	});
 
+	it("keeps polling while an idle parent still has a running child", async () => {
+		vi.useFakeTimers();
+		try {
+			invokeMock.mockResolvedValue([runningRow("a", "one")]);
+			await render({ sessionId: "a", sessionActive: false });
+			const afterFirst = invokeMock.mock.calls.length;
+
+			await act(async () => {
+				vi.advanceTimersByTime(2500);
+			});
+			expect(invokeMock.mock.calls.length).toBeGreaterThan(afterFirst);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("skips malformed rows rather than surfacing partial agents", async () => {
 		invokeMock.mockResolvedValue([
 			agentRow("a", "good"),

--- a/apps/examples/desktop-app/webview/hooks/use-session-agents.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-agents.test.tsx
@@ -419,6 +419,36 @@ describe("useSessionAgents", () => {
 		}
 	});
 
+	it("lets a slow poll settle an idle parent's completed child", async () => {
+		vi.useFakeTimers();
+		try {
+			let listCount = 0;
+			invokeMock.mockImplementation(async () => {
+				listCount += 1;
+				if (listCount === 1) return [runningRow("a", "one")];
+				return await new Promise((resolve) => {
+					setTimeout(() => resolve([agentRow("a", "one")]), 3000);
+				});
+			});
+
+			await render({ sessionId: "a", sessionActive: false });
+			expect(current.agents[0]?.status).toBe("running");
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5500);
+			});
+			expect(current.agents[0]?.status).toBe("completed");
+
+			const settledCallCount = invokeMock.mock.calls.length;
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(10_000);
+			});
+			expect(invokeMock).toHaveBeenCalledTimes(settledCallCount);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("skips malformed rows rather than surfacing partial agents", async () => {
 		invokeMock.mockResolvedValue([
 			agentRow("a", "good"),

--- a/apps/examples/desktop-app/webview/hooks/use-session-agents.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-agents.ts
@@ -72,8 +72,8 @@ function parseAgentEntries(value: unknown): SessionAgentEntry[] {
 /**
  * Roster of the child agents a session started.
  *
- * Read once per displayed session and then polled only while that session is
- * active. Deliberately *not* gated on whether the header is currently showing
+ * Read once per displayed session and then polled while that session or one of
+ * its children is active. Deliberately *not* gated on whether the header shows
  * any agents: that tally is derived from the newest messages only, so gating on
  * it would deadlock — a session whose spawn calls have aged out of the message
  * window would report zero agents, never query the database that still
@@ -196,8 +196,13 @@ export function useSessionAgents({
 		if (!sessionId || (!sessionActive && !hasRunningAgents)) {
 			return;
 		}
+		let polling = false;
 		const timer = window.setInterval(() => {
-			void refresh(sessionId, { quiet: true });
+			if (polling) return;
+			polling = true;
+			void refresh(sessionId, { quiet: true }).finally(() => {
+				polling = false;
+			});
 		}, ACTIVE_POLL_INTERVAL_MS);
 		return () => {
 			window.clearInterval(timer);

--- a/apps/examples/desktop-app/webview/hooks/use-session-agents.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-agents.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { desktopClient } from "@/lib/desktop-client";
-import type { SessionAgentEntry } from "@/lib/session-agents";
+import { agentEntryState, type SessionAgentEntry } from "@/lib/session-agents";
 
 /** While a turn runs, child agents come and go faster than a one-shot fetch sees. */
 const ACTIVE_POLL_INTERVAL_MS = 2500;
@@ -167,6 +167,9 @@ export function useSessionAgents({
 	const agents = isCurrent ? roster.entries : NO_AGENTS;
 	const loading = isCurrent && roster.loading;
 	const error = isCurrent ? roster.error : null;
+	const hasRunningAgents = agents.some(
+		(agent) => agentEntryState(agent.status) === "running",
+	);
 
 	// One read per displayed session, repeated when the session starts or stops
 	// running — a turn can finish up to a poll interval after the last read, so
@@ -190,7 +193,7 @@ export function useSessionAgents({
 	}, [panelOpen, refresh, sessionId]);
 
 	useEffect(() => {
-		if (!sessionId || !sessionActive) {
+		if (!sessionId || (!sessionActive && !hasRunningAgents)) {
 			return;
 		}
 		const timer = window.setInterval(() => {
@@ -199,7 +202,7 @@ export function useSessionAgents({
 		return () => {
 			window.clearInterval(timer);
 		};
-	}, [refresh, sessionActive, sessionId]);
+	}, [hasRunningAgents, refresh, sessionActive, sessionId]);
 
 	return { agents, loading, error, refresh };
 }


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to #13647 and companion to #13677

### Description

A parent session can appear idle while a delegated subagent or teammate run is still active. Desktop then replaced the Stop control with the send control, so the user had to open the child session to cancel it.

This change:

- keeps polling the persisted child-agent roster while any child remains active, without overlapping slow polls
- shows Stop in the parent composer when child-agent activity is running
- preserves authoritative session status updates while an abort request is pending, and restores the prior status if the request fails
- reconciles persisted tool activity after abort so an interrupted `spawn_agent` row does not remain visually running

Runtime propagation for delegated `spawn_agent` sessions is implemented by #13677, which should merge first. The broader terminal-status presentation question, such as showing a persistent Run stopped row, remains outside this PR.

<img width="1484" height="967" alt="Screenshot 2026-08-28 at 6 17 56 PM" src="https://github.com/user-attachments/assets/b33160f5-f1ea-4a40-836c-ac10de034061" />


### Test Procedure

Automated:

- `cd apps/examples/desktop-app && NODE_OPTIONS=--no-experimental-webstorage bunx vitest run webview/components/views/chat/chat-input-bar.test.tsx webview/hooks/use-session-agents.test.tsx webview/hooks/use-chat-session.test.tsx --config vitest.config.ts` — 100 tests passed
- `cd apps/examples/desktop-app && bun run typecheck`
- `bunx biome check` on the changed files
- `git diff --check`

Manual:

1. Run Desktop against a source Hub containing #13677.
2. Ask the parent to spawn a subagent that sleeps for two minutes.
3. Confirm Stop remains available in the parent session while the child runs.
4. Click Stop and verify the child transitions to cancelled and the inline spawn row no longer appears running.

The broad all-file Desktop Vitest glob currently includes incompatible `bun:test` script suites and unrelated sidecar auth-test failures; the focused changed suites pass.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not attached. The behavioral change is covered by the manual procedure above.

### Additional Notes

This PR intentionally does not add a generic aborted or Run stopped transcript treatment. That behavior affects all cancellation sources and reopened session history, so it should be designed independently.
