### PR TITLE
docs: fix typo overwriten -> overwritten

### DIFF
--- a/apps/vscode/src/shared/constants.ts
+++ b/apps/vscode/src/shared/constants.ts
@@ -1,5 +1,5 @@
 /**
- * `BUILD_CONSTANTS` represent the variables that will be overwriten at build-time with predefined values.
+ * `BUILD_CONSTANTS` represent the variables that will be overwritten at build-time with predefined values.
  * Once the extension has been built, the values in this object will be fixed.
  *
  * @see [esbuild.mjs](../../esbuild.mjs)


### PR DESCRIPTION
Corrects the misspelling `overwriten` -> `overwritten` in `apps/vscode/src/shared/constants.ts`.

Documentation only, no behaviour change.