### PR TITLE
feat(cli): handle outdated hub sessions with drain and replace flow

### DIFF
--- a/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
@@ -15,6 +15,27 @@ export function resolveHubUpdateRequiredKeyAction(
 }
 
 /**
+ * Human phrase for the live work an outdated Hub is serving, used by the
+ * "Hub update required" dialog. Falls back to an unquantified phrase when the
+ * Hub could not answer the activity query.
+ */
+export function describeOutdatedHubSessions(counts: {
+	activeSessionCount?: number;
+	participantClientCount?: number;
+}): string {
+	const sessions = counts.activeSessionCount;
+	if (typeof sessions !== "number" || sessions <= 0) {
+		return "active sessions from other Cline clients";
+	}
+	const sessionsPhrase = `${sessions} active session${sessions === 1 ? "" : "s"}`;
+	const clients = counts.participantClientCount;
+	if (typeof clients !== "number" || clients <= 0) {
+		return sessionsPhrase;
+	}
+	return `${sessionsPhrase} from ${clients} connected Cline client${clients === 1 ? "" : "s"}`;
+}
+
+/**
  * Yolo and sandbox sessions force the local backend and never attach to the
  * shared managed Hub (see the forceLocalBackend condition in the interactive
  * session runtime), so a build mismatch on that Hub is another installation's

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
@@ -76,7 +76,6 @@ export function HubOutdatedContent(
 		activeSessionCount,
 		dialogId,
 		dismiss,
-		hubCoreVersion,
 		participantClientCount,
 		resolve,
 	} = props;
@@ -97,9 +96,7 @@ export function HubOutdatedContent(
 			<text fg="yellow">Cline Hub update required</text>
 			<box flexDirection="column">
 				<text selectable>
-					This CLI needs a newer Cline Hub than the one currently running
-					{hubCoreVersion ? ` (core ${hubCoreVersion})` : ""}. It was left
-					running because it is still serving{" "}
+					This CLI needs a newer Cline Hub, but the running one is still serving{" "}
 					{describeOutdatedHubSessions({
 						activeSessionCount,
 						participantClientCount,
@@ -107,17 +104,16 @@ export function HubOutdatedContent(
 					.
 				</text>
 				<text selectable>
-					Updating now stops that Hub and interrupts those sessions. Dismiss to
-					keep it running and update later.
+					Updating stops that Hub and interrupts its sessions.
 				</text>
 			</box>
 			<box flexDirection="row">
 				<box paddingX={1} backgroundColor={palette.act}>
-					<text fg={palette.textOnSelection}>Update Hub now</text>
+					<text fg={palette.textOnSelection}>Update Now</text>
 				</box>
 			</box>
 			<text fg={palette.muted}>
-				Press Enter to update the Hub now, Esc to keep it running
+				Press Enter to update now, Esc to keep the Hub running
 			</text>
 		</box>
 	);

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
@@ -2,12 +2,21 @@
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useDialogPalette } from "../../hooks/use-theme";
-import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
+import {
+	describeOutdatedHubSessions,
+	resolveHubUpdateRequiredKeyAction,
+} from "./hub-update-required-helpers";
 
 export interface HubUpdateRequiredDetails {
 	hubCoreVersion?: string;
 }
 
+/**
+ * Shown only for `unsupported_protocol`: the running Hub speaks a protocol
+ * this CLI cannot, so nothing hub-backed works until the CLI updates. The
+ * softer `build_mismatch` case (newer Hub, compatible protocol) is a toast
+ * in root.tsx, not this modal.
+ */
 export function HubUpdateRequiredContent(
 	props: ChoiceContext<boolean> & HubUpdateRequiredDetails,
 ) {
@@ -29,13 +38,12 @@ export function HubUpdateRequiredContent(
 			<text fg="yellow">Cline Hub was updated</text>
 			<box flexDirection="column">
 				<text selectable>
-					Another Cline installation restarted the shared Cline Hub
-					{hubCoreVersion ? ` (core ${hubCoreVersion})` : ""}, and it no longer
-					matches this CLI.
+					Another Cline installation updated the shared Cline Hub
+					{hubCoreVersion ? ` (core ${hubCoreVersion})` : ""} to a version this
+					CLI cannot talk to.
 				</text>
 				<text selectable>
-					Update and restart Cline so this CLI and the Hub run the same version
-					again.
+					Update and restart Cline to reconnect to the running Hub.
 				</text>
 			</box>
 			<box flexDirection="row">
@@ -45,6 +53,71 @@ export function HubUpdateRequiredContent(
 			</box>
 			<text fg={palette.muted}>
 				Press Enter to update and restart, Esc to dismiss
+			</text>
+		</box>
+	);
+}
+
+export interface HubOutdatedDetails {
+	hubCoreVersion?: string;
+	activeSessionCount?: number;
+	participantClientCount?: number;
+}
+
+/**
+ * Shown when this CLI is the newer build and the shared Hub was left running
+ * an older one because it is still serving other clients' sessions. Enter
+ * replaces the Hub now (interrupting that work); Esc keeps it running.
+ */
+export function HubOutdatedContent(
+	props: ChoiceContext<boolean> & HubOutdatedDetails,
+) {
+	const {
+		activeSessionCount,
+		dialogId,
+		dismiss,
+		hubCoreVersion,
+		participantClientCount,
+		resolve,
+	} = props;
+	const palette = useDialogPalette();
+
+	useDialogKeyboard((key) => {
+		const action = resolveHubUpdateRequiredKeyAction(key);
+		if (action === "ignore") return;
+		if (action === "update") {
+			resolve(true);
+			return;
+		}
+		dismiss();
+	}, dialogId);
+
+	return (
+		<box flexDirection="column" paddingX={1} gap={1}>
+			<text fg="yellow">Cline Hub update required</text>
+			<box flexDirection="column">
+				<text selectable>
+					This CLI needs a newer Cline Hub than the one currently running
+					{hubCoreVersion ? ` (core ${hubCoreVersion})` : ""}. It was left
+					running because it is still serving{" "}
+					{describeOutdatedHubSessions({
+						activeSessionCount,
+						participantClientCount,
+					})}
+					.
+				</text>
+				<text selectable>
+					Updating now stops that Hub and interrupts those sessions. Dismiss to
+					keep it running and update later.
+				</text>
+			</box>
+			<box flexDirection="row">
+				<box paddingX={1} backgroundColor={palette.act}>
+					<text fg={palette.textOnSelection}>Update Hub now</text>
+				</box>
+			</box>
+			<text fg={palette.muted}>
+				Press Enter to update the Hub now, Esc to keep it running
 			</text>
 		</box>
 	);

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -618,12 +618,19 @@ function App(props: TuiProps) {
 							force: true,
 							reason: "cline TUI hub update",
 						});
-						showToast(
-							result.outcome === "replaced" || result.outcome === "started"
-								? "Cline Hub updated."
-								: "Cline Hub is already up to date.",
-							"success",
-						);
+						if (result.outcome === "still_busy") {
+							showToast(
+								"The Hub picked up new sessions before it could be replaced. Try again in a moment.",
+								"info",
+							);
+						} else {
+							showToast(
+								result.outcome === "replaced" || result.outcome === "started"
+									? "Cline Hub updated."
+									: "Cline Hub is already up to date.",
+								"success",
+							);
+						}
 					} catch (error) {
 						showToast(
 							error instanceof Error && error.message

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -610,6 +610,12 @@ function App(props: TuiProps) {
 				})
 				.then(async (update) => {
 					if (!update) {
+						// choice() resolves undefined on Esc; it does not reject.
+						showToast(
+							"The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish.",
+							"info",
+						);
+						refocusTextareaRef.current();
 						return;
 					}
 					showToast("Updating the Cline Hub…", "info");
@@ -642,10 +648,6 @@ function App(props: TuiProps) {
 					refocusTextareaRef.current();
 				})
 				.catch(() => {
-					showToast(
-						"The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish.",
-						"info",
-					);
 					refocusTextareaRef.current();
 				});
 			return;

--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -2,6 +2,7 @@ import {
 	getCurrentContextSize,
 	type ManagedHubBuildMismatchEvent,
 	summarizeUsageFromMessages,
+	upgradeManagedHub,
 	watchManagedHubBuildMismatch,
 } from "@cline/core";
 import { formatDisplayUserInput } from "@cline/shared";
@@ -40,7 +41,10 @@ import {
 	buildCommandPaletteItems,
 	findCommandPaletteShortcut,
 } from "./components/dialogs/command-palette-items";
-import { HubUpdateRequiredContent } from "./components/dialogs/hub-update-required";
+import {
+	HubOutdatedContent,
+	HubUpdateRequiredContent,
+} from "./components/dialogs/hub-update-required";
 import { shouldWatchManagedHubBuild } from "./components/dialogs/hub-update-required-helpers";
 import {
 	SKILLS_MARKETPLACE_ACTION,
@@ -586,17 +590,76 @@ function App(props: TuiProps) {
 		setHubBuildMismatch(null);
 		const hubCoreVersion = hubBuildMismatch.hubCoreVersion;
 		if (hubBuildMismatch.reason === "outdated_hub") {
-			// This CLI is already the newer build. The Hub is behind only because
-			// retiring it would kill the sessions it is serving, and it is
-			// replaced on its own at the next launch. Nothing is wrong, nothing is
-			// asked, and nothing the user can act on differs - so say nothing, the
-			// same conclusion the desktop surface reached.
-			//
-			// The classification still earns its keep here: it is what stops the
-			// update-and-restart prompt below from firing at someone who has
-			// nothing to update.
+			// This CLI is already the newer build; the Hub is behind only because
+			// retiring it would kill the sessions it is serving. Left alone it
+			// would stay behind for as long as those sessions run, so put the
+			// choice to the user: replace it now (interrupting that work), or
+			// keep it running and update later. This session itself is safe
+			// either way - a CLI that could not attach to the outdated Hub is
+			// running on the local backend.
+			const details = {
+				hubCoreVersion,
+				activeSessionCount: hubBuildMismatch.activeSessionCount,
+				participantClientCount: hubBuildMismatch.participantClientCount,
+			};
+			void dialog
+				.choice<boolean>({
+					content: (ctx: ChoiceContext<boolean>) => (
+						<HubOutdatedContent {...ctx} {...details} />
+					),
+				})
+				.then(async (update) => {
+					if (!update) {
+						return;
+					}
+					showToast("Updating the Cline Hub…", "info");
+					try {
+						const result = await upgradeManagedHub({
+							force: true,
+							reason: "cline TUI hub update",
+						});
+						showToast(
+							result.outcome === "replaced" || result.outcome === "started"
+								? "Cline Hub updated."
+								: "Cline Hub is already up to date.",
+							"success",
+						);
+					} catch (error) {
+						showToast(
+							error instanceof Error && error.message
+								? error.message
+								: "Updating the Cline Hub failed. Run 'cline doctor fix' and try again.",
+							"error",
+						);
+					}
+					refocusTextareaRef.current();
+				})
+				.catch(() => {
+					showToast(
+						"The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish.",
+						"info",
+					);
+					refocusTextareaRef.current();
+				});
 			return;
 		}
+		if (hubBuildMismatch.reason === "build_mismatch") {
+			// The Hub is newer but still speaks this CLI's protocol, so the
+			// session keeps working and parity is advisable rather than urgent.
+			// A modal mid-session is too heavy for advice; a toast (once per
+			// observed Hub build, the watcher dedupes) says what changed and
+			// how to catch up without stealing focus.
+			showToast(
+				`The shared Cline Hub was updated${
+					hubCoreVersion ? ` (core ${hubCoreVersion})` : ""
+				}. Run 'cline update' and restart when convenient.`,
+				"info",
+			);
+			return;
+		}
+		// unsupported_protocol: this CLI cannot speak the running Hub's
+		// protocol at all, so nothing hub-backed can work until it updates.
+		// That is worth a blocking prompt.
 		void dialog
 			.choice<boolean>({
 				content: (ctx: ChoiceContext<boolean>) => (

--- a/apps/examples/desktop-app/sidecar/commands-hub-upgrade.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-hub-upgrade.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SidecarContext, SidecarWebSocketClient } from "./types";
+
+const upgradeManagedHubMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@cline/core", async () => {
+	const actual =
+		await vi.importActual<typeof import("@cline/core")>("@cline/core");
+	return {
+		...actual,
+		upgradeManagedHub: upgradeManagedHubMock,
+	};
+});
+
+function createContext(): SidecarContext {
+	return {
+		workspaceRoot: "/workspace",
+		wsClients: new Set(),
+		hubBuildMismatch: {
+			url: "ws://127.0.0.1:25463/hub",
+			reason: "outdated_hub",
+			expectedBuildId: "current-build",
+		},
+		logger: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+	} as unknown as SidecarContext;
+}
+
+function connection(canApproveTools: boolean): SidecarWebSocketClient {
+	return { data: { canApproveTools } } as unknown as SidecarWebSocketClient;
+}
+
+beforeEach(() => {
+	upgradeManagedHubMock.mockReset();
+});
+
+describe("hub_upgrade command", () => {
+	it("rejects connections without the approval token, before touching the hub", async () => {
+		const { handleCommand } = await import("./commands");
+		const ctx = createContext();
+
+		await expect(
+			handleCommand(ctx, "hub_upgrade", {}, { connection: connection(false) }),
+		).rejects.toThrow(/trusted desktop connection/);
+		await expect(handleCommand(ctx, "hub_upgrade", {}, {})).rejects.toThrow(
+			/trusted desktop connection/,
+		);
+		expect(upgradeManagedHubMock).not.toHaveBeenCalled();
+		// The pending mismatch must survive a refused request.
+		expect(ctx.hubBuildMismatch).not.toBeNull();
+	});
+
+	it("forces the upgrade for the trusted webview connection and clears the mismatch", async () => {
+		upgradeManagedHubMock.mockResolvedValue({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+			activeSessionCount: 2,
+		});
+		const { handleCommand } = await import("./commands");
+		const ctx = createContext();
+
+		const result = await handleCommand(
+			ctx,
+			"hub_upgrade",
+			{},
+			{ connection: connection(true) },
+		);
+
+		expect(upgradeManagedHubMock).toHaveBeenCalledWith({
+			workspaceRoot: "/workspace",
+			force: true,
+			reason: "Cline Desktop hub update",
+		});
+		expect(result).toEqual({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:25463/hub",
+			interruptedSessionCount: 2,
+		});
+		expect(ctx.hubBuildMismatch).toBeNull();
+	});
+
+	it("surfaces a newer running hub as an error instead of replacing it", async () => {
+		upgradeManagedHubMock.mockResolvedValue({
+			outcome: "hub_not_older",
+			url: "ws://127.0.0.1:25463/hub",
+		});
+		const { handleCommand } = await import("./commands");
+		const ctx = createContext();
+
+		await expect(
+			handleCommand(ctx, "hub_upgrade", {}, { connection: connection(true) }),
+		).rejects.toThrow(/newer than this app/);
+		expect(ctx.hubBuildMismatch).not.toBeNull();
+	});
+});

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -45,6 +45,7 @@ import {
 	transcribeConfiguredVoiceInput,
 	updateLocalProvider,
 	updateMcpSettingsFileSync,
+	upgradeManagedHub,
 } from "@cline/core";
 import { resolveAudioTranscriptionRoute } from "@cline/llms";
 import {
@@ -1381,6 +1382,33 @@ export async function handleCommand(
 	}
 	if (command === "get_chat_ws_endpoint") {
 		return "";
+	}
+
+	// ── Managed hub upgrade ───────────────────────────────────────────
+	if (command === "hub_upgrade") {
+		// Only reached after the user accepted the blocking "Hub update
+		// required" dialog, so force: the old Hub is replaced even though it
+		// is still serving other clients' sessions. Drain-first semantics
+		// still give in-flight turns the wait window to finish.
+		const result = await upgradeManagedHub({
+			workspaceRoot: ctx.workspaceRoot,
+			force: true,
+			reason: "Cline Desktop hub update",
+		});
+		if (result.outcome === "hub_not_older") {
+			throw new Error(
+				"The running Cline Hub is newer than this app, so it was not replaced. Update Cline instead.",
+			);
+		}
+		// The mismatch is resolved: a null broadcast closes the dialog in
+		// every connected webview and stops the replay-on-connect.
+		ctx.hubBuildMismatch = null;
+		broadcastEvent(ctx, "hub_build_mismatch", null);
+		return {
+			outcome: result.outcome,
+			url: result.url ?? null,
+			interruptedSessionCount: result.activeSessionCount ?? 0,
+		};
 	}
 
 	// ── Tool approvals (in-memory) ────────────────────────────────────

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1386,6 +1386,13 @@ export async function handleCommand(
 
 	// ── Managed hub upgrade ───────────────────────────────────────────
 	if (command === "hub_upgrade") {
+		// Replacing the shared Hub interrupts other clients' sessions, so it
+		// carries the same per-connection gate as the tool-approval commands:
+		// only the webview connection dialed with the approval token may ask,
+		// never an arbitrary local WebSocket client.
+		if (!options?.connection?.data?.canApproveTools) {
+			throw new Error("hub upgrade requires a trusted desktop connection");
+		}
 		// Only reached after the user accepted the blocking "Hub update
 		// required" dialog, so force: the old Hub is replaced even though it
 		// is still serving other clients' sessions. Drain-first semantics

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1407,6 +1407,11 @@ export async function handleCommand(
 				"The running Cline Hub is newer than this app, so it was not replaced. Update Cline instead.",
 			);
 		}
+		if (result.outcome === "still_busy") {
+			throw new Error(
+				"The running Cline Hub picked up new sessions before it could be replaced, so it was left running. Try again.",
+			);
+		}
 		// The mismatch is resolved: a null broadcast closes the dialog in
 		// every connected webview and stops the replay-on-connect.
 		ctx.hubBuildMismatch = null;

--- a/apps/examples/desktop-app/sidecar/index.ts
+++ b/apps/examples/desktop-app/sidecar/index.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import {
+	checkManagedHubBuildMismatch,
 	createClineTelemetryServiceConfig,
 	setHomeDirIfUnset,
 	watchManagedHubBuildMismatch,
@@ -148,6 +149,34 @@ async function main() {
 			broadcastEvent(ctx, "hub_build_mismatch", mismatch);
 		},
 	});
+	// The watcher's first check only runs after its interval, but a mismatch
+	// that already exists at startup - an older Hub this app attached to
+	// because it is still serving other clients' sessions - must prompt
+	// before the user starts working, not half a minute in. Session-manager
+	// init has already settled the hub state, so check once right away. The
+	// broadcast reaches webviews that are already connected; the replay in
+	// createWebSocketHandler covers ones that connect later. Skipped when
+	// CLINE_HUB_PORT pins an explicit endpoint, matching the watcher: such
+	// hosts keep protocol-only compatibility and must not show update prompts.
+	if (!process.env.CLINE_HUB_PORT?.trim()) {
+		void checkManagedHubBuildMismatch()
+			.then((mismatch) => {
+				if (!mismatch || ctx.hubBuildMismatch) {
+					return;
+				}
+				ctx.hubBuildMismatch = mismatch;
+				observability.logger.log(
+					"Managed hub build mismatch detected at startup",
+					{
+						hubBuildId: mismatch.hubBuildId,
+						hubCoreVersion: mismatch.hubCoreVersion,
+						reason: mismatch.reason,
+					},
+				);
+				broadcastEvent(ctx, "hub_build_mismatch", mismatch);
+			})
+			.catch(() => undefined);
+	}
 
 	// A wildcard bind isn't a dialable address; advertise loopback instead.
 	const dialHost = SIDECAR_HOST === "0.0.0.0" ? "127.0.0.1" : SIDECAR_HOST;

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -755,6 +755,25 @@ fn restart_to_apply_update(
     app.restart();
 }
 
+/// Relaunch the current version of the app. Used after the sidecar replaces
+/// the shared Cline Hub under the running app (the "Cline Hub update
+/// required" flow): a fresh launch attaches everything to the new Hub instead
+/// of trying to migrate live connections. restart() never returns, so the
+/// run-loop Exit handler cannot stop the sidecar; do it explicitly first.
+#[tauri::command]
+fn relaunch_app(app: tauri::AppHandle, backend_state: State<'_, Arc<DesktopBackendState>>) {
+    backend_state.stop();
+    app.restart();
+}
+
+/// Quit the app. Used by the "Cline Hub update required" flow when the user
+/// chooses to keep the older running Hub (and its live sessions) and update
+/// later. The run-loop Exit handler stops the sidecar.
+#[tauri::command]
+fn quit_app(app: tauri::AppHandle) {
+    app.exit(0);
+}
+
 /// Run one updater check/download/stage cycle immediately instead of waiting
 /// for the next background interval, and report the resulting status. Used by
 /// flows that need an update staged right now (e.g. the "Cline Hub was
@@ -1212,7 +1231,9 @@ fn main() {
             set_app_icon,
             show_session_notification,
             drain_desktop_actions,
-            set_tray_status
+            set_tray_status,
+            relaunch_app,
+            quit_app
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri app")

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -148,17 +148,13 @@ export function HubUpdateRequiredDialog() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Cline Hub update required</AlertDialogTitle>
 						<AlertDialogDescription>
-							This version of Cline needs a newer Cline Hub than the one
-							currently running
-							{mismatch.hubCoreVersion
-								? ` (core ${mismatch.hubCoreVersion})`
-								: ""}
-							. The running Hub was left in place because it is still serving{" "}
-							{describeOutdatedHubSessions(mismatch)}.
+							Cline needs a newer Cline Hub, but the running one is still
+							serving {describeOutdatedHubSessions(mismatch)}.
 						</AlertDialogDescription>
 						<AlertDialogDescription>
-							Updating now stops the running Hub and interrupts those sessions.
-							Quitting keeps it running so you can update later.
+							Update Now stops that Hub and interrupts its sessions. Quit Cline
+							closes this app and leaves the Hub running, so you can update
+							later.
 						</AlertDialogDescription>
 						{updateHint ? (
 							<AlertDialogDescription>{updateHint}</AlertDialogDescription>
@@ -184,10 +180,10 @@ export function HubUpdateRequiredDialog() {
 							{phase === "restarting"
 								? "Restarting…"
 								: phase === "updating"
-									? "Updating Hub…"
+									? "Updating…"
 									: updateHint
 										? "Try again"
-										: "Update Hub now"}
+										: "Update Now"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -16,12 +16,17 @@ import {
 	restartToApplyUpdate,
 } from "@/hooks/use-app-update";
 import { desktopClient } from "@/lib/desktop-client";
-import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
+import {
+	describeOutdatedHubSessions,
+	resolveHubUpdateRestartDecision,
+} from "./hub-update-required-helpers";
 
 type HubBuildMismatchPayload = {
 	hubBuildId?: string;
 	hubCoreVersion?: string;
 	reason?: string;
+	activeSessionCount?: number;
+	participantClientCount?: number;
 };
 
 function mismatchKeyOf(payload: HubBuildMismatchPayload): string {
@@ -30,14 +35,24 @@ function mismatchKeyOf(payload: HubBuildMismatchPayload): string {
 
 type UpdatePhase = "idle" | "updating" | "restarting";
 
+/** Generous deadline: drain wait + graceful retire + fresh daemon startup. */
+const HUB_UPGRADE_TIMEOUT_MS = 60_000;
+
 /**
- * Blocking prompt shown when the sidecar reports that another Cline
- * installation (for example an updated CLI) replaced the shared Cline Hub
- * with a different build. Accepting runs an updater check/download right
- * away and, once an update is staged, restarts into it so the app and the
- * Hub run the same version again. If nothing is staged (no release published
- * yet, or the check failed), the dialog explains why instead of restarting
- * into the same version and immediately re-prompting.
+ * Blocking prompt shown when the sidecar reports that the shared Cline Hub
+ * does not match this app's build.
+ *
+ * Two directions, two dialogs:
+ * - `build_mismatch` / `unsupported_protocol`: the Hub is newer than this
+ *   app. Accepting runs an updater check/download right away and, once an
+ *   update is staged, restarts into it so the app and the Hub run the same
+ *   version again. Dismissible - the app keeps working over the compatible
+ *   wire protocol.
+ * - `outdated_hub`: this app is the newer build, and the running Hub was
+ *   left in place only because it is still serving other clients' sessions.
+ *   Not dismissible: the user chooses between updating the Hub now (which
+ *   interrupts those sessions, then relaunches the app onto the fresh Hub)
+ *   and quitting the app (the old Hub keeps running for its clients).
  */
 export function HubUpdateRequiredDialog() {
 	const [mismatch, setMismatch] = useState<HubBuildMismatchPayload | null>(
@@ -49,6 +64,13 @@ export function HubUpdateRequiredDialog() {
 
 	useEffect(() => {
 		return desktopClient.subscribe("hub_build_mismatch", (payload) => {
+			// A null broadcast means the mismatch was resolved (the Hub was
+			// upgraded, possibly from another window): close the dialog.
+			if (payload === null) {
+				setMismatch(null);
+				setUpdateHint(null);
+				return;
+			}
 			if (!payload || typeof payload !== "object") {
 				return;
 			}
@@ -61,7 +83,6 @@ export function HubUpdateRequiredDialog() {
 	}, []);
 
 	const mismatchKey = mismatch ? mismatchKeyOf(mismatch) : null;
-	const open = mismatchKey !== null && mismatchKey !== dismissedKey;
 
 	const handleUpdateAndRestart = useCallback(async () => {
 		setPhase("updating");
@@ -79,13 +100,102 @@ export function HubUpdateRequiredDialog() {
 		setPhase("idle");
 	}, []);
 
-	// `outdated_hub` is purely informational: this app is already the newer
-	// build, nothing is asked of the user, and the Hub is replaced on its own
-	// once its sessions end. Interrupting with a modal to say "ignore me"
-	// helps nobody, so that reason renders nothing.
+	const handleUpgradeHub = useCallback(async () => {
+		setPhase("updating");
+		setUpdateHint(null);
+		try {
+			await desktopClient.invoke("hub_upgrade", undefined, {
+				timeoutMs: HUB_UPGRADE_TIMEOUT_MS,
+			});
+		} catch (error) {
+			setUpdateHint(
+				error instanceof Error && error.message
+					? error.message
+					: "Updating the Cline Hub failed. Try again, or run 'cline doctor fix' in a terminal.",
+			);
+			setPhase("idle");
+			return;
+		}
+		setPhase("restarting");
+		setMismatch(null);
+		// Relaunch into a clean slate attached to the fresh Hub. In plain
+		// web/dev mode there is no Tauri shell to relaunch; reloading the page
+		// reconnects everything instead.
+		try {
+			await desktopClient.invoke("relaunch_app");
+		} catch {
+			window.location.reload();
+		}
+	}, []);
+
+	const handleQuit = useCallback(async () => {
+		try {
+			await desktopClient.invoke("quit_app");
+		} catch {
+			// Plain web/dev mode: no Tauri shell to exit. Best-effort close;
+			// browsers only honor this for script-opened windows.
+			window.close();
+		}
+	}, []);
+
+	// This app needs a newer Hub than the one running, and the running one was
+	// deliberately left in place because it is serving sessions. Block until
+	// the user picks a side: replace the Hub now, or quit and update later.
 	if (mismatch?.reason === "outdated_hub") {
-		return null;
+		return (
+			<AlertDialog open>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Cline Hub update required</AlertDialogTitle>
+						<AlertDialogDescription>
+							This version of Cline needs a newer Cline Hub than the one
+							currently running
+							{mismatch.hubCoreVersion
+								? ` (core ${mismatch.hubCoreVersion})`
+								: ""}
+							. The running Hub was left in place because it is still serving{" "}
+							{describeOutdatedHubSessions(mismatch)}.
+						</AlertDialogDescription>
+						<AlertDialogDescription>
+							Updating now stops the running Hub and interrupts those sessions.
+							Quitting keeps it running so you can update later.
+						</AlertDialogDescription>
+						{updateHint ? (
+							<AlertDialogDescription>{updateHint}</AlertDialogDescription>
+						) : null}
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel
+							disabled={phase !== "idle"}
+							onClick={(event) => {
+								event.preventDefault();
+								void handleQuit();
+							}}
+						>
+							Quit Cline
+						</AlertDialogCancel>
+						<AlertDialogAction
+							disabled={phase !== "idle"}
+							onClick={(event) => {
+								event.preventDefault();
+								void handleUpgradeHub();
+							}}
+						>
+							{phase === "restarting"
+								? "Restarting…"
+								: phase === "updating"
+									? "Updating Hub…"
+									: updateHint
+										? "Try again"
+										: "Update Hub now"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		);
 	}
+
+	const open = mismatchKey !== null && mismatchKey !== dismissedKey;
 
 	return (
 		<AlertDialog

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from "vitest";
-import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
+import {
+	describeOutdatedHubSessions,
+	resolveHubUpdateRestartDecision,
+} from "./hub-update-required-helpers";
+
+describe("describeOutdatedHubSessions", () => {
+	it("quantifies sessions and clients when the hub reported both", () => {
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 2,
+				participantClientCount: 1,
+			}),
+		).toBe("2 active sessions from 1 connected Cline client");
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 1,
+				participantClientCount: 3,
+			}),
+		).toBe("1 active session from 3 connected Cline clients");
+	});
+
+	it("omits the client clause when participant ids were unavailable", () => {
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 4,
+				participantClientCount: 0,
+			}),
+		).toBe("4 active sessions");
+	});
+
+	it("falls back to an unquantified phrase when the hub could not answer", () => {
+		expect(describeOutdatedHubSessions({})).toBe(
+			"active sessions from other Cline clients",
+		);
+	});
+});
 
 describe("resolveHubUpdateRestartDecision", () => {
 	it("restarts only once an update is staged", () => {

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -5,6 +5,27 @@ export type HubUpdateRestartDecision =
 	| { action: "stay"; hint: string };
 
 /**
+ * Human phrase for the live work an outdated Hub is serving, used by the
+ * blocking "Hub update required" dialog. Falls back to an unquantified
+ * phrase when the Hub could not answer the activity query.
+ */
+export function describeOutdatedHubSessions(counts: {
+	activeSessionCount?: number;
+	participantClientCount?: number;
+}): string {
+	const sessions = counts.activeSessionCount;
+	if (typeof sessions !== "number" || sessions <= 0) {
+		return "active sessions from other Cline clients";
+	}
+	const sessionsPhrase = `${sessions} active session${sessions === 1 ? "" : "s"}`;
+	const clients = counts.participantClientCount;
+	if (typeof clients !== "number" || clients <= 0) {
+		return sessionsPhrase;
+	}
+	return `${sessionsPhrase} from ${clients} connected Cline client${clients === 1 ? "" : "s"}`;
+}
+
+/**
  * Decide what "Update and restart" should do after an on-demand updater
  * check. Restart only when an update is actually staged - relaunching the
  * same version would bring the mismatch dialog straight back without

--- a/apps/examples/desktop-app/webview/lib/desktop-client.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-client.ts
@@ -238,6 +238,8 @@ const NATIVE_COMMANDS = new Set([
 	"show_session_notification",
 	"drain_desktop_actions",
 	"set_tray_status",
+	"relaunch_app",
+	"quit_app",
 ]);
 
 class DesktopClient {

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -970,10 +970,18 @@ function sameNormalizedHubUrl(left: string, right: string): boolean {
 	}
 }
 
+export interface HubSessionActivity {
+	/** Sessions with at least one live participant attached. */
+	activeSessionCount: number;
+	/** Distinct client ids attached to those sessions. */
+	participantClientCount: number;
+}
+
 /**
- * Whether any client is attached to a session on the hub - the one signal
- * that cannot go stale, because participants are live socket subscriptions
- * the hub drops the moment a client's connection closes.
+ * Summarize live activity from a `session.list` payload. A session counts as
+ * active only while a client is attached to it - the one signal that cannot
+ * go stale, because participants are live socket subscriptions the hub drops
+ * the moment a client's connection closes.
  *
  * Deliberately NOT based on session status: a client that dies without
  * stopping its session leaves the hub-side runtime behind in a non-terminal
@@ -983,27 +991,56 @@ function sameNormalizedHubUrl(left: string, right: string): boolean {
  * exact moment of a hub swap dies with the old hub - rare, and its next
  * scheduled tick runs normally on the replacement.
  */
-export function hasActiveHubSessions(payload: unknown): boolean {
+export function summarizeHubSessionActivity(
+	payload: unknown,
+): HubSessionActivity {
 	const sessions =
 		payload &&
 		typeof payload === "object" &&
 		Array.isArray((payload as { sessions?: unknown }).sessions)
 			? (payload as { sessions: unknown[] }).sessions
 			: [];
-	return sessions.some((session) => {
+	let activeSessionCount = 0;
+	const clientIds = new Set<string>();
+	for (const session of sessions) {
 		if (!session || typeof session !== "object") {
-			return false;
+			continue;
 		}
-		const record = session as { participants?: unknown };
-		return Array.isArray(record.participants) && record.participants.length > 0;
-	});
+		const participants = (session as { participants?: unknown }).participants;
+		if (!Array.isArray(participants) || participants.length === 0) {
+			continue;
+		}
+		activeSessionCount += 1;
+		for (const participant of participants) {
+			const clientId =
+				participant && typeof participant === "object"
+					? (participant as { clientId?: unknown }).clientId
+					: undefined;
+			if (typeof clientId === "string" && clientId.trim()) {
+				clientIds.add(clientId);
+			}
+		}
+	}
+	return { activeSessionCount, participantClientCount: clientIds.size };
 }
 
-export async function localHubHasNoActiveSessions(
+export function hasActiveHubSessions(payload: unknown): boolean {
+	return summarizeHubSessionActivity(payload).activeSessionCount > 0;
+}
+
+/**
+ * Ask a hub how much live work it is serving. Throws when the hub cannot
+ * answer (unreachable, auth rejected, or too old to serve `session.list`),
+ * because the safe default points in opposite directions per caller: a
+ * replacement path treats an unanswerable hub as idle and retires it, while
+ * a recovery path treats it as busy and leaves it alone. Callers pick their
+ * own fallback instead of inheriting a hidden one.
+ */
+export async function queryHubSessionActivity(
 	url: string,
 	authToken?: string,
 	options?: Pick<HubClientOptions, "workspaceRoot" | "cwd">,
-): Promise<boolean> {
+): Promise<HubSessionActivity> {
 	const client = new NodeHubClient({
 		url,
 		authToken,
@@ -1019,11 +1056,24 @@ export async function localHubHasNoActiveSessions(
 			undefined,
 			{ timeoutMs: HUB_RECOVERY_SESSION_LIST_TIMEOUT_MS },
 		);
-		return !hasActiveHubSessions(reply.payload);
-	} catch {
-		return false;
+		return summarizeHubSessionActivity(reply.payload);
 	} finally {
 		await client.dispose().catch(() => undefined);
+	}
+}
+
+export async function localHubHasNoActiveSessions(
+	url: string,
+	authToken?: string,
+	options?: Pick<HubClientOptions, "workspaceRoot" | "cwd">,
+): Promise<boolean> {
+	try {
+		const activity = await queryHubSessionActivity(url, authToken, options);
+		return activity.activeSessionCount === 0;
+	} catch {
+		// Recovery callers must not treat a hub they cannot positively observe
+		// idle as safe to stop, so an unanswerable hub reports as busy here.
+		return false;
 	}
 }
 

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
@@ -4,9 +4,24 @@ type DiscoveryMockOptions = {
 	record?: Record<string, unknown>;
 	probe?: Record<string, unknown> | undefined;
 	expectedBuildId?: string;
+	/**
+	 * What the session-activity query reports for an outdated hub; omitted
+	 * means the hub cannot answer (the query throws) and the event carries no
+	 * counts. Always mocked: the real query opens a socket, which never
+	 * settles under this file's fake timers.
+	 */
+	activity?: { activeSessionCount: number; participantClientCount: number };
 };
 
 function mockDiscovery(options: DiscoveryMockOptions): void {
+	vi.doMock("./index", () => ({
+		queryHubSessionActivity: vi.fn(async () => {
+			if (!options.activity) {
+				throw new Error("hub activity unavailable");
+			}
+			return options.activity;
+		}),
+	}));
 	vi.doMock("../discovery/workspace", () => ({
 		resolveProductionHubOwnerContext: () => ({
 			ownerId: "hub-test",
@@ -86,6 +101,7 @@ describe("checkManagedHubBuildMismatch", () => {
 				port: 59999,
 				url: "ws://127.0.0.1:59999/hub",
 			},
+			activity: { activeSessionCount: 2, participantClientCount: 1 },
 		});
 		const { checkManagedHubBuildMismatch } = await import(
 			"./managed-hub-build-watcher"
@@ -93,7 +109,32 @@ describe("checkManagedHubBuildMismatch", () => {
 
 		await expect(checkManagedHubBuildMismatch()).resolves.toMatchObject({
 			reason: "outdated_hub",
+			activeSessionCount: 2,
+			participantClientCount: 1,
 		});
+	});
+
+	it("reports an outdated hub without counts when it cannot answer the activity query", async () => {
+		vi.stubEnv("CLINE_HUB_BUILD_EPOCH_MS", "1000");
+		mockDiscovery({
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "old-build",
+				buildEpochMs: 500,
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		const mismatch = await checkManagedHubBuildMismatch();
+		expect(mismatch).toMatchObject({ reason: "outdated_hub" });
+		expect(mismatch?.activeSessionCount).toBeUndefined();
+		expect(mismatch?.participantClientCount).toBeUndefined();
 	});
 
 	// A Hub carrying no ordering metadata cannot be placed relative to this

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -13,6 +13,7 @@ import {
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 } from "../discovery/workspace";
+import { queryHubSessionActivity } from "./index";
 
 const DEFAULT_WATCH_INTERVAL_MS = 10_000;
 const WATCH_INTERVAL_ENV = "CLINE_HUB_BUILD_WATCH_INTERVAL_MS";
@@ -43,6 +44,36 @@ export interface ManagedHubBuildMismatchEvent {
 	hubCoreVersion?: string;
 	/** Build identity this client expects a managed Hub to match. */
 	expectedBuildId: string;
+	/**
+	 * Sessions with live participants on the Hub (best-effort, `outdated_hub`
+	 * only): the work that replacing the Hub would interrupt. Unset when the
+	 * Hub cannot answer the query.
+	 */
+	activeSessionCount?: number;
+	/** Distinct clients attached to those sessions (best-effort, `outdated_hub` only). */
+	participantClientCount?: number;
+}
+
+/**
+ * Best-effort enrichment for the `outdated_hub` case: how much live work the
+ * older Hub is serving, so surfaces can say "updating now interrupts N
+ * sessions" instead of asking for blind consent. A Hub that cannot answer
+ * leaves the fields unset rather than failing the check.
+ */
+async function withHubSessionActivity(
+	event: ManagedHubBuildMismatchEvent,
+	authToken?: string,
+): Promise<ManagedHubBuildMismatchEvent> {
+	try {
+		const activity = await queryHubSessionActivity(event.url, authToken);
+		return {
+			...event,
+			activeSessionCount: activity.activeSessionCount,
+			participantClientCount: activity.participantClientCount,
+		};
+	} catch {
+		return event;
+	}
 }
 
 function resolveDefaultHubOwnerContext(): HubOwnerContext {
@@ -118,7 +149,10 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	// this client is what supplies the missing ordering - is a client-update
 	// prompt as before.
 	if (compareHubBuilds(resolveHubBuildIdentity(), healthy) > 0) {
-		return report("outdated_hub");
+		return await withHubSessionActivity(
+			report("outdated_hub"),
+			record.authToken,
+		);
 	}
 	return report("build_mismatch");
 }

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1003,6 +1003,73 @@ describe("upgradeManagedHub", () => {
 		expect(requestHubShutdown).not.toHaveBeenCalled();
 	});
 
+	it("refuses to replace a busy hub when the drain request fails, even when forced", async () => {
+		requestHubDrain.mockResolvedValue(false);
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 2,
+			participantClientCount: 1,
+		});
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		await expect(upgradeManagedHub({ force: true })).rejects.toThrow(
+			/did not accept a drain request/,
+		);
+		// Only the initial drain attempt: nothing to un-drain, nothing retired.
+		expect(requestHubDrain).toHaveBeenCalledTimes(1);
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("still replaces an idle hub when the drain request fails (pre-drain hubs answer 404)", async () => {
+		requestHubDrain.mockResolvedValue(false);
+		readHubDiscovery
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "old-token",
+				pid: 12345,
+			})
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "new-token",
+			});
+		probeHubServer
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				buildEpochMs: 500,
+				pid: 12345,
+			})
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+			});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ workspaceRoot: "/workspace" });
+
+		expect(result).toEqual({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+			activeSessionCount: 0,
+		});
+		expect(requestHubShutdown).toHaveBeenCalled();
+	});
+
 	it("un-drains and reports failure when the old hub survives the retire ladder", async () => {
 		queryHubSessionActivity.mockResolvedValue({
 			activeSessionCount: 1,

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1070,6 +1070,111 @@ describe("upgradeManagedHub", () => {
 		expect(requestHubShutdown).toHaveBeenCalled();
 	});
 
+	it("treats a failed activity reading as unknown and keeps polling instead of concluding idle", async () => {
+		queryHubSessionActivity
+			.mockRejectedValueOnce(new Error("session.list timed out"))
+			.mockResolvedValue({ activeSessionCount: 2, participantClientCount: 1 });
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ waitForIdleMs: 600 });
+
+		// The transient failure neither ended the wait window nor read as
+		// idle: the loop polled again, saw the real busy reading, and handed
+		// the hub back un-drained.
+		expect(result).toMatchObject({
+			outcome: "still_busy",
+			activeSessionCount: 2,
+		});
+		expect(queryHubSessionActivity.mock.calls.length).toBeGreaterThan(1);
+		expect(requestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+			"hub upgrade aborted",
+			{ off: true },
+		);
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+	});
+
+	it("never retires a hub whose activity could not be confirmed unless forced", async () => {
+		queryHubSessionActivity.mockRejectedValue(
+			new Error("session.list unavailable"),
+		);
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ waitForIdleMs: 0 });
+
+		expect(result.outcome).toBe("still_busy");
+		// Unknown, not zero: no count is reported for a hub that never answered.
+		expect(result.activeSessionCount).toBeUndefined();
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("replaces an unanswerable hub only under force with an accepted drain", async () => {
+		queryHubSessionActivity.mockRejectedValue(
+			new Error("session.list unavailable"),
+		);
+		readHubDiscovery
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "old-token",
+				pid: 12345,
+			})
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "new-token",
+			});
+		probeHubServer
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				buildEpochMs: 500,
+				pid: 12345,
+			})
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+			});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({
+			workspaceRoot: "/workspace",
+			force: true,
+			waitForIdleMs: 0,
+		});
+
+		expect(result).toEqual({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+			activeSessionCount: 0,
+		});
+	});
+
 	it("un-drains and reports failure when the old hub survives the retire ladder", async () => {
 		queryHubSessionActivity.mockResolvedValue({
 			activeSessionCount: 1,

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1030,7 +1030,7 @@ describe("upgradeManagedHub", () => {
 		expect(spawn).not.toHaveBeenCalled();
 	});
 
-	it("still replaces an idle hub when the drain request fails (pre-drain hubs answer 404)", async () => {
+	it("hands an undrained idle hub to the ensure path instead of retiring it directly (pre-drain hubs answer 404)", async () => {
 		requestHubDrain.mockResolvedValue(false);
 		readHubDiscovery
 			.mockResolvedValueOnce({
@@ -1038,6 +1038,7 @@ describe("upgradeManagedHub", () => {
 				authToken: "old-token",
 				pid: 12345,
 			})
+			// The ensure path observes the already-swapped record.
 			.mockResolvedValueOnce({
 				url: "ws://127.0.0.1:25463/hub",
 				authToken: "new-token",
@@ -1050,8 +1051,9 @@ describe("upgradeManagedHub", () => {
 				buildEpochMs: 500,
 				pid: 12345,
 			})
-			.mockResolvedValueOnce(undefined)
-			.mockResolvedValueOnce({
+			// The ensure probe and the post-ensure discriminator probe both
+			// see a current-build hub.
+			.mockResolvedValue({
 				url: "ws://127.0.0.1:25463/hub",
 				protocolVersion: "v1",
 				buildId: "current-build",
@@ -1067,7 +1069,43 @@ describe("upgradeManagedHub", () => {
 			authToken: "new-token",
 			activeSessionCount: 0,
 		});
-		expect(requestHubShutdown).toHaveBeenCalled();
+		// The delegation is the point: the swap ran under the ensure path's
+		// startup lock, and upgradeManagedHub issued no retirement of its own.
+		expect(withHubStartupLock).toHaveBeenCalled();
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+	});
+
+	it("defers when the ensure re-check finds the undrained hub busy again after the idle snapshot", async () => {
+		requestHubDrain.mockResolvedValue(false);
+		// Idle at the upgrade's snapshot, busy again by the time the ensure
+		// path re-checks - the race the delegation exists to close.
+		queryHubSessionActivity
+			.mockResolvedValueOnce({
+				activeSessionCount: 0,
+				participantClientCount: 0,
+			})
+			.mockResolvedValue({ activeSessionCount: 1, participantClientCount: 1 });
+		readHubDiscovery.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		probeHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ workspaceRoot: "/workspace" });
+
+		expect(result).toMatchObject({
+			outcome: "still_busy",
+			url: "ws://127.0.0.1:25463/hub",
+		});
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
 	});
 
 	it("treats a failed activity reading as unknown and keeps polling instead of concluding idle", async () => {

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1003,12 +1003,8 @@ describe("upgradeManagedHub", () => {
 		expect(requestHubShutdown).not.toHaveBeenCalled();
 	});
 
-	it("refuses to replace a busy hub when the drain request fails, even when forced", async () => {
+	it("fails fast when the hub does not accept the drain, even when idle and forced", async () => {
 		requestHubDrain.mockResolvedValue(false);
-		queryHubSessionActivity.mockResolvedValue({
-			activeSessionCount: 2,
-			participantClientCount: 1,
-		});
 		readHubDiscovery.mockResolvedValueOnce({
 			url: "ws://127.0.0.1:25463/hub",
 			authToken: "old-token",
@@ -1024,86 +1020,13 @@ describe("upgradeManagedHub", () => {
 		await expect(upgradeManagedHub({ force: true })).rejects.toThrow(
 			/did not accept a drain request/,
 		);
-		// Only the initial drain attempt: nothing to un-drain, nothing retired.
+		// No admission barrier means no upgrade at all: the failure comes
+		// before the wait window (no activity readings), nothing is un-drained
+		// (only the initial drain attempt), and nothing is retired or spawned.
+		// Even an idle snapshot would not help - a session admitted right
+		// after it would die in a retire the consent prompt never covered.
+		expect(queryHubSessionActivity).not.toHaveBeenCalled();
 		expect(requestHubDrain).toHaveBeenCalledTimes(1);
-		expect(requestHubShutdown).not.toHaveBeenCalled();
-		expect(spawn).not.toHaveBeenCalled();
-	});
-
-	it("hands an undrained idle hub to the ensure path instead of retiring it directly (pre-drain hubs answer 404)", async () => {
-		requestHubDrain.mockResolvedValue(false);
-		readHubDiscovery
-			.mockResolvedValueOnce({
-				url: "ws://127.0.0.1:25463/hub",
-				authToken: "old-token",
-				pid: 12345,
-			})
-			// The ensure path observes the already-swapped record.
-			.mockResolvedValueOnce({
-				url: "ws://127.0.0.1:25463/hub",
-				authToken: "new-token",
-			});
-		probeHubServer
-			.mockResolvedValueOnce({
-				url: "ws://127.0.0.1:25463/hub",
-				protocolVersion: "v1",
-				buildId: "old-build",
-				buildEpochMs: 500,
-				pid: 12345,
-			})
-			// The ensure probe and the post-ensure discriminator probe both
-			// see a current-build hub.
-			.mockResolvedValue({
-				url: "ws://127.0.0.1:25463/hub",
-				protocolVersion: "v1",
-				buildId: "current-build",
-			});
-		verifyHubConnection.mockResolvedValue(true);
-
-		const { upgradeManagedHub } = await import(".");
-		const result = await upgradeManagedHub({ workspaceRoot: "/workspace" });
-
-		expect(result).toEqual({
-			outcome: "replaced",
-			url: "ws://127.0.0.1:25463/hub",
-			authToken: "new-token",
-			activeSessionCount: 0,
-		});
-		// The delegation is the point: the swap ran under the ensure path's
-		// startup lock, and upgradeManagedHub issued no retirement of its own.
-		expect(withHubStartupLock).toHaveBeenCalled();
-		expect(requestHubShutdown).not.toHaveBeenCalled();
-	});
-
-	it("defers when the ensure re-check finds the undrained hub busy again after the idle snapshot", async () => {
-		requestHubDrain.mockResolvedValue(false);
-		// Idle at the upgrade's snapshot, busy again by the time the ensure
-		// path re-checks - the race the delegation exists to close.
-		queryHubSessionActivity
-			.mockResolvedValueOnce({
-				activeSessionCount: 0,
-				participantClientCount: 0,
-			})
-			.mockResolvedValue({ activeSessionCount: 1, participantClientCount: 1 });
-		readHubDiscovery.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			authToken: "old-token",
-		});
-		probeHubServer.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			protocolVersion: "v1",
-			buildId: "old-build",
-			buildEpochMs: 500,
-		});
-		verifyHubConnection.mockResolvedValue(true);
-
-		const { upgradeManagedHub } = await import(".");
-		const result = await upgradeManagedHub({ workspaceRoot: "/workspace" });
-
-		expect(result).toMatchObject({
-			outcome: "still_busy",
-			url: "ws://127.0.0.1:25463/hub",
-		});
 		expect(requestHubShutdown).not.toHaveBeenCalled();
 		expect(spawn).not.toHaveBeenCalled();
 	});

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -7,12 +7,13 @@ const {
 	openSync,
 	rememberRecoverableLocalHubUrl,
 	verifyHubConnection,
-	localHubHasNoActiveSessions,
+	queryHubSessionActivity,
 	requestHubDrain,
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 	createHubServerUrl,
 	clearHubDiscovery,
+	compareHubBuilds,
 	getManagedHubCompatibility,
 	isManagedHubReusable,
 	probeHubServer,
@@ -20,6 +21,7 @@ const {
 	readHubDiscovery,
 	resolveClineDataDir,
 	resolveHubBuildId,
+	resolveHubBuildIdentity,
 	withHubStartupLock,
 	writeHubDiscovery,
 	CLINE_RUN_AS_HUB_DAEMON_ENV,
@@ -31,7 +33,10 @@ const {
 	rememberRecoverableLocalHubUrl: vi.fn((url: string) => url),
 	verifyHubConnection: vi.fn(),
 	// Idle by default, so existing replacement cases are unaffected.
-	localHubHasNoActiveSessions: vi.fn(async () => true),
+	queryHubSessionActivity: vi.fn(async () => ({
+		activeSessionCount: 0,
+		participantClientCount: 0,
+	})),
 	requestHubDrain: vi.fn(async () => true),
 	resolveProductionHubOwnerContext: vi.fn(() => ({
 		discoveryPath: "/tmp/hub-discovery.json",
@@ -44,6 +49,17 @@ const {
 			`ws://${host}:${port}${pathname}`,
 	),
 	clearHubDiscovery: vi.fn(async () => undefined),
+	// Mirrors the real total order closely enough for these cases: order by
+	// build epoch, treating a missing epoch as oldest.
+	compareHubBuilds: vi.fn(
+		(
+			self: { buildEpochMs?: number },
+			record: { buildId?: string; buildEpochMs?: number },
+		) =>
+			record.buildId === "current-build"
+				? 0
+				: (self.buildEpochMs ?? 0) - (record.buildEpochMs ?? 0),
+	),
 	getManagedHubCompatibility: vi.fn(
 		(record: { protocolVersion?: string; buildId?: string }) => ({
 			compatible:
@@ -66,6 +82,10 @@ const {
 	readHubDiscovery: vi.fn(),
 	resolveClineDataDir: vi.fn(() => "/tmp/cline-data"),
 	resolveHubBuildId: vi.fn(() => "current-build"),
+	resolveHubBuildIdentity: vi.fn(() => ({
+		buildId: "current-build",
+		buildEpochMs: 1_000_000,
+	})),
 	withHubStartupLock: vi.fn(
 		async (_discoveryPath: string, callback: () => Promise<unknown>) =>
 			await callback(),
@@ -101,7 +121,7 @@ vi.mock("@cline/shared", () => ({
 }));
 
 vi.mock("../client", () => ({
-	localHubHasNoActiveSessions,
+	queryHubSessionActivity,
 	rememberRecoverableLocalHubUrl,
 	requestHubDrain,
 	requestHubShutdown,
@@ -115,6 +135,7 @@ vi.mock("../discovery/workspace", () => ({
 
 vi.mock("../discovery", () => ({
 	clearHubDiscovery,
+	compareHubBuilds,
 	createHubServerUrl,
 	getManagedHubCompatibility,
 	isManagedHubReusable,
@@ -122,6 +143,7 @@ vi.mock("../discovery", () => ({
 	readHubDiscovery,
 	resolveClineDataDir,
 	resolveHubBuildId,
+	resolveHubBuildIdentity,
 	withHubStartupLock,
 	writeHubDiscovery,
 }));
@@ -144,8 +166,11 @@ describe("ensureDetachedHubServer", () => {
 		rememberRecoverableLocalHubUrl.mockReset();
 		rememberRecoverableLocalHubUrl.mockImplementation((url: string) => url);
 		verifyHubConnection.mockReset();
-		localHubHasNoActiveSessions.mockReset();
-		localHubHasNoActiveSessions.mockResolvedValue(true);
+		queryHubSessionActivity.mockReset();
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 0,
+			participantClientCount: 0,
+		});
 		clearHubDiscovery.mockReset();
 		clearHubDiscovery.mockResolvedValue(undefined);
 		probeHubServer.mockReset();
@@ -428,7 +453,10 @@ describe("ensureDetachedHubServer", () => {
 	it("attaches to an older hub that is still serving sessions instead of retiring it", async () => {
 		const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 		try {
-			localHubHasNoActiveSessions.mockResolvedValue(false);
+			queryHubSessionActivity.mockResolvedValue({
+				activeSessionCount: 1,
+				participantClientCount: 1,
+			});
 			readHubDiscovery.mockResolvedValueOnce({
 				url: "ws://127.0.0.1:25463/hub",
 				authToken: "busy-token",
@@ -766,5 +794,243 @@ describe("ensureDetachedHubServer", () => {
 			kill.mockRestore();
 			vi.useRealTimers();
 		}
+	});
+});
+
+describe("upgradeManagedHub", () => {
+	const fetchMock = vi.fn(async () => ({ ok: true }));
+
+	beforeEach(async () => {
+		const { __test__ } = await import(".");
+		__test__.resetRetireAttempts();
+		delete process.env[CLINE_RUN_AS_HUB_DAEMON_ENV];
+		spawn.mockReset();
+		spawn.mockImplementation(() => ({ unref: vi.fn() }));
+		rememberRecoverableLocalHubUrl.mockReset();
+		rememberRecoverableLocalHubUrl.mockImplementation((url: string) => url);
+		verifyHubConnection.mockReset();
+		queryHubSessionActivity.mockReset();
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 0,
+			participantClientCount: 0,
+		});
+		clearHubDiscovery.mockReset();
+		clearHubDiscovery.mockResolvedValue(undefined);
+		probeHubServer.mockReset();
+		requestHubShutdown.mockReset();
+		requestHubShutdown.mockResolvedValue(true);
+		requestHubDrain.mockReset();
+		requestHubDrain.mockResolvedValue(true);
+		readHubDiscovery.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+		if (originalRunAsHubDaemon === undefined) {
+			delete process.env[CLINE_RUN_AS_HUB_DAEMON_ENV];
+		} else {
+			process.env[CLINE_RUN_AS_HUB_DAEMON_ENV] = originalRunAsHubDaemon;
+		}
+	});
+
+	it("drains and replaces an older busy hub when forced", async () => {
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 2,
+			participantClientCount: 1,
+		});
+		readHubDiscovery
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "old-token",
+				pid: 12345,
+			})
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "new-token",
+			});
+		probeHubServer
+			// The live probe of the recorded hub: an older build.
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "old-build",
+				buildEpochMs: 500,
+				pid: 12345,
+			})
+			// The retire wait: the hub is gone.
+			.mockResolvedValueOnce(undefined)
+			// The ensure probe of the replacement.
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+			});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({
+			workspaceRoot: "/workspace",
+			force: true,
+			waitForIdleMs: 0,
+			reason: "test upgrade",
+		});
+
+		expect(result).toEqual({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+			activeSessionCount: 2,
+		});
+		// Drained with the caller's reason before the retire ladder ran.
+		expect(requestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+			"test upgrade",
+		);
+		expect(requestHubShutdown).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+		);
+		expect(clearHubDiscovery).toHaveBeenCalledWith("/tmp/hub-discovery.json");
+	});
+
+	it("leaves a busy hub running and un-drains it when not forced", async () => {
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 3,
+			participantClientCount: 2,
+		});
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ waitForIdleMs: 0 });
+
+		expect(result).toEqual({
+			outcome: "still_busy",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+			activeSessionCount: 3,
+		});
+		expect(requestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+			"hub upgrade aborted",
+			{ off: true },
+		);
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("refuses to replace a hub running a newer build", async () => {
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "newer-hub-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "newer-build",
+			buildEpochMs: 2_000_000,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ force: true });
+
+		expect(result).toEqual({
+			outcome: "hub_not_older",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "newer-hub-token",
+		});
+		expect(requestHubDrain).not.toHaveBeenCalled();
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("reports a hub already on this build without touching it", async () => {
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "current-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "current-build",
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub();
+
+		expect(result).toEqual({
+			outcome: "already_current",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "current-token",
+		});
+		expect(requestHubDrain).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("starts a hub when none is running", async () => {
+		readHubDiscovery.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "current-build",
+		});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({ workspaceRoot: "/workspace" });
+
+		expect(result).toEqual({
+			outcome: "started",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "new-token",
+		});
+		expect(requestHubDrain).not.toHaveBeenCalled();
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+	});
+
+	it("un-drains and reports failure when the old hub survives the retire ladder", async () => {
+		queryHubSessionActivity.mockResolvedValue({
+			activeSessionCount: 1,
+			participantClientCount: 1,
+		});
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "old-token",
+		});
+		// The hub stays alive through the drain, shutdown, and retire waits.
+		probeHubServer.mockResolvedValue({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "old-build",
+			buildEpochMs: 500,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		await expect(
+			upgradeManagedHub({ force: true, waitForIdleMs: 0 }),
+		).rejects.toThrow(/could not be stopped/);
+		expect(requestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+			"hub upgrade aborted",
+			{ off: true },
+		);
+		expect(clearHubDiscovery).not.toHaveBeenCalled();
+		expect(spawn).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -481,6 +481,23 @@ describe("ensureDetachedHubServer", () => {
 			expect(kill).not.toHaveBeenCalled();
 			expect(clearHubDiscovery).not.toHaveBeenCalled();
 			expect(spawn).not.toHaveBeenCalled();
+			// The admission barrier is requested BEFORE the busy reading, so an
+			// idle result could not be invalidated by a session admitted right
+			// after it - and deferring hands the drained hub back to its work.
+			expect(requestHubDrain).toHaveBeenCalledWith(
+				"ws://127.0.0.1:25463/hub",
+				"busy-token",
+				"retired by newer install",
+			);
+			expect(requestHubDrain.mock.invocationCallOrder[0]).toBeLessThan(
+				queryHubSessionActivity.mock.invocationCallOrder[0] ?? 0,
+			);
+			expect(requestHubDrain).toHaveBeenCalledWith(
+				"ws://127.0.0.1:25463/hub",
+				"busy-token",
+				"hub retirement deferred",
+				{ off: true },
+			);
 		} finally {
 			kill.mockRestore();
 		}

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -729,8 +729,9 @@ export type UpgradeManagedHubOutcome =
 	 * the fix.
 	 */
 	| "hub_not_older"
-	/** `force` was not set and sessions never finished; the hub was un-drained
-	 * and left running. */
+	/** `force` was not set and sessions never finished - or the hub's
+	 * activity could never be confirmed, which counts as busy here; the hub
+	 * was un-drained and left running. */
 	| "still_busy";
 
 export interface UpgradeManagedHubResult {
@@ -740,7 +741,7 @@ export interface UpgradeManagedHubResult {
 	/**
 	 * Live sessions observed on the old hub at decision time: the sessions
 	 * that were interrupted (`replaced`) or that kept it running
-	 * (`still_busy`).
+	 * (`still_busy`). Omitted when the hub never answered the activity query.
 	 */
 	activeSessionCount?: number;
 }
@@ -752,8 +753,11 @@ export interface UpgradeManagedHubResult {
  * is serving sessions: drain first (the hub refuses new work while in-flight
  * turns get `waitForIdleMs` to finish), then the shared graceful retire
  * ladder, then a fresh daemon. Drain-first is a guarantee, not a courtesy:
- * a hub that refuses the drain is replaced only if it is observed idle, and
- * a busy one makes the upgrade fail instead - `force` does not override that.
+ * a hub that refuses the drain is replaced only if it is positively observed
+ * idle, and a busy one makes the upgrade fail instead - `force` does not
+ * override that. Activity readings that fail are treated as unknown, not
+ * idle: they never shorten the wait window, and without `force` an
+ * unconfirmed hub is handed back un-drained rather than retired.
  *
  * Never replaces a hub this build is not strictly newer than - the build
  * total order guarantees at most one side of any install pair can reach the
@@ -807,7 +811,6 @@ export async function upgradeManagedHub(
 			off: true,
 		}).catch(() => false);
 	};
-	let activeSessionCount = 0;
 	// The wait window is only meaningful under an established drain: an
 	// undrained hub keeps admitting new sessions and runs, so waiting would
 	// widen what a replacement kills instead of letting work finish. Without
@@ -815,40 +818,55 @@ export async function upgradeManagedHub(
 	const deadline = drained
 		? Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS)
 		: Date.now();
-	// Check at least once so waitForIdleMs: 0 still observes an idle hub.
+	// A failed reading is "unknown", never "idle": it must not end the wait
+	// window early, overwrite the last real observation, or authorize a
+	// retirement by itself - a transient query blip while turns are still
+	// finishing must not cut short the grace the drain exists to provide.
+	// Only an observed-zero reading ends the window before the deadline.
+	// (Checks at least once so waitForIdleMs: 0 still observes an idle hub.)
+	let observedSessionCount: number | undefined;
 	for (;;) {
 		try {
-			activeSessionCount = (
+			observedSessionCount = (
 				await queryHubSessionActivity(record.url, record.authToken)
 			).activeSessionCount;
+			if (observedSessionCount === 0) {
+				break;
+			}
 		} catch {
-			// Same fail-open as the automatic retire path: a hub that cannot
-			// answer is not pinned alive by sessions nobody can observe.
-			activeSessionCount = 0;
+			// Unknown; keep polling until the deadline.
 		}
-		if (activeSessionCount === 0 || Date.now() >= deadline) {
+		if (Date.now() >= deadline) {
 			break;
 		}
 		await new Promise((resolve) =>
 			setTimeout(resolve, HUB_UPGRADE_IDLE_POLL_MS),
 		);
 	}
-	// A busy hub that never entered the drained state is not replaced, forced
-	// or not: the drain is the guarantee that nothing new starts between the
-	// busy reading and the retire, and without it a forced replacement would
-	// kill work the user never saw in the consent prompt.
-	if (activeSessionCount > 0 && !drained) {
+	const confirmedIdle = observedSessionCount === 0;
+	// A hub that never entered the drained state is not replaced unless it
+	// was positively observed idle, forced or not: the drain is the guarantee
+	// that nothing new starts between the busy reading and the retire, and
+	// without it a forced replacement would kill work the user never saw in
+	// the consent prompt.
+	if (!confirmedIdle && !drained) {
 		throw new Error(
-			`The running Cline Hub at ${record.url} did not accept a drain request and is still serving sessions, so it was not replaced. Finish those sessions or run 'cline doctor fix', then try again.`,
+			`The running Cline Hub at ${record.url} did not accept a drain request and was not observed idle, so it was not replaced. Finish its sessions or run 'cline doctor fix', then try again.`,
 		);
 	}
-	if (activeSessionCount > 0 && options.force !== true) {
+	// Without force, only a positively idle hub may be replaced: a busy or
+	// unanswerable hub is handed back un-drained. With force, the user has
+	// already consented to interrupting the sessions the prompt showed them,
+	// and the accepted drain has kept new work out during the window.
+	if (!confirmedIdle && options.force !== true) {
 		await undrain();
 		return {
 			outcome: "still_busy",
 			url: record.url,
 			authToken: record.authToken,
-			activeSessionCount,
+			...(observedSessionCount !== undefined
+				? { activeSessionCount: observedSessionCount }
+				: {}),
 		};
 	}
 	if (!(await retireDiscoveredHub(record, owner.discoveryPath))) {
@@ -858,5 +876,9 @@ export async function upgradeManagedHub(
 		);
 	}
 	const ensured = await ensureDetachedHubServer(workspaceRoot);
-	return { outcome: "replaced", ...ensured, activeSessionCount };
+	return {
+		outcome: "replaced",
+		...ensured,
+		activeSessionCount: observedSessionCount ?? 0,
+	};
 }

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -706,6 +706,9 @@ export interface UpgradeManagedHubOptions {
 	/**
 	 * Replace the hub even if sessions are still live once the wait expires.
 	 * Only set this on a user-consented path: those sessions die mid-turn.
+	 * Honored only once the hub has accepted the drain - a busy hub that
+	 * refused the drain is never replaced, because the drain is what protects
+	 * work started during the wait window.
 	 */
 	force?: boolean;
 	/** Recorded as the hub's drain reason, visible in `hub.status`. */
@@ -748,7 +751,9 @@ export interface UpgradeManagedHubResult {
  * replacement in `ensureDetachedHubServer`, which defers while the older hub
  * is serving sessions: drain first (the hub refuses new work while in-flight
  * turns get `waitForIdleMs` to finish), then the shared graceful retire
- * ladder, then a fresh daemon.
+ * ladder, then a fresh daemon. Drain-first is a guarantee, not a courtesy:
+ * a hub that refuses the drain is replaced only if it is observed idle, and
+ * a busy one makes the upgrade fail instead - `force` does not override that.
  *
  * Never replaces a hub this build is not strictly newer than - the build
  * total order guarantees at most one side of any install pair can reach the
@@ -803,8 +808,13 @@ export async function upgradeManagedHub(
 		}).catch(() => false);
 	};
 	let activeSessionCount = 0;
-	const deadline =
-		Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS);
+	// The wait window is only meaningful under an established drain: an
+	// undrained hub keeps admitting new sessions and runs, so waiting would
+	// widen what a replacement kills instead of letting work finish. Without
+	// the drain, take a single busy reading and decide from that.
+	const deadline = drained
+		? Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS)
+		: Date.now();
 	// Check at least once so waitForIdleMs: 0 still observes an idle hub.
 	for (;;) {
 		try {
@@ -821,6 +831,15 @@ export async function upgradeManagedHub(
 		}
 		await new Promise((resolve) =>
 			setTimeout(resolve, HUB_UPGRADE_IDLE_POLL_MS),
+		);
+	}
+	// A busy hub that never entered the drained state is not replaced, forced
+	// or not: the drain is the guarantee that nothing new starts between the
+	// busy reading and the retire, and without it a forced replacement would
+	// kill work the user never saw in the consent prompt.
+	if (activeSessionCount > 0 && !drained) {
+		throw new Error(
+			`The running Cline Hub at ${record.url} did not accept a drain request and is still serving sessions, so it was not replaced. Finish those sessions or run 'cline doctor fix', then try again.`,
 		);
 	}
 	if (activeSessionCount > 0 && options.force !== true) {

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -282,6 +282,15 @@ export async function hubHasLiveSessions(
  * dies mid-turn with an abnormal close. Defer instead while it is busy: the
  * caller attaches to the older Hub, the build-mismatch watcher tells the user a
  * newer build is waiting, and the swap happens at a boundary they choose.
+ *
+ * The drain comes BEFORE the busy check, not after: an idle reading is only
+ * a snapshot, and a session admitted between it and the shutdown would die
+ * in a retirement that "idle" was supposed to rule out. With the drain
+ * accepted first, the hub admits no new work, so the reading stays true
+ * through the retire. A hub that does not accept the drain (builds that
+ * predate /drain answer 404; a wedged one may not answer at all) keeps the
+ * historical best-effort snapshot - never replacing such a hub would strand
+ * every client on it permanently, the very failure this path exists to fix.
  */
 async function retireIncompatibleHub(
 	record: HubServerProbeRecord,
@@ -290,12 +299,37 @@ async function retireIncompatibleHub(
 	if (isReusableHubRecord(record)) {
 		return "reusable";
 	}
+	const drained = await requestHubDrain(
+		record.url,
+		record.authToken,
+		"retired by newer install",
+	).catch(() => false);
 	if (await hubHasLiveSessions(record)) {
+		// Deferring means the hub keeps serving its sessions, so hand it back:
+		// a deferred hub left draining would refuse all new work until restart.
+		if (drained) {
+			await requestHubDrain(
+				record.url,
+				record.authToken,
+				"hub retirement deferred",
+				{ off: true },
+			).catch(() => false);
+		}
 		return "deferred_busy";
 	}
-	return (await retireDiscoveredHub(record, discoveryPath))
-		? "retired"
-		: "failed";
+	const retired = await retireDiscoveredHub(record, discoveryPath);
+	// A hub that survived the ladder (or was skipped by the retire circuit
+	// breaker) keeps running, so hand it back too - drained-but-alive is a
+	// limbo that refuses all new work until something restarts it.
+	if (!retired && drained) {
+		await requestHubDrain(
+			record.url,
+			record.authToken,
+			"hub retirement failed",
+			{ off: true },
+		).catch(() => false);
+	}
+	return retired ? "retired" : "failed";
 }
 
 /**

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -754,14 +754,16 @@ export interface UpgradeManagedHubResult {
  * turns get `waitForIdleMs` to finish), then the shared graceful retire
  * ladder, then a fresh daemon. Drain-first is a guarantee, not a courtesy:
  * this function retires a hub only under an accepted drain, because the
- * drain is the admission barrier that makes an idle or consented-busy
- * reading trustworthy through the retire. A hub that refuses the drain
- * fails the upgrade while it has (or may have) sessions - `force` does not
- * override that - and when observed idle it is handed to the locked ensure
- * path, which re-checks activity right before its own retire ladder.
- * Activity readings that fail are treated as unknown, not idle: they never
- * shorten the wait window, and without `force` an unconfirmed hub is handed
- * back un-drained rather than retired.
+ * drain is the admission barrier that keeps any busy or idle reading true
+ * through the retire. A hub that refuses the drain fails the upgrade
+ * outright - `force` does not override that, and neither does an idle
+ * reading, which without the drain is only a snapshot that a newly admitted
+ * session could invalidate before the retire lands. (Such a hub is still
+ * replaced by the automatic ensure path once idle at the next client
+ * startup, the pre-existing recovery route for hubs too old to serve
+ * /drain.) Activity readings that fail are treated as unknown, not idle:
+ * they never shorten the wait window, and without `force` an unconfirmed
+ * hub is handed back un-drained rather than retired.
  *
  * Never replaces a hub this build is not strictly newer than - the build
  * total order guarantees at most one side of any install pair can reach the
@@ -805,23 +807,27 @@ export async function upgradeManagedHub(
 		record.authToken,
 		options.reason ?? "hub upgrade requested",
 	).catch(() => false);
+	// No accepted drain, no upgrade - unconditionally. The drain is the
+	// admission barrier that keeps every reading below true through the
+	// retire; without it even a positively idle reading is a snapshot that a
+	// session admitted a moment later would invalidate, and that session
+	// would die in a retire the user's consent prompt never covered. A hub
+	// too old or too wedged to accept the drain is still replaced by the
+	// automatic ensure path once it is idle at the next client startup.
+	if (!drained) {
+		throw new Error(
+			`The running Cline Hub at ${record.url} did not accept a drain request, so it was not replaced. It is replaced automatically once idle when a Cline client next starts, or run 'cline doctor fix' to stop it now.`,
+		);
+	}
 	// An aborted upgrade must hand the hub back: leaving it draining refuses
 	// all new mutating work until a restart.
 	const undrain = async (): Promise<void> => {
-		if (!drained) {
-			return;
-		}
 		await requestHubDrain(record.url, record.authToken, "hub upgrade aborted", {
 			off: true,
 		}).catch(() => false);
 	};
-	// The wait window is only meaningful under an established drain: an
-	// undrained hub keeps admitting new sessions and runs, so waiting would
-	// widen what a replacement kills instead of letting work finish. Without
-	// the drain, take a single busy reading and decide from that.
-	const deadline = drained
-		? Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS)
-		: Date.now();
+	const deadline =
+		Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS);
 	// A failed reading is "unknown", never "idle": it must not end the wait
 	// window early, overwrite the last real observation, or authorize a
 	// retirement by itself - a transient query blip while turns are still
@@ -848,37 +854,6 @@ export async function upgradeManagedHub(
 		);
 	}
 	const confirmedIdle = observedSessionCount === 0;
-	if (!drained) {
-		// A hub that never entered the drained state has no admission
-		// barrier, so this function never retires it directly: busy (or
-		// unconfirmed) activity fails the upgrade, and even an idle reading
-		// is only a snapshot - a session admitted right after it would die in
-		// a retire the user's consent prompt never covered. Hand the idle
-		// case to the locked ensure path instead: it re-checks activity
-		// immediately before its own retire ladder and attaches (deferring
-		// the swap) when new work arrived in the meantime.
-		if (!confirmedIdle) {
-			throw new Error(
-				`The running Cline Hub at ${record.url} did not accept a drain request and was not observed idle, so it was not replaced. Finish its sessions or run 'cline doctor fix', then try again.`,
-			);
-		}
-		const ensured = await ensureDetachedHubServer(workspaceRoot);
-		const replacement = await safeProbeHubServer(
-			ensured.url,
-			ensured.authToken,
-		);
-		if (
-			replacement?.url &&
-			getManagedHubCompatibility(replacement).compatible
-		) {
-			return { outcome: "replaced", ...ensured, activeSessionCount: 0 };
-		}
-		// The ensure path found the hub serving sessions again and attached
-		// to it instead of replacing it (or the replacement cannot be
-		// confirmed right now, which reports the same way and self-corrects
-		// on the next mismatch check).
-		return { outcome: "still_busy", ...ensured };
-	}
 	// Without force, only a positively idle hub may be replaced: a busy or
 	// unanswerable hub is handed back un-drained. With force, the user has
 	// already consented to interrupting the sessions the prompt showed them,

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -15,7 +15,7 @@ import {
 	withResolvedClineBuildEnv,
 } from "@cline/shared";
 import {
-	localHubHasNoActiveSessions,
+	queryHubSessionActivity,
 	rememberRecoverableLocalHubUrl,
 	requestHubDrain,
 	requestHubShutdown,
@@ -23,7 +23,9 @@ import {
 } from "../client";
 import {
 	clearHubDiscovery,
+	compareHubBuilds,
 	createHubServerUrl,
+	getManagedHubCompatibility,
 	type HubOwnerContext,
 	type HubServerDiscoveryRecord,
 	type HubServerProbeRecord,
@@ -31,6 +33,7 @@ import {
 	probeHubServer,
 	readHubDiscovery,
 	resolveClineDataDir,
+	resolveHubBuildIdentity,
 	withHubStartupLock,
 	writeHubDiscovery,
 } from "../discovery";
@@ -264,7 +267,11 @@ export async function hubHasLiveSessions(
 	record: Pick<HubServerProbeRecord, "url" | "authToken">,
 ): Promise<boolean> {
 	try {
-		return !(await localHubHasNoActiveSessions(record.url, record.authToken));
+		const activity = await queryHubSessionActivity(
+			record.url,
+			record.authToken,
+		);
+		return activity.activeSessionCount > 0;
 	} catch {
 		return false;
 	}
@@ -684,4 +691,153 @@ export async function ensureDetachedHubServer(
 	return await withHubStartupLock(owner.discoveryPath, async () =>
 		ensureDetachedHubServerLocked(owner, workspaceRoot, endpointOverrides),
 	);
+}
+
+const HUB_UPGRADE_DEFAULT_WAIT_MS = 5_000;
+const HUB_UPGRADE_IDLE_POLL_MS = 500;
+
+export interface UpgradeManagedHubOptions {
+	workspaceRoot?: string;
+	/**
+	 * How long to wait, after draining, for the hub's live sessions to finish
+	 * before replacing it (`force`) or giving up (`still_busy`).
+	 */
+	waitForIdleMs?: number;
+	/**
+	 * Replace the hub even if sessions are still live once the wait expires.
+	 * Only set this on a user-consented path: those sessions die mid-turn.
+	 */
+	force?: boolean;
+	/** Recorded as the hub's drain reason, visible in `hub.status`. */
+	reason?: string;
+}
+
+export type UpgradeManagedHubOutcome =
+	/** The running older hub was retired and a current-build hub is up. */
+	| "replaced"
+	/** No live hub was found; a current-build hub was started. */
+	| "started"
+	/** The running hub already matches this build; nothing to do. */
+	| "already_current"
+	/**
+	 * The running hub is newer than (or unorderable against) this build.
+	 * Replacing it would downgrade another install's hub and reopen the
+	 * mutual-retire loop (#13145), so it is refused; updating this client is
+	 * the fix.
+	 */
+	| "hub_not_older"
+	/** `force` was not set and sessions never finished; the hub was un-drained
+	 * and left running. */
+	| "still_busy";
+
+export interface UpgradeManagedHubResult {
+	outcome: UpgradeManagedHubOutcome;
+	url?: string;
+	authToken?: string;
+	/**
+	 * Live sessions observed on the old hub at decision time: the sessions
+	 * that were interrupted (`replaced`) or that kept it running
+	 * (`still_busy`).
+	 */
+	activeSessionCount?: number;
+}
+
+/**
+ * Replace the managed local hub with one running this build, on the user's
+ * explicit say-so. This is the deliberate counterpart to the automatic
+ * replacement in `ensureDetachedHubServer`, which defers while the older hub
+ * is serving sessions: drain first (the hub refuses new work while in-flight
+ * turns get `waitForIdleMs` to finish), then the shared graceful retire
+ * ladder, then a fresh daemon.
+ *
+ * Never replaces a hub this build is not strictly newer than - the build
+ * total order guarantees at most one side of any install pair can reach the
+ * retire step, which is what keeps two mixed installs from taking turns
+ * "upgrading" the hub to their own build.
+ */
+export async function upgradeManagedHub(
+	options: UpgradeManagedHubOptions = {},
+): Promise<UpgradeManagedHubResult> {
+	const owner = resolveDefaultHubOwnerContext();
+	const workspaceRoot = options.workspaceRoot ?? process.cwd();
+	const discovered = await readHubDiscovery(owner.discoveryPath);
+	const live = discovered?.url
+		? await safeProbeHubServer(discovered.url, discovered.authToken)
+		: undefined;
+	if (!live?.url) {
+		const ensured = await ensureDetachedHubServer(workspaceRoot);
+		return { outcome: "started", ...ensured };
+	}
+	const record = {
+		...live,
+		authToken: live.authToken ?? discovered?.authToken,
+		pid: live.pid ?? discovered?.pid,
+	};
+	if (getManagedHubCompatibility(live).compatible) {
+		return {
+			outcome: "already_current",
+			url: live.url,
+			authToken: record.authToken,
+		};
+	}
+	if (compareHubBuilds(resolveHubBuildIdentity(), live) <= 0) {
+		return {
+			outcome: "hub_not_older",
+			url: live.url,
+			authToken: record.authToken,
+		};
+	}
+	const drained = await requestHubDrain(
+		record.url,
+		record.authToken,
+		options.reason ?? "hub upgrade requested",
+	).catch(() => false);
+	// An aborted upgrade must hand the hub back: leaving it draining refuses
+	// all new mutating work until a restart.
+	const undrain = async (): Promise<void> => {
+		if (!drained) {
+			return;
+		}
+		await requestHubDrain(record.url, record.authToken, "hub upgrade aborted", {
+			off: true,
+		}).catch(() => false);
+	};
+	let activeSessionCount = 0;
+	const deadline =
+		Date.now() + (options.waitForIdleMs ?? HUB_UPGRADE_DEFAULT_WAIT_MS);
+	// Check at least once so waitForIdleMs: 0 still observes an idle hub.
+	for (;;) {
+		try {
+			activeSessionCount = (
+				await queryHubSessionActivity(record.url, record.authToken)
+			).activeSessionCount;
+		} catch {
+			// Same fail-open as the automatic retire path: a hub that cannot
+			// answer is not pinned alive by sessions nobody can observe.
+			activeSessionCount = 0;
+		}
+		if (activeSessionCount === 0 || Date.now() >= deadline) {
+			break;
+		}
+		await new Promise((resolve) =>
+			setTimeout(resolve, HUB_UPGRADE_IDLE_POLL_MS),
+		);
+	}
+	if (activeSessionCount > 0 && options.force !== true) {
+		await undrain();
+		return {
+			outcome: "still_busy",
+			url: record.url,
+			authToken: record.authToken,
+			activeSessionCount,
+		};
+	}
+	if (!(await retireDiscoveredHub(record, owner.discoveryPath))) {
+		await undrain();
+		throw new Error(
+			`The running Cline Hub at ${record.url} could not be stopped. Run 'cline doctor fix' to stop stale hub daemons, then try again.`,
+		);
+	}
+	const ensured = await ensureDetachedHubServer(workspaceRoot);
+	return { outcome: "replaced", ...ensured, activeSessionCount };
 }

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -753,11 +753,15 @@ export interface UpgradeManagedHubResult {
  * is serving sessions: drain first (the hub refuses new work while in-flight
  * turns get `waitForIdleMs` to finish), then the shared graceful retire
  * ladder, then a fresh daemon. Drain-first is a guarantee, not a courtesy:
- * a hub that refuses the drain is replaced only if it is positively observed
- * idle, and a busy one makes the upgrade fail instead - `force` does not
- * override that. Activity readings that fail are treated as unknown, not
- * idle: they never shorten the wait window, and without `force` an
- * unconfirmed hub is handed back un-drained rather than retired.
+ * this function retires a hub only under an accepted drain, because the
+ * drain is the admission barrier that makes an idle or consented-busy
+ * reading trustworthy through the retire. A hub that refuses the drain
+ * fails the upgrade while it has (or may have) sessions - `force` does not
+ * override that - and when observed idle it is handed to the locked ensure
+ * path, which re-checks activity right before its own retire ladder.
+ * Activity readings that fail are treated as unknown, not idle: they never
+ * shorten the wait window, and without `force` an unconfirmed hub is handed
+ * back un-drained rather than retired.
  *
  * Never replaces a hub this build is not strictly newer than - the build
  * total order guarantees at most one side of any install pair can reach the
@@ -844,20 +848,41 @@ export async function upgradeManagedHub(
 		);
 	}
 	const confirmedIdle = observedSessionCount === 0;
-	// A hub that never entered the drained state is not replaced unless it
-	// was positively observed idle, forced or not: the drain is the guarantee
-	// that nothing new starts between the busy reading and the retire, and
-	// without it a forced replacement would kill work the user never saw in
-	// the consent prompt.
-	if (!confirmedIdle && !drained) {
-		throw new Error(
-			`The running Cline Hub at ${record.url} did not accept a drain request and was not observed idle, so it was not replaced. Finish its sessions or run 'cline doctor fix', then try again.`,
+	if (!drained) {
+		// A hub that never entered the drained state has no admission
+		// barrier, so this function never retires it directly: busy (or
+		// unconfirmed) activity fails the upgrade, and even an idle reading
+		// is only a snapshot - a session admitted right after it would die in
+		// a retire the user's consent prompt never covered. Hand the idle
+		// case to the locked ensure path instead: it re-checks activity
+		// immediately before its own retire ladder and attaches (deferring
+		// the swap) when new work arrived in the meantime.
+		if (!confirmedIdle) {
+			throw new Error(
+				`The running Cline Hub at ${record.url} did not accept a drain request and was not observed idle, so it was not replaced. Finish its sessions or run 'cline doctor fix', then try again.`,
+			);
+		}
+		const ensured = await ensureDetachedHubServer(workspaceRoot);
+		const replacement = await safeProbeHubServer(
+			ensured.url,
+			ensured.authToken,
 		);
+		if (
+			replacement?.url &&
+			getManagedHubCompatibility(replacement).compatible
+		) {
+			return { outcome: "replaced", ...ensured, activeSessionCount: 0 };
+		}
+		// The ensure path found the hub serving sessions again and attached
+		// to it instead of replacing it (or the replacement cannot be
+		// confirmed right now, which reports the same way and self-corrects
+		// on the next mismatch check).
+		return { outcome: "still_busy", ...ensured };
 	}
 	// Without force, only a positively idle hub may be replaced: a busy or
 	// unanswerable hub is handed back un-drained. With force, the user has
 	// already consented to interrupting the sessions the prompt showed them,
-	// and the accepted drain has kept new work out during the window.
+	// and the accepted drain keeps new work out from here through the retire.
 	if (!confirmedIdle && options.force !== true) {
 		await undrain();
 		return {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add logic to detect when the CLI is newer than the running Hub and provide users with options to either keep the older Hub running (to avoid interrupting active sessions from other clients) or force-replace it.

Implement `describeOutdatedHubSessions` helper to show quantified session activity in the dialog, and add `HubOutdatedContent` UI component with detailed messaging for the `build_mismatch` case. The `unsupported_protocol` case remains a modal requiring update, while the softer mismatch now uses a toast with enter-to-replace or escape-to-keep choices.

Includes tests for draining and replacing an older busy hub when forced.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Automated: unit tests cover the upgrade flow's gating (`sdk/packages/core/src/hub/daemon/index.test.ts`: forced replacement, busy deferral, drain-refusal fail-fast, transient-activity-failure handling, build-order gating), the sidecar authorization gate (`apps/examples/desktop-app/sidecar/commands-hub-upgrade.test.ts`), and the dialog copy helpers.

#### Manually testing the branch

The scenario needs an "older busy Hub" on the **production** owner path plus a newer client. Build identity is env-overridable, so no old install is required — but two things matter:

- Everything must run with `CLINE_BUILD_ENV=production`. Dev builds deliberately get per-build owner paths and never contend, so a dev-env hub and a production-env client will never see each other.
- Do **not** use `bun run cli` for the hub/TUI steps — apps/cli's `dev` script hardcodes `CLINE_BUILD_ENV=development` and silently overrides yours. Invoke `src/index.ts` directly as below.

**1. Stop any current production hub** (skip if none is running):

```bash
CLINE_BUILD_ENV=production bun --conditions=development --cwd apps/cli src/index.ts doctor fix
```

**2. Start an "old" hub on the production path:**

```bash
CLINE_BUILD_ENV=production CLINE_HUB_BUILD_ID=old-build CLINE_HUB_BUILD_EPOCH_MS=1000 bun --conditions=development --cwd apps/cli src/index.ts hub ensure
```

Verify it landed: `curl -s http://127.0.0.1:25463/health` must show `"buildId":"old-build"`.

**3. Make it busy** — attach an old-build TUI, start a conversation, and leave it open:

```bash
CLINE_BUILD_ENV=production CLINE_HUB_BUILD_ID=old-build CLINE_HUB_BUILD_EPOCH_MS=1000 bun --conditions=development --cwd apps/cli src/index.ts -i
```

**4a. Desktop flow** — from `apps/examples/desktop-app`:

```bash
CLINE_BUILD_ENV=production bun run dev
```

Expected:
- A blocking **"Cline Hub update required"** dialog appears over the loading screen, reporting "1 active session from 1 connected Cline client".
- **Update Hub now** → the old hub drains and is replaced (the TUI from step 3 loses its hub session), and the app relaunches onto the fresh hub.
- **Quit Cline** → the app exits; the old hub and TUI keep running; the dialog returns on the next launch.

**4b. CLI flow** — instead of the desktop, open a *new-build* TUI (add `CLINE_HUB_BUILD_WATCH_INTERVAL_MS=2000` to shorten the wait):

```bash
CLINE_BUILD_ENV=production bun --conditions=development --cwd apps/cli src/index.ts -i
```

Expected: after ~2 watcher intervals, a **"Cline Hub update required"** dialog with the session counts — Enter replaces the Hub, Esc keeps it running (with a reminder toast).

**Non-dialog cases worth confirming:**
- Old hub **idle** (close the TUI first): the newer client replaces it silently at startup — the pre-existing auto-upgrade path; no dialog is expected.
- Hub **newer** than the client (after 4a's update succeeds, the still-open old TUI is now the stale side): the TUI shows a one-time toast suggesting `cline update` instead of the old modal; the modal remains only for `unsupported_protocol`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="1022" height="604" alt="image" src="https://github.com/user-attachments/assets/489f5a16-5c63-4837-bc6e-46bef2cda2a5" />

<img width="1495" height="978" alt="image" src="https://github.com/user-attachments/assets/2133774f-7dd0-4490-bfdb-f9b3581630b0" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

