### PR TITLE
fix(sdk): stop re-truncating budgeted tool output, and make truncation limits configurable

### DIFF
--- a/apps/vscode/src/sdk/vscode-file-read-executor.ts
+++ b/apps/vscode/src/sdk/vscode-file-read-executor.ts
@@ -1,4 +1,4 @@
-import { createDefaultExecutors, type ToolExecutors } from "@cline/core"
+import { createDefaultExecutors, resolveContextLimits, type ToolExecutors } from "@cline/core"
 import * as path from "path"
 
 type FileReadExecutor = NonNullable<ToolExecutors["readFile"]>
@@ -13,7 +13,16 @@ type FileReadExecutor = NonNullable<ToolExecutors["readFile"]>
  * and editor tools already run against the workspace root; this makes reads match.
  */
 export function createWorkspaceFileReadExecutor(getWorkspaceRoot: () => Promise<string>): FileReadExecutor {
-	const readFile = createDefaultExecutors().readFile
+	// Without resolved limits this executor would silently keep the compiled
+	// defaults, ignoring every CLINE_TOOL_* override the rest of the host honors.
+	const limits = resolveContextLimits().tool
+	const readFile = createDefaultExecutors({
+		fileRead: {
+			maxReadLines: limits.readLines,
+			maxLineChars: limits.lineChars,
+			maxReadOutputChars: limits.readOutputChars,
+		},
+	}).readFile
 	if (!readFile) {
 		throw new Error("SDK default executors did not provide a readFile executor")
 	}

--- a/apps/vscode/src/sdk/vscode-run-commands-tool.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.ts
@@ -15,9 +15,10 @@ import {
 	CommandExitError,
 	createShellExecutor,
 	createShellTool,
-	MAX_COMMAND_OUTPUT_CHARS,
+	resolveContextLimits,
 	type ShellExecutor,
 	type StructuredCommandInput,
+	type ToolContextLimits,
 	truncateCommandOutput,
 } from "@cline/core"
 import type { AgentTool } from "@cline/shared"
@@ -528,9 +529,11 @@ function takeShellSnapshot(): ShellSnapshot {
  */
 export function createVscodeRunCommandsTool(options: VscodeRunCommandsToolOptions): AgentTool {
 	const state = { snapshot: takeShellSnapshot() }
-	return createShellTool(createVscodeShellExecutor(options, state), {
+	const limits = resolveContextLimits().tool
+	return createShellTool(createVscodeShellExecutor(options, state, limits), {
 		cwd: options.cwd,
 		bashTimeoutMs: options.bashTimeoutMs,
+		limits,
 		shell: () => {
 			state.snapshot = takeShellSnapshot()
 			return state.snapshot.shell
@@ -538,7 +541,11 @@ export function createVscodeRunCommandsTool(options: VscodeRunCommandsToolOption
 	})
 }
 
-function createVscodeShellExecutor(options: VscodeRunCommandsToolOptions, state: { snapshot: ShellSnapshot }): ShellExecutor {
+function createVscodeShellExecutor(
+	options: VscodeRunCommandsToolOptions,
+	state: { snapshot: ShellSnapshot },
+	limits: ToolContextLimits,
+): ShellExecutor {
 	const { cwd, getTerminalManager } = options
 	const executionMode = options.vscodeTerminalExecutionMode ?? "vscodeTerminal"
 
@@ -563,6 +570,7 @@ function createVscodeShellExecutor(options: VscodeRunCommandsToolOptions, state:
 				bgExecutorShell = shell
 				bgExecutor = createShellExecutor({
 					shell,
+					maxOutputChars: limits.commandOutputChars,
 					// Set SHELL env to match the shell we're spawning so child
 					// processes see the correct value instead of the inherited parent's.
 					env: { SHELL: shell },
@@ -595,7 +603,7 @@ function createVscodeShellExecutor(options: VscodeRunCommandsToolOptions, state:
 			command,
 			commandCwd || cwd,
 			terminalManager,
-			MAX_COMMAND_OUTPUT_CHARS,
+			limits.commandOutputChars,
 			context.signal,
 			options.foregroundCommands,
 			profileId,

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -14,6 +14,36 @@ export interface StartSessionResult {
 
 export const MAX_COMMAND_OUTPUT_CHARS = 200_000
 
+export const DEFAULT_CONTEXT_LIMITS = {
+	message: {
+		toolResultChars: 50_000,
+		fileContentChars: 50_000,
+		totalTextBytes: 6_000_000,
+		assistantTextChars: 200_000,
+		assistantToolMarkupChars: 12_000,
+		minOutdatedRewriteBytes: 65_536,
+	},
+	tool: {
+		commandOutputChars: 48_000,
+		readLines: 2_000,
+		lineChars: 2_000,
+		readOutputChars: 48_000,
+		searchOutputChars: 48_000,
+		webFetchContentChars: 50_000,
+		editorInputChars: 50_000,
+		commandInputChars: 12_000,
+		editorDiffLines: 200,
+		commandPreviewChars: 200,
+	},
+}
+
+export type ContextLimits = typeof DEFAULT_CONTEXT_LIMITS
+export type ToolContextLimits = ContextLimits["tool"]
+
+export function resolveContextLimits() {
+	return DEFAULT_CONTEXT_LIMITS
+}
+
 export interface StoredModelEntry {
 	id?: string
 	name?: string

--- a/docs/getting-started/config.mdx
+++ b/docs/getting-started/config.mdx
@@ -115,6 +115,8 @@ cline dev log
 | `CLINE_SANDBOX_DATA_DIR` | Sandbox session storage directory |
 | `CLINE_HOOKS_DIR` | Additional hooks directory |
 | `CLINE_COMMAND_PERMISSIONS` | JSON policy restricting shell commands |
+| `CLINE_TOOL_MAX_*` | Caps on what each tool returns and accepts ([Context limits](#context-limits)) |
+| `CLINE_MESSAGE_BUILDER_*` | Caps on the text in each provider request ([Context limits](#context-limits)) |
 
 ### CLINE_DATA_DIR
 
@@ -146,6 +148,42 @@ Rules:
 - `deny` overrides `allow`
 - If `allow` is set, commands not matching `allow` are denied
 - `allowRedirects` controls shell redirects (`>`, `>>`, `<`), default `false`
+
+### Context limits
+
+Cap how much text moves between the model and its tools. Values are characters
+unless the name says bytes or lines.
+
+| Variable | Default | Governs |
+|----------|---------|---------|
+| `CLINE_TOOL_MAX_COMMAND_OUTPUT_CHARS` | `48000` | `run_commands` output; beyond this the middle is elided |
+| `CLINE_TOOL_MAX_READ_LINES` | `2000` | Lines per `read_files` window |
+| `CLINE_TOOL_MAX_LINE_CHARS` | `2000` | Characters per line in reads and search results |
+| `CLINE_TOOL_MAX_READ_OUTPUT_CHARS` | `48000` | Characters per `read_files` window |
+| `CLINE_TOOL_MAX_SEARCH_OUTPUT_CHARS` | `48000` | `search_codebase` output per query |
+| `CLINE_TOOL_MAX_WEB_FETCH_CONTENT_CHARS` | `48000` | Page content kept per `fetch_web_content` request |
+| `CLINE_TOOL_MAX_EDITOR_INPUT_CHARS` | `50000` | `old_text`/`new_text` accepted per `editor` call |
+| `CLINE_TOOL_MAX_COMMAND_INPUT_CHARS` | `12000` | Length of a single shell command |
+| `CLINE_TOOL_MAX_EDITOR_DIFF_LINES` | `200` | Diff lines in the `editor` result summary |
+| `CLINE_TOOL_MAX_COMMAND_PREVIEW_CHARS` | `200` | Command text echoed back in the tool result |
+| `CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS` | `50000` | Each tool result forwarded to the model |
+| `CLINE_MESSAGE_BUILDER_MAX_FILE_CONTENT_CHARS` | `50000` | Each file attached to a message |
+| `CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES` | `6000000` | Text across the whole request |
+| `CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TEXT_CHARS` | `200000` | Each assistant message |
+| `CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TOOL_MARKUP_CHARS` | `12000` | Assistant text carrying repeated tool-call markup |
+| `CLINE_MESSAGE_BUILDER_MIN_OUTDATED_REWRITE_BYTES` | `65536` | Reclaimable bytes before stale file reads are rewritten |
+
+Rules:
+
+- Values that are not positive integers are ignored, and the default applies
+- Lowering `CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS` lowers the tool caps with
+  it, so output is never trimmed twice; raising a tool cap raises it to match
+- `CLINE_MESSAGE_BUILDER_MIN_OUTDATED_REWRITE_BYTES` also accepts `0` to rewrite
+  superseded file reads immediately, or `infinity` to leave them in place
+- A tool result is re-sent on every later turn of a task, so larger limits cost
+  tokens for the rest of that task
+- The IDE reads the environment its editor was launched with, which on a desktop
+  launch is not your shell's; restart the editor after changing these
 
 ## Related Docs
 

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./definitions";
 import { CommandExitError } from "./executors/bash";
 import { RUN_COMMAND_QUERY_PREVIEW_LIMIT, TimeoutError } from "./helpers";
-import { type EditFileInput, INPUT_ARG_CHAR_LIMIT } from "./schemas";
+import { EDITOR_INPUT_CHAR_LIMIT, type EditFileInput } from "./schemas";
 import type { SkillsExecutorWithMetadata } from "./types";
 
 function hasSchemaKey(value: unknown, key: string): boolean {
@@ -1998,6 +1998,44 @@ describe("default editor tool", () => {
 		);
 	});
 
+	it("accepts a whole-file write in a single call", async () => {
+		const execute = vi.fn(async () => "created");
+		const tools = createDefaultTools({
+			executors: {
+				editor: execute,
+			},
+			enableReadFiles: false,
+			enableSearch: false,
+			enableBash: false,
+			enableWebFetch: false,
+			enableSkills: false,
+			enableAskQuestion: false,
+			enableApplyPatch: false,
+			enableEditor: true,
+		});
+		const editorTool = tools.find((tool) => tool.name === "editor");
+		if (!editorTool) {
+			throw new Error("Expected editor tool to be defined.");
+		}
+
+		// Comfortably past the old 6k guard and around the 90th percentile of
+		// this repo's own source files, so a typical file arrives in one call.
+		const wholeFile = "x".repeat(16_000);
+		const result = await editorTool.execute(
+			{ path: "/tmp/example.ts", new_text: wholeFile },
+			{ agentId: "agent-1", conversationId: "conv-1", iteration: 1 },
+		);
+
+		expect(result).toMatchObject({ success: true });
+		expect(execute).toHaveBeenCalledTimes(1);
+		// The payload reaches the executor whole.
+		expect(execute).toHaveBeenCalledWith(
+			expect.objectContaining({ new_text: wholeFile }),
+			expect.anything(),
+			expect.anything(),
+		);
+	});
+
 	it("returns a recoverable tool error when text exceeds the soft character limit", async () => {
 		const execute = vi.fn(async () => "patched");
 		const tools = createDefaultTools({
@@ -2019,7 +2057,7 @@ describe("default editor tool", () => {
 			throw new Error("Expected editor tool to be defined.");
 		}
 
-		const oversizedText = "x".repeat(INPUT_ARG_CHAR_LIMIT + 1);
+		const oversizedText = "x".repeat(EDITOR_INPUT_CHAR_LIMIT + 1);
 		const result = await editorTool.execute(
 			{
 				path: "/tmp/example.ts",
@@ -2041,9 +2079,7 @@ describe("default editor tool", () => {
 		if (typeof result !== "object" || result == null || !("error" in result)) {
 			throw new Error("Expected editor tool result to include an error.");
 		}
-		expect(result.error).toContain(
-			`recommended limit of ${INPUT_ARG_CHAR_LIMIT}`,
-		);
+		expect(result.error).toContain(`over the ${EDITOR_INPUT_CHAR_LIMIT} limit`);
 		expect(execute).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -16,13 +16,11 @@ import {
 	zodToJsonSchema,
 } from "@cline/shared";
 import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
-import { CommandExitError } from "./executors/bash";
 import {
-	MAX_COMMAND_OUTPUT_CHARS,
-	MAX_READ_LINES,
-	MAX_READ_OUTPUT_CHARS,
-	MAX_SEARCH_OUTPUT_CHARS,
-} from "./executors/output-limits";
+	DEFAULT_CONTEXT_LIMITS,
+	type ToolContextLimits,
+} from "../../settings/context-limits";
+import { CommandExitError } from "./executors/bash";
 import {
 	coalesceOrphanReadRanges,
 	formatError,
@@ -40,15 +38,15 @@ import {
 	ApplyPatchInputUnionSchema,
 	type AskQuestionInput,
 	AskQuestionInputSchema,
+	createEditFileInputSchema,
+	createRunCommandsInputSchema,
 	type EditFileInput,
-	EditFileInputSchema,
 	type FetchWebContentInput,
 	FetchWebContentInputSchema,
 	type ReadFileRequest,
 	type ReadFilesInput,
 	ReadFilesInputSchema,
 	ReadFilesInputUnionSchema,
-	RunCommandsInputSchema,
 	type SearchCodebaseInput,
 	SearchCodebaseInputSchema,
 	SearchCodebaseUnionInputSchema,
@@ -186,16 +184,27 @@ async function executeShellCommands(
 		timeoutMs: number;
 		timeoutSource: "default_setting" | "configured_setting";
 		telemetry?: ITelemetryService;
+		commandPreviewChars: number;
 	},
 ): Promise<ToolOperationResult[]> {
-	const { executor, cwd, context, timeoutMs, timeoutSource, telemetry } =
-		options;
+	const {
+		executor,
+		cwd,
+		context,
+		timeoutMs,
+		timeoutSource,
+		telemetry,
+		commandPreviewChars,
+	} = options;
 
 	return Promise.all(
 		commands.map(
 			async (command, commandIndex): Promise<ToolOperationResult> => {
 				const startedAt = Date.now();
-				const query = formatRunCommandQueryPreview(command);
+				const query = formatRunCommandQueryPreview(
+					command,
+					commandPreviewChars,
+				);
 				const commandContext: AgentToolContext = context.emitUpdate
 					? {
 							...context,
@@ -264,16 +273,17 @@ async function executeShellCommands(
  */
 export function createReadFilesTool(
 	executor: FileReadExecutor,
-	config: Pick<DefaultToolsConfig, "fileReadTimeoutMs"> = {},
+	config: Pick<DefaultToolsConfig, "fileReadTimeoutMs" | "limits"> = {},
 ): AgentTool<ReadFilesInput, ToolOperationResult[]> {
 	const timeoutMs = config.fileReadTimeoutMs ?? 10000;
+	const limits = config.limits ?? DEFAULT_CONTEXT_LIMITS.tool;
 
 	return createTool<ReadFilesInput, ToolOperationResult[]>({
 		name: "read_files",
 		description:
 			"Read the content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided on the same file entry as its path. " +
 			"When you already know multiple files you need, read them together in one call, and call this tool in the same response as other independent tool calls. " +
-			`Each read returns at most ${MAX_READ_LINES} lines / ~${Math.round(MAX_READ_OUTPUT_CHARS / 1024)}k characters; longer files report their total line count, page through them with start_line/end_line on that file's entry. ` +
+			`Each read returns at most ${limits.readLines} lines / ~${Math.round(limits.readOutputChars / 1024)}k characters; longer files report their total line count, page through them with start_line/end_line on that file's entry. ` +
 			"Binary files that are not image and large files are not supported. " +
 			"Returns file contents or error messages for each path. ",
 		inputSchema: zodToJsonSchema(ReadFilesInputSchema),
@@ -360,9 +370,10 @@ export function createReadFilesTool(
  */
 export function createSearchTool(
 	executor: SearchExecutor,
-	config: Pick<DefaultToolsConfig, "cwd" | "searchTimeoutMs"> = {},
+	config: Pick<DefaultToolsConfig, "cwd" | "searchTimeoutMs" | "limits"> = {},
 ): AgentTool<SearchCodebaseInput, ToolOperationResult[]> {
 	const timeoutMs = config.searchTimeoutMs ?? 30000;
+	const limits = config.limits ?? DEFAULT_CONTEXT_LIMITS.tool;
 	const cwd = config.cwd ?? process.cwd();
 
 	return createTool<SearchCodebaseInput, ToolOperationResult[]>({
@@ -371,7 +382,7 @@ export function createSearchTool(
 			"Perform regex pattern searches across the codebase. " +
 			"Supports multiple parallel searches. When several search patterns could be useful and do not depend on each other, run them together in one call, and call this tool in the same response as other independent tool calls. " +
 			"Use for finding code patterns, function definitions, class names, imports, etc. " +
-			`Output beyond ~${Math.round(MAX_SEARCH_OUTPUT_CHARS / 1000)}k characters per query is middle-truncated; narrow patterns beat broad ones.`,
+			`Output beyond ~${Math.round(limits.searchOutputChars / 1000)}k characters per query is middle-truncated; narrow patterns beat broad ones.`,
 		inputSchema: zodToJsonSchema(SearchCodebaseInputSchema),
 		timeoutMs: timeoutMs * 2,
 		retryable: true,
@@ -428,6 +439,7 @@ const RUN_COMMANDS_SHARED_INSTRUCTIONS =
 export function buildRunCommandsDescription(
 	shellKind: ShellKind,
 	isWindows: boolean,
+	limits: ToolContextLimits = DEFAULT_CONTEXT_LIMITS.tool,
 ): string {
 	if (shellKind === "powershell" || shellKind === "cmd") {
 		const shellName = shellKind === "powershell" ? "PowerShell" : "cmd.exe";
@@ -435,7 +447,7 @@ export function buildRunCommandsDescription(
 		return (
 			"Run non-interactive shell commands from the root of the workspace in Windows environment. " +
 			RUN_COMMANDS_SHARED_INSTRUCTIONS +
-			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
+			`Output beyond ~${Math.round(limits.commandOutputChars / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
 			`Commands run through ${shellName}; quote paths and arguments for ${shellName} and use ${sequencingOperator} to sequence commands. ` +
 			"Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."
 		);
@@ -452,7 +464,7 @@ export function buildRunCommandsDescription(
 		RUN_COMMANDS_SHARED_INSTRUCTIONS +
 		environmentNote +
 		"Commands should be properly shell-escaped and targeted to avoid error or timeout. Include multiple commands in the same call when they are independent complete shell commands and safe to run concurrently; multiline scripts and heredocs must be a single command string. When independent reads, searches, or edits are also needed, call those tools in the same response. " +
-		`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); pipe through grep/head/tail when you need specific sections of large output. ` +
+		`Output beyond ~${Math.round(limits.commandOutputChars / 1000)}k characters is middle-truncated (start and end preserved); pipe through grep/head/tail when you need specific sections of large output. ` +
 		"For long-running commands, run them in background and redirect output to a tmp file that you can read from later."
 	);
 }
@@ -474,11 +486,15 @@ export function buildRunCommandsDescription(
  */
 export function createShellTool(
 	executor: ShellExecutor,
-	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs" | "telemetry"> & {
+	config: Pick<
+		DefaultToolsConfig,
+		"cwd" | "bashTimeoutMs" | "telemetry" | "limits"
+	> & {
 		shell?: string | (() => string);
 	} = {},
 ): AgentTool<unknown, ToolOperationResult[]> {
 	const timeoutMs = config.bashTimeoutMs ?? 30000;
+	const limits = config.limits ?? DEFAULT_CONTEXT_LIMITS.tool;
 	const timeoutSource =
 		config.bashTimeoutMs === undefined
 			? "default_setting"
@@ -491,12 +507,18 @@ export function createShellTool(
 			? configShell
 			: () => configShell ?? getDefaultShell(process.platform);
 	const describe = () =>
-		buildRunCommandsDescription(getShellKind(resolveShell()), isWindows);
+		buildRunCommandsDescription(
+			getShellKind(resolveShell()),
+			isWindows,
+			limits,
+		);
 
 	const tool = createTool<unknown, ToolOperationResult[]>({
 		name: "run_commands",
 		description: describe(),
-		inputSchema: zodToJsonSchema(RunCommandsInputSchema),
+		inputSchema: zodToJsonSchema(
+			createRunCommandsInputSchema(limits.commandInputChars),
+		),
 		timeoutMs: timeoutMs * 2,
 		retryable: false,
 		maxRetries: 0,
@@ -512,6 +534,7 @@ export function createShellTool(
 				timeoutMs,
 				timeoutSource,
 				telemetry: config.telemetry,
+				commandPreviewChars: limits.commandPreviewChars,
 			});
 		},
 	});
@@ -535,16 +558,18 @@ export function createShellTool(
  */
 export function createWebFetchTool(
 	executor: WebFetchExecutor,
-	config: Pick<DefaultToolsConfig, "webFetchTimeoutMs"> = {},
+	config: Pick<DefaultToolsConfig, "webFetchTimeoutMs" | "limits"> = {},
 ): AgentTool<FetchWebContentInput, ToolOperationResult[]> {
 	const timeoutMs = config.webFetchTimeoutMs ?? 30000;
+	const limits = config.limits ?? DEFAULT_CONTEXT_LIMITS.tool;
 
 	return createTool<FetchWebContentInput, ToolOperationResult[]>({
 		name: "fetch_web_content",
 		description:
 			"Fetch content from URLs and analyze them using the provided prompts. " +
 			"Use for retrieving documentation, API references, or any web content. " +
-			"Each request includes a URL and a prompt describing what information to extract. Fetch independent URLs together in one call, and call this tool in the same response as other independent tool calls.",
+			"Each request includes a URL and a prompt describing what information to extract. Fetch independent URLs together in one call, and call this tool in the same response as other independent tool calls. " +
+			`Content beyond ~${Math.round(limits.webFetchContentChars / 1000)}k characters per URL is dropped; fetch a more specific page when a document is larger.`,
 		inputSchema: zodToJsonSchema(FetchWebContentInputSchema),
 		timeoutMs: timeoutMs * 2,
 		retryable: true,
@@ -677,10 +702,14 @@ export function createApplyPatchTool(
  */
 export function createEditorTool(
 	executor: EditorExecutor,
-	config: Pick<DefaultToolsConfig, "cwd" | "editorTimeoutMs"> = {},
+	config: Pick<DefaultToolsConfig, "cwd" | "editorTimeoutMs" | "limits"> = {},
 ): AgentTool<EditFileInput, ToolOperationResult> {
 	const timeoutMs = config.editorTimeoutMs ?? 30000;
 	const cwd = config.cwd ?? process.cwd();
+	const limits = config.limits ?? DEFAULT_CONTEXT_LIMITS.tool;
+	const editFileInputSchema = createEditFileInputSchema(
+		limits.editorInputChars,
+	);
 
 	return createTool<EditFileInput, ToolOperationResult>({
 		name: "editor",
@@ -690,14 +719,17 @@ export function createEditorTool(
 			"Otherwise, the tool replaces `old_text` with `new_text`, or creates the file with `new_text` if file does not exist. " +
 			"Use this tool for making small, precise edits to existing files or creating new files over shell commands. If several edits to different files or non-overlapping regions are already known, emit multiple editor tool calls in the same response instead of serializing them across turns.",
 
-		inputSchema: zodToJsonSchema(EditFileInputSchema),
+		inputSchema: zodToJsonSchema(editFileInputSchema),
 		timeoutMs,
 		retryable: false, // Editing operations are stateful and should not auto-retry
 		maxRetries: 0,
 		execute: async (input, context) => {
-			const validatedInput = validateWithZod(EditFileInputSchema, input);
+			const validatedInput = validateWithZod(editFileInputSchema, input);
 			const operation = validatedInput.insert_line == null ? "edit" : "insert";
-			const sizeError = getEditorSizeError(validatedInput);
+			const sizeError = getEditorSizeError(
+				validatedInput,
+				limits.editorInputChars,
+			);
 
 			if (sizeError) {
 				return {

--- a/sdk/packages/core/src/extensions/tools/executors/editor.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/editor.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolContext } from "@cline/shared";
+import { DEFAULT_CONTEXT_LIMITS } from "../../../settings/context-limits";
 import type { EditFileInput } from "../schemas";
 import type { EditorExecutor } from "../types";
 import {
@@ -224,7 +225,7 @@ export function createEditorExecutor(
 	const {
 		encoding = "utf-8",
 		restrictToCwd = true,
-		maxDiffLines = 200,
+		maxDiffLines = DEFAULT_CONTEXT_LIMITS.tool.editorDiffLines,
 	} = options;
 
 	return async (

--- a/sdk/packages/core/src/extensions/tools/executors/file-read.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/file-read.ts
@@ -47,12 +47,33 @@ export interface FileReadExecutorOptions {
 	 * @default false
 	 */
 	includeLineNumbers?: boolean;
+
+	/**
+	 * Max lines returned per read window.
+	 * @default MAX_READ_LINES
+	 */
+	maxReadLines?: number;
+
+	/**
+	 * Max characters kept per line.
+	 * @default MAX_LINE_CHARS
+	 */
+	maxLineChars?: number;
+
+	/**
+	 * Max characters returned per read window.
+	 * @default MAX_READ_OUTPUT_CHARS
+	 */
+	maxReadOutputChars?: number;
 }
 
 const DEFAULT_FILE_READ_OPTIONS: Required<FileReadExecutorOptions> = {
 	maxFileSizeBytes: 10_000_000, // 10MB default limit
 	encoding: "utf-8", // Default to UTF-8 encoding
 	includeLineNumbers: true, // Include line numbers by default
+	maxReadLines: MAX_READ_LINES,
+	maxLineChars: MAX_LINE_CHARS,
+	maxReadOutputChars: MAX_READ_OUTPUT_CHARS,
 };
 
 const MAX_TEXT_STREAM_BYTES = 100_000_000;
@@ -74,12 +95,19 @@ function getAbortError(signal: AbortSignal): Error {
 	return new Error("File read was aborted");
 }
 
+interface ReadWindowCaps {
+	maxReadLines: number;
+	maxLineChars: number;
+	maxReadOutputChars: number;
+}
+
 async function readTextWindow(
 	filePath: string,
 	encoding: BufferEncoding,
 	includeLineNumbers: boolean,
 	startLine: number | null | undefined,
 	endLine: number | null | undefined,
+	caps: ReadWindowCaps,
 	signal?: AbortSignal,
 ): Promise<string> {
 	if (signal?.aborted) {
@@ -98,8 +126,8 @@ async function readTextWindow(
 	let capped = false;
 	let approximateTotalLines = false;
 	const maxCapturedLineNumber = Number.isFinite(requestedEndLine)
-		? Math.min(requestedEndLine, requestedStartLine + MAX_READ_LINES - 1)
-		: requestedStartLine + MAX_READ_LINES - 1;
+		? Math.min(requestedEndLine, requestedStartLine + caps.maxReadLines - 1)
+		: requestedStartLine + caps.maxReadLines - 1;
 	const lineNumberPrefixChars = includeLineNumbers
 		? String(maxCapturedLineNumber).length + 3
 		: 0;
@@ -131,18 +159,18 @@ async function readTextWindow(
 			if (totalLines < requestedStartLine || capped) {
 				continue;
 			}
-			if (captured.length >= MAX_READ_LINES) {
+			if (captured.length >= caps.maxReadLines) {
 				capped = true;
 				continue;
 			}
 
 			let line = rawLine;
-			if (line.length > MAX_LINE_CHARS) {
-				line = `${line.slice(0, MAX_LINE_CHARS)} [line truncated]`;
+			if (line.length > caps.maxLineChars) {
+				line = `${line.slice(0, caps.maxLineChars)} [line truncated]`;
 			}
 
 			const nextChars = chars + line.length + lineNumberPrefixChars + 1;
-			if (nextChars > MAX_READ_OUTPUT_CHARS && captured.length > 0) {
+			if (nextChars > caps.maxReadOutputChars && captured.length > 0) {
 				capped = true;
 				continue;
 			}
@@ -204,9 +232,21 @@ async function readTextWindow(
 export function createFileReadExecutor(
 	options: FileReadExecutorOptions = {},
 ): FileReadExecutor {
-	const { maxFileSizeBytes, encoding, includeLineNumbers } = {
+	const {
+		maxFileSizeBytes,
+		encoding,
+		includeLineNumbers,
+		maxReadLines,
+		maxLineChars,
+		maxReadOutputChars,
+	} = {
 		...DEFAULT_FILE_READ_OPTIONS,
 		...options,
+	};
+	const caps: ReadWindowCaps = {
+		maxReadLines,
+		maxLineChars,
+		maxReadOutputChars,
 	};
 
 	return async (request: ReadFileRequest, context: AgentToolContext) => {
@@ -263,6 +303,7 @@ export function createFileReadExecutor(
 			includeLineNumbers,
 			start_line,
 			end_line,
+			caps,
 			context.signal,
 		);
 	};

--- a/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
@@ -13,8 +13,17 @@
  * these budgets, so an executor's own sizing stands.
  */
 
+import { DEFAULT_CONTEXT_LIMITS } from "../../../settings/context-limits";
+
+/**
+ * Compile-time defaults. Each executor takes its effective cap from resolved
+ * options at construction; these remain for callers that build an executor
+ * without configuring one.
+ */
+
 /** Max characters of command output kept; beyond this the middle is elided. */
-export const MAX_COMMAND_OUTPUT_CHARS = 48_000;
+export const MAX_COMMAND_OUTPUT_CHARS =
+	DEFAULT_CONTEXT_LIMITS.tool.commandOutputChars;
 
 export function truncateCommandOutput(
 	text: string,
@@ -37,13 +46,15 @@ export function truncateCommandOutput(
 }
 
 /** Max lines returned per file read when the range is larger or absent. */
-export const MAX_READ_LINES = 2_000;
+export const MAX_READ_LINES = DEFAULT_CONTEXT_LIMITS.tool.readLines;
 
 /** Max characters kept per line in file reads (defangs minified files). */
-export const MAX_LINE_CHARS = 2_000;
+export const MAX_LINE_CHARS = DEFAULT_CONTEXT_LIMITS.tool.lineChars;
 
 /** Max characters returned per file read window. */
-export const MAX_READ_OUTPUT_CHARS = 48_000;
+export const MAX_READ_OUTPUT_CHARS =
+	DEFAULT_CONTEXT_LIMITS.tool.readOutputChars;
 
 /** Max characters returned per search query; beyond this the middle is elided. */
-export const MAX_SEARCH_OUTPUT_CHARS = 48_000;
+export const MAX_SEARCH_OUTPUT_CHARS =
+	DEFAULT_CONTEXT_LIMITS.tool.searchOutputChars;

--- a/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/output-limits.ts
@@ -8,10 +8,9 @@
  * reference them so the model pages or narrows instead of retrying.
  *
  * Truncation notices always live in the preserved head/tail of an entry,
- * never in the elided middle. Provider-request building may re-truncate
- * long strings with its own (possibly tighter) middle-cut backstop
- * (session/services/message-builder.ts); keeping the notices at the edges
- * means the recovery guidance survives that cut too.
+ * never in the elided middle, so they survive a later cut. Provider-request
+ * building keeps its own backstop (session/services/message-builder.ts) above
+ * these budgets, so an executor's own sizing stands.
  */
 
 /** Max characters of command output kept; beyond this the middle is elided. */

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -55,6 +55,18 @@ export interface SearchExecutorOptions {
 	 * @default 20
 	 */
 	maxDepth?: number;
+
+	/**
+	 * Max characters returned per query; beyond this the middle is elided.
+	 * @default MAX_SEARCH_OUTPUT_CHARS
+	 */
+	maxSearchOutputChars?: number;
+
+	/**
+	 * Max characters kept per matched line.
+	 * @default MAX_LINE_CHARS
+	 */
+	maxLineChars?: number;
 }
 
 const DEFAULT_INCLUDE_EXTENSIONS = [
@@ -333,6 +345,8 @@ export function createSearchExecutor(
 		maxResults = 100,
 		contextLines = 2,
 		maxDepth = 20,
+		maxSearchOutputChars = MAX_SEARCH_OUTPUT_CHARS,
+		maxLineChars = MAX_LINE_CHARS,
 	} = options;
 	const excludeDirsSet = new Set(excludeDirs);
 	const includeExtensionsSet = new Set(
@@ -371,7 +385,15 @@ export function createSearchExecutor(
 
 			for (const match of rgMatches) {
 				resultLines.push(`${match.file}:${match.line}:${match.column}`);
-				resultLines.push(...match.context);
+				// Matches the regex fallback below: a minified file must not be
+				// able to return one multi-megabyte line through this path.
+				resultLines.push(
+					...match.context.map((line) =>
+						line.length > maxLineChars
+							? `${line.slice(0, maxLineChars)} [line truncated]`
+							: line,
+					),
+				);
 				resultLines.push("");
 			}
 
@@ -381,7 +403,7 @@ export function createSearchExecutor(
 				);
 			}
 
-			return capSearchOutput(resultLines.join("\n"));
+			return capSearchOutput(resultLines.join("\n"), maxSearchOutputChars);
 		}
 
 		// Fallback to manual regex search
@@ -445,7 +467,7 @@ export function createSearchExecutor(
 						for (let i = contextStart; i <= contextEnd; i++) {
 							const prefix = i === lineIdx ? ">" : " ";
 							contextLinesArr.push(
-								`${prefix} ${i + 1}: ${lines[i].slice(0, MAX_LINE_CHARS)}`,
+								`${prefix} ${i + 1}: ${lines[i].slice(0, maxLineChars)}`,
 							);
 						}
 
@@ -490,7 +512,7 @@ export function createSearchExecutor(
 			);
 		}
 
-		return capSearchOutput(resultLines.join("\n"));
+		return capSearchOutput(resultLines.join("\n"), maxSearchOutputChars);
 	};
 }
 
@@ -501,12 +523,15 @@ export function createSearchExecutor(
  * are preserved and the middle is elided with a notice teaching the model
  * to narrow the pattern instead of retrying.
  */
-function capSearchOutput(text: string): string {
-	if (text.length <= MAX_SEARCH_OUTPUT_CHARS) {
+function capSearchOutput(
+	text: string,
+	maxChars: number = MAX_SEARCH_OUTPUT_CHARS,
+): string {
+	if (text.length <= maxChars) {
 		return text;
 	}
-	const headLimit = Math.ceil(MAX_SEARCH_OUTPUT_CHARS / 2);
-	const tailLimit = Math.max(1, MAX_SEARCH_OUTPUT_CHARS - headLimit);
+	const headLimit = Math.ceil(maxChars / 2);
+	const tailLimit = Math.max(1, maxChars - headLimit);
 	return (
 		`${text.slice(0, headLimit)}\n` +
 		`[... search output truncated: ${text.length} chars total. ` +

--- a/sdk/packages/core/src/extensions/tools/executors/web-fetch.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/web-fetch.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AgentToolContext } from "@cline/shared";
+import { DEFAULT_CONTEXT_LIMITS } from "../../../settings/context-limits";
 import type { WebFetchExecutor } from "../types";
 
 /**
@@ -45,6 +46,12 @@ export interface WebFetchExecutorOptions {
 	 * @default 5
 	 */
 	maxRedirects?: number;
+
+	/**
+	 * Max characters of fetched content included in the result.
+	 * @default DEFAULT_CONTEXT_LIMITS.tool.webFetchContentChars
+	 */
+	maxContentChars?: number;
 }
 
 /**
@@ -101,6 +108,7 @@ export function createWebFetchExecutor(
 	const {
 		timeoutMs = 30000,
 		maxResponseBytes = 5_000_000,
+		maxContentChars = DEFAULT_CONTEXT_LIMITS.tool.webFetchContentChars,
 		userAgent = "Mozilla/5.0 (compatible; AgentBot/1.0)",
 		headers = {},
 		followRedirects = true,
@@ -228,12 +236,12 @@ export function createWebFetchExecutor(
 				`Size: ${totalSize} bytes`,
 				``,
 				`--- Content ---`,
-				content.slice(0, 50000), // Limit content size for output
+				content.slice(0, maxContentChars),
 			];
 
-			if (content.length > 50000) {
+			if (content.length > maxContentChars) {
 				outputLines.push(
-					`\n[Content truncated: showing first 50000 of ${content.length} characters]`,
+					`\n[Content truncated: showing first ${maxContentChars} of ${content.length} characters]`,
 				);
 			}
 

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -1,7 +1,7 @@
 import { validateWithZod } from "@cline/shared";
 import {
+	EDITOR_INPUT_CHAR_LIMIT,
 	type EditFileInput,
-	INPUT_ARG_CHAR_LIMIT,
 	type ReadFileRequest,
 	RunCommandsInputUnionSchema,
 	type StructuredCommandInput,
@@ -20,13 +20,13 @@ export function formatError(error: unknown): string {
 export function getEditorSizeError(input: EditFileInput): string | null {
 	if (
 		typeof input.old_text === "string" &&
-		input.old_text.length > INPUT_ARG_CHAR_LIMIT
+		input.old_text.length > EDITOR_INPUT_CHAR_LIMIT
 	) {
-		return `Editor input too large: old_text was ${input.old_text.length} characters, exceeding the recommended limit of ${INPUT_ARG_CHAR_LIMIT}. Split the edit into smaller tool calls so later tool calls are less likely to be truncated or time out.`;
+		return `Editor input too large: old_text was ${input.old_text.length} characters, over the ${EDITOR_INPUT_CHAR_LIMIT} limit. Target a smaller region, or edit the file in sections.`;
 	}
 
-	if (input.new_text.length > INPUT_ARG_CHAR_LIMIT) {
-		return `Editor input too large: new_text was ${input.new_text.length} characters, exceeding the recommended limit of ${INPUT_ARG_CHAR_LIMIT}. Split the edit into smaller tool calls so later tool calls are less likely to be truncated or time out.`;
+	if (input.new_text.length > EDITOR_INPUT_CHAR_LIMIT) {
+		return `Editor input too large: new_text was ${input.new_text.length} characters, over the ${EDITOR_INPUT_CHAR_LIMIT} limit. Target a smaller region, or edit the file in sections.`;
 	}
 
 	return null;

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -1,4 +1,5 @@
 import { validateWithZod } from "@cline/shared";
+import { DEFAULT_CONTEXT_LIMITS } from "../../settings/context-limits";
 import {
 	EDITOR_INPUT_CHAR_LIMIT,
 	type EditFileInput,
@@ -17,16 +18,16 @@ export function formatError(error: unknown): string {
 	return String(error);
 }
 
-export function getEditorSizeError(input: EditFileInput): string | null {
-	if (
-		typeof input.old_text === "string" &&
-		input.old_text.length > EDITOR_INPUT_CHAR_LIMIT
-	) {
-		return `Editor input too large: old_text was ${input.old_text.length} characters, over the ${EDITOR_INPUT_CHAR_LIMIT} limit. Target a smaller region, or edit the file in sections.`;
+export function getEditorSizeError(
+	input: EditFileInput,
+	limit: number = EDITOR_INPUT_CHAR_LIMIT,
+): string | null {
+	if (typeof input.old_text === "string" && input.old_text.length > limit) {
+		return `Editor input too large: old_text was ${input.old_text.length} characters, over the ${limit} limit. Target a smaller region, or edit the file in sections.`;
 	}
 
-	if (input.new_text.length > EDITOR_INPUT_CHAR_LIMIT) {
-		return `Editor input too large: new_text was ${input.new_text.length} characters, over the ${EDITOR_INPUT_CHAR_LIMIT} limit. Target a smaller region, or edit the file in sections.`;
+	if (input.new_text.length > limit) {
+		return `Editor input too large: new_text was ${input.new_text.length} characters, over the ${limit} limit. Target a smaller region, or edit the file in sections.`;
 	}
 
 	return null;
@@ -188,7 +189,8 @@ export function formatRunCommandQuery(
  * input, so repeating it in the result only duplicates tokens in the
  * provider request (expensive for large heredoc/file-generation commands).
  */
-export const RUN_COMMAND_QUERY_PREVIEW_LIMIT = 200;
+export const RUN_COMMAND_QUERY_PREVIEW_LIMIT =
+	DEFAULT_CONTEXT_LIMITS.tool.commandPreviewChars;
 
 /**
  * Bound the command echo placed in a provider-facing tool result.
@@ -197,11 +199,12 @@ export const RUN_COMMAND_QUERY_PREVIEW_LIMIT = 200;
  */
 export function formatRunCommandQueryPreview(
 	command: string | StructuredCommandInput,
+	limit: number = RUN_COMMAND_QUERY_PREVIEW_LIMIT,
 ): string {
 	const rendered = formatRunCommandQuery(command);
-	if (rendered.length <= RUN_COMMAND_QUERY_PREVIEW_LIMIT) {
+	if (rendered.length <= limit) {
 		return rendered;
 	}
-	const truncatedChars = rendered.length - RUN_COMMAND_QUERY_PREVIEW_LIMIT;
-	return `${rendered.slice(0, RUN_COMMAND_QUERY_PREVIEW_LIMIT)} ... [command truncated: ${truncatedChars} more chars; full command is in the tool call input]`;
+	const truncatedChars = rendered.length - limit;
+	return `${rendered.slice(0, limit)} ... [command truncated: ${truncatedChars} more chars; full command is in the tool call input]`;
 }

--- a/sdk/packages/core/src/extensions/tools/index.ts
+++ b/sdk/packages/core/src/extensions/tools/index.ts
@@ -135,6 +135,7 @@ export type {
 // =============================================================================
 
 import { type AgentTool, getDefaultShell } from "@cline/shared";
+import { resolveContextLimits } from "../../settings/context-limits";
 import { createDefaultTools } from "./definitions";
 import {
 	createDefaultExecutors,
@@ -204,11 +205,34 @@ export function createBuiltinTools(
 		toolsConfig.shell ??
 		executorOptions.bash?.shell ??
 		getDefaultShell(process.platform);
+	// One resolution per tool set, shared by the executors that enforce the
+	// caps and the descriptions that quote them.
+	const limits = toolsConfig.limits ?? resolveContextLimits().tool;
 	const resolvedExecutorOptions: DefaultExecutorsOptions = {
 		...executorOptions,
 		bash: {
+			maxOutputChars: limits.commandOutputChars,
 			...executorOptions.bash,
 			shell,
+		},
+		fileRead: {
+			maxReadLines: limits.readLines,
+			maxLineChars: limits.lineChars,
+			maxReadOutputChars: limits.readOutputChars,
+			...executorOptions.fileRead,
+		},
+		search: {
+			maxSearchOutputChars: limits.searchOutputChars,
+			maxLineChars: limits.lineChars,
+			...executorOptions.search,
+		},
+		webFetch: {
+			maxContentChars: limits.webFetchContentChars,
+			...executorOptions.webFetch,
+		},
+		editor: {
+			maxDiffLines: limits.editorDiffLines,
+			...executorOptions.editor,
 		},
 	};
 
@@ -219,6 +243,7 @@ export function createBuiltinTools(
 
 	return createDefaultTools({
 		...toolsConfig,
+		limits,
 		shell,
 		executors,
 	});

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -130,11 +130,14 @@ export const SearchCodebaseUnionInputSchema = z.union([
 	z.object({ queries: z.string() }),
 ]);
 
-const CommandInputSchema = z
-	.string()
-	.describe(
-		`The non-interactive shell command to execute - MUST keep input short and concise (within ${COMMAND_INPUT_CHAR_LIMIT} characters) to avoid timeouts.`,
-	);
+const commandInputSchemaFor = (limit: number) =>
+	z
+		.string()
+		.describe(
+			`The non-interactive shell command to execute - MUST keep input short and concise (within ${limit} characters) to avoid timeouts.`,
+		);
+
+const CommandInputSchema = commandInputSchemaFor(COMMAND_INPUT_CHAR_LIMIT);
 
 export const StructuredCommandInputSchema = z.object({
 	command: z
@@ -152,11 +155,17 @@ export const StructuredCommandEntrySchema = z.union([
 	StructuredCommandInputSchema,
 ]);
 
-export const RunCommandsInputSchema = z.object({
-	commands: z
-		.array(CommandInputSchema)
-		.describe("Array of complete shell command strings to execute."),
-});
+export function createRunCommandsInputSchema(
+	commandInputChars: number = COMMAND_INPUT_CHAR_LIMIT,
+) {
+	return z.object({
+		commands: z
+			.array(commandInputSchemaFor(commandInputChars))
+			.describe("Array of complete shell command strings to execute."),
+	});
+}
+
+export const RunCommandsInputSchema = createRunCommandsInputSchema();
 
 const StructuredCommandsInputSchema = z.object({
 	commands: z.array(StructuredCommandEntrySchema),
@@ -197,37 +206,43 @@ export const FetchWebContentInputSchema = z.object({
 /**
  * Schema for editor tool input
  */
-export const EditFileInputSchema = z
-	.object({
-		path: z
-			.string()
-			.min(1)
-			.describe("The absolute path for the action to be performed on"),
-		old_text: z
-			.string()
-			.nullable()
-			.optional()
-			.describe(
-				`Exact text to replace (must match exactly once). Omit this when creating a missing file or inserting via insert_line. Send the whole block you are replacing, up to ${EDITOR_INPUT_CHAR_LIMIT} characters.`,
-			),
-		new_text: z
-			.string()
-			.describe(
-				`The new content to write when creating a missing file, the replacement text for edits, or the inserted text when insert_line is provided. Send the complete text for the region you are changing, up to ${EDITOR_INPUT_CHAR_LIMIT} characters; a call cut short by your own output limit is wasted, so split only when the content genuinely exceeds what you can emit in one response.`,
-			),
-		// See start_line above: coerced so a stringified line number still applies.
-		insert_line: z.coerce
-			.number()
-			.int()
-			.nullable()
-			.optional()
-			.describe(
-				"Optional positive one-based boundary line. When provided, the tool inserts new_text before that line instead of performing a replacement edit; use line_count + 1 to append at EOF.",
-			),
-	})
-	.describe(
-		"Edit a text file by replacing old_text with new_text, create the file with new_text if it does not exist, or insert new_text at insert_line when insert_line is provided. Prefer using this tool for file edits over shell commands. IMPORTANT: large edits can time out, so use small chunks and multiple calls when possible.",
-	);
+export function createEditFileInputSchema(
+	editorInputChars: number = EDITOR_INPUT_CHAR_LIMIT,
+) {
+	return z
+		.object({
+			path: z
+				.string()
+				.min(1)
+				.describe("The absolute path for the action to be performed on"),
+			old_text: z
+				.string()
+				.nullable()
+				.optional()
+				.describe(
+					`Exact text to replace (must match exactly once). Omit this when creating a missing file or inserting via insert_line. Send the whole block you are replacing, up to ${editorInputChars} characters.`,
+				),
+			new_text: z
+				.string()
+				.describe(
+					`The new content to write when creating a missing file, the replacement text for edits, or the inserted text when insert_line is provided. Send the complete text for the region you are changing, up to ${editorInputChars} characters; a call cut short by your own output limit is wasted, so split only when the content genuinely exceeds what you can emit in one response.`,
+				),
+			// See start_line above: coerced so a stringified line number still applies.
+			insert_line: z.coerce
+				.number()
+				.int()
+				.nullable()
+				.optional()
+				.describe(
+					"Optional positive one-based boundary line. When provided, the tool inserts new_text before that line instead of performing a replacement edit; use line_count + 1 to append at EOF.",
+				),
+		})
+		.describe(
+			"Edit a text file by replacing old_text with new_text, create the file with new_text if it does not exist, or insert new_text at insert_line when insert_line is provided. Prefer using this tool for file edits over shell commands.",
+		);
+}
+
+export const EditFileInputSchema = createEditFileInputSchema();
 
 /**
  * Schema for apply_patch tool input

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -7,7 +7,13 @@
 
 import { z } from "zod";
 
-export const INPUT_ARG_CHAR_LIMIT = 6000;
+// Sized so a whole source file usually fits in one call; edits that arrive
+// complete are cheaper than the extra read/verify round-trips chunking costs.
+export const EDITOR_INPUT_CHAR_LIMIT = 50_000;
+
+// Long shell commands are typed into a terminal, where the cost of an oversized
+// input is a timeout rather than a rewrite.
+export const COMMAND_INPUT_CHAR_LIMIT = 12_000;
 
 /**
  * Schema for read tool input
@@ -127,7 +133,7 @@ export const SearchCodebaseUnionInputSchema = z.union([
 const CommandInputSchema = z
 	.string()
 	.describe(
-		`The non-interactive shell command to execute - MUST keep input short and concise (within ${INPUT_ARG_CHAR_LIMIT * 2} characters) to avoid timeouts.`,
+		`The non-interactive shell command to execute - MUST keep input short and concise (within ${COMMAND_INPUT_CHAR_LIMIT} characters) to avoid timeouts.`,
 	);
 
 export const StructuredCommandInputSchema = z.object({
@@ -202,12 +208,12 @@ export const EditFileInputSchema = z
 			.nullable()
 			.optional()
 			.describe(
-				`Exact text to replace (must match exactly once). Omit this when creating a missing file or inserting via insert_line. Keep this at or below ${INPUT_ARG_CHAR_LIMIT} characters when possible; larger payloads should be split across multiple tool calls to avoid timeouts.`,
+				`Exact text to replace (must match exactly once). Omit this when creating a missing file or inserting via insert_line. Send the whole block you are replacing, up to ${EDITOR_INPUT_CHAR_LIMIT} characters.`,
 			),
 		new_text: z
 			.string()
 			.describe(
-				`The new content to write when creating a missing file, the replacement text for edits, or the inserted text when insert_line is provided. Keep this at or below ${INPUT_ARG_CHAR_LIMIT} characters when possible; for large edits, use multiple calls with small chunks of old_text and new_text to iteratively edit the file.`,
+				`The new content to write when creating a missing file, the replacement text for edits, or the inserted text when insert_line is provided. Send the complete text for the region you are changing, up to ${EDITOR_INPUT_CHAR_LIMIT} characters; a call cut short by your own output limit is wasted, so split only when the content genuinely exceeds what you can emit in one response.`,
 			),
 		// See start_line above: coerced so a stringified line number still applies.
 		insert_line: z.coerce

--- a/sdk/packages/core/src/extensions/tools/types.ts
+++ b/sdk/packages/core/src/extensions/tools/types.ts
@@ -10,6 +10,7 @@ import type {
 	ITelemetryService,
 	TextContent,
 } from "@cline/shared";
+import type { ToolContextLimits } from "../../settings/context-limits";
 import type {
 	ApplyPatchInput,
 	EditFileInput,
@@ -239,6 +240,12 @@ export type DefaultToolName =
  * Configuration for enabling/disabling default tools
  */
 export interface DefaultToolsConfig {
+	/**
+	 * Resolved output and input caps. Tool descriptions quote these, so the
+	 * numbers the model is told always match the ones enforced.
+	 */
+	limits?: ToolContextLimits;
+
 	/**
 	 * Host telemetry service, injected at tool construction time. Tools that
 	 * emit operational telemetry (e.g. run_commands timeouts) close over this

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -874,6 +874,16 @@ export {
 	CoreSettingsService,
 	createCoreSettingsService,
 } from "./settings";
+export {
+	type ContextLimitOverrides,
+	type ContextLimits,
+	DEFAULT_CONTEXT_LIMITS,
+	MESSAGE_LIMIT_ENV,
+	type MessageContextLimits,
+	resolveContextLimits,
+	TOOL_LIMIT_ENV,
+	type ToolContextLimits,
+} from "./settings/context-limits";
 export * from "./tasks";
 export type {
 	ChatMessage,

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -6,6 +6,10 @@ import {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
+	MAX_COMMAND_OUTPUT_CHARS,
+	truncateCommandOutput,
+} from "../../extensions/tools/executors/output-limits";
+import {
 	agentMessagesToMessages,
 	messagesToAgentMessages,
 } from "../../runtime/config/agent-message-codec";
@@ -210,8 +214,25 @@ describe("MessageBuilder", () => {
 		expect(block.content).toContain("...[truncated");
 	});
 
-	it("uses an aggressive per-result cap and a loose aggregate budget", () => {
-		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBe(8_000);
+	it("keeps the per-result cap clear of the executor budget and the aggregate budget loose", () => {
+		// The cap must clear the largest output a budgeted executor can emit.
+		// Measured here because the notice interpolates a character count, so a
+		// bigger input widens it.
+		const worstCaseBudgetedOutput = truncateCommandOutput(
+			"z".repeat(Number.MAX_SAFE_INTEGER.toString().length * 1_000_000),
+			{ maxChars: MAX_COMMAND_OUTPUT_CHARS },
+		);
+		expect(worstCaseBudgetedOutput.length).toBeGreaterThan(
+			MAX_COMMAND_OUTPUT_CHARS,
+		);
+		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBeGreaterThan(
+			worstCaseBudgetedOutput.length,
+		);
+		// Bounded above too, so the headroom stays sized for the notice and the
+		// backstop keeps its reach over unbudgeted producers.
+		expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBeLessThanOrEqual(
+			MAX_COMMAND_OUTPUT_CHARS + 2_000,
+		);
 		expect(DEFAULT_MAX_FILE_CONTENT_CHARS).toBe(50_000);
 		// The aggregate budget stays loose on purpose: budget truncation
 		// rewrites mid-transcript bytes and breaks provider prefix caching, so
@@ -802,40 +823,87 @@ describe("MessageBuilder with structured ToolOperationResult content", () => {
 		);
 	});
 
-	it("materially shrinks provider-formatted payloads compared with previous defaults", () => {
-		const messages: Message[] = [];
-		for (let i = 0; i < 20; i++) {
-			messages.push(
-				toolUseMessage(`call_${i}`, "run_commands", {
-					commands: [`python noisy_task_${i}.py`],
-				}),
-				structuredToolResultMessage(`call_${i}`, "run_commands", [
-					{
-						query: `python noisy_task_${i}.py`,
-						result: hugeText(300_000),
-						success: true,
-						duration: 1000 + i,
-					},
-				]),
-			);
-		}
-		const previousDefaults = new MessageBuilder({
-			maxToolResultChars: 50_000,
-			maxTotalTextBytes: 6_000_000,
+	it("leaves output an executor already budgeted untouched", () => {
+		const builder = new MessageBuilder();
+		// Sitting exactly at the executor cap, so it passes through whole.
+		const executorSized = "y".repeat(MAX_COMMAND_OUTPUT_CHARS);
+		const messages: Message[] = [
+			toolUseMessage("call_1", "run_commands", {
+				commands: ["pytest -q"],
+			}),
+			structuredToolResultMessage("call_1", "run_commands", [
+				{
+					query: "pytest -q",
+					result: executorSized,
+					success: true,
+					duration: 1000,
+				},
+			]),
+		];
+
+		const built = builder.buildForApi(messages);
+
+		expect(firstToolOperationResult(built).result).toBe(executorSized);
+		// Survives all the way into the provider-formatted payload.
+		expect(serializeForAiSdk(built)).toContain(executorSized);
+	});
+
+	it("preserves the executor's truncation notice on an already-capped result", () => {
+		const builder = new MessageBuilder();
+		// Real executor output for an oversized command: elided to budget plus a
+		// notice, landing just past it. The headroom is what keeps the notice —
+		// now sitting mid-string — out of a second middle cut.
+		const executorOutput = truncateCommandOutput("z".repeat(206_639), {
+			maxChars: MAX_COMMAND_OUTPUT_CHARS,
 		});
-		const currentDefaults = new MessageBuilder();
+		expect(executorOutput.length).toBeGreaterThan(MAX_COMMAND_OUTPUT_CHARS);
 
-		const previousPayload = serializeForAiSdk(
-			previousDefaults.buildForApi(messages),
-		);
-		const currentPayload = serializeForAiSdk(
-			currentDefaults.buildForApi(messages),
-		);
+		const built = builder.buildForApi([
+			toolUseMessage("call_1", "run_commands", { commands: ["pytest -q"] }),
+			structuredToolResultMessage("call_1", "run_commands", [
+				{
+					query: "pytest -q",
+					result: executorOutput,
+					success: true,
+					duration: 1000,
+				},
+			]),
+		]);
+		const output = firstToolOperationResult(built).result;
 
-		expect(previousPayload.length).toBeGreaterThan(900_000);
-		expect(currentPayload.length).toBeLessThan(previousPayload.length * 0.25);
-		expect(currentPayload.length).toBeLessThan(250_000);
-		expect(currentPayload).not.toContain(MIDDLE_SENTINEL);
+		expect(output).toBe(executorOutput);
+		expect(output).toContain("output truncated");
+		expect(output).not.toContain("...[truncated");
+	});
+
+	it("still bounds output from producers that have no executor budget", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			toolUseMessage("call_1", "mcp__warehouse__query", {
+				sql: "select * from events",
+			}),
+			structuredToolResultMessage("call_1", "mcp__warehouse__query", [
+				{
+					query: "select * from events",
+					result: hugeText(),
+					success: true,
+					duration: 1000,
+				},
+			]),
+		];
+
+		const operation = firstToolOperationResult(builder.buildForApi(messages));
+		const output = operation.result;
+
+		expect(typeof output).toBe("string");
+		if (typeof output !== "string") {
+			throw new Error("expected string result");
+		}
+		expect(output.length).toBeLessThanOrEqual(DEFAULT_MAX_TOOL_RESULT_CHARS);
+		expect(output).toContain("...[truncated");
+		expect(output).not.toContain(MIDDLE_SENTINEL);
+		expect(output).toContain(HEAD_MARKER);
+		expect(output).toContain(TAIL_MARKER);
 	});
 
 	it("truncates a huge nested `result` string in run_commands structured output", () => {
@@ -2019,7 +2087,7 @@ describe("MessageBuilder outdated-read rewrite batching (prefix-cache stability)
 	});
 
 	it("uses provider-bound stale bytes after per-result truncation", () => {
-		const builder = new MessageBuilder({ minOutdatedRewriteBytes: 20_000 });
+		const builder = new MessageBuilder({ minOutdatedRewriteBytes: 60_000 });
 		const messages: Message[] = [
 			{ role: "user", content: "task" },
 			readToolUse("t1"),
@@ -2030,8 +2098,8 @@ describe("MessageBuilder outdated-read rewrite batching (prefix-cache stability)
 
 		const result = builder.buildForApi(messages);
 
-		// Raw t1 history is ~140KB, but the provider-bound stale entry is capped
-		// near 8KB before threshold accounting. A 20KB threshold must defer.
+		// Threshold sits between the provider-bound stale entry (capped) and raw
+		// t1 history (~140KB), so only provider-bound accounting defers here.
 		expect(JSON.stringify(result[2])).not.toContain("outdated");
 		expect(JSON.stringify(result[2])).toContain("...[truncated");
 	});

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -375,8 +375,28 @@ describe("MessageBuilder", () => {
 			CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS: "0",
 			CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES: "0",
 		});
-		expect(options.maxToolResultChars).toBeUndefined();
-		expect(options.maxTotalTextBytes).toBeUndefined();
+		expect(options.maxToolResultChars).toBe(DEFAULT_MAX_TOOL_RESULT_CHARS);
+		expect(options.maxTotalTextBytes).toBe(DEFAULT_MAX_TOTAL_TEXT_BYTES);
+	});
+
+	it("reads an env override for every message-builder limit", () => {
+		const options = getMessageBuilderOptionsFromEnv({
+			CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS: "111000",
+			CLINE_MESSAGE_BUILDER_MAX_FILE_CONTENT_CHARS: "112000",
+			CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES: "113000",
+			CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TEXT_CHARS: "114000",
+			CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TOOL_MARKUP_CHARS: "115000",
+			CLINE_MESSAGE_BUILDER_MIN_OUTDATED_REWRITE_BYTES: "116000",
+		});
+
+		expect(options).toMatchObject({
+			maxToolResultChars: 111_000,
+			maxFileContentChars: 112_000,
+			maxTotalTextBytes: 113_000,
+			maxAssistantTextChars: 114_000,
+			maxAssistantToolMarkupChars: 115_000,
+			minOutdatedRewriteBytes: 116_000,
+		});
 	});
 
 	it("applies an aggregate text budget across targeted tool results", () => {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -24,32 +24,34 @@ import {
 	type ToolResultContent,
 	validateAndReserveImageMedia,
 } from "@cline/shared";
-import { MAX_COMMAND_OUTPUT_CHARS } from "../../extensions/tools/executors/output-limits";
+import {
+	DEFAULT_CONTEXT_LIMITS,
+	MESSAGE_LIMIT_ENV,
+	resolveContextLimits,
+} from "../../settings/context-limits";
 
-// Executors append their truncation notice past their own budget, so a capped
-// result runs slightly over it; this headroom keeps the backstop clear of that
-// overshoot, preserving the notice.
-const EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS = 2_000;
 export const DEFAULT_MAX_TOOL_RESULT_CHARS =
-	MAX_COMMAND_OUTPUT_CHARS + EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS;
-export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
-// The aggregate budget intentionally stays far above what the per-result cap
-// usually produces: budget truncation rewrites bytes mid-transcript, which
-// invalidates provider prefix caches from the first rewritten block onward,
-// so it must remain a rare overflow valve rather than the steady state.
-export const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
-export const DEFAULT_MAX_ASSISTANT_TEXT_CHARS = 200_000;
-export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS = 12_000;
-// Batch stale-read rewrites to avoid breaking provider prefix caches on every re-read.
-// 64KB is roughly 8 provider-capped read results; set to 0 for eager rewriting.
-export const DEFAULT_MIN_OUTDATED_REWRITE_BYTES = 65_536;
+	DEFAULT_CONTEXT_LIMITS.message.toolResultChars;
+export const DEFAULT_MAX_FILE_CONTENT_CHARS =
+	DEFAULT_CONTEXT_LIMITS.message.fileContentChars;
+export const DEFAULT_MAX_TOTAL_TEXT_BYTES =
+	DEFAULT_CONTEXT_LIMITS.message.totalTextBytes;
+export const DEFAULT_MAX_ASSISTANT_TEXT_CHARS =
+	DEFAULT_CONTEXT_LIMITS.message.assistantTextChars;
+export const DEFAULT_MAX_ASSISTANT_TOOL_MARKUP_CHARS =
+	DEFAULT_CONTEXT_LIMITS.message.assistantToolMarkupChars;
+export const DEFAULT_MIN_OUTDATED_REWRITE_BYTES =
+	DEFAULT_CONTEXT_LIMITS.message.minOutdatedRewriteBytes;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 2_000;
 const MIN_TOTAL_BUDGET_ASSISTANT_TEXT_BYTES = 40_000;
 const REPEATED_TOOL_CALL_MARKUP_THRESHOLD = 8;
 export const MESSAGE_BUILDER_LIMIT_ENV = {
-	maxToolResultChars: "CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS",
-	maxTotalTextBytes: "CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES",
-	minOutdatedRewriteBytes: "CLINE_MESSAGE_BUILDER_MIN_OUTDATED_REWRITE_BYTES",
+	maxToolResultChars: MESSAGE_LIMIT_ENV.toolResultChars,
+	maxFileContentChars: MESSAGE_LIMIT_ENV.fileContentChars,
+	maxTotalTextBytes: MESSAGE_LIMIT_ENV.totalTextBytes,
+	maxAssistantTextChars: MESSAGE_LIMIT_ENV.assistantTextChars,
+	maxAssistantToolMarkupChars: MESSAGE_LIMIT_ENV.assistantToolMarkupChars,
+	minOutdatedRewriteBytes: MESSAGE_LIMIT_ENV.minOutdatedRewriteBytes,
 } as const;
 const READ_TOOL_NAMES = new Set(["read", "read_files"]);
 const OUTDATED_FILE_CONTENT = "[outdated - see the latest file content]";
@@ -93,18 +95,14 @@ export interface MessageBuilderOptions {
 export function getMessageBuilderOptionsFromEnv(
 	env: Record<string, string | undefined> = process.env,
 ): MessageBuilderOptions {
-	// Size caps reject zero/negative overrides; stale-read batching accepts 0
-	// for eager mode and "disable"/"Infinity" for rollback.
+	const { message } = resolveContextLimits({}, env);
 	return {
-		maxToolResultChars: parsePositiveIntegerEnv(
-			env[MESSAGE_BUILDER_LIMIT_ENV.maxToolResultChars],
-		),
-		maxTotalTextBytes: parsePositiveIntegerEnv(
-			env[MESSAGE_BUILDER_LIMIT_ENV.maxTotalTextBytes],
-		),
-		minOutdatedRewriteBytes: parseNonNegativeLimitEnv(
-			env[MESSAGE_BUILDER_LIMIT_ENV.minOutdatedRewriteBytes],
-		),
+		maxToolResultChars: message.toolResultChars,
+		maxFileContentChars: message.fileContentChars,
+		maxTotalTextBytes: message.totalTextBytes,
+		maxAssistantTextChars: message.assistantTextChars,
+		maxAssistantToolMarkupChars: message.assistantToolMarkupChars,
+		minOutdatedRewriteBytes: message.minOutdatedRewriteBytes,
 	};
 }
 
@@ -1493,30 +1491,6 @@ const TOOL_CALL_MARKUP_PATTERN = new RegExp(
 
 function utf8ByteLength(text: string): number {
 	return Buffer.byteLength(text, "utf8");
-}
-
-function parsePositiveIntegerEnv(
-	value: string | undefined,
-): number | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function parseNonNegativeLimitEnv(
-	value: string | undefined,
-): number | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-	const normalized = value.trim().toLowerCase();
-	if (normalized === "infinity" || normalized === "disable") {
-		return Number.POSITIVE_INFINITY;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
 function normalizePositiveLimit(

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -24,8 +24,14 @@ import {
 	type ToolResultContent,
 	validateAndReserveImageMedia,
 } from "@cline/shared";
+import { MAX_COMMAND_OUTPUT_CHARS } from "../../extensions/tools/executors/output-limits";
 
-export const DEFAULT_MAX_TOOL_RESULT_CHARS = 8_000;
+// Executors append their truncation notice past their own budget, so a capped
+// result runs slightly over it; this headroom keeps the backstop clear of that
+// overshoot, preserving the notice.
+const EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS = 2_000;
+export const DEFAULT_MAX_TOOL_RESULT_CHARS =
+	MAX_COMMAND_OUTPUT_CHARS + EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS;
 export const DEFAULT_MAX_FILE_CONTENT_CHARS = 50_000;
 // The aggregate budget intentionally stays far above what the per-result cap
 // usually produces: budget truncation rewrites bytes mid-transcript, which

--- a/sdk/packages/core/src/settings/context-limits.test.ts
+++ b/sdk/packages/core/src/settings/context-limits.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_CONTEXT_LIMITS,
+	MESSAGE_LIMIT_ENV,
+	resolveContextLimits,
+	TOOL_LIMIT_ENV,
+} from "./context-limits";
+
+describe("resolveContextLimits", () => {
+	it("returns defaults when nothing is set", () => {
+		expect(resolveContextLimits({}, {})).toEqual(DEFAULT_CONTEXT_LIMITS);
+	});
+
+	it("applies env over explicit overrides over defaults", () => {
+		const limits = resolveContextLimits(
+			{ tool: { readLines: 5_000, lineChars: 4_000 } },
+			{ [TOOL_LIMIT_ENV.readLines]: "9000" },
+		);
+
+		expect(limits.tool.readLines).toBe(9_000);
+		expect(limits.tool.lineChars).toBe(4_000);
+		expect(limits.tool.searchOutputChars).toBe(
+			DEFAULT_CONTEXT_LIMITS.tool.searchOutputChars,
+		);
+	});
+
+	it("ignores values that are not positive integers", () => {
+		for (const raw of ["0", "-5", "abc", "1.5", "", "  "]) {
+			const limits = resolveContextLimits(
+				{},
+				{ [MESSAGE_LIMIT_ENV.toolResultChars]: raw },
+			);
+			expect(limits.message.toolResultChars).toBe(
+				DEFAULT_CONTEXT_LIMITS.message.toolResultChars,
+			);
+		}
+	});
+
+	it("accepts 0 for minOutdatedRewriteBytes, which rewrites eagerly", () => {
+		const limits = resolveContextLimits(
+			{},
+			{ [MESSAGE_LIMIT_ENV.minOutdatedRewriteBytes]: "0" },
+		);
+		expect(limits.message.minOutdatedRewriteBytes).toBe(0);
+	});
+
+	it("keeps the infinity/disable sentinels that switch stale-read rewriting off", () => {
+		for (const raw of ["Infinity", "infinity", "disable", "  DISABLE  "]) {
+			const limits = resolveContextLimits(
+				{},
+				{ [MESSAGE_LIMIT_ENV.minOutdatedRewriteBytes]: raw },
+			);
+			expect(limits.message.minOutdatedRewriteBytes).toBe(
+				Number.POSITIVE_INFINITY,
+			);
+		}
+	});
+
+	it("keeps every executor cap clear of the forwarding cap by default", () => {
+		const { message, tool } = resolveContextLimits({}, {});
+		const largest = Math.max(
+			tool.commandOutputChars,
+			tool.readOutputChars,
+			tool.searchOutputChars,
+		);
+		// The gap must cover a truncation notice, not merely be positive: an
+		// executor's capped output arrives at its budget plus that notice.
+		expect(message.toolResultChars - largest).toBeGreaterThanOrEqual(2_000);
+	});
+
+	it("lowers executor caps to match a reduced forwarding cap", () => {
+		// Spending fewer tokens is a supported choice; the executors follow it
+		// down so their output still arrives whole rather than being re-cut.
+		const { message, tool } = resolveContextLimits(
+			{},
+			{ [MESSAGE_LIMIT_ENV.toolResultChars]: "10000" },
+		);
+
+		expect(message.toolResultChars).toBe(10_000);
+		for (const cap of [
+			tool.commandOutputChars,
+			tool.readOutputChars,
+			tool.searchOutputChars,
+		]) {
+			expect(cap).toBeLessThan(message.toolResultChars);
+		}
+	});
+
+	it("raises executor caps together with the forwarding cap", () => {
+		const { message, tool } = resolveContextLimits(
+			{},
+			{
+				[MESSAGE_LIMIT_ENV.toolResultChars]: "200000",
+				[TOOL_LIMIT_ENV.commandOutputChars]: "150000",
+			},
+		);
+
+		expect(tool.commandOutputChars).toBe(150_000);
+		expect(message.toolResultChars).toBeGreaterThan(tool.commandOutputChars);
+	});
+
+	it("keeps a usable executor cap when the forwarding cap is set absurdly low", () => {
+		// Collapsing toward 1 would leave an executor emitting a truncation notice
+		// longer than the result itself. The floor holds, and the forwarding cap
+		// the caller asked for is still respected rather than raised back.
+		for (const raw of ["1", "1500"]) {
+			const { message, tool } = resolveContextLimits(
+				{},
+				{ [MESSAGE_LIMIT_ENV.toolResultChars]: raw },
+			);
+			expect(message.toolResultChars).toBe(Number(raw));
+			for (const cap of [
+				tool.commandOutputChars,
+				tool.readOutputChars,
+				tool.searchOutputChars,
+				tool.webFetchContentChars,
+			]) {
+				expect(cap).toBeGreaterThanOrEqual(1_000);
+			}
+		}
+	});
+
+	it("honors an explicitly raised executor cap by raising the forwarding cap", () => {
+		// Silently discarding the value the caller asked for would be worse than
+		// spending the tokens they asked to spend.
+		const { message, tool } = resolveContextLimits(
+			{},
+			{ [TOOL_LIMIT_ENV.commandOutputChars]: "49000" },
+		);
+
+		expect(tool.commandOutputChars).toBe(49_000);
+		expect(message.toolResultChars).toBeGreaterThanOrEqual(51_000);
+	});
+
+	it("clears web-fetch content by the notice headroom too", () => {
+		// web-fetch adds headers and the prompt echo on top of its content slice,
+		// so it needs the same clearance as the other budgeted producers.
+		const { message, tool } = resolveContextLimits({}, {});
+		expect(message.toolResultChars - tool.webFetchContentChars).toBe(2_000);
+	});
+});

--- a/sdk/packages/core/src/settings/context-limits.ts
+++ b/sdk/packages/core/src/settings/context-limits.ts
@@ -1,0 +1,205 @@
+/**
+ * Every cap governing how much text moves between the model and its tools.
+ *
+ * Two layers are represented here, and they interact. Executors cap what they
+ * return (`command`/`read`/`search` output); the provider-request builder caps
+ * what it forwards (`toolResult` and friends). A builder cap at or below an
+ * executor cap re-cuts output the executor already sized, eliding the recovery
+ * notice it placed in the tail, so `resolveContextLimits` keeps the two apart.
+ *
+ * Every value is in characters (UTF-16 code units) except `totalTextBytes`,
+ * which is bytes, and the two line counts.
+ */
+
+/** Provider-request budgets, applied while assembling messages for the API. */
+export interface MessageContextLimits {
+	toolResultChars: number;
+	fileContentChars: number;
+	totalTextBytes: number;
+	assistantTextChars: number;
+	assistantToolMarkupChars: number;
+	minOutdatedRewriteBytes: number;
+}
+
+/** Executor and tool-input budgets, applied before a result is ever returned. */
+export interface ToolContextLimits {
+	commandOutputChars: number;
+	readLines: number;
+	lineChars: number;
+	readOutputChars: number;
+	searchOutputChars: number;
+	webFetchContentChars: number;
+	editorInputChars: number;
+	commandInputChars: number;
+	editorDiffLines: number;
+	commandPreviewChars: number;
+}
+
+export interface ContextLimits {
+	message: MessageContextLimits;
+	tool: ToolContextLimits;
+}
+
+export const DEFAULT_CONTEXT_LIMITS: ContextLimits = {
+	message: {
+		toolResultChars: 50_000,
+		fileContentChars: 50_000,
+		// Budget truncation rewrites bytes mid-transcript, which invalidates
+		// provider prefix caches from the first rewritten block onward, so this
+		// stays far above the per-result cap: a rare overflow valve.
+		totalTextBytes: 6_000_000,
+		assistantTextChars: 200_000,
+		assistantToolMarkupChars: 12_000,
+		// Batch stale-read rewrites to spare prefix caches; 0 rewrites eagerly.
+		minOutdatedRewriteBytes: 65_536,
+	},
+	tool: {
+		commandOutputChars: 48_000,
+		readLines: 2_000,
+		// Keeps a minified bundle's single 3MB line from swallowing the window.
+		lineChars: 2_000,
+		readOutputChars: 48_000,
+		searchOutputChars: 48_000,
+		webFetchContentChars: 48_000,
+		editorInputChars: 50_000,
+		commandInputChars: 12_000,
+		editorDiffLines: 200,
+		commandPreviewChars: 200,
+	},
+};
+
+/**
+ * Executors append a truncation notice past their own budget, so a capped
+ * result arrives slightly over it. The forwarding cap has to clear that.
+ */
+const EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS = 2_000;
+
+export const MESSAGE_LIMIT_ENV: Record<keyof MessageContextLimits, string> = {
+	toolResultChars: "CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS",
+	fileContentChars: "CLINE_MESSAGE_BUILDER_MAX_FILE_CONTENT_CHARS",
+	totalTextBytes: "CLINE_MESSAGE_BUILDER_MAX_TOTAL_TEXT_BYTES",
+	assistantTextChars: "CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TEXT_CHARS",
+	assistantToolMarkupChars:
+		"CLINE_MESSAGE_BUILDER_MAX_ASSISTANT_TOOL_MARKUP_CHARS",
+	minOutdatedRewriteBytes: "CLINE_MESSAGE_BUILDER_MIN_OUTDATED_REWRITE_BYTES",
+};
+
+export const TOOL_LIMIT_ENV: Record<keyof ToolContextLimits, string> = {
+	commandOutputChars: "CLINE_TOOL_MAX_COMMAND_OUTPUT_CHARS",
+	readLines: "CLINE_TOOL_MAX_READ_LINES",
+	lineChars: "CLINE_TOOL_MAX_LINE_CHARS",
+	readOutputChars: "CLINE_TOOL_MAX_READ_OUTPUT_CHARS",
+	searchOutputChars: "CLINE_TOOL_MAX_SEARCH_OUTPUT_CHARS",
+	webFetchContentChars: "CLINE_TOOL_MAX_WEB_FETCH_CONTENT_CHARS",
+	editorInputChars: "CLINE_TOOL_MAX_EDITOR_INPUT_CHARS",
+	commandInputChars: "CLINE_TOOL_MAX_COMMAND_INPUT_CHARS",
+	editorDiffLines: "CLINE_TOOL_MAX_EDITOR_DIFF_LINES",
+	commandPreviewChars: "CLINE_TOOL_MAX_COMMAND_PREVIEW_CHARS",
+};
+
+/** Parses a positive integer; anything else leaves the default in place. */
+function parsePositiveEnv(raw: string | undefined): number | undefined {
+	if (raw === undefined) return undefined;
+	const trimmed = raw.trim();
+	if (!/^\d+$/.test(trimmed)) return undefined;
+	const value = Number.parseInt(trimmed, 10);
+	return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * `minOutdatedRewriteBytes` alone accepts 0 to rewrite eagerly, and
+ * "infinity"/"disable" to switch stale-read rewriting off entirely.
+ */
+function parseNonNegativeEnv(raw: string | undefined): number | undefined {
+	if (raw === undefined) return undefined;
+	const trimmed = raw.trim();
+	const normalized = trimmed.toLowerCase();
+	if (normalized === "infinity" || normalized === "disable") {
+		return Number.POSITIVE_INFINITY;
+	}
+	if (trimmed === "0") return 0;
+	return parsePositiveEnv(trimmed);
+}
+
+export interface ContextLimitOverrides {
+	message?: Partial<MessageContextLimits>;
+	tool?: Partial<ToolContextLimits>;
+}
+
+/** Caps on output an executor sizes itself, which the forwarding cap must clear. */
+const BUDGETED_OUTPUT_KEYS = [
+	"commandOutputChars",
+	"readOutputChars",
+	"searchOutputChars",
+	"webFetchContentChars",
+] as const;
+
+/**
+ * Floor for a budgeted cap. Below roughly this, an executor's own truncation
+ * notice would be most of what it returns.
+ */
+const MIN_BUDGETED_OUTPUT_CHARS = 1_000;
+
+/**
+ * Resolves limits from env over explicit overrides over defaults, then restores
+ * the invariant the two layers share: `toolResultChars` must exceed every
+ * budgeted executor cap by the notice headroom, or forwarding re-cuts output an
+ * executor already sized and elides the notice from its middle.
+ *
+ * Lowering `toolResultChars` is a supported way to spend fewer tokens, so caps
+ * the caller did not set follow it down (never below
+ * {@link MIN_BUDGETED_OUTPUT_CHARS}). A cap the caller did set is never
+ * discarded — `toolResultChars` rises to clear it instead.
+ */
+export function resolveContextLimits(
+	overrides: ContextLimitOverrides = {},
+	env: Record<string, string | undefined> = process.env,
+): ContextLimits {
+	const message = { ...DEFAULT_CONTEXT_LIMITS.message, ...overrides.message };
+	const tool = { ...DEFAULT_CONTEXT_LIMITS.tool, ...overrides.tool };
+	const explicitTool = new Set<keyof ToolContextLimits>(
+		Object.keys(overrides.tool ?? {}) as Array<keyof ToolContextLimits>,
+	);
+
+	for (const key of Object.keys(message) as Array<keyof MessageContextLimits>) {
+		const parse =
+			key === "minOutdatedRewriteBytes"
+				? parseNonNegativeEnv
+				: parsePositiveEnv;
+		const fromEnv = parse(env[MESSAGE_LIMIT_ENV[key]]);
+		if (fromEnv !== undefined) message[key] = fromEnv;
+	}
+	for (const key of Object.keys(tool) as Array<keyof ToolContextLimits>) {
+		const fromEnv = parsePositiveEnv(env[TOOL_LIMIT_ENV[key]]);
+		if (fromEnv !== undefined) {
+			tool[key] = fromEnv;
+			explicitTool.add(key);
+		}
+	}
+
+	const ceiling = Math.max(
+		MIN_BUDGETED_OUTPUT_CHARS,
+		message.toolResultChars - EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS,
+	);
+	for (const key of BUDGETED_OUTPUT_KEYS) {
+		if (!explicitTool.has(key)) {
+			tool[key] = Math.min(tool[key], ceiling);
+		}
+	}
+
+	// Only a cap the caller set can push the forwarding cap up. Raising it to
+	// clear a floored cap would override the smaller `toolResultChars` they
+	// asked for, which is the same silent discard this branch avoids elsewhere.
+	const explicitBudgetedCaps = BUDGETED_OUTPUT_KEYS.filter((key) =>
+		explicitTool.has(key),
+	).map((key) => tool[key]);
+	if (explicitBudgetedCaps.length > 0) {
+		message.toolResultChars = Math.max(
+			message.toolResultChars,
+			Math.max(...explicitBudgetedCaps) +
+				EXECUTOR_TRUNCATION_NOTICE_HEADROOM_CHARS,
+		);
+	}
+
+	return { message, tool };
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #13263

Resolves #13263
Resolves #13278 
Resolves #13276 
Resolves #13545 

### Description

Two truncation layers disagreed, and the tighter one silently won.

Tool executors budget their output to `MAX_COMMAND_OUTPUT_CHARS` (48k) and place their truncation notice in the preserved head/tail so it survives a later cut — `output-limits.ts` says so in its header. `MessageBuilder` then re-truncated **every** tool result to 8k while building the provider request. The model received 8k of a 48k result, and every executor budget below that was dead weight. `read_files` took the same path: `maxFileContentChars` (50k) applies only to top-level file attachments, not read results.

Three commits:

**1. `fix(sdk): stop the provider request from re-truncating budgeted tool output`**
The per-result cap now derives from the executor budget plus headroom for the notice executors append past it. Equality alone would not do — a capped `run_commands` result measures 48,113 chars, so cutting at exactly 48,000 re-cuts it and elides the notice from the middle, which is the failure `output-limits.ts` warns about.

**2. `fix(sdk): let the editor tool accept a whole file in one call`**
The editor rejected `old_text`/`new_text` over 6,000 chars and its schema told the model to split larger edits into chunks. Measured against this repo: only 0.6% of real edit hunks exceed 6k, but **32% of source files do**, so creating or rewriting one routinely took several calls. The guard only ever bounced complete, schema-valid payloads, a generation cut short by `max_tokens` fails validation earlier, so it never prevented the failure its own message described. Raised to 50,000 with the advice rewritten. This also splits `INPUT_ARG_CHAR_LIMIT`, which set both that guard and, doubled, the `run_commands` command-length advisory.

**3. `feat(sdk): make every context limit configurable`**
`settings/context-limits.ts` owns the caps and resolves them from env over explicit overrides over defaults. The message-builder variables grow from covering 3 limits to all 6 (existing names unchanged), and the nine tool caps gain `CLINE_TOOL_*` equivalents. Resolved values reach both the executors that enforce them and the descriptions that quote them, so the model is never told a number that no longer applies. Budgeted caps stay clear of the forwarding cap, so no override can reintroduce the re-cut from commit 1.

It also fixes three host paths that kept the compiled defaults and ignored any override: the VS Code file-read wrapper built executors with no options, and its `run_commands` tool used the constant directly in both its foreground and background paths.

**Related open issues**: 

- **#13278** reports the 6k chunking failure and a duplicate of #13263 (*"causes regular rework and often failures greatly slowing coding"*; the reporter reverted to 3.89.2). Commit 2 removes that trigger.
- **#13276** — a model invented an unavailable `write_file` tool after *"new_text was 7084 characters, exceeding the 6000 character limit."* Commit 2 removes the trigger; the underlying `AI_NoSuchToolError` handling is untouched.
- **#13545** asks for what commit 3 provides: *"could the limit be derived rather than fixed?… or simply exposed as a setting."* Its `insert_line` EOF off-by-one is **not** addressed here.

**On the cost** Raising the default per-result cap from 8k to 50k makes steady-state requests larger, and there are open issues regardingthis: #12111 and #12067 report context growing until it exceeds the model limit, #12118 reports memory growth over long sessions, #13089 hit a transport size limit, and #13134 notes whole-file edits are already token-expensive.  
Total request size is still governed by the 6MB aggregate budget and the compaction pipeline, neither of which changes here. The old 8k did not actually save the work it appeared to: truncated output can drive re-reads and repeated tool calls, which is the cost #13263's reporters describe. And commit 3 makes the trade adjustable in both directions: anyone who wants the previous behaviour can set `CLINE_MESSAGE_BUILDER_MAX_TOOL_RESULT_CHARS=8000` and the executor caps follow it down.

**Not a breaking change.** No public export is removed or renamed, the renamed
constants (`INPUT_ARG_CHAR_LIMIT` and friends) were not reachable from
`@cline/core`, whose only subpaths are `.`, `/hub`, `/hub/daemon-entry`,
`/telemetry` and `/services/feature-flags/posthog`. New signature parameters are
optional, and the Zod input shapes are unchanged; only their descriptions differ.

Two defaults do get slightly smaller, both deliberate: `fetch_web_content` keeps
48k of content rather than 50k, aligning it with the other budgeted caps, and the
ripgrep search path now applies the per-line cap it previously skipped while the
regex fallback applied it. Both are raisable with `CLINE_TOOL_MAX_*`.

### Test Procedure

- `bun run test:unit` — core 2141, cli 1158, llms 737, agents 72, vscode 1078, all passing. `bun run lint`, `bun run format`, `tsc --noEmit`, and `bun run build:sdk` clean. (Three files fail `organizeImports` on this branch and on `main` alike — pre-existing drift, untouched here.)
- Each commit was checked out and verified in isolation: commit 1 alone passes 2128 tests, commits 1+2 pass 2129, all three pass 2141. No commit leaves the tree broken.
- The regression test for commit 1 is built from real `truncateCommandOutput` output rather than a synthetic string, and was confirmed to fail when the headroom is set to 0. The cap invariant is bounded on both sides, so neither shrinking nor inflating the headroom passes silently.
- End-to-end check that configuration reaches the model, not just the enforcement path:

```
default:                       at most 2000 lines / ~47k characters
CLINE_TOOL_MAX_READ_LINES=9000: at most 9000 lines / ~117k characters
```

- Clamp behaviour verified at the edges: an absurdly low forwarding cap floors the executor caps at a usable value instead of collapsing them toward 1; an explicitly raised executor cap raises the forwarding cap rather than being silently discarded.
- Back-compat checked: the three existing `CLINE_MESSAGE_BUILDER_*` names are unchanged, and the `infinity`/`disable` sentinels for `MIN_OUTDATED_REWRITE_BYTES` still work (a user documents relying on that in #13482).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-  Note: this PR targets single feature, namely the truncating and includes the configuration for it as well
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

A 206,639-char command output through the provider-request builder, before and after commit 1:

```
executor budget          : 48000
executor output          : 48113   (48k head+tail + its truncation notice)
after MessageBuilder     : 47999   ->  48113
executor notice survived : false   ->  true
```

### Additional Notes

**Not included.** The issue lists further limits (`read_files` line and per-line caps, `fetch_web_content` content) whose *defaults* it proposes raising to 100k. Those are now configurable, but their defaults are unchanged: `lineChars` in particular exists to stop a single minified line from consuming the window, and raising it by default would undo that.
