### PR TITLE
fix(desktop): support Linux helper builds on Windows

### DIFF
--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -9,6 +9,9 @@ on:
       - "apps/examples/desktop-app/package.json"
       - "apps/examples/desktop-app/scripts/dmg-background.ts"
       - "apps/examples/desktop-app/scripts/dmg-background.test.ts"
+      - "apps/examples/desktop-app/scripts/build-sidecar-bin.ts"
+      - "apps/examples/desktop-app/scripts/bun-cross-compile-runtime.ts"
+      - "apps/examples/desktop-app/scripts/bun-cross-compile-runtime.test.ts"
       - "apps/examples/desktop-app/src-tauri/dmg/background.png"
       - "apps/examples/desktop-app/src-tauri/dmg/background@2x.png"
       - ".github/workflows/desktop-test.yml"
@@ -20,6 +23,9 @@ on:
       - "apps/examples/desktop-app/package.json"
       - "apps/examples/desktop-app/scripts/dmg-background.ts"
       - "apps/examples/desktop-app/scripts/dmg-background.test.ts"
+      - "apps/examples/desktop-app/scripts/build-sidecar-bin.ts"
+      - "apps/examples/desktop-app/scripts/bun-cross-compile-runtime.ts"
+      - "apps/examples/desktop-app/scripts/bun-cross-compile-runtime.test.ts"
       - "apps/examples/desktop-app/src-tauri/dmg/background.png"
       - "apps/examples/desktop-app/src-tauri/dmg/background@2x.png"
       - ".github/workflows/desktop-test.yml"
@@ -48,3 +54,29 @@ jobs:
       # not need a workspace dependency install or macOS runner.
       - name: Test DMG background tooling
         run: bun run test:dmg-background
+
+  windows-linux-cross-compile:
+    name: Test Windows to Linux Bun cross-compilation
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: apps/examples/desktop-app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Test runtime selection and validation
+        run: bun run test:bun-cross-compile-runtime
+
+      - name: Prepare pinned Linux runtimes
+        run: bun scripts/bun-cross-compile-runtime.ts bun-linux-x64 bun-linux-arm64
+
+      - name: Cross-compile Linux smoke executables
+        run: |
+          bun build scripts/bun-cross-compile-runtime.ts --compile --target=bun-linux-x64 --outfile "$env:RUNNER_TEMP/runtime-smoke-x64"
+          bun build scripts/bun-cross-compile-runtime.ts --compile --target=bun-linux-arm64 --outfile "$env:RUNNER_TEMP/runtime-smoke-arm64"

--- a/apps/examples/desktop-app/CHANGELOG.md
+++ b/apps/examples/desktop-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cline Desktop Changelog
 
-## 0.0.21-beta.1
+## 0.0.21-beta.2
 
 - Beta: hand off local sessions to Cline Cloud and continue working from cloud workspaces, with recovery for interrupted transfers and preservation of the prompt, attachments, and session state.
 - Beta: choose between local, SSH remote, and Cloud environments from the desktop app, with the experimental realtime voice and avatar overlay experiences included.

--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cline/code",
-	"version": "0.0.21-beta.1",
+	"version": "0.0.21-beta.2",
 	"private": true,
 	"scripts": {
 		"build:ui": "bun -F @cline/ui build",

--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -17,6 +17,7 @@
 		"build:binary": "tauri build",
 		"dmg:background": "bun run scripts/dmg-background.ts",
 		"test:dmg-background": "bun test scripts/dmg-background.test.ts",
+		"test:bun-cross-compile-runtime": "bun test scripts/bun-cross-compile-runtime.test.ts",
 		"package": "bun run package:desktop",
 		"package:desktop": "bun run scripts/package-desktop.ts",
 		"package:desktop:mac": "bun run scripts/package-desktop.ts --platform mac",

--- a/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { prepareWindowsCrossCompileRuntime } from "./bun-cross-compile-runtime";
 import { telemetryDefineArgs } from "./telemetry-define-args";
 
 const resolveTargetTriple = async (): Promise<string> => {
@@ -62,6 +63,7 @@ const buildSidecar = async (
 		"--no-compile-autoload-bunfig",
 	];
 	if (bunTarget) {
+		await prepareWindowsCrossCompileRuntime(bunTarget);
 		await $`bun build ${entrypoint} --compile --target=${bunTarget} ${runtimeIsolationArgs} ${optimizationArgs} ${defines} --outfile ${outfile}`;
 	} else {
 		await $`bun build ${entrypoint} --compile ${runtimeIsolationArgs} ${optimizationArgs} ${defines} --outfile ${outfile}`;

--- a/apps/examples/desktop-app/scripts/bun-cross-compile-runtime.test.ts
+++ b/apps/examples/desktop-app/scripts/bun-cross-compile-runtime.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isExpectedElfExecutable,
+	resolveWindowsCrossCompileRuntime,
+} from "./bun-cross-compile-runtime";
+
+describe("resolveWindowsCrossCompileRuntime", () => {
+	test("maps Bun's x64 target to its pinned release asset and cache name", () => {
+		expect(
+			resolveWindowsCrossCompileRuntime("bun-linux-x64", "1.3.13"),
+		).toMatchObject({
+			archiveName: "bun-linux-x64",
+			cacheFilename: "bun-linux-x64-v1.3.13",
+			downloadUrl:
+				"https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip",
+			expectedMachine: 62,
+		});
+	});
+
+	test("maps Bun's arm64 target to its aarch64 asset and cache name", () => {
+		expect(
+			resolveWindowsCrossCompileRuntime("bun-linux-arm64", "1.3.13"),
+		).toMatchObject({
+			archiveName: "bun-linux-aarch64",
+			cacheFilename: "bun-linux-aarch64-v1.3.13",
+			expectedMachine: 183,
+		});
+	});
+
+	test("does not intercept native or non-Linux targets", () => {
+		expect(
+			resolveWindowsCrossCompileRuntime("bun-windows-x64", "1.3.13"),
+		).toBeUndefined();
+		expect(
+			resolveWindowsCrossCompileRuntime("bun-darwin-arm64", "1.3.13"),
+		).toBeUndefined();
+	});
+
+	test("fails closed when Bun changes without updated checksums", () => {
+		expect(() =>
+			resolveWindowsCrossCompileRuntime("bun-linux-x64", "1.3.14"),
+		).toThrow("requires Bun 1.3.13");
+	});
+});
+
+describe("isExpectedElfExecutable", () => {
+	const elfHeader = (machine: number): Uint8Array => {
+		const header = new Uint8Array(20);
+		header.set([0x7f, 0x45, 0x4c, 0x46]);
+		header[5] = 1;
+		header[18] = machine & 0xff;
+		header[19] = (machine >> 8) & 0xff;
+		return header;
+	};
+
+	test("accepts the expected little-endian ELF architecture", () => {
+		expect(isExpectedElfExecutable(elfHeader(62), 62)).toBe(true);
+		expect(isExpectedElfExecutable(elfHeader(183), 183)).toBe(true);
+	});
+
+	test("rejects the wrong architecture and malformed files", () => {
+		expect(isExpectedElfExecutable(elfHeader(62), 183)).toBe(false);
+		expect(isExpectedElfExecutable(new Uint8Array(20), 62)).toBe(false);
+		expect(isExpectedElfExecutable(new Uint8Array(10), 62)).toBe(false);
+	});
+});

--- a/apps/examples/desktop-app/scripts/bun-cross-compile-runtime.ts
+++ b/apps/examples/desktop-app/scripts/bun-cross-compile-runtime.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import {
+	copyFile,
+	mkdir,
+	mkdtemp,
+	open,
+	rename,
+	rm,
+	stat,
+} from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+
+const PINNED_BUN_VERSION = "1.3.13";
+
+type RuntimeSpec = {
+	archiveName: string;
+	cacheName: string;
+	expectedMachine: number;
+	sha256: string;
+};
+
+const WINDOWS_LINUX_RUNTIME_SPECS: Record<string, RuntimeSpec> = {
+	"bun-linux-x64": {
+		archiveName: "bun-linux-x64",
+		cacheName: "bun-linux-x64",
+		expectedMachine: 62,
+		sha256: "79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a",
+	},
+	"bun-linux-arm64": {
+		archiveName: "bun-linux-aarch64",
+		cacheName: "bun-linux-aarch64",
+		expectedMachine: 183,
+		sha256: "70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22",
+	},
+};
+
+export type WindowsCrossCompileRuntime = RuntimeSpec & {
+	cacheFilename: string;
+	downloadUrl: string;
+};
+
+export const resolveWindowsCrossCompileRuntime = (
+	bunTarget: string,
+	bunVersion: string,
+): WindowsCrossCompileRuntime | undefined => {
+	const spec = WINDOWS_LINUX_RUNTIME_SPECS[bunTarget];
+	if (!spec) return undefined;
+	if (bunVersion !== PINNED_BUN_VERSION) {
+		throw new Error(
+			`Windows Linux cross-compilation requires Bun ${PINNED_BUN_VERSION}; received ${bunVersion}`,
+		);
+	}
+	return {
+		...spec,
+		cacheFilename: `${spec.cacheName}-v${bunVersion}`,
+		downloadUrl: `https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/${spec.archiveName}.zip`,
+	};
+};
+
+export const isExpectedElfExecutable = (
+	header: Uint8Array,
+	expectedMachine: number,
+): boolean =>
+	header.length >= 20 &&
+	header[0] === 0x7f &&
+	header[1] === 0x45 &&
+	header[2] === 0x4c &&
+	header[3] === 0x46 &&
+	header[5] === 1 &&
+	header[18] === (expectedMachine & 0xff) &&
+	header[19] === ((expectedMachine >> 8) & 0xff);
+
+const hasExpectedRuntime = async (
+	filePath: string,
+	expectedMachine: number,
+): Promise<boolean> => {
+	try {
+		const fileStat = await stat(filePath);
+		if (!fileStat.isFile() || fileStat.size < 1_000_000) return false;
+		const file = await open(filePath, "r");
+		try {
+			const header = new Uint8Array(20);
+			const { bytesRead } = await file.read(header, 0, header.length, 0);
+			return (
+				bytesRead === header.length &&
+				isExpectedElfExecutable(header, expectedMachine)
+			);
+		} finally {
+			await file.close();
+		}
+	} catch {
+		return false;
+	}
+};
+
+const powershellLiteral = (value: string): string =>
+	`'${value.replaceAll("'", "''")}'`;
+
+/**
+ * Bun cannot currently unpack Linux cross-compile runtimes on Windows. Put the
+ * official pinned runtime in Bun's normal cache so `bun build --compile` can
+ * use it without taking the broken extractor path.
+ */
+export const prepareWindowsCrossCompileRuntime = async (
+	bunTarget: string,
+): Promise<void> => {
+	if (process.platform !== "win32") return;
+	const spec = resolveWindowsCrossCompileRuntime(bunTarget, Bun.version);
+	if (!spec) return;
+
+	const bunInstall =
+		process.env.BUN_INSTALL?.trim() || path.join(homedir(), ".bun");
+	const cacheDir = path.join(bunInstall, "install", "cache");
+	const cachePath = path.join(cacheDir, spec.cacheFilename);
+	if (await hasExpectedRuntime(cachePath, spec.expectedMachine)) return;
+
+	const stagingDir = await mkdtemp(
+		path.join(tmpdir(), `cline-${spec.archiveName}-`),
+	);
+	try {
+		const archivePath = path.join(stagingDir, `${spec.archiveName}.zip`);
+		const extractDir = path.join(stagingDir, "extracted");
+		const response = await fetch(spec.downloadUrl);
+		if (!response.ok) {
+			throw new Error(
+				`Failed to download ${spec.archiveName}: HTTP ${response.status}`,
+			);
+		}
+		const archive = new Uint8Array(await response.arrayBuffer());
+		const actualSha256 = createHash("sha256").update(archive).digest("hex");
+		if (actualSha256 !== spec.sha256) {
+			throw new Error(
+				`${spec.archiveName} checksum mismatch: expected ${spec.sha256}, received ${actualSha256}`,
+			);
+		}
+		await Bun.write(archivePath, archive);
+		await mkdir(extractDir, { recursive: true });
+
+		const expandCommand = `Expand-Archive -LiteralPath ${powershellLiteral(archivePath)} -DestinationPath ${powershellLiteral(extractDir)} -Force`;
+		const expand = Bun.spawn(
+			[
+				"powershell.exe",
+				"-NoLogo",
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				expandCommand,
+			],
+			{ stdout: "inherit", stderr: "inherit" },
+		);
+		const expandExitCode = await expand.exited;
+		if (expandExitCode !== 0) {
+			throw new Error(
+				`Failed to extract ${spec.archiveName} (exit ${expandExitCode})`,
+			);
+		}
+
+		const extractedRuntime = path.join(extractDir, spec.archiveName, "bun");
+		if (!(await hasExpectedRuntime(extractedRuntime, spec.expectedMachine))) {
+			throw new Error(
+				`${spec.archiveName} did not contain the expected Linux executable`,
+			);
+		}
+
+		await mkdir(cacheDir, { recursive: true });
+		const stagedCachePath = `${cachePath}.${process.pid}.tmp`;
+		await copyFile(extractedRuntime, stagedCachePath);
+		await rm(cachePath, { force: true, recursive: true });
+		await rename(stagedCachePath, cachePath);
+		console.log(`Prepared Bun cross-compile runtime: ${spec.cacheFilename}`);
+	} finally {
+		await rm(stagingDir, { force: true, recursive: true });
+	}
+};
+
+const main = async (): Promise<void> => {
+	const targets = process.argv.slice(2);
+	if (targets.length === 0) {
+		throw new Error("Pass at least one Bun compile target to prepare");
+	}
+	for (const target of targets) {
+		await prepareWindowsCrossCompileRuntime(target);
+	}
+};
+
+if (import.meta.main) {
+	main().catch((error: unknown) => {
+		console.error(error);
+		process.exitCode = 1;
+	});
+}

--- a/apps/examples/desktop-app/src-tauri/tauri.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Cline",
-	"version": "0.0.21-beta.1",
+	"version": "0.0.21-beta.2",
 	"identifier": "bot.cline.app",
 	"build": {
 		"beforeDevCommand": "bun run build:sidecar:bin && bun run dev:web",


### PR DESCRIPTION
## Summary

- work around Bun 1.3.13 Windows-to-Linux cross-compilation extraction failures by securely preparing the pinned Linux runtimes in Bun's cache
- verify the official runtime archives by SHA-256 and ELF architecture before use
- add a Windows CI smoke test that prepares and cross-compiles both x64 and arm64 Linux executables

This is scoped to `desktop-experimental`; `main` and stable are unchanged.

## Context

The `desktop-v0.0.21-beta.1` publish failed three times in the Windows job after the native Windows sidecar succeeded, when Bun attempted to extract `bun-linux-x64-v1.3.13` for the experimental SSH remote helper.

- Failed release run: https://github.com/cline/cline/actions/runs/33430505979
- Upstream Bun issue: https://github.com/oven-sh/bun/issues/25346

## Validation

- `bun run build:sdk`
- `bun run typecheck` in `apps/examples/desktop-app`
- `bun run test:bun-cross-compile-runtime` (6 tests)
- Biome checks for all changed TypeScript/JSON files
- local cache-injection smoke build produced valid Linux x86-64 and ARM64 ELF helpers with Bun 1.3.13
- PR CI runs the same cache preparation and both Bun cross-compiles on `windows-latest`