### PR TITLE
fix(shell): resolve the default shell through PATH

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -57,6 +57,27 @@ describe("createShellExecutor", () => {
 		expect(output.trim()).toBe("hello");
 	});
 
+	it.skipIf(process.platform === "win32")(
+		"resolves the default shell through PATH",
+		async () => {
+			// NixOS ships no /bin/bash — bash lives in the Nix store and is only
+			// reachable through PATH, so an absolute default never starts. Point
+			// PATH at a directory whose only `bash` is a shim: an absolute
+			// /bin/bash would ignore PATH and run the real shell instead.
+			const dir = await mkdtemp(join(tmpdir(), "cline-shell-path-"));
+			try {
+				await writeFile(join(dir, "bash"), "#!/bin/sh\necho shim-on-path\n", {
+					mode: 0o755,
+				});
+				const shell = createShellExecutor({ env: { PATH: dir } });
+				const output = await shell("echo hello", process.cwd(), ctx);
+				expect(output.trim()).toBe("shim-on-path");
+			} finally {
+				await rm(dir, { recursive: true, force: true });
+			}
+		},
+	);
+
 	it("streams stdout and stderr with ANSI escapes before completion", async () => {
 		const updates: Array<Record<string, unknown>> = [];
 		let resolveBothStreams: (() => void) | undefined;

--- a/sdk/packages/core/src/extensions/tools/executors/bash.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.ts
@@ -327,7 +327,7 @@ export class CommandExitError extends Error {
 export interface ShellExecutorOptions {
 	/**
 	 * Shell to use for execution
-	 * @default "/bin/bash" on Unix, "powershell" on Windows
+	 * @default "bash" on Unix, "powershell" on Windows
 	 */
 	shell?: string;
 

--- a/sdk/packages/core/src/extensions/tools/types.ts
+++ b/sdk/packages/core/src/extensions/tools/types.ts
@@ -310,7 +310,7 @@ export interface DefaultToolsConfig {
 	 * Shell executable (name or full path) the run_commands executor will use.
 	 * The tool description tells the model which shell syntax to write, so this
 	 * must match the shell configured on the executor.
-	 * @default getDefaultShell(process.platform) — "/bin/bash" on Unix, "powershell" on Windows
+	 * @default getDefaultShell(process.platform) — "bash" on Unix, "powershell" on Windows
 	 */
 	shell?: string;
 

--- a/sdk/packages/shared/src/parse/shell.test.ts
+++ b/sdk/packages/shared/src/parse/shell.test.ts
@@ -9,8 +9,18 @@ import {
 describe("shell helpers", () => {
 	it("selects PowerShell on Windows and bash elsewhere", () => {
 		expect(getDefaultShell("win32")).toBe("powershell");
-		expect(getDefaultShell("darwin")).toBe("/bin/bash");
-		expect(getDefaultShell("linux")).toBe("/bin/bash");
+		expect(getDefaultShell("darwin")).toBe("bash");
+		expect(getDefaultShell("linux")).toBe("bash");
+	});
+
+	it("keeps the default shell classified as posix", () => {
+		// Execution and prompting both branch on getShellKind, so a default that
+		// stopped classifying as posix would advertise the wrong syntax.
+		expect(getShellKind(getDefaultShell("linux"))).toBe("posix");
+		expect(getShellInvocation(getDefaultShell("linux"), "ls").args).toEqual([
+			"-c",
+			"ls",
+		]);
 	});
 
 	it("uses an ASCII bootstrap with Unicode-safe PowerShell stdin", () => {

--- a/sdk/packages/shared/src/parse/shell.ts
+++ b/sdk/packages/shared/src/parse/shell.ts
@@ -9,7 +9,11 @@ function normalizeShellName(shell: string): string {
 }
 
 export function getDefaultShell(platform: string): string {
-	return platform === "win32" ? "powershell" : "/bin/bash";
+	// Unqualified so the OS resolves it through PATH. Distributions like NixOS
+	// ship no /bin/bash, and an absolute default fails to spawn there even
+	// though bash is installed. The name still classifies as "posix" below, so
+	// the syntax advertised to the model matches the shell that runs it.
+	return platform === "win32" ? "powershell" : "bash";
 }
 
 /**


### PR DESCRIPTION
### Related Issue

**Issue:** #13722

### Description

On NixOS, Bash is available through `PATH` but `/bin/bash` doesn't exist. The default shell uses that absolute path, so `run_commands` fails with `ENOENT` before running anything.

`getDefaultShell()` now returns `bash`, which lets `spawn()` find it through `PATH`. It still resolves to the same shell kind and uses the same `-c` invocation. The two doc comments describing the default are updated too.

Using `$SHELL` here could select fish or nushell while the model is still being given Bash syntax. Keeping Bash avoids that mismatch. Explicitly configured shells and the Windows/WSL paths keep their existing behaviour.

### Test Procedure

The regression puts a Bash shim on `PATH` and checks that the executor actually runs it. On the original code, `/bin/bash` bypasses the shim and the test fails.

A `bwrap` reproduction also runs the built SDK with an empty `/bin` and Bash available through `PATH`. The default executor succeeds; explicitly choosing `/bin/bash` fails with `ENOENT`. This recreates the missing-path condition, but it wasn't tested on a NixOS installation.

The shell tests and full monorepo unit suite passed, along with the SDK build, type checks for `@cline/shared` and `@cline/core`, and Biome on the changed files. Repository-wide lint and formatting output matched `main`. The tests also cover shell classification, invocation flags and the existing Windows/WSL cases.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change; the executor reproduction is described above.

### Additional Notes

A check on an actual NixOS installation would still be useful.
