### PR TITLE
feat: add llmman as a local provider

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1037,6 +1037,22 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		modelsSourceUrl: "http://localhost:11434/api/tags",
 	},
 	{
+		id: "llmman",
+		name: "llmman",
+		description: "Local model runner serving the Ollama API",
+		// Routed to the native Ollama API vendor (`vendors/ollama.ts`) for the
+		// same reason as the entry above: the OpenAI-compatible `/v1` endpoint
+		// ignores `options.num_ctx`.
+		family: "ollama",
+		capabilities: ["tools"],
+		defaultModelId: "",
+		// Models are whatever the user has pulled locally, discovered
+		// dynamically rather than from a published catalog.
+		modelsFactory: () => ({}),
+		defaults: { baseUrl: "http://localhost:17434" },
+		modelsSourceUrl: "http://localhost:17434/api/tags",
+	},
+	{
 		id: "lmstudio",
 		name: "LM Studio",
 		description: "Local model inference with LM Studio",

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -27,6 +27,7 @@ export enum BUILT_IN_PROVIDER {
 	GEMINI = "gemini",
 	// Local/self-hosted
 	OLLAMA = "ollama",
+	LLMMAN = "llmman",
 	LMSTUDIO = "lmstudio",
 	// OpenAI-compatible
 	DEEPSEEK = "deepseek",


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the **Ollama API** (alongside OpenAI- and Anthropic-compatible ones) on port 17434.

It routes to the native vendor (`vendors/ollama.ts`) rather than the OpenAI-compatible path, for exactly the reason already documented on the neighbouring entry: `/v1` ignores `options.num_ctx`, so models would load at the server's default context size.

Models are whatever the user has pulled locally, so `modelsFactory` is empty and discovery goes through `/api/tags` on the configured host.

**Testing:** `tsc --noEmit -p sdk/packages/llms/tsconfig.json` gives 133 errors both before and after (all pre-existing unresolved `@cline/*` workspace imports), so nothing new is introduced. That check earned its keep — it caught me adding `case "llmman"` to a switch over `ProviderFamily` rather than provider ID; since the spec sets `family: "ollama"`, the existing case already covers it, and the stray case is gone. Biome clean.

Not verified: no run of the extension against a live server.

> AI-assisted, reviewed before submitting.
