### PR TITLE
fix(shared): preserve Windows path backslashes in tool inputs

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1394,7 +1394,7 @@ describe("AgentRuntime", () => {
 		]);
 	});
 
-	it("normalizes JSON-encoded string fields when the tool schema expects arrays", async () => {
+	it("normalizes JSON-encoded command arrays with Windows path backslashes", async () => {
 		const executeTool = vi.fn(async (input: { commands: string[] }) => ({
 			joined: input.commands.join(" && "),
 		}));
@@ -1405,9 +1405,7 @@ describe("AgentRuntime", () => {
 					type: "tool-call-delta",
 					toolCallId: "call_commands",
 					toolName: "commands",
-					inputText: JSON.stringify({
-						commands: JSON.stringify(["git status", "bun test"]),
-					}),
+					inputText: String.raw`{"commands":"[\"dir C:\\Dev\",\"echo done\"]"}`,
 				},
 				{ type: "finish", reason: "tool-calls" },
 			],
@@ -1417,7 +1415,7 @@ describe("AgentRuntime", () => {
 				expect(toolMessage.content[0]).toMatchObject({
 					type: "tool-result",
 					toolName: "commands",
-					output: { joined: "git status && bun test" },
+					output: { joined: String.raw`dir C:\Dev && echo done` },
 				});
 				return [
 					{ type: "text-delta", text: "done" },
@@ -1452,14 +1450,14 @@ describe("AgentRuntime", () => {
 
 		expect(result.status).toBe("completed");
 		expect(executeTool).toHaveBeenCalledWith(
-			{ commands: ["git status", "bun test"] },
+			{ commands: [String.raw`dir C:\Dev`, "echo done"] },
 			expect.anything(),
 		);
 		expect(beforeTool).toHaveBeenCalledWith(
 			expect.objectContaining({
-				input: { commands: ["git status", "bun test"] },
+				input: { commands: [String.raw`dir C:\Dev`, "echo done"] },
 				toolCall: expect.objectContaining({
-					input: { commands: ["git status", "bun test"] },
+					input: { commands: [String.raw`dir C:\Dev`, "echo done"] },
 				}),
 			}),
 		);

--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -81,6 +81,23 @@ describe("normalizeJsonLikeStringsForSchema", () => {
 		).toEqual({ commands: ["git status", "bun test"] });
 	});
 
+	it("repairs JSON-encoded arrays containing Windows path backslashes", () => {
+		expect(
+			normalizeJsonLikeStringsForSchema(
+				{ commands: String.raw`["dir C:\Dev"]` },
+				{
+					type: "object",
+					properties: {
+						commands: {
+							type: "array",
+							items: { type: "string" },
+						},
+					},
+				},
+			),
+		).toEqual({ commands: [String.raw`dir C:\Dev`] });
+	});
+
 	it("preserves JSON-looking strings when the schema expects strings", () => {
 		const text = JSON.stringify({ keep: "as text" });
 

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -168,6 +168,45 @@ function schemaAcceptsKind(
 	return false;
 }
 
+function preserveInvalidJsonStringEscapes(text: string): string {
+	let output = "";
+	let inString = false;
+
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index];
+		if (char === '"') {
+			inString = !inString;
+			output += char;
+			continue;
+		}
+		if (!inString || char !== "\\") {
+			output += char;
+			continue;
+		}
+
+		const next = text[index + 1];
+		if (next !== undefined && '"\\/bfnrt'.includes(next)) {
+			output += `\\${next}`;
+			index += 1;
+			continue;
+		}
+		if (
+			next === "u" &&
+			/^[0-9a-fA-F]{4}$/.test(text.slice(index + 2, index + 6))
+		) {
+			output += text.slice(index, index + 6);
+			index += 5;
+			continue;
+		}
+
+		// Preserve the slash when a JSON-encoded tool field lost one escaping
+		// layer (for example C:\Dev).
+		output += "\\\\";
+	}
+
+	return output;
+}
+
 function parseJsonStringForSchema(
 	value: unknown,
 	schema: Record<string, unknown>,
@@ -187,7 +226,9 @@ function parseJsonStringForSchema(
 	}
 
 	try {
-		const parsed = JSON.parse(trimmed) as unknown;
+		const parsed = JSON.parse(
+			preserveInvalidJsonStringEscapes(trimmed),
+		) as unknown;
 		if (Array.isArray(parsed)) {
 			return expectsArray ? parsed : value;
 		}


### PR DESCRIPTION
### Related Issue

**Issue:** #13665

Fixes #13665

### Description

When a provider emits an array-valued tool argument as a JSON-encoded string, Windows paths can arrive at the schema normalizer with one escaping layer already consumed. For example, `C:\Dev` leaves an invalid `\D` JSON escape. The nested parse then fails, so the raw JSON array string reaches the command tool and PowerShell reports a parser error.

This change:

- preserves backslashes for invalid escape sequences inside JSON string values before the schema-aware nested parse;
- keeps valid JSON escape handling and strict parsing unchanged;
- adds shared-parser and `AgentRuntime` regressions proving that `dir C:\Dev` reaches the tool as a plain command rather than a serialized array.

### Test Procedure

Run from the repository root:

```text
bun run build:sdk
cd sdk
bun -F @cline/shared test
bun -F @cline/agents test
bun -F @cline/shared typecheck
bun -F @cline/agents typecheck
cd ..
bun biome check --diagnostic-level=error \
  sdk/packages/shared/src/parse/json.ts \
  sdk/packages/shared/src/parse/json.test.ts \
  sdk/packages/agents/src/agent-runtime.test.ts
```

Results:

- `@cline/shared`: 381 tests passed
- `@cline/agents`: 72 tests passed
- both package typechecks passed
- full SDK build passed
- Biome check passed for all three changed files

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a command parsing fix with automated regression coverage.

### Additional Notes

The repair is intentionally scoped to invalid escape sequences in JSON-looking fields whose declared schema expects an array or object. Ordinary string fields are left untouched.
