### PR TITLE
fix(cli): stop assistant text flashing when a response settles

### DIFF
--- a/apps/cli/src/tui/components/chat-entry.tsx
+++ b/apps/cli/src/tui/components/chat-entry.tsx
@@ -657,11 +657,18 @@ export function ChatEntryView(props: {
 						 * token identity, so settled content never re-renders.
 						 * tableOptions preserves the bordered table style that coalesced
 						 * mode used by default (top-level defaults to borderless columns).
+						 *
+						 * streaming stays true even after the entry settles: flipping the
+						 * prop makes MarkdownRenderable rebuild every block from scratch
+						 * (updateBlocks(true) skips all reuse paths), so the finished
+						 * message flashes back to unhighlighted text while tree-sitter
+						 * re-highlights. opencode's TUI keeps streaming={true} for the
+						 * same reason. entry.streaming still drives the spinner glyph.
 						 */}
 						<markdown
 							content={content}
 							syntaxStyle={getSyntaxStyle(theme, mode)}
-							streaming={entry.streaming}
+							streaming={true}
 							internalBlockMode="top-level"
 							tableOptions={{ style: "grid" }}
 							fg={defaultFg}


### PR DESCRIPTION
## Problem

In the CLI TUI, assistant text sometimes visibly flashes while the agent is responding. The flash happens at the end of every streamed text segment (end of message, or right before a tool call splits the message).

## Root cause

`chat-entry.tsx` passed `streaming={entry.streaming}` to the `<markdown>` renderable, and `entry.streaming` flips from true to false when a segment settles. In `@opentui/core`, the `streaming` setter calls `updateBlocks(true)`, and that forced update skips every block-reuse path in `updateTopLevelBlocks`: all block renderables are destroyed and recreated, then re-highlighted asynchronously by tree-sitter. Until the highlight round-trip completes, the entire message renders blank/unhighlighted, which is the flash users see.

Reproduced deterministically with opentui's test renderer and a manually resolved mock tree-sitter client: after flipping `streaming` to false, the settled message disappears from the frame entirely for every render pass until re-highlighting completes; keeping `streaming` true produces zero flashed frames.

```
=== OLD behavior: streaming={entry.streaming} flips false on settle ===
  streamed + highlighted: heading is HIGHLIGHTED
  frame 1 after settle: heading is MISSING (blank frame)
  frame 2 after settle: heading is MISSING (blank frame)
  frame 3 after settle: heading is MISSING (blank frame)
  after re-highlight completes: heading is HIGHLIGHTED
  -> 3 flashed frame(s)

=== FIXED behavior: streaming={true} kept for settled entries ===
  frame 1 after settle: heading is HIGHLIGHTED
  frame 2 after settle: heading is HIGHLIGHTED
  frame 3 after settle: heading is HIGHLIGHTED
  -> 0 flashed frame(s)
```

## Fix

Keep `streaming={true}` on the transcript markdown permanently, so the prop never flips and settled blocks are reused by token identity. This is the same approach opencode's TUI uses for assistant text (`TextPart` in their session route passes `streaming={true}` unconditionally). `entry.streaming` still drives the spinner-vs-asterisk glyph. One-line change plus a comment.

Note: opencode hit the related fenced-code streaming flicker upstream (opencode issue 27897), which opentui fixed in `48c02d1` ("no markdown fenced code flicker"); that fix is already in the `@opentui/core` 0.4.3 we ship. This PR addresses the remaining settle-time flash.

## Testing

- Deterministic before/after frame comparison with `@opentui/core/testing` (output above).
- `bun run test:unit` in `apps/cli`: 1158 tests pass.
- Live TUI run via tuistory with a VCR cassette (`CLINE_VCR=playback`) streaming a long response: polled ~290 screen snapshots across the full streaming-and-settle window, and the response text never vanished. Consecutive settled frames are byte-identical.

![Response streaming in the TUI](https://cursor.com/artifacts/c/art-1c8cb056-0b81-4ccd-8aa2-d50d648b52ec)
![Settled response rendered stably after the turn completes](https://cursor.com/artifacts/c/art-445c1655-2d20-4f4e-a702-2f98066042af)