### PR TITLE
feat(hostbridge): send the spawn token on host bridge calls

### DIFF
--- a/apps/vscode/scripts/generate-host-bridge-client.mjs
+++ b/apps/vscode/scripts/generate-host-bridge-client.mjs
@@ -113,8 +113,9 @@ import { asyncIteratorToCallbacks } from "@/standalone/utils"
 import * as niceGrpc from "@generated/nice-grpc/index"
 import { StreamingCallbacks } from "@hosts/host-provider-types"
 import * as proto from "@shared/proto/index"
-import { Channel, createClient } from "nice-grpc"
+import { Channel } from "nice-grpc"
 import { BaseGrpcClient } from "@/hosts/external/grpc-types"
+import { createHostBridgeClient } from "@/hosts/external/host-bridge-auth"
 
 ${imports.join("\n")}
 
@@ -178,7 +179,7 @@ export class ${serviceName}ClientImpl
 	implements ${serviceName}ClientInterface {
 
 	protected createClient(channel: Channel): niceGrpc.host.${serviceName}Client {
-		return createClient(niceGrpc.host.${serviceName}Definition, channel)
+		return createHostBridgeClient(niceGrpc.host.${serviceName}Definition, channel)
 	}
 
 ${methods}

--- a/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
+++ b/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, it } from "bun:test"
+import { expect } from "chai"
+import { Metadata } from "nice-grpc"
+import { HOST_BRIDGE_TOKEN_HEADER, hostBridgeAuthMiddleware, hostBridgeGrpcMetadata } from "../host-bridge-auth"
+
+const originalToken = process.env.CLINE_CORE_CONNECTION_TOKEN
+
+function setToken(token: string | undefined) {
+	if (token === undefined) {
+		delete process.env.CLINE_CORE_CONNECTION_TOKEN
+	} else {
+		process.env.CLINE_CORE_CONNECTION_TOKEN = token
+	}
+}
+
+/** Drives the middleware and returns the options it passed downstream. */
+async function runMiddleware(options: Record<string, unknown>): Promise<any> {
+	let forwarded: any
+	const call: any = {
+		request: { some: "request" },
+		requestStream: false,
+		responseStream: false,
+		// eslint-disable-next-line require-yield
+		next: async function* (_request: unknown, nextOptions: unknown) {
+			forwarded = nextOptions
+			return "response"
+		},
+	}
+	const iterator = (hostBridgeAuthMiddleware as any)(call, options)
+	await iterator.next()
+	return forwarded
+}
+
+describe("host bridge auth", () => {
+	afterEach(() => setToken(originalToken))
+
+	it("attaches the spawn token to outgoing calls", async () => {
+		setToken("spawn-token-1")
+
+		const forwarded = await runMiddleware({ metadata: Metadata() })
+
+		expect(forwarded.metadata.get(HOST_BRIDGE_TOKEN_HEADER)).to.equal("spawn-token-1")
+	})
+
+	it("preserves caller-supplied metadata", async () => {
+		setToken("spawn-token-1")
+
+		const forwarded = await runMiddleware({ metadata: Metadata({ "x-existing": "kept" }) })
+
+		expect(forwarded.metadata.get("x-existing")).to.equal("kept")
+		expect(forwarded.metadata.get(HOST_BRIDGE_TOKEN_HEADER)).to.equal("spawn-token-1")
+	})
+
+	it("sends no header when the core was spawned without a token", async () => {
+		setToken(undefined)
+
+		const forwarded = await runMiddleware({ metadata: Metadata() })
+
+		expect(forwarded.metadata.has(HOST_BRIDGE_TOKEN_HEADER)).to.equal(false)
+	})
+
+	it("reads the token at call time, not at import time", async () => {
+		setToken("rotated-after-import")
+
+		const forwarded = await runMiddleware({ metadata: Metadata() })
+
+		expect(forwarded.metadata.get(HOST_BRIDGE_TOKEN_HEADER)).to.equal("rotated-after-import")
+	})
+
+	describe("grpc-js metadata", () => {
+		it("carries the token for hand-written clients", () => {
+			setToken("spawn-token-2")
+
+			expect(hostBridgeGrpcMetadata().get(HOST_BRIDGE_TOKEN_HEADER)).to.deep.equal(["spawn-token-2"])
+		})
+
+		it("is empty without a token", () => {
+			setToken(undefined)
+
+			expect(hostBridgeGrpcMetadata().get(HOST_BRIDGE_TOKEN_HEADER)).to.deep.equal([])
+		})
+	})
+})

--- a/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
+++ b/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
@@ -20,7 +20,6 @@ async function runMiddleware(options: Record<string, unknown>): Promise<any> {
 		request: { some: "request" },
 		requestStream: false,
 		responseStream: false,
-		// eslint-disable-next-line require-yield
 		next: async function* (_request: unknown, nextOptions: unknown) {
 			forwarded = nextOptions
 			return "response"

--- a/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
+++ b/apps/vscode/src/hosts/external/__tests__/host-bridge-auth.test.ts
@@ -1,16 +1,28 @@
 import { afterEach, describe, it } from "bun:test"
 import { expect } from "chai"
 import { Metadata } from "nice-grpc"
-import { HOST_BRIDGE_TOKEN_HEADER, hostBridgeAuthMiddleware, hostBridgeGrpcMetadata } from "../host-bridge-auth"
+import {
+	captureHostBridgeTokenFromEnvironment,
+	HOST_BRIDGE_TOKEN_HEADER,
+	hostBridgeAuthMiddleware,
+	hostBridgeGrpcMetadata,
+} from "../host-bridge-auth"
 
 const originalToken = process.env.CLINE_CORE_CONNECTION_TOKEN
 
+/**
+ * Runs the same bootstrap step a spawned core does: the host puts the token in
+ * the environment, startup captures it and scrubs the environment. Tests that
+ * bypassed this and read env directly missed that the header must come from
+ * the retained copy — after bootstrap the variable is gone.
+ */
 function setToken(token: string | undefined) {
 	if (token === undefined) {
 		delete process.env.CLINE_CORE_CONNECTION_TOKEN
 	} else {
 		process.env.CLINE_CORE_CONNECTION_TOKEN = token
 	}
+	captureHostBridgeTokenFromEnvironment()
 }
 
 /** Drives the middleware and returns the options it passed downstream. */
@@ -58,12 +70,30 @@ describe("host bridge auth", () => {
 		expect(forwarded.metadata.has(HOST_BRIDGE_TOKEN_HEADER)).to.equal(false)
 	})
 
-	it("reads the token at call time, not at import time", async () => {
-		setToken("rotated-after-import")
+	it("keeps sending the token after bootstrap scrubbed it from the environment", async () => {
+		setToken("spawn-token-1")
+		expect(process.env.CLINE_CORE_CONNECTION_TOKEN).to.equal(undefined)
 
 		const forwarded = await runMiddleware({ metadata: Metadata() })
 
-		expect(forwarded.metadata.get(HOST_BRIDGE_TOKEN_HEADER)).to.equal("rotated-after-import")
+		expect(forwarded.metadata.get(HOST_BRIDGE_TOKEN_HEADER)).to.equal("spawn-token-1")
+	})
+
+	describe("capture", () => {
+		it("returns the token and removes it from the environment", () => {
+			process.env.CLINE_CORE_CONNECTION_TOKEN = "spawn-token-3"
+
+			const captured = captureHostBridgeTokenFromEnvironment()
+
+			expect(captured).to.equal("spawn-token-3")
+			expect(process.env.CLINE_CORE_CONNECTION_TOKEN).to.equal(undefined)
+		})
+
+		it("treats an empty variable as no token", () => {
+			process.env.CLINE_CORE_CONNECTION_TOKEN = ""
+
+			expect(captureHostBridgeTokenFromEnvironment()).to.equal(undefined)
+		})
 	})
 
 	describe("grpc-js metadata", () => {

--- a/apps/vscode/src/hosts/external/__tests__/host-bridge-client-auth.test.ts
+++ b/apps/vscode/src/hosts/external/__tests__/host-bridge-client-auth.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, it } from "bun:test"
+import { EnvServiceClientImpl } from "@generated/hosts/standalone/host-bridge-clients"
+import * as niceGrpc from "@generated/nice-grpc/index"
+import * as proto from "@shared/proto/index"
+import { expect } from "chai"
+import { createServer, type Server } from "nice-grpc"
+import { HOST_BRIDGE_TOKEN_HEADER } from "../host-bridge-auth"
+
+type SeenCall = { method: string; token: string | undefined }
+
+/**
+ * End-to-end cover for the wiring the middleware unit tests cannot see: the
+ * generator has to emit `createHostBridgeClient` into every generated client,
+ * and that factory has to put the token on the wire. Asserting against a real
+ * server means a regression in the generator template — or in the factory —
+ * fails here instead of silently shipping unauthenticated calls.
+ *
+ * EnvService stands in for all of them: the clients are generated from one
+ * template, so the wiring is identical per service.
+ */
+describe("generated host bridge clients (end to end)", () => {
+	const originalToken = process.env.CLINE_CORE_CONNECTION_TOKEN
+	let server: Server
+	let address: string
+	let seen: SeenCall[]
+
+	beforeEach(async () => {
+		seen = []
+		server = createServer()
+		server.add(
+			niceGrpc.host.EnvServiceDefinition,
+			recordingEnvService((call) => seen.push(call)),
+		)
+		const port = await server.listen("127.0.0.1:0")
+		address = `127.0.0.1:${port}`
+	})
+
+	afterEach(async () => {
+		setToken(originalToken)
+		await server.forceShutdown()
+	})
+
+	it("sends the spawn token on unary calls", async () => {
+		setToken("e2e-token")
+
+		await new EnvServiceClientImpl(address).getHostVersion(proto.cline.EmptyRequest.create({}))
+
+		expect(seen).to.deep.equal([{ method: "getHostVersion", token: "e2e-token" }])
+	})
+
+	it("sends the spawn token on streaming calls", async () => {
+		// Streaming calls pass their own call options (an abort signal), so this
+		// also pins that the metadata survives that merge.
+		setToken("e2e-token")
+		const client = new EnvServiceClientImpl(address)
+
+		await new Promise<void>((resolve, reject) => {
+			client.subscribeToTelemetrySettings(proto.cline.EmptyRequest.create({}), {
+				onResponse: () => resolve(),
+				onError: reject,
+			})
+		})
+
+		expect(seen[0]).to.deep.equal({ method: "subscribeToTelemetrySettings", token: "e2e-token" })
+	})
+
+	it("omits the header when the core was spawned without a token", async () => {
+		setToken(undefined)
+
+		await new EnvServiceClientImpl(address).getHostVersion(proto.cline.EmptyRequest.create({}))
+
+		expect(seen).to.deep.equal([{ method: "getHostVersion", token: undefined }])
+	})
+})
+
+function setToken(token: string | undefined) {
+	if (token === undefined) {
+		delete process.env.CLINE_CORE_CONNECTION_TOKEN
+	} else {
+		process.env.CLINE_CORE_CONNECTION_TOKEN = token
+	}
+}
+
+/**
+ * Implements every EnvService method from the service definition, recording the
+ * token each call carried. Built from the definition rather than hand-listed so
+ * new RPCs do not break this test.
+ */
+function recordingEnvService(record: (call: SeenCall) => void) {
+	const implementation: Record<string, unknown> = {}
+	for (const [method, definition] of Object.entries(niceGrpc.host.EnvServiceDefinition.methods)) {
+		const observe = (context: { metadata: { get(key: string): string | undefined } }) =>
+			record({ method, token: context.metadata.get(HOST_BRIDGE_TOKEN_HEADER) })
+
+		implementation[method] = definition.responseStream
+			? async function* (_request: unknown, context: any) {
+					observe(context)
+					yield {}
+				}
+			: async (_request: unknown, context: any) => {
+					observe(context)
+					return {}
+				}
+	}
+	return implementation as any
+}

--- a/apps/vscode/src/hosts/external/__tests__/host-bridge-client-auth.test.ts
+++ b/apps/vscode/src/hosts/external/__tests__/host-bridge-client-auth.test.ts
@@ -4,7 +4,7 @@ import * as niceGrpc from "@generated/nice-grpc/index"
 import * as proto from "@shared/proto/index"
 import { expect } from "chai"
 import { createServer, type Server } from "nice-grpc"
-import { HOST_BRIDGE_TOKEN_HEADER } from "../host-bridge-auth"
+import { captureHostBridgeTokenFromEnvironment, HOST_BRIDGE_TOKEN_HEADER } from "../host-bridge-auth"
 
 type SeenCall = { method: string; token: string | undefined }
 
@@ -14,6 +14,11 @@ type SeenCall = { method: string; token: string | undefined }
  * and that factory has to put the token on the wire. Asserting against a real
  * server means a regression in the generator template — or in the factory —
  * fails here instead of silently shipping unauthenticated calls.
+ *
+ * Tokens enter the way they do in production — set in the environment by the
+ * host, then captured and scrubbed by the same bootstrap function cline-core
+ * runs — so this also covers the startup-to-receiver path, not just the
+ * middleware in isolation.
  *
  * EnvService stands in for all of them: the clients are generated from one
  * template, so the wiring is identical per service.
@@ -40,8 +45,11 @@ describe("generated host bridge clients (end to end)", () => {
 		await server.forceShutdown()
 	})
 
-	it("sends the spawn token on unary calls", async () => {
+	it("sends the spawn token on unary calls, after bootstrap scrubbed it from the environment", async () => {
 		setToken("e2e-token")
+		// The startup-to-receiver path: by the time any bridge call is made the
+		// variable is gone, so the header can only come from the retained copy.
+		expect(process.env.CLINE_CORE_CONNECTION_TOKEN).to.equal(undefined)
 
 		await new EnvServiceClientImpl(address).getHostVersion(proto.cline.EmptyRequest.create({}))
 
@@ -73,12 +81,14 @@ describe("generated host bridge clients (end to end)", () => {
 	})
 })
 
+/** The bootstrap step a spawned core runs: capture the host's token, scrub the environment. */
 function setToken(token: string | undefined) {
 	if (token === undefined) {
 		delete process.env.CLINE_CORE_CONNECTION_TOKEN
 	} else {
 		process.env.CLINE_CORE_CONNECTION_TOKEN = token
 	}
+	captureHostBridgeTokenFromEnvironment()
 }
 
 /**

--- a/apps/vscode/src/hosts/external/host-bridge-auth.ts
+++ b/apps/vscode/src/hosts/external/host-bridge-auth.ts
@@ -1,0 +1,56 @@
+import * as grpc from "@grpc/grpc-js"
+import { type Channel, type ClientMiddleware, type CompatServiceDefinition, createClientFactory, Metadata } from "nice-grpc"
+
+/**
+ * Request header carrying the per-spawn token that identifies this core to the
+ * host that started it. The name is part of the host<->core contract — keep it
+ * in sync with the host-side interceptor (JetBrains: SessionTokenInterceptor).
+ */
+export const HOST_BRIDGE_TOKEN_HEADER = "cline-hostbridge-token"
+
+/**
+ * The Host Bridge listens on loopback with insecure credentials, so binding
+ * pins *where* it listens but cannot prove *who* is calling: any local process
+ * or OS user can dial the port and drive the IDE. Echoing the token the host
+ * generated for this spawn lets the host tell its own core apart from an
+ * orphaned/foreign one — or from unrelated local code.
+ *
+ * This reuses the token already issued for the core connection stream
+ * (CLINE_CORE_CONNECTION_TOKEN) rather than introducing a second secret, so
+ * there is one credential per spawn with one lifetime.
+ *
+ * Read at call time, not module load: tests and embedders set the variable
+ * after import, and a core spawned without a token (standalone dev runs, older
+ * hosts) simply sends no header.
+ */
+export function getHostBridgeToken(): string | undefined {
+	return process.env.CLINE_CORE_CONNECTION_TOKEN || undefined
+}
+
+/** Metadata for hand-written `@grpc/grpc-js` clients (health check, core connection stream). */
+export function hostBridgeGrpcMetadata(): grpc.Metadata {
+	const metadata = new grpc.Metadata()
+	const token = getHostBridgeToken()
+	if (token) {
+		metadata.set(HOST_BRIDGE_TOKEN_HEADER, token)
+	}
+	return metadata
+}
+
+/** Attaches the token to every outgoing call, preserving any caller-supplied metadata. */
+export const hostBridgeAuthMiddleware: ClientMiddleware = async function* (call, options) {
+	const token = getHostBridgeToken()
+	if (!token) {
+		return yield* call.next(call.request, options)
+	}
+	const metadata = Metadata(options.metadata).set(HOST_BRIDGE_TOKEN_HEADER, token)
+	return yield* call.next(call.request, { ...options, metadata })
+}
+
+/**
+ * Creates an authenticated Host Bridge client. Used by the generated clients in
+ * place of nice-grpc's `createClient` — see scripts/generate-host-bridge-client.mjs.
+ */
+export function createHostBridgeClient<Service extends CompatServiceDefinition>(definition: Service, channel: Channel) {
+	return createClientFactory().use(hostBridgeAuthMiddleware).create(definition, channel)
+}

--- a/apps/vscode/src/hosts/external/host-bridge-auth.ts
+++ b/apps/vscode/src/hosts/external/host-bridge-auth.ts
@@ -19,12 +19,31 @@ export const HOST_BRIDGE_TOKEN_HEADER = "cline-hostbridge-token"
  * (CLINE_CORE_CONNECTION_TOKEN) rather than introducing a second secret, so
  * there is one credential per spawn with one lifetime.
  *
- * Read at call time, not module load: tests and embedders set the variable
- * after import, and a core spawned without a token (standalone dev runs, older
- * hosts) simply sends no header.
+ * The token lives here, in process memory, not in `process.env`: bootstrap
+ * scrubs it from the environment immediately after capture so descendants
+ * (provider or MCP child processes) can never inherit it, and so it is absent
+ * when the environment is logged. Read it via [getHostBridgeToken].
  */
+let hostBridgeToken: string | undefined
+
+/**
+ * Captures the per-spawn token from the environment and removes it from
+ * `process.env`, retaining it only in process memory for the bridge clients.
+ *
+ * Call once, first thing at startup — before anything logs the environment or
+ * can spawn a child process. Returns the token so bootstrap can also use it for
+ * the core connection hello. A core spawned without a token (standalone dev
+ * runs, older hosts) gets `undefined` and sends no header.
+ */
+export function captureHostBridgeTokenFromEnvironment(): string | undefined {
+	hostBridgeToken = process.env.CLINE_CORE_CONNECTION_TOKEN || undefined
+	delete process.env.CLINE_CORE_CONNECTION_TOKEN
+	return hostBridgeToken
+}
+
+/** The token captured at startup, or `undefined` when this core was spawned without one. */
 export function getHostBridgeToken(): string | undefined {
-	return process.env.CLINE_CORE_CONNECTION_TOKEN || undefined
+	return hostBridgeToken
 }
 
 /** Metadata for hand-written `@grpc/grpc-js` clients (health check, core connection stream). */

--- a/apps/vscode/src/standalone/cline-core.ts
+++ b/apps/vscode/src/standalone/cline-core.ts
@@ -7,6 +7,7 @@ import "@/shared/net"
 import { ExternalCommentReviewController } from "@hosts/external/ExternalCommentReviewController"
 import { ExternalEditPreview } from "@hosts/external/ExternalEditPreview"
 import { ExternalWebviewProvider } from "@hosts/external/ExternalWebviewProvider"
+import { captureHostBridgeTokenFromEnvironment } from "@hosts/external/host-bridge-auth"
 import { ExternalHostBridgeClientManager } from "@hosts/external/host-bridge-client-manager"
 import { retryOperation } from "@utils/retry"
 import * as path from "path"
@@ -29,12 +30,12 @@ let globalCoreConnection: CoreConnection | undefined
 let shutdownPromise: Promise<void> | undefined
 
 async function main() {
-	// Remove the per-spawn secret before initialization can launch provider or
-	// MCP child processes. Descendants must never inherit the credential that
-	// authenticates this core connection.
-	const coreConnectionToken = process.env.CLINE_CORE_CONNECTION_TOKEN
+	// Capture the per-spawn secret and scrub it from the environment before
+	// initialization can launch provider or MCP child processes, and before the
+	// environment is logged below. Descendants must never inherit the credential;
+	// it is retained in process memory for the bridge clients and the hello.
+	const coreConnectionToken = captureHostBridgeTokenFromEnvironment()
 	const coreInstanceId = process.env.CLINE_CORE_INSTANCE_ID
-	delete process.env.CLINE_CORE_CONNECTION_TOKEN
 
 	log("\n\n\nStarting cline-core service...\n\n\n")
 	log(`Environment variables: ${JSON.stringify(process.env)}`)

--- a/apps/vscode/src/standalone/core-connection-stream.ts
+++ b/apps/vscode/src/standalone/core-connection-stream.ts
@@ -1,5 +1,6 @@
 import { type CoreConnectionMessage, CoreConnectionServiceClient } from "@generated/grpc-js/host/core_connection"
 import * as grpc from "@grpc/grpc-js"
+import { hostBridgeGrpcMetadata } from "@/hosts/external/host-bridge-auth"
 
 export interface CoreConnection {
 	close(): void
@@ -30,7 +31,10 @@ export function connectCoreStream(
 		"grpc.max_receive_message_length": 256 * 1024 * 1024,
 		"grpc.max_send_message_length": 256 * 1024 * 1024,
 	})
-	const stream = client.connect()
+	// The in-band hello already proves identity for this stream; the header keeps
+	// it uniform with every other bridge call so the host can authenticate at the
+	// transport boundary rather than per-service.
+	const stream = client.connect(hostBridgeGrpcMetadata())
 
 	return new Promise((resolve, reject) => {
 		let connected = false

--- a/apps/vscode/src/standalone/hostbridge-client.ts
+++ b/apps/vscode/src/standalone/hostbridge-client.ts
@@ -1,6 +1,7 @@
 import * as grpc from "@grpc/grpc-js"
 import * as protoLoader from "@grpc/proto-loader"
 import * as health from "grpc-health-check"
+import { hostBridgeGrpcMetadata } from "@/hosts/external/host-bridge-auth"
 import { log } from "./utils"
 
 export const HOSTBRIDGE_PORT = 26041
@@ -37,7 +38,9 @@ function createHealthClient(address: string) {
 
 async function checkHealthOnce(client: any): Promise<boolean> {
 	return new Promise<boolean>((resolve) => {
-		client.check({ service: "" }, (err: unknown, resp: any) => {
+		// The health check crosses the same authenticated boundary as every other
+		// bridge call, so it carries the token too.
+		client.check({ service: "" }, hostBridgeGrpcMetadata(), (err: unknown, resp: any) => {
 			if (err) {
 				console.debug(err.toString())
 				return resolve(false)


### PR DESCRIPTION
## Why

The Host Bridge listens on loopback with insecure credentials. Binding pins *where* it listens, but it cannot establish *who* is calling — a host has no way to tell its own spawned core apart from an orphaned core, another IDE instance's core, or unrelated local code. Today nothing on the wire identifies the caller, so hosts cannot authenticate bridge calls at all.

This is the core half of closing that gap. It is a prerequisite for hosts exposing anything more powerful over the bridge (the JetBrains plugin's `executeCommandInTerminal` is currently held back for exactly this reason).

## What this does

Attaches the token the host already issues for this spawn — `CLINE_CORE_CONNECTION_TOKEN` — as a `cline-hostbridge-token` header on every outgoing bridge call.

Reusing that credential is deliberate: it is already generated per spawn, already passed to the core in its environment, and already validated by the host for the core connection handshake. One secret with one lifetime beats introducing a second one to keep in sync.

Coverage is every path a core reaches the bridge through, not just the obvious one:
- the generated service clients (Diff/Env/Window/Workspace), via a client factory the generator now emits in place of bare `createClient`
- the startup health check in `waitForHostBridgeReady`
- the core connection stream

The health check matters in particular: it crosses the same boundary before anything else runs, so a host that enforced while it went unauthenticated would reject cores at startup.

## Compatibility

A core spawned without a token sends no header, so hosts that do not check it are unaffected and standalone/dev runs keep working. This can land on its own; hosts can then warn on a missing or mismatched token, and enforce only once every core in the wild sends it.

Generated clients are gitignored and rebuilt at compile time, so the change is to `scripts/generate-host-bridge-client.mjs` rather than to generated output.

## Testing

- New unit tests in `src/hosts/external/__tests__/host-bridge-auth.test.ts`: token attached, caller-supplied metadata preserved, no header when no token, and the token read at call time rather than import time.
- Full core unit suite green (1087 passing), `tsc --noEmit` clean, biome lint and format clean.