### PR TITLE
feat(mcp): install public OAuth client policy

### DIFF
--- a/apps/cli/src/cli.e2e.test.ts
+++ b/apps/cli/src/cli.e2e.test.ts
@@ -767,6 +767,85 @@ Break work into clear steps.`,
 		);
 	});
 
+	it("routes public MCP OAuth install policy and exposes no secret flag", () => {
+		const tempRoot = mkdtempSync(path.join(os.tmpdir(), "cli-e2e-mcp-oauth-"));
+		tempDirs.push(tempRoot);
+		const settingsPath = path.join(tempRoot, "cline_mcp_settings.json");
+		const env = createIsolatedEnv({
+			CLINE_MCP_SETTINGS_PATH: settingsPath,
+		});
+		const help = runCli(["mcp", "install", "--help"], { env });
+		expect(help.status).toBe(0);
+		expect(asText(help.stdout)).toContain("--oauth-client-id");
+		expect(asText(help.stdout)).toContain("--oauth-allowed-scope");
+		expect(asText(help.stdout)).toContain("--oauth-loopback-hostname");
+		expect(asText(help.stdout)).not.toContain("oauth-client-secret");
+
+		const result = runCli(
+			[
+				"mcp",
+				"install",
+				"slack",
+				"--yes",
+				"--json",
+				"--transport",
+				"http",
+				"--oauth-client-id",
+				"public-client",
+				"--oauth-allowed-scope",
+				"search:read.public",
+				"--oauth-allowed-scope",
+				"channels:history",
+				"--oauth-loopback-hostname",
+				"localhost",
+				"https://mcp.slack.com/mcp",
+			],
+			{ env },
+		);
+
+		expect(result.status).toBe(0);
+		const output = JSON.parse(asText(result.stdout).trim()) as {
+			oauthClient?: Record<string, unknown>;
+		};
+		expect(output.oauthClient).toEqual({
+			clientId: "public-client",
+			allowedScopes: ["channels:history", "search:read.public"],
+			loopbackHostname: "localhost",
+		});
+		expect(output.oauthClient).not.toHaveProperty("clientSecret");
+		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+			mcpServers: Record<
+				string,
+				{ oauth?: unknown; oauthClient?: Record<string, unknown> }
+			>;
+		};
+		expect(settings.mcpServers.slack?.oauthClient).toEqual(output.oauthClient);
+		expect(settings.mcpServers.slack?.oauth).toBeUndefined();
+	});
+
+	it("rejects duplicate singleton MCP OAuth install flags", () => {
+		const result = runCli(
+			[
+				"mcp",
+				"install",
+				"slack",
+				"--yes",
+				"--transport",
+				"http",
+				"--oauth-client-id",
+				"one",
+				"--oauth-client-id=two",
+				"https://mcp.slack.com/mcp",
+			],
+			{ env: createIsolatedEnv() },
+		);
+
+		expect(result.status).toBe(1);
+		expect(asText(result.stderr)).toContain(
+			"--oauth-client-id may only be specified once",
+		);
+	});
+
 	it("routes mcp uninstall and its rm alias", () => {
 		const tempRoot = mkdtempSync(path.join(os.tmpdir(), "cli-e2e-mcp-rm-"));
 		tempDirs.push(tempRoot);

--- a/apps/cli/src/commands/mcp.test.ts
+++ b/apps/cli/src/commands/mcp.test.ts
@@ -15,12 +15,13 @@ vi.mock("@cline/core", async (importOriginal) => {
 	return {
 		...actual,
 		installMcpServer: vi.fn((options) => {
-			const { name, transport, warnings } =
+			const { name, oauthClient, transport, warnings } =
 				actual.buildMcpInstallTransport(options);
 			return {
 				name,
 				status: "installed",
 				transport,
+				oauthClient,
 				warnings,
 			};
 		}),
@@ -58,6 +59,49 @@ describe("mcp install command", () => {
 			type: "streamableHttp",
 			url: "https://mcp.context7.com/mcp",
 		});
+	});
+
+	it("prefills only normalized public OAuth policy in the wizard", () => {
+		expect(
+			buildMcpInstallDefaults({
+				name: "slack",
+				transport: "http",
+				targetArgs: ["https://mcp.slack.com/mcp"],
+				oauthClientId: "public-client",
+				oauthAllowedScopes: ["search:read.public", "channels:history"],
+				oauthLoopbackHostname: "localhost",
+			}),
+		).toEqual({
+			name: "slack",
+			type: "streamableHttp",
+			url: "https://mcp.slack.com/mcp",
+			oauthClient: {
+				clientId: "public-client",
+				allowedScopes: ["channels:history", "search:read.public"],
+				loopbackHostname: "localhost",
+			},
+		});
+	});
+
+	it("uses Core validation for incomplete or duplicate OAuth policy", () => {
+		const remote = {
+			name: "slack",
+			transport: "http",
+			targetArgs: ["https://mcp.slack.com/mcp"],
+		};
+		expect(() =>
+			buildMcpInstallDefaults({
+				...remote,
+				oauthLoopbackHostname: "localhost",
+			}),
+		).toThrow(/--oauth-client-id is required/);
+		expect(() =>
+			buildMcpInstallDefaults({
+				...remote,
+				oauthClientId: "public-client",
+				oauthAllowedScopes: ["channels:history", "channels:history"],
+			}),
+		).toThrow(/Duplicate MCP OAuth scope/);
 	});
 
 	it("shows mcp-remote marketplace entries as native remote servers", () => {
@@ -154,8 +198,8 @@ describe("mcp install command", () => {
 			buildMcpInstallTransport({
 				name: "docs",
 				transport: "http",
-				headers: ["Authorization: Bearer <token>"],
-				targetArgs: ["https://example.com/mcp", "--header=X-Extra: yes"],
+				headers: ["Authorization: Bearer <token>", "X-Extra: yes"],
+				targetArgs: ["https://example.com/mcp"],
 			}),
 		).toEqual({
 			name: "docs",
@@ -190,6 +234,34 @@ describe("mcp install command", () => {
 			name: "ctx7",
 			type: "streamableHttp",
 			url: "https://mcp.context7.com/mcp",
+		});
+	});
+
+	it("passes public OAuth policy to the wizard without a secret", async () => {
+		const runWizard = vi.fn(async () => 0);
+
+		const code = await runMcpInstallCommand({
+			name: "slack",
+			transport: "http",
+			targetArgs: ["https://mcp.slack.com/mcp"],
+			oauthClientId: "public-client",
+			oauthAllowedScopes: ["search:read.public", "channels:history"],
+			oauthLoopbackHostname: "localhost",
+			isTty: true,
+			runWizard,
+			io: { writeErr: vi.fn() },
+		});
+
+		expect(code).toBe(0);
+		expect(runWizard).toHaveBeenCalledWith({
+			name: "slack",
+			type: "streamableHttp",
+			url: "https://mcp.slack.com/mcp",
+			oauthClient: {
+				clientId: "public-client",
+				allowedScopes: ["channels:history", "search:read.public"],
+				loopbackHostname: "localhost",
+			},
 		});
 	});
 
@@ -235,11 +307,8 @@ describe("mcp install command", () => {
 		const code = await runMcpInstallCommand({
 			name: "docs",
 			transport: "http",
-			targetArgs: [
-				"https://example.com/mcp",
-				"--header",
-				"Authorization: Bearer token",
-			],
+			headers: ["Authorization: Bearer token"],
+			targetArgs: ["https://example.com/mcp"],
 			isTty: false,
 			yes: true,
 			io: { writeln, writeErr },
@@ -249,11 +318,8 @@ describe("mcp install command", () => {
 		expect(installMcpServer).toHaveBeenCalledWith({
 			name: "docs",
 			transport: "http",
-			targetArgs: [
-				"https://example.com/mcp",
-				"--header",
-				"Authorization: Bearer token",
-			],
+			headers: ["Authorization: Bearer token"],
+			targetArgs: ["https://example.com/mcp"],
 			isTty: false,
 			yes: true,
 			io: { writeln, writeErr },
@@ -284,6 +350,36 @@ describe("mcp install command", () => {
 				args: ["server.js"],
 			},
 		});
+	});
+
+	it("reports normalized OAuth policy for a direct install without authorizing", async () => {
+		const writeln = vi.fn();
+
+		const code = await runMcpInstallCommand({
+			name: "slack",
+			transport: "http",
+			targetArgs: ["https://mcp.slack.com/mcp"],
+			oauthClientId: "public-client",
+			oauthAllowedScopes: ["search:read.public", "channels:history"],
+			oauthLoopbackHostname: "localhost",
+			isTty: false,
+			yes: true,
+			json: true,
+			io: { writeln, writeErr: vi.fn() },
+		});
+
+		expect(code).toBe(0);
+		const output = JSON.parse(writeln.mock.calls[0]?.[0]) as Record<
+			string,
+			unknown
+		>;
+		expect(output.oauthClient).toEqual({
+			clientId: "public-client",
+			allowedScopes: ["channels:history", "search:read.public"],
+			loopbackHostname: "localhost",
+		});
+		expect(output).not.toHaveProperty("oauth");
+		expect(output.oauthClient).not.toHaveProperty("clientSecret");
 	});
 });
 

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -1,11 +1,11 @@
 import {
 	buildMcpInstallTransport as buildCoreMcpInstallTransport,
 	type McpInstallOptions as CoreMcpInstallOptions,
+	type McpUninstallOptions as CoreMcpUninstallOptions,
+	type McpUninstallResult as CoreMcpUninstallResult,
 	installMcpServer,
 	type McpInstallResult,
 	type McpServerTransportConfig,
-	type McpUninstallOptions as CoreMcpUninstallOptions,
-	type McpUninstallResult as CoreMcpUninstallResult,
 	uninstallMcpServer,
 } from "@cline/core";
 import type { McpAddDefaults } from "../wizards/mcp";
@@ -29,6 +29,7 @@ export interface McpInstallDirectResult {
 	name: string;
 	status: "installed";
 	transport: McpServerTransportConfig;
+	oauthClient?: McpAddDefaults["oauthClient"];
 	warnings: string[];
 }
 
@@ -39,12 +40,22 @@ function quoteCommandArg(arg: string): string {
 	return `"${arg.replace(/(["\\])/g, "\\$1")}"`;
 }
 
-export function buildMcpInstallDefaults(options: {
-	name: string;
-	targetArgs?: string[];
-	transport?: string;
-}): McpAddDefaults {
-	const { name, transport } = buildCoreMcpInstallTransport(options);
+export function buildMcpInstallDefaults(
+	options: CoreMcpInstallOptions,
+): McpAddDefaults {
+	const { name, oauthClient, transport } =
+		buildCoreMcpInstallTransport(options);
+	const publicOAuthClient = oauthClient
+		? {
+				clientId: oauthClient.clientId,
+				...(oauthClient.allowedScopes
+					? { allowedScopes: oauthClient.allowedScopes }
+					: {}),
+				...(oauthClient.loopbackHostname
+					? { loopbackHostname: oauthClient.loopbackHostname }
+					: {}),
+			}
+		: undefined;
 	if (transport.type === "stdio") {
 		return {
 			name,
@@ -58,6 +69,8 @@ export function buildMcpInstallDefaults(options: {
 		name,
 		type: transport.type,
 		url: transport.url,
+		...(transport.headers ? { headers: transport.headers } : {}),
+		...(publicOAuthClient ? { oauthClient: publicOAuthClient } : {}),
 	};
 }
 
@@ -69,6 +82,21 @@ export function installMcpServerDirect(
 		name: result.name,
 		status: result.status,
 		transport: result.transport,
+		...(result.oauthClient
+			? {
+					oauthClient: {
+						clientId: result.oauthClient.clientId,
+						...(result.oauthClient.allowedScopes
+							? { allowedScopes: result.oauthClient.allowedScopes }
+							: {}),
+						...(result.oauthClient.loopbackHostname
+							? {
+									loopbackHostname: result.oauthClient.loopbackHostname,
+								}
+							: {}),
+					},
+				}
+			: {}),
 		warnings: result.warnings,
 	};
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,7 +1,7 @@
 import { fstatSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename } from "node:path";
-import type { ToolPolicy } from "@cline/core";
+import type { McpOAuthLoopbackHostname, ToolPolicy } from "@cline/core";
 
 import { registerDisposable } from "@cline/shared";
 import type { Command } from "commander";
@@ -124,6 +124,21 @@ export function resolveConfigDirArg(argv: string[]): string | undefined {
 
 function collectOption(value: string, previous: string[] = []): string[] {
 	return [...previous, value];
+}
+
+function collectSingleOption(
+	flag: string,
+): (value: string, previous?: string) => string {
+	return (value, previous) => {
+		if (previous !== undefined) {
+			throw new CommanderError(
+				1,
+				"commander.duplicateOption",
+				`${flag} may only be specified once`,
+			);
+		}
+		return value;
+	};
 }
 
 // Shells strip quote characters before argv reaches us, so a prompt that was
@@ -484,14 +499,34 @@ export async function runCli(): Promise<void> {
 		.option(
 			"--transport <transport>",
 			"stdio, sse, http, streamable-http, or streamableHttp (default: stdio)",
+			collectSingleOption("--transport"),
 		)
 		.option("--header <header>", "Remote MCP request header", collectOption, [])
+		.option(
+			"--oauth-client-id <public-id>",
+			"Public OAuth client ID for a pre-registered remote MCP client",
+			collectSingleOption("--oauth-client-id"),
+		)
+		.option(
+			"--oauth-allowed-scope <scope>",
+			"Maximum OAuth scope allowed for the client (repeatable)",
+			collectOption,
+			[],
+		)
+		.option(
+			"--oauth-loopback-hostname <hostname>",
+			"OAuth redirect hostname: 127.0.0.1 or localhost",
+			collectSingleOption("--oauth-loopback-hostname"),
+		)
 		.option("--yes", "Install noninteractively without opening the wizard")
 		.option("--json", "Output as JSON")
 		.action(async (name: string, targetArgs: string[]) => {
 			const opts = mcpInstallCmd.opts<{
 				header?: string[];
 				json?: boolean;
+				oauthAllowedScope?: string[];
+				oauthClientId?: string;
+				oauthLoopbackHostname?: string;
 				transport?: string;
 				yes?: boolean;
 			}>();
@@ -499,6 +534,14 @@ export async function runCli(): Promise<void> {
 			ctx.exitCode = await runMcpInstallCommand({
 				name,
 				headers: opts.header,
+				oauthAllowedScopes:
+					opts.oauthAllowedScope && opts.oauthAllowedScope.length > 0
+						? opts.oauthAllowedScope
+						: undefined,
+				oauthClientId: opts.oauthClientId,
+				oauthLoopbackHostname: opts.oauthLoopbackHostname as
+					| McpOAuthLoopbackHostname
+					| undefined,
 				targetArgs,
 				transport: opts.transport,
 				json: opts.json === true || program.opts().json === true,

--- a/apps/cli/src/wizards/mcp/index.test.ts
+++ b/apps/cli/src/wizards/mcp/index.test.ts
@@ -196,6 +196,67 @@ describe("MCP OAuth editor", () => {
 		).toThrow(/RFC 6749/);
 	});
 
+	it("uses public install policy as OAuth add defaults without prefilling a secret", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "cline-mcp-install-defaults-"));
+		tempDirs.push(dir);
+		const settingsPath = join(dir, "cline_mcp_settings.json");
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		promptMocks.text
+			.mockResolvedValueOnce("slack")
+			.mockResolvedValueOnce("https://mcp.slack.com/mcp")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("public-client")
+			.mockResolvedValueOnce("channels:history search:read.public");
+		promptMocks.select
+			.mockResolvedValueOnce("streamableHttp")
+			.mockResolvedValueOnce("oauth")
+			.mockResolvedValueOnce("localhost");
+		promptMocks.password.mockResolvedValueOnce("");
+
+		await expect(
+			runMcpWizard({
+				initialAction: "add",
+				exitAfterInitialAction: true,
+				addDefaults: {
+					name: "slack",
+					type: "streamableHttp",
+					url: "https://mcp.slack.com/mcp",
+					oauthClient: {
+						clientId: "public-client",
+						allowedScopes: ["channels:history", "search:read.public"],
+						loopbackHostname: "localhost",
+					},
+				},
+			}),
+		).resolves.toBe(0);
+
+		const authPrompt = promptMocks.select.mock.calls.find(
+			([options]) => options.message === "Authentication",
+		)?.[0];
+		expect(authPrompt?.initialValue).toBe("oauth");
+		const clientIdPrompt = promptMocks.text.mock.calls.find(([options]) =>
+			options.message.startsWith("OAuth client ID"),
+		)?.[0];
+		expect(clientIdPrompt?.initialValue).toBe("public-client");
+		const secretPrompt = promptMocks.password.mock.calls[0]?.[0];
+		expect(secretPrompt?.initialValue).toBeUndefined();
+
+		const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+			mcpServers: {
+				slack: { oauthClient?: Record<string, unknown> };
+			};
+		};
+		expect(parsed.mcpServers.slack.oauthClient).toEqual({
+			clientId: "public-client",
+			allowedScopes: ["channels:history", "search:read.public"],
+			loopbackHostname: "localhost",
+		});
+		expect(parsed.mcpServers.slack.oauthClient).not.toHaveProperty(
+			"clientSecret",
+		);
+		expect(oauthMocks.authorize).toHaveBeenCalledWith("slack");
+	});
+
 	it("lists every exact callback URI for either supported redirect hostname", () => {
 		expect(getMcpOAuthRedirectUris("127.0.0.1")).toEqual([
 			"http://127.0.0.1:1456/mcp/oauth/callback",

--- a/apps/cli/src/wizards/mcp/index.ts
+++ b/apps/cli/src/wizards/mcp/index.ts
@@ -76,6 +76,13 @@ export interface McpAddDefaults {
 	type?: McpTransport["type"];
 	command?: string;
 	url?: string;
+	headers?: Record<string, string>;
+	/**
+	 * Install definitions may prefill only the public OAuth client policy. Client
+	 * secrets remain an explicit wizard-only input and are never accepted from a
+	 * marketplace or CLI install flag.
+	 */
+	oauthClient?: Omit<McpServerOAuthClientConfig, "clientSecret">;
 }
 
 export interface RunMcpWizardOptions {
@@ -505,6 +512,13 @@ async function actionAdd(defaults?: McpAddDefaults): Promise<void> {
 	} else {
 		const config = await collectUrlTransport(type as "sse" | "streamableHttp", {
 			url: defaults?.url,
+			headers: defaults?.headers,
+			authMode: defaults?.oauthClient
+				? "oauth"
+				: defaults?.headers
+					? "headers"
+					: undefined,
+			oauthClient: defaults?.oauthClient,
 		});
 		transport = config?.transport ?? null;
 		authMode = config?.authMode ?? "none";

--- a/apps/examples/desktop-app/sidecar/marketplace.test.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { installPlugin } from "@cline/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	buildMarketplaceMcpInput,
 	getOfficialPluginInstallPath,
 	installMarketplaceEntry,
 	listMarketplaceInstalledEntries,
@@ -165,6 +166,114 @@ describe("official plugin install detection", () => {
 				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
 			}
 		}
+	});
+
+	it("persists forward-compatible Marketplace OAuth policy without authorizing", async () => {
+		// This synthetic entry locks the forward-compatible adapter contract
+		// without changing the live catalog; existing entries may omit the policy.
+		const settingsPath = join(tempClineDir, "cline_mcp_settings.json");
+		const previousSettingsPath = process.env.CLINE_MCP_SETTINGS_PATH;
+		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		try {
+			const installArgs = [
+				"slack",
+				"--transport",
+				"http",
+				"--oauth-client-id",
+				"marketplace-public-client",
+				"--oauth-allowed-scope",
+				"search:read.public",
+				"--oauth-allowed-scope=channels:history",
+				"--oauth-loopback-hostname",
+				"localhost",
+				"https://mcp.slack.com/mcp",
+			];
+			expect(buildMarketplaceMcpInput(installArgs)).toMatchObject({
+				name: "slack",
+				transportType: "streamableHttp",
+				url: "https://mcp.slack.com/mcp",
+				oauthClient: {
+					clientId: "marketplace-public-client",
+					allowedScopes: ["channels:history", "search:read.public"],
+					loopbackHostname: "localhost",
+				},
+			});
+
+			await installMarketplaceEntry({
+				entry: {
+					id: "slack",
+					type: "mcp",
+					name: "Slack",
+					install: { args: installArgs },
+				},
+			});
+
+			const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
+				mcpServers: Record<
+					string,
+					{
+						oauth?: unknown;
+						oauthClient?: Record<string, unknown>;
+					}
+				>;
+			};
+			expect(settings.mcpServers.slack?.oauthClient).toEqual({
+				clientId: "marketplace-public-client",
+				allowedScopes: ["channels:history", "search:read.public"],
+				loopbackHostname: "localhost",
+			});
+			expect(settings.mcpServers.slack?.oauthClient).not.toHaveProperty(
+				"clientSecret",
+			);
+			expect(settings.mcpServers.slack?.oauth).toBeUndefined();
+		} finally {
+			if (previousSettingsPath === undefined) {
+				delete process.env.CLINE_MCP_SETTINGS_PATH;
+			} else {
+				process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
+			}
+		}
+	});
+
+	it("rejects malformed or duplicate Marketplace OAuth install flags", () => {
+		const remote = ["--transport", "http", "https://mcp.example.com/mcp"];
+		expect(() =>
+			buildMarketplaceMcpInput([
+				"bad",
+				"--oauth-allowed-scope",
+				"read",
+				...remote,
+			]),
+		).toThrow(/client[- ]id/i);
+		expect(() =>
+			buildMarketplaceMcpInput([
+				"bad",
+				"--oauth-client-id",
+				"one",
+				"--oauth-client-id=two",
+				...remote,
+			]),
+		).toThrow(/oauth-client-id.*once|duplicate/i);
+		expect(() =>
+			buildMarketplaceMcpInput([
+				"bad",
+				"--oauth-client-id",
+				"public-client",
+				"--oauth-allowed-scope=read",
+				"--oauth-allowed-scope",
+				"read",
+				...remote,
+			]),
+		).toThrow(/duplicate/i);
+		expect(() =>
+			buildMarketplaceMcpInput([
+				"bad",
+				"--oauth-client-id",
+				"public-client",
+				"--oauth-loopback-hostname=example.com",
+				...remote,
+			]),
+		).toThrow(/loopback|hostname/i);
 	});
 
 	it("excludes partial install directories from the installed entries list", async () => {

--- a/apps/examples/desktop-app/sidecar/marketplace.ts
+++ b/apps/examples/desktop-app/sidecar/marketplace.ts
@@ -18,6 +18,7 @@ import {
 	resolve,
 } from "node:path";
 import {
+	buildMcpInstallTransport,
 	installPlugin as installCorePlugin,
 	installMcpServer,
 	type MarketplaceActionResult,
@@ -348,114 +349,28 @@ const defaultSpawnCommand: SpawnCommand = async (command, args, options = {}) =>
 		});
 	});
 
-function normalizeTransport(value: string | undefined): string {
-	const normalized = (value ?? "stdio").trim();
-	if (normalized === "http" || normalized === "streamable-http") {
-		return "streamableHttp";
-	}
-	if (
-		normalized === "stdio" ||
-		normalized === "sse" ||
-		normalized === "streamableHttp"
-	) {
-		return normalized;
-	}
-	throw new Error(
-		`Unsupported MCP transport "${normalized}". Expected stdio, sse, http, streamable-http, or streamableHttp.`,
-	);
-}
-
-function assertUrl(value: string): void {
-	let parsed: URL;
-	try {
-		parsed = new URL(value);
-	} catch {
-		throw new Error(`Invalid MCP server URL: ${value}`);
-	}
-	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		throw new Error(`Invalid MCP server URL: ${value}`);
-	}
-}
-
 export function buildMarketplaceMcpInput(args: string[]): JsonRecord {
-	const [rawName, ...rest] = args;
-	const name = rawName?.trim();
-	if (!name) {
-		throw new Error("MCP marketplace install requires a server name");
-	}
-	let transportType = "stdio";
-	const headers: Record<string, string> = {};
-	const targetArgs: string[] = [];
-	let parsingMarketplaceOptions = true;
-	for (let index = 0; index < rest.length; index++) {
-		const arg = rest[index];
-		if (parsingMarketplaceOptions && arg === "--") {
-			targetArgs.push(...rest.slice(index + 1));
-			break;
-		}
-		if (parsingMarketplaceOptions && (arg === "--transport" || arg === "-t")) {
-			const next = rest[index + 1]?.trim();
-			if (!next) throw new Error("--transport requires a value");
-			transportType = normalizeTransport(next);
-			index++;
-			continue;
-		}
-		const shouldParseHeader =
-			parsingMarketplaceOptions ||
-			normalizeTransport(transportType) !== "stdio";
-		if (
-			shouldParseHeader &&
-			(arg === "--header" || arg?.startsWith("--header="))
-		) {
-			const rawHeader =
-				arg === "--header" ? rest[++index] : arg.slice("--header=".length);
-			if (!rawHeader) throw new Error("--header requires a value");
-			const separatorIndex = rawHeader.indexOf(":");
-			if (separatorIndex <= 0) {
-				throw new Error(
-					`Invalid MCP header "${rawHeader}". Expected "Header-Name: header value".`,
-				);
-			}
-			const headerName = rawHeader.slice(0, separatorIndex).trim();
-			const headerValue = rawHeader.slice(separatorIndex + 1).trim();
-			if (!headerName || !headerValue) {
-				throw new Error(
-					`Invalid MCP header "${rawHeader}". Expected "Header-Name: header value".`,
-				);
-			}
-			headers[headerName] = headerValue;
-			continue;
-		}
-		parsingMarketplaceOptions = false;
-		targetArgs.push(arg);
-	}
-	transportType = normalizeTransport(transportType);
-	if (transportType === "stdio") {
-		if (Object.keys(headers).length > 0) {
-			throw new Error("Stdio MCP installs do not support request headers.");
-		}
-		const [command, ...commandArgs] = targetArgs;
-		if (!command?.trim()) {
-			throw new Error("Stdio MCP install requires a command");
-		}
+	// Current catalog entries can keep omitting this policy or using the legacy
+	// mcp-remote command shape. Core owns both that compatibility normalization
+	// and the strict grammar for forward-compatible OAuth definitions.
+	const { name, oauthClient, transport } = buildMcpInstallTransport(
+		parseMcpInstallArgs(args),
+	);
+	if (transport.type === "stdio") {
 		return {
 			name,
-			transportType,
-			command,
-			args: commandArgs.length > 0 ? commandArgs : undefined,
+			transportType: transport.type,
+			command: transport.command,
+			args: transport.args,
 			disabled: false,
 		};
 	}
-	if (targetArgs.length !== 1) {
-		throw new Error("Remote MCP install requires exactly one URL");
-	}
-	const url = targetArgs[0]?.trim() ?? "";
-	assertUrl(url);
 	return {
 		name,
-		transportType,
-		url,
-		headers: Object.keys(headers).length > 0 ? headers : undefined,
+		transportType: transport.type,
+		url: transport.url,
+		headers: transport.headers,
+		oauthClient,
 		disabled: false,
 	};
 }

--- a/sdk/packages/core/src/services/mcp-install.test.ts
+++ b/sdk/packages/core/src/services/mcp-install.test.ts
@@ -16,13 +16,13 @@ import {
 } from "./mcp-install";
 
 function readSettings(settingsPath: string): Record<string, unknown> & {
-	mcpServers?: Record<string, { transport?: unknown }>;
+	mcpServers?: Record<string, { oauthClient?: unknown; transport?: unknown }>;
 } {
 	return JSON.parse(readFileSync(settingsPath, "utf8")) as Record<
 		string,
 		unknown
 	> & {
-		mcpServers?: Record<string, { transport?: unknown }>;
+		mcpServers?: Record<string, { oauthClient?: unknown; transport?: unknown }>;
 	};
 }
 
@@ -75,13 +75,47 @@ describe("MCP install service", () => {
 		});
 	});
 
+	it("applies OAuth policy after resolving legacy mcp-remote entries", () => {
+		// Current marketplace data can still use the legacy proxy command shape;
+		// it must receive the same policy as an explicitly remote declaration.
+		expect(
+			buildMcpInstallTransport(
+				parseMcpInstallArgs([
+					"linear",
+					"--oauth-client-id=public-client",
+					"--oauth-allowed-scope=write",
+					"--oauth-allowed-scope=read",
+					"--header",
+					"X-Tenant: public",
+					"--",
+					"npx",
+					"-y",
+					"mcp-remote",
+					"https://mcp.linear.app/mcp",
+				]),
+			),
+		).toEqual({
+			name: "linear",
+			oauthClient: {
+				clientId: "public-client",
+				allowedScopes: ["read", "write"],
+			},
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.linear.app/mcp",
+				headers: { "X-Tenant": "public" },
+			},
+			warnings: [],
+		});
+	});
+
 	it("installs remote MCP servers with headers into the settings file", () => {
 		const settingsPath = join(root, "cline_mcp_settings.json");
 		const result = installMcpServer({
 			name: "docs",
 			transport: "http",
-			headers: ["Authorization: Bearer <token>"],
-			targetArgs: ["https://example.com/mcp", "--header=X-Extra: yes"],
+			headers: ["Authorization: Bearer <token>", "X-Extra: yes"],
+			targetArgs: ["https://example.com/mcp"],
 			settingsPath,
 		});
 
@@ -127,6 +161,190 @@ describe("MCP install service", () => {
 		);
 	});
 
+	it("preserves the legacy Desktop Marketplace -t transport alias", () => {
+		const parsed = parseMcpInstallArgs([
+			"docs",
+			"-t",
+			"http",
+			"https://example.com/mcp",
+		]);
+		expect(parsed).toEqual({
+			name: "docs",
+			transport: "http",
+			targetArgs: ["https://example.com/mcp"],
+			headers: [],
+		});
+		expect(buildMcpInstallTransport(parsed).transport).toEqual({
+			type: "streamableHttp",
+			url: "https://example.com/mcp",
+		});
+	});
+
+	it("parses and canonicalizes marketplace OAuth client policy flags", () => {
+		expect(
+			parseMcpInstallArgs([
+				"slack",
+				"--transport=http",
+				"--oauth-client-id",
+				"  public-client  ",
+				"--oauth-allowed-scope=search:read.public",
+				"--oauth-allowed-scope",
+				"channels:history",
+				"--oauth-loopback-hostname=localhost",
+				"https://mcp.slack.com/mcp",
+			]),
+		).toEqual({
+			name: "slack",
+			transport: "http",
+			targetArgs: ["https://mcp.slack.com/mcp"],
+			headers: [],
+			oauthClientId: "public-client",
+			oauthAllowedScopes: ["channels:history", "search:read.public"],
+			oauthLoopbackHostname: "localhost",
+		});
+	});
+
+	it("persists only the normalized public OAuth client policy", () => {
+		const settingsPath = join(root, "cline_mcp_settings.json");
+		const result = installMcpServer({
+			name: "slack",
+			transport: "http",
+			targetArgs: ["https://mcp.slack.com/mcp"],
+			oauthClientId: " public-client ",
+			oauthAllowedScopes: ["search:read.public", "channels:history"],
+			oauthLoopbackHostname: "127.0.0.1",
+			settingsPath,
+		});
+
+		expect(result).toEqual({
+			name: "slack",
+			status: "installed",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.slack.com/mcp",
+			},
+			oauthClient: {
+				clientId: "public-client",
+				allowedScopes: ["channels:history", "search:read.public"],
+				loopbackHostname: "127.0.0.1",
+			},
+			warnings: [],
+		});
+		expect(readSettings(settingsPath).mcpServers?.slack).toEqual({
+			transport: result.transport,
+			oauthClient: result.oauthClient,
+		});
+	});
+
+	it("requires a client ID for OAuth scope and loopback policy", () => {
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-allowed-scope",
+				"channels:history",
+				"--transport=http",
+				"https://mcp.slack.com/mcp",
+			]),
+		).toThrow(/--oauth-client-id is required/);
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-loopback-hostname=localhost",
+				"--transport=http",
+				"https://mcp.slack.com/mcp",
+			]),
+		).toThrow(/--oauth-client-id is required/);
+	});
+
+	it("uses the Core OAuth scope policy for invalid and duplicate scopes", () => {
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-client-id=public-client",
+				"--oauth-allowed-scope=channels:history chat:write",
+				"--transport=http",
+				"https://mcp.slack.com/mcp",
+			]),
+		).toThrow(/Invalid MCP OAuth scope token/);
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-client-id=public-client",
+				"--oauth-allowed-scope=channels:history",
+				"--oauth-allowed-scope",
+				"channels:history",
+				"--transport=http",
+				"https://mcp.slack.com/mcp",
+			]),
+		).toThrow(/Duplicate MCP OAuth scope/);
+	});
+
+	it("rejects unsupported loopback hostnames and OAuth policy on stdio", () => {
+		expect(() =>
+			buildMcpInstallTransport({
+				name: "slack",
+				transport: "http",
+				targetArgs: ["https://mcp.slack.com/mcp"],
+				oauthClientId: "public-client",
+				oauthLoopbackHostname: "example.com" as "localhost",
+			}),
+		).toThrow(/Expected 127\.0\.0\.1 or localhost/);
+		expect(() =>
+			buildMcpInstallTransport({
+				name: "local",
+				targetArgs: ["node", "server.js"],
+				oauthClientId: "public-client",
+			}),
+		).toThrow(/Stdio MCP installs do not support OAuth client policy/);
+	});
+
+	it("rejects static Authorization headers with OAuth client policy", () => {
+		expect(() =>
+			buildMcpInstallTransport({
+				name: "slack",
+				transport: "http",
+				targetArgs: ["https://mcp.slack.com/mcp"],
+				headers: ["authorization: Bearer static-token"],
+				oauthClientId: "public-client",
+			}),
+		).toThrow(/static Authorization header/);
+	});
+
+	it("fails closed on malformed, duplicate, and unsupported OAuth flags", () => {
+		for (const args of [
+			["slack", "--oauth-client-id"],
+			["slack", "--oauth-client-id="],
+			["slack", "--oauth-allowed-scope="],
+			["slack", "--oauth-loopback-hostname", "--transport=http"],
+		]) {
+			expect(() => parseMcpInstallArgs(args)).toThrow(/requires a value/);
+		}
+
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-client-id=one",
+				"--oauth-client-id",
+				"two",
+			]),
+		).toThrow(/--oauth-client-id may only be specified once/);
+		expect(() =>
+			parseMcpInstallArgs([
+				"slack",
+				"--oauth-client-id=one",
+				"--oauth-loopback-hostname=localhost",
+				"--oauth-loopback-hostname",
+				"127.0.0.1",
+			]),
+		).toThrow(/--oauth-loopback-hostname may only be specified once/);
+		expect(() =>
+			parseMcpInstallArgs(["slack", "--oauth-client-secret=not-supported"]),
+		).toThrow(/Unsupported MCP OAuth install option/);
+		expect(() =>
+			parseMcpInstallArgs(["slack", "--oauth-client-identifier=one"]),
+		).toThrow(/Unsupported MCP OAuth install option/);
+	});
+
 	it("treats -- in marketplace args as the end of option parsing", () => {
 		// Marketplace catalog entries mark the start of the stdio command with
 		// "--" (matching the CLI form `cline mcp install name -- npx ...`).
@@ -143,6 +361,40 @@ describe("MCP install service", () => {
 			type: "stdio",
 			command: "npx",
 			args: ["-y", "@aikidosec/mcp@1.0.9"],
+		});
+	});
+
+	it("does not interpret OAuth-like command arguments after --", () => {
+		const parsed = parseMcpInstallArgs([
+			"local",
+			"--",
+			"node",
+			"server.js",
+			"--oauth-client-secret=command-argument",
+			"--header",
+			"X-Command: argument",
+		]);
+		expect(parsed).toEqual({
+			name: "local",
+			headers: [],
+			targetArgs: [
+				"node",
+				"server.js",
+				"--oauth-client-secret=command-argument",
+				"--header",
+				"X-Command: argument",
+			],
+			transport: undefined,
+		});
+		expect(buildMcpInstallTransport(parsed).transport).toEqual({
+			type: "stdio",
+			command: "node",
+			args: [
+				"server.js",
+				"--oauth-client-secret=command-argument",
+				"--header",
+				"X-Command: argument",
+			],
 		});
 	});
 

--- a/sdk/packages/core/src/services/mcp-install.ts
+++ b/sdk/packages/core/src/services/mcp-install.ts
@@ -1,13 +1,26 @@
-import type { McpServerTransportConfig } from "../extensions/mcp";
+import type {
+	McpOAuthLoopbackHostname,
+	McpServerOAuthClientConfig,
+	McpServerTransportConfig,
+} from "../extensions/mcp";
 import {
 	resolveDefaultMcpSettingsPath,
 	updateMcpSettingsFileSync,
 } from "../extensions/mcp";
+import { normalizeMcpOAuthAllowedScopes } from "../extensions/mcp/oauth-scope-policy";
 import { resolveNativeMcpTransport } from "../extensions/mcp/remote-proxy";
+
+type McpInstallOAuthClientPolicy = Pick<
+	McpServerOAuthClientConfig,
+	"clientId" | "allowedScopes" | "loopbackHostname"
+>;
 
 export interface McpInstallOptions {
 	name: string;
 	headers?: string[];
+	oauthAllowedScopes?: string[];
+	oauthClientId?: string;
+	oauthLoopbackHostname?: McpOAuthLoopbackHostname;
 	targetArgs?: string[];
 	transport?: string;
 	settingsPath?: string;
@@ -17,6 +30,7 @@ export interface McpInstallResult {
 	name: string;
 	status: "installed";
 	transport: McpServerTransportConfig;
+	oauthClient?: McpInstallOAuthClientPolicy;
 	warnings: string[];
 }
 
@@ -80,14 +94,44 @@ function containsPlaceholder(value: string): boolean {
 
 function splitTargetArgsAndHeaders(input: {
 	headers?: string[];
+	oauthAllowedScopes?: string[];
+	oauthClientId?: string;
+	oauthLoopbackHostname?: string;
 	parseTransport?: boolean;
 	targetArgs?: string[];
 	transport?: string;
-}): { headers: string[]; targetArgs: string[]; transport?: string } {
+}): {
+	headers: string[];
+	oauthAllowedScopes?: string[];
+	oauthClientId?: string;
+	oauthLoopbackHostname?: string;
+	targetArgs: string[];
+	transport?: string;
+} {
 	const headers = [...(input.headers ?? [])];
+	const oauthAllowedScopes = [...(input.oauthAllowedScopes ?? [])];
 	const targetArgs: string[] = [];
+	let oauthClientId = input.oauthClientId;
+	let oauthLoopbackHostname = input.oauthLoopbackHostname;
+	let sawOauthAllowedScope = input.oauthAllowedScopes !== undefined;
+	let sawOauthClientId = input.oauthClientId !== undefined;
+	let sawOauthLoopbackHostname = input.oauthLoopbackHostname !== undefined;
 	let transport = input.transport;
+	let sawTransport = input.transport !== undefined;
 	const args = input.targetArgs ?? [];
+	const requireOptionValue = (index: number, option: string): string => {
+		const value = args[index + 1];
+		if (!value || value.startsWith("--")) {
+			throw new Error(`${option} requires a value`);
+		}
+		return value;
+	};
+	const requireInlineOptionValue = (value: string, option: string): string => {
+		if (!value) {
+			throw new Error(`${option} requires a value`);
+		}
+		return value;
+	};
 	for (let index = 0; index < args.length; index++) {
 		const arg = args[index];
 		// Marketplace-style args use "--" to end option parsing (matching how
@@ -97,20 +141,92 @@ function splitTargetArgsAndHeaders(input: {
 			targetArgs.push(...args.slice(index + 1));
 			break;
 		}
-		if (input.parseTransport && arg === "--transport") {
-			const value = args[index + 1];
-			if (!value) {
-				throw new Error("--transport requires a value");
+		if (input.parseTransport && (arg === "--transport" || arg === "-t")) {
+			if (sawTransport) {
+				throw new Error("--transport may only be specified once");
 			}
+			const value = requireOptionValue(index, "--transport");
 			transport = value;
+			sawTransport = true;
 			index++;
 			continue;
 		}
 		if (input.parseTransport && arg?.startsWith("--transport=")) {
-			transport = arg.slice("--transport=".length);
+			if (sawTransport) {
+				throw new Error("--transport may only be specified once");
+			}
+			transport = requireInlineOptionValue(
+				arg.slice("--transport=".length),
+				"--transport",
+			);
+			sawTransport = true;
 			continue;
 		}
-		if (arg === "--header") {
+		if (input.parseTransport && arg === "--oauth-client-id") {
+			if (sawOauthClientId) {
+				throw new Error("--oauth-client-id may only be specified once");
+			}
+			oauthClientId = requireOptionValue(index, "--oauth-client-id");
+			sawOauthClientId = true;
+			index++;
+			continue;
+		}
+		if (input.parseTransport && arg?.startsWith("--oauth-client-id=")) {
+			if (sawOauthClientId) {
+				throw new Error("--oauth-client-id may only be specified once");
+			}
+			oauthClientId = requireInlineOptionValue(
+				arg.slice("--oauth-client-id=".length),
+				"--oauth-client-id",
+			);
+			sawOauthClientId = true;
+			continue;
+		}
+		if (input.parseTransport && arg === "--oauth-allowed-scope") {
+			oauthAllowedScopes.push(
+				requireOptionValue(index, "--oauth-allowed-scope"),
+			);
+			sawOauthAllowedScope = true;
+			index++;
+			continue;
+		}
+		if (input.parseTransport && arg?.startsWith("--oauth-allowed-scope=")) {
+			oauthAllowedScopes.push(
+				requireInlineOptionValue(
+					arg.slice("--oauth-allowed-scope=".length),
+					"--oauth-allowed-scope",
+				),
+			);
+			sawOauthAllowedScope = true;
+			continue;
+		}
+		if (input.parseTransport && arg === "--oauth-loopback-hostname") {
+			if (sawOauthLoopbackHostname) {
+				throw new Error("--oauth-loopback-hostname may only be specified once");
+			}
+			oauthLoopbackHostname = requireOptionValue(
+				index,
+				"--oauth-loopback-hostname",
+			);
+			sawOauthLoopbackHostname = true;
+			index++;
+			continue;
+		}
+		if (input.parseTransport && arg?.startsWith("--oauth-loopback-hostname=")) {
+			if (sawOauthLoopbackHostname) {
+				throw new Error("--oauth-loopback-hostname may only be specified once");
+			}
+			oauthLoopbackHostname = requireInlineOptionValue(
+				arg.slice("--oauth-loopback-hostname=".length),
+				"--oauth-loopback-hostname",
+			);
+			sawOauthLoopbackHostname = true;
+			continue;
+		}
+		if (input.parseTransport && arg?.startsWith("--oauth-")) {
+			throw new Error(`Unsupported MCP OAuth install option "${arg}".`);
+		}
+		if (input.parseTransport && arg === "--header") {
 			const value = args[index + 1];
 			if (!value) {
 				throw new Error("--header requires a value");
@@ -119,13 +235,63 @@ function splitTargetArgsAndHeaders(input: {
 			index++;
 			continue;
 		}
-		if (arg?.startsWith("--header=")) {
+		if (input.parseTransport && arg?.startsWith("--header=")) {
 			headers.push(arg.slice("--header=".length));
 			continue;
 		}
 		targetArgs.push(arg);
 	}
-	return { headers, targetArgs, transport };
+	return {
+		headers,
+		...(sawOauthAllowedScope ? { oauthAllowedScopes } : {}),
+		...(sawOauthClientId ? { oauthClientId } : {}),
+		...(sawOauthLoopbackHostname ? { oauthLoopbackHostname } : {}),
+		targetArgs,
+		transport,
+	};
+}
+
+function normalizeMcpInstallOAuthClient(options: {
+	oauthAllowedScopes?: string[];
+	oauthClientId?: string;
+	oauthLoopbackHostname?: string;
+}): McpInstallOAuthClientPolicy | undefined {
+	const clientId = options.oauthClientId?.trim();
+	if (!clientId) {
+		if (
+			options.oauthAllowedScopes !== undefined ||
+			options.oauthLoopbackHostname !== undefined
+		) {
+			throw new Error(
+				"--oauth-client-id is required when --oauth-allowed-scope or --oauth-loopback-hostname is provided.",
+			);
+		}
+		if (options.oauthClientId !== undefined) {
+			throw new Error("--oauth-client-id requires a non-empty value");
+		}
+		return undefined;
+	}
+
+	const allowedScopes = normalizeMcpOAuthAllowedScopes(
+		options.oauthAllowedScopes,
+	);
+	const rawLoopbackHostname = options.oauthLoopbackHostname;
+	const loopbackHostname = rawLoopbackHostname?.trim();
+	if (
+		loopbackHostname !== undefined &&
+		loopbackHostname !== "127.0.0.1" &&
+		loopbackHostname !== "localhost"
+	) {
+		throw new Error(
+			`Unsupported MCP OAuth loopback hostname "${rawLoopbackHostname}". Expected 127.0.0.1 or localhost.`,
+		);
+	}
+
+	return {
+		clientId,
+		...(allowedScopes ? { allowedScopes } : {}),
+		...(loopbackHostname ? { loopbackHostname } : {}),
+	};
 }
 
 function buildHeaders(values: string[]): {
@@ -150,28 +316,45 @@ function buildHeaders(values: string[]): {
 export function buildMcpInstallTransport(options: {
 	headers?: string[];
 	name: string;
+	oauthAllowedScopes?: string[];
+	oauthClientId?: string;
+	oauthLoopbackHostname?: McpOAuthLoopbackHostname;
 	targetArgs?: string[];
 	transport?: string;
-}): { name: string; transport: McpServerTransportConfig; warnings: string[] } {
+}): {
+	name: string;
+	oauthClient?: McpInstallOAuthClientPolicy;
+	transport: McpServerTransportConfig;
+	warnings: string[];
+} {
 	const name = options.name.trim();
 	if (!name) {
 		throw new Error("MCP server name is required");
 	}
-	const {
-		headers: rawHeaders,
-		targetArgs,
-		transport,
-	} = splitTargetArgsAndHeaders({
+	const parsed = splitTargetArgsAndHeaders({
 		headers: options.headers,
+		oauthAllowedScopes: options.oauthAllowedScopes,
+		oauthClientId: options.oauthClientId,
+		oauthLoopbackHostname: options.oauthLoopbackHostname,
 		targetArgs: options.targetArgs,
 		transport: options.transport,
 	});
-	const type = normalizeTransportType(transport);
+	const oauthClient = normalizeMcpInstallOAuthClient(parsed);
+	const type = normalizeTransportType(parsed.transport);
+	const targetArgs = parsed.targetArgs;
+	const rawHeaders = parsed.headers;
 	const { headers, warnings } = buildHeaders(rawHeaders);
+	if (
+		oauthClient &&
+		Object.keys(headers ?? {}).some(
+			(headerName) => headerName.toLowerCase() === "authorization",
+		)
+	) {
+		throw new Error(
+			"MCP OAuth installs do not support a static Authorization header.",
+		);
+	}
 	if (type === "stdio") {
-		if (rawHeaders.length > 0) {
-			throw new Error("Stdio MCP installs do not support request headers.");
-		}
 		const [command, ...args] = targetArgs;
 		if (!command?.trim()) {
 			throw new Error(
@@ -183,6 +366,23 @@ export function buildMcpInstallTransport(options: {
 			command,
 			args: args.length > 0 ? args : undefined,
 		});
+		// Older marketplace entries still declare `npx mcp-remote <url>` as
+		// stdio. Resolve that exact safe shape before deciding whether remote-only
+		// headers and OAuth client policy are applicable.
+		if (stdioTransport.type !== "stdio") {
+			return {
+				name,
+				...(oauthClient ? { oauthClient } : {}),
+				transport: headers ? { ...stdioTransport, headers } : stdioTransport,
+				warnings,
+			};
+		}
+		if (oauthClient) {
+			throw new Error("Stdio MCP installs do not support OAuth client policy.");
+		}
+		if (rawHeaders.length > 0) {
+			throw new Error("Stdio MCP installs do not support request headers.");
+		}
 		return {
 			name,
 			transport: stdioTransport,
@@ -199,6 +399,7 @@ export function buildMcpInstallTransport(options: {
 	assertValidUrl(url);
 	return {
 		name,
+		...(oauthClient ? { oauthClient } : {}),
 		transport: headers ? { type, url, headers } : { type, url },
 		warnings,
 	};
@@ -211,18 +412,30 @@ export function parseMcpInstallArgs(args: string[]): McpInstallOptions {
 			"Marketplace MCP install args must start with a server name.",
 		);
 	}
+	const parsed = splitTargetArgsAndHeaders({
+		parseTransport: true,
+		targetArgs,
+	});
+	const oauthClient = normalizeMcpInstallOAuthClient(parsed);
 	return {
 		name,
-		...splitTargetArgsAndHeaders({
-			parseTransport: true,
-			targetArgs,
-		}),
+		headers: parsed.headers,
+		...(oauthClient?.allowedScopes
+			? { oauthAllowedScopes: oauthClient.allowedScopes }
+			: {}),
+		...(oauthClient ? { oauthClientId: oauthClient.clientId } : {}),
+		...(oauthClient?.loopbackHostname
+			? { oauthLoopbackHostname: oauthClient.loopbackHostname }
+			: {}),
+		targetArgs: parsed.targetArgs,
+		transport: parsed.transport,
 	};
 }
 
 function addMcpServer(
 	name: string,
 	transport: McpServerTransportConfig,
+	oauthClient: McpInstallOAuthClientPolicy | undefined,
 	settingsPath: string,
 ): void {
 	updateMcpSettingsFileSync(settingsPath, (settings) => {
@@ -233,20 +446,26 @@ function addMcpServer(
 			!Array.isArray(serversValue)
 				? { ...(serversValue as Record<string, unknown>) }
 				: {};
-		servers[name] = { transport };
+		servers[name] = {
+			transport,
+			...(oauthClient ? { oauthClient } : {}),
+		};
 		settings.mcpServers = servers;
 	});
 }
 
 export function installMcpServer(options: McpInstallOptions): McpInstallResult {
-	const { name, transport, warnings } = buildMcpInstallTransport(options);
+	const { name, oauthClient, transport, warnings } =
+		buildMcpInstallTransport(options);
 	addMcpServer(
 		name,
 		transport,
+		oauthClient,
 		options.settingsPath ?? resolveDefaultMcpSettingsPath(),
 	);
 	return {
 		name,
+		...(oauthClient ? { oauthClient } : {}),
 		status: "installed",
 		transport,
 		warnings,


### PR DESCRIPTION
## Stack

Depends on #13676. Review this PR after the fixed-client callback and policy-binding layer in that PR.

## Summary

- add generic `--oauth-client-id`, repeatable `--oauth-allowed-scope`, and `--oauth-loopback-hostname` install metadata
- centralize Marketplace, CLI, and Desktop normalization in Core while preserving legacy `mcp-remote`, `-t`, and hard `--` behavior
- persist and return only the public OAuth client policy; installation never stores tokens, OAuth state, or a client secret
- prefill the interactive wizard without authorizing; noninteractive `--yes` only writes configuration

This is the client-side layer needed for providers such as Slack's hosted MCP server, which requires a pre-registered client and does not support dynamic client registration.

## Security boundaries

- no client-secret install option exists
- duplicate or malformed OAuth flags fail closed
- duplicate/invalid scopes and unsupported callback hostnames fail closed
- OAuth policy cannot be combined with a static `Authorization` header or a true stdio transport
- Core and Desktop Marketplace installation do not start authorization

## Validation

- Core focused tests: 27/27
- CLI focused unit tests: 27/27
- CLI targeted E2E: 2/2 (31 unrelated tests skipped by filter)
- Desktop Marketplace focused tests: 8/8
- Core, CLI, and Desktop typechecks: passed
- full SDK build: passed
- targeted Biome check and `git diff --check`: passed
- independent cross-layer review: no remaining P0-P2 findings

No provider, OAuth flow, or live user setting was contacted during validation.
