### PR TITLE
fix(core): sanitize credential fields when saving provider settings

### DIFF
--- a/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.test.ts
@@ -591,4 +591,156 @@ describe("ProviderSettingsManager", () => {
 			providers: {},
 		});
 	});
+
+	describe("credential sanitization on save", () => {
+		const createManager = () => {
+			const tempDir = mkdtempSync(
+				path.join(os.tmpdir(), "core-provider-settings-"),
+			);
+			tempDirs.push(tempDir);
+			const filePath = path.join(tempDir, "provider-settings.json");
+			return {
+				manager: new ProviderSettingsManager({ filePath }),
+				filePath,
+			};
+		};
+
+		const readStoredSettings = (filePath: string, providerId: string) => {
+			const raw = JSON.parse(readFileSync(filePath, "utf8")) as {
+				providers: Record<string, { settings: Record<string, unknown> }>;
+			};
+			return raw.providers[providerId]?.settings;
+		};
+
+		it("strips invisible characters and whitespace from the api key", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "mistral",
+				apiKey: "\ufeff\u200b sk-mistral-key\u202e\r\n ",
+			});
+
+			expect(manager.getProviderSettings("mistral")?.apiKey).toBe(
+				"sk-mistral-key",
+			);
+			expect(readStoredSettings(filePath, "mistral")?.apiKey).toBe(
+				"sk-mistral-key",
+			);
+		});
+
+		it("drops an api key that is only whitespace and invisible characters", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "mistral",
+				model: "mistral-large-latest",
+				apiKey: " \u200b \r\n ",
+			});
+
+			expect(manager.getProviderSettings("mistral")?.apiKey).toBeUndefined();
+			const stored = readStoredSettings(filePath, "mistral");
+			expect(stored).not.toHaveProperty("apiKey");
+			expect(stored?.model).toBe("mistral-large-latest");
+		});
+
+		it("sanitizes auth tokens while preserving the rest of the auth block", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "cline",
+				auth: {
+					apiKey: " auth-key\u200b ",
+					accessToken: " access-token ",
+					refreshToken: " refresh-token\ufeff",
+					expiresAt: 1234567890,
+					accountId: "acct-1",
+				},
+			});
+
+			expect(readStoredSettings(filePath, "cline")?.auth).toEqual({
+				apiKey: "auth-key",
+				accessToken: "access-token",
+				refreshToken: "refresh-token",
+				expiresAt: 1234567890,
+				accountId: "acct-1",
+			});
+		});
+
+		it("sanitizes aws credentials while preserving non-credential aws fields", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "bedrock",
+				aws: {
+					accessKey: " AKIA-EXAMPLE\u200b",
+					secretKey: "\ufeffsecret-value ",
+					sessionToken: " session-value\r\n",
+					region: "us-east-1",
+					profile: "default",
+				},
+			});
+
+			expect(readStoredSettings(filePath, "bedrock")?.aws).toEqual({
+				accessKey: "AKIA-EXAMPLE",
+				secretKey: "secret-value",
+				sessionToken: "session-value",
+				region: "us-east-1",
+				profile: "default",
+			});
+		});
+
+		it("sanitizes gcp fields", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "vertex",
+				gcp: {
+					projectId: " my-project\u200b ",
+					region: " us-central1 ",
+				},
+			});
+
+			expect(readStoredSettings(filePath, "vertex")?.gcp).toEqual({
+				projectId: "my-project",
+				region: "us-central1",
+			});
+		});
+
+		it("sanitizes sap client credentials", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "sapaicore",
+				sap: {
+					clientId: " client-id\u200b",
+					clientSecret: "\ufeffclient-secret ",
+					resourceGroup: "default",
+				},
+			});
+
+			expect(readStoredSettings(filePath, "sapaicore")?.sap).toEqual({
+				clientId: "client-id",
+				clientSecret: "client-secret",
+				resourceGroup: "default",
+			});
+		});
+
+		it("sanitizes header values without touching header names", () => {
+			const { manager, filePath } = createManager();
+
+			manager.saveProviderSettings({
+				provider: "litellm",
+				baseUrl: "https://litellm.example.com",
+				headers: {
+					Authorization: " Bearer token-value\u200b\r\n",
+					"X-Custom": "plain-value",
+				},
+			});
+
+			expect(readStoredSettings(filePath, "litellm")?.headers).toEqual({
+				Authorization: "Bearer token-value",
+				"X-Custom": "plain-value",
+			});
+		});
+	});
 });

--- a/sdk/packages/core/src/services/storage/provider-settings-manager.ts
+++ b/sdk/packages/core/src/services/storage/provider-settings-manager.ts
@@ -52,6 +52,72 @@ export interface ResolveLastUsedProviderSettingsOptions {
 const CLINE_PROVIDER_ID = "cline";
 const CLINE_PASS_PROVIDER_ID = "cline-pass";
 
+/**
+ * A pasted credential can carry invisible control or format characters (BOM,
+ * zero-width spaces, bidirectional marks) that make the provider reject it
+ * with a 401 indistinguishable from a genuinely wrong key — while masked
+ * rendering hides the corruption from the user. Strip those characters and
+ * surrounding whitespace from every credential-bearing field before the
+ * value is persisted.
+ */
+const INVISIBLE_CHARS = /[\p{Cc}\p{Cf}]/gu;
+
+function sanitizeSecret(value: string | undefined): string | undefined {
+	if (typeof value !== "string") {
+		return value;
+	}
+	const cleaned = value.replace(INVISIBLE_CHARS, "").trim();
+	return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function sanitizeCredentialFields(
+	settings: ProviderSettings,
+): ProviderSettings {
+	const next: ProviderSettings = {
+		...settings,
+		apiKey: sanitizeSecret(settings.apiKey),
+	};
+	if (settings.auth) {
+		next.auth = {
+			...settings.auth,
+			apiKey: sanitizeSecret(settings.auth.apiKey),
+			accessToken: sanitizeSecret(settings.auth.accessToken),
+			refreshToken: sanitizeSecret(settings.auth.refreshToken),
+		};
+	}
+	if (settings.aws) {
+		next.aws = {
+			...settings.aws,
+			accessKey: sanitizeSecret(settings.aws.accessKey),
+			secretKey: sanitizeSecret(settings.aws.secretKey),
+			sessionToken: sanitizeSecret(settings.aws.sessionToken),
+		};
+	}
+	if (settings.gcp) {
+		next.gcp = {
+			...settings.gcp,
+			projectId: sanitizeSecret(settings.gcp.projectId),
+			region: sanitizeSecret(settings.gcp.region),
+		};
+	}
+	if (settings.sap) {
+		next.sap = {
+			...settings.sap,
+			clientId: sanitizeSecret(settings.sap.clientId),
+			clientSecret: sanitizeSecret(settings.sap.clientSecret),
+		};
+	}
+	if (settings.headers) {
+		next.headers = Object.fromEntries(
+			Object.entries(settings.headers).map(([name, value]) => [
+				name,
+				value.replace(INVISIBLE_CHARS, "").trim(),
+			]),
+		);
+	}
+	return next;
+}
+
 function inferLegacyDataDir(filePath: string): string | undefined {
 	if (basename(filePath) !== "providers.json") {
 		return undefined;
@@ -151,7 +217,9 @@ export class ProviderSettingsManager {
 		settings: unknown,
 		options: SaveProviderSettingsOptions = {},
 	): StoredProviderSettings {
-		const validatedSettings = ProviderSettingsSchema.parse(settings);
+		const validatedSettings = sanitizeCredentialFields(
+			ProviderSettingsSchema.parse(settings),
+		);
 		const previous = this.read();
 		const providerId = validatedSettings.provider;
 		const shouldSetLastUsed = options.setLastUsed !== false;


### PR DESCRIPTION
Follow-up to #13549, addressing abeatrix's non-blocking review suggestion to sanitize credentials at the shared storage layer rather than only in the VS Code store. Related: [CLINE-2982](https://linear.app/cline-bot/issue/CLINE-2982/mistral-invalid-api-key).

### What

`ProviderSettingsManager.saveProviderSettings()` — the providers.json write funnel shared by the CLI, desktop, and the VS Code SDK store — now sanitizes every credential-bearing string field after the zod parse and before persisting:

- `apiKey`
- `auth.apiKey` / `auth.accessToken` / `auth.refreshToken`
- `aws.accessKey` / `aws.secretKey` / `aws.sessionToken`
- `gcp.projectId` / `gcp.region`
- `sap.clientId` / `sap.clientSecret`
- `headers` values (names untouched)

Sanitization mirrors `sanitizeApiKeyPatch` in the VS Code model-catalog store: strip Unicode control/format characters (`\p{Cc}`/`\p{Cf}` — BOM, zero-width spaces, bidi marks, CR/LF) and trim surrounding whitespace. A pasted key carrying one of these renders masked in the UI, so the corruption is invisible, and the provider rejects it with a 401 indistinguishable from a genuinely wrong key — the failure mode behind CLINE-2982.

An optional secret that sanitizes to empty (whitespace/invisible characters only) is dropped from the stored settings, i.e. whitespace-only clears the field. Header entries keep their (possibly empty) sanitized value so a deliberately set header name is never silently removed.

`sanitizeApiKeyPatch` in `apps/vscode/src/sdk/model-catalog/store.ts` stays: it also feeds the legacy StateManager secret mirror, which core never sees.

### Tests

New `credential sanitization on save` block in `provider-settings-manager.test.ts`: one test per field family asserting both the in-memory result and the raw persisted JSON, plus whitespace-only-clears for `apiKey` and preservation of neighboring non-credential fields (`aws.region`, `aws.profile`, `auth.expiresAt`, `sap.resourceGroup`).

Verified locally: `vitest run src/services/storage/` (53 passed) and `bun tsc -p tsconfig.dev.json --noEmit` + smoke typecheck in `sdk/packages/core`.
