### PR TITLE
feat(desktop): Composio connectors on desktop-experimental

### DIFF
--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -35,6 +35,7 @@
 		"@base-ui/react": "^1.2.0",
 		"@cline/core": "workspace:*",
 		"@cline/llms": "workspace:*",
+		"@composio/core": "^0.18.0",
 		"@cline/shared": "workspace:*",
 		"@cline/ui": "workspace:*",
 		"ai": "^7.0.58",

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -80,6 +80,16 @@ import {
 	resolveGitHubInstallUrl,
 } from "./commands-integrations";
 import {
+	cancelComposioConnect,
+	clearComposioApiKey,
+	connectComposioToolkit,
+	disconnectComposioToolkit,
+	getComposioStatus,
+	listComposioToolkits,
+	parseComposioToolkitSlug,
+	setComposioApiKey,
+} from "./composio";
+import {
 	connectorChannelsPayload,
 	startConnectorChannel,
 	stopConnectorChannel,
@@ -2351,6 +2361,49 @@ export async function handleCommand(
 			default:
 				throw new Error(
 					`Unsupported Cline integrations operation: ${operation}`,
+				);
+		}
+	}
+
+	// ── Composio connectors (Gmail / Google Calendar / GitHub / catalog) ─
+	if (command === "composio_integrations") {
+		const operation = String(args?.operation ?? "").trim();
+		if (!operation) throw new Error("operation is required");
+		switch (operation) {
+			case "status":
+				return await getComposioStatus({
+					refresh: args?.refresh === true,
+					logger: ctx.logger,
+				});
+			case "listToolkits":
+				return await listComposioToolkits(ctx.logger);
+			case "setApiKey": {
+				const apiKey = String(args?.apiKey ?? "").trim();
+				if (!apiKey) throw new Error("apiKey is required");
+				return await setComposioApiKey(apiKey, ctx.logger);
+			}
+			case "clearApiKey":
+				return await clearComposioApiKey(ctx.logger);
+			case "connect": {
+				const toolkit = parseComposioToolkitSlug(args?.toolkit);
+				const result = await connectComposioToolkit(toolkit, ctx.logger);
+				if (result.redirectUrl) {
+					await openUrlInDefaultBrowser(result.redirectUrl);
+				}
+				return result;
+			}
+			case "cancelConnect": {
+				const toolkit = parseComposioToolkitSlug(args?.toolkit);
+				cancelComposioConnect(toolkit);
+				return await getComposioStatus({ logger: ctx.logger });
+			}
+			case "disconnect": {
+				const toolkit = parseComposioToolkitSlug(args?.toolkit);
+				return await disconnectComposioToolkit(toolkit, ctx.logger);
+			}
+			default:
+				throw new Error(
+					`Unsupported Composio integrations operation: ${operation}`,
 				);
 		}
 	}

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -1,0 +1,638 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	buildConnectableCatalog,
+	COMPOSIO_PLUGIN_SOURCE,
+	getComposioStatus,
+	initiateToolkitConnection,
+	parseComposioToolkitSlug,
+} from "./composio";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+// The generated plugin imports @cline/core, so the copy under test must live
+// inside the workspace tree where node module resolution can find it.
+const PLUGIN_TMP_ROOT = join(MODULE_DIR, ".vitest-composio-tmp");
+
+type RegisteredTool = {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	retryable?: boolean;
+	execute: (input: unknown, context?: unknown) => Promise<unknown>;
+};
+
+const originalDataDir = process.env.CLINE_DATA_DIR;
+const originalClineDir = process.env.CLINE_DIR;
+const originalEnvApiKey = process.env.COMPOSIO_API_KEY;
+const cleanupPaths: string[] = [];
+
+// Sandboxes both the state file (CLINE_DATA_DIR) and the plugin directory
+// (CLINE_DIR), since env-key reconciliation can write the plugin file.
+function useTempDataDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "composio-test-"));
+	cleanupPaths.push(dir);
+	process.env.CLINE_DATA_DIR = dir;
+	process.env.CLINE_DIR = dir;
+	return dir;
+}
+
+function writeState(dataDir: string, state: unknown): void {
+	const settingsDir = join(dataDir, "settings");
+	mkdirSync(settingsDir, { recursive: true });
+	writeFileSync(
+		join(settingsDir, "composio.json"),
+		JSON.stringify(state, null, "\t"),
+	);
+}
+
+async function loadGeneratedPlugin(): Promise<{
+	setup: (api: unknown, ctx?: unknown) => void | Promise<void>;
+	name: string;
+	manifest: { capabilities: string[] };
+}> {
+	mkdirSync(PLUGIN_TMP_ROOT, { recursive: true });
+	cleanupPaths.push(PLUGIN_TMP_ROOT);
+	// Unique file name per import: module caches are keyed by path.
+	const pluginPath = join(
+		PLUGIN_TMP_ROOT,
+		`composio-tools-${Date.now()}-${Math.random().toString(36).slice(2)}.ts`,
+	);
+	writeFileSync(pluginPath, COMPOSIO_PLUGIN_SOURCE);
+	const module = (await import(pluginPath)) as {
+		default: {
+			setup: (api: unknown, ctx?: unknown) => void | Promise<void>;
+			name: string;
+			manifest: { capabilities: string[] };
+		};
+	};
+	return module.default;
+}
+
+async function setupPluginTools(): Promise<RegisteredTool[]> {
+	const plugin = await loadGeneratedPlugin();
+	const tools: RegisteredTool[] = [];
+	await plugin.setup({
+		registerTool: (tool: RegisteredTool) => tools.push(tool),
+	});
+	return tools;
+}
+
+beforeEach(() => {
+	// The host machine may export a real COMPOSIO_API_KEY; tests opt in
+	// explicitly so env-fallback behavior stays deterministic.
+	delete process.env.COMPOSIO_API_KEY;
+});
+
+afterEach(() => {
+	restoreEnv("CLINE_DATA_DIR", originalDataDir);
+	restoreEnv("CLINE_DIR", originalClineDir);
+	restoreEnv("COMPOSIO_API_KEY", originalEnvApiKey);
+	vi.unstubAllGlobals();
+	for (const path of cleanupPaths.splice(0)) {
+		rmSync(path, { recursive: true, force: true });
+	}
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}
+
+describe("parseComposioToolkitSlug", () => {
+	it("accepts well-formed toolkit slugs case-insensitively", () => {
+		expect(parseComposioToolkitSlug("gmail")).toBe("gmail");
+		expect(parseComposioToolkitSlug("GitHub ")).toBe("github");
+		expect(parseComposioToolkitSlug("googlecalendar")).toBe("googlecalendar");
+		expect(parseComposioToolkitSlug("slack")).toBe("slack");
+		expect(parseComposioToolkitSlug("one_drive")).toBe("one_drive");
+	});
+
+	it("rejects malformed slugs", () => {
+		expect(() => parseComposioToolkitSlug("")).toThrow(
+			/Invalid Composio toolkit slug/,
+		);
+		expect(() => parseComposioToolkitSlug("bad slug!")).toThrow(
+			/Invalid Composio toolkit slug/,
+		);
+		expect(() => parseComposioToolkitSlug("a".repeat(80))).toThrow(
+			/Invalid Composio toolkit slug/,
+		);
+	});
+});
+
+describe("getComposioStatus", () => {
+	it("reports unconfigured state with all integrations disconnected", async () => {
+		useTempDataDir();
+		const status = await getComposioStatus();
+		expect(status.configured).toBe(false);
+		expect(status.integrations.map((entry) => entry.toolkit)).toEqual([
+			"gmail",
+			"googlecalendar",
+			"github",
+		]);
+		expect(
+			status.integrations.every((entry) => entry.status === "not_connected"),
+		).toBe(true);
+	});
+
+	it("reports connected toolkits from persisted state without hitting the network", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_123",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE", name: "Create issue" }],
+				},
+			},
+		});
+		const status = await getComposioStatus();
+		expect(status.configured).toBe(true);
+		const github = status.integrations.find(
+			(entry) => entry.toolkit === "github",
+		);
+		expect(github?.status).toBe("connected");
+		expect(github?.recommended).toBe(true);
+		expect(github?.toolNames).toEqual(["Create issue"]);
+		const gmail = status.integrations.find(
+			(entry) => entry.toolkit === "gmail",
+		);
+		expect(gmail?.status).toBe("not_connected");
+	});
+
+	it("includes connected non-recommended toolkits alongside the recommended set", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				slack: {
+					connectedAccountId: "ca_slack",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					name: "Slack",
+					tools: [{ slug: "SLACK_SEND_MESSAGE" }],
+				},
+			},
+		});
+		const status = await getComposioStatus();
+		const slack = status.integrations.find(
+			(entry) => entry.toolkit === "slack",
+		);
+		expect(slack?.status).toBe("connected");
+		expect(slack?.recommended).toBe(false);
+		expect(slack?.name).toBe("Slack");
+		// The recommended set is still always present.
+		expect(
+			status.integrations.filter((entry) => entry.recommended),
+		).toHaveLength(3);
+	});
+});
+
+describe("buildConnectableCatalog", () => {
+	it("keeps managed toolkits and drops unmanaged ones without an auth config", () => {
+		const entries = buildConnectableCatalog(
+			[
+				{
+					slug: "gmail",
+					name: "Gmail",
+					composio_managed_auth_schemes: ["OAUTH2"],
+					meta: {
+						description: "Email",
+						logo: "https://logos/gmail.png",
+						tools_count: 20,
+						categories: [{ slug: "email", name: "Email" }],
+					},
+				},
+				// No managed credentials and no project auth config — a Connect
+				// click would fail, so it is hidden.
+				{ slug: "canvas", name: "Canvas", composio_managed_auth_schemes: [] },
+				// Unmanaged, but the project configured its own OAuth app.
+				{ slug: "internaltool", name: "Internal Tool" },
+			],
+			new Set(["internaltool"]),
+		);
+		expect(entries.map((entry) => entry.slug)).toEqual([
+			"gmail",
+			"internaltool",
+		]);
+		const gmail = entries[0];
+		expect(gmail.recommended).toBe(true);
+		expect(gmail.toolsCount).toBe(20);
+		expect(gmail.categories).toEqual(["Email"]);
+	});
+
+	it("dedupes and drops malformed slugs", () => {
+		const entries = buildConnectableCatalog(
+			[
+				{
+					slug: "GitHub",
+					name: "GitHub",
+					composio_managed_auth_schemes: ["OAUTH2"],
+				},
+				{
+					slug: "github",
+					name: "GitHub dup",
+					composio_managed_auth_schemes: ["OAUTH2"],
+				},
+				{
+					slug: "bad slug!",
+					name: "Broken",
+					composio_managed_auth_schemes: ["OAUTH2"],
+				},
+			],
+			new Set(),
+		);
+		expect(entries.map((entry) => entry.slug)).toEqual(["github"]);
+	});
+});
+
+describe("initiateToolkitConnection", () => {
+	type FakeClient = Parameters<typeof initiateToolkitConnection>[0];
+	const LEGACY_ERROR = new Error(
+		'400 {"error":{"message":"Creating connections on this endpoint for Composio-managed OAuth auth configs is no longer supported. Use POST /api/v3/connected_accounts/link instead.","code":600}}',
+	);
+	const request = (id: string) => ({
+		id,
+		redirectUrl: `https://connect.example/${id}`,
+		waitForConnection: async () => ({}),
+	});
+
+	it("prefers a custom (org-branded) auth config and links through it directly", async () => {
+		const link = vi.fn(async () => request("ca_custom"));
+		const client = {
+			toolkits: { authorize: vi.fn() },
+			authConfigs: {
+				list: vi.fn(async () => ({
+					items: [
+						{ id: "ac_managed", isComposioManaged: true },
+						{ id: "ac_custom", isComposioManaged: false },
+					],
+				})),
+				create: vi.fn(),
+			},
+			connectedAccounts: { link },
+		} as unknown as FakeClient;
+		const result = await initiateToolkitConnection(client, "user", "github");
+		expect(result.id).toBe("ca_custom");
+		expect(link).toHaveBeenCalledWith("user", "ac_custom");
+		expect(client.toolkits.authorize).not.toHaveBeenCalled();
+	});
+
+	it("returns the authorize result when the legacy endpoint still works", async () => {
+		const client = {
+			toolkits: { authorize: vi.fn(async () => request("ca_direct")) },
+			authConfigs: { list: vi.fn(), create: vi.fn() },
+			connectedAccounts: { link: vi.fn() },
+		} as unknown as FakeClient;
+		const result = await initiateToolkitConnection(client, "user", "gmail");
+		expect(result.id).toBe("ca_direct");
+		expect(client.connectedAccounts.link).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the link flow with the existing auth config on the retired-endpoint error", async () => {
+		const link = vi.fn(async () => request("ca_linked"));
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => {
+					throw LEGACY_ERROR;
+				}),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [{ id: "ac_gmail" }] })),
+				create: vi.fn(),
+			},
+			connectedAccounts: { link },
+		} as unknown as FakeClient;
+		const result = await initiateToolkitConnection(client, "user", "gmail");
+		expect(result.id).toBe("ca_linked");
+		expect(link).toHaveBeenCalledWith("user", "ac_gmail");
+		expect(client.authConfigs.create).not.toHaveBeenCalled();
+	});
+
+	it("creates a managed auth config when none exists before linking", async () => {
+		const create = vi.fn(async () => ({ id: "ac_created" }));
+		const link = vi.fn(async () => request("ca_linked"));
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => {
+					throw LEGACY_ERROR;
+				}),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create,
+			},
+			connectedAccounts: { link },
+		} as unknown as FakeClient;
+		await initiateToolkitConnection(client, "user", "github");
+		expect(create).toHaveBeenCalledWith("github", {
+			type: "use_composio_managed_auth",
+		});
+		expect(link).toHaveBeenCalledWith("user", "ac_created");
+	});
+
+	it("rethrows unrelated authorize errors without linking", async () => {
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => {
+					throw new Error("401 invalid api key");
+				}),
+			},
+			authConfigs: { list: vi.fn(), create: vi.fn() },
+			connectedAccounts: { link: vi.fn() },
+		} as unknown as FakeClient;
+		await expect(
+			initiateToolkitConnection(client, "user", "gmail"),
+		).rejects.toThrow(/invalid api key/);
+		expect(client.connectedAccounts.link).not.toHaveBeenCalled();
+	});
+});
+
+describe("COMPOSIO_API_KEY environment fallback", () => {
+	function readStateFile(dir: string): {
+		apiKey?: string;
+		apiKeySource?: string;
+		userId?: string;
+	} {
+		return JSON.parse(
+			readFileSync(join(dir, "settings", "composio.json"), "utf8"),
+		);
+	}
+
+	it("adopts the env key, persists it for the plugin, and reports the source", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_from_env";
+		const status = await getComposioStatus();
+		expect(status.configured).toBe(true);
+		expect(status.keySource).toBe("environment");
+		const persisted = readStateFile(dir);
+		expect(persisted.apiKey).toBe("ck_from_env");
+		expect(persisted.apiKeySource).toBe("environment");
+		expect(persisted.userId).toMatch(/^cline-desktop-/);
+	});
+
+	it("rotates the persisted copy when the env var changes and drops it when unset", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_first";
+		await getComposioStatus();
+		process.env.COMPOSIO_API_KEY = "ck_second";
+		const rotated = await getComposioStatus();
+		expect(rotated.keySource).toBe("environment");
+		expect(readStateFile(dir).apiKey).toBe("ck_second");
+		delete process.env.COMPOSIO_API_KEY;
+		const dropped = await getComposioStatus();
+		expect(dropped.configured).toBe(false);
+		expect(dropped.keySource).toBeUndefined();
+		expect(readStateFile(dir).apiKey).toBeUndefined();
+	});
+
+	it("keeps a user-entered key over the env var", async () => {
+		const dir = useTempDataDir();
+		writeState(dir, {
+			apiKey: "ck_user",
+			apiKeySource: "user",
+			userId: "cline-desktop-user",
+			toolkits: {},
+		});
+		process.env.COMPOSIO_API_KEY = "ck_from_env";
+		const status = await getComposioStatus();
+		expect(status.keySource).toBe("user");
+		expect(readStateFile(dir).apiKey).toBe("ck_user");
+	});
+
+	it("materializes and removes the plugin file as the env key comes and goes", async () => {
+		const dir = useTempDataDir();
+		writeState(dir, {
+			userId: "cline-desktop-env",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_github",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		const pluginPath = join(dir, "plugins", "composio-tools.ts");
+		process.env.COMPOSIO_API_KEY = "ck_from_env";
+		await getComposioStatus();
+		expect(existsSync(pluginPath)).toBe(true);
+		delete process.env.COMPOSIO_API_KEY;
+		await getComposioStatus();
+		expect(existsSync(pluginPath)).toBe(false);
+	});
+
+	it("plugin execute falls back to the Hub process env when the state file has no key", async () => {
+		const dir = useTempDataDir();
+		writeState(dir, {
+			userId: "cline-desktop-env",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_github",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		process.env.COMPOSIO_API_KEY = "ck_hub_env";
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ successful: true, data: {} }), {
+					status: 200,
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const tools = await setupPluginTools();
+		expect(tools).toHaveLength(1);
+		await tools[0].execute({ title: "bug" });
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			{ headers: Record<string, string> },
+		];
+		expect(init.headers["x-api-key"]).toBe("ck_hub_env");
+	});
+});
+
+describe("generated composio plugin", () => {
+	it("declares the tools capability and registers nothing when unconfigured", async () => {
+		useTempDataDir();
+		const plugin = await loadGeneratedPlugin();
+		expect(plugin.name).toBe("composio-tools");
+		expect(plugin.manifest.capabilities).toEqual(["tools"]);
+		const tools: RegisteredTool[] = [];
+		await plugin.setup({
+			registerTool: (tool: RegisteredTool) => tools.push(tool),
+		});
+		expect(tools).toHaveLength(0);
+	});
+
+	it("registers one snake_case tool per stored tool schema", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				gmail: {
+					connectedAccountId: "ca_gmail",
+					tools: [
+						{
+							slug: "GMAIL_SEND_EMAIL",
+							description: "Send an email.",
+							version: "20250101_00",
+							inputParameters: {
+								type: "object",
+								properties: { to: { type: "string" } },
+								required: ["to"],
+							},
+						},
+						{ slug: "GMAIL_FETCH_EMAILS" },
+					],
+				},
+				github: {
+					connectedAccountId: "ca_github",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		const tools = await setupPluginTools();
+		expect(tools.map((tool) => tool.name).sort()).toEqual([
+			"github_create_an_issue",
+			"gmail_fetch_emails",
+			"gmail_send_email",
+		]);
+		const sendEmail = tools.find((tool) => tool.name === "gmail_send_email");
+		expect(sendEmail?.description).toContain("Send an email.");
+		expect(sendEmail?.inputSchema).toMatchObject({
+			type: "object",
+			required: ["to"],
+		});
+		expect(sendEmail?.retryable).toBe(false);
+	});
+
+	it("executes tools against the Composio REST API with the pinned version", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				gmail: {
+					connectedAccountId: "ca_gmail",
+					tools: [{ slug: "GMAIL_SEND_EMAIL", version: "20250101_00" }],
+				},
+			},
+		});
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						successful: true,
+						data: { messageId: "msg_1" },
+						error: null,
+					}),
+					{ status: 200 },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const tools = await setupPluginTools();
+		const result = await tools[0].execute({
+			to: "someone@example.com",
+			subject: "hi",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			{ method: string; headers: Record<string, string>; body: string },
+		];
+		expect(url).toBe(
+			"https://backend.composio.dev/api/v3.1/tools/execute/GMAIL_SEND_EMAIL",
+		);
+		expect(init.method).toBe("POST");
+		expect(init.headers["x-api-key"]).toBe("ck_test");
+		expect(JSON.parse(init.body)).toEqual({
+			user_id: "cline-desktop-test",
+			arguments: { to: "someone@example.com", subject: "hi" },
+			version: "20250101_00",
+		});
+		expect(result).toEqual({
+			successful: true,
+			data: { messageId: "msg_1" },
+			error: null,
+		});
+	});
+
+	it("returns structured errors instead of throwing on HTTP failures", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_github",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ error: "connection expired" }), {
+						status: 401,
+					}),
+			),
+		);
+
+		const tools = await setupPluginTools();
+		const result = (await tools[0].execute({ title: "bug" })) as {
+			successful: boolean;
+			error: string;
+		};
+		expect(result.successful).toBe(false);
+		expect(result.error).toContain("HTTP 401");
+		expect(result.error).toContain("GITHUB_CREATE_AN_ISSUE");
+	});
+
+	it("returns structured errors when the network is unreachable", async () => {
+		const dataDir = useTempDataDir();
+		writeState(dataDir, {
+			apiKey: "ck_test",
+			userId: "cline-desktop-test",
+			toolkits: {
+				gmail: {
+					connectedAccountId: "ca_gmail",
+					tools: [{ slug: "GMAIL_FETCH_EMAILS" }],
+				},
+			},
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network down");
+			}),
+		);
+
+		const tools = await setupPluginTools();
+		const result = (await tools[0].execute({})) as {
+			successful: boolean;
+			error: string;
+		};
+		expect(result.successful).toBe(false);
+		expect(result.error).toContain("network down");
+	});
+});

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -415,6 +415,26 @@ describe("COMPOSIO_API_KEY environment fallback", () => {
 		expect(readStateFile(dir).apiKey).toBe("ck_user");
 	});
 
+	it("status reads survive an unwritable plugins directory", async () => {
+		const dir = useTempDataDir();
+		writeState(dir, {
+			userId: "cline-desktop-env",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_github",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		// A file where the plugins directory should be makes the plugin sync
+		// throw; the passive status path must log-and-continue instead.
+		writeFileSync(join(dir, "plugins"), "not a directory");
+		process.env.COMPOSIO_API_KEY = "ck_from_env";
+		const status = await getComposioStatus();
+		expect(status.configured).toBe(true);
+	});
+
 	it("materializes and removes the plugin file as the env key comes and goes", async () => {
 		const dir = useTempDataDir();
 		writeState(dir, {

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -1,0 +1,1072 @@
+import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { BasicLogger } from "@cline/shared";
+import { resolveClineDataDir, resolveClineDir } from "@cline/shared/storage";
+import {
+	COMPOSIO_RECOMMENDED_TOOLKITS,
+	type ComposioCatalogResponse,
+	type ComposioCatalogToolkit,
+	type ComposioConnectResponse,
+	type ComposioIntegrationStatus,
+	type ComposioIntegrationSummary,
+	type ComposioStatusResponse,
+	type ComposioToolkitSlug,
+	findRecommendedToolkit,
+	isComposioToolkitSlug,
+} from "../webview/lib/composio-types";
+
+/**
+ * Management plane for Composio-backed integrations (Gmail, Google Calendar,
+ * GitHub).
+ *
+ * The sidecar owns the OAuth handshake and connection bookkeeping, but agent
+ * sessions run in the shared Hub daemon, so the sidecar cannot register tools
+ * in-process. Instead, connection state plus the fetched tool schemas are
+ * persisted to `<cline-data>/settings/composio.json`, and a single-file plugin
+ * is materialized into `~/.cline/plugins/` that reads that file at session
+ * start and registers one tool per connected Composio tool. New sessions pick
+ * the plugin up automatically; running sessions keep their frozen tool set.
+ */
+
+const COMPOSIO_STATE_FILE_NAME = "composio.json";
+const COMPOSIO_PLUGIN_FILE_NAME = "composio-tools.ts";
+/** Mirrors `PLUGINS_DIRECTORY_NAME` in `@cline/shared` (not exported). */
+const PLUGINS_DIRECTORY_NAME = "plugins";
+/** How long the background waiter gives the user to finish the browser flow. */
+const CONNECT_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+/** Cap on tools materialized per toolkit; Composio orders by importance. */
+const TOOLS_PER_TOOLKIT_LIMIT = 20;
+const MAX_TOOL_DESCRIPTION_LENGTH = 1024;
+
+type StoredComposioTool = {
+	slug: string;
+	name?: string;
+	description?: string;
+	version?: string;
+	inputParameters?: Record<string, unknown>;
+};
+
+type StoredComposioToolkit = {
+	connectedAccountId: string;
+	connectedAt: string;
+	/** Display metadata captured from the catalog at connect time. */
+	name?: string;
+	logo?: string;
+	tools: StoredComposioTool[];
+};
+
+type StoredComposioState = {
+	apiKey?: string;
+	/**
+	 * Where the stored key came from. "user" keys are entered in Settings and
+	 * only change through Settings; "environment" keys are copies of the
+	 * COMPOSIO_API_KEY env var (persisted so the plugin, which runs in the Hub
+	 * process without the sidecar's environment, can execute tools) and are
+	 * re-synced against the env var on every read — rotated when it changes,
+	 * dropped when it disappears.
+	 */
+	apiKeySource?: "user" | "environment";
+	/** Stable per-install Composio user id; generated on first configuration. */
+	userId?: string;
+	toolkits?: Partial<Record<string, StoredComposioToolkit>>;
+};
+
+type PendingConnection = {
+	attemptId: string;
+	connectedAccountId: string;
+	redirectUrl?: string;
+	startedAt: number;
+};
+
+type ComposioConnectionRequest = {
+	id: string;
+	redirectUrl?: string | null;
+	waitForConnection: (timeout?: number) => Promise<unknown>;
+};
+
+/** One toolkit from the raw catalog endpoint (`GET /api/v3/toolkits`). The
+ * SDK's wrapper strips the auth-availability fields we filter on, so the
+ * catalog is fetched over REST directly. */
+type RawComposioToolkitItem = {
+	slug: string;
+	name: string;
+	meta?: {
+		description?: string;
+		logo?: string;
+		tools_count?: number;
+		categories?: Array<{ slug: string; name: string }>;
+	};
+	/** Auth methods Composio manages credentials for; empty/absent means the
+	 * org must bring its own auth config for this toolkit. */
+	composio_managed_auth_schemes?: string[];
+	no_auth?: boolean;
+};
+
+/** Minimal surface of the `@composio/core` client this module uses; the SDK is
+ * loaded lazily so sidecar startup does not pay its import cost. */
+type ComposioClient = {
+	toolkits: {
+		authorize: (
+			userId: string,
+			toolkitSlug: string,
+		) => Promise<ComposioConnectionRequest>;
+	};
+	authConfigs: {
+		list: (query?: { toolkit?: string }) => Promise<{
+			items: Array<{
+				id: string;
+				isComposioManaged?: boolean;
+				toolkit?: { slug: string };
+			}>;
+		}>;
+		create: (
+			toolkit: string,
+			options: { type: "use_composio_managed_auth"; name?: string },
+		) => Promise<{ id: string }>;
+	};
+	tools: {
+		getRawComposioTools: (query: {
+			toolkits: string[];
+			limit?: number;
+		}) => Promise<
+			Array<{
+				slug: string;
+				name?: string;
+				description?: string;
+				version?: string;
+				inputParameters?: unknown;
+			}>
+		>;
+	};
+	connectedAccounts: {
+		list: (query?: { userIds?: string[]; toolkitSlugs?: string[] }) => Promise<{
+			items: Array<{
+				id: string;
+				status: string;
+				isDisabled?: boolean;
+				toolkit: { slug: string };
+			}>;
+		}>;
+		link: (
+			userId: string,
+			authConfigId: string,
+		) => Promise<ComposioConnectionRequest>;
+		delete: (id: string) => Promise<unknown>;
+	};
+};
+
+const pendingConnections = new Map<ComposioToolkitSlug, PendingConnection>();
+const lastConnectionErrors = new Map<ComposioToolkitSlug, string>();
+
+/** Usage-ranked toolkit catalog, cached per key since it changes rarely. */
+const CATALOG_TTL_MS = 60 * 60 * 1000;
+const CATALOG_FETCH_LIMIT = 500;
+let catalogCache: {
+	apiKey: string;
+	fetchedAt: number;
+	entries: ComposioCatalogToolkit[];
+} | null = null;
+
+let cachedClient: { apiKey: string; client: ComposioClient } | null = null;
+
+async function getComposioClient(apiKey: string): Promise<ComposioClient> {
+	if (cachedClient?.apiKey === apiKey) {
+		return cachedClient.client;
+	}
+	const { Composio } = await import("@composio/core");
+	const client = new Composio({ apiKey }) as unknown as ComposioClient;
+	cachedClient = { apiKey, client };
+	return client;
+}
+
+/** Composio SDK errors embed the raw response JSON ("401 {...}"); pull out
+ * the human-readable message when one is present. */
+function formatComposioError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	const jsonStart = message.indexOf("{");
+	if (jsonStart !== -1) {
+		try {
+			const parsed = JSON.parse(message.slice(jsonStart)) as {
+				error?: { message?: unknown };
+				message?: unknown;
+			};
+			const nested = parsed.error?.message ?? parsed.message;
+			if (typeof nested === "string" && nested.trim()) {
+				return nested.trim();
+			}
+		} catch {
+			// Fall through to the raw message.
+		}
+	}
+	return message;
+}
+
+export function parseComposioToolkitSlug(value: unknown): ComposioToolkitSlug {
+	const slug = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	if (!isComposioToolkitSlug(slug)) {
+		throw new Error(`Invalid Composio toolkit slug: ${String(value)}`);
+	}
+	return slug;
+}
+
+/** Composio retired the legacy connection-create endpoint that
+ * `toolkits.authorize()` uses for Composio-managed OAuth auth configs; the
+ * error directs callers to the connected-account link flow instead. */
+function isLegacyConnectionEndpointError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes("connected_accounts/link");
+}
+
+/** A custom auth config is the org's own OAuth app registered in Composio —
+ * the consent screen then shows that app's branding ("Authorize Cline")
+ * instead of Composio's shared OAuth app ("Authorize Composio"). */
+async function findCustomAuthConfigId(
+	client: ComposioClient,
+	toolkit: ComposioToolkitSlug,
+): Promise<string | undefined> {
+	try {
+		const existing = await client.authConfigs.list({ toolkit });
+		return existing.items?.find((item) => item.isComposioManaged === false)?.id;
+	} catch {
+		// Lookup is an optimization; the authorize path below still works.
+		return undefined;
+	}
+}
+
+async function resolveToolkitAuthConfigId(
+	client: ComposioClient,
+	toolkit: ComposioToolkitSlug,
+): Promise<string> {
+	const existing = await client.authConfigs.list({ toolkit });
+	const items = existing.items ?? [];
+	// Prefer a custom (org-branded) auth config when both kinds exist.
+	const preferred =
+		items.find((item) => item.isComposioManaged === false) ?? items[0];
+	if (preferred?.id) {
+		return preferred.id;
+	}
+	const created = await client.authConfigs.create(toolkit, {
+		type: "use_composio_managed_auth",
+	});
+	return created.id;
+}
+
+/**
+ * Start an OAuth connection for a toolkit.
+ *
+ * When a custom auth config exists (the org's own OAuth app), connect through
+ * it directly with the connected-account link flow so the consent screen
+ * carries the org's branding. Otherwise fall back to `toolkits.authorize()`
+ * (which finds or creates a Composio-managed auth config in one call) — and
+ * because Composio retired that method's connection-create endpoint for
+ * managed OAuth configs, retry the specific rejection through the link flow
+ * against the same auth config.
+ */
+export async function initiateToolkitConnection(
+	client: ComposioClient,
+	userId: string,
+	toolkit: ComposioToolkitSlug,
+	logger?: BasicLogger,
+): Promise<ComposioConnectionRequest> {
+	const customAuthConfigId = await findCustomAuthConfigId(client, toolkit);
+	if (customAuthConfigId) {
+		logger?.log?.(
+			`composio connect ${toolkit}: using custom auth config ${customAuthConfigId}`,
+		);
+		return await client.connectedAccounts.link(userId, customAuthConfigId);
+	}
+	try {
+		return await client.toolkits.authorize(userId, toolkit);
+	} catch (error) {
+		if (!isLegacyConnectionEndpointError(error)) {
+			throw error;
+		}
+		logger?.log?.(
+			`composio authorize ${toolkit}: legacy endpoint retired, using connected-account link flow`,
+		);
+		const authConfigId = await resolveToolkitAuthConfigId(client, toolkit);
+		return await client.connectedAccounts.link(userId, authConfigId);
+	}
+}
+
+// ── Persisted state ──────────────────────────────────────────────────────
+
+export function resolveComposioStatePath(): string {
+	return join(resolveClineDataDir(), "settings", COMPOSIO_STATE_FILE_NAME);
+}
+
+function readComposioState(): StoredComposioState {
+	const path = resolveComposioStatePath();
+	if (!existsSync(path)) {
+		return {};
+	}
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as StoredComposioState)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
+function writeComposioState(state: StoredComposioState): void {
+	const path = resolveComposioStatePath();
+	mkdirSync(dirname(path), { recursive: true });
+	// The file holds the Composio API key; keep it owner-readable only.
+	writeFileSync(path, `${JSON.stringify(state, null, "\t")}\n`, {
+		mode: 0o600,
+	});
+}
+
+function resolveEnvComposioApiKey(): string | undefined {
+	return process.env.COMPOSIO_API_KEY?.trim() || undefined;
+}
+
+/**
+ * Keep an environment-sourced key in sync with the COMPOSIO_API_KEY env var:
+ * adopt it when no user key is stored, rotate the stored copy when the env
+ * var changes, and drop it when the env var disappears. A key the user typed
+ * into Settings ("user" source) always wins and is never touched here.
+ *
+ * Persists (and re-syncs the plugin file) only when something changed.
+ */
+function reconcileEnvApiKey(
+	state: StoredComposioState,
+	logger?: BasicLogger,
+): void {
+	const envKey = resolveEnvComposioApiKey();
+	let changed = false;
+	if (state.apiKeySource === "environment") {
+		if (!envKey) {
+			delete state.apiKey;
+			delete state.apiKeySource;
+			changed = true;
+		} else if (state.apiKey !== envKey) {
+			state.apiKey = envKey;
+			changed = true;
+		}
+	} else if (!state.apiKey && envKey) {
+		state.apiKey = envKey;
+		state.apiKeySource = "environment";
+		changed = true;
+	}
+	if (changed && state.apiKey && !state.userId) {
+		state.userId = `cline-desktop-${randomUUID()}`;
+	}
+	if (changed) {
+		writeComposioState(state);
+		syncComposioPluginFile(state, logger);
+		logger?.log?.(
+			state.apiKey
+				? "composio api key adopted from COMPOSIO_API_KEY environment variable"
+				: "composio api key dropped: COMPOSIO_API_KEY environment variable is gone",
+		);
+	}
+}
+
+function readReconciledComposioState(
+	logger?: BasicLogger,
+): StoredComposioState {
+	const state = readComposioState();
+	reconcileEnvApiKey(state, logger);
+	return state;
+}
+
+// ── Status ───────────────────────────────────────────────────────────────
+
+function summarizeToolkit(
+	state: StoredComposioState,
+	slug: ComposioToolkitSlug,
+): ComposioIntegrationSummary {
+	const recommended = findRecommendedToolkit(slug);
+	const stored = state.toolkits?.[slug];
+	let status: ComposioIntegrationStatus = "not_connected";
+	if (pendingConnections.has(slug)) {
+		status = "pending";
+	} else if (stored) {
+		status = "connected";
+	}
+	const catalogEntry = catalogCache?.entries.find(
+		(entry) => entry.slug === slug,
+	);
+	return {
+		toolkit: slug,
+		name: recommended?.name ?? stored?.name ?? catalogEntry?.name ?? slug,
+		description: recommended?.description ?? catalogEntry?.description ?? "",
+		logo: stored?.logo ?? catalogEntry?.logo,
+		recommended: Boolean(recommended),
+		status,
+		connectedAccountId: stored?.connectedAccountId,
+		connectedAt: stored?.connectedAt,
+		toolNames: stored?.tools.map((tool) => tool.name?.trim() || tool.slug),
+		error: lastConnectionErrors.get(slug),
+	};
+}
+
+function buildStatusResponse(
+	state: StoredComposioState,
+): ComposioStatusResponse {
+	// Recommended toolkits are always listed; any other toolkit appears while
+	// it is connected or mid-connection (so the catalog UI can join on it).
+	const slugs = new Set<ComposioToolkitSlug>(
+		COMPOSIO_RECOMMENDED_TOOLKITS.map((entry) => entry.slug),
+	);
+	for (const slug of Object.keys(state.toolkits ?? {})) {
+		slugs.add(slug);
+	}
+	for (const slug of pendingConnections.keys()) {
+		slugs.add(slug);
+	}
+	return {
+		configured: Boolean(state.apiKey),
+		keySource: state.apiKey ? (state.apiKeySource ?? "user") : undefined,
+		integrations: [...slugs].map((slug) => summarizeToolkit(state, slug)),
+	};
+}
+
+export async function getComposioStatus(options?: {
+	refresh?: boolean;
+	logger?: BasicLogger;
+}): Promise<ComposioStatusResponse> {
+	const state = readReconciledComposioState(options?.logger);
+	if (!options?.refresh || !state.apiKey || !state.userId) {
+		return buildStatusResponse(state);
+	}
+	// Reconcile with Composio: connections can be revoked (or added) from the
+	// Composio dashboard without this app knowing.
+	try {
+		const client = await getComposioClient(state.apiKey);
+		const accounts = await client.connectedAccounts.list({
+			userIds: [state.userId],
+		});
+		const activeByToolkit = new Map<string, string>();
+		for (const account of accounts.items ?? []) {
+			if (account.status === "ACTIVE" && !account.isDisabled) {
+				activeByToolkit.set(account.toolkit.slug.toLowerCase(), account.id);
+			}
+		}
+		let changed = false;
+		const toolkits = { ...(state.toolkits ?? {}) };
+		const slugsToReconcile = new Set<ComposioToolkitSlug>([
+			...Object.keys(toolkits),
+			...activeByToolkit.keys(),
+		]);
+		for (const slug of slugsToReconcile) {
+			const remoteAccountId = activeByToolkit.get(slug);
+			const stored = toolkits[slug];
+			if (stored && !remoteAccountId) {
+				delete toolkits[slug];
+				changed = true;
+			} else if (
+				remoteAccountId &&
+				(!stored || stored.connectedAccountId !== remoteAccountId) &&
+				!pendingConnections.has(slug)
+			) {
+				toolkits[slug] = {
+					connectedAccountId: remoteAccountId,
+					connectedAt: new Date().toISOString(),
+					...lookupCatalogDisplayInfo(slug),
+					tools: await fetchToolkitTools(client, slug),
+				};
+				changed = true;
+			}
+		}
+		if (changed) {
+			state.toolkits = toolkits;
+			writeComposioState(state);
+			syncComposioPluginFile(state, options?.logger);
+		}
+	} catch (error) {
+		options?.logger?.log?.(
+			`composio status refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	return buildStatusResponse(state);
+}
+
+// ── Toolkit catalog ──────────────────────────────────────────────────────
+
+function lookupCatalogDisplayInfo(slug: ComposioToolkitSlug): {
+	name?: string;
+	logo?: string;
+} {
+	const entry = catalogCache?.entries.find((item) => item.slug === slug);
+	return { name: entry?.name, logo: entry?.logo };
+}
+
+const COMPOSIO_BASE_URL = (
+	process.env.COMPOSIO_BASE_URL || "https://backend.composio.dev"
+).replace(/\/+$/, "");
+
+/** The SDK's catalog wrapper strips `composio_managed_auth_schemes`, which
+ * the connectable filter needs, so fetch the same endpoint over REST. */
+async function fetchRawToolkitCatalog(
+	apiKey: string,
+): Promise<RawComposioToolkitItem[]> {
+	const url = new URL(`${COMPOSIO_BASE_URL}/api/v3/toolkits`);
+	url.searchParams.set("sort_by", "usage");
+	url.searchParams.set("limit", String(CATALOG_FETCH_LIMIT));
+	const response = await fetch(url, { headers: { "x-api-key": apiKey } });
+	if (!response.ok) {
+		throw new Error(`toolkit catalog request failed (HTTP ${response.status})`);
+	}
+	const parsed = (await response.json()) as {
+		items?: RawComposioToolkitItem[];
+	};
+	return parsed.items ?? [];
+}
+
+async function listConfiguredToolkitSlugs(
+	client: ComposioClient,
+): Promise<Set<string>> {
+	const configured = new Set<string>();
+	try {
+		const response = await client.authConfigs.list();
+		for (const item of response.items ?? []) {
+			const slug = item.toolkit?.slug?.trim().toLowerCase();
+			if (slug) {
+				configured.add(slug);
+			}
+		}
+	} catch {
+		// Best-effort: without the list, only managed toolkits are shown.
+	}
+	return configured;
+}
+
+/**
+ * Maps the raw catalog onto browsable entries, keeping only toolkits a
+ * Connect click can actually finish: Composio manages credentials for them,
+ * or the project already has an auth config (e.g. the org's own OAuth app).
+ * Exported for tests.
+ */
+export function buildConnectableCatalog(
+	items: RawComposioToolkitItem[],
+	configuredSlugs: ReadonlySet<string>,
+): ComposioCatalogToolkit[] {
+	const seen = new Set<string>();
+	const entries: ComposioCatalogToolkit[] = [];
+	for (const item of items ?? []) {
+		const slug = item?.slug?.trim().toLowerCase();
+		if (!slug || seen.has(slug) || !isComposioToolkitSlug(slug)) {
+			continue;
+		}
+		seen.add(slug);
+		const managed = (item.composio_managed_auth_schemes?.length ?? 0) > 0;
+		if (!managed && !configuredSlugs.has(slug)) {
+			continue;
+		}
+		entries.push({
+			slug,
+			name: item.name?.trim() || slug,
+			description: item.meta?.description?.trim() || undefined,
+			logo: item.meta?.logo || undefined,
+			categories: item.meta?.categories
+				?.map((category) => category.name)
+				.filter(Boolean),
+			toolsCount: item.meta?.tools_count,
+			recommended: Boolean(findRecommendedToolkit(slug)),
+		});
+	}
+	return entries;
+}
+
+async function ensureToolkitCatalog(
+	client: ComposioClient,
+	apiKey: string,
+): Promise<ComposioCatalogToolkit[]> {
+	if (
+		catalogCache &&
+		catalogCache.apiKey === apiKey &&
+		Date.now() - catalogCache.fetchedAt < CATALOG_TTL_MS
+	) {
+		return catalogCache.entries;
+	}
+	const [items, configuredSlugs] = await Promise.all([
+		fetchRawToolkitCatalog(apiKey),
+		listConfiguredToolkitSlugs(client),
+	]);
+	const entries = buildConnectableCatalog(items, configuredSlugs);
+	catalogCache = { apiKey, fetchedAt: Date.now(), entries };
+	return entries;
+}
+
+/** The browsable toolkit catalog (usage-ranked), for the Connectors UI. */
+export async function listComposioToolkits(
+	logger?: BasicLogger,
+): Promise<ComposioCatalogResponse> {
+	const state = readReconciledComposioState(logger);
+	if (!state.apiKey) {
+		return { configured: false, toolkits: [] };
+	}
+	const client = await getComposioClient(state.apiKey);
+	try {
+		return {
+			configured: true,
+			toolkits: await ensureToolkitCatalog(client, state.apiKey),
+		};
+	} catch (error) {
+		throw new Error(
+			`Could not load the Composio connector catalog: ${formatComposioError(error)}`,
+		);
+	}
+}
+
+// ── API key management ───────────────────────────────────────────────────
+
+export async function setComposioApiKey(
+	apiKey: string,
+	logger?: BasicLogger,
+): Promise<ComposioStatusResponse> {
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("apiKey is required");
+	}
+	const client = await getComposioClient(trimmed);
+	try {
+		// Any authenticated call proves the key; listing is cheap and also
+		// warms the reconcile below.
+		await client.connectedAccounts.list();
+	} catch (error) {
+		cachedClient = null;
+		throw new Error(
+			`Composio rejected this API key: ${formatComposioError(error)}`,
+		);
+	}
+	const state = readComposioState();
+	state.apiKey = trimmed;
+	state.apiKeySource = "user";
+	if (!state.userId) {
+		state.userId = `cline-desktop-${randomUUID()}`;
+	}
+	writeComposioState(state);
+	syncComposioPluginFile(state, logger);
+	return await getComposioStatus({ refresh: true, logger });
+}
+
+export async function clearComposioApiKey(
+	logger?: BasicLogger,
+): Promise<ComposioStatusResponse> {
+	const state = readComposioState();
+	// Keep the userId so reconnecting later finds the same Composio user, but
+	// drop the key and materialized connections: without a key the tools
+	// cannot execute (and connections are only valid within one key's
+	// Composio project anyway).
+	delete state.apiKey;
+	delete state.apiKeySource;
+	state.toolkits = {};
+	writeComposioState(state);
+	pendingConnections.clear();
+	lastConnectionErrors.clear();
+	cachedClient = null;
+	catalogCache = null;
+	syncComposioPluginFile(state, logger);
+	// A COMPOSIO_API_KEY env var immediately takes over as the fallback key;
+	// the response reflects that so the UI shows the environment source.
+	reconcileEnvApiKey(state, logger);
+	return buildStatusResponse(state);
+}
+
+// ── Connect / disconnect ─────────────────────────────────────────────────
+
+export async function connectComposioToolkit(
+	toolkit: ComposioToolkitSlug,
+	logger?: BasicLogger,
+): Promise<ComposioConnectResponse> {
+	const state = readReconciledComposioState(logger);
+	if (!state.apiKey || !state.userId) {
+		throw new Error(
+			"Add a Composio API key in Settings (or set COMPOSIO_API_KEY in the sidecar environment) before connecting an integration.",
+		);
+	}
+	const existingPending = pendingConnections.get(toolkit);
+	if (existingPending) {
+		return {
+			redirectUrl: existingPending.redirectUrl,
+			status: buildStatusResponse(state),
+		};
+	}
+	lastConnectionErrors.delete(toolkit);
+	const client = await getComposioClient(state.apiKey);
+	let connectionRequest: ComposioConnectionRequest;
+	try {
+		connectionRequest = await initiateToolkitConnection(
+			client,
+			state.userId,
+			toolkit,
+			logger,
+		);
+	} catch (error) {
+		throw new Error(
+			`Could not start the ${toolkit} connection: ${formatComposioError(error)}`,
+		);
+	}
+	const redirectUrl = connectionRequest.redirectUrl?.trim() || undefined;
+	if (!redirectUrl) {
+		// No browser step needed (e.g. the account is already authorized on
+		// Composio's side) — finalize right away.
+		await finalizeToolkitConnection(
+			client,
+			toolkit,
+			connectionRequest.id,
+			logger,
+		);
+		return {
+			alreadyConnected: true,
+			status: buildStatusResponse(readComposioState()),
+		};
+	}
+
+	const attemptId = randomUUID();
+	pendingConnections.set(toolkit, {
+		attemptId,
+		connectedAccountId: connectionRequest.id,
+		redirectUrl,
+		startedAt: Date.now(),
+	});
+
+	// The OAuth flow finishes in the external browser, which cannot navigate
+	// the app back. Wait for Composio to report the connection in the
+	// background; the webview polls `status` to observe the flip.
+	void (async () => {
+		try {
+			await connectionRequest.waitForConnection(CONNECT_WAIT_TIMEOUT_MS);
+			if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
+				return; // Cancelled or superseded while we waited.
+			}
+			await finalizeToolkitConnection(
+				client,
+				toolkit,
+				connectionRequest.id,
+				logger,
+			);
+		} catch (error) {
+			if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
+				return;
+			}
+			const reason = formatComposioError(error);
+			lastConnectionErrors.set(
+				toolkit,
+				`Connection was not completed: ${reason}`,
+			);
+			logger?.log?.(`composio connect ${toolkit} failed: ${reason}`);
+		} finally {
+			if (pendingConnections.get(toolkit)?.attemptId === attemptId) {
+				pendingConnections.delete(toolkit);
+			}
+		}
+	})();
+
+	return { redirectUrl, status: buildStatusResponse(state) };
+}
+
+export function cancelComposioConnect(toolkit: ComposioToolkitSlug): void {
+	pendingConnections.delete(toolkit);
+}
+
+export async function disconnectComposioToolkit(
+	toolkit: ComposioToolkitSlug,
+	logger?: BasicLogger,
+): Promise<ComposioStatusResponse> {
+	pendingConnections.delete(toolkit);
+	lastConnectionErrors.delete(toolkit);
+	const state = readReconciledComposioState(logger);
+	const stored = state.toolkits?.[toolkit];
+	if (stored && state.apiKey) {
+		try {
+			const client = await getComposioClient(state.apiKey);
+			await client.connectedAccounts.delete(stored.connectedAccountId);
+		} catch (error) {
+			// The account may already be gone on Composio's side; local
+			// removal is what actually turns the tools off.
+			logger?.log?.(
+				`composio disconnect ${toolkit}: remote delete failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+	if (state.toolkits) {
+		delete state.toolkits[toolkit];
+	}
+	writeComposioState(state);
+	syncComposioPluginFile(state, logger);
+	return buildStatusResponse(state);
+}
+
+// ── Tool materialization ─────────────────────────────────────────────────
+
+async function fetchToolkitTools(
+	client: ComposioClient,
+	toolkit: ComposioToolkitSlug,
+): Promise<StoredComposioTool[]> {
+	const rawTools = await client.tools.getRawComposioTools({
+		toolkits: [toolkit],
+		limit: TOOLS_PER_TOOLKIT_LIMIT,
+	});
+	const tools: StoredComposioTool[] = [];
+	for (const raw of rawTools) {
+		if (!raw?.slug) {
+			continue;
+		}
+		const description = raw.description?.trim();
+		tools.push({
+			slug: raw.slug,
+			name: raw.name?.trim() || undefined,
+			description:
+				description && description.length > MAX_TOOL_DESCRIPTION_LENGTH
+					? `${description.slice(0, MAX_TOOL_DESCRIPTION_LENGTH)}…`
+					: description || undefined,
+			version:
+				typeof raw.version === "string" && raw.version.trim()
+					? raw.version.trim()
+					: undefined,
+			inputParameters:
+				typeof raw.inputParameters === "object" && raw.inputParameters !== null
+					? (raw.inputParameters as Record<string, unknown>)
+					: undefined,
+		});
+	}
+	return tools;
+}
+
+async function finalizeToolkitConnection(
+	client: ComposioClient,
+	toolkit: ComposioToolkitSlug,
+	connectedAccountId: string,
+	logger?: BasicLogger,
+): Promise<void> {
+	const tools = await fetchToolkitTools(client, toolkit);
+	const state = readComposioState();
+	state.toolkits = {
+		...(state.toolkits ?? {}),
+		[toolkit]: {
+			connectedAccountId,
+			connectedAt: new Date().toISOString(),
+			...lookupCatalogDisplayInfo(toolkit),
+			tools,
+		},
+	};
+	writeComposioState(state);
+	syncComposioPluginFile(state, logger);
+	logger?.log?.(`composio connected ${toolkit} with ${tools.length} tool(s)`);
+}
+
+// ── Plugin materialization ───────────────────────────────────────────────
+
+export function resolveComposioPluginPath(): string {
+	return join(
+		resolveClineDir(),
+		PLUGINS_DIRECTORY_NAME,
+		COMPOSIO_PLUGIN_FILE_NAME,
+	);
+}
+
+function syncComposioPluginFile(
+	state: StoredComposioState,
+	logger?: BasicLogger,
+): void {
+	const pluginPath = resolveComposioPluginPath();
+	const hasConnectedToolkit =
+		Boolean(state.apiKey) &&
+		Object.values(state.toolkits ?? {}).some(
+			(toolkit) => toolkit && toolkit.tools.length > 0,
+		);
+	try {
+		if (!hasConnectedToolkit) {
+			rmSync(pluginPath, { force: true });
+			return;
+		}
+		mkdirSync(dirname(pluginPath), { recursive: true });
+		writeFileSync(pluginPath, COMPOSIO_PLUGIN_SOURCE);
+	} catch (error) {
+		logger?.log?.(
+			`composio plugin sync failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+/**
+ * Source of the single-file plugin the Hub loads into every new session. It
+ * is static: all dynamic state (API key, user id, tool schemas) is read from
+ * composio.json at session start, so connecting or disconnecting a toolkit
+ * never needs to rewrite this file — only create or remove it.
+ *
+ * The plugin executes tools against Composio's REST API directly (the
+ * `@composio/core` package is not resolvable from `~/.cline/plugins/`); the
+ * endpoint below is the same one the official SDK calls.
+ */
+export const COMPOSIO_PLUGIN_SOURCE = `// AUTO-GENERATED by the Cline desktop app — do not edit.
+// Exposes Composio-connected integrations (Gmail, Google Calendar, GitHub)
+// as agent tools. Manage connections from the desktop app under
+// Settings -> Customize -> Integrations. Connection state and tool schemas
+// live in <cline-data>/settings/composio.json; deleting that file (or
+// disconnecting every integration) turns these tools off.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type AgentPlugin, createTool } from "@cline/core";
+import { resolveClineDataDir } from "@cline/shared/storage";
+
+const COMPOSIO_BASE_URL = (
+	process.env.COMPOSIO_BASE_URL || "https://backend.composio.dev"
+).replace(/\\/+$/, "");
+
+type StoredTool = {
+	slug: string;
+	name?: string;
+	description?: string;
+	version?: string;
+	inputParameters?: Record<string, unknown>;
+};
+
+type StoredState = {
+	apiKey?: string;
+	userId?: string;
+	toolkits?: Record<
+		string,
+		{ connectedAccountId?: string; tools?: StoredTool[] } | undefined
+	>;
+};
+
+function loadComposioState(): StoredState | undefined {
+	try {
+		const path = join(resolveClineDataDir(), "settings", "composio.json");
+		if (!existsSync(path)) {
+			return undefined;
+		}
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as StoredState)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function executeComposioTool(
+	apiKey: string,
+	userId: string,
+	tool: StoredTool,
+	input: unknown,
+): Promise<unknown> {
+	const url =
+		COMPOSIO_BASE_URL +
+		"/api/v3.1/tools/execute/" +
+		encodeURIComponent(tool.slug);
+	const body: Record<string, unknown> = {
+		user_id: userId,
+		arguments: input && typeof input === "object" ? input : {},
+	};
+	if (tool.version) {
+		body.version = tool.version;
+	}
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				"x-api-key": apiKey,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify(body),
+		});
+	} catch (error) {
+		return {
+			successful: false,
+			error:
+				"Composio request failed: " +
+				(error instanceof Error ? error.message : String(error)),
+		};
+	}
+	const text = await response.text();
+	let parsed: unknown;
+	try {
+		parsed = text ? JSON.parse(text) : undefined;
+	} catch {
+		parsed = undefined;
+	}
+	if (!response.ok) {
+		const preview =
+			parsed !== undefined
+				? JSON.stringify(parsed).slice(0, 600)
+				: text.slice(0, 600);
+		return {
+			successful: false,
+			error:
+				"Composio returned HTTP " +
+				String(response.status) +
+				" for " +
+				tool.slug +
+				(preview ? ": " + preview : ""),
+		};
+	}
+	return parsed ?? { successful: true };
+}
+
+const plugin: AgentPlugin = {
+	name: "composio-tools",
+	manifest: { capabilities: ["tools"] },
+	setup(api) {
+		const state = loadComposioState();
+		// The desktop app persists the effective key into composio.json, but a
+		// COMPOSIO_API_KEY exported to this (Hub) process works as a fallback.
+		const apiKey =
+			state?.apiKey || (process.env.COMPOSIO_API_KEY || "").trim() || undefined;
+		const userId = state?.userId;
+		if (!state || !apiKey || !userId || !state.toolkits) {
+			return;
+		}
+		const registered = new Set<string>();
+		for (const [toolkitSlug, toolkitState] of Object.entries(
+			state.toolkits,
+		)) {
+			if (!toolkitState || !toolkitState.connectedAccountId) {
+				continue;
+			}
+			for (const tool of toolkitState.tools ?? []) {
+				if (!tool || !tool.slug) {
+					continue;
+				}
+				const toolName = tool.slug
+					.toLowerCase()
+					.replace(/[^a-z0-9_]/g, "_");
+				if (registered.has(toolName)) {
+					continue;
+				}
+				registered.add(toolName);
+				api.registerTool(
+					createTool({
+						name: toolName,
+						description:
+							(tool.description || tool.name || tool.slug) +
+							" (" +
+							toolkitSlug +
+							" account connected via Composio)",
+						inputSchema: (tool.inputParameters ?? {
+							type: "object",
+							properties: {},
+						}) as never,
+						timeoutMs: 120_000,
+						// Composio tools can have side effects (send an email,
+						// open an issue); never auto-retry them.
+						retryable: false,
+						execute: (input: unknown) =>
+							executeComposioTool(apiKey, userId, tool, input),
+					}),
+				);
+			}
+		}
+	},
+};
+
+export { plugin };
+export default plugin;
+`;

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -83,6 +83,10 @@ type PendingConnection = {
 	connectedAccountId: string;
 	redirectUrl?: string;
 	startedAt: number;
+	/** The key/user the attempt was started under; finalization is dropped if
+	 * either changed while the browser flow was in flight. */
+	apiKey: string;
+	userId: string;
 };
 
 type ComposioConnectionRequest = {
@@ -164,6 +168,9 @@ type ComposioClient = {
 
 const pendingConnections = new Map<ComposioToolkitSlug, PendingConnection>();
 const lastConnectionErrors = new Map<ComposioToolkitSlug, string>();
+/** When each toolkit was last disconnected, so state snapshots taken before
+ * the disconnect cannot write it back. */
+const lastDisconnectedAt = new Map<ComposioToolkitSlug, number>();
 
 /** Usage-ranked toolkit catalog, cached per key since it changes rarely. */
 const CATALOG_TTL_MS = 60 * 60 * 1000;
@@ -365,7 +372,7 @@ function reconcileEnvApiKey(
 	}
 	if (changed) {
 		writeComposioState(state);
-		syncComposioPluginFile(state, logger);
+		syncComposioPluginFileQuietly(state, logger);
 		logger?.log?.(
 			state.apiKey
 				? "composio api key adopted from COMPOSIO_API_KEY environment variable"
@@ -445,6 +452,7 @@ export async function getComposioStatus(options?: {
 	// Reconcile with Composio: connections can be revoked (or added) from the
 	// Composio dashboard without this app knowing.
 	try {
+		const refreshStartedAt = Date.now();
 		const client = await getComposioClient(state.apiKey);
 		const accounts = await client.connectedAccounts.list({
 			userIds: [state.userId],
@@ -470,7 +478,10 @@ export async function getComposioStatus(options?: {
 			} else if (
 				remoteAccountId &&
 				(!stored || stored.connectedAccountId !== remoteAccountId) &&
-				!pendingConnections.has(slug)
+				!pendingConnections.has(slug) &&
+				// The remote snapshot predates a local disconnect of this
+				// toolkit; writing it back would resurrect the connection.
+				(lastDisconnectedAt.get(slug) ?? 0) < refreshStartedAt
 			) {
 				toolkits[slug] = {
 					connectedAccountId: remoteAccountId,
@@ -482,9 +493,21 @@ export async function getComposioStatus(options?: {
 			}
 		}
 		if (changed) {
-			state.toolkits = toolkits;
-			writeComposioState(state);
-			syncComposioPluginFile(state, options?.logger);
+			// Re-read before writing: the tool fetches above are slow enough
+			// for a disconnect or key change to have landed meanwhile.
+			const fresh = readComposioState();
+			if (fresh.apiKey !== state.apiKey || fresh.userId !== state.userId) {
+				return buildStatusResponse(fresh);
+			}
+			for (const slug of slugsToReconcile) {
+				if ((lastDisconnectedAt.get(slug) ?? 0) >= refreshStartedAt) {
+					delete toolkits[slug];
+				}
+			}
+			fresh.toolkits = toolkits;
+			writeComposioState(fresh);
+			syncComposioPluginFileQuietly(fresh, options?.logger);
+			return buildStatusResponse(fresh);
 		}
 	} catch (error) {
 		options?.logger?.log?.(
@@ -644,13 +667,26 @@ export async function setComposioApiKey(
 		);
 	}
 	const state = readComposioState();
+	if (state.apiKey !== trimmed) {
+		// In-flight OAuth attempts belong to the previous key's Composio
+		// project; finalizing them under the new key would bind foreign
+		// accounts to it.
+		pendingConnections.clear();
+		lastConnectionErrors.clear();
+	}
 	state.apiKey = trimmed;
 	state.apiKeySource = "user";
 	if (!state.userId) {
 		state.userId = `cline-desktop-${randomUUID()}`;
 	}
 	writeComposioState(state);
-	syncComposioPluginFile(state, logger);
+	try {
+		syncComposioPluginFile(state);
+	} catch (error) {
+		throw new Error(
+			`The key was saved, but updating the local tools plugin failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 	return await getComposioStatus({ refresh: true, logger });
 }
 
@@ -670,7 +706,13 @@ export async function clearComposioApiKey(
 	lastConnectionErrors.clear();
 	cachedClient = null;
 	catalogCache = null;
-	syncComposioPluginFile(state, logger);
+	try {
+		syncComposioPluginFile(state);
+	} catch (error) {
+		throw new Error(
+			`The key was removed, but deleting the local tools plugin failed: ${error instanceof Error ? error.message : String(error)}. Its tools may remain available to new sessions.`,
+		);
+	}
 	// A COMPOSIO_API_KEY env var immediately takes over as the fallback key;
 	// the response reflects that so the UI shows the environment source.
 	reconcileEnvApiKey(state, logger);
@@ -712,6 +754,7 @@ export async function connectComposioToolkit(
 		);
 	}
 	const redirectUrl = connectionRequest.redirectUrl?.trim() || undefined;
+	const guard = { apiKey: state.apiKey, userId: state.userId };
 	if (!redirectUrl) {
 		// No browser step needed (e.g. the account is already authorized on
 		// Composio's side) — finalize right away.
@@ -719,6 +762,7 @@ export async function connectComposioToolkit(
 			client,
 			toolkit,
 			connectionRequest.id,
+			guard,
 			logger,
 		);
 		return {
@@ -733,6 +777,7 @@ export async function connectComposioToolkit(
 		connectedAccountId: connectionRequest.id,
 		redirectUrl,
 		startedAt: Date.now(),
+		...guard,
 	});
 
 	// The OAuth flow finishes in the external browser, which cannot navigate
@@ -744,10 +789,14 @@ export async function connectComposioToolkit(
 			if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
 				return; // Cancelled or superseded while we waited.
 			}
+			// finalizeToolkitConnection re-checks the attempt and the key/user
+			// at write time, so a cancel, disconnect, or key change that lands
+			// during the tool fetch cannot be overwritten by this attempt.
 			await finalizeToolkitConnection(
 				client,
 				toolkit,
 				connectionRequest.id,
+				{ ...guard, attemptId },
 				logger,
 			);
 		} catch (error) {
@@ -797,8 +846,15 @@ export async function disconnectComposioToolkit(
 	if (state.toolkits) {
 		delete state.toolkits[toolkit];
 	}
+	lastDisconnectedAt.set(toolkit, Date.now());
 	writeComposioState(state);
-	syncComposioPluginFile(state, logger);
+	try {
+		syncComposioPluginFile(state);
+	} catch (error) {
+		throw new Error(
+			`The connector was removed, but updating the local tools plugin failed: ${error instanceof Error ? error.message : String(error)}. Its tools may remain available to new sessions.`,
+		);
+	}
 	return buildStatusResponse(state);
 }
 
@@ -838,14 +894,42 @@ async function fetchToolkitTools(
 	return tools;
 }
 
+type FinalizeGuard = {
+	/** Present for browser-flow attempts; the pending entry must still carry
+	 * this id at write time (cancel/disconnect/key changes clear it). */
+	attemptId?: string;
+	/** The key/user the connection was initiated under. */
+	apiKey: string;
+	userId: string;
+};
+
 async function finalizeToolkitConnection(
 	client: ComposioClient,
 	toolkit: ComposioToolkitSlug,
 	connectedAccountId: string,
+	guard: FinalizeGuard,
 	logger?: BasicLogger,
 ): Promise<void> {
 	const tools = await fetchToolkitTools(client, toolkit);
+	// Everything below runs synchronously (no awaits), so these write-time
+	// checks cannot be raced by a cancel, disconnect, or key change that
+	// happened while the tool fetch (or the browser flow) was in flight.
+	if (
+		guard.attemptId &&
+		pendingConnections.get(toolkit)?.attemptId !== guard.attemptId
+	) {
+		logger?.log?.(
+			`composio connect ${toolkit}: attempt superseded before finalize; dropping result`,
+		);
+		return;
+	}
 	const state = readComposioState();
+	if (state.apiKey !== guard.apiKey || state.userId !== guard.userId) {
+		logger?.log?.(
+			`composio connect ${toolkit}: API key or user changed mid-flow; dropping stale connection`,
+		);
+		return;
+	}
 	state.toolkits = {
 		...(state.toolkits ?? {}),
 		[toolkit]: {
@@ -856,8 +940,20 @@ async function finalizeToolkitConnection(
 		},
 	};
 	writeComposioState(state);
-	syncComposioPluginFile(state, logger);
 	logger?.log?.(`composio connected ${toolkit} with ${tools.length} tool(s)`);
+	try {
+		syncComposioPluginFile(state);
+	} catch (error) {
+		// The connection is recorded, but without the plugin file new sessions
+		// get no tools — keep the connector marked connected and surface why
+		// the tools are missing.
+		const reason = error instanceof Error ? error.message : String(error);
+		lastConnectionErrors.set(
+			toolkit,
+			`Connected, but writing the local tools plugin failed: ${reason}. New sessions will not see these tools until it succeeds.`,
+		);
+		logger?.log?.(`composio plugin sync failed after connect: ${reason}`);
+	}
 }
 
 // ── Plugin materialization ───────────────────────────────────────────────
@@ -870,23 +966,35 @@ export function resolveComposioPluginPath(): string {
 	);
 }
 
-function syncComposioPluginFile(
-	state: StoredComposioState,
-	logger?: BasicLogger,
-): void {
+/**
+ * Creates or removes the Hub-loaded plugin file to match the persisted state.
+ * Throws on filesystem failure — callers on user-initiated paths surface the
+ * error (a swallowed failure would report a connector as installed while new
+ * sessions receive no tools); passive read paths use
+ * {@link syncComposioPluginFileQuietly}.
+ */
+function syncComposioPluginFile(state: StoredComposioState): void {
 	const pluginPath = resolveComposioPluginPath();
 	const hasConnectedToolkit =
 		Boolean(state.apiKey) &&
 		Object.values(state.toolkits ?? {}).some(
 			(toolkit) => toolkit && toolkit.tools.length > 0,
 		);
+	if (!hasConnectedToolkit) {
+		rmSync(pluginPath, { force: true });
+		return;
+	}
+	mkdirSync(dirname(pluginPath), { recursive: true });
+	writeFileSync(pluginPath, COMPOSIO_PLUGIN_SOURCE);
+}
+
+/** For status-read reconciliation, which must not throw: log and move on. */
+function syncComposioPluginFileQuietly(
+	state: StoredComposioState,
+	logger?: BasicLogger,
+): void {
 	try {
-		if (!hasConnectedToolkit) {
-			rmSync(pluginPath, { force: true });
-			return;
-		}
-		mkdirSync(dirname(pluginPath), { recursive: true });
-		writeFileSync(pluginPath, COMPOSIO_PLUGIN_SOURCE);
+		syncComposioPluginFile(state);
 	} catch (error) {
 		logger?.log?.(
 			`composio plugin sync failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/examples/desktop-app/webview/components/views/marketplace-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-view.tsx
@@ -27,6 +27,8 @@ import {
 } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { fetchComposioToolkitCatalog } from "@/lib/composio";
+import type { ComposioCatalogToolkit } from "@/lib/composio-types";
 import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import {
 	fetchMarketplaceCatalog,
@@ -37,6 +39,10 @@ import {
 } from "@/lib/marketplace";
 import { cn } from "@/lib/utils";
 import { CommandBadge, PageFrame, PageHeader } from "./page-layout";
+import {
+	ComposioConnectorBrowser,
+	connectorMatchesQuery,
+} from "./settings/composio-connector-browser";
 
 type EntryActionState =
 	| { status: "idle" }
@@ -107,7 +113,7 @@ const primitivePageDetails = {
 const directoryPageDetails: MarketplacePageDetails = {
 	title: "Marketplace",
 	description:
-		"Browse and install plugins, MCP servers, and skills from the Cline marketplace.",
+		"Browse and install plugins, MCP servers, skills, and connectors from the Cline marketplace.",
 	emptyInstalled: "Nothing installed yet.",
 	emptyCatalog: "No marketplace entries match the current filters.",
 	icon: Store,
@@ -659,9 +665,15 @@ export function MarketplaceView({
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [query, setQuery] = useState("");
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
-	const [typeFilter, setTypeFilter] = useState<MarketplacePrimitiveType | null>(
-		defaultTypeFilter ?? null,
-	);
+	const [typeFilter, setTypeFilter] = useState<
+		MarketplacePrimitiveType | "connectors" | null
+	>(defaultTypeFilter ?? null);
+	// Connector catalog (Composio) prefetched for the filter-chip counts; the
+	// fetch is served from the sidecar's hourly cache. Null while unavailable
+	// (no API key, request failed), in which case the chips omit connectors.
+	const [connectorEntries, setConnectorEntries] = useState<
+		ComposioCatalogToolkit[] | null
+	>(null);
 	const [expandedEntryKey, setExpandedEntryKey] = useState<string | null>(null);
 	const [installedEntryKeys, setInstalledEntryKeys] = useState<Set<string>>(
 		() => new Set(),
@@ -698,6 +710,25 @@ export function MarketplaceView({
 			cancelled = true;
 		};
 	}, []);
+
+	useEffect(() => {
+		if (variant !== "directory" || primitive) {
+			return;
+		}
+		let cancelled = false;
+		void fetchComposioToolkitCatalog()
+			.then((response) => {
+				if (!cancelled && response.configured) {
+					setConnectorEntries(response.toolkits);
+				}
+			})
+			.catch(() => {
+				// Counts are cosmetic; the Connectors chip works without them.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [variant, primitive]);
 
 	// Recheck installed status whenever the locally installed items change (e.g.
 	// after a server is deleted through its own card controls) so marketplace
@@ -954,6 +985,19 @@ export function MarketplaceView({
 
 	const installedStatusReady = installedStatusState === "ready";
 
+	const filteredConnectorCount = useMemo(() => {
+		if (!connectorEntries) {
+			return null;
+		}
+		const trimmedQuery = query.trim().toLowerCase();
+		if (!trimmedQuery) {
+			return connectorEntries.length;
+		}
+		return connectorEntries.filter((entry) =>
+			connectorMatchesQuery(entry, trimmedQuery),
+		).length;
+	}, [connectorEntries, query]);
+
 	const typeFilterChips =
 		variant === "directory" && !primitive ? (
 			<div className="flex min-w-0 gap-2 overflow-x-auto pb-1">
@@ -966,7 +1010,7 @@ export function MarketplaceView({
 				>
 					All
 					<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
-						{queryFilteredEntries.length}
+						{queryFilteredEntries.length + (filteredConnectorCount ?? 0)}
 					</span>
 				</Button>
 				{TYPE_FILTER_ORDER.map((type) => (
@@ -986,6 +1030,24 @@ export function MarketplaceView({
 						</span>
 					</Button>
 				))}
+				<Button
+					aria-pressed={typeFilter === "connectors"}
+					onClick={() =>
+						setTypeFilter((current) =>
+							current === "connectors" ? null : "connectors",
+						)
+					}
+					size="sm"
+					type="button"
+					variant={typeFilter === "connectors" ? "default" : "outline"}
+				>
+					Connectors
+					{filteredConnectorCount !== null ? (
+						<span className="rounded bg-background/30 px-1.5 py-0.5 text-xs">
+							{filteredConnectorCount}
+						</span>
+					) : null}
+				</Button>
 			</div>
 		) : null;
 
@@ -1195,27 +1257,53 @@ export function MarketplaceView({
 					) : null}
 
 					{variant !== "installed" ? (
-						<MarketplaceSection
-							actionStates={actionStates}
-							emptyMessage={pageDetails.emptyCatalog}
-							entries={catalogEntries}
-							expandedEntryKey={expandedEntryKey}
-							headerContent={
-								typeFilterChips || marketplaceTagFilters ? (
-									<div className="grid min-w-0 gap-2">
-										{typeFilterChips}
-										{marketplaceTagFilters}
-									</div>
-								) : null
-							}
-							installedEntryKeys={installedEntryKeys}
-							installedStatusReady={installedStatusReady}
-							onInstall={installEntry}
-							onToggleExpanded={toggleExpanded}
-							onUninstall={uninstallEntry}
-							tagLabels={tagLabels}
-							title={variant === "directory" ? undefined : "Browse"}
-						/>
+						typeFilter === "connectors" ? (
+							<div className="grid min-w-0 gap-3">
+								{typeFilterChips}
+								<div aria-hidden="true" className="h-px bg-border/70" />
+								<ComposioConnectorBrowser
+									hideSearch
+									onCatalogLoaded={() => {
+										if (connectorEntries) {
+											return;
+										}
+										// The prefetch missed (key configured later); the
+										// sidecar cache is warm now, so this is instant.
+										void fetchComposioToolkitCatalog()
+											.then((response) => {
+												if (response.configured) {
+													setConnectorEntries(response.toolkits);
+												}
+											})
+											.catch(() => {});
+									}}
+									onOpenSetup={onOpenInstalled}
+									query={query}
+								/>
+							</div>
+						) : (
+							<MarketplaceSection
+								actionStates={actionStates}
+								emptyMessage={pageDetails.emptyCatalog}
+								entries={catalogEntries}
+								expandedEntryKey={expandedEntryKey}
+								headerContent={
+									typeFilterChips || marketplaceTagFilters ? (
+										<div className="grid min-w-0 gap-2">
+											{typeFilterChips}
+											{marketplaceTagFilters}
+										</div>
+									) : null
+								}
+								installedEntryKeys={installedEntryKeys}
+								installedStatusReady={installedStatusReady}
+								onInstall={installEntry}
+								onToggleExpanded={toggleExpanded}
+								onUninstall={uninstallEntry}
+								tagLabels={tagLabels}
+								title={variant === "directory" ? undefined : "Browse"}
+							/>
+						)
 					) : null}
 				</div>
 			) : null}

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { GitHubIcon } from "@cline/ui";
+import { CalendarDays, Loader2, Mail, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { fetchComposioToolkitCatalog } from "@/lib/composio";
+import type {
+	ComposioCatalogToolkit,
+	ComposioIntegrationStatus,
+	ComposioIntegrationSummary,
+	ComposioToolkitSlug,
+} from "@/lib/composio-types";
+import { useComposioConnections } from "@/lib/use-composio-connections";
+
+/**
+ * Browsable Composio connector catalog: search, a fixed-height scrollable
+ * result list (top connectors by usage until the user searches), and a detail
+ * dialog per connector with the connect/disconnect actions.
+ *
+ * Rendered on the Marketplace page's Connectors tab; API key management lives
+ * in Installed > Connectors.
+ */
+
+/** How many catalog entries to show before asking the user to search. */
+const CATALOG_PREVIEW_COUNT = 24;
+const CATALOG_SEARCH_RESULT_LIMIT = 50;
+
+/** Shared with the Marketplace filter chips so connector counts follow the
+ * same search semantics as the list itself. */
+export function connectorMatchesQuery(
+	entry: ComposioCatalogToolkit,
+	trimmedQuery: string,
+): boolean {
+	return (
+		entry.slug.includes(trimmedQuery) ||
+		entry.name.toLowerCase().includes(trimmedQuery) ||
+		entry.description?.toLowerCase().includes(trimmedQuery) ||
+		entry.categories?.some((category) =>
+			category.toLowerCase().includes(trimmedQuery),
+		) ||
+		false
+	);
+}
+
+const FALLBACK_ICONS: Record<
+	string,
+	(props: { className?: string }) => React.ReactNode
+> = {
+	gmail: (props) => <Mail aria-hidden="true" {...props} />,
+	googlecalendar: (props) => <CalendarDays aria-hidden="true" {...props} />,
+	github: (props) => <GitHubIcon {...props} />,
+};
+
+export function ConnectorLogo({
+	slug,
+	name,
+	logo,
+	className = "size-5",
+}: {
+	slug: string;
+	name: string;
+	logo?: string;
+	className?: string;
+}) {
+	const [failed, setFailed] = useState(false);
+	if (logo && !failed) {
+		return (
+			// biome-ignore lint/performance/noImgElement: Composio logos live on arbitrary remote hosts Next's optimizer is not configured for.
+			<img
+				alt=""
+				// The white backing keeps dark brand marks (GitHub's, for one)
+				// visible on dark tiles.
+				className={`${className} rounded-sm bg-white object-contain p-px`}
+				onError={() => setFailed(true)}
+				src={logo}
+			/>
+		);
+	}
+	// Themed fallbacks for the recommended toolkits when the catalog (and its
+	// official logos) has not loaded yet.
+	const LocalIcon = FALLBACK_ICONS[slug];
+	if (LocalIcon) {
+		return <LocalIcon className={className} />;
+	}
+	return (
+		<span className="text-xs font-semibold uppercase text-muted-foreground">
+			{name.slice(0, 1)}
+		</span>
+	);
+}
+
+export function ConnectorActionButton({
+	status,
+	configured,
+	busy,
+	variant = "ghost",
+	showUninstall = false,
+	onConnect,
+	onCancel,
+	onDisconnect,
+	onView,
+}: {
+	status: ComposioIntegrationStatus;
+	configured: boolean;
+	busy: boolean;
+	/** Visual weight of the Install button; state buttons stay subtle. */
+	variant?: "ghost" | "default";
+	/** Installed connectors show an Uninstall action where management is
+	 * expected (the detail dialog, Installed > Connectors); list rows show a
+	 * View button that opens the detail dialog instead. */
+	showUninstall?: boolean;
+	onConnect: () => void;
+	onCancel: () => void;
+	onDisconnect: () => void;
+	/** Opens the detail dialog; used by the View state in list rows. */
+	onView?: () => void;
+}) {
+	if (status === "connected") {
+		if (!showUninstall) {
+			return (
+				<Button
+					onClick={(event) => {
+						event.stopPropagation();
+						onView?.();
+					}}
+					size="sm"
+					type="button"
+					variant={variant}
+				>
+					View
+				</Button>
+			);
+		}
+		return (
+			<Button
+				disabled={busy}
+				onClick={(event) => {
+					event.stopPropagation();
+					onDisconnect();
+				}}
+				size="sm"
+				type="button"
+				variant="destructive"
+			>
+				{busy ? <Loader2 className="size-4 animate-spin" /> : null}
+				Uninstall
+			</Button>
+		);
+	}
+	if (status === "pending") {
+		return (
+			<Button
+				onClick={(event) => {
+					event.stopPropagation();
+					onCancel();
+				}}
+				size="sm"
+				type="button"
+				variant="ghost"
+			>
+				<Loader2 className="size-4 animate-spin" />
+				Cancel
+			</Button>
+		);
+	}
+	return (
+		<Button
+			disabled={!configured || busy}
+			onClick={(event) => {
+				event.stopPropagation();
+				onConnect();
+			}}
+			size="sm"
+			type="button"
+			variant={variant}
+		>
+			{busy ? <Loader2 className="size-4 animate-spin" /> : null}
+			Install
+		</Button>
+	);
+}
+
+export function ComposioConnectorBrowser({
+	onChanged,
+	onOpenSetup,
+	query: externalQuery,
+	hideSearch = false,
+	onCatalogLoaded,
+}: {
+	onChanged?: () => void;
+	/** Navigate to Installed > Connectors, where the API key is managed. */
+	onOpenSetup?: () => void;
+	/** Externally controlled search text (e.g. the Marketplace search bar);
+	 * when provided the built-in search input is usually hidden. */
+	query?: string;
+	hideSearch?: boolean;
+	/** Reports the catalog size, e.g. for a count badge on a filter chip. */
+	onCatalogLoaded?: (count: number) => void;
+}) {
+	const {
+		status,
+		statusBySlug,
+		configured,
+		loadError,
+		actionError,
+		busyToolkit,
+		connect,
+		cancelConnect,
+		disconnect,
+	} = useComposioConnections({ onChanged });
+
+	const [catalog, setCatalog] = useState<ComposioCatalogToolkit[] | null>(null);
+	const [catalogError, setCatalogError] = useState<string | null>(null);
+	const [catalogLoading, setCatalogLoading] = useState(false);
+	const [ownQuery, setOwnQuery] = useState("");
+	const [detailSlug, setDetailSlug] = useState<ComposioToolkitSlug | null>(
+		null,
+	);
+	const query = externalQuery ?? ownQuery;
+
+	const onCatalogLoadedRef = useRef(onCatalogLoaded);
+	useEffect(() => {
+		onCatalogLoadedRef.current = onCatalogLoaded;
+	}, [onCatalogLoaded]);
+
+	const loadCatalog = useCallback(async () => {
+		setCatalogLoading(true);
+		setCatalogError(null);
+		try {
+			const response = await fetchComposioToolkitCatalog();
+			setCatalog(response.toolkits);
+			onCatalogLoadedRef.current?.(response.toolkits.length);
+		} catch (error) {
+			setCatalogError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setCatalogLoading(false);
+		}
+	}, []);
+
+	// The catalog needs an API key; (re)load it once configured.
+	useEffect(() => {
+		if (configured) {
+			void loadCatalog();
+		} else {
+			setCatalog(null);
+		}
+	}, [configured, loadCatalog]);
+
+	const trimmedQuery = query.trim().toLowerCase();
+	const visibleCatalog = useMemo(() => {
+		const entries = catalog ?? [];
+		if (!trimmedQuery) {
+			return entries.slice(0, CATALOG_PREVIEW_COUNT);
+		}
+		return entries
+			.filter((entry) => connectorMatchesQuery(entry, trimmedQuery))
+			.slice(0, CATALOG_SEARCH_RESULT_LIMIT);
+	}, [catalog, trimmedQuery]);
+
+	const hiddenCount = trimmedQuery
+		? 0
+		: Math.max(0, (catalog?.length ?? 0) - CATALOG_PREVIEW_COUNT);
+
+	const detailEntry = detailSlug
+		? (catalog?.find((entry) => entry.slug === detailSlug) ?? null)
+		: null;
+	const detailStatus = detailSlug ? statusBySlug.get(detailSlug) : undefined;
+
+	if (loadError) {
+		return (
+			<p className="text-sm text-destructive" role="alert">
+				Failed to load connectors: {loadError}
+			</p>
+		);
+	}
+
+	if (!status) {
+		return (
+			<output
+				aria-label="Loading connectors"
+				className="flex items-center justify-center py-16"
+			>
+				<Loader2 className="size-6 animate-spin text-muted-foreground" />
+			</output>
+		);
+	}
+
+	if (!configured) {
+		return (
+			<div className="flex flex-col items-start gap-3">
+				<p className="text-sm text-muted-foreground">
+					Add your Composio API key to browse and connect connectors.
+				</p>
+				{onOpenSetup ? (
+					<Button
+						onClick={onOpenSetup}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						Set up in Installed › Connectors
+					</Button>
+				) : null}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<p className="text-sm text-muted-foreground">
+					Connect your accounts to give Cline tools for your favorite apps.
+					Connected tools become available in new sessions.
+				</p>
+				{hideSearch ? null : (
+					<div className="relative">
+						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+						<Input
+							className="h-8 w-64 pl-8"
+							onChange={(event) => setOwnQuery(event.target.value)}
+							placeholder="Search connectors"
+							value={ownQuery}
+						/>
+					</div>
+				)}
+			</div>
+
+			{actionError ? (
+				<p className="text-xs text-destructive" role="alert">
+					{actionError}
+				</p>
+			) : null}
+
+			{catalogLoading && !catalog ? (
+				<output
+					aria-label="Loading connector catalog"
+					className="flex items-center justify-center py-10"
+				>
+					<Loader2 className="size-5 animate-spin text-muted-foreground" />
+				</output>
+			) : catalogError ? (
+				<div className="flex flex-wrap items-center gap-3">
+					<p className="text-xs text-destructive" role="alert">
+						{catalogError}
+					</p>
+					<Button
+						onClick={() => void loadCatalog()}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						Retry
+					</Button>
+				</div>
+			) : (
+				<>
+					{/* Fill the remaining viewport below the marketplace header,
+					    search, and filter chips; scroll inside the box. */}
+					<div className="max-h-[calc(100dvh-370px)] min-h-80 overflow-y-auto pr-1">
+						<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+							{visibleCatalog.map((entry) => (
+								<ConnectorRow
+									busy={busyToolkit === entry.slug}
+									entry={entry}
+									key={entry.slug}
+									onCancel={() => void cancelConnect(entry.slug)}
+									onConnect={() => void connect(entry.slug)}
+									onDisconnect={() => void disconnect(entry.slug)}
+									onOpenDetails={() => setDetailSlug(entry.slug)}
+									status={
+										statusBySlug.get(entry.slug)?.status ?? "not_connected"
+									}
+								/>
+							))}
+						</div>
+						{visibleCatalog.length === 0 ? (
+							<p className="py-4 text-sm text-muted-foreground">
+								No connectors match "{query.trim()}".
+							</p>
+						) : null}
+					</div>
+					{hiddenCount > 0 ? (
+						<p className="text-xs text-muted-foreground">
+							Showing the {CATALOG_PREVIEW_COUNT} most-used connectors — search
+							to find {hiddenCount} more.
+						</p>
+					) : null}
+				</>
+			)}
+
+			<ConnectorDetailDialog
+				busy={detailSlug !== null && busyToolkit === detailSlug}
+				entry={detailEntry}
+				onCancel={() => {
+					if (detailSlug) {
+						void cancelConnect(detailSlug);
+					}
+				}}
+				onConnect={() => {
+					if (detailSlug) {
+						void connect(detailSlug);
+					}
+				}}
+				onDisconnect={() => {
+					if (detailSlug) {
+						void disconnect(detailSlug);
+					}
+				}}
+				onOpenChange={(open) => {
+					if (!open) {
+						setDetailSlug(null);
+					}
+				}}
+				summary={detailStatus}
+			/>
+		</div>
+	);
+}
+
+function ConnectorRow({
+	entry,
+	status,
+	busy,
+	onConnect,
+	onCancel,
+	onDisconnect,
+	onOpenDetails,
+}: {
+	entry: ComposioCatalogToolkit;
+	status: ComposioIntegrationStatus;
+	busy: boolean;
+	onConnect: () => void;
+	onCancel: () => void;
+	onDisconnect: () => void;
+	onOpenDetails: () => void;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-3 rounded-xl border border-border/70 bg-background/60 px-3 py-2.5 transition-colors hover:border-border hover:bg-background">
+			{/* A real button (nested interactives are invalid HTML, so the
+			    connect/disconnect control stays outside it). */}
+			<button
+				className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
+				onClick={onOpenDetails}
+				type="button"
+			>
+				<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+					<ConnectorLogo
+						logo={entry.logo}
+						name={entry.name}
+						slug={entry.slug}
+					/>
+				</span>
+				<span className="min-w-0">
+					<span className="block truncate text-sm font-medium text-foreground">
+						{entry.name}
+					</span>
+					{entry.description ? (
+						<span className="block truncate text-xs text-muted-foreground">
+							{entry.description}
+						</span>
+					) : null}
+				</span>
+			</button>
+			<ConnectorActionButton
+				busy={busy}
+				configured
+				onCancel={onCancel}
+				onConnect={onConnect}
+				onDisconnect={onDisconnect}
+				onView={onOpenDetails}
+				status={status}
+			/>
+		</div>
+	);
+}
+
+function ConnectorDetailDialog({
+	entry,
+	summary,
+	busy,
+	onConnect,
+	onCancel,
+	onDisconnect,
+	onOpenChange,
+}: {
+	entry: ComposioCatalogToolkit | null;
+	summary?: ComposioIntegrationSummary;
+	busy: boolean;
+	onConnect: () => void;
+	onCancel: () => void;
+	onDisconnect: () => void;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const status = summary?.status ?? "not_connected";
+	const toolNames = summary?.toolNames ?? [];
+	return (
+		<Dialog onOpenChange={onOpenChange} open={entry !== null}>
+			{/* Fixed dimensions so every connector opens the same-sized window;
+			    the body scrolls when content overflows. */}
+			<DialogContent className="flex h-[480px] flex-col sm:max-w-lg">
+				{entry ? (
+					<>
+						<DialogHeader>
+							<div className="flex items-center gap-3">
+								<span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary text-foreground">
+									<ConnectorLogo
+										className="size-6"
+										logo={entry.logo}
+										name={entry.name}
+										slug={entry.slug}
+									/>
+								</span>
+								<div>
+									<DialogTitle>{entry.name}</DialogTitle>
+									{entry.categories && entry.categories.length > 0 ? (
+										<div className="mt-1 flex flex-wrap gap-1">
+											{entry.categories.map((category) => (
+												<Badge
+													className="font-normal"
+													key={category}
+													variant="outline"
+												>
+													{category}
+												</Badge>
+											))}
+										</div>
+									) : null}
+								</div>
+							</div>
+						</DialogHeader>
+
+						<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+							{entry.description ? (
+								<DialogDescription className="text-left">
+									{entry.description}
+								</DialogDescription>
+							) : null}
+
+							<dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5 text-sm">
+								{typeof entry.toolsCount === "number" ? (
+									<>
+										<dt className="text-muted-foreground">Tools</dt>
+										<dd className="text-foreground">{entry.toolsCount}</dd>
+									</>
+								) : null}
+								<dt className="text-muted-foreground">Slug</dt>
+								<dd className="font-mono text-xs leading-5 text-foreground">
+									{entry.slug}
+								</dd>
+								{summary?.connectedAt ? (
+									<>
+										<dt className="text-muted-foreground">Connected</dt>
+										<dd className="text-foreground">
+											{new Date(summary.connectedAt).toLocaleString()}
+										</dd>
+									</>
+								) : null}
+							</dl>
+
+							{status === "pending" ? (
+								<p className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+									<Loader2 className="size-4 animate-spin" />
+									Finish authorizing {entry.name} in your browser…
+								</p>
+							) : null}
+
+							{summary?.error ? (
+								<p className="text-xs text-destructive" role="alert">
+									{summary.error}
+								</p>
+							) : null}
+
+							{status === "connected" && toolNames.length > 0 ? (
+								<div>
+									<p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+										{toolNames.length} tool{toolNames.length === 1 ? "" : "s"}{" "}
+										available in new sessions
+									</p>
+									<ul className="flex flex-wrap gap-1.5">
+										{toolNames.map((name) => (
+											<li key={name}>
+												<Badge className="font-normal" variant="outline">
+													{name}
+												</Badge>
+											</li>
+										))}
+									</ul>
+								</div>
+							) : null}
+						</div>
+
+						<DialogFooter>
+							<ConnectorActionButton
+								busy={busy}
+								configured
+								onCancel={onCancel}
+								onConnect={onConnect}
+								onDisconnect={onDisconnect}
+								showUninstall
+								status={status}
+								variant="default"
+							/>
+						</DialogFooter>
+					</>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { ExternalLink, Loader2, Store } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { fetchComposioToolkitCatalog } from "@/lib/composio";
+import {
+	COMPOSIO_DASHBOARD_URL,
+	type ComposioIntegrationSummary,
+} from "@/lib/composio-types";
+import { openExternalUrl } from "@/lib/desktop-client";
+import { useComposioConnections } from "@/lib/use-composio-connections";
+import {
+	ConnectorActionButton,
+	ConnectorLogo,
+} from "./composio-connector-browser";
+
+/**
+ * Installed > Connectors: manage the Composio API key and the connected
+ * accounts. Gmail, Google Calendar, and GitHub are pinned as recommended;
+ * the full catalog is browsed from the Marketplace's Connectors tab.
+ */
+
+export function ComposioConnectorsView({
+	onChanged,
+	onOpenMarketplace,
+}: {
+	onChanged?: () => void;
+	onOpenMarketplace?: () => void;
+}) {
+	const {
+		status,
+		configured,
+		loadError,
+		actionError,
+		busyToolkit,
+		savingKey,
+		saveKey,
+		removeKey,
+		connect,
+		cancelConnect,
+		disconnect,
+	} = useComposioConnections({ onChanged });
+
+	const [apiKeyDraft, setApiKeyDraft] = useState("");
+	const [showKeyEditor, setShowKeyEditor] = useState(false);
+	// Official logos come from the Composio catalog; summaries only carry one
+	// once a toolkit is connected, so join the catalog for the rest.
+	const [logoBySlug, setLogoBySlug] = useState<Map<string, string>>(
+		() => new Map(),
+	);
+
+	useEffect(() => {
+		if (!configured) {
+			return;
+		}
+		let cancelled = false;
+		void fetchComposioToolkitCatalog()
+			.then((response) => {
+				if (cancelled) {
+					return;
+				}
+				const next = new Map<string, string>();
+				for (const entry of response.toolkits) {
+					if (entry.logo) {
+						next.set(entry.slug, entry.logo);
+					}
+				}
+				setLogoBySlug(next);
+			})
+			.catch(() => {
+				// Logos are cosmetic; the themed fallback icons cover this.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [configured]);
+
+	if (loadError) {
+		return (
+			<p className="text-sm text-destructive" role="alert">
+				Failed to load connectors: {loadError}
+			</p>
+		);
+	}
+
+	if (!status) {
+		return (
+			<output
+				aria-label="Loading connectors"
+				className="flex items-center justify-center py-16"
+			>
+				<Loader2 className="size-6 animate-spin text-muted-foreground" />
+			</output>
+		);
+	}
+
+	const envSourced = status.keySource === "environment";
+	const keyEditorOpen = !configured || showKeyEditor;
+	const recommended = status.integrations.filter(
+		(integration) => integration.recommended,
+	);
+	const otherConnected = status.integrations.filter(
+		(integration) =>
+			!integration.recommended && integration.status !== "not_connected",
+	);
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div>
+				<p className="text-sm text-muted-foreground">
+					Connect your accounts through{" "}
+					<button
+						className="inline-flex items-center gap-1 text-foreground underline decoration-muted-foreground/50 underline-offset-2 transition-colors hover:decoration-foreground"
+						onClick={() => void openExternalUrl(COMPOSIO_DASHBOARD_URL)}
+						type="button"
+					>
+						Composio
+						<ExternalLink className="size-3" />
+					</button>{" "}
+					to give Cline tools for your favorite apps. Connected tools become
+					available in new sessions.
+				</p>
+			</div>
+
+			<section className="rounded-2xl border border-border/70 bg-background/60 p-4">
+				<div className="flex flex-wrap items-center justify-between gap-3">
+					<div>
+						<p className="text-sm font-semibold text-foreground">
+							Composio API key
+						</p>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							{envSourced
+								? "Using the COMPOSIO_API_KEY environment variable. Save a key here to override it."
+								: configured
+									? "A key is configured. Tool calls run through your Composio account."
+									: "Create a key in the Composio dashboard, then paste it here to enable connectors."}
+						</p>
+					</div>
+					{configured && !showKeyEditor ? (
+						<div className="flex items-center gap-2">
+							<Badge className="bg-primary/15 text-primary" variant="secondary">
+								{envSourced ? "From environment" : "Configured"}
+							</Badge>
+							<Button
+								onClick={() => setShowKeyEditor(true)}
+								size="sm"
+								type="button"
+								variant="outline"
+							>
+								{envSourced ? "Use custom key" : "Replace key"}
+							</Button>
+							{envSourced ? null : (
+								<Button
+									disabled={savingKey}
+									onClick={() => void removeKey()}
+									size="sm"
+									type="button"
+									variant="ghost"
+								>
+									Remove
+								</Button>
+							)}
+						</div>
+					) : null}
+				</div>
+				{keyEditorOpen ? (
+					<form
+						className="mt-3 flex flex-wrap items-center gap-2"
+						onSubmit={(event) => {
+							event.preventDefault();
+							void saveKey(apiKeyDraft).then((saved) => {
+								if (saved) {
+									setApiKeyDraft("");
+									setShowKeyEditor(false);
+								}
+							});
+						}}
+					>
+						<Input
+							autoComplete="off"
+							className="max-w-sm"
+							onChange={(event) => setApiKeyDraft(event.target.value)}
+							placeholder="Composio API key"
+							type="password"
+							value={apiKeyDraft}
+						/>
+						<Button
+							disabled={savingKey || !apiKeyDraft.trim()}
+							size="sm"
+							type="submit"
+						>
+							{savingKey ? <Loader2 className="size-4 animate-spin" /> : null}
+							Save key
+						</Button>
+						{configured ? (
+							<Button
+								onClick={() => {
+									setShowKeyEditor(false);
+									setApiKeyDraft("");
+								}}
+								size="sm"
+								type="button"
+								variant="ghost"
+							>
+								Cancel
+							</Button>
+						) : null}
+					</form>
+				) : null}
+			</section>
+
+			{actionError ? (
+				<p className="text-xs text-destructive" role="alert">
+					{actionError}
+				</p>
+			) : null}
+
+			<section>
+				<h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					Recommended
+				</h3>
+				<div className="flex flex-col gap-3">
+					{recommended.map((integration) => (
+						<ConnectorCard
+							busy={busyToolkit === integration.toolkit}
+							configured={configured}
+							integration={integration}
+							key={integration.toolkit}
+							logo={integration.logo ?? logoBySlug.get(integration.toolkit)}
+							onCancel={() => void cancelConnect(integration.toolkit)}
+							onConnect={() => void connect(integration.toolkit)}
+							onDisconnect={() => void disconnect(integration.toolkit)}
+						/>
+					))}
+				</div>
+			</section>
+
+			{otherConnected.length > 0 ? (
+				<section>
+					<h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						Also connected
+					</h3>
+					<div className="flex flex-col gap-3">
+						{otherConnected.map((integration) => (
+							<ConnectorCard
+								busy={busyToolkit === integration.toolkit}
+								configured={configured}
+								integration={integration}
+								key={integration.toolkit}
+								logo={integration.logo ?? logoBySlug.get(integration.toolkit)}
+								onCancel={() => void cancelConnect(integration.toolkit)}
+								onConnect={() => void connect(integration.toolkit)}
+								onDisconnect={() => void disconnect(integration.toolkit)}
+							/>
+						))}
+					</div>
+				</section>
+			) : null}
+
+			{onOpenMarketplace ? (
+				<div>
+					<Button
+						onClick={onOpenMarketplace}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						<Store className="size-4" />
+						Browse all connectors in the Marketplace
+					</Button>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function ConnectorCard({
+	integration,
+	logo,
+	configured,
+	busy,
+	onConnect,
+	onCancel,
+	onDisconnect,
+}: {
+	integration: ComposioIntegrationSummary;
+	logo?: string;
+	configured: boolean;
+	busy: boolean;
+	onConnect: () => void;
+	onCancel: () => void;
+	onDisconnect: () => void;
+}) {
+	const toolNames = integration.toolNames ?? [];
+	return (
+		<div className="rounded-2xl border border-border/70 bg-background/60 p-4">
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+						<ConnectorLogo
+							logo={logo}
+							name={integration.name}
+							slug={integration.toolkit}
+						/>
+					</span>
+					<div>
+						<p className="text-sm font-semibold text-foreground">
+							{integration.name}
+						</p>
+						{integration.description ? (
+							<p className="mt-0.5 text-xs text-muted-foreground">
+								{integration.description}
+							</p>
+						) : null}
+					</div>
+				</div>
+				<ConnectorActionButton
+					busy={busy}
+					configured={configured}
+					onCancel={onCancel}
+					onConnect={onConnect}
+					onDisconnect={onDisconnect}
+					showUninstall
+					status={integration.status}
+					variant="default"
+				/>
+			</div>
+
+			{integration.status === "pending" ? (
+				<p className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground">
+					<Loader2 className="size-4 animate-spin" />
+					Finish authorizing {integration.name} in your browser…
+				</p>
+			) : null}
+
+			{integration.error ? (
+				<p className="mt-2 text-xs text-destructive" role="alert">
+					{integration.error}
+				</p>
+			) : null}
+
+			{integration.status === "connected" && toolNames.length > 0 ? (
+				<details className="mt-3 border-t border-border/70 pt-3">
+					<summary className="cursor-pointer text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						{toolNames.length} tool{toolNames.length === 1 ? "" : "s"} available
+						in new sessions
+					</summary>
+					<ul className="mt-2 flex flex-wrap gap-1.5">
+						{toolNames.map((name) => (
+							<li key={name}>
+								<Badge className="font-normal" variant="outline">
+									{name}
+								</Badge>
+							</li>
+						))}
+					</ul>
+				</details>
+			) : null}
+		</div>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
@@ -2,9 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { fetchComposioStatus } from "@/lib/composio";
 import { desktopClient } from "@/lib/desktop-client";
 import { cn } from "@/lib/utils";
 import { PageFrame, PageHeader } from "../page-layout";
+import { ComposioConnectorBrowser } from "./composio-connector-browser";
+import { ComposioConnectorsView } from "./composio-connectors-view";
 import { CustomizationSectionView } from "./extensions-view";
 import { McpServersContent } from "./mcp-view";
 
@@ -16,7 +19,14 @@ import { McpServersContent } from "./mcp-view";
  * there is no separate Marketplace page.
  */
 
-type CustomizeTab = "skills" | "mcp" | "plugins" | "rules" | "hooks" | "tools";
+type CustomizeTab =
+	| "skills"
+	| "mcp"
+	| "integrations"
+	| "plugins"
+	| "rules"
+	| "hooks"
+	| "tools";
 
 const CUSTOMIZE_TABS: { id: CustomizeTab; label: string }[] = [
 	{ id: "skills", label: "Skills" },
@@ -25,6 +35,7 @@ const CUSTOMIZE_TABS: { id: CustomizeTab; label: string }[] = [
 	{ id: "rules", label: "Rules" },
 	{ id: "hooks", label: "Hooks" },
 	{ id: "tools", label: "Tools" },
+	{ id: "integrations", label: "Connectors" },
 ];
 
 type TabCounts = Partial<Record<CustomizeTab, number>>;
@@ -48,15 +59,30 @@ export function CustomizeView() {
 	const [counts, setCounts] = useState<TabCounts>({});
 
 	const refreshCounts = useCallback(async () => {
-		const inventory = await desktopClient
-			.invoke<HubInventoryResponse>("list_user_instruction_configs")
-			.catch(() => null);
+		const [inventory, composioStatus] = await Promise.all([
+			desktopClient
+				.invoke<HubInventoryResponse>("list_user_instruction_configs")
+				.catch(() => null),
+			fetchComposioStatus().catch(() => null),
+		]);
+		const connectedIntegrations = composioStatus
+			? composioStatus.integrations.filter(
+					(integration) => integration.status === "connected",
+				).length
+			: undefined;
 		if (!inventory) {
+			if (connectedIntegrations !== undefined) {
+				setCounts((previous) => ({
+					...previous,
+					integrations: connectedIntegrations,
+				}));
+			}
 			return;
 		}
 		setCounts({
 			skills: asCount(inventory.skills) + asCount(inventory.workflows),
 			mcp: asCount(inventory.mcp?.servers),
+			integrations: connectedIntegrations,
 			plugins: asCount(inventory.plugins),
 			rules: asCount(inventory.rules),
 			hooks: asCount(inventory.hooks),
@@ -134,6 +160,19 @@ export function CustomizeView() {
 					chrome="embedded"
 					onInventoryChanged={handleInventoryChanged}
 				/>
+			) : tab === "integrations" ? (
+				// Installed connectors + key management, with the browsable
+				// catalog inline below — this branch has no separate
+				// Marketplace page, so the tab is the whole surface.
+				<div className="flex flex-col gap-8">
+					<ComposioConnectorsView onChanged={handleInventoryChanged} />
+					<section>
+						<h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							All connectors
+						</h3>
+						<ComposioConnectorBrowser onChanged={handleInventoryChanged} />
+					</section>
+				</div>
 			) : tab === "plugins" ? (
 				<CustomizationSectionView
 					catalogPrimitive="plugin"

--- a/apps/examples/desktop-app/webview/lib/composio-types.ts
+++ b/apps/examples/desktop-app/webview/lib/composio-types.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared shapes for the Composio connectors feature (Gmail, Google Calendar,
+ * GitHub, and the wider Composio toolkit catalog). Imported by both the
+ * webview and the sidecar, mirroring `cline-integrations-types.ts`.
+ */
+
+/** A Composio toolkit slug, e.g. "gmail", "googlecalendar", "github". */
+export type ComposioToolkitSlug = string;
+
+const TOOLKIT_SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isComposioToolkitSlug(
+	value: unknown,
+): value is ComposioToolkitSlug {
+	return typeof value === "string" && TOOLKIT_SLUG_PATTERN.test(value);
+}
+
+export type ComposioIntegrationStatus =
+	| "not_connected"
+	/** Auth flow started; waiting for the browser OAuth flow to finish. */
+	| "pending"
+	| "connected";
+
+export type ComposioIntegrationSummary = {
+	toolkit: ComposioToolkitSlug;
+	name: string;
+	description: string;
+	/** Logo URL from the Composio catalog, when known. */
+	logo?: string;
+	/** True for the curated toolkits pinned at the top of the Connectors UI. */
+	recommended: boolean;
+	status: ComposioIntegrationStatus;
+	connectedAccountId?: string;
+	connectedAt?: string;
+	toolNames?: string[];
+	/** Why the most recent connection attempt failed, if it did. */
+	error?: string;
+};
+
+export type ComposioStatusResponse = {
+	/** True once a Composio API key is available. */
+	configured: boolean;
+	/**
+	 * Where the active key came from: entered in Settings ("user") or the
+	 * sidecar's COMPOSIO_API_KEY environment variable ("environment").
+	 * Absent when unconfigured.
+	 */
+	keySource?: "user" | "environment";
+	/**
+	 * The recommended toolkits (always present) plus any other toolkit that
+	 * is currently connected or mid-connection.
+	 */
+	integrations: ComposioIntegrationSummary[];
+};
+
+export type ComposioConnectResponse = {
+	/** OAuth URL the user finishes in the external browser. Empty when the
+	 * toolkit turned out to already be connected. */
+	redirectUrl?: string;
+	alreadyConnected?: boolean;
+	status: ComposioStatusResponse;
+};
+
+/** One entry in the browsable Composio toolkit catalog. */
+export type ComposioCatalogToolkit = {
+	slug: ComposioToolkitSlug;
+	name: string;
+	description?: string;
+	logo?: string;
+	categories?: string[];
+	toolsCount?: number;
+	recommended: boolean;
+};
+
+export type ComposioCatalogResponse = {
+	/** True once a Composio API key is available. */
+	configured: boolean;
+	/** Usage-ranked toolkit catalog; empty until a key is configured. */
+	toolkits: ComposioCatalogToolkit[];
+};
+
+export type ComposioRecommendedToolkit = {
+	slug: ComposioToolkitSlug;
+	name: string;
+	description: string;
+};
+
+/** The connectors pinned as "Recommended". Order controls display order. */
+export const COMPOSIO_RECOMMENDED_TOOLKITS: ComposioRecommendedToolkit[] = [
+	{
+		slug: "gmail",
+		name: "Gmail",
+		description: "Read, search, draft, and send email from your Gmail account.",
+	},
+	{
+		slug: "googlecalendar",
+		name: "Google Calendar",
+		description: "List, create, and update events on your Google Calendar.",
+	},
+	{
+		slug: "github",
+		name: "GitHub",
+		description: "Work with issues, pull requests, and repositories on GitHub.",
+	},
+];
+
+export function findRecommendedToolkit(
+	slug: string,
+): ComposioRecommendedToolkit | undefined {
+	return COMPOSIO_RECOMMENDED_TOOLKITS.find((entry) => entry.slug === slug);
+}
+
+/** Where users create a Composio API key. */
+export const COMPOSIO_DASHBOARD_URL = "https://platform.composio.dev";

--- a/apps/examples/desktop-app/webview/lib/composio.ts
+++ b/apps/examples/desktop-app/webview/lib/composio.ts
@@ -1,0 +1,78 @@
+import type {
+	ComposioCatalogResponse,
+	ComposioConnectResponse,
+	ComposioStatusResponse,
+	ComposioToolkitSlug,
+} from "./composio-types";
+import { desktopClient } from "./desktop-client";
+
+/**
+ * Webview client for the sidecar's `composio_integrations` command — the
+ * management plane for the Gmail / Google Calendar / GitHub integrations.
+ */
+
+/** `connect` performs a round-trip to Composio (create auth config, initiate
+ * the connection) before it can return the OAuth URL — give it headroom. */
+const CONNECT_TIMEOUT_MS = 60_000;
+
+export function fetchComposioStatus(options?: {
+	refresh?: boolean;
+}): Promise<ComposioStatusResponse> {
+	return desktopClient.invoke<ComposioStatusResponse>("composio_integrations", {
+		operation: "status",
+		refresh: options?.refresh === true,
+	});
+}
+
+export function fetchComposioToolkitCatalog(): Promise<ComposioCatalogResponse> {
+	return desktopClient.invoke<ComposioCatalogResponse>(
+		"composio_integrations",
+		{ operation: "listToolkits" },
+		{ timeoutMs: CONNECT_TIMEOUT_MS },
+	);
+}
+
+export function saveComposioApiKey(
+	apiKey: string,
+): Promise<ComposioStatusResponse> {
+	return desktopClient.invoke<ComposioStatusResponse>(
+		"composio_integrations",
+		{ operation: "setApiKey", apiKey },
+		{ timeoutMs: CONNECT_TIMEOUT_MS },
+	);
+}
+
+export function clearComposioApiKey(): Promise<ComposioStatusResponse> {
+	return desktopClient.invoke<ComposioStatusResponse>("composio_integrations", {
+		operation: "clearApiKey",
+	});
+}
+
+export function connectComposioIntegration(
+	toolkit: ComposioToolkitSlug,
+): Promise<ComposioConnectResponse> {
+	return desktopClient.invoke<ComposioConnectResponse>(
+		"composio_integrations",
+		{ operation: "connect", toolkit },
+		{ timeoutMs: CONNECT_TIMEOUT_MS },
+	);
+}
+
+export function cancelComposioConnect(
+	toolkit: ComposioToolkitSlug,
+): Promise<ComposioStatusResponse> {
+	return desktopClient.invoke<ComposioStatusResponse>("composio_integrations", {
+		operation: "cancelConnect",
+		toolkit,
+	});
+}
+
+export function disconnectComposioIntegration(
+	toolkit: ComposioToolkitSlug,
+): Promise<ComposioStatusResponse> {
+	return desktopClient.invoke<ComposioStatusResponse>(
+		"composio_integrations",
+		{ operation: "disconnect", toolkit },
+		{ timeoutMs: CONNECT_TIMEOUT_MS },
+	);
+}

--- a/apps/examples/desktop-app/webview/lib/use-composio-connections.ts
+++ b/apps/examples/desktop-app/webview/lib/use-composio-connections.ts
@@ -1,0 +1,210 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	cancelComposioConnect,
+	clearComposioApiKey,
+	connectComposioIntegration,
+	disconnectComposioIntegration,
+	fetchComposioStatus,
+	saveComposioApiKey,
+} from "./composio";
+import type {
+	ComposioStatusResponse,
+	ComposioToolkitSlug,
+} from "./composio-types";
+
+const CONNECT_POLL_INTERVAL_MS = 3_000;
+
+/**
+ * Shared state machine for Composio connections, used by both the Customize >
+ * Connectors tab and the Marketplace connector browser.
+ *
+ * The OAuth flow finishes in the external browser, which cannot navigate the
+ * app back, so while a connection is pending this hook polls the sidecar
+ * until the connection lands — the same pattern as the GitHub App install
+ * step in onboarding.
+ */
+export function useComposioConnections({
+	onChanged,
+}: {
+	onChanged?: () => void;
+} = {}) {
+	const [status, setStatus] = useState<ComposioStatusResponse | null>(null);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [actionError, setActionError] = useState<string | null>(null);
+	const [busyToolkit, setBusyToolkit] = useState<ComposioToolkitSlug | null>(
+		null,
+	);
+	const [savingKey, setSavingKey] = useState(false);
+
+	const onChangedRef = useRef(onChanged);
+	useEffect(() => {
+		onChangedRef.current = onChanged;
+	}, [onChanged]);
+
+	const applyStatus = useCallback((next: ComposioStatusResponse) => {
+		setStatus(next);
+		onChangedRef.current?.();
+	}, []);
+
+	// Initial load reconciles against Composio (connections can be revoked
+	// from the Composio dashboard without this app knowing).
+	useEffect(() => {
+		let cancelled = false;
+		void (async () => {
+			try {
+				const initial = await fetchComposioStatus({ refresh: true });
+				if (!cancelled) {
+					setStatus(initial);
+				}
+			} catch (error) {
+				if (!cancelled) {
+					setLoadError(error instanceof Error ? error.message : String(error));
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const hasPending = useMemo(
+		() =>
+			status?.integrations.some(
+				(integration) => integration.status === "pending",
+			) ?? false,
+		[status],
+	);
+
+	useEffect(() => {
+		if (!hasPending) {
+			return;
+		}
+		let cancelled = false;
+		let inFlight = false;
+		const interval = setInterval(() => {
+			if (inFlight) {
+				return;
+			}
+			inFlight = true;
+			void fetchComposioStatus()
+				.then((next) => {
+					if (!cancelled) {
+						applyStatus(next);
+					}
+				})
+				.catch(() => {
+					// Transient failures keep polling; the user can cancel.
+				})
+				.finally(() => {
+					inFlight = false;
+				});
+		}, CONNECT_POLL_INTERVAL_MS);
+		return () => {
+			cancelled = true;
+			clearInterval(interval);
+		};
+	}, [hasPending, applyStatus]);
+
+	const saveKey = useCallback(
+		async (apiKey: string): Promise<boolean> => {
+			const trimmed = apiKey.trim();
+			if (!trimmed) {
+				return false;
+			}
+			setSavingKey(true);
+			setActionError(null);
+			try {
+				applyStatus(await saveComposioApiKey(trimmed));
+				return true;
+			} catch (error) {
+				setActionError(error instanceof Error ? error.message : String(error));
+				return false;
+			} finally {
+				setSavingKey(false);
+			}
+		},
+		[applyStatus],
+	);
+
+	const removeKey = useCallback(async () => {
+		setSavingKey(true);
+		setActionError(null);
+		try {
+			applyStatus(await clearComposioApiKey());
+		} catch (error) {
+			setActionError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setSavingKey(false);
+		}
+	}, [applyStatus]);
+
+	const connect = useCallback(
+		async (toolkit: ComposioToolkitSlug) => {
+			setBusyToolkit(toolkit);
+			setActionError(null);
+			try {
+				const result = await connectComposioIntegration(toolkit);
+				applyStatus(result.status);
+			} catch (error) {
+				setActionError(error instanceof Error ? error.message : String(error));
+			} finally {
+				setBusyToolkit(null);
+			}
+		},
+		[applyStatus],
+	);
+
+	const cancelConnect = useCallback(
+		async (toolkit: ComposioToolkitSlug) => {
+			try {
+				applyStatus(await cancelComposioConnect(toolkit));
+			} catch {
+				// Cancel is best-effort; the poll loop will settle the state.
+			}
+		},
+		[applyStatus],
+	);
+
+	const disconnect = useCallback(
+		async (toolkit: ComposioToolkitSlug) => {
+			setBusyToolkit(toolkit);
+			setActionError(null);
+			try {
+				applyStatus(await disconnectComposioIntegration(toolkit));
+			} catch (error) {
+				setActionError(error instanceof Error ? error.message : String(error));
+			} finally {
+				setBusyToolkit(null);
+			}
+		},
+		[applyStatus],
+	);
+
+	const statusBySlug = useMemo(() => {
+		const map = new Map<
+			string,
+			ComposioStatusResponse["integrations"][number]
+		>();
+		for (const integration of status?.integrations ?? []) {
+			map.set(integration.toolkit, integration);
+		}
+		return map;
+	}, [status]);
+
+	return {
+		status,
+		statusBySlug,
+		configured: status?.configured ?? false,
+		loadError,
+		actionError,
+		busyToolkit,
+		savingKey,
+		saveKey,
+		removeKey,
+		connect,
+		cancelConnect,
+		disconnect,
+	};
+}

--- a/bun.lock
+++ b/bun.lock
@@ -176,6 +176,7 @@
         "@cline/llms": "workspace:*",
         "@cline/shared": "workspace:*",
         "@cline/ui": "workspace:*",
+        "@composio/core": "^0.18.0",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
         "@hookform/resolvers": "^3.9.1",
@@ -1116,6 +1117,12 @@
     "@cline/vscode-rollout": ["@cline/vscode-rollout@workspace:apps/vscode-rollout"],
 
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@composio/client": ["@composio/client@0.1.0-alpha.76", "", {}, "sha512-MXC5JGRVdiQ4EgLricy9o/mqBa1+1T7wHFZ6Q4ZJkrjzZqOMvxTgy21Zlb5J/1oGkB2bg9UDzpH8PkXCp/D4zA=="],
+
+    "@composio/core": ["@composio/core@0.18.0", "", { "dependencies": { "@composio/client": "0.1.0-alpha.76", "@composio/json-schema-to-zod": "0.3.1", "@types/json-schema": "^7.0.15", "is-fs-case-sensitive": "^2.0.0", "openai": "^7.2.0", "picocolors": "^1.1.1", "pusher-js": "^8.6.0", "semver": "^7.8.5", "undici": "^7.29.0", "zod-to-json-schema": "^3.25.2" }, "peerDependencies": { "zod": ">=3.25.76 <5" } }, "sha512-u8dfSDJV+BYiQYJBxbk6xRI8o8f7O6nb8xE0rJmvC+8zKNJdY/M119R8a30grLh07a6fcLeVFYCJlTRpCjwKyg=="],
+
+    "@composio/json-schema-to-zod": ["@composio/json-schema-to-zod@0.3.1", "", { "peerDependencies": { "zod": ">=3.25.76 <5" } }, "sha512-ZmDksfKZrkJZj6XCgR+AmjsxqvFnfc4XDEQPfJJZMYxIqhE3MBZ2KimLuPT+YGahO4h9uzT2EYi9asMF4qR4+g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -3717,6 +3724,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fs-case-sensitive": ["is-fs-case-sensitive@2.0.0", "", {}, "sha512-JoCsyGITdYPM+pUbeMQ4IiEuQ4wjPdeWORlG7n644isewbcxiQIr+9gmF5k7UabTP/jLBRkbgydEamR7JZBKHA=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -4413,6 +4422,8 @@
 
     "puppeteer-core": ["puppeteer-core@23.11.1", "", { "dependencies": { "@puppeteer/browsers": "2.6.1", "chromium-bidi": "0.11.0", "debug": "^4.4.0", "devtools-protocol": "0.0.1367902", "typed-query-selector": "^2.12.0", "ws": "^8.18.0" } }, "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg=="],
 
+    "pusher-js": ["pusher-js@8.6.0", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-wShJPfCS/kYkCBVzVW67wa9cnQIgHTszEK2XHNrFkOgGruuGw081aERAxfRjfdFU+WcIt8x6dvbwkTW4iZuQ8Q=="],
+
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
@@ -4905,6 +4916,8 @@
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
@@ -5190,6 +5203,8 @@
     "@cline/vscode-rollout/@types/vscode": ["@types/vscode@1.84.0", "", {}, "sha512-lCGOSrhT3cL+foUEqc8G1PVZxoDbiMmxgnUZZTEnHF4mC47eKAUtBGAuMLY6o6Ua8PAuNCoKXbqPmJd1JYnQfg=="],
 
     "@cline/vscode-rollout/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@composio/core/openai": ["openai@7.8.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "undici": ">=5 <9", "ws": "^8.21.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "undici", "ws", "zod"] }, "sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 


### PR DESCRIPTION
## What

Port of the **Composio connectors** feature (#13684, `bee/poc-connectors-composio` on `main`) onto `desktop-experimental`, so the beta channel gets it too.

Same feature set as #13684 — Gmail / Google Calendar / GitHub recommended connectors, the connectable-only Composio catalog (~usage-ranked, filtered to toolkits with managed credentials or a project auth config), OAuth via the system browser, tools materialized as a Hub-loaded single-file plugin, Composio API key management with `COMPOSIO_API_KEY` env fallback, Install / View rows with Uninstall in the fixed-size detail dialog.

## Branch adaptation

`desktop-experimental` has no separate Marketplace page (marketplace browsing is inline per Customize tab), so the integration point differs from main:

- The **Customize → Connectors tab** hosts everything: the installed view (key management, recommended, connected accounts) with the browsable **All connectors** catalog inline below — matching this branch's `marketplaceVariant="full"` philosophy.
- The Marketplace-page filter-chip wiring from main is kept in `marketplace-view.tsx` but is dormant here (the `directory` variant is unreachable on this branch); keeping it aligned makes the eventual main ↔ experimental merge cleaner.

Applied as a single squashed commit (the three main commits create-then-delete an intermediate file, so sequential cherry-picks churn); one conflict in `marketplace-view.tsx` resolved by wrapping this branch's simplified section header in the connectors render branch.

## Testing

- `bunx vitest run sidecar/composio.test.ts` — 22/22 on this base
- `bun run typecheck` and biome clean on this base
- Feature verified end to end on main against a live Composio project (see #13684)