### PR TITLE
fix(desktop): enable macOS voice input

### DIFF
--- a/apps/examples/desktop-app/src-tauri/Info.plist
+++ b/apps/examples/desktop-app/src-tauri/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Cline uses the microphone to transcribe speech into chat input.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Cline uses speech recognition to turn your voice into chat input.</string>
 </dict>
 </plist>

--- a/apps/examples/desktop-app/src-tauri/entitlements.plist
+++ b/apps/examples/desktop-app/src-tauri/entitlements.plist
@@ -9,5 +9,8 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<!-- Voice input requires audio capture access when Hardened Runtime is enabled. -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/examples/desktop-app/src-tauri/src/main.rs
+++ b/apps/examples/desktop-app/src-tauri/src/main.rs
@@ -1238,6 +1238,16 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
+    fn macos_bundle_declares_voice_input_permissions() {
+        let info_plist = include_str!("../Info.plist");
+        assert!(info_plist.contains("<key>NSMicrophoneUsageDescription</key>"));
+        assert!(info_plist.contains("<key>NSSpeechRecognitionUsageDescription</key>"));
+
+        let entitlements = include_str!("../entitlements.plist");
+        assert!(entitlements.contains("<key>com.apple.security.device.audio-input</key>"));
+    }
+
+    #[test]
     fn desktop_actions_are_buffered_in_order_until_drained() {
         let state = DesktopActionState::default();
         state.enqueue(DesktopAction::NewSession);

--- a/apps/examples/desktop-app/webview/components/ai-elements/speech-input.test.tsx
+++ b/apps/examples/desktop-app/webview/components/ai-elements/speech-input.test.tsx
@@ -90,6 +90,15 @@ class FakeSpeechRecognition extends EventTarget {
 		});
 		this.dispatchEvent(event);
 	}
+
+	emitError(error: string, message?: string): void {
+		const event = new Event("error");
+		Object.defineProperties(event, {
+			error: { value: error },
+			message: { value: message },
+		});
+		this.dispatchEvent(event);
+	}
 }
 
 let container: HTMLDivElement;
@@ -178,6 +187,28 @@ describe("SpeechInput", () => {
 		);
 		expect(onAudioRecorded).not.toHaveBeenCalled();
 		expect(button?.getAttribute("aria-label")).toBe("Stop recording");
+	});
+
+	it("preserves browser speech-recognition error details", async () => {
+		const onError = vi.fn();
+
+		await act(async () => {
+			root.render(<SpeechInput onError={onError} recordingMode="auto" />);
+		});
+
+		const button = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Record speech"]',
+		);
+		await act(async () => button?.click());
+		await act(async () => {
+			FakeSpeechRecognition.instances[0]?.emitError("not-allowed");
+		});
+
+		expect(onError).toHaveBeenCalledOnce();
+		expect(onError.mock.calls[0]?.[0]).toEqual(
+			new Error("Speech recognition failed: not-allowed"),
+		);
+		expect(button?.getAttribute("aria-label")).toBe("Record speech");
 	});
 
 	it("records audio and forwards the provider transcript", async () => {

--- a/apps/examples/desktop-app/webview/components/ai-elements/speech-input.tsx
+++ b/apps/examples/desktop-app/webview/components/ai-elements/speech-input.tsx
@@ -21,6 +21,11 @@ interface SpeechRecognitionEvent extends Event {
 	resultIndex: number;
 }
 
+interface SpeechRecognitionErrorEvent extends Event {
+	error: string;
+	message?: string;
+}
+
 interface SpeechRecognitionResultList {
 	readonly length: number;
 	[index: number]: SpeechRecognitionResult;
@@ -35,6 +40,20 @@ interface SpeechRecognitionResult {
 interface SpeechRecognitionAlternative {
 	transcript: string;
 	confidence: number;
+}
+
+function errorFromEvent(event: Event, fallbackMessage: string): Error {
+	const eventError = (event as Event & { error?: unknown }).error;
+	if (eventError instanceof Error) return eventError;
+
+	const eventMessage = (event as Event & { message?: unknown }).message;
+	if (typeof eventMessage === "string" && eventMessage.trim()) {
+		return new Error(eventMessage.trim());
+	}
+	if (typeof eventError === "string" && eventError.trim()) {
+		return new Error(`${fallbackMessage}: ${eventError.trim()}`);
+	}
+	return new Error(fallbackMessage);
 }
 
 declare global {
@@ -191,7 +210,10 @@ export function SpeechInput({
 		};
 		const handleError = (event: Event) => {
 			setIsListening(false);
-			onErrorRef.current?.(event);
+			const speechError = event as SpeechRecognitionErrorEvent;
+			onErrorRef.current?.(
+				errorFromEvent(speechError, "Speech recognition failed"),
+			);
 		};
 
 		recognition.addEventListener("start", handleStart);
@@ -302,7 +324,7 @@ export function SpeechInput({
 				for (const track of stream.getTracks()) track.stop();
 				streamRef.current = null;
 				mediaRecorderRef.current = null;
-				onErrorRef.current?.(event);
+				onErrorRef.current?.(errorFromEvent(event, "Audio recording failed"));
 			});
 			recorder.addEventListener("stop", async () => {
 				for (const track of stream.getTracks()) track.stop();


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes voice input failing immediately in the macOS desktop app with the generic "Check microphone permission and audio provider settings" toast.

The packaged app enables Hardened Runtime but did not include the `com.apple.security.device.audio-input` entitlement required to capture microphone audio. The WebKit speech-recognition path also lacked `NSSpeechRecognitionUsageDescription`. In addition, browser speech and recorder failures arrive as error events rather than JavaScript `Error` instances, so the UI discarded the underlying error code and always showed its generic fallback.

This PR:

- adds the macOS Hardened Runtime audio-input entitlement;
- declares microphone and speech-recognition usage in the packaged app;
- converts Web Speech and MediaRecorder error events into real errors while preserving their details; and
- adds regression coverage for both bundle permissions and speech-recognition error propagation.

### Test Procedure

1. Ran the focused voice-input component suite:
   `bunx vitest run webview/components/ai-elements/speech-input.test.tsx --config vitest.config.ts` (8 tests passed).
2. Ran desktop TypeScript validation with `bun run typecheck`.
3. Ran Biome against the modified TypeScript files.
4. Validated both plist files with `plutil -lint Info.plist entitlements.plist`.
5. Ran `cargo test macos_bundle_declares_voice_input_permissions`.
6. Built the full macOS app with `bunx tauri build --debug --bundles app`; the build and Apple notarization completed successfully.
7. Inspected the generated app bundle and confirmed both privacy descriptions are present and the signed executable contains `com.apple.security.device.audio-input = true`.

The affected paths are batch recording through MediaRecorder and live transcription through WebKit microphone capture. Existing streaming, batch transcription, stop/cancel, and stale-result behavior remain covered by the focused component suite.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before: mic input click return error

<img width="1094" height="466" alt="image" src="https://github.com/user-attachments/assets/d422cf3f-1c48-46fb-a669-d5119f0b12b4" />

After: mic input works after enabled

<img width="1003" height="254" alt="image" src="https://github.com/user-attachments/assets/7a1febf4-3e1e-4aaa-b5c0-0d49530a3151" />


### Additional Notes

This is a small, self-contained bug fix without an associated issue. Focused tests, typechecking, plist validation, the permission regression test, and a complete notarized macOS bundle build passed. The full monorepo `bun test` suite was not run locally and is left to CI.
