### PR TITLE
docs: add OpenZoo provider setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,6 +92,7 @@
 											"provider-config/openai",
 											"provider-config/openai-compatible",
 											"provider-config/openrouter",
+											"provider-config/openzoo",
 											"provider-config/poolside",
 											"provider-config/zai",
 											"provider-config/other-30-plus-providers"

--- a/docs/provider-config/openzoo.mdx
+++ b/docs/provider-config/openzoo.mdx
@@ -17,15 +17,16 @@ OpenAI-compatible endpoint.
 3. Set **Base URL** to `http://localhost:8402/v1`.
 4. Set **API Key** to any non-empty value, e.g. `sk-openzoo` — the local proxy
    ignores it.
-5. Set **Model ID** to a model from the catalog, e.g. `z-ai/glm-5.3-flash`.
+5. Set **Model ID** to `auto` (the proxy picks a model per request) or any id
+   from the catalog, e.g. `claude-sonnet-5`.
 
 ### Notes
 
 -   **Wallet:** `npx openzoo address` prints the proxy's wallet; fund it with
     USDC on Solana or Base. `npx openzoo balance` shows what is left.
 -   **Model list:** fetch live model ids and pricing (free) from
-    `http://localhost:8402/v1/models`. Ids are namespaced, like
-    `z-ai/glm-5.3-flash` or `qwen/qwen3.7-flash`.
+    `http://localhost:8402/v1/models`. Ids are bare model names, like
+    `claude-sonnet-5` or `gpt-4o-mini`.
 -   **Streaming:** SSE streaming is supported.
 -   **Hosted endpoint:** `https://api.openzoo.fun/v1` answers HTTP 402 unless
     the caller pays x402 or presents an OpenZoo subscription key

--- a/docs/provider-config/openzoo.mdx
+++ b/docs/provider-config/openzoo.mdx
@@ -1,0 +1,37 @@
+---
+title: "OpenZoo"
+description: "Configure Cline with OpenZoo, an OpenAI-compatible provider with no signup — pay per call by card or via x402, hosted or local with npx."
+---
+
+OpenZoo is an OpenAI-compatible model provider that requires no account. Any API
+key value is accepted, and usage is paid per request — by card, or automatically
+via the x402 protocol when running the local gateway.
+
+**Website:** [https://openzoo.fun](https://openzoo.fun)
+
+### Quickstart
+
+1. In Cline settings, set **API Provider** to "OpenAI Compatible".
+2. Set **Base URL** to `https://api.openzoo.fun/v1` — or run `npx openzoo` and
+   use `http://localhost:8402/v1`.
+3. Set **API Key** to any value, e.g. `sk-openzoo` (no signup exists).
+4. Set **Model ID** to a model from the catalog, e.g. `z-ai/glm-5.3-flash`.
+
+### Notes
+
+-   **No signup:** any API key is accepted; billing is per call.
+-   **Model list:** fetch live model ids and pricing (free) from
+    `https://api.openzoo.fun/v1/models`. Ids are namespaced, like
+    `z-ai/glm-5.3-flash` or `qwen/qwen3.7-flash`.
+-   **Streaming:** SSE streaming is supported.
+-   **Local mode:** `npx openzoo` serves the same API at
+    `http://localhost:8402/v1` and pays per call from a local burner wallet.
+
+### Troubleshooting
+
+-   **Connection errors (local):** confirm `npx openzoo` is running and the
+    Base URL is `http://localhost:8402/v1`.
+-   **HTTP 402:** the wallet behind the request is unfunded — the error body
+    carries directions (card link, `npx openzoo address` / `balance`).
+-   **"Model Not Found":** copy the model id exactly as returned by
+    `/v1/models`.

--- a/docs/provider-config/openzoo.mdx
+++ b/docs/provider-config/openzoo.mdx
@@ -1,37 +1,44 @@
 ---
 title: "OpenZoo"
-description: "Configure Cline with OpenZoo, an OpenAI-compatible provider with no signup — pay per call by card or via x402, hosted or local with npx."
+description: "Configure Cline with OpenZoo, an OpenAI-compatible provider that pays per call over x402 from a local proxy — no account."
 ---
 
-OpenZoo is an OpenAI-compatible model provider that requires no account. Any API
-key value is accepted, and usage is paid per request — by card, or automatically
-via the x402 protocol when running the local gateway.
+OpenZoo is an OpenAI-compatible model provider with no account. You run a small
+local proxy (`npx openzoo`) that pays for each request over the x402 protocol
+from a local burner wallet; Cline talks to the proxy like any other
+OpenAI-compatible endpoint.
 
 **Website:** [https://openzoo.fun](https://openzoo.fun)
 
 ### Quickstart
 
-1. In Cline settings, set **API Provider** to "OpenAI Compatible".
-2. Set **Base URL** to `https://api.openzoo.fun/v1` — or run `npx openzoo` and
-   use `http://localhost:8402/v1`.
-3. Set **API Key** to any value, e.g. `sk-openzoo` (no signup exists).
-4. Set **Model ID** to a model from the catalog, e.g. `z-ai/glm-5.3-flash`.
+1. Start the proxy: `npx openzoo` (listens on `http://localhost:8402/v1`).
+2. In Cline settings, set **API Provider** to "OpenAI Compatible".
+3. Set **Base URL** to `http://localhost:8402/v1`.
+4. Set **API Key** to any non-empty value, e.g. `sk-openzoo` — the local proxy
+   ignores it.
+5. Set **Model ID** to a model from the catalog, e.g. `z-ai/glm-5.3-flash`.
 
 ### Notes
 
--   **No signup:** any API key is accepted; billing is per call.
+-   **Wallet:** `npx openzoo address` prints the proxy's wallet; fund it with
+    USDC on Solana or Base. `npx openzoo balance` shows what is left.
 -   **Model list:** fetch live model ids and pricing (free) from
-    `https://api.openzoo.fun/v1/models`. Ids are namespaced, like
+    `http://localhost:8402/v1/models`. Ids are namespaced, like
     `z-ai/glm-5.3-flash` or `qwen/qwen3.7-flash`.
 -   **Streaming:** SSE streaming is supported.
--   **Local mode:** `npx openzoo` serves the same API at
-    `http://localhost:8402/v1` and pays per call from a local burner wallet.
+-   **Hosted endpoint:** `https://api.openzoo.fun/v1` answers HTTP 402 unless
+    the caller pays x402 or presents an OpenZoo subscription key
+    (`ozk_live_…`). Plain OpenAI clients cannot pay x402, so use the local
+    proxy.
 
 ### Troubleshooting
 
--   **Connection errors (local):** confirm `npx openzoo` is running and the
-    Base URL is `http://localhost:8402/v1`.
--   **HTTP 402:** the wallet behind the request is unfunded — the error body
-    carries directions (card link, `npx openzoo address` / `balance`).
+-   **Connection errors:** confirm `npx openzoo` is running and the Base URL is
+    `http://localhost:8402/v1`.
+-   **HTTP 402 from the proxy:** the local wallet is unfunded — send USDC to
+    the address from `npx openzoo address`.
+-   **HTTP 402 from `api.openzoo.fun`:** Cline is pointed at the hosted
+    endpoint without a subscription key; use the local proxy instead.
 -   **"Model Not Found":** copy the model id exactly as returned by
     `/v1/models`.


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

Adds a provider setup page for [OpenZoo](https://openzoo.fun) plus its nav entry in `docs/docs.json` — the same 2-file shape as the merged Poolside guide (#12586).

OpenZoo works with Cline today through the existing "OpenAI Compatible" provider type; this page documents the local `npx openzoo` proxy as the base URL (`http://localhost:8402/v1`; the proxy ignores the API key, so any non-empty value works; billing is per call from the proxy's wallet), and notes that the hosted endpoint needs x402 or a subscription key.

Disclosure: I operate OpenZoo. Verification: `npx openzoo` then `curl http://localhost:8402/v1/models` is free and lists model ids + pricing; the quickstart runs as-is against the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
