### PR TITLE
Fix ask-question option text not wrapping in desktop app

### DIFF
--- a/sdk/packages/ui/components/agent-ask-question.css
+++ b/sdk/packages/ui/components/agent-ask-question.css
@@ -27,6 +27,12 @@
 	font-variant: inherit;
 	letter-spacing: inherit;
 	line-height: inherit;
+	/* The Button base sets `whitespace-nowrap`, and clsx keeps both classes on
+	 * the element, letting the utility stylesheet's order pick nowrap. This
+	 * unlayered rule beats layered utilities so long options wrap instead of
+	 * clipping under the item's overflow:hidden. */
+	white-space: normal;
+	overflow-wrap: anywhere;
 }
 
 .cline-ui-agent-ask-question__option:hover:not(:disabled) {

--- a/sdk/packages/ui/components/agent-ask-question.tsx
+++ b/sdk/packages/ui/components/agent-ask-question.tsx
@@ -188,7 +188,7 @@ export function AgentAskQuestion({
 								<Button
 									aria-pressed={selected.includes(option)}
 									autoFocus={itemIndex === 0 && index === 0 && !isPending}
-									className="cline-ui-agent-ask-question__option h-auto min-h-9.5 w-full max-w-full justify-start gap-3 whitespace-normal rounded-cline-ui-md p-2 text-left text-cline-ui-sm wrap-anywhere"
+									className="cline-ui-agent-ask-question__option h-auto min-h-9.5 w-full max-w-full justify-start gap-3 rounded-cline-ui-md p-2 text-left text-cline-ui-sm"
 									disabled={isPending}
 									key={option}
 									onClick={() => selectOption(option)}


### PR DESCRIPTION
### Description

Fixes the reported question tool UI bug where long option text does not wrap and gets hidden, with no horizontal scroll available.

Root cause: each option in `AgentAskQuestion` renders through the shared `Button`, whose base classes include `whitespace-nowrap`. The option added `whitespace-normal`, but `Button` merges classes with plain `clsx` (no tailwind-merge), so both utilities land on the element and the generated stylesheet's order decides the winner. Tailwind v4 emits `.whitespace-nowrap` after `.whitespace-normal`, so nowrap wins, and the long line is then clipped by the question card's `overflow: hidden`.

Fix: move the wrapping to `agent-ask-question.css` (`white-space: normal; overflow-wrap: anywhere;` on the option). The component CSS is unlayered while Tailwind v4 utilities live in a cascade layer, so this reliably wins without `!important`, the same pattern already used for the shared chat markdown styles. The now-superseded `whitespace-normal` / `wrap-anywhere` utilities were removed from the option className.

### Before

![Option A text clipped at card edge, rest hidden](https://cursor.com/artifacts/c/art-f66e3198-bfe4-4594-b143-9188389fa750)

### After

![Option A text wrapping onto two lines, fully readable](https://cursor.com/artifacts/c/art-47f3f681-3299-445a-84bf-721aad41afb2)

### Test Plan

- `bun -F @cline/ui test` passes (148 tests).
- Verified end to end in the desktop app (headless sidecar + web UI on :3125) by triggering a real question tool response with a ~230 character Option A: the text wraps onto two lines and is fully readable, and selecting the option still works. The before screenshot reproduces the original report with the same question card and the fix reverted.