### PR TITLE
fix(llms): make Langfuse tracer detection survive minified release builds

### DIFF
--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -32,16 +32,22 @@ const {
 	shutdownSpy,
 	getDelegateSpy,
 	getTracerProviderSpy,
+	registeredGlobalProvider,
 } = vi.hoisted(() => ({
 	addSpanProcessorSpy: vi.fn(),
 	forceFlushSpy: vi.fn(async () => undefined),
 	shutdownSpy: vi.fn(async () => undefined),
 	getDelegateSpy: vi.fn(),
 	getTracerProviderSpy: vi.fn(),
+	registeredGlobalProvider: { current: undefined as unknown },
 }));
 
 class MockNodeTracerProvider {
-	register = vi.fn();
+	// Mirrors OpenTelemetry's registerGlobal semantics: the first
+	// registration wins and later ones are silently ignored.
+	register = vi.fn(() => {
+		registeredGlobalProvider.current ??= this;
+	});
 }
 
 vi.mock("@cline/shared", () => ({
@@ -87,6 +93,7 @@ describe("langfuse telemetry", () => {
 			forceFlush: forceFlushSpy,
 			shutdown: shutdownSpy,
 		});
+		registeredGlobalProvider.current = undefined;
 		getTracerProviderSpy.mockReturnValue({
 			addSpanProcessor: addSpanProcessorSpy,
 			getDelegate: getDelegateSpy,
@@ -131,6 +138,57 @@ describe("langfuse telemetry", () => {
 		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
 		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
 		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers its own provider when minification renames the proxy provider", async () => {
+		// Simulates the compiled release binary: the ProxyTracerProvider and
+		// its no-op delegate carry mangled constructor names, expose no
+		// addSpanProcessor, and only reflect a registration through
+		// getDelegate.
+		getTracerProviderSpy.mockReturnValue({
+			constructor: { name: "Zt" },
+			getDelegate: () =>
+				registeredGlobalProvider.current ?? { constructor: { name: "Qn" } },
+		});
+
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		expect(registeredGlobalProvider.current).toBeInstanceOf(
+			MockNodeTracerProvider,
+		);
+		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("attaches to an already registered tracer provider through its delegate", async () => {
+		getTracerProviderSpy.mockReturnValue({
+			getDelegate: () => ({ addSpanProcessor: addSpanProcessorSpy }),
+		});
+
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
+		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables telemetry when a foreign provider owns the slot and accepts no processors", async () => {
+		getTracerProviderSpy.mockReturnValue({
+			getDelegate: () => ({
+				forceFlush: forceFlushSpy,
+				shutdown: shutdownSpy,
+			}),
+		});
+
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
+		expect(registerTelemetrySpy).not.toHaveBeenCalled();
+	});
+
+	it("disables telemetry when the global slot rejects the registration", async () => {
+		// The delegate never reflects the attempted registration, matching an
+		// API whose global slot is stuck with an inert owner.
+		getTracerProviderSpy.mockReturnValue({
+			getDelegate: () => ({ constructor: { name: "SomethingInert" } }),
+		});
+
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
+		expect(registerTelemetrySpy).not.toHaveBeenCalled();
 	});
 
 	it("connects an AI SDK 7 call to the registered telemetry integration", async () => {

--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -26,13 +26,19 @@ vi.mock("@langfuse/vercel-ai-sdk", () => ({
 	},
 }));
 
-const { addSpanProcessorSpy, forceFlushSpy, shutdownSpy, getDelegateSpy } =
-	vi.hoisted(() => ({
-		addSpanProcessorSpy: vi.fn(),
-		forceFlushSpy: vi.fn(async () => undefined),
-		shutdownSpy: vi.fn(async () => undefined),
-		getDelegateSpy: vi.fn(),
-	}));
+const {
+	addSpanProcessorSpy,
+	forceFlushSpy,
+	shutdownSpy,
+	getDelegateSpy,
+	getTracerProviderSpy,
+} = vi.hoisted(() => ({
+	addSpanProcessorSpy: vi.fn(),
+	forceFlushSpy: vi.fn(async () => undefined),
+	shutdownSpy: vi.fn(async () => undefined),
+	getDelegateSpy: vi.fn(),
+	getTracerProviderSpy: vi.fn(),
+}));
 
 class MockNodeTracerProvider {
 	register = vi.fn();
@@ -48,10 +54,7 @@ vi.mock("@langfuse/otel", () => ({
 
 vi.mock("@opentelemetry/api", () => ({
 	trace: {
-		getTracerProvider: () => ({
-			addSpanProcessor: addSpanProcessorSpy,
-			getDelegate: getDelegateSpy,
-		}),
+		getTracerProvider: getTracerProviderSpy,
 	},
 }));
 
@@ -84,6 +87,10 @@ describe("langfuse telemetry", () => {
 			forceFlush: forceFlushSpy,
 			shutdown: shutdownSpy,
 		});
+		getTracerProviderSpy.mockReturnValue({
+			addSpanProcessor: addSpanProcessorSpy,
+			getDelegate: getDelegateSpy,
+		});
 		process.env.LANGFUSE_BASE_URL = "https://langfuse.example";
 		process.env.LANGFUSE_PUBLIC_KEY = "public-key";
 		process.env.LANGFUSE_SECRET_KEY = "secret-key";
@@ -114,6 +121,16 @@ describe("langfuse telemetry", () => {
 		expect(forceFlushSpy.mock.invocationCallOrder[0]).toBeLessThan(
 			shutdownSpy.mock.invocationCallOrder[0],
 		);
+	});
+
+	it("recognizes a directly registered tracer provider", async () => {
+		getTracerProviderSpy.mockReturnValue({
+			addSpanProcessor: addSpanProcessorSpy,
+		});
+
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
+		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("connects an AI SDK 7 call to the registered telemetry integration", async () => {

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -167,8 +167,17 @@ function hasActiveTracerDelegate(traceApi: {
 }): boolean {
 	const tracerProvider = traceApi.getTracerProvider() as {
 		getDelegate?: () => { constructor?: { name?: string } };
+		addSpanProcessor?: (spanProcessor: unknown) => void;
 	};
-	const delegate = tracerProvider.getDelegate?.();
+	if (typeof tracerProvider.getDelegate !== "function") {
+		// Some runtimes expose the registered tracer provider directly rather
+		// than through OpenTelemetry's ProxyTracerProvider. A direct provider
+		// has no delegate to inspect, but its addSpanProcessor API is sufficient
+		// evidence that it can receive and export spans.
+		return typeof tracerProvider.addSpanProcessor === "function";
+	}
+
+	const delegate = tracerProvider.getDelegate();
 	const delegateName = delegate?.constructor?.name;
 
 	return Boolean(delegateName && delegateName !== "NoopTracerProvider");

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -1,8 +1,6 @@
 type MutableTracerProvider = {
 	addSpanProcessor?: (spanProcessor: unknown) => void;
-	constructor?: {
-		name?: string;
-	};
+	getDelegate?: () => unknown;
 };
 
 type LangfuseTelemetryConfig = {
@@ -133,12 +131,27 @@ async function initializeLangfuseTelemetry(): Promise<boolean> {
 			return hasDelegate;
 		}
 
-		const providerName = tracerProvider?.constructor?.name;
-		if (
-			providerName &&
-			providerName !== "ProxyTracerProvider" &&
-			providerName !== "NoopTracerProvider"
-		) {
+		// Class names are unreliable here: release binaries are minified, which
+		// renames classes like ProxyTracerProvider, so all provider detection
+		// below is structural (method presence, object identity) instead of
+		// comparing constructor names.
+		const existingDelegate =
+			typeof tracerProvider?.getDelegate === "function"
+				? tracerProvider.getDelegate()
+				: undefined;
+		if (isRecordingTracerProvider(existingDelegate)) {
+			// Another provider already owns the global slot, so registering our
+			// own would be rejected. Attach to it when it accepts processors.
+			const delegate = existingDelegate as MutableTracerProvider;
+			if (typeof delegate.addSpanProcessor === "function") {
+				delegate.addSpanProcessor(spanProcessor);
+				registerTelemetry(new LangfuseVercelAiSdkIntegration());
+				debugLangfuse("attached processor to registered tracer delegate");
+				return true;
+			}
+			debugLangfuse(
+				"tracer provider slot already owned; disabling Langfuse export",
+			);
 			return false;
 		}
 
@@ -146,14 +159,18 @@ async function initializeLangfuseTelemetry(): Promise<boolean> {
 			spanProcessors: [spanProcessor],
 		} as unknown as ConstructorParameters<typeof NodeTracerProvider>[0]);
 		nodeTracerProvider.register();
-		const hasDelegate = hasActiveTracerDelegate(trace);
-		if (hasDelegate) {
-			registerTelemetry(new LangfuseVercelAiSdkIntegration());
+		if (!isRegisteredGlobalTracerProvider(trace, nodeTracerProvider)) {
+			debugLangfuse(
+				"tracer provider registration was not accepted; disabling Langfuse export",
+			);
+			// Shut the orphaned provider down so its span processor does not
+			// keep buffering spans that can never be exported.
+			await nodeTracerProvider.shutdown?.();
+			return false;
 		}
-		debugLangfuse(
-			`registered NodeTracerProvider delegateReady=${String(hasDelegate)}`,
-		);
-		return hasDelegate;
+		registerTelemetry(new LangfuseVercelAiSdkIntegration());
+		debugLangfuse("registered NodeTracerProvider delegateReady=true");
+		return true;
 	} catch (error) {
 		debugLangfuse(
 			`initialization failed error=${error instanceof Error ? error.message : String(error)}`,
@@ -165,10 +182,7 @@ async function initializeLangfuseTelemetry(): Promise<boolean> {
 function hasActiveTracerDelegate(traceApi: {
 	getTracerProvider: () => unknown;
 }): boolean {
-	const tracerProvider = traceApi.getTracerProvider() as {
-		getDelegate?: () => { constructor?: { name?: string } };
-		addSpanProcessor?: (spanProcessor: unknown) => void;
-	};
+	const tracerProvider = traceApi.getTracerProvider() as MutableTracerProvider;
 	if (typeof tracerProvider.getDelegate !== "function") {
 		// Some runtimes expose the registered tracer provider directly rather
 		// than through OpenTelemetry's ProxyTracerProvider. A direct provider
@@ -177,10 +191,52 @@ function hasActiveTracerDelegate(traceApi: {
 		return typeof tracerProvider.addSpanProcessor === "function";
 	}
 
-	const delegate = tracerProvider.getDelegate();
-	const delegateName = delegate?.constructor?.name;
+	return isRecordingTracerProvider(tracerProvider.getDelegate());
+}
 
-	return Boolean(delegateName && delegateName !== "NoopTracerProvider");
+/**
+ * Distinguishes a recording tracer provider from OpenTelemetry's no-op
+ * fallback without relying on constructor names, which minified release
+ * builds rename. Real SDK providers expose lifecycle methods the no-op
+ * provider lacks.
+ */
+function isRecordingTracerProvider(provider: unknown): boolean {
+	if (!provider || typeof provider !== "object") {
+		return false;
+	}
+	const candidate = provider as {
+		addSpanProcessor?: unknown;
+		forceFlush?: unknown;
+		shutdown?: unknown;
+	};
+	return (
+		typeof candidate.addSpanProcessor === "function" ||
+		typeof candidate.forceFlush === "function" ||
+		typeof candidate.shutdown === "function"
+	);
+}
+
+/**
+ * Confirms the OpenTelemetry API accepted a provider registration. The API
+ * silently keeps the previous owner when the global slot is taken, so the
+ * only reliable signal is identity: the global provider (or its proxy
+ * delegate) must be the exact instance that was just registered.
+ */
+function isRegisteredGlobalTracerProvider(
+	traceApi: { getTracerProvider: () => unknown },
+	provider: unknown,
+): boolean {
+	const globalProvider = traceApi.getTracerProvider() as
+		| MutableTracerProvider
+		| null
+		| undefined;
+	if (globalProvider === provider) {
+		return true;
+	}
+	return (
+		typeof globalProvider?.getDelegate === "function" &&
+		globalProvider.getDelegate() === provider
+	);
 }
 
 async function flushLangfuseTelemetry(): Promise<void> {


### PR DESCRIPTION
### Related Issue

N/A — diagnosed from production hub-daemon logs.

### Description

Production CLI sessions read the Langfuse credentials and constructed the span processor, but telemetry initialization always returned `false`. The hub-daemon debug log showed `creating span processor` followed immediately by `initialized readiness=false`, with none of the branch messages in between — which pins the failure to the constructor-name guard in `initializeLangfuseTelemetry`:

```ts
const providerName = tracerProvider?.constructor?.name;
if (providerName && providerName !== "ProxyTracerProvider" && providerName !== "NoopTracerProvider") {
    return false;
}
```

Release binaries are compiled with `minify: true` (`apps/cli/script/build.ts`), which renames classes — `ProxyTracerProvider`'s constructor name mangles to something like `H2` — so the guard matched neither literal and bailed before ever registering a tracer provider. Dev runs (`bun run cli`) execute unminified source, which is why the same env vars worked there.

This PR removes every constructor-name comparison and replaces it with checks that survive minification:

- The proxy provider is detected structurally (presence of a `getDelegate` function); method names are not mangled by the minifier, only class bindings are.
- A recording provider is distinguished from OpenTelemetry's no-op fallback by its lifecycle methods (`forceFlush`/`shutdown`/`addSpanProcessor`) instead of `constructor.name !== "NoopTracerProvider"`.
- Registration of our `NodeTracerProvider` is confirmed by object identity — the global delegate must be the exact instance just registered — since the OTEL API silently keeps the previous owner when the global slot is taken.
- When a foreign provider already owns the global slot, the Langfuse span processor is attached to it when it accepts processors; otherwise the orphaned provider is shut down and the rejection is logged instead of failing silently.
- The previously silent bail-out paths now emit `[langfuse-debug]` messages.

The direct-provider fallback in `hasActiveTracerDelegate` (a registered provider exposed without a proxy, recognized via its `addSpanProcessor` API) is preserved from the first revision of this PR.

### Test Procedure

- Reproduced the production failure in a minified harness: bundled the module with `bun build --minify --target bun` against the real OpenTelemetry packages. The pre-fix code reproduces the exact production log signature (`creating span processor` → `initialized readiness=false`, provider class name mangled to `H2`); the fixed code initializes with `readiness=true` and registers the `NodeTracerProvider`.
- Added regression tests: minified-proxy registration verified by identity, attach-through-delegate, foreign owner that accepts no processors, and a global slot that rejects registration (8/8 in `langfuse-telemetry.test.ts`).
- Ran `bun -F @cline/llms test --run` (743 passed, 4 skipped).
- Ran `tsc --noEmit` in `sdk/packages/llms` cleanly.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable.

### Additional Notes

Langfuse credentials continue to be read from `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` at runtime — env propagation was never the problem (the production hub daemon had all three vars in its environment). Once this ships in a nightly, exporting the vars in the shell profile works as-is.
