### PR TITLE
feat(desktop): import sessions from Claude Code, Codex, and opencode

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -462,6 +462,89 @@ describe("session forks", () => {
 		expect(ctx.restoringWorkspacePaths.size).toBe(0);
 	});
 
+	it("forks trimmed messages without restoring when the edited run has no checkpoint", async () => {
+		const sourceSessionId = `source-imported-fork-${Date.now()}`;
+		const sourceMessages = [
+			{ role: "user" as const, content: "imported prompt" },
+			{ role: "assistant" as const, content: "imported response" },
+			{ role: "user" as const, content: "prompt to edit" },
+			{ role: "assistant" as const, content: "response to replace" },
+		];
+		const expectedMessages = sourceMessages.slice(0, 2);
+		const start = vi.fn(async () => ({ sessionId: "imported-fork" }));
+		const restore = vi.fn(async () => {
+			throw new Error("restore must not run without a checkpoint");
+		});
+		const readMessages = vi.fn(async () => expectedMessages);
+		const ctx = {
+			liveSessions: new Map([
+				[
+					sourceSessionId,
+					{
+						config: {
+							provider: "cline",
+							model: "anthropic/claude-sonnet-4.6",
+						},
+						messages: sourceMessages,
+						promptsInQueue: [],
+						busy: false,
+						startedAt: Date.now(),
+						status: "completed",
+					},
+				],
+			]),
+			restoringWorkspacePaths: new Set(),
+			sessionManager: {
+				get: vi.fn(async () => ({
+					sessionId: sourceSessionId,
+					source: "desktop",
+					status: "completed",
+					provider: "cline",
+					model: "anthropic/claude-sonnet-4.6",
+					cwd: "/workspace/project",
+					workspaceRoot: "/workspace/project",
+					metadata: {
+						importedFrom: { tool: "codex", sourceId: "cdx-1" },
+					},
+				})),
+				readMessages,
+				restore,
+				start,
+			},
+			streamIndices: new Map(),
+			wsClients: new Set(),
+		} as unknown as SidecarContext;
+
+		const result = (await handleChatSessionCommand(ctx, {
+			action: "fork",
+			sessionId: sourceSessionId,
+			forkBeforeRunCount: 2,
+			config: {
+				provider: "cline",
+				model: "anthropic/claude-sonnet-4.6",
+			},
+		})) as { sessionId: string };
+
+		expect(restore).not.toHaveBeenCalled();
+		expect(start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				initialMessages: expectedMessages,
+				sessionMetadata: expect.objectContaining({
+					fork: expect.objectContaining({
+						forkedFromSessionId: sourceSessionId,
+						beforeRunCount: 2,
+					}),
+				}),
+			}),
+		);
+		expect(result.sessionId).toBe("imported-fork");
+		expect(ctx.liveSessions.has(sourceSessionId)).toBe(false);
+		expect(ctx.liveSessions.get("imported-fork")?.messages).toEqual(
+			expectedMessages,
+		);
+		expect(ctx.restoringWorkspacePaths.size).toBe(0);
+	});
+
 	it("keeps a full-history fork on the current workspace without restoring", async () => {
 		const sourceSessionId = `source-full-fork-${Date.now()}`;
 		const sourceMessages = [

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -8,10 +8,12 @@ import {
 	type ClineCoreStartConfig,
 	createSessionCompactionState,
 	createUserInstructionConfigService,
+	findCheckpointForRun,
 	getCoreBuiltinToolCatalog,
 	isSkillsToolAvailable,
 	projectSessionCompactionState,
 	readGlobalSettings,
+	readSessionCheckpointHistory,
 	type SessionCompactionState,
 	type SessionPendingPrompt,
 	type SessionRecord,
@@ -1299,8 +1301,18 @@ async function handleForkUnlocked(
 		sessionMetadata: forkMetadata,
 		toolPolicies: resolveToolPolicies(forkConfig),
 	};
+	// Sessions without a checkpoint at or before the edited run (imported
+	// transcripts, checkpoints disabled) have no workspace state to roll back,
+	// so fork the trimmed messages onto the current workspace instead of
+	// failing the edit.
+	const canRestoreWorkspace =
+		forkBeforeRunCount !== undefined &&
+		findCheckpointForRun(
+			readSessionCheckpointHistory({ metadata: sourceMetadata }),
+			forkBeforeRunCount,
+		) !== undefined;
 	let newSessionId: string;
-	if (forkBeforeRunCount !== undefined) {
+	if (forkBeforeRunCount !== undefined && canRestoreWorkspace) {
 		const cwd =
 			restoreWorkspacePath ||
 			(typeof forkConfig.cwd === "string" && forkConfig.cwd.trim()) ||

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -35,6 +35,10 @@ import {
 	resolveMcpServerRegistration,
 	resolveSessionBackend,
 	resolveAgentConfigSearchPaths as resolveSharedAgentConfigSearchPaths,
+	SESSION_IMPORT_TOOLS,
+	SessionImportService,
+	type SessionImportRequest,
+	type SessionImportTool,
 	SqliteSessionStore,
 	saveLocalProviderSettings,
 	saveVoiceInputSettings,
@@ -1513,6 +1517,45 @@ export async function handleCommand(
 		const sessionId = String(args?.sessionId ?? args?.session_id ?? "").trim();
 		if (!sessionId) throw new Error("session id is required");
 		return (await getSessionFromSidecarManager(ctx, sessionId)) ?? null;
+	}
+
+	// ── Session import from other coding tools ────────────────────────
+	if (command === "list_importable_sessions") {
+		const backend = await resolveSessionBackend({ backendMode: "local" });
+		const importer = new SessionImportService(backend);
+		return {
+			installedTools: importer.installedTools(),
+			sessions: await importer.discover(),
+		};
+	}
+	if (command === "import_sessions") {
+		const rawSelections = Array.isArray(args?.selections)
+			? args.selections
+			: [];
+		const requests: SessionImportRequest[] = [];
+		for (const selection of rawSelections) {
+			if (!selection || typeof selection !== "object") continue;
+			const tool = String((selection as JsonRecord).tool ?? "").trim();
+			const sourceId = String((selection as JsonRecord).sourceId ?? "").trim();
+			if (!sourceId) continue;
+			if (!(SESSION_IMPORT_TOOLS as readonly string[]).includes(tool)) {
+				continue;
+			}
+			requests.push({ tool: tool as SessionImportTool, sourceId });
+		}
+		if (requests.length === 0) {
+			throw new Error("at least one { tool, sourceId } selection is required");
+		}
+		const backend = await resolveSessionBackend({ backendMode: "local" });
+		const importer = new SessionImportService(backend);
+		const results = await importer.importMany(requests, (result, index) => {
+			broadcastEvent(ctx, "session_import_progress", {
+				index,
+				total: requests.length,
+				result,
+			});
+		});
+		return { results };
 	}
 	if (command === "update_chat_session_title") {
 		const sessionId = String(args?.sessionId ?? "").trim();

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -36,8 +36,8 @@ import {
 	resolveSessionBackend,
 	resolveAgentConfigSearchPaths as resolveSharedAgentConfigSearchPaths,
 	SESSION_IMPORT_TOOLS,
-	SessionImportService,
 	type SessionImportRequest,
+	SessionImportService,
 	type SessionImportTool,
 	SqliteSessionStore,
 	saveLocalProviderSettings,
@@ -1548,13 +1548,22 @@ export async function handleCommand(
 		}
 		const backend = await resolveSessionBackend({ backendMode: "local" });
 		const importer = new SessionImportService(backend);
-		const results = await importer.importMany(requests, (result, index) => {
-			broadcastEvent(ctx, "session_import_progress", {
-				index,
-				total: requests.length,
-				result,
-			});
-		});
+		// Opening a history session resumes on the row's provider/model, so the
+		// UI passes what a new chat would run on; the source tool's own
+		// provider/model stay in metadata.importedFrom.
+		const provider = asTrimmedString(args?.provider);
+		const model = asTrimmedString(args?.model);
+		const results = await importer.importMany(
+			requests,
+			(result, index) => {
+				broadcastEvent(ctx, "session_import_progress", {
+					index,
+					total: requests.length,
+					result,
+				});
+			},
+			{ ...(provider ? { provider } : {}), ...(model ? { model } : {}) },
+		);
 		return { results };
 	}
 	if (command === "update_chat_session_title") {

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1551,8 +1551,11 @@ export async function handleCommand(
 		// Opening a history session resumes on the row's provider/model, so the
 		// UI passes what a new chat would run on; the source tool's own
 		// provider/model stay in metadata.importedFrom.
-		const provider = asTrimmedString(args?.provider);
-		const model = asTrimmedString(args?.model);
+		// Never let the source tool's provider become the resume target: when
+		// the caller sends no selection, use the app default like other
+		// server-started sessions do.
+		const provider = asTrimmedString(args?.provider) ?? "cline";
+		const model = asTrimmedString(args?.model) ?? CLINE_DEFAULT_MODEL_ID;
 		const results = await importer.importMany(
 			requests,
 			(result, index) => {
@@ -1562,7 +1565,7 @@ export async function handleCommand(
 					result,
 				});
 			},
-			{ ...(provider ? { provider } : {}), ...(model ? { model } : {}) },
+			{ provider, model },
 		);
 		return { results };
 	}

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -22,9 +22,9 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
+import { getInitialChatConfig } from "@/hooks/chat-session/constants";
 import { basenamePath, formatRelativeTime } from "@/hooks/use-session-history";
 import { desktopClient } from "@/lib/desktop-client";
-import { readModelSelectionStorageFromWindow } from "@/lib/model-selection";
 import {
 	type ImportableSession,
 	importSelectionKey,
@@ -46,17 +46,17 @@ type ImportSessionsDialogProps = {
 };
 
 /**
- * Provider/model a new chat would start with right now. Imported sessions
- * are stamped with it so "continue this in Cline" runs on something the user
- * has actually configured instead of the source tool's provider.
+ * Provider/model a new chat would start with right now, resolved the same
+ * way a new chat resolves it (remembered selection, then the built-in
+ * default). Imported sessions are stamped with it so "continue this in
+ * Cline" runs on what the user actually uses instead of the source tool's
+ * provider. Reading model-selection storage directly is not enough: the
+ * composer only records a model when the user picks one explicitly, so
+ * anyone on the default model has no entry there.
  */
-function resumeTarget(): { provider?: string; model?: string } {
-	const selection = readModelSelectionStorageFromWindow();
-	const provider = selection.lastProvider.trim();
-	const model = provider
-		? (selection.lastModelByProvider[provider] ?? "").trim()
-		: "";
-	return provider && model ? { provider, model } : {};
+function resumeTarget(): { provider: string; model: string } {
+	const { provider, model } = getInitialChatConfig();
+	return { provider, model };
 }
 
 function matchesQuery(session: ImportableSession, query: string): boolean {

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -204,7 +204,13 @@ export function ImportSessionsDialog({
 			}}
 			open={open}
 		>
-			<DialogContent className="grid h-[min(680px,calc(100dvh-2rem))] w-[min(620px,calc(100vw-2rem))] max-w-none grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden">
+			{/* The single column must be minmax(0,1fr): with the default auto
+			    track, one unbreakable string in a session title widens the
+			    column's min-content beyond the fixed dialog width and
+			    overflow-hidden clips the header and search field. The explicit
+			    sm:max-w-none is needed because the primitive's sm:max-w-lg
+			    survives class merging across variants. */}
+			<DialogContent className="grid h-[min(680px,calc(100dvh-2rem))] w-[min(620px,calc(100vw-2rem))] max-w-none grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden sm:max-w-none">
 				<DialogHeader>
 					<DialogTitle>Import sessions</DialogTitle>
 					<DialogDescription>
@@ -240,7 +246,7 @@ export function ImportSessionsDialog({
 						) : null}
 						{sessions.length > 0 ? (
 							<>
-								<div className="relative">
+								<div className="relative shrink-0">
 									<Search className="-translate-y-1/2 pointer-events-none absolute left-2.5 top-1/2 size-4 text-muted-foreground" />
 									<Input
 										aria-label="Filter sessions"
@@ -250,7 +256,7 @@ export function ImportSessionsDialog({
 										value={query}
 									/>
 								</div>
-								<div className="flex items-center gap-2 border-b pb-2">
+								<div className="flex shrink-0 items-center gap-2 border-b pb-2">
 									<Checkbox
 										aria-label="Select all sessions"
 										checked={

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, Loader2, Search } from "lucide-react";
+import {
+	AlertCircle,
+	CheckCircle2,
+	ChevronDown,
+	ChevronRight,
+	Loader2,
+	Search,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -56,6 +63,7 @@ export function ImportSessionsDialog({
 	const [scanError, setScanError] = useState<string | null>(null);
 	const [sessions, setSessions] = useState<ImportableSession[]>([]);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [collapsedTools, setCollapsedTools] = useState<Set<string>>(new Set());
 	const [query, setQuery] = useState("");
 	const [progress, setProgress] = useState<{ done: number; total: number }>({
 		done: 0,
@@ -87,6 +95,7 @@ export function ImportSessionsDialog({
 	useEffect(() => {
 		if (!open) return;
 		setSelected(new Set());
+		setCollapsedTools(new Set());
 		setQuery("");
 		setResults([]);
 		setProgress({ done: 0, total: 0 });
@@ -126,6 +135,15 @@ export function ImportSessionsDialog({
 				.map((session) => importSelectionKey(session.tool, session.sourceId)),
 		[],
 	);
+
+	const isFiltering = query.trim().length > 0;
+	const visibleSelectableKeys = selectableKeys(visibleSessions);
+	const selectedVisibleCount = visibleSelectableKeys.filter((key) =>
+		selected.has(key),
+	).length;
+	const allVisibleSelected =
+		visibleSelectableKeys.length > 0 &&
+		selectedVisibleCount === visibleSelectableKeys.length;
 
 	const toggleAll = (items: ImportableSession[], checked: boolean) => {
 		setSelected((previous) => {
@@ -232,6 +250,33 @@ export function ImportSessionsDialog({
 										value={query}
 									/>
 								</div>
+								<div className="flex items-center gap-2 border-b pb-2">
+									<Checkbox
+										aria-label="Select all sessions"
+										checked={
+											allVisibleSelected
+												? true
+												: selectedVisibleCount > 0
+													? "indeterminate"
+													: false
+										}
+										disabled={visibleSelectableKeys.length === 0}
+										id="import-select-all"
+										onCheckedChange={(checked) =>
+											toggleAll(visibleSessions, checked === true)
+										}
+									/>
+									<label
+										className="cursor-pointer text-sm text-foreground"
+										htmlFor="import-select-all"
+									>
+										Select all
+									</label>
+									<span className="ml-auto text-xs text-muted-foreground">
+										{selectedVisibleCount} of {visibleSelectableKeys.length}{" "}
+										selected
+									</span>
+								</div>
 								<div className="min-h-0 flex-1 overflow-y-auto pr-1">
 									{groups.map((group) => {
 										const keys = selectableKeys(group.sessions);
@@ -240,6 +285,10 @@ export function ImportSessionsDialog({
 										).length;
 										const allChecked =
 											keys.length > 0 && selectedInGroup === keys.length;
+										// A collapsed section would hide filter matches, so
+										// filtering forces every section open.
+										const collapsed =
+											!isFiltering && collapsedTools.has(group.tool);
 										return (
 											<section className="mb-4" key={group.tool}>
 												<div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background py-1.5">
@@ -257,14 +306,39 @@ export function ImportSessionsDialog({
 															toggleAll(group.sessions, checked === true)
 														}
 													/>
-													<h3 className="text-sm font-semibold text-foreground">
-														{SESSION_IMPORT_TOOL_LABELS[group.tool]}
-													</h3>
-													<span className="text-xs text-muted-foreground">
-														{group.sessions.length}
-													</span>
+													<button
+														aria-expanded={!collapsed}
+														className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-sm py-0.5 text-left hover:text-foreground"
+														onClick={() =>
+															setCollapsedTools((previous) => {
+																const next = new Set(previous);
+																if (next.has(group.tool)) {
+																	next.delete(group.tool);
+																} else {
+																	next.add(group.tool);
+																}
+																return next;
+															})
+														}
+														type="button"
+													>
+														<h3 className="text-sm font-semibold text-foreground">
+															{SESSION_IMPORT_TOOL_LABELS[group.tool]}
+														</h3>
+														<span className="text-xs text-muted-foreground">
+															{group.sessions.length}
+															{selectedInGroup > 0
+																? ` · ${selectedInGroup} selected`
+																: ""}
+														</span>
+														{collapsed ? (
+															<ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+														) : (
+															<ChevronDown className="ml-auto size-4 shrink-0 text-muted-foreground" />
+														)}
+													</button>
 												</div>
-												<ul>
+												<ul hidden={collapsed}>
 													{group.sessions.map((session) => {
 														const key = importSelectionKey(
 															session.tool,
@@ -301,8 +375,8 @@ export function ImportSessionsDialog({
 																		}
 																	/>
 																	<span className="min-w-0 flex-1">
-																		<span className="flex items-center gap-2">
-																			<span className="truncate text-sm text-foreground">
+																		<span className="flex min-w-0 items-start gap-2">
+																			<span className="line-clamp-2 min-w-0 break-words text-sm text-foreground">
 																				{session.title}
 																			</span>
 																			{alreadyImported ? (
@@ -314,8 +388,8 @@ export function ImportSessionsDialog({
 																				</Badge>
 																			) : null}
 																		</span>
-																		<span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
-																			<span>
+																		<span className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+																			<span className="shrink-0">
 																				{formatRelativeTime(
 																					new Date(
 																						session.updatedAtMs,
@@ -323,14 +397,14 @@ export function ImportSessionsDialog({
 																				)}
 																			</span>
 																			<span aria-hidden>·</span>
-																			<span>
+																			<span className="shrink-0">
 																				{session.messageCount} message
 																				{session.messageCount === 1 ? "" : "s"}
 																			</span>
 																			{session.cwd ? (
 																				<>
 																					<span aria-hidden>·</span>
-																					<span className="truncate">
+																					<span className="min-w-0 truncate">
 																						{basenamePath(session.cwd)}
 																					</span>
 																				</>
@@ -384,7 +458,7 @@ export function ImportSessionsDialog({
 									) : (
 										<AlertCircle className="size-4 shrink-0 text-destructive" />
 									)}
-									<span className="truncate text-muted-foreground">
+									<span className="min-w-0 truncate text-muted-foreground">
 										{result.title ?? result.sourceId}
 									</span>
 								</li>

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Loader2, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { basenamePath, formatRelativeTime } from "@/hooks/use-session-history";
+import { desktopClient } from "@/lib/desktop-client";
+import {
+	type ImportableSession,
+	importSelectionKey,
+	type ListImportableSessionsResponse,
+	SESSION_IMPORT_TOOL_LABELS,
+	SESSION_IMPORT_TOOL_ORDER,
+	type SessionImportProgressEvent,
+	type SessionImportResult,
+} from "@/lib/session-import";
+import { cn } from "@/lib/utils";
+
+type ImportPhase = "loading" | "pick" | "importing" | "done";
+
+type ImportSessionsDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Called after at least one session imported successfully. */
+	onImported?: () => void;
+};
+
+function matchesQuery(session: ImportableSession, query: string): boolean {
+	if (!query) return true;
+	const haystack =
+		`${session.title} ${session.cwd} ${session.preview ?? ""}`.toLowerCase();
+	return query
+		.toLowerCase()
+		.split(/\s+/)
+		.every((term) => haystack.includes(term));
+}
+
+export function ImportSessionsDialog({
+	open,
+	onOpenChange,
+	onImported,
+}: ImportSessionsDialogProps) {
+	const [phase, setPhase] = useState<ImportPhase>("loading");
+	const [scanError, setScanError] = useState<string | null>(null);
+	const [sessions, setSessions] = useState<ImportableSession[]>([]);
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [query, setQuery] = useState("");
+	const [progress, setProgress] = useState<{ done: number; total: number }>({
+		done: 0,
+		total: 0,
+	});
+	const [results, setResults] = useState<SessionImportResult[]>([]);
+
+	const scan = useCallback(async () => {
+		setPhase("loading");
+		setScanError(null);
+		try {
+			const response =
+				await desktopClient.invoke<ListImportableSessionsResponse>(
+					"list_importable_sessions",
+					{},
+					// Scanning reads every source session file once; large
+					// histories can take longer than the default RPC timeout.
+					{ timeoutMs: 120_000 },
+				);
+			setSessions(response.sessions ?? []);
+			setPhase("pick");
+		} catch (error) {
+			setScanError(error instanceof Error ? error.message : String(error));
+			setPhase("pick");
+		}
+	}, []);
+
+	// Fresh state on every open, then scan.
+	useEffect(() => {
+		if (!open) return;
+		setSelected(new Set());
+		setQuery("");
+		setResults([]);
+		setProgress({ done: 0, total: 0 });
+		void scan();
+	}, [open, scan]);
+
+	useEffect(() => {
+		if (!open) return;
+		return desktopClient.subscribe("session_import_progress", (payload) => {
+			const event = payload as SessionImportProgressEvent | undefined;
+			if (!event || typeof event.index !== "number") return;
+			setProgress({ done: event.index + 1, total: event.total });
+			if (event.result) {
+				setResults((previous) => [...previous, event.result]);
+			}
+		});
+	}, [open]);
+
+	const visibleSessions = useMemo(
+		() => sessions.filter((session) => matchesQuery(session, query.trim())),
+		[sessions, query],
+	);
+
+	const groups = useMemo(
+		() =>
+			SESSION_IMPORT_TOOL_ORDER.map((tool) => ({
+				tool,
+				sessions: visibleSessions.filter((session) => session.tool === tool),
+			})).filter((group) => group.sessions.length > 0),
+		[visibleSessions],
+	);
+
+	const selectableKeys = useCallback(
+		(items: ImportableSession[]) =>
+			items
+				.filter((session) => !session.alreadyImportedSessionId)
+				.map((session) => importSelectionKey(session.tool, session.sourceId)),
+		[],
+	);
+
+	const toggleAll = (items: ImportableSession[], checked: boolean) => {
+		setSelected((previous) => {
+			const next = new Set(previous);
+			for (const key of selectableKeys(items)) {
+				if (checked) next.add(key);
+				else next.delete(key);
+			}
+			return next;
+		});
+	};
+
+	const startImport = async () => {
+		const selections = sessions
+			.filter((session) =>
+				selected.has(importSelectionKey(session.tool, session.sourceId)),
+			)
+			.map((session) => ({ tool: session.tool, sourceId: session.sourceId }));
+		if (selections.length === 0) return;
+		setPhase("importing");
+		setResults([]);
+		setProgress({ done: 0, total: selections.length });
+		try {
+			const response = await desktopClient.invoke<{
+				results: SessionImportResult[];
+			}>("import_sessions", { selections }, { timeoutMs: null });
+			// The progress events already streamed results; trust the final
+			// response as the authoritative list.
+			setResults(response.results ?? []);
+			if ((response.results ?? []).some((result) => result.ok)) {
+				onImported?.();
+			}
+		} catch (error) {
+			setResults([
+				{
+					tool: "claude-code",
+					sourceId: "",
+					ok: false,
+					error: error instanceof Error ? error.message : String(error),
+				},
+			]);
+		}
+		setPhase("done");
+	};
+
+	const succeeded = results.filter((result) => result.ok);
+	const failures = results.filter((result) => !result.ok);
+	const importableCount = sessions.filter(
+		(session) => !session.alreadyImportedSessionId,
+	).length;
+
+	return (
+		<Dialog
+			onOpenChange={(next) => {
+				// Don't let a stray overlay click abandon a running import.
+				if (!next && phase === "importing") return;
+				onOpenChange(next);
+			}}
+			open={open}
+		>
+			<DialogContent className="grid h-[min(680px,calc(100dvh-2rem))] w-[min(620px,calc(100vw-2rem))] max-w-none grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden">
+				<DialogHeader>
+					<DialogTitle>Import sessions</DialogTitle>
+					<DialogDescription>
+						Bring your conversation history from other coding tools into Cline.
+						Imported sessions appear in your history and can be continued here.
+					</DialogDescription>
+				</DialogHeader>
+
+				{phase === "loading" ? (
+					<div className="flex min-h-0 flex-col items-center justify-center gap-3 text-muted-foreground">
+						<Loader2 className="size-5 animate-spin" />
+						<p className="text-sm">Scanning for sessions…</p>
+					</div>
+				) : null}
+
+				{phase === "pick" ? (
+					<div className="flex min-h-0 flex-col gap-3">
+						{scanError ? (
+							<p className="text-sm text-destructive" role="alert">
+								Couldn't scan for sessions: {scanError}
+							</p>
+						) : null}
+						{sessions.length === 0 && !scanError ? (
+							<div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-center">
+								<p className="text-sm font-medium text-foreground">
+									No sessions found
+								</p>
+								<p className="max-w-sm text-sm text-muted-foreground">
+									Cline looks for local history from Claude Code, Codex, and
+									opencode. Nothing importable turned up on this machine.
+								</p>
+							</div>
+						) : null}
+						{sessions.length > 0 ? (
+							<>
+								<div className="relative">
+									<Search className="-translate-y-1/2 pointer-events-none absolute left-2.5 top-1/2 size-4 text-muted-foreground" />
+									<Input
+										aria-label="Filter sessions"
+										className="h-8 pl-8"
+										onChange={(event) => setQuery(event.target.value)}
+										placeholder="Filter by title or folder"
+										value={query}
+									/>
+								</div>
+								<div className="min-h-0 flex-1 overflow-y-auto pr-1">
+									{groups.map((group) => {
+										const keys = selectableKeys(group.sessions);
+										const selectedInGroup = keys.filter((key) =>
+											selected.has(key),
+										).length;
+										const allChecked =
+											keys.length > 0 && selectedInGroup === keys.length;
+										return (
+											<section className="mb-4" key={group.tool}>
+												<div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background py-1.5">
+													<Checkbox
+														aria-label={`Select all ${SESSION_IMPORT_TOOL_LABELS[group.tool]} sessions`}
+														checked={
+															allChecked
+																? true
+																: selectedInGroup > 0
+																	? "indeterminate"
+																	: false
+														}
+														disabled={keys.length === 0}
+														onCheckedChange={(checked) =>
+															toggleAll(group.sessions, checked === true)
+														}
+													/>
+													<h3 className="text-sm font-semibold text-foreground">
+														{SESSION_IMPORT_TOOL_LABELS[group.tool]}
+													</h3>
+													<span className="text-xs text-muted-foreground">
+														{group.sessions.length}
+													</span>
+												</div>
+												<ul>
+													{group.sessions.map((session) => {
+														const key = importSelectionKey(
+															session.tool,
+															session.sourceId,
+														);
+														const alreadyImported = Boolean(
+															session.alreadyImportedSessionId,
+														);
+														const checked = selected.has(key);
+														const checkboxId = `import-session-${key}`;
+														return (
+															<li key={key}>
+																<label
+																	className={cn(
+																		"flex cursor-pointer items-start gap-2.5 rounded-md px-1.5 py-2 hover:bg-muted/40",
+																		alreadyImported &&
+																			"cursor-default opacity-60",
+																	)}
+																	htmlFor={checkboxId}
+																>
+																	<Checkbox
+																		aria-label={`Import "${session.title}"`}
+																		checked={checked}
+																		className="mt-0.5"
+																		disabled={alreadyImported}
+																		id={checkboxId}
+																		onCheckedChange={(next) =>
+																			setSelected((previous) => {
+																				const nextSet = new Set(previous);
+																				if (next === true) nextSet.add(key);
+																				else nextSet.delete(key);
+																				return nextSet;
+																			})
+																		}
+																	/>
+																	<span className="min-w-0 flex-1">
+																		<span className="flex items-center gap-2">
+																			<span className="truncate text-sm text-foreground">
+																				{session.title}
+																			</span>
+																			{alreadyImported ? (
+																				<Badge
+																					className="shrink-0"
+																					variant="secondary"
+																				>
+																					Imported
+																				</Badge>
+																			) : null}
+																		</span>
+																		<span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+																			<span>
+																				{formatRelativeTime(
+																					session.updatedAtMs,
+																				)}
+																			</span>
+																			<span aria-hidden>·</span>
+																			<span>
+																				{session.messageCount} message
+																				{session.messageCount === 1 ? "" : "s"}
+																			</span>
+																			{session.cwd ? (
+																				<>
+																					<span aria-hidden>·</span>
+																					<span className="truncate">
+																						{basenamePath(session.cwd)}
+																					</span>
+																				</>
+																			) : null}
+																		</span>
+																	</span>
+																</label>
+															</li>
+														);
+													})}
+												</ul>
+											</section>
+										);
+									})}
+									{groups.length === 0 ? (
+										<p className="py-8 text-center text-sm text-muted-foreground">
+											No sessions match "{query.trim()}".
+										</p>
+									) : null}
+								</div>
+							</>
+						) : null}
+					</div>
+				) : null}
+
+				{phase === "importing" ? (
+					<div className="flex min-h-0 flex-col gap-4">
+						<div className="flex flex-col gap-2">
+							<div className="flex items-center justify-between text-sm">
+								<span className="text-foreground">Importing sessions…</span>
+								<span className="text-muted-foreground">
+									{progress.done} / {progress.total}
+								</span>
+							</div>
+							<Progress
+								value={
+									progress.total > 0
+										? (progress.done / progress.total) * 100
+										: 0
+								}
+							/>
+						</div>
+						<ul className="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1 text-sm">
+							{results.map((result) => (
+								<li
+									className="flex items-center gap-2"
+									key={importSelectionKey(result.tool, result.sourceId)}
+								>
+									{result.ok ? (
+										<CheckCircle2 className="size-4 shrink-0 text-muted-foreground" />
+									) : (
+										<AlertCircle className="size-4 shrink-0 text-destructive" />
+									)}
+									<span className="truncate text-muted-foreground">
+										{result.title ?? result.sourceId}
+									</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				) : null}
+
+				{phase === "done" ? (
+					<div className="flex min-h-0 flex-col gap-3">
+						<p className="text-sm text-foreground">
+							{succeeded.length > 0
+								? `Imported ${succeeded.length} session${succeeded.length === 1 ? "" : "s"}.`
+								: "No sessions were imported."}
+							{failures.length > 0
+								? ` ${failures.length} failed.`
+								: succeeded.length > 0
+									? " They're in your history now."
+									: ""}
+						</p>
+						{failures.length > 0 ? (
+							<ul className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1 text-sm">
+								{failures.map((failure) => (
+									<li
+										className="flex items-start gap-2"
+										key={importSelectionKey(failure.tool, failure.sourceId)}
+									>
+										<AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+										<span className="min-w-0">
+											<span className="block truncate text-foreground">
+												{failure.title ?? failure.sourceId}
+											</span>
+											<span className="block text-xs text-muted-foreground">
+												{failure.error}
+											</span>
+										</span>
+									</li>
+								))}
+							</ul>
+						) : null}
+					</div>
+				) : null}
+
+				<DialogFooter>
+					{phase === "pick" ? (
+						<>
+							<span className="mr-auto self-center text-xs text-muted-foreground">
+								{selected.size > 0
+									? `${selected.size} selected`
+									: importableCount > 0
+										? `${importableCount} available`
+										: ""}
+							</span>
+							<Button
+								onClick={() => onOpenChange(false)}
+								type="button"
+								variant="ghost"
+							>
+								Cancel
+							</Button>
+							<Button
+								disabled={selected.size === 0}
+								onClick={() => void startImport()}
+								type="button"
+							>
+								Import{selected.size > 0 ? ` ${selected.size}` : ""}
+							</Button>
+						</>
+					) : null}
+					{phase === "importing" ? (
+						<Button disabled type="button">
+							<Loader2 className="size-4 animate-spin" />
+							Importing…
+						</Button>
+					) : null}
+					{phase === "done" ? (
+						<Button onClick={() => onOpenChange(false)} type="button">
+							Done
+						</Button>
+					) : null}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { basenamePath, formatRelativeTime } from "@/hooks/use-session-history";
 import { desktopClient } from "@/lib/desktop-client";
+import { readModelSelectionStorageFromWindow } from "@/lib/model-selection";
 import {
 	type ImportableSession,
 	importSelectionKey,
@@ -43,6 +44,20 @@ type ImportSessionsDialogProps = {
 	/** Called after at least one session imported successfully. */
 	onImported?: () => void;
 };
+
+/**
+ * Provider/model a new chat would start with right now. Imported sessions
+ * are stamped with it so "continue this in Cline" runs on something the user
+ * has actually configured instead of the source tool's provider.
+ */
+function resumeTarget(): { provider?: string; model?: string } {
+	const selection = readModelSelectionStorageFromWindow();
+	const provider = selection.lastProvider.trim();
+	const model = provider
+		? (selection.lastModelByProvider[provider] ?? "").trim()
+		: "";
+	return provider && model ? { provider, model } : {};
+}
 
 function matchesQuery(session: ImportableSession, query: string): boolean {
 	if (!query) return true;
@@ -169,7 +184,11 @@ export function ImportSessionsDialog({
 		try {
 			const response = await desktopClient.invoke<{
 				results: SessionImportResult[];
-			}>("import_sessions", { selections }, { timeoutMs: null });
+			}>(
+				"import_sessions",
+				{ selections, ...resumeTarget() },
+				{ timeoutMs: null },
+			);
 			// The progress events already streamed results; trust the final
 			// response as the authoritative list.
 			setResults(response.results ?? []);

--- a/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/import-sessions-dialog.tsx
@@ -317,7 +317,9 @@ export function ImportSessionsDialog({
 																		<span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
 																			<span>
 																				{formatRelativeTime(
-																					session.updatedAtMs,
+																					new Date(
+																						session.updatedAtMs,
+																					).toISOString(),
 																				)}
 																			</span>
 																			<span aria-hidden>·</span>

--- a/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
@@ -834,18 +834,36 @@ function ConnectStep({
 }
 
 /**
- * Offers to bring session history over from other coding tools. Scans on
- * entry and silently advances when there is nothing to import, so only
+ * Offers to bring session history over from other coding tools. Scans once
+ * on entry and silently advances when there is nothing to import, so only
  * people who actually have Claude Code / Codex / opencode history ever see
- * this step.
+ * this step. After a successful import, onFinish closes onboarding directly
+ * — a second "you're all set" screen right after the import confirmation
+ * reads as a loop, not a finish.
  */
-function ImportHistoryStep({ onContinue }: { onContinue: () => void }) {
+function ImportHistoryStep({
+	onContinue,
+	onFinish,
+}: {
+	onContinue: () => void;
+	onFinish: () => void;
+}) {
 	const [found, setFound] = useState<{
 		count: number;
 		tools: SessionImportTool[];
 	} | null>(null);
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [imported, setImported] = useState(false);
+
+	// The parent recreates onContinue every render, and importing itself
+	// re-renders the app shell (history refresh). Keep the callback in a ref
+	// so the scan effect runs exactly once per step entry: a re-scan after
+	// importing would see zero remaining sessions and auto-advance out from
+	// under the user's own import confirmation.
+	const skipRef = useRef(onContinue);
+	useEffect(() => {
+		skipRef.current = onContinue;
+	});
 
 	useEffect(() => {
 		let cancelled = false;
@@ -862,7 +880,7 @@ function ImportHistoryStep({ onContinue }: { onContinue: () => void }) {
 					(session) => !session.alreadyImportedSessionId,
 				);
 				if (sessions.length === 0) {
-					onContinue();
+					skipRef.current();
 					return;
 				}
 				const tools = SESSION_IMPORT_TOOL_ORDER.filter((tool) =>
@@ -871,13 +889,13 @@ function ImportHistoryStep({ onContinue }: { onContinue: () => void }) {
 				setFound({ count: sessions.length, tools });
 			} catch {
 				// Onboarding must never dead-end on a scan failure.
-				if (!cancelled) onContinue();
+				if (!cancelled) skipRef.current();
 			}
 		})();
 		return () => {
 			cancelled = true;
 		};
-	}, [onContinue]);
+	}, []);
 
 	if (!found) {
 		return (
@@ -923,13 +941,13 @@ function ImportHistoryStep({ onContinue }: { onContinue: () => void }) {
 				{imported ? (
 					<Button
 						className="mt-8 w-full max-w-64"
-						onClick={onContinue}
+						onClick={onFinish}
 						size="lg"
 						tone="accent"
 						type="button"
 						variant="fill"
 					>
-						Continue
+						Start building
 					</Button>
 				) : (
 					<>
@@ -1054,7 +1072,10 @@ export function OnboardingView({
 						<GitHubConnectStep onContinue={() => setStep("import")} />
 					</OnboardingContent>
 				) : step === "import" ? (
-					<ImportHistoryStep onContinue={() => setStep("done")} />
+					<ImportHistoryStep
+						onContinue={() => setStep("done")}
+						onFinish={onComplete}
+					/>
 				) : (
 					<DoneStep connection={connection} onFinish={onComplete} />
 				)}

--- a/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/onboarding/onboarding-view.tsx
@@ -6,11 +6,13 @@ import {
 	CheckCircle2,
 	ChevronDown,
 	ExternalLink,
+	Import,
 	KeyRound,
 	Loader2,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ClineLogo } from "@/components/cline-logo";
+import { ImportSessionsDialog } from "@/components/import-sessions-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -39,13 +41,24 @@ import {
 	invalidateProviderCatalogCache,
 } from "@/lib/provider-model-catalog";
 import type { Provider } from "@/lib/provider-schema";
+import {
+	type ListImportableSessionsResponse,
+	SESSION_IMPORT_TOOL_LABELS,
+	SESSION_IMPORT_TOOL_ORDER,
+	type SessionImportTool,
+} from "@/lib/session-import";
 import { cn } from "@/lib/utils";
 
 const CREATE_ACCOUNT_URL = "https://app.cline.bot";
 
 export const GITHUB_ONBOARDING_FEATURE_FLAG = "code-onboarding-github";
 
-export type OnboardingStep = "welcome" | "connect" | "github" | "done";
+export type OnboardingStep =
+	| "welcome"
+	| "connect"
+	| "github"
+	| "import"
+	| "done";
 
 type OnboardingConnection =
 	| { kind: "cline" }
@@ -820,6 +833,137 @@ function ConnectStep({
 	);
 }
 
+/**
+ * Offers to bring session history over from other coding tools. Scans on
+ * entry and silently advances when there is nothing to import, so only
+ * people who actually have Claude Code / Codex / opencode history ever see
+ * this step.
+ */
+function ImportHistoryStep({ onContinue }: { onContinue: () => void }) {
+	const [found, setFound] = useState<{
+		count: number;
+		tools: SessionImportTool[];
+	} | null>(null);
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [imported, setImported] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const response =
+					await desktopClient.invoke<ListImportableSessionsResponse>(
+						"list_importable_sessions",
+						{},
+						{ timeoutMs: 120_000 },
+					);
+				if (cancelled) return;
+				const sessions = (response.sessions ?? []).filter(
+					(session) => !session.alreadyImportedSessionId,
+				);
+				if (sessions.length === 0) {
+					onContinue();
+					return;
+				}
+				const tools = SESSION_IMPORT_TOOL_ORDER.filter((tool) =>
+					sessions.some((session) => session.tool === tool),
+				);
+				setFound({ count: sessions.length, tools });
+			} catch {
+				// Onboarding must never dead-end on a scan failure.
+				if (!cancelled) onContinue();
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [onContinue]);
+
+	if (!found) {
+		return (
+			<OnboardingContent surface="transparent">
+				<div className="flex flex-col items-center py-10 text-center">
+					<Loader2
+						aria-hidden="true"
+						className="size-6 animate-spin text-muted-foreground"
+					/>
+					<p className="mt-4 text-md text-muted-foreground">
+						Checking for session history from other tools…
+					</p>
+					<Button
+						className="mt-8"
+						onClick={onContinue}
+						size="sm"
+						type="button"
+						variant="ghost"
+					>
+						Skip
+					</Button>
+				</div>
+			</OnboardingContent>
+		);
+	}
+
+	const toolList = found.tools
+		.map((tool) => SESSION_IMPORT_TOOL_LABELS[tool])
+		.join(found.tools.length === 2 ? " and " : ", ");
+
+	return (
+		<OnboardingContent surface="transparent">
+			<div className="flex flex-col items-center py-4 text-center">
+				<Import aria-hidden="true" className="size-10 text-primary" />
+				<h1 className="mt-4 text-3xl font-semibold tracking-tight text-foreground">
+					Bring your history with you
+				</h1>
+				<p className="mt-3 text-md text-muted-foreground">
+					{imported
+						? "Your sessions are in Cline's history now. You can import more anytime from the Sessions page."
+						: `Cline found ${found.count} session${found.count === 1 ? "" : "s"} from ${toolList} on this machine. Import them to keep your past conversations — and continue them here.`}
+				</p>
+				{imported ? (
+					<Button
+						className="mt-8 w-full max-w-64"
+						onClick={onContinue}
+						size="lg"
+						tone="accent"
+						type="button"
+						variant="fill"
+					>
+						Continue
+					</Button>
+				) : (
+					<>
+						<Button
+							className="mt-8 w-full max-w-64"
+							onClick={() => setDialogOpen(true)}
+							size="lg"
+							tone="accent"
+							type="button"
+							variant="fill"
+						>
+							Choose sessions to import
+						</Button>
+						<Button
+							className="mt-3"
+							onClick={onContinue}
+							size="sm"
+							type="button"
+							variant="ghost"
+						>
+							Skip for now
+						</Button>
+					</>
+				)}
+				<ImportSessionsDialog
+					onImported={() => setImported(true)}
+					onOpenChange={setDialogOpen}
+					open={dialogOpen}
+				/>
+			</div>
+		</OnboardingContent>
+	);
+}
+
 function DoneStep({
 	connection,
 	onFinish,
@@ -900,15 +1044,17 @@ export function OnboardingView({
 							setStep(
 								nextConnection.kind === "cline" && githubStepEnabled
 									? "github"
-									: "done",
+									: "import",
 							);
 						}}
 						onSkip={onComplete}
 					/>
 				) : step === "github" ? (
 					<OnboardingContent surface="panel">
-						<GitHubConnectStep onContinue={() => setStep("done")} />
+						<GitHubConnectStep onContinue={() => setStep("import")} />
 					</OnboardingContent>
+				) : step === "import" ? (
+					<ImportHistoryStep onContinue={() => setStep("done")} />
 				) : (
 					<DoneStep connection={connection} onFinish={onComplete} />
 				)}

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
@@ -10,6 +10,7 @@ import {
 	Filter,
 	Folder,
 	GitFork,
+	Import,
 	Loader2,
 	MoreHorizontal,
 	Pencil,
@@ -19,6 +20,7 @@ import {
 	X,
 } from "lucide-react";
 import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { ImportSessionsDialog } from "@/components/import-sessions-dialog";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -155,6 +157,7 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 	);
 	const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
 	const [editingTitle, setEditingTitle] = useState("");
+	const [importDialogOpen, setImportDialogOpen] = useState(false);
 	const [deleteCandidate, setDeleteCandidate] = useState<SessionThread | null>(
 		null,
 	);
@@ -333,6 +336,18 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 							value={query}
 						/>
 					</div>
+					<Button
+						aria-label="Import sessions from other tools"
+						className="h-8 rounded-md px-2.5"
+						onClick={() => setImportDialogOpen(true)}
+						size="sm"
+						title="Import sessions from Claude Code, Codex, or opencode"
+						type="button"
+						variant="outline"
+					>
+						<Import className="size-4" />
+						Import
+					</Button>
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button
@@ -783,6 +798,12 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 					</AlertDialogFooter>
 				</AlertDialogContent>
 			</AlertDialog>
+
+			<ImportSessionsDialog
+				onImported={() => void history.refreshSessions()}
+				onOpenChange={setImportDialogOpen}
+				open={importDialogOpen}
+			/>
 		</div>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -1,6 +1,7 @@
 import { providerOffersModelTool } from "@cline/llms/browser";
-import { Minus, Plus, RotateCcw } from "lucide-react";
+import { Import, Minus, Plus, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ImportSessionsDialog } from "@/components/import-sessions-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -665,6 +666,7 @@ function GeneralSettingsContent({
 		if (typeof window === "undefined") return "light";
 		return readStoredHubTheme() ?? readSystemHubTheme();
 	});
+	const [importDialogOpen, setImportDialogOpen] = useState(false);
 	const [accent, setAccent] = useState<HubAccent>(() => {
 		if (typeof window === "undefined") return "violet";
 		return readStoredHubAccent();
@@ -1124,6 +1126,31 @@ function GeneralSettingsContent({
 						onCheckedChange={(checked) => void updateTelemetryOptOut(!checked)}
 					/>
 				</div>
+				<div className="flex py-4 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
+					<div className="flex flex-col gap-1">
+						<p className="text-base font-semibold text-foreground">
+							Import sessions
+						</p>
+						<p className="text-sm text-muted-foreground">
+							Bring your conversation history from Claude Code, Codex, or
+							opencode into Cline.
+						</p>
+					</div>
+					<Button
+						className="shrink-0"
+						onClick={() => setImportDialogOpen(true)}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						<Import className="size-3" />
+						Import
+					</Button>
+				</div>
+				<ImportSessionsDialog
+					onOpenChange={setImportDialogOpen}
+					open={importDialogOpen}
+				/>
 				<div className="flex py-4 items-center justify-between gap-5 border-b max-[720px]:flex-col max-[720px]:items-stretch max-[720px]:py-4">
 					<div className="flex flex-col gap-1">
 						<p className="text-base font-semibold text-foreground">

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -1041,6 +1041,20 @@ export function useSessionHistory({
 				}
 			},
 		);
+		const unsubscribeTransportImport = desktopClient.subscribe(
+			"session_import_progress",
+			(payload) => {
+				if (!payload || typeof payload !== "object") {
+					return;
+				}
+				// Imported sessions land directly in the store; refresh so they
+				// appear in history no matter where the import was started from.
+				const result = (payload as { result?: { ok?: boolean } }).result;
+				if (result?.ok) {
+					scheduleRefresh(HISTORY_EVENT_REFRESH_DELAY_MS, { force: true });
+				}
+			},
+		);
 		const unsubscribeTransportChatEvent = desktopClient.subscribe(
 			"chat_event",
 			(payload) => {
@@ -1079,6 +1093,7 @@ export function useSessionHistory({
 			unsubscribeTransportDelete();
 			unsubscribeTransportStatus();
 			unsubscribeTransportEnded();
+			unsubscribeTransportImport();
 			unsubscribeTransportChatEvent();
 		};
 	}, [activeSessionId, scheduleRefresh]);

--- a/apps/examples/desktop-app/webview/lib/session-import.ts
+++ b/apps/examples/desktop-app/webview/lib/session-import.ts
@@ -44,6 +44,8 @@ export interface SessionImportResult {
 	sessionId?: string;
 	title?: string;
 	error?: string;
+	/** The source was already imported; sessionId is the existing session. */
+	alreadyImported?: boolean;
 }
 
 export interface SessionImportProgressEvent {

--- a/apps/examples/desktop-app/webview/lib/session-import.ts
+++ b/apps/examples/desktop-app/webview/lib/session-import.ts
@@ -1,0 +1,57 @@
+/**
+ * Wire types for the sidecar's session-import commands
+ * (list_importable_sessions / import_sessions). Mirrors
+ * sdk/packages/core/src/services/session-import/types.ts — kept as a local
+ * copy so the client bundle never imports node-only core code.
+ */
+
+export type SessionImportTool = "claude-code" | "codex" | "opencode";
+
+export const SESSION_IMPORT_TOOL_ORDER: SessionImportTool[] = [
+	"claude-code",
+	"codex",
+	"opencode",
+];
+
+export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
+	"claude-code": "Claude Code",
+	codex: "Codex",
+	opencode: "opencode",
+};
+
+export interface ImportableSession {
+	tool: SessionImportTool;
+	sourceId: string;
+	sourcePath: string;
+	title: string;
+	cwd: string;
+	startedAtMs: number;
+	updatedAtMs: number;
+	messageCount: number;
+	preview?: string;
+	alreadyImportedSessionId?: string;
+}
+
+export interface ListImportableSessionsResponse {
+	installedTools: SessionImportTool[];
+	sessions: ImportableSession[];
+}
+
+export interface SessionImportResult {
+	tool: SessionImportTool;
+	sourceId: string;
+	ok: boolean;
+	sessionId?: string;
+	title?: string;
+	error?: string;
+}
+
+export interface SessionImportProgressEvent {
+	index: number;
+	total: number;
+	result: SessionImportResult;
+}
+
+export function importSelectionKey(tool: string, sourceId: string): string {
+	return `${tool}:${sourceId}`;
+}

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -695,6 +695,7 @@ export {
 	type ProviderConfigFields,
 } from "./services/providers/provider-config-fields";
 export { isProviderSettingsUsable } from "./services/providers/provider-readiness";
+export * from "./services/session-import";
 export {
 	type MigrateLegacyProviderSettingsOptions,
 	type MigrateLegacyProviderSettingsResult,

--- a/sdk/packages/core/src/services/session-import/claude-code.ts
+++ b/sdk/packages/core/src/services/session-import/claude-code.ts
@@ -1,0 +1,449 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type * as LlmsProviders from "@cline/llms";
+import {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	type SessionImportAdapter,
+	truncateForDisplay,
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+interface ClaudeCodeLine {
+	type?: string;
+	uuid?: string;
+	parentUuid?: string | null;
+	isSidechain?: boolean;
+	isMeta?: boolean;
+	cwd?: string;
+	gitBranch?: string;
+	timestamp?: string;
+	message?: JsonRecord;
+	aiTitle?: string;
+	summary?: string;
+	leafUuid?: string;
+}
+
+/** Wrapper prefixes Claude Code uses for non-conversational user lines. */
+const SKIPPED_USER_TEXT_PREFIXES = [
+	"<command-name>",
+	"<local-command-stdout>",
+	"<local-command-stderr>",
+	"<command-message>",
+	"<local-command-caveat>",
+];
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseLine(line: string): ClaudeCodeLine | undefined {
+	const trimmed = line.trim();
+	if (!trimmed) return undefined;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		return isRecord(parsed) ? (parsed as ClaudeCodeLine) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isSkippedUserText(text: string): boolean {
+	const trimmed = text.trimStart();
+	return SKIPPED_USER_TEXT_PREFIXES.some((prefix) =>
+		trimmed.startsWith(prefix),
+	);
+}
+
+function isConversationLine(line: ClaudeCodeLine): boolean {
+	return (
+		(line.type === "user" || line.type === "assistant") &&
+		line.isSidechain !== true &&
+		typeof line.uuid === "string" &&
+		isRecord(line.message)
+	);
+}
+
+function firstUserText(line: ClaudeCodeLine): string | undefined {
+	const content = line.message?.content;
+	if (typeof content === "string") {
+		return isSkippedUserText(content) ? undefined : content;
+	}
+	if (!Array.isArray(content)) return undefined;
+	for (const block of content) {
+		if (
+			isRecord(block) &&
+			block.type === "text" &&
+			typeof block.text === "string"
+		) {
+			if (!isSkippedUserText(block.text)) return block.text;
+		}
+	}
+	return undefined;
+}
+
+function toolResultContent(
+	value: unknown,
+): LlmsProviders.ToolResultContent["content"] {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return JSON.stringify(value ?? "");
+	const blocks: Array<LlmsProviders.TextContent | LlmsProviders.ImageContent> =
+		[];
+	for (const item of value) {
+		if (!isRecord(item)) continue;
+		if (item.type === "text" && typeof item.text === "string") {
+			blocks.push({ type: "text", text: item.text });
+		} else if (item.type === "image" && isRecord(item.source)) {
+			const source = item.source;
+			if (
+				source.type === "base64" &&
+				typeof source.data === "string" &&
+				typeof source.media_type === "string"
+			) {
+				blocks.push({
+					type: "image",
+					data: source.data,
+					mediaType: source.media_type,
+				});
+			}
+		}
+	}
+	return blocks.length > 0 ? blocks : JSON.stringify(value);
+}
+
+function convertBlocks(
+	content: unknown,
+	role: "user" | "assistant",
+	toolNames: Map<string, string>,
+): LlmsProviders.ContentBlock[] {
+	if (typeof content === "string") {
+		if (role === "user" && isSkippedUserText(content)) return [];
+		return content.trim() ? [{ type: "text", text: content }] : [];
+	}
+	if (!Array.isArray(content)) return [];
+	const blocks: LlmsProviders.ContentBlock[] = [];
+	for (const raw of content) {
+		if (!isRecord(raw)) continue;
+		switch (raw.type) {
+			case "text":
+				if (typeof raw.text === "string" && raw.text.trim()) {
+					if (role === "user" && isSkippedUserText(raw.text)) break;
+					blocks.push({ type: "text", text: raw.text });
+				}
+				break;
+			case "thinking":
+				if (typeof raw.thinking === "string" && raw.thinking.trim()) {
+					blocks.push({ type: "thinking", thinking: raw.thinking });
+				}
+				break;
+			case "tool_use":
+				if (typeof raw.id === "string" && typeof raw.name === "string") {
+					toolNames.set(raw.id, raw.name);
+					blocks.push({
+						type: "tool_use",
+						id: raw.id,
+						name: raw.name,
+						input: isRecord(raw.input) ? raw.input : {},
+					});
+				}
+				break;
+			case "tool_result":
+				if (typeof raw.tool_use_id === "string") {
+					blocks.push({
+						type: "tool_result",
+						tool_use_id: raw.tool_use_id,
+						name: toolNames.get(raw.tool_use_id) ?? "",
+						content: toolResultContent(raw.content),
+						...(raw.is_error === true ? { is_error: true } : {}),
+					});
+				}
+				break;
+			case "image": {
+				const source = isRecord(raw.source) ? raw.source : undefined;
+				if (
+					source?.type === "base64" &&
+					typeof source.data === "string" &&
+					typeof source.media_type === "string"
+				) {
+					blocks.push({
+						type: "image",
+						data: source.data,
+						mediaType: source.media_type,
+					});
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	}
+	return blocks;
+}
+
+/**
+ * Claude Code session files are event logs where lines form a tree via
+ * parentUuid (message edits and retries create branches). The active
+ * conversation is the parent chain ending at the most recent line, so we walk
+ * backwards from the file's last conversation line and reverse. The chain
+ * passes through non-conversation lines too (attachment, system, meta), so
+ * every uuid-bearing line participates in the walk; emission filters later.
+ */
+function reconstructThread(lines: ClaudeCodeLine[]): ClaudeCodeLine[] {
+	const byUuid = new Map<string, ClaudeCodeLine>();
+	let leaf: ClaudeCodeLine | undefined;
+	for (const line of lines) {
+		if (typeof line.uuid !== "string" || line.isSidechain === true) continue;
+		byUuid.set(line.uuid, line);
+		if (isConversationLine(line)) leaf = line;
+	}
+	if (!leaf) return [];
+	const thread: ClaudeCodeLine[] = [];
+	const seen = new Set<string>();
+	let current: ClaudeCodeLine | undefined = leaf;
+	while (current) {
+		const uuid = current.uuid as string;
+		if (seen.has(uuid)) break;
+		seen.add(uuid);
+		thread.push(current);
+		current =
+			typeof current.parentUuid === "string"
+				? byUuid.get(current.parentUuid)
+				: undefined;
+	}
+	return thread.reverse();
+}
+
+export interface ClaudeCodeAdapterOptions {
+	/** Defaults to ~/.claude/projects */
+	projectsDir?: string;
+}
+
+export class ClaudeCodeImportAdapter implements SessionImportAdapter {
+	readonly tool = "claude-code" as const;
+	private readonly projectsDir: string;
+
+	constructor(options: ClaudeCodeAdapterOptions = {}) {
+		this.projectsDir =
+			options.projectsDir ?? join(homedir(), ".claude", "projects");
+	}
+
+	isInstalled(): boolean {
+		return existsSync(this.projectsDir);
+	}
+
+	private sessionFiles(): string[] {
+		if (!this.isInstalled()) return [];
+		const files: string[] = [];
+		for (const project of readdirSync(this.projectsDir, {
+			withFileTypes: true,
+		})) {
+			if (!project.isDirectory()) continue;
+			const projectDir = join(this.projectsDir, project.name);
+			for (const entry of readdirSync(projectDir, { withFileTypes: true })) {
+				if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+					files.push(join(projectDir, entry.name));
+				}
+			}
+		}
+		return files;
+	}
+
+	private findSessionFile(sourceId: string): string | undefined {
+		return this.sessionFiles().find(
+			(file) => basename(file, ".jsonl") === sourceId,
+		);
+	}
+
+	discover(): ImportableSessionSummary[] {
+		const out: ImportableSessionSummary[] = [];
+		for (const file of this.sessionFiles()) {
+			try {
+				const summary = this.summarizeFile(file);
+				if (summary) out.push(summary);
+			} catch {
+				// A single corrupt session log never blocks discovery.
+			}
+		}
+		return out;
+	}
+
+	private summarizeFile(file: string): ImportableSessionSummary | undefined {
+		const raw = readFileSync(file, "utf8");
+		let messageCount = 0;
+		let assistantCount = 0;
+		let title: string | undefined;
+		let summaryTitle: string | undefined;
+		let preview: string | undefined;
+		let cwd = "";
+		let firstTs: number | undefined;
+		let lastTs: number | undefined;
+		for (const rawLine of raw.split("\n")) {
+			const line = parseLine(rawLine);
+			if (!line) continue;
+			if (line.type === "ai-title" && typeof line.aiTitle === "string") {
+				title = line.aiTitle;
+				continue;
+			}
+			if (line.type === "summary" && typeof line.summary === "string") {
+				summaryTitle = line.summary;
+				continue;
+			}
+			if (!isConversationLine(line)) continue;
+			if (line.isMeta === true) continue;
+			if (line.type === "user" && !preview) {
+				preview = firstUserText(line);
+			}
+			if (line.type === "assistant") assistantCount++;
+			messageCount++;
+			if (!cwd && typeof line.cwd === "string") cwd = line.cwd;
+			const ts = line.timestamp ? Date.parse(line.timestamp) : Number.NaN;
+			if (Number.isFinite(ts)) {
+				firstTs = firstTs ?? ts;
+				lastTs = ts;
+			}
+		}
+		// Sessions with neither an assistant reply nor real user text are
+		// slash-command shells (/fast and friends) — nothing to import.
+		if (messageCount === 0 || (assistantCount === 0 && !preview)) {
+			return undefined;
+		}
+		const displayPreview = truncateForDisplay(preview);
+		return {
+			tool: this.tool,
+			sourceId: basename(file, ".jsonl"),
+			sourcePath: file,
+			title:
+				truncateForDisplay(title ?? summaryTitle, 120) ??
+				truncateForDisplay(preview, 120) ??
+				"Untitled session",
+			cwd,
+			startedAtMs: firstTs ?? Date.now(),
+			updatedAtMs: lastTs ?? firstTs ?? Date.now(),
+			messageCount,
+			...(displayPreview ? { preview: displayPreview } : {}),
+		};
+	}
+
+	convert(sourceId: string): ConvertedImportedSession {
+		const file = this.findSessionFile(sourceId);
+		if (!file) {
+			throw new Error(`Claude Code session ${sourceId} not found`);
+		}
+		const raw = readFileSync(file, "utf8");
+		const lines = raw
+			.split("\n")
+			.map(parseLine)
+			.filter((line): line is ClaudeCodeLine => line !== undefined);
+
+		const thread = reconstructThread(lines);
+		const toolNames = new Map<string, string>();
+		const messages: LlmsProviders.MessageWithMetadata[] = [];
+		let cwd = "";
+		let gitBranch: string | undefined;
+		let model: string | undefined;
+		let firstTs: number | undefined;
+		let lastTs: number | undefined;
+		let prompt: string | undefined;
+
+		for (const line of thread) {
+			if (!isConversationLine(line) || line.isMeta === true) continue;
+			const role = line.type === "assistant" ? "assistant" : "user";
+			const blocks = convertBlocks(line.message?.content, role, toolNames);
+			if (blocks.length === 0) continue;
+
+			if (!cwd && typeof line.cwd === "string") cwd = line.cwd;
+			if (!gitBranch && typeof line.gitBranch === "string" && line.gitBranch) {
+				gitBranch = line.gitBranch;
+			}
+			const ts = line.timestamp ? Date.parse(line.timestamp) : Number.NaN;
+			if (Number.isFinite(ts)) {
+				firstTs = firstTs ?? ts;
+				lastTs = ts;
+			}
+			if (role === "user" && !prompt) {
+				const text = blocks.find((block) => block.type === "text");
+				if (text?.type === "text") prompt = text.text;
+			}
+
+			const lineModel =
+				typeof line.message?.model === "string"
+					? line.message.model
+					: undefined;
+			// "<synthetic>" marks locally generated error notices, not API output.
+			const realModel =
+				lineModel && !lineModel.startsWith("<") ? lineModel : undefined;
+			if (realModel) model = realModel;
+
+			// Claude Code streams one API turn across several assistant lines
+			// sharing message.id; merge them back into a single message.
+			const previous = messages[messages.length - 1];
+			const messageId =
+				typeof line.message?.id === "string" ? line.message.id : undefined;
+			if (
+				role === "assistant" &&
+				previous?.role === "assistant" &&
+				messageId &&
+				previous.metadata?.sourceMessageId === messageId &&
+				Array.isArray(previous.content)
+			) {
+				previous.content = [...previous.content, ...blocks];
+				continue;
+			}
+
+			const message: LlmsProviders.MessageWithMetadata = {
+				role,
+				content: blocks,
+				...(Number.isFinite(ts) ? { ts } : {}),
+			};
+			if (role === "assistant") {
+				if (messageId) message.metadata = { sourceMessageId: messageId };
+				if (realModel) {
+					message.modelInfo = { id: realModel, provider: "anthropic" };
+				}
+				const usage = isRecord(line.message?.usage)
+					? line.message.usage
+					: undefined;
+				if (usage) {
+					message.metrics = {
+						inputTokens: Number(usage.input_tokens) || 0,
+						outputTokens: Number(usage.output_tokens) || 0,
+						cacheReadTokens: Number(usage.cache_read_input_tokens) || 0,
+						cacheWriteTokens: Number(usage.cache_creation_input_tokens) || 0,
+						cost: 0,
+					};
+				}
+			}
+			messages.push(message);
+		}
+
+		// The merge marker is internal; drop it before persistence.
+		for (const message of messages) {
+			if (message.metadata && "sourceMessageId" in message.metadata) {
+				delete message.metadata.sourceMessageId;
+				if (Object.keys(message.metadata).length === 0) {
+					delete message.metadata;
+				}
+			}
+		}
+
+		const summary = this.summarizeFile(file);
+		return {
+			tool: this.tool,
+			sourceId,
+			sourcePath: file,
+			title: summary?.title ?? "Untitled session",
+			...(truncateForDisplay(prompt, 2000)
+				? { prompt: truncateForDisplay(prompt, 2000) }
+				: {}),
+			provider: "anthropic",
+			model: model ?? "claude",
+			cwd,
+			...(gitBranch ? { gitBranch } : {}),
+			startedAtMs: firstTs ?? Date.now(),
+			endedAtMs: lastTs ?? firstTs ?? Date.now(),
+			messages,
+		};
+	}
+}

--- a/sdk/packages/core/src/services/session-import/codex.ts
+++ b/sdk/packages/core/src/services/session-import/codex.ts
@@ -1,11 +1,4 @@
-import {
-	closeSync,
-	existsSync,
-	openSync,
-	readdirSync,
-	readFileSync,
-	readSync,
-} from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type * as LlmsProviders from "@cline/llms";
@@ -213,49 +206,16 @@ export class CodexImportAdapter implements SessionImportAdapter {
 		return (b.meta.endedAtMs ?? 0) > (a.meta.endedAtMs ?? 0);
 	}
 
-	private findSessionFile(sourceId: string): string | undefined {
-		let best: { file: string; meta: CodexFileMeta } | undefined;
-		for (const file of this.sessionFiles()) {
-			// Rollout filenames embed their own id (rollout-<ts>-<id>.jsonl);
-			// resumed rollouts only carry the original id in session_meta.
-			if (!file.includes(sourceId) && !this.firstLineHasId(file, sourceId)) {
-				continue;
-			}
-			try {
-				const meta = scanFileMeta(readFileSync(file, "utf8"));
-				if (meta.sessionId !== sourceId) continue;
-				const candidate = { file, meta };
-				if (!best || CodexImportAdapter.pickRicherFile(best, candidate)) {
-					best = candidate;
-				}
-			} catch {
-				// Skip unreadable candidates.
-			}
-		}
-		return best?.file;
-	}
+	/**
+	 * Session id → richest rollout file. Building it means reading every
+	 * rollout once (resumed rollouts only carry the original id inside
+	 * session_meta, not in their filename), so it is cached for the batch:
+	 * without the cache, importing N sessions re-read the whole store N times.
+	 */
+	private index?: Map<string, { file: string; meta: CodexFileMeta }>;
 
-	private firstLineHasId(file: string, sourceId: string): boolean {
-		try {
-			const fd = openSync(file, "r");
-			try {
-				// session_meta is the first line; base_instructions makes it
-				// large, so read a generous head instead of the whole file.
-				const buffer = Buffer.alloc(262144);
-				const bytes = readSync(fd, buffer, 0, buffer.length, 0);
-				const head = buffer.toString("utf8", 0, bytes);
-				const firstLine = head.split("\n", 1)[0] ?? head;
-				return firstLine.includes(`"${sourceId}"`);
-			} finally {
-				closeSync(fd);
-			}
-		} catch {
-			return false;
-		}
-	}
-
-	discover(): ImportableSessionSummary[] {
-		const titles = this.readTitleIndex();
+	private buildIndex(): Map<string, { file: string; meta: CodexFileMeta }> {
+		if (this.index) return this.index;
 		const best = new Map<string, { file: string; meta: CodexFileMeta }>();
 		for (const file of this.sessionFiles()) {
 			try {
@@ -271,8 +231,22 @@ export class CodexImportAdapter implements SessionImportAdapter {
 				// A single corrupt rollout never blocks discovery.
 			}
 		}
+		this.index = best;
+		return best;
+	}
+
+	dispose(): void {
+		this.index = undefined;
+	}
+
+	private findSessionFile(sourceId: string): string | undefined {
+		return this.buildIndex().get(sourceId)?.file;
+	}
+
+	discover(): ImportableSessionSummary[] {
+		const titles = this.readTitleIndex();
 		const out: ImportableSessionSummary[] = [];
-		for (const [sessionId, { file, meta }] of best) {
+		for (const [sessionId, { file, meta }] of this.buildIndex()) {
 			const userCount = meta.userMessageCount || meta.fallbackUserCount;
 			const preview = truncateForDisplay(meta.firstUserText);
 			out.push({
@@ -323,7 +297,7 @@ export class CodexImportAdapter implements SessionImportAdapter {
 				role: "assistant",
 				content: assistantBlocks,
 				...(currentModel
-					? { modelInfo: { id: currentModel, provider: "openai" } }
+					? { modelInfo: { id: currentModel, provider: "openai-native" } }
 					: {}),
 				...(pendingMetrics ? { metrics: pendingMetrics } : {}),
 				...(assistantTs ? { ts: assistantTs } : {}),
@@ -508,7 +482,7 @@ export class CodexImportAdapter implements SessionImportAdapter {
 				truncateForDisplay(meta.firstUserText, 120) ??
 				"Untitled session",
 			...(prompt ? { prompt } : {}),
-			provider: "openai",
+			provider: "openai-native",
 			model: currentModel ?? "gpt-5",
 			cwd: meta.cwd,
 			...(meta.gitBranch ? { gitBranch: meta.gitBranch } : {}),

--- a/sdk/packages/core/src/services/session-import/codex.ts
+++ b/sdk/packages/core/src/services/session-import/codex.ts
@@ -43,6 +43,28 @@ function messageText(payload: JsonRecord): string {
 		.join("\n");
 }
 
+/**
+ * Tool outputs are a plain string in older rollouts, but newer Codex writes
+ * custom_tool_call_output.output as Responses-API content blocks
+ * ({type:"input_text", text}). Flatten those to text so the transcript holds
+ * the real output instead of a JSON-encoded block list.
+ */
+function toolOutputText(output: unknown): string {
+	if (typeof output === "string") return output;
+	if (Array.isArray(output)) {
+		const parts: string[] = [];
+		for (const item of output) {
+			if (typeof item === "string") {
+				parts.push(item);
+			} else if (isRecord(item) && typeof item.text === "string") {
+				parts.push(item.text);
+			}
+		}
+		if (parts.length > 0 || output.length === 0) return parts.join("");
+	}
+	return JSON.stringify(output ?? "");
+}
+
 /** Context Codex injects as user-role response items, not typed by a person. */
 function isInjectedUserContext(text: string): boolean {
 	const trimmed = text.trimStart();
@@ -450,10 +472,7 @@ export class CodexImportAdapter implements SessionImportAdapter {
 					const callId =
 						typeof payload.call_id === "string" ? payload.call_id : undefined;
 					if (!callId) break;
-					const output =
-						typeof payload.output === "string"
-							? payload.output
-							: JSON.stringify(payload.output ?? "");
+					const output = toolOutputText(payload.output);
 					flushAssistant();
 					pendingToolResults.push({
 						type: "tool_result",

--- a/sdk/packages/core/src/services/session-import/codex.ts
+++ b/sdk/packages/core/src/services/session-import/codex.ts
@@ -1,0 +1,520 @@
+import {
+	closeSync,
+	existsSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	readSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type * as LlmsProviders from "@cline/llms";
+import { nanoid } from "nanoid";
+import {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	type SessionImportAdapter,
+	truncateForDisplay,
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+interface CodexLine {
+	timestamp?: string;
+	type?: string;
+	payload?: JsonRecord;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseLine(line: string): CodexLine | undefined {
+	const trimmed = line.trim();
+	if (!trimmed) return undefined;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		return isRecord(parsed) ? (parsed as CodexLine) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function messageText(payload: JsonRecord): string {
+	const content = payload.content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter(isRecord)
+		.map((block) => (typeof block.text === "string" ? block.text : ""))
+		.filter((text) => text.trim().length > 0)
+		.join("\n");
+}
+
+/** Context Codex injects as user-role response items, not typed by a person. */
+function isInjectedUserContext(text: string): boolean {
+	const trimmed = text.trimStart();
+	return (
+		trimmed.startsWith("<user_instructions>") ||
+		trimmed.startsWith("<environment_context>") ||
+		trimmed.startsWith("<ENVIRONMENT_CONTEXT>") ||
+		trimmed.startsWith("<turn_aborted>") ||
+		trimmed.startsWith("# AGENTS.md instructions") ||
+		trimmed.startsWith("<INSTRUCTIONS>")
+	);
+}
+
+interface CodexFileMeta {
+	sessionId?: string;
+	cwd: string;
+	gitBranch?: string;
+	model?: string;
+	startedAtMs?: number;
+	endedAtMs?: number;
+	userMessageCount: number;
+	/** User-role response items that aren't injected context (fallback for
+	 * rollouts without user_message events). */
+	fallbackUserCount: number;
+	assistantEventCount: number;
+	firstUserText?: string;
+}
+
+function scanFileMeta(raw: string): CodexFileMeta {
+	const meta: CodexFileMeta = {
+		cwd: "",
+		userMessageCount: 0,
+		fallbackUserCount: 0,
+		assistantEventCount: 0,
+	};
+	for (const rawLine of raw.split("\n")) {
+		const line = parseLine(rawLine);
+		if (!line?.payload) continue;
+		const ts = line.timestamp ? Date.parse(line.timestamp) : Number.NaN;
+		if (Number.isFinite(ts)) {
+			meta.startedAtMs = meta.startedAtMs ?? ts;
+			meta.endedAtMs = ts;
+		}
+		const payload = line.payload;
+		if (line.type === "session_meta") {
+			if (typeof payload.id === "string") meta.sessionId = payload.id;
+			if (typeof payload.cwd === "string") meta.cwd = payload.cwd;
+			const git = isRecord(payload.git) ? payload.git : undefined;
+			if (typeof git?.branch === "string") meta.gitBranch = git.branch;
+			continue;
+		}
+		if (line.type === "turn_context") {
+			if (typeof payload.model === "string") meta.model = payload.model;
+			if (!meta.cwd && typeof payload.cwd === "string") meta.cwd = payload.cwd;
+			continue;
+		}
+		if (line.type === "event_msg" && payload.type === "user_message") {
+			const text = typeof payload.message === "string" ? payload.message : "";
+			if (text.trim()) {
+				meta.userMessageCount++;
+				meta.firstUserText = meta.firstUserText ?? text;
+			}
+			continue;
+		}
+		if (line.type === "response_item" && payload.type === "message") {
+			if (payload.role === "assistant") {
+				meta.assistantEventCount++;
+			} else if (payload.role === "user") {
+				const text = messageText(payload);
+				if (text.trim() && !isInjectedUserContext(text)) {
+					meta.fallbackUserCount++;
+					meta.firstUserText = meta.firstUserText ?? text;
+				}
+			}
+		}
+	}
+	return meta;
+}
+
+export interface CodexAdapterOptions {
+	/** Defaults to $CODEX_HOME or ~/.codex */
+	codexHome?: string;
+}
+
+export class CodexImportAdapter implements SessionImportAdapter {
+	readonly tool = "codex" as const;
+	private readonly codexHome: string;
+
+	constructor(options: CodexAdapterOptions = {}) {
+		this.codexHome =
+			options.codexHome ?? process.env.CODEX_HOME ?? join(homedir(), ".codex");
+	}
+
+	private get sessionsDir(): string {
+		return join(this.codexHome, "sessions");
+	}
+
+	isInstalled(): boolean {
+		return existsSync(this.sessionsDir);
+	}
+
+	/** thread_name by session id, from Codex's own index. */
+	private readTitleIndex(): Map<string, string> {
+		const titles = new Map<string, string>();
+		const indexPath = join(this.codexHome, "session_index.jsonl");
+		if (!existsSync(indexPath)) return titles;
+		try {
+			for (const rawLine of readFileSync(indexPath, "utf8").split("\n")) {
+				const line = parseLine(rawLine) as JsonRecord | undefined;
+				if (
+					line &&
+					typeof line.id === "string" &&
+					typeof line.thread_name === "string" &&
+					line.thread_name.trim()
+				) {
+					titles.set(line.id, line.thread_name.trim());
+				}
+			}
+		} catch {
+			// The index is a convenience; sessions still import without it.
+		}
+		return titles;
+	}
+
+	private sessionFiles(): string[] {
+		if (!this.isInstalled()) return [];
+		const files: string[] = [];
+		const walk = (dir: string) => {
+			for (const entry of readdirSync(dir, { withFileTypes: true })) {
+				const full = join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(full);
+				} else if (
+					entry.isFile() &&
+					entry.name.startsWith("rollout-") &&
+					entry.name.endsWith(".jsonl")
+				) {
+					files.push(full);
+				}
+			}
+		};
+		walk(this.sessionsDir);
+		return files;
+	}
+
+	/**
+	 * Resuming a Codex thread writes a new rollout file that re-embeds the
+	 * original session_meta id, so one logical session can span several files.
+	 * Prefer the file with the most conversation (the resumed rollout replays
+	 * history), tie-breaking on the most recent activity.
+	 */
+	private static pickRicherFile(
+		a: { meta: CodexFileMeta },
+		b: { meta: CodexFileMeta },
+	): boolean {
+		const userCount = (meta: CodexFileMeta) =>
+			meta.userMessageCount || meta.fallbackUserCount;
+		if (userCount(b.meta) !== userCount(a.meta)) {
+			return userCount(b.meta) > userCount(a.meta);
+		}
+		return (b.meta.endedAtMs ?? 0) > (a.meta.endedAtMs ?? 0);
+	}
+
+	private findSessionFile(sourceId: string): string | undefined {
+		let best: { file: string; meta: CodexFileMeta } | undefined;
+		for (const file of this.sessionFiles()) {
+			// Rollout filenames embed their own id (rollout-<ts>-<id>.jsonl);
+			// resumed rollouts only carry the original id in session_meta.
+			if (!file.includes(sourceId) && !this.firstLineHasId(file, sourceId)) {
+				continue;
+			}
+			try {
+				const meta = scanFileMeta(readFileSync(file, "utf8"));
+				if (meta.sessionId !== sourceId) continue;
+				const candidate = { file, meta };
+				if (!best || CodexImportAdapter.pickRicherFile(best, candidate)) {
+					best = candidate;
+				}
+			} catch {
+				// Skip unreadable candidates.
+			}
+		}
+		return best?.file;
+	}
+
+	private firstLineHasId(file: string, sourceId: string): boolean {
+		try {
+			const fd = openSync(file, "r");
+			try {
+				// session_meta is the first line; base_instructions makes it
+				// large, so read a generous head instead of the whole file.
+				const buffer = Buffer.alloc(262144);
+				const bytes = readSync(fd, buffer, 0, buffer.length, 0);
+				const head = buffer.toString("utf8", 0, bytes);
+				const firstLine = head.split("\n", 1)[0] ?? head;
+				return firstLine.includes(`"${sourceId}"`);
+			} finally {
+				closeSync(fd);
+			}
+		} catch {
+			return false;
+		}
+	}
+
+	discover(): ImportableSessionSummary[] {
+		const titles = this.readTitleIndex();
+		const best = new Map<string, { file: string; meta: CodexFileMeta }>();
+		for (const file of this.sessionFiles()) {
+			try {
+				const meta = scanFileMeta(readFileSync(file, "utf8"));
+				const userCount = meta.userMessageCount || meta.fallbackUserCount;
+				if (!meta.sessionId || userCount === 0) continue;
+				const candidate = { file, meta };
+				const current = best.get(meta.sessionId);
+				if (!current || CodexImportAdapter.pickRicherFile(current, candidate)) {
+					best.set(meta.sessionId, candidate);
+				}
+			} catch {
+				// A single corrupt rollout never blocks discovery.
+			}
+		}
+		const out: ImportableSessionSummary[] = [];
+		for (const [sessionId, { file, meta }] of best) {
+			const userCount = meta.userMessageCount || meta.fallbackUserCount;
+			const preview = truncateForDisplay(meta.firstUserText);
+			out.push({
+				tool: this.tool,
+				sourceId: sessionId,
+				sourcePath: file,
+				title:
+					titles.get(sessionId) ??
+					truncateForDisplay(meta.firstUserText, 120) ??
+					"Untitled session",
+				cwd: meta.cwd,
+				startedAtMs: meta.startedAtMs ?? Date.now(),
+				updatedAtMs: meta.endedAtMs ?? meta.startedAtMs ?? Date.now(),
+				messageCount: userCount + meta.assistantEventCount,
+				...(preview ? { preview } : {}),
+			});
+		}
+		return out;
+	}
+
+	convert(sourceId: string): ConvertedImportedSession {
+		const file = this.findSessionFile(sourceId);
+		if (!file) {
+			throw new Error(`Codex session ${sourceId} not found`);
+		}
+		const raw = readFileSync(file, "utf8");
+		const meta = scanFileMeta(raw);
+		const titles = this.readTitleIndex();
+
+		const messages: LlmsProviders.MessageWithMetadata[] = [];
+		const toolNames = new Map<string, string>();
+		let assistantBlocks: LlmsProviders.ContentBlock[] = [];
+		let pendingToolResults: LlmsProviders.ToolResultContent[] = [];
+		let currentModel = meta.model;
+		let assistantTs: number | undefined;
+		let pendingMetrics:
+			| NonNullable<LlmsProviders.MessageWithMetadata["metrics"]>
+			| undefined;
+
+		const flushToolResults = () => {
+			if (pendingToolResults.length === 0) return;
+			messages.push({ role: "user", content: pendingToolResults });
+			pendingToolResults = [];
+		};
+		const flushAssistant = () => {
+			if (assistantBlocks.length === 0) return;
+			messages.push({
+				role: "assistant",
+				content: assistantBlocks,
+				...(currentModel
+					? { modelInfo: { id: currentModel, provider: "openai" } }
+					: {}),
+				...(pendingMetrics ? { metrics: pendingMetrics } : {}),
+				...(assistantTs ? { ts: assistantTs } : {}),
+			});
+			assistantBlocks = [];
+			assistantTs = undefined;
+			pendingMetrics = undefined;
+		};
+
+		for (const rawLine of raw.split("\n")) {
+			const line = parseLine(rawLine);
+			if (!line?.payload) continue;
+			const payload = line.payload;
+			const ts = line.timestamp ? Date.parse(line.timestamp) : Number.NaN;
+
+			if (line.type === "turn_context") {
+				if (typeof payload.model === "string") currentModel = payload.model;
+				continue;
+			}
+
+			if (line.type === "event_msg") {
+				if (payload.type === "user_message") {
+					const text =
+						typeof payload.message === "string" ? payload.message : "";
+					if (!text.trim()) continue;
+					flushAssistant();
+					flushToolResults();
+					messages.push({
+						role: "user",
+						content: [{ type: "text", text }],
+						...(Number.isFinite(ts) ? { ts } : {}),
+					});
+				} else if (payload.type === "token_count") {
+					// Stamp the latest per-turn usage on the most recent assistant
+					// message — which may still be accumulating in assistantBlocks.
+					const info = isRecord(payload.info) ? payload.info : undefined;
+					const usage = isRecord(info?.last_token_usage)
+						? info.last_token_usage
+						: undefined;
+					if (usage) {
+						const metrics = {
+							inputTokens: Number(usage.input_tokens) || 0,
+							outputTokens: Number(usage.output_tokens) || 0,
+							cacheReadTokens: Number(usage.cached_input_tokens) || 0,
+							cacheWriteTokens: 0,
+							cost: 0,
+						};
+						if (assistantBlocks.length > 0) {
+							pendingMetrics = metrics;
+						} else {
+							const target = [...messages]
+								.reverse()
+								.find((message) => message.role === "assistant");
+							if (target) target.metrics = metrics;
+						}
+					}
+				}
+				continue;
+			}
+
+			if (line.type === "compacted") {
+				const summary =
+					typeof payload.message === "string" ? payload.message : undefined;
+				if (summary?.trim()) {
+					flushAssistant();
+					flushToolResults();
+					messages.push({
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: `[Conversation summarized by Codex]\n${summary}`,
+							},
+						],
+					});
+				}
+				continue;
+			}
+
+			if (line.type !== "response_item") continue;
+
+			switch (payload.type) {
+				case "message": {
+					if (payload.role === "user") {
+						// User-role response items are mostly AGENTS.md /
+						// environment context Codex injects; real prompts arrive
+						// as user_message events. Only fall back to them when
+						// this rollout has no user_message events at all.
+						if (meta.userMessageCount > 0) break;
+						const text = messageText(payload);
+						if (!text.trim() || isInjectedUserContext(text)) break;
+						flushAssistant();
+						flushToolResults();
+						messages.push({
+							role: "user",
+							content: [{ type: "text", text }],
+							...(Number.isFinite(ts) ? { ts } : {}),
+						});
+						break;
+					}
+					if (payload.role !== "assistant") break;
+					const text = messageText(payload);
+					if (!text.trim()) break;
+					flushToolResults();
+					assistantBlocks.push({ type: "text", text });
+					if (Number.isFinite(ts)) assistantTs = assistantTs ?? ts;
+					break;
+				}
+				case "reasoning": {
+					const summary = Array.isArray(payload.summary) ? payload.summary : [];
+					const text = summary
+						.filter(isRecord)
+						.map((item) => (typeof item.text === "string" ? item.text : ""))
+						.filter((item) => item.trim().length > 0)
+						.join("\n");
+					if (!text) break;
+					flushToolResults();
+					assistantBlocks.push({ type: "thinking", thinking: text });
+					if (Number.isFinite(ts)) assistantTs = assistantTs ?? ts;
+					break;
+				}
+				case "function_call":
+				case "custom_tool_call": {
+					const name = typeof payload.name === "string" ? payload.name : "tool";
+					const callId =
+						typeof payload.call_id === "string"
+							? payload.call_id
+							: `import_${nanoid()}`;
+					let input: Record<string, unknown> = {};
+					if (typeof payload.arguments === "string") {
+						try {
+							const parsed = JSON.parse(payload.arguments) as unknown;
+							input = isRecord(parsed) ? parsed : { arguments: parsed };
+						} catch {
+							input = { arguments: payload.arguments };
+						}
+					} else if (typeof payload.input === "string") {
+						input = { input: payload.input };
+					} else if (isRecord(payload.input)) {
+						input = payload.input;
+					}
+					toolNames.set(callId, name);
+					flushToolResults();
+					assistantBlocks.push({ type: "tool_use", id: callId, name, input });
+					if (Number.isFinite(ts)) assistantTs = assistantTs ?? ts;
+					break;
+				}
+				case "function_call_output":
+				case "custom_tool_call_output": {
+					const callId =
+						typeof payload.call_id === "string" ? payload.call_id : undefined;
+					if (!callId) break;
+					const output =
+						typeof payload.output === "string"
+							? payload.output
+							: JSON.stringify(payload.output ?? "");
+					flushAssistant();
+					pendingToolResults.push({
+						type: "tool_result",
+						tool_use_id: callId,
+						name: toolNames.get(callId) ?? "",
+						content: output,
+					});
+					break;
+				}
+				default:
+					// web_search_call and friends have no replayable payload; the
+					// assistant text already narrates what they did.
+					break;
+			}
+		}
+		flushAssistant();
+		flushToolResults();
+
+		const prompt = truncateForDisplay(meta.firstUserText, 2000);
+		return {
+			tool: this.tool,
+			sourceId,
+			sourcePath: file,
+			title:
+				titles.get(sourceId) ??
+				truncateForDisplay(meta.firstUserText, 120) ??
+				"Untitled session",
+			...(prompt ? { prompt } : {}),
+			provider: "openai",
+			model: currentModel ?? "gpt-5",
+			cwd: meta.cwd,
+			...(meta.gitBranch ? { gitBranch: meta.gitBranch } : {}),
+			startedAtMs: meta.startedAtMs ?? Date.now(),
+			endedAtMs: meta.endedAtMs ?? meta.startedAtMs ?? Date.now(),
+			messages,
+		};
+	}
+}

--- a/sdk/packages/core/src/services/session-import/index.ts
+++ b/sdk/packages/core/src/services/session-import/index.ts
@@ -1,0 +1,28 @@
+export {
+	type ClaudeCodeAdapterOptions,
+	ClaudeCodeImportAdapter,
+} from "./claude-code";
+export { type CodexAdapterOptions, CodexImportAdapter } from "./codex";
+export {
+	type OpencodeAdapterOptions,
+	OpencodeImportAdapter,
+} from "./opencode";
+export {
+	IMPORT_MISSING_TOOL_RESULT_TEXT,
+	sanitizeImportedMessages,
+} from "./sanitize";
+export {
+	type ImportedFromMetadata,
+	readImportedFromMetadata,
+	SessionImportService,
+} from "./service";
+export {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	SESSION_IMPORT_TOOL_LABELS,
+	SESSION_IMPORT_TOOLS,
+	type SessionImportAdapter,
+	type SessionImportRequest,
+	type SessionImportResult,
+	type SessionImportTool,
+} from "./types";

--- a/sdk/packages/core/src/services/session-import/index.ts
+++ b/sdk/packages/core/src/services/session-import/index.ts
@@ -22,6 +22,7 @@ export {
 	SESSION_IMPORT_TOOL_LABELS,
 	SESSION_IMPORT_TOOLS,
 	type SessionImportAdapter,
+	type SessionImportOptions,
 	type SessionImportRequest,
 	type SessionImportResult,
 	type SessionImportTool,

--- a/sdk/packages/core/src/services/session-import/opencode.ts
+++ b/sdk/packages/core/src/services/session-import/opencode.ts
@@ -1,0 +1,356 @@
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as LlmsProviders from "@cline/llms";
+import { loadSqliteDb, type SqliteDb } from "@cline/shared/db";
+import { nanoid } from "nanoid";
+import {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	type SessionImportAdapter,
+	truncateForDisplay,
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseData(value: unknown): JsonRecord | undefined {
+	if (typeof value !== "string") return undefined;
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function asMs(value: unknown): number | undefined {
+	const num = Number(value);
+	return Number.isFinite(num) && num > 0 ? num : undefined;
+}
+
+export interface OpencodeAdapterOptions {
+	/** Defaults to $XDG_DATA_HOME/opencode or ~/.local/share/opencode */
+	dataDir?: string;
+}
+
+export class OpencodeImportAdapter implements SessionImportAdapter {
+	readonly tool = "opencode" as const;
+	private readonly dbPath: string;
+
+	constructor(options: OpencodeAdapterOptions = {}) {
+		const dataDir =
+			options.dataDir ??
+			join(
+				process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share"),
+				"opencode",
+			);
+		this.dbPath = join(dataDir, "opencode.db");
+	}
+
+	isInstalled(): boolean {
+		return existsSync(this.dbPath);
+	}
+
+	/**
+	 * opencode keeps its database open in WAL mode while the app runs.
+	 * Snapshot the db (+ WAL/SHM) into a temp dir and read the copy so we
+	 * never contend with — or corrupt — the live store.
+	 */
+	private withDbCopy<T>(fn: (db: SqliteDb) => T): T {
+		const dir = mkdtempSync(join(tmpdir(), "cline-opencode-import-"));
+		try {
+			const copied = join(dir, "opencode.db");
+			copyFileSync(this.dbPath, copied);
+			for (const suffix of ["-wal", "-shm"]) {
+				const sidecarFile = `${this.dbPath}${suffix}`;
+				if (existsSync(sidecarFile)) {
+					copyFileSync(sidecarFile, `${copied}${suffix}`);
+				}
+			}
+			const db = loadSqliteDb(copied);
+			try {
+				return fn(db);
+			} finally {
+				db.close?.();
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	}
+
+	discover(): ImportableSessionSummary[] {
+		if (!this.isInstalled()) return [];
+		return this.withDbCopy((db) => {
+			const counts = new Map<string, number>();
+			for (const row of db
+				.prepare(
+					`SELECT session_id, COUNT(*) AS n FROM message GROUP BY session_id`,
+				)
+				.all()) {
+				counts.set(String(row.session_id), Number(row.n) || 0);
+			}
+			const out: ImportableSessionSummary[] = [];
+			const sessions = db
+				.prepare(
+					`SELECT id, title, directory, time_created, time_updated
+					 FROM session WHERE parent_id IS NULL
+					 ORDER BY time_created DESC`,
+				)
+				.all();
+			for (const row of sessions) {
+				const sourceId = String(row.id ?? "");
+				const messageCount = counts.get(sourceId) ?? 0;
+				if (!sourceId || messageCount === 0) continue;
+				const title =
+					typeof row.title === "string" && row.title.trim()
+						? row.title.trim()
+						: undefined;
+				// opencode's placeholder titles ("New session - <date>") carry no
+				// signal; fall back to the first user prompt for those.
+				const needsFallback = !title || title.startsWith("New session");
+				const preview = this.firstUserText(db, sourceId);
+				const displayPreview = truncateForDisplay(preview);
+				out.push({
+					tool: this.tool,
+					sourceId,
+					sourcePath: this.dbPath,
+					title:
+						(needsFallback ? truncateForDisplay(preview, 120) : undefined) ??
+						truncateForDisplay(title, 120) ??
+						"Untitled session",
+					cwd: typeof row.directory === "string" ? row.directory : "",
+					startedAtMs: asMs(row.time_created) ?? Date.now(),
+					updatedAtMs:
+						asMs(row.time_updated) ?? asMs(row.time_created) ?? Date.now(),
+					messageCount,
+					...(displayPreview ? { preview: displayPreview } : {}),
+				});
+			}
+			return out;
+		});
+	}
+
+	private firstUserText(db: SqliteDb, sessionId: string): string | undefined {
+		const rows = db
+			.prepare(
+				`SELECT m.id, m.data FROM message m
+				 WHERE m.session_id = ? ORDER BY m.time_created ASC, m.id ASC LIMIT 10`,
+			)
+			.all(sessionId);
+		for (const row of rows) {
+			const data = parseData(row.data);
+			if (data?.role !== "user") continue;
+			const parts = db
+				.prepare(
+					`SELECT data FROM part WHERE message_id = ? ORDER BY id ASC LIMIT 10`,
+				)
+				.all(String(row.id));
+			for (const part of parts) {
+				const partData = parseData(part.data);
+				if (
+					partData?.type === "text" &&
+					typeof partData.text === "string" &&
+					partData.text.trim() &&
+					partData.synthetic !== true
+				) {
+					return partData.text;
+				}
+			}
+		}
+		return undefined;
+	}
+
+	convert(sourceId: string): ConvertedImportedSession {
+		if (!this.isInstalled()) {
+			throw new Error("opencode database not found");
+		}
+		return this.withDbCopy((db) => {
+			const session = db
+				.prepare(
+					`SELECT id, title, directory, time_created, time_updated
+					 FROM session WHERE id = ?`,
+				)
+				.get(sourceId);
+			if (!session) {
+				throw new Error(`opencode session ${sourceId} not found`);
+			}
+
+			const messageRows = db
+				.prepare(
+					`SELECT id, data FROM message WHERE session_id = ?
+					 ORDER BY time_created ASC, id ASC`,
+				)
+				.all(sourceId);
+
+			const messages: LlmsProviders.MessageWithMetadata[] = [];
+			let provider: string | undefined;
+			let model: string | undefined;
+			let prompt: string | undefined;
+			let endedAtMs: number | undefined;
+
+			for (const row of messageRows) {
+				const data = parseData(row.data);
+				if (!data) continue;
+				const role = data.role === "assistant" ? "assistant" : "user";
+				const time = isRecord(data.time) ? data.time : undefined;
+				const ts = asMs(time?.created);
+				if (ts) endedAtMs = ts;
+
+				const parts = db
+					.prepare(`SELECT data FROM part WHERE message_id = ? ORDER BY id ASC`)
+					.all(String(row.id))
+					.map((part) => parseData(part.data))
+					.filter((part): part is JsonRecord => part !== undefined);
+
+				if (role === "user") {
+					const blocks: LlmsProviders.ContentBlock[] = [];
+					for (const part of parts) {
+						if (part.synthetic === true) continue;
+						if (part.type === "text" && typeof part.text === "string") {
+							if (!part.text.trim()) continue;
+							blocks.push({ type: "text", text: part.text });
+							prompt = prompt ?? part.text;
+						} else if (
+							part.type === "file" &&
+							typeof part.url === "string" &&
+							part.url.startsWith("data:") &&
+							typeof part.mime === "string" &&
+							part.mime.startsWith("image/")
+						) {
+							const base64 = part.url.split(",", 2)[1];
+							if (base64) {
+								blocks.push({
+									type: "image",
+									data: base64,
+									mediaType: part.mime,
+								});
+							}
+						}
+					}
+					if (blocks.length > 0) {
+						messages.push({
+							role: "user",
+							content: blocks,
+							...(ts ? { ts } : {}),
+						});
+					}
+					continue;
+				}
+
+				// Assistant: tool parts carry both the call and its result, so a
+				// tool part splits the assistant message (tool_use closes it, the
+				// tool_result forms the next user message) to keep the
+				// user/assistant structure providers expect.
+				if (typeof data.providerID === "string" && data.providerID.trim()) {
+					provider = data.providerID.trim();
+				}
+				if (typeof data.modelID === "string" && data.modelID.trim()) {
+					model = data.modelID.trim();
+				}
+				const modelInfo =
+					provider && model ? { id: model, provider } : undefined;
+				const tokens = isRecord(data.tokens) ? data.tokens : undefined;
+				const cache = isRecord(tokens?.cache) ? tokens.cache : undefined;
+				const metrics = tokens
+					? {
+							inputTokens: Number(tokens.input) || 0,
+							outputTokens: Number(tokens.output) || 0,
+							cacheReadTokens: Number(cache?.read) || 0,
+							cacheWriteTokens: Number(cache?.write) || 0,
+							cost: Number(data.cost) || 0,
+						}
+					: undefined;
+
+				let blocks: LlmsProviders.ContentBlock[] = [];
+				let stampedMetrics = false;
+				const flushAssistant = (withMetrics: boolean) => {
+					if (blocks.length === 0) return;
+					messages.push({
+						role: "assistant",
+						content: blocks,
+						...(modelInfo ? { modelInfo } : {}),
+						...(withMetrics && metrics && !stampedMetrics ? { metrics } : {}),
+						...(ts ? { ts } : {}),
+					});
+					if (withMetrics && metrics && !stampedMetrics) stampedMetrics = true;
+					blocks = [];
+				};
+
+				for (const part of parts) {
+					if (part.type === "text" && typeof part.text === "string") {
+						if (part.text.trim())
+							blocks.push({ type: "text", text: part.text });
+					} else if (
+						part.type === "reasoning" &&
+						typeof part.text === "string" &&
+						part.text.trim()
+					) {
+						blocks.push({ type: "thinking", thinking: part.text });
+					} else if (part.type === "tool") {
+						const state = isRecord(part.state) ? part.state : {};
+						const name = typeof part.tool === "string" ? part.tool : "tool";
+						const callId =
+							typeof part.callID === "string"
+								? part.callID
+								: `import_${nanoid()}`;
+						blocks.push({
+							type: "tool_use",
+							id: callId,
+							name,
+							input: isRecord(state.input) ? state.input : {},
+						});
+						flushAssistant(false);
+						const output =
+							typeof state.output === "string"
+								? state.output
+								: JSON.stringify(state.output ?? "");
+						messages.push({
+							role: "user",
+							content: [
+								{
+									type: "tool_result",
+									tool_use_id: callId,
+									name,
+									content: output,
+									...(state.status === "error" ? { is_error: true } : {}),
+								},
+							],
+						});
+					}
+				}
+				flushAssistant(true);
+			}
+
+			const title =
+				typeof session.title === "string" && session.title.trim()
+					? session.title.trim()
+					: undefined;
+			const needsFallback = !title || title.startsWith("New session");
+			const displayPrompt = truncateForDisplay(prompt, 2000);
+			return {
+				tool: this.tool,
+				sourceId,
+				sourcePath: this.dbPath,
+				title:
+					(needsFallback ? truncateForDisplay(prompt, 120) : undefined) ??
+					truncateForDisplay(title, 120) ??
+					"Untitled session",
+				...(displayPrompt ? { prompt: displayPrompt } : {}),
+				provider: provider ?? "opencode",
+				model: model ?? "opencode",
+				cwd: typeof session.directory === "string" ? session.directory : "",
+				startedAtMs: asMs(session.time_created) ?? Date.now(),
+				endedAtMs:
+					endedAtMs ??
+					asMs(session.time_updated) ??
+					asMs(session.time_created) ??
+					Date.now(),
+				messages,
+			};
+		});
+	}
+}

--- a/sdk/packages/core/src/services/session-import/opencode.ts
+++ b/sdk/packages/core/src/services/session-import/opencode.ts
@@ -32,6 +32,16 @@ function asMs(value: unknown): number | undefined {
 	return Number.isFinite(num) && num > 0 ? num : undefined;
 }
 
+/** opencode provider ids that differ from Cline's for the same vendor. */
+const OPENCODE_TO_CLINE_PROVIDER: Record<string, string> = {
+	openai: "openai-native",
+	google: "gemini",
+};
+
+function toClineProviderId(providerId: string): string {
+	return OPENCODE_TO_CLINE_PROVIDER[providerId] ?? providerId;
+}
+
 export interface OpencodeAdapterOptions {
 	/** Defaults to $XDG_DATA_HOME/opencode or ~/.local/share/opencode */
 	dataDir?: string;
@@ -58,9 +68,14 @@ export class OpencodeImportAdapter implements SessionImportAdapter {
 	/**
 	 * opencode keeps its database open in WAL mode while the app runs.
 	 * Snapshot the db (+ WAL/SHM) into a temp dir and read the copy so we
-	 * never contend with — or corrupt — the live store.
+	 * never contend with — or corrupt — the live store. The snapshot is kept
+	 * for the batch (a large db copied once per imported session was the
+	 * dominant cost) and released by dispose().
 	 */
-	private withDbCopy<T>(fn: (db: SqliteDb) => T): T {
+	private snapshot?: { dir: string; db: SqliteDb };
+
+	private openSnapshot(): SqliteDb {
+		if (this.snapshot) return this.snapshot.db;
 		const dir = mkdtempSync(join(tmpdir(), "cline-opencode-import-"));
 		try {
 			const copied = join(dir, "opencode.db");
@@ -72,14 +87,27 @@ export class OpencodeImportAdapter implements SessionImportAdapter {
 				}
 			}
 			const db = loadSqliteDb(copied);
-			try {
-				return fn(db);
-			} finally {
-				db.close?.();
-			}
-		} finally {
+			this.snapshot = { dir, db };
+			return db;
+		} catch (error) {
 			rmSync(dir, { recursive: true, force: true });
+			throw error;
 		}
+	}
+
+	dispose(): void {
+		const snapshot = this.snapshot;
+		this.snapshot = undefined;
+		if (!snapshot) return;
+		try {
+			snapshot.db.close?.();
+		} finally {
+			rmSync(snapshot.dir, { recursive: true, force: true });
+		}
+	}
+
+	private withDbCopy<T>(fn: (db: SqliteDb) => T): T {
+		return fn(this.openSnapshot());
 	}
 
 	discover(): ImportableSessionSummary[] {
@@ -246,7 +274,7 @@ export class OpencodeImportAdapter implements SessionImportAdapter {
 				// tool_result forms the next user message) to keep the
 				// user/assistant structure providers expect.
 				if (typeof data.providerID === "string" && data.providerID.trim()) {
-					provider = data.providerID.trim();
+					provider = toClineProviderId(data.providerID.trim());
 				}
 				if (typeof data.modelID === "string" && data.modelID.trim()) {
 					model = data.modelID.trim();

--- a/sdk/packages/core/src/services/session-import/sanitize.ts
+++ b/sdk/packages/core/src/services/session-import/sanitize.ts
@@ -1,0 +1,145 @@
+import type * as LlmsProviders from "@cline/llms";
+
+type Block = LlmsProviders.ContentBlock;
+type Message = LlmsProviders.MessageWithMetadata;
+
+export const IMPORT_MISSING_TOOL_RESULT_TEXT =
+	"[import] Tool result was not captured in the source session history.";
+
+function isNonEmptyText(block: Block): boolean {
+	return block.type !== "text" || block.text.trim().length > 0;
+}
+
+/**
+ * Strips provider-session-scoped fields that only validate against the
+ * original provider conversation (thinking/tool signatures, encrypted
+ * reasoning) and drops empty text blocks, which some gateways reject
+ * outright (all-empty-content 400s).
+ */
+function cleanBlocks(content: string | Block[]): string | Block[] {
+	if (typeof content === "string") return content;
+	const cleaned: Block[] = [];
+	for (const block of content) {
+		if (!isNonEmptyText(block)) continue;
+		switch (block.type) {
+			case "redacted_thinking":
+				// Only replayable against the original provider session.
+				continue;
+			case "thinking": {
+				if (!block.thinking?.trim()) continue;
+				const { signature: _signature, ...rest } = block;
+				cleaned.push(rest);
+				break;
+			}
+			case "text": {
+				const { signature: _signature, ...rest } = block;
+				cleaned.push(rest);
+				break;
+			}
+			case "tool_use": {
+				const { signature: _signature, ...rest } = block;
+				cleaned.push(rest);
+				break;
+			}
+			default:
+				cleaned.push(block);
+		}
+	}
+	return cleaned;
+}
+
+function getToolUses(message: Message): Array<{ id: string; name: string }> {
+	if (!Array.isArray(message.content)) return [];
+	return message.content
+		.filter((block) => block.type === "tool_use")
+		.map((block) => ({ id: block.id, name: block.name }));
+}
+
+/**
+ * Prepares foreign conversation history for persistence and eventual replay
+ * to a provider:
+ * - cleans blocks (see cleanBlocks) and drops messages left empty,
+ * - guarantees every assistant tool_use has a matching tool_result in the
+ *   user messages that follow (synthesizing placeholders for orphans),
+ * - drops tool_result blocks whose tool_use no longer exists.
+ *
+ * Providers hard-reject histories that violate tool pairing, so this must
+ * run on every imported session regardless of source quality.
+ */
+export function sanitizeImportedMessages(messages: Message[]): Message[] {
+	const cleaned: Message[] = [];
+	for (const message of messages) {
+		const content = cleanBlocks(message.content);
+		if (typeof content === "string") {
+			if (content.trim().length === 0) continue;
+			cleaned.push({ ...message, content });
+			continue;
+		}
+		if (content.length === 0) continue;
+		cleaned.push({ ...message, content });
+	}
+
+	// Pass 1: collect every tool_use id so orphaned tool_results can be culled.
+	const knownToolUseIds = new Map<string, string>();
+	for (const message of cleaned) {
+		if (message.role !== "assistant") continue;
+		for (const toolUse of getToolUses(message)) {
+			knownToolUseIds.set(toolUse.id, toolUse.name);
+		}
+	}
+
+	// Pass 2: drop tool_results with no matching tool_use.
+	const paired: Message[] = [];
+	for (const message of cleaned) {
+		if (message.role !== "user" || !Array.isArray(message.content)) {
+			paired.push(message);
+			continue;
+		}
+		const kept = message.content.filter(
+			(block) =>
+				block.type !== "tool_result" || knownToolUseIds.has(block.tool_use_id),
+		);
+		if (kept.length === 0) continue;
+		paired.push(
+			kept.length === message.content.length
+				? message
+				: { ...message, content: kept },
+		);
+	}
+
+	// Pass 3: every assistant tool_use must be answered by a tool_result in
+	// the consecutive user messages that follow it.
+	const repaired: Message[] = [];
+	for (let i = 0; i < paired.length; i++) {
+		const message = paired[i];
+		repaired.push(message);
+		if (message.role !== "assistant") continue;
+		const toolUses = getToolUses(message);
+		if (toolUses.length === 0) continue;
+
+		const answered = new Set<string>();
+		let scan = i + 1;
+		while (scan < paired.length && paired[scan].role === "user") {
+			const content = paired[scan].content;
+			if (Array.isArray(content)) {
+				for (const block of content) {
+					if (block.type === "tool_result") answered.add(block.tool_use_id);
+				}
+			}
+			scan++;
+		}
+		const missing = toolUses.filter((toolUse) => !answered.has(toolUse.id));
+		if (missing.length === 0) continue;
+		repaired.push({
+			role: "user",
+			content: missing.map((toolUse) => ({
+				type: "tool_result" as const,
+				tool_use_id: toolUse.id,
+				name: toolUse.name,
+				content: IMPORT_MISSING_TOOL_RESULT_TEXT,
+			})),
+		});
+	}
+
+	return repaired;
+}

--- a/sdk/packages/core/src/services/session-import/sanitize.ts
+++ b/sdk/packages/core/src/services/session-import/sanitize.ts
@@ -107,8 +107,13 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 		);
 	}
 
-	// Pass 3: every assistant tool_use must be answered by a tool_result in
-	// the consecutive user messages that follow it.
+	// Pass 3: every assistant tool_use must be answered by a tool_result, and
+	// providers (Anthropic strictly) want all of a turn's results in the user
+	// message immediately following it. Whenever the span of user messages
+	// after an assistant turn is incomplete or split across messages, rebuild
+	// it as one consolidated results message (tool_use order, placeholders
+	// for anything missing) followed by a message with whatever else was
+	// there, mirroring the legacy migration sanitizer.
 	const repaired: Message[] = [];
 	for (let i = 0; i < paired.length; i++) {
 		const message = paired[i];
@@ -117,28 +122,56 @@ export function sanitizeImportedMessages(messages: Message[]): Message[] {
 		const toolUses = getToolUses(message);
 		if (toolUses.length === 0) continue;
 
-		const answered = new Set<string>();
-		let scan = i + 1;
-		while (scan < paired.length && paired[scan].role === "user") {
-			const content = paired[scan].content;
-			if (Array.isArray(content)) {
-				for (const block of content) {
-					if (block.type === "tool_result") answered.add(block.tool_use_id);
+		const toolUseIds = new Set(toolUses.map((toolUse) => toolUse.id));
+		const results = new Map<string, Block>();
+		const otherBlocks: Block[] = [];
+		let spanEnd = i + 1;
+		while (spanEnd < paired.length && paired[spanEnd].role === "user") {
+			const content = paired[spanEnd].content;
+			const blocks: Block[] =
+				typeof content === "string"
+					? [{ type: "text", text: content }]
+					: content;
+			for (const block of blocks) {
+				if (
+					block.type === "tool_result" &&
+					toolUseIds.has(block.tool_use_id) &&
+					!results.has(block.tool_use_id)
+				) {
+					results.set(block.tool_use_id, block);
+				} else if (
+					block.type !== "tool_result" ||
+					!toolUseIds.has(block.tool_use_id)
+				) {
+					otherBlocks.push(block);
 				}
+				// Duplicate results for an already-answered id are dropped.
 			}
-			scan++;
+			spanEnd++;
 		}
-		const missing = toolUses.filter((toolUse) => !answered.has(toolUse.id));
-		if (missing.length === 0) continue;
+		const span = paired.slice(i + 1, spanEnd);
+		const missing = toolUses.filter((toolUse) => !results.has(toolUse.id));
+		const alreadyConsolidated =
+			missing.length === 0 && span.length === 1 && otherBlocks.length === 0;
+		if (alreadyConsolidated) continue;
+
 		repaired.push({
+			...(span[0] ?? {}),
 			role: "user",
-			content: missing.map((toolUse) => ({
-				type: "tool_result" as const,
-				tool_use_id: toolUse.id,
-				name: toolUse.name,
-				content: IMPORT_MISSING_TOOL_RESULT_TEXT,
-			})),
+			content: toolUses.map(
+				(toolUse) =>
+					results.get(toolUse.id) ?? {
+						type: "tool_result" as const,
+						tool_use_id: toolUse.id,
+						name: toolUse.name,
+						content: IMPORT_MISSING_TOOL_RESULT_TEXT,
+					},
+			),
 		});
+		if (otherBlocks.length > 0) {
+			repaired.push({ role: "user", content: otherBlocks });
+		}
+		i = spanEnd - 1;
 	}
 
 	return repaired;

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -78,11 +78,15 @@ export class SessionImportService {
 			.map((adapter) => adapter.tool);
 	}
 
-	/** `tool:sourceId` → existing Cline session id, from prior imports. */
+	/**
+	 * `tool:sourceId` → existing Cline session id, from prior imports. Reads
+	 * every row's metadata (not the 2000-row listSessions window) so a marker
+	 * on an old session still prevents a duplicate.
+	 */
 	private async existingImports(): Promise<Map<string, string>> {
 		const existing = new Map<string, string>();
 		try {
-			for (const row of await this.sessions.listSessions(2000)) {
+			for (const row of await this.sessions.listSessionMetadata()) {
 				const imported = readImportedFromMetadata(row.metadata);
 				if (imported) {
 					existing.set(
@@ -139,16 +143,14 @@ export class SessionImportService {
 		request: SessionImportRequest,
 		options: SessionImportOptions = {},
 	): Promise<SessionImportResult> {
-		try {
-			return await this.importOneUnmanaged(request, options);
-		} finally {
-			this.disposeAdapters();
-		}
+		const [result] = await this.importMany([request], undefined, options);
+		return result;
 	}
 
 	private async importOneUnmanaged(
 		request: SessionImportRequest,
 		options: SessionImportOptions,
+		existing: Map<string, string>,
 	): Promise<SessionImportResult> {
 		const adapter = this.adapters.find(
 			(candidate) => candidate.tool === request.tool,
@@ -161,9 +163,24 @@ export class SessionImportService {
 				error: `No importer for tool "${request.tool}"`,
 			};
 		}
+		// Idempotency at import time, not only at discovery: a stale picker or
+		// a repeated request must never produce a second copy.
+		const existingSessionId = existing.get(
+			importKey(request.tool, request.sourceId),
+		);
+		if (existingSessionId) {
+			return {
+				tool: request.tool,
+				sourceId: request.sourceId,
+				ok: true,
+				sessionId: existingSessionId,
+				alreadyImported: true,
+			};
+		}
 		try {
 			const converted = adapter.convert(request.sourceId);
 			const sessionId = await this.persistConverted(converted, options);
+			existing.set(importKey(request.tool, request.sourceId), sessionId);
 			return {
 				tool: request.tool,
 				sourceId: request.sourceId,
@@ -187,12 +204,17 @@ export class SessionImportService {
 		options: SessionImportOptions = {},
 	): Promise<SessionImportResult[]> {
 		const results: SessionImportResult[] = [];
+		const existing = await this.existingImports();
 		try {
 			for (const [index, request] of requests.entries()) {
 				// Per-session transactional: one bad source session fails one
 				// item. Adapter caches (file indexes, db snapshots) live for the
 				// whole batch and are released once at the end.
-				const result = await this.importOneUnmanaged(request, options);
+				const result = await this.importOneUnmanaged(
+					request,
+					options,
+					existing,
+				);
 				results.push(result);
 				onProgress?.(result, index);
 			}
@@ -265,23 +287,37 @@ export class SessionImportService {
 			startedAt: new Date(startedAtMs).toISOString(),
 		});
 
-		await this.sessions.persistSessionMessages(sessionId, messages);
+		try {
+			await this.sessions.persistSessionMessages(sessionId, messages);
 
-		// Imported sessions are history from the moment they land: terminal
-		// status, or the stale-session reconciler flips pid-0 rows to failed.
-		await this.sessions.updateSessionStatus(sessionId, "completed", 0);
-		const endedAtMs = Number.isFinite(converted.endedAtMs)
-			? converted.endedAtMs
-			: startedAtMs;
-		const manifest = artifacts.manifest;
-		manifest.status = "completed";
-		manifest.ended_at = new Date(endedAtMs).toISOString();
-		manifest.exit_code = 0;
-		this.sessions.writeSessionManifest(artifacts.manifestPath, manifest);
+			// Imported sessions are history from the moment they land: terminal
+			// status, or the stale-session reconciler flips pid-0 rows to failed.
+			await this.sessions.updateSessionStatus(sessionId, "completed", 0);
+			const endedAtMs = Number.isFinite(converted.endedAtMs)
+				? converted.endedAtMs
+				: startedAtMs;
+			const manifest = artifacts.manifest;
+			manifest.status = "completed";
+			manifest.ended_at = new Date(endedAtMs).toISOString();
+			manifest.exit_code = 0;
+			this.sessions.writeSessionManifest(artifacts.manifestPath, manifest);
 
-		// Session creation derives metadata.title from the prompt; restore the
-		// source tool's own title on both the row and the manifest.
-		await this.sessions.updateSession({ sessionId, title: converted.title });
+			// Session creation derives metadata.title from the prompt; restore
+			// the source tool's own title on both the row and the manifest.
+			await this.sessions.updateSession({
+				sessionId,
+				title: converted.title,
+			});
+		} catch (error) {
+			// A half-written session would show up as a broken history entry
+			// and its importedFrom marker would block retrying the source.
+			try {
+				await this.sessions.deleteSession(sessionId);
+			} catch {
+				// Best-effort; the original failure is what the caller needs.
+			}
+			throw error;
+		}
 
 		return sessionId;
 	}

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -10,6 +10,7 @@ import type {
 	ConvertedImportedSession,
 	ImportableSessionSummary,
 	SessionImportAdapter,
+	SessionImportOptions,
 	SessionImportRequest,
 	SessionImportResult,
 	SessionImportTool,
@@ -20,6 +21,9 @@ export interface ImportedFromMetadata {
 	sourceSessionId: string;
 	sourcePath: string;
 	importedAt: string;
+	/** Provider/model the source tool ran the session on. */
+	sourceProvider?: string;
+	sourceModel?: string;
 }
 
 export function readImportedFromMetadata(
@@ -93,31 +97,59 @@ export class SessionImportService {
 		return existing;
 	}
 
+	private disposeAdapters(): void {
+		for (const adapter of this.adapters) {
+			try {
+				adapter.dispose?.();
+			} catch {
+				// Cache cleanup is best-effort.
+			}
+		}
+	}
+
 	async discover(): Promise<ImportableSessionSummary[]> {
 		const existing = await this.existingImports();
 		const out: ImportableSessionSummary[] = [];
-		for (const adapter of this.adapters) {
-			try {
-				if (!adapter.isInstalled()) continue;
-				for (const summary of adapter.discover()) {
-					const alreadyImportedSessionId = existing.get(
-						importKey(summary.tool, summary.sourceId),
-					);
-					out.push(
-						alreadyImportedSessionId
-							? { ...summary, alreadyImportedSessionId }
-							: summary,
-					);
+		try {
+			for (const adapter of this.adapters) {
+				try {
+					if (!adapter.isInstalled()) continue;
+					for (const summary of adapter.discover()) {
+						const alreadyImportedSessionId = existing.get(
+							importKey(summary.tool, summary.sourceId),
+						);
+						out.push(
+							alreadyImportedSessionId
+								? { ...summary, alreadyImportedSessionId }
+								: summary,
+						);
+					}
+				} catch {
+					// One unreadable store must not hide the other tools' sessions.
 				}
-			} catch {
-				// One unreadable store must not hide the other tools' sessions.
 			}
+		} finally {
+			this.disposeAdapters();
 		}
 		out.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
 		return out;
 	}
 
-	async importOne(request: SessionImportRequest): Promise<SessionImportResult> {
+	async importOne(
+		request: SessionImportRequest,
+		options: SessionImportOptions = {},
+	): Promise<SessionImportResult> {
+		try {
+			return await this.importOneUnmanaged(request, options);
+		} finally {
+			this.disposeAdapters();
+		}
+	}
+
+	private async importOneUnmanaged(
+		request: SessionImportRequest,
+		options: SessionImportOptions,
+	): Promise<SessionImportResult> {
 		const adapter = this.adapters.find(
 			(candidate) => candidate.tool === request.tool,
 		);
@@ -131,7 +163,7 @@ export class SessionImportService {
 		}
 		try {
 			const converted = adapter.convert(request.sourceId);
-			const sessionId = await this.persistConverted(converted);
+			const sessionId = await this.persistConverted(converted, options);
 			return {
 				tool: request.tool,
 				sourceId: request.sourceId,
@@ -152,19 +184,27 @@ export class SessionImportService {
 	async importMany(
 		requests: SessionImportRequest[],
 		onProgress?: (result: SessionImportResult, index: number) => void,
+		options: SessionImportOptions = {},
 	): Promise<SessionImportResult[]> {
 		const results: SessionImportResult[] = [];
-		for (const [index, request] of requests.entries()) {
-			// Per-session transactional: one bad source session fails one item.
-			const result = await this.importOne(request);
-			results.push(result);
-			onProgress?.(result, index);
+		try {
+			for (const [index, request] of requests.entries()) {
+				// Per-session transactional: one bad source session fails one
+				// item. Adapter caches (file indexes, db snapshots) live for the
+				// whole batch and are released once at the end.
+				const result = await this.importOneUnmanaged(request, options);
+				results.push(result);
+				onProgress?.(result, index);
+			}
+		} finally {
+			this.disposeAdapters();
 		}
 		return results;
 	}
 
 	private async persistConverted(
 		converted: ConvertedImportedSession,
+		options: SessionImportOptions,
 	): Promise<string> {
 		const messages = sanitizeImportedMessages(converted.messages);
 		if (messages.length === 0) {
@@ -186,13 +226,22 @@ export class SessionImportService {
 			: Date.now();
 		const sessionId = `${startedAtMs}_${nanoid(5)}`;
 
+		// Resume adopts the row's provider/model, so stamp what the user will
+		// actually run on; both halves must be present to avoid pairing a
+		// Cline provider with a foreign model id.
+		const resumeProvider = options.provider?.trim();
+		const resumeModel = options.model?.trim();
+		const useResumeTarget = Boolean(resumeProvider && resumeModel);
+
 		const artifacts = await this.sessions.createRootSessionWithArtifacts({
 			sessionId,
 			source: SessionSource.DESKTOP,
 			pid: 0,
 			interactive: true,
-			provider: converted.provider,
-			model: converted.model,
+			provider: useResumeTarget
+				? (resumeProvider as string)
+				: converted.provider,
+			model: useResumeTarget ? (resumeModel as string) : converted.model,
 			cwd,
 			workspaceRoot: cwd,
 			enableTools: true,
@@ -206,6 +255,8 @@ export class SessionImportService {
 					sourceSessionId: converted.sourceId,
 					sourcePath: converted.sourcePath,
 					importedAt: new Date().toISOString(),
+					sourceProvider: converted.provider,
+					sourceModel: converted.model,
 				} satisfies ImportedFromMetadata,
 				...(converted.gitBranch
 					? { git: { branch: converted.gitBranch } }

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -48,6 +48,15 @@ export function readImportedFromMetadata(
 	};
 }
 
+/**
+ * Imports currently being written, keyed by source. Each import_sessions
+ * request builds its own service and snapshots the existing markers once,
+ * so two overlapping requests for one source (a second window, a
+ * double-fired command) would otherwise both pass the dedupe check and
+ * persist two sessions. The later caller waits on the first write instead.
+ */
+const inFlightImports = new Map<string, Promise<SessionImportResult>>();
+
 function importKey(tool: string, sourceId: string): string {
 	return `${tool}:${sourceId}`;
 }
@@ -177,10 +186,41 @@ export class SessionImportService {
 				alreadyImported: true,
 			};
 		}
+		const key = importKey(request.tool, request.sourceId);
+		const inFlight = inFlightImports.get(key);
+		if (inFlight) {
+			const first = await inFlight;
+			if (first.ok && first.sessionId) {
+				existing.set(key, first.sessionId);
+				return {
+					tool: request.tool,
+					sourceId: request.sourceId,
+					ok: true,
+					sessionId: first.sessionId,
+					alreadyImported: true,
+				};
+			}
+			return { ...first, tool: request.tool, sourceId: request.sourceId };
+		}
+		const work = this.importFresh(adapter, request, options);
+		inFlightImports.set(key, work);
+		try {
+			const result = await work;
+			if (result.ok && result.sessionId) existing.set(key, result.sessionId);
+			return result;
+		} finally {
+			inFlightImports.delete(key);
+		}
+	}
+
+	private async importFresh(
+		adapter: SessionImportAdapter,
+		request: SessionImportRequest,
+		options: SessionImportOptions,
+	): Promise<SessionImportResult> {
 		try {
 			const converted = adapter.convert(request.sourceId);
 			const sessionId = await this.persistConverted(converted, options);
-			existing.set(importKey(request.tool, request.sourceId), sessionId);
 			return {
 				tool: request.tool,
 				sourceId: request.sourceId,
@@ -266,30 +306,32 @@ export class SessionImportService {
 		// Created already completed: an imported session is history from
 		// birth, and a transient running/pid-0 row is exactly what the
 		// stale-session reconciler — running in the hub daemon against the
-		// same DB — would flip to failed mid-import.
-		await this.sessions.createRootSessionWithArtifacts({
-			sessionId,
-			source: SessionSource.DESKTOP,
-			pid: 0,
-			interactive: true,
-			provider: useResumeTarget
-				? (resumeProvider as string)
-				: converted.provider,
-			model: useResumeTarget ? (resumeModel as string) : converted.model,
-			cwd,
-			workspaceRoot: cwd,
-			enableTools: true,
-			enableSpawn: false,
-			enableTeams: false,
-			...(converted.prompt ? { prompt: converted.prompt } : {}),
-			metadata: baseMetadata,
-			startedAt: new Date(startedAtMs).toISOString(),
-			status: "completed",
-			endedAt: new Date(endedAtMs).toISOString(),
-			exitCode: 0,
-		});
-
+		// same DB — would flip to failed mid-import. Creation sits inside the
+		// rollback: it upserts the row before writing the artifact files, so a
+		// failed file write must not leave a completed row with no transcript.
 		try {
+			await this.sessions.createRootSessionWithArtifacts({
+				sessionId,
+				source: SessionSource.DESKTOP,
+				pid: 0,
+				interactive: true,
+				provider: useResumeTarget
+					? (resumeProvider as string)
+					: converted.provider,
+				model: useResumeTarget ? (resumeModel as string) : converted.model,
+				cwd,
+				workspaceRoot: cwd,
+				enableTools: true,
+				enableSpawn: false,
+				enableTeams: false,
+				...(converted.prompt ? { prompt: converted.prompt } : {}),
+				metadata: baseMetadata,
+				startedAt: new Date(startedAtMs).toISOString(),
+				status: "completed",
+				endedAt: new Date(endedAtMs).toISOString(),
+				exitCode: 0,
+			});
+
 			await this.sessions.persistSessionMessages(sessionId, messages);
 
 			// Last step on purpose: the importedFrom marker means "this import
@@ -312,7 +354,8 @@ export class SessionImportService {
 			});
 		} catch (error) {
 			// Remove the half-written session so history never shows a broken
-			// entry; even if this fails, the row carries no importedFrom marker.
+			// entry (deleteSession tolerates a missing row or missing files);
+			// even if this fails, the row carries no importedFrom marker.
 			try {
 				await this.sessions.deleteSession(sessionId);
 			} catch {

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -1,0 +1,237 @@
+import { nanoid } from "nanoid";
+import type { UnifiedSessionPersistenceService } from "../../session/services/persistence-service";
+import { SessionSource } from "../../types/common";
+import { ensureChatWorkspace } from "../workspace/chat-workspace";
+import { ClaudeCodeImportAdapter } from "./claude-code";
+import { CodexImportAdapter } from "./codex";
+import { OpencodeImportAdapter } from "./opencode";
+import { sanitizeImportedMessages } from "./sanitize";
+import type {
+	ConvertedImportedSession,
+	ImportableSessionSummary,
+	SessionImportAdapter,
+	SessionImportRequest,
+	SessionImportResult,
+	SessionImportTool,
+} from "./types";
+
+export interface ImportedFromMetadata {
+	tool: SessionImportTool;
+	sourceSessionId: string;
+	sourcePath: string;
+	importedAt: string;
+}
+
+export function readImportedFromMetadata(
+	metadata: Record<string, unknown> | null | undefined,
+): ImportedFromMetadata | undefined {
+	const value = metadata?.importedFrom;
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	if (
+		typeof record.tool !== "string" ||
+		typeof record.sourceSessionId !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		tool: record.tool as SessionImportTool,
+		sourceSessionId: record.sourceSessionId,
+		sourcePath: typeof record.sourcePath === "string" ? record.sourcePath : "",
+		importedAt: typeof record.importedAt === "string" ? record.importedAt : "",
+	};
+}
+
+function importKey(tool: string, sourceId: string): string {
+	return `${tool}:${sourceId}`;
+}
+
+export class SessionImportService {
+	private readonly adapters: SessionImportAdapter[];
+
+	constructor(
+		private readonly sessions: UnifiedSessionPersistenceService,
+		adapters?: SessionImportAdapter[],
+	) {
+		this.adapters = adapters ?? [
+			new ClaudeCodeImportAdapter(),
+			new CodexImportAdapter(),
+			new OpencodeImportAdapter(),
+		];
+	}
+
+	installedTools(): SessionImportTool[] {
+		return this.adapters
+			.filter((adapter) => {
+				try {
+					return adapter.isInstalled();
+				} catch {
+					return false;
+				}
+			})
+			.map((adapter) => adapter.tool);
+	}
+
+	/** `tool:sourceId` → existing Cline session id, from prior imports. */
+	private async existingImports(): Promise<Map<string, string>> {
+		const existing = new Map<string, string>();
+		try {
+			for (const row of await this.sessions.listSessions(2000)) {
+				const imported = readImportedFromMetadata(row.metadata);
+				if (imported) {
+					existing.set(
+						importKey(imported.tool, imported.sourceSessionId),
+						row.sessionId,
+					);
+				}
+			}
+		} catch {
+			// Dedup markers are a convenience; discovery still works without them.
+		}
+		return existing;
+	}
+
+	async discover(): Promise<ImportableSessionSummary[]> {
+		const existing = await this.existingImports();
+		const out: ImportableSessionSummary[] = [];
+		for (const adapter of this.adapters) {
+			try {
+				if (!adapter.isInstalled()) continue;
+				for (const summary of adapter.discover()) {
+					const alreadyImportedSessionId = existing.get(
+						importKey(summary.tool, summary.sourceId),
+					);
+					out.push(
+						alreadyImportedSessionId
+							? { ...summary, alreadyImportedSessionId }
+							: summary,
+					);
+				}
+			} catch {
+				// One unreadable store must not hide the other tools' sessions.
+			}
+		}
+		out.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
+		return out;
+	}
+
+	async importOne(request: SessionImportRequest): Promise<SessionImportResult> {
+		const adapter = this.adapters.find(
+			(candidate) => candidate.tool === request.tool,
+		);
+		if (!adapter) {
+			return {
+				tool: request.tool,
+				sourceId: request.sourceId,
+				ok: false,
+				error: `No importer for tool "${request.tool}"`,
+			};
+		}
+		try {
+			const converted = adapter.convert(request.sourceId);
+			const sessionId = await this.persistConverted(converted);
+			return {
+				tool: request.tool,
+				sourceId: request.sourceId,
+				ok: true,
+				sessionId,
+				title: converted.title,
+			};
+		} catch (error) {
+			return {
+				tool: request.tool,
+				sourceId: request.sourceId,
+				ok: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+	}
+
+	async importMany(
+		requests: SessionImportRequest[],
+		onProgress?: (result: SessionImportResult, index: number) => void,
+	): Promise<SessionImportResult[]> {
+		const results: SessionImportResult[] = [];
+		for (const [index, request] of requests.entries()) {
+			// Per-session transactional: one bad source session fails one item.
+			const result = await this.importOne(request);
+			results.push(result);
+			onProgress?.(result, index);
+		}
+		return results;
+	}
+
+	private async persistConverted(
+		converted: ConvertedImportedSession,
+	): Promise<string> {
+		const messages = sanitizeImportedMessages(converted.messages);
+		if (messages.length === 0) {
+			throw new Error("Session has no importable messages");
+		}
+
+		// Empty cwd/workspace fails manifest validation and history filters;
+		// sessions whose original directory is unknown live in the shared chat
+		// workspace, exactly like Cline's own project-less sessions.
+		let cwd = converted.cwd.trim();
+		if (!cwd) {
+			cwd = await ensureChatWorkspace();
+		}
+
+		// History sorts by the epoch prefix baked into the session id, so an
+		// imported session keeps its original chronology.
+		const startedAtMs = Number.isFinite(converted.startedAtMs)
+			? converted.startedAtMs
+			: Date.now();
+		const sessionId = `${startedAtMs}_${nanoid(5)}`;
+
+		const artifacts = await this.sessions.createRootSessionWithArtifacts({
+			sessionId,
+			source: SessionSource.DESKTOP,
+			pid: 0,
+			interactive: true,
+			provider: converted.provider,
+			model: converted.model,
+			cwd,
+			workspaceRoot: cwd,
+			enableTools: true,
+			enableSpawn: false,
+			enableTeams: false,
+			...(converted.prompt ? { prompt: converted.prompt } : {}),
+			metadata: {
+				title: converted.title,
+				importedFrom: {
+					tool: converted.tool,
+					sourceSessionId: converted.sourceId,
+					sourcePath: converted.sourcePath,
+					importedAt: new Date().toISOString(),
+				} satisfies ImportedFromMetadata,
+				...(converted.gitBranch
+					? { git: { branch: converted.gitBranch } }
+					: {}),
+			},
+			startedAt: new Date(startedAtMs).toISOString(),
+		});
+
+		await this.sessions.persistSessionMessages(sessionId, messages);
+
+		// Imported sessions are history from the moment they land: terminal
+		// status, or the stale-session reconciler flips pid-0 rows to failed.
+		await this.sessions.updateSessionStatus(sessionId, "completed", 0);
+		const endedAtMs = Number.isFinite(converted.endedAtMs)
+			? converted.endedAtMs
+			: startedAtMs;
+		const manifest = artifacts.manifest;
+		manifest.status = "completed";
+		manifest.ended_at = new Date(endedAtMs).toISOString();
+		manifest.exit_code = 0;
+		this.sessions.writeSessionManifest(artifacts.manifestPath, manifest);
+
+		// Session creation derives metadata.title from the prompt; restore the
+		// source tool's own title on both the row and the manifest.
+		await this.sessions.updateSession({ sessionId, title: converted.title });
+
+		return sessionId;
+	}
+}

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -255,7 +255,19 @@ export class SessionImportService {
 		const resumeModel = options.model?.trim();
 		const useResumeTarget = Boolean(resumeProvider && resumeModel);
 
-		const artifacts = await this.sessions.createRootSessionWithArtifacts({
+		const endedAtMs = Number.isFinite(converted.endedAtMs)
+			? converted.endedAtMs
+			: startedAtMs;
+		const baseMetadata: Record<string, unknown> = {
+			title: converted.title,
+			...(converted.gitBranch ? { git: { branch: converted.gitBranch } } : {}),
+		};
+
+		// Created already completed: an imported session is history from
+		// birth, and a transient running/pid-0 row is exactly what the
+		// stale-session reconciler — running in the hub daemon against the
+		// same DB — would flip to failed mid-import.
+		await this.sessions.createRootSessionWithArtifacts({
 			sessionId,
 			source: SessionSource.DESKTOP,
 			pid: 0,
@@ -270,47 +282,37 @@ export class SessionImportService {
 			enableSpawn: false,
 			enableTeams: false,
 			...(converted.prompt ? { prompt: converted.prompt } : {}),
-			metadata: {
-				title: converted.title,
-				importedFrom: {
-					tool: converted.tool,
-					sourceSessionId: converted.sourceId,
-					sourcePath: converted.sourcePath,
-					importedAt: new Date().toISOString(),
-					sourceProvider: converted.provider,
-					sourceModel: converted.model,
-				} satisfies ImportedFromMetadata,
-				...(converted.gitBranch
-					? { git: { branch: converted.gitBranch } }
-					: {}),
-			},
+			metadata: baseMetadata,
 			startedAt: new Date(startedAtMs).toISOString(),
+			status: "completed",
+			endedAt: new Date(endedAtMs).toISOString(),
+			exitCode: 0,
 		});
 
 		try {
 			await this.sessions.persistSessionMessages(sessionId, messages);
 
-			// Imported sessions are history from the moment they land: terminal
-			// status, or the stale-session reconciler flips pid-0 rows to failed.
-			await this.sessions.updateSessionStatus(sessionId, "completed", 0);
-			const endedAtMs = Number.isFinite(converted.endedAtMs)
-				? converted.endedAtMs
-				: startedAtMs;
-			const manifest = artifacts.manifest;
-			manifest.status = "completed";
-			manifest.ended_at = new Date(endedAtMs).toISOString();
-			manifest.exit_code = 0;
-			this.sessions.writeSessionManifest(artifacts.manifestPath, manifest);
-
-			// Session creation derives metadata.title from the prompt; restore
-			// the source tool's own title on both the row and the manifest.
+			// Last step on purpose: the importedFrom marker means "this import
+			// finished", so a session that fails before this point can never
+			// claim the source and block a retry, whatever happens to the row.
+			// (updateSession also restores the source tool's title, which
+			// creation replaced with a prompt-derived one.)
+			const importedFrom: ImportedFromMetadata = {
+				tool: converted.tool,
+				sourceSessionId: converted.sourceId,
+				sourcePath: converted.sourcePath,
+				importedAt: new Date().toISOString(),
+				sourceProvider: converted.provider,
+				sourceModel: converted.model,
+			};
 			await this.sessions.updateSession({
 				sessionId,
 				title: converted.title,
+				metadata: { ...baseMetadata, importedFrom },
 			});
 		} catch (error) {
-			// A half-written session would show up as a broken history entry
-			// and its importedFrom marker would block retrying the source.
+			// Remove the half-written session so history never shows a broken
+			// entry; even if this fails, the row carries no importedFrom marker.
 			try {
 				await this.sessions.deleteSession(sessionId);
 			} catch {

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -881,6 +881,42 @@ describe("SessionImportService", () => {
 		expect(store.list(50)).toHaveLength(1);
 	});
 
+	it("never marks a session as imported unless every write succeeded", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const store = new SqliteSessionStore({ sessionsDir: tempDir("cline-db-") });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: tempDir("cline-sessions-"),
+		});
+		// Worst case: the messages write fails AND the rollback delete fails,
+		// so a row survives. It must not carry the importedFrom marker.
+		sessions.persistSessionMessages = async () => {
+			throw new Error("disk full");
+		};
+		sessions.deleteSession = async () => {
+			throw new Error("also broken");
+		};
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const [failed] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(failed.ok).toBe(false);
+		const survivor = store.list(50)[0];
+		expect(survivor).toBeDefined();
+		expect(
+			(survivor.metadata as Record<string, unknown> | undefined)?.importedFrom,
+		).toBeUndefined();
+		// Rows are created terminal — never a running/pid-0 state that the
+		// stale-session reconciler could flip to failed mid-import.
+		expect(survivor.status).toBe("completed");
+		const rediscovered = await importer.discover();
+		expect(rediscovered[0].alreadyImportedSessionId).toBeUndefined();
+	});
+
 	it("never duplicates a source session that was already imported", async () => {
 		const projectsDir = tempDir("cc-import-");
 		writeClaudeCodeFixture(projectsDir);

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -403,6 +403,68 @@ describe("CodexImportAdapter", () => {
 		});
 	});
 
+	it("flattens content-block tool outputs from newer rollouts into text", () => {
+		const codexHome = tempDir("codex-import-blocks-");
+		const dayDir = join(codexHome, "sessions", "2026", "02", "01");
+		mkdirSync(dayDir, { recursive: true });
+		writeFileSync(
+			join(dayDir, "rollout-2026-02-01T09-00-00-cdx-2.jsonl"),
+			jsonl([
+				{
+					timestamp: "2026-02-01T09:00:00.000Z",
+					type: "session_meta",
+					payload: { id: "cdx-2", cwd: "/workspace/api" },
+				},
+				{
+					timestamp: "2026-02-01T09:00:01.000Z",
+					type: "event_msg",
+					payload: { type: "user_message", message: "list the routes" },
+				},
+				{
+					timestamp: "2026-02-01T09:00:02.000Z",
+					type: "response_item",
+					payload: {
+						type: "custom_tool_call",
+						name: "exec",
+						call_id: "call_blocks",
+						input: 'const r = await tools.exec_command({"cmd":"ls"});',
+					},
+				},
+				{
+					timestamp: "2026-02-01T09:00:03.000Z",
+					type: "response_item",
+					payload: {
+						type: "custom_tool_call_output",
+						call_id: "call_blocks",
+						output: [
+							{ type: "input_text", text: "Script completed\nOutput:\n" },
+							{ type: "input_text", text: "health.ts\nusers.ts\n" },
+						],
+					},
+				},
+				{
+					timestamp: "2026-02-01T09:00:04.000Z",
+					type: "response_item",
+					payload: {
+						type: "message",
+						role: "assistant",
+						content: [{ type: "output_text", text: "Two routes." }],
+					},
+				},
+			]),
+		);
+		const adapter = new CodexImportAdapter({ codexHome });
+		const converted = adapter.convert("cdx-2");
+		const toolResult = (
+			converted.messages[2].content as unknown as Array<Record<string, unknown>>
+		)[0];
+		expect(toolResult.type).toBe("tool_result");
+		expect(toolResult.content).toBe(
+			"Script completed\nOutput:\nhealth.ts\nusers.ts\n",
+		);
+		expect(JSON.stringify(converted.messages)).not.toContain("input_text");
+	});
+
 	it("dedupes resumed rollouts sharing one session id, keeping the richer file", () => {
 		const codexHome = tempDir("codex-import-");
 		writeCodexFixture(codexHome);

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -943,6 +943,70 @@ describe("SessionImportService", () => {
 		expect(store.list(50)).toHaveLength(1);
 	});
 
+	it("rolls back a session whose creation fails after the row is written", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const store = new SqliteSessionStore({ sessionsDir: tempDir("cline-db-") });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: tempDir("cline-sessions-"),
+		});
+		// createRootSessionWithArtifacts upserts the row, then writes the
+		// messages file and manifest; simulate the file write failing.
+		const original = sessions.createRootSessionWithArtifacts.bind(sessions);
+		let failNext = true;
+		sessions.createRootSessionWithArtifacts = async (input) => {
+			const created = await original(input);
+			if (failNext) {
+				failNext = false;
+				throw new Error("manifest write failed");
+			}
+			return created;
+		};
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const [failed] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(failed.ok).toBe(false);
+		expect(failed.error).toContain("manifest write failed");
+		expect(store.list(50)).toHaveLength(0);
+
+		const [retried] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(retried.ok).toBe(true);
+		expect(store.list(50)).toHaveLength(1);
+	});
+
+	it("coalesces overlapping imports of the same source into one session", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const store = new SqliteSessionStore({ sessionsDir: tempDir("cline-db-") });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: tempDir("cline-sessions-"),
+		});
+		// Two separate services, as two import_sessions requests would build,
+		// each snapshotting an empty set of existing imports.
+		const makeImporter = () =>
+			new SessionImportService(sessions, [
+				new ClaudeCodeImportAdapter({ projectsDir }),
+			]);
+		const request = [{ tool: "claude-code" as const, sourceId: "abc" }];
+		const [[first], [second]] = await Promise.all([
+			makeImporter().importMany(request),
+			makeImporter().importMany(request),
+		]);
+		expect(first.ok).toBe(true);
+		expect(second.ok).toBe(true);
+		expect(first.sessionId).toBe(second.sessionId);
+		expect([first.alreadyImported, second.alreadyImported]).toContain(true);
+		expect(store.list(50)).toHaveLength(1);
+	});
+
 	it("never marks a session as imported unless every write succeeded", async () => {
 		const projectsDir = tempDir("cc-import-");
 		writeClaudeCodeFixture(projectsDir);

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -39,6 +39,11 @@ function jsonl(lines: unknown[]): string {
 	return `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`;
 }
 
+/** Message content as loosely-typed blocks for assertions on raw fields. */
+function blocks(message: { content: unknown }): Array<Record<string, unknown>> {
+	return message.content as Array<Record<string, unknown>>;
+}
+
 // ---------------------------------------------------------------------------
 // Claude Code fixtures
 // ---------------------------------------------------------------------------
@@ -382,10 +387,7 @@ describe("CodexImportAdapter", () => {
 		);
 		expect(types).toEqual(["thinking", "tool_use"]);
 
-		const toolResultMsg = converted.messages[2];
-		const toolResult = (
-			toolResultMsg.content as Array<Record<string, unknown>>
-		)[0];
+		const toolResult = blocks(converted.messages[2])[0];
 		expect(toolResult.type).toBe("tool_result");
 		expect(toolResult.tool_use_id).toBe("call_1");
 		expect(toolResult.name).toBe("exec_command");
@@ -603,9 +605,7 @@ describe("OpencodeImportAdapter", () => {
 			"thinking",
 			"tool_use",
 		]);
-		const toolResult = (
-			converted.messages[2].content as Array<Record<string, unknown>>
-		)[0];
+		const toolResult = blocks(converted.messages[2])[0];
 		expect(toolResult.tool_use_id).toBe("call_a");
 		expect(toolResult.content).toBe("edited");
 
@@ -650,7 +650,7 @@ describe("sanitizeImportedMessages", () => {
 			"assistant",
 			"user",
 		]);
-		const repair = sanitized[2].content as Array<Record<string, unknown>>;
+		const repair = blocks(sanitized[2]);
 		expect(repair[0].type).toBe("tool_result");
 		expect(repair[0].tool_use_id).toBe("t1");
 		expect(repair[0].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
@@ -694,14 +694,14 @@ describe("sanitizeImportedMessages", () => {
 			"user",
 			"assistant",
 		]);
-		const consolidated = sanitized[2].content as Array<Record<string, unknown>>;
+		const consolidated = blocks(sanitized[2]);
 		expect(consolidated.map((block) => block.tool_use_id)).toEqual([
 			"a",
 			"b",
 			"c",
 		]);
 		expect(consolidated[2].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
-		const leftovers = sanitized[3].content as Array<Record<string, unknown>>;
+		const leftovers = blocks(sanitized[3]);
 		expect(leftovers).toEqual([{ type: "text", text: "also do this next" }]);
 	});
 });

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -365,7 +365,7 @@ describe("CodexImportAdapter", () => {
 		expect(discovered[0].cwd).toBe("/workspace/api");
 
 		const converted = adapter.convert("cdx-1");
-		expect(converted.provider).toBe("openai");
+		expect(converted.provider).toBe("openai-native");
 		expect(converted.model).toBe("gpt-5.5");
 		expect(converted.gitBranch).toBe("feat/x");
 
@@ -657,6 +657,53 @@ describe("sanitizeImportedMessages", () => {
 		expect(JSON.stringify(sanitized)).not.toContain("ghost");
 		expect(JSON.stringify(sanitized)).not.toContain("gemini-sig");
 	});
+
+	it("consolidates a turn's tool_results into the message right after the tool_use", () => {
+		const sanitized = sanitizeImportedMessages([
+			{ role: "user", content: "run both" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "tool_use", id: "a", name: "bash", input: {} },
+					{ type: "tool_use", id: "b", name: "bash", input: {} },
+					{ type: "tool_use", id: "c", name: "bash", input: {} },
+				],
+			},
+			// Results split across messages, out of order, one missing (c),
+			// plus a real follow-up prompt mixed into the span.
+			{
+				role: "user",
+				content: [
+					{ type: "tool_result", tool_use_id: "b", name: "bash", content: "B" },
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{ type: "tool_result", tool_use_id: "a", name: "bash", content: "A" },
+					{ type: "text", text: "also do this next" },
+				],
+			},
+			{ role: "assistant", content: "ok" },
+		]);
+
+		expect(sanitized.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"user",
+			"assistant",
+		]);
+		const consolidated = sanitized[2].content as Array<Record<string, unknown>>;
+		expect(consolidated.map((block) => block.tool_use_id)).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+		expect(consolidated[2].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
+		const leftovers = sanitized[3].content as Array<Record<string, unknown>>;
+		expect(leftovers).toEqual([{ type: "text", text: "also do this next" }]);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -729,5 +776,54 @@ describe("SessionImportService", () => {
 		// Re-discovery flags the import instead of duplicating it.
 		const rediscovered = await importer.discover();
 		expect(rediscovered[0].alreadyImportedSessionId).toBe(sessionId);
+	});
+
+	it("stamps the resume provider/model on the row and keeps the source in metadata", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const dbDir = tempDir("cline-db-");
+		const artifactsDir = tempDir("cline-sessions-");
+		const store = new SqliteSessionStore({ sessionsDir: dbDir });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: artifactsDir,
+		});
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const [result] = await importer.importMany(
+			[{ tool: "claude-code", sourceId: "abc" }],
+			undefined,
+			{ provider: "cline", model: "anthropic/claude-sonnet-5" },
+		);
+		expect(result.ok).toBe(true);
+		const row = store.get(result.sessionId as string);
+		// Opening the session resumes on the row's provider/model.
+		expect(row?.provider).toBe("cline");
+		expect(row?.model).toBe("anthropic/claude-sonnet-5");
+		const importedFrom = (
+			row?.metadata as Record<string, Record<string, unknown>>
+		)?.importedFrom;
+		expect(importedFrom?.sourceProvider).toBe("anthropic");
+		expect(importedFrom?.sourceModel).toBe("claude-fable-5");
+		// Per-message model info still reflects what actually produced it.
+		const payload = JSON.parse(readFileSync(row?.messagesPath ?? "", "utf8"));
+		const assistant = payload.messages.find(
+			(message: { role: string }) => message.role === "assistant",
+		);
+		expect(assistant.modelInfo).toEqual({
+			id: "claude-fable-5",
+			provider: "anthropic",
+		});
+
+		// A half-specified target is ignored rather than mixing provider and
+		// model from different worlds.
+		const [partial] = await importer.importMany(
+			[{ tool: "claude-code", sourceId: "abc" }],
+			undefined,
+			{ provider: "cline" },
+		);
+		expect(store.get(partial.sessionId as string)?.provider).toBe("anthropic");
 	});
 });

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -818,12 +818,96 @@ describe("SessionImportService", () => {
 		});
 
 		// A half-specified target is ignored rather than mixing provider and
-		// model from different worlds.
-		const [partial] = await importer.importMany(
+		// model from different worlds. (Fresh store: the same source is never
+		// imported twice into one store.)
+		const partialStore = new SqliteSessionStore({
+			sessionsDir: tempDir("cline-db-"),
+		});
+		partialStore.init();
+		const partialImporter = new SessionImportService(
+			new CoreSessionService(partialStore, {
+				sessionArtifactsDir: tempDir("cline-sessions-"),
+			}),
+			[new ClaudeCodeImportAdapter({ projectsDir })],
+		);
+		const [partial] = await partialImporter.importMany(
 			[{ tool: "claude-code", sourceId: "abc" }],
 			undefined,
 			{ provider: "cline" },
 		);
-		expect(store.get(partial.sessionId as string)?.provider).toBe("anthropic");
+		expect(partialStore.get(partial.sessionId as string)?.provider).toBe(
+			"anthropic",
+		);
+	});
+
+	it("rolls back a half-written session when a later write fails", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const dbDir = tempDir("cline-db-");
+		const artifactsDir = tempDir("cline-sessions-");
+		const store = new SqliteSessionStore({ sessionsDir: dbDir });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: artifactsDir,
+		});
+		const original = sessions.persistSessionMessages.bind(sessions);
+		let failNext = true;
+		sessions.persistSessionMessages = async (...args) => {
+			if (failNext) {
+				failNext = false;
+				throw new Error("disk full");
+			}
+			return original(...args);
+		};
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const [failed] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(failed.ok).toBe(false);
+		expect(failed.error).toContain("disk full");
+		// Nothing persisted: no row, no importedFrom marker blocking a retry.
+		expect(store.list(50)).toHaveLength(0);
+		const rediscovered = await importer.discover();
+		expect(rediscovered[0].alreadyImportedSessionId).toBeUndefined();
+
+		// The retry succeeds normally.
+		const [retried] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(retried.ok).toBe(true);
+		expect(store.list(50)).toHaveLength(1);
+	});
+
+	it("never duplicates a source session that was already imported", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const dbDir = tempDir("cline-db-");
+		const artifactsDir = tempDir("cline-sessions-");
+		const store = new SqliteSessionStore({ sessionsDir: dbDir });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: artifactsDir,
+		});
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const [first] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		// Same request again — from a stale picker, a double click, whatever —
+		// resolves to the existing session instead of writing a second copy.
+		const [second, third] = await importer.importMany([
+			{ tool: "claude-code", sourceId: "abc" },
+			{ tool: "claude-code", sourceId: "abc" },
+		]);
+		expect(second.ok).toBe(true);
+		expect(second.alreadyImported).toBe(true);
+		expect(second.sessionId).toBe(first.sessionId);
+		expect(third.sessionId).toBe(first.sessionId);
+		expect(store.list(50)).toHaveLength(1);
 	});
 });

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -1,0 +1,733 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSqliteDb } from "@cline/shared/db";
+import { afterEach, describe, expect, it } from "vitest";
+import { CoreSessionService } from "../../session/services/session-service";
+import { SqliteSessionStore } from "../storage/sqlite-session-store";
+import { ClaudeCodeImportAdapter } from "./claude-code";
+import { CodexImportAdapter } from "./codex";
+import { OpencodeImportAdapter } from "./opencode";
+import {
+	IMPORT_MISSING_TOOL_RESULT_TEXT,
+	sanitizeImportedMessages,
+} from "./sanitize";
+import { SessionImportService } from "./service";
+
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function jsonl(lines: unknown[]): string {
+	return `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code fixtures
+// ---------------------------------------------------------------------------
+
+function writeClaudeCodeFixture(projectsDir: string): string {
+	const dir = join(projectsDir, "-workspace-demo");
+	mkdirSync(dir, { recursive: true });
+	const base = {
+		cwd: "/workspace/demo",
+		gitBranch: "main",
+		isSidechain: false,
+		sessionId: "abc",
+		version: "2.0.0",
+	};
+	const lines = [
+		{ type: "mode", mode: "normal", sessionId: "abc" },
+		{
+			...base,
+			type: "user",
+			uuid: "u1",
+			parentUuid: null,
+			timestamp: "2026-01-02T10:00:00.000Z",
+			message: { role: "user", content: "fix the bug in parser.ts" },
+		},
+		{
+			...base,
+			type: "assistant",
+			uuid: "a1",
+			parentUuid: "u1",
+			timestamp: "2026-01-02T10:00:05.000Z",
+			message: {
+				id: "msg_1",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [
+					{ type: "thinking", thinking: "let me look", signature: "sig-abc" },
+					{ type: "text", text: "Looking at the parser now." },
+				],
+				usage: { input_tokens: 100, output_tokens: 20 },
+			},
+		},
+		// Same API turn continues on a second line sharing message.id.
+		{
+			...base,
+			type: "assistant",
+			uuid: "a2",
+			parentUuid: "a1",
+			timestamp: "2026-01-02T10:00:06.000Z",
+			message: {
+				id: "msg_1",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [
+					{
+						type: "tool_use",
+						id: "toolu_1",
+						name: "Read",
+						input: { file_path: "/workspace/demo/parser.ts" },
+						caller: { type: "direct" },
+					},
+				],
+				usage: { input_tokens: 100, output_tokens: 30 },
+			},
+		},
+		{
+			...base,
+			type: "user",
+			uuid: "u2",
+			parentUuid: "a2",
+			timestamp: "2026-01-02T10:00:07.000Z",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_1",
+						content: "export function parse() {}",
+					},
+				],
+			},
+		},
+		// Sidechain (subagent) traffic must be ignored.
+		{
+			...base,
+			isSidechain: true,
+			type: "user",
+			uuid: "s1",
+			parentUuid: null,
+			message: { role: "user", content: "sidechain prompt" },
+		},
+		// Abandoned branch: an earlier retry off a1 that nothing continues.
+		{
+			...base,
+			type: "assistant",
+			uuid: "dead1",
+			parentUuid: "u1",
+			timestamp: "2026-01-02T10:00:04.000Z",
+			message: {
+				id: "msg_dead",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [{ type: "text", text: "abandoned branch answer" }],
+			},
+		},
+		// Meta/command lines must not become conversation.
+		{
+			...base,
+			type: "user",
+			uuid: "m1",
+			parentUuid: "u2",
+			isMeta: true,
+			message: { role: "user", content: "<local-command-caveat>noise" },
+		},
+		{
+			...base,
+			type: "assistant",
+			uuid: "a3",
+			parentUuid: "m1",
+			timestamp: "2026-01-02T10:00:10.000Z",
+			message: {
+				id: "msg_2",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [{ type: "text", text: "Fixed. The parser now handles it." }],
+				usage: {
+					input_tokens: 200,
+					output_tokens: 40,
+					cache_read_input_tokens: 50,
+				},
+			},
+		},
+		{ type: "ai-title", aiTitle: "Fix parser bug", sessionId: "abc" },
+	];
+	writeFileSync(join(dir, "abc.jsonl"), jsonl(lines));
+	return dir;
+}
+
+describe("ClaudeCodeImportAdapter", () => {
+	it("discovers, walks the active branch, merges turns, and strips noise", () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const adapter = new ClaudeCodeImportAdapter({ projectsDir });
+
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].title).toBe("Fix parser bug");
+		expect(discovered[0].cwd).toBe("/workspace/demo");
+		expect(discovered[0].preview).toBe("fix the bug in parser.ts");
+
+		const converted = adapter.convert("abc");
+		expect(converted.provider).toBe("anthropic");
+		expect(converted.model).toBe("claude-fable-5");
+		expect(converted.gitBranch).toBe("main");
+
+		const roles = converted.messages.map((message) => message.role);
+		expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+
+		// Turn merge: thinking + text + tool_use in one assistant message.
+		const firstAssistant = converted.messages[1];
+		expect(Array.isArray(firstAssistant.content)).toBe(true);
+		const types = (firstAssistant.content as Array<{ type: string }>).map(
+			(block) => block.type,
+		);
+		expect(types).toEqual(["thinking", "text", "tool_use"]);
+		expect(firstAssistant.modelInfo).toEqual({
+			id: "claude-fable-5",
+			provider: "anthropic",
+		});
+		expect(firstAssistant.metrics?.inputTokens).toBe(100);
+
+		// The abandoned branch and sidechain never appear.
+		const allText = JSON.stringify(converted.messages);
+		expect(allText).not.toContain("abandoned branch answer");
+		expect(allText).not.toContain("sidechain prompt");
+		expect(allText).not.toContain("local-command-caveat");
+		// Thinking signatures are session-scoped; adapters drop them.
+		expect(allText).not.toContain("sig-abc");
+	});
+
+	it("skips slash-command-only sessions in discovery", () => {
+		const projectsDir = tempDir("cc-import-");
+		const dir = join(projectsDir, "-workspace-empty");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, "empty.jsonl"),
+			jsonl([
+				{
+					type: "user",
+					uuid: "u1",
+					parentUuid: null,
+					isSidechain: false,
+					message: {
+						role: "user",
+						content: "<command-name>/fast</command-name>",
+					},
+				},
+			]),
+		);
+		const adapter = new ClaudeCodeImportAdapter({ projectsDir });
+		expect(adapter.discover()).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Codex fixtures
+// ---------------------------------------------------------------------------
+
+function writeCodexFixture(codexHome: string): void {
+	const dayDir = join(codexHome, "sessions", "2026", "01", "05");
+	mkdirSync(dayDir, { recursive: true });
+	const lines = [
+		{
+			timestamp: "2026-01-05T09:00:00.000Z",
+			type: "session_meta",
+			payload: {
+				id: "cdx-1",
+				cwd: "/workspace/api",
+				model_provider: "openai",
+				git: { branch: "feat/x" },
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:00.100Z",
+			type: "turn_context",
+			payload: { model: "gpt-5.5", cwd: "/workspace/api" },
+		},
+		// Injected context arrives as a user response_item — never imported.
+		{
+			timestamp: "2026-01-05T09:00:00.200Z",
+			type: "response_item",
+			payload: {
+				type: "message",
+				role: "user",
+				content: [
+					{
+						type: "input_text",
+						text: "<user_instructions>be nice</user_instructions>",
+					},
+				],
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:01.000Z",
+			type: "event_msg",
+			payload: { type: "user_message", message: "add a healthcheck endpoint" },
+		},
+		{
+			timestamp: "2026-01-05T09:00:02.000Z",
+			type: "response_item",
+			payload: {
+				type: "reasoning",
+				summary: [{ type: "summary_text", text: "Need to add a route." }],
+				encrypted_content: "opaque",
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:03.000Z",
+			type: "response_item",
+			payload: {
+				type: "function_call",
+				name: "exec_command",
+				call_id: "call_1",
+				arguments: JSON.stringify({ cmd: "ls src/routes" }),
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:04.000Z",
+			type: "response_item",
+			payload: {
+				type: "function_call_output",
+				call_id: "call_1",
+				output: "health.ts\nusers.ts",
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:05.000Z",
+			type: "response_item",
+			payload: {
+				type: "message",
+				role: "assistant",
+				content: [{ type: "output_text", text: "Added the /health route." }],
+			},
+		},
+		{
+			timestamp: "2026-01-05T09:00:05.500Z",
+			type: "event_msg",
+			payload: {
+				type: "token_count",
+				info: {
+					last_token_usage: {
+						input_tokens: 900,
+						cached_input_tokens: 400,
+						output_tokens: 80,
+					},
+				},
+			},
+		},
+	];
+	writeFileSync(
+		join(dayDir, "rollout-2026-01-05T09-00-00-cdx-1.jsonl"),
+		jsonl(lines),
+	);
+	writeFileSync(
+		join(codexHome, "session_index.jsonl"),
+		jsonl([
+			{
+				id: "cdx-1",
+				thread_name: "healthcheck endpoint",
+				updated_at: "2026-01-05T09:10:00Z",
+			},
+		]),
+	);
+}
+
+describe("CodexImportAdapter", () => {
+	it("imports prompts from user_message events and pairs tool calls", () => {
+		const codexHome = tempDir("codex-import-");
+		writeCodexFixture(codexHome);
+		const adapter = new CodexImportAdapter({ codexHome });
+
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].title).toBe("healthcheck endpoint");
+		expect(discovered[0].cwd).toBe("/workspace/api");
+
+		const converted = adapter.convert("cdx-1");
+		expect(converted.provider).toBe("openai");
+		expect(converted.model).toBe("gpt-5.5");
+		expect(converted.gitBranch).toBe("feat/x");
+
+		const roles = converted.messages.map((message) => message.role);
+		expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+
+		const allText = JSON.stringify(converted.messages);
+		expect(allText).not.toContain("user_instructions");
+		expect(allText).not.toContain("opaque");
+
+		const firstAssistant = converted.messages[1];
+		const types = (firstAssistant.content as Array<{ type: string }>).map(
+			(block) => block.type,
+		);
+		expect(types).toEqual(["thinking", "tool_use"]);
+
+		const toolResultMsg = converted.messages[2];
+		const toolResult = (
+			toolResultMsg.content as Array<Record<string, unknown>>
+		)[0];
+		expect(toolResult.type).toBe("tool_result");
+		expect(toolResult.tool_use_id).toBe("call_1");
+		expect(toolResult.name).toBe("exec_command");
+
+		// token_count usage lands on the final assistant message.
+		const lastAssistant = converted.messages[3];
+		expect(lastAssistant.metrics).toEqual({
+			inputTokens: 900,
+			outputTokens: 80,
+			cacheReadTokens: 400,
+			cacheWriteTokens: 0,
+			cost: 0,
+		});
+	});
+
+	it("dedupes resumed rollouts sharing one session id, keeping the richer file", () => {
+		const codexHome = tempDir("codex-import-");
+		writeCodexFixture(codexHome);
+		// A resumed rollout for the same session with more conversation.
+		const dayDir = join(codexHome, "sessions", "2026", "01", "06");
+		mkdirSync(dayDir, { recursive: true });
+		writeFileSync(
+			join(dayDir, "rollout-2026-01-06T09-00-00-resume.jsonl"),
+			jsonl([
+				{
+					timestamp: "2026-01-06T09:00:00.000Z",
+					type: "session_meta",
+					payload: { id: "cdx-1", cwd: "/workspace/api" },
+				},
+				{
+					timestamp: "2026-01-06T09:00:01.000Z",
+					type: "event_msg",
+					payload: {
+						type: "user_message",
+						message: "add a healthcheck endpoint",
+					},
+				},
+				{
+					timestamp: "2026-01-06T09:00:02.000Z",
+					type: "event_msg",
+					payload: { type: "user_message", message: "now add tests for it" },
+				},
+				{
+					timestamp: "2026-01-06T09:00:03.000Z",
+					type: "response_item",
+					payload: {
+						type: "message",
+						role: "assistant",
+						content: [{ type: "output_text", text: "Tests added." }],
+					},
+				},
+			]),
+		);
+		const adapter = new CodexImportAdapter({ codexHome });
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].sourcePath).toContain("resume");
+
+		const converted = adapter.convert("cdx-1");
+		const text = JSON.stringify(converted.messages);
+		expect(text).toContain("now add tests for it");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// opencode fixtures
+// ---------------------------------------------------------------------------
+
+function writeOpencodeFixture(dataDir: string): void {
+	mkdirSync(dataDir, { recursive: true });
+	const db = loadSqliteDb(join(dataDir, "opencode.db"));
+	db.exec(`
+		CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT,
+			slug TEXT, directory TEXT, title TEXT, version TEXT,
+			time_created INTEGER, time_updated INTEGER);
+		CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT,
+			time_created INTEGER, time_updated INTEGER, data TEXT);
+		CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+			time_created INTEGER, time_updated INTEGER, data TEXT);
+	`);
+	const t0 = 1767600000000;
+	db.prepare(
+		`INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, time_created, time_updated)
+		 VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		"ses_1",
+		"prj",
+		"slug",
+		"/workspace/web",
+		"Refactor navbar",
+		"1.0",
+		t0,
+		t0 + 60000,
+	);
+	// Child (subagent) session must be ignored.
+	db.prepare(
+		`INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, time_created, time_updated)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		"ses_child",
+		"prj",
+		"ses_1",
+		"s",
+		"/workspace/web",
+		"child",
+		"1.0",
+		t0,
+		t0,
+	);
+
+	const insertMessage = db.prepare(
+		`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`,
+	);
+	const insertPart = db.prepare(
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`,
+	);
+	insertMessage.run(
+		"msg_1",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({ role: "user", time: { created: t0 } }),
+	);
+	insertPart.run(
+		"prt_1",
+		"msg_1",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({ type: "text", text: "make the navbar sticky" }),
+	);
+	insertPart.run(
+		"prt_2",
+		"msg_1",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({ type: "text", text: "AGENTS ctx", synthetic: true }),
+	);
+	insertMessage.run(
+		"msg_2",
+		"ses_1",
+		t0 + 1000,
+		t0 + 1000,
+		JSON.stringify({
+			role: "assistant",
+			providerID: "anthropic",
+			modelID: "claude-sonnet-5",
+			cost: 0.12,
+			tokens: { input: 500, output: 60, cache: { read: 100, write: 5 } },
+			time: { created: t0 + 1000 },
+		}),
+	);
+	insertPart.run(
+		"prt_3",
+		"msg_2",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({ type: "reasoning", text: "css change" }),
+	);
+	insertPart.run(
+		"prt_4",
+		"msg_2",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({
+			type: "tool",
+			tool: "edit",
+			callID: "call_a",
+			state: {
+				status: "completed",
+				input: { filePath: "nav.css" },
+				output: "edited",
+			},
+		}),
+	);
+	insertPart.run(
+		"prt_5",
+		"msg_2",
+		"ses_1",
+		t0,
+		t0,
+		JSON.stringify({ type: "text", text: "Done — navbar is sticky." }),
+	);
+	db.close?.();
+}
+
+describe("OpencodeImportAdapter", () => {
+	it("splits inline tool parts into tool_use/tool_result and skips children", () => {
+		const dataDir = tempDir("oc-import-");
+		writeOpencodeFixture(dataDir);
+		const adapter = new OpencodeImportAdapter({ dataDir });
+
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].sourceId).toBe("ses_1");
+		expect(discovered[0].title).toBe("Refactor navbar");
+
+		const converted = adapter.convert("ses_1");
+		expect(converted.provider).toBe("anthropic");
+		expect(converted.model).toBe("claude-sonnet-5");
+
+		const roles = converted.messages.map((message) => message.role);
+		expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+
+		const allText = JSON.stringify(converted.messages);
+		expect(allText).not.toContain("AGENTS ctx");
+
+		const firstAssistant = converted.messages[1].content as Array<{
+			type: string;
+		}>;
+		expect(firstAssistant.map((block) => block.type)).toEqual([
+			"thinking",
+			"tool_use",
+		]);
+		const toolResult = (
+			converted.messages[2].content as Array<Record<string, unknown>>
+		)[0];
+		expect(toolResult.tool_use_id).toBe("call_a");
+		expect(toolResult.content).toBe("edited");
+
+		const lastAssistant = converted.messages[3];
+		expect(lastAssistant.metrics).toEqual({
+			inputTokens: 500,
+			outputTokens: 60,
+			cacheReadTokens: 100,
+			cacheWriteTokens: 5,
+			cost: 0.12,
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sanitizer
+// ---------------------------------------------------------------------------
+
+describe("sanitizeImportedMessages", () => {
+	it("repairs orphaned tool_use, drops orphaned tool_result and empty text", () => {
+		const sanitized = sanitizeImportedMessages([
+			{ role: "user", content: [{ type: "text", text: "   " }] },
+			{ role: "user", content: "do the thing" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "on it", signature: "gemini-sig" },
+					{ type: "tool_use", id: "t1", name: "bash", input: {} },
+				],
+			},
+			// No tool_result for t1; and an orphan result for a nonexistent id.
+			{
+				role: "user",
+				content: [
+					{ type: "tool_result", tool_use_id: "ghost", name: "", content: "x" },
+				],
+			},
+		]);
+
+		expect(sanitized.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+		]);
+		const repair = sanitized[2].content as Array<Record<string, unknown>>;
+		expect(repair[0].type).toBe("tool_result");
+		expect(repair[0].tool_use_id).toBe("t1");
+		expect(repair[0].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
+		expect(JSON.stringify(sanitized)).not.toContain("ghost");
+		expect(JSON.stringify(sanitized)).not.toContain("gemini-sig");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: service writes listable, gate-passing sessions
+// ---------------------------------------------------------------------------
+
+describe("SessionImportService", () => {
+	it("imports a discovered session into a listable completed Cline session", async () => {
+		const projectsDir = tempDir("cc-import-");
+		writeClaudeCodeFixture(projectsDir);
+		const dbDir = tempDir("cline-db-");
+		const artifactsDir = tempDir("cline-sessions-");
+
+		const store = new SqliteSessionStore({ sessionsDir: dbDir });
+		store.init();
+		const sessions = new CoreSessionService(store, {
+			sessionArtifactsDir: artifactsDir,
+		});
+		const importer = new SessionImportService(sessions, [
+			new ClaudeCodeImportAdapter({ projectsDir }),
+		]);
+
+		const discovered = await importer.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].alreadyImportedSessionId).toBeUndefined();
+
+		const [result] = await importer.importMany([
+			{ tool: "claude-code", sourceId: discovered[0].sourceId },
+		]);
+		expect(result.ok).toBe(true);
+		const sessionId = result.sessionId as string;
+		// Chronology: id epoch prefix comes from the source session start.
+		expect(sessionId.startsWith(String(discovered[0].startedAtMs))).toBe(true);
+
+		// Row passes every history-visibility gate.
+		const row = store.get(sessionId);
+		expect(row?.status).toBe("completed");
+		expect(row?.exitCode).toBe(0);
+		expect(row?.provider).toBe("anthropic");
+		expect(row?.model).toBe("claude-fable-5");
+		expect(row?.isSubagent).toBe(false);
+		expect(row?.cwd).toBe("/workspace/demo");
+		expect((row?.metadata as Record<string, unknown>)?.title).toBe(
+			"Fix parser bug",
+		);
+		const importedFrom = (
+			row?.metadata as Record<string, Record<string, unknown>>
+		)?.importedFrom;
+		expect(importedFrom?.tool).toBe("claude-code");
+		expect(importedFrom?.sourceSessionId).toBe("abc");
+		// No fabricated checkpoint refs.
+		expect(
+			(row?.metadata as Record<string, unknown>)?.checkpoint,
+		).toBeUndefined();
+
+		// Messages artifact is a valid v1 payload with ≥1 message.
+		const payload = JSON.parse(readFileSync(row?.messagesPath ?? "", "utf8"));
+		expect(payload.version).toBe(1);
+		expect(payload.messages.length).toBeGreaterThan(0);
+		for (const message of payload.messages) {
+			expect(typeof message.id).toBe("string");
+		}
+
+		// Manifest carries terminal status and source-era timestamps.
+		const manifest = sessions.readSessionManifest(sessionId);
+		expect(manifest?.status).toBe("completed");
+		expect(manifest?.ended_at).toBe("2026-01-02T10:00:10.000Z");
+		expect(manifest?.metadata?.title).toBe("Fix parser bug");
+
+		// Re-discovery flags the import instead of duplicating it.
+		const rediscovered = await importer.discover();
+		expect(rediscovered[0].alreadyImportedSessionId).toBe(sessionId);
+	});
+});

--- a/sdk/packages/core/src/services/session-import/types.ts
+++ b/sdk/packages/core/src/services/session-import/types.ts
@@ -1,0 +1,90 @@
+import type * as LlmsProviders from "@cline/llms";
+
+/** External tools whose session history Cline can import. */
+export const SESSION_IMPORT_TOOLS = [
+	"claude-code",
+	"codex",
+	"opencode",
+] as const;
+
+export type SessionImportTool = (typeof SESSION_IMPORT_TOOLS)[number];
+
+export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
+	"claude-code": "Claude Code",
+	codex: "Codex",
+	opencode: "opencode",
+};
+
+/**
+ * A session found in an external tool's on-disk store, described with just
+ * enough metadata to render an import picker. Discovery must stay cheap; the
+ * full conversation is only parsed when the session is actually imported.
+ */
+export interface ImportableSessionSummary {
+	tool: SessionImportTool;
+	/** Stable identifier within the source tool's store. */
+	sourceId: string;
+	/** File (or database) the session was discovered in. */
+	sourcePath: string;
+	title: string;
+	/** Original working directory, when the source recorded one. */
+	cwd: string;
+	startedAtMs: number;
+	updatedAtMs: number;
+	/** Conversational user/assistant events (not raw store lines). */
+	messageCount: number;
+	/** First real user prompt, trimmed for display. */
+	preview?: string;
+	/** Set when a prior import of this source session already exists. */
+	alreadyImportedSessionId?: string;
+}
+
+/** A source session fully translated to Cline's native message format. */
+export interface ConvertedImportedSession {
+	tool: SessionImportTool;
+	sourceId: string;
+	sourcePath: string;
+	title: string;
+	/** First real user prompt (used for the session's prompt field). */
+	prompt?: string;
+	provider: string;
+	model: string;
+	cwd: string;
+	gitBranch?: string;
+	startedAtMs: number;
+	endedAtMs: number;
+	messages: LlmsProviders.MessageWithMetadata[];
+}
+
+export interface SessionImportAdapter {
+	readonly tool: SessionImportTool;
+	/** Whether the tool's session store exists on this machine. */
+	isInstalled(): boolean;
+	discover(): ImportableSessionSummary[];
+	/** Throws if the source session cannot be found or parsed. */
+	convert(sourceId: string): ConvertedImportedSession;
+}
+
+export interface SessionImportRequest {
+	tool: SessionImportTool;
+	sourceId: string;
+}
+
+export interface SessionImportResult {
+	tool: SessionImportTool;
+	sourceId: string;
+	ok: boolean;
+	/** Cline session id created for this import (on success). */
+	sessionId?: string;
+	title?: string;
+	error?: string;
+}
+
+export function truncateForDisplay(
+	value: string | undefined,
+	max = 200,
+): string | undefined {
+	const trimmed = value?.replace(/\s+/g, " ").trim();
+	if (!trimmed) return undefined;
+	return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}

--- a/sdk/packages/core/src/services/session-import/types.ts
+++ b/sdk/packages/core/src/services/session-import/types.ts
@@ -63,11 +63,30 @@ export interface SessionImportAdapter {
 	discover(): ImportableSessionSummary[];
 	/** Throws if the source session cannot be found or parsed. */
 	convert(sourceId: string): ConvertedImportedSession;
+	/**
+	 * Releases per-batch caches (file indexes, database snapshots). Called by
+	 * the service after each discover/import batch; adapters stay usable after.
+	 */
+	dispose?(): void;
 }
 
 export interface SessionImportRequest {
 	tool: SessionImportTool;
 	sourceId: string;
+}
+
+export interface SessionImportOptions {
+	/**
+	 * Cline provider/model the imported sessions should resume with. Opening a
+	 * history session adopts the row's provider/model, so without this the
+	 * session would try to run on the source tool's provider (openai-native,
+	 * or an opencode provider id Cline doesn't know) which the user may never
+	 * have configured. Both must be set to take effect; the source tool's own
+	 * provider/model are always preserved in metadata.importedFrom and in
+	 * per-message modelInfo.
+	 */
+	provider?: string;
+	model?: string;
 }
 
 export interface SessionImportResult {

--- a/sdk/packages/core/src/services/session-import/types.ts
+++ b/sdk/packages/core/src/services/session-import/types.ts
@@ -97,6 +97,9 @@ export interface SessionImportResult {
 	sessionId?: string;
 	title?: string;
 	error?: string;
+	/** Set when the source session had already been imported; sessionId is
+	 * the existing Cline session and nothing new was written. */
+	alreadyImported?: boolean;
 }
 
 export function truncateForDisplay(

--- a/sdk/packages/core/src/session/models/session-row.ts
+++ b/sdk/packages/core/src/session/models/session-row.ts
@@ -72,6 +72,16 @@ export interface CreateRootSessionWithArtifactsInput {
 	prompt?: string;
 	metadata?: Record<string, unknown>;
 	startedAt?: string;
+	/**
+	 * Create the session already in a terminal state (defaults to "running").
+	 * Sessions that are pure history from birth — imports — use this so they
+	 * never pass through a transient running/pid-0 state that the
+	 * stale-session reconciler (in any process sharing the DB) could flip to
+	 * failed before the creator finishes writing.
+	 */
+	status?: SessionStatus;
+	endedAt?: string;
+	exitCode?: number;
 }
 
 export interface RootSessionArtifacts {

--- a/sdk/packages/core/src/session/services/persistence-service.ts
+++ b/sdk/packages/core/src/session/services/persistence-service.ts
@@ -531,6 +531,24 @@ export class UnifiedSessionPersistenceService {
 		});
 	}
 
+	/**
+	 * Lightweight, effectively unbounded listing of session ids + metadata
+	 * (no manifest reads, no dead-session reconciliation). listSessions caps
+	 * its scan at 2000 rows; callers that must see every row — e.g. import
+	 * dedup markers — use this instead.
+	 */
+	async listSessionMetadata(
+		limit = 100_000,
+	): Promise<Array<{ sessionId: string; metadata?: Record<string, unknown> }>> {
+		const rows = await this.adapter.listSessions({
+			limit: Math.max(1, Math.floor(limit)),
+		});
+		return rows.map((row) => ({
+			sessionId: row.sessionId,
+			metadata: sanitizeMetadata(row.metadata ?? undefined),
+		}));
+	}
+
 	async reconcileDeadSessions(limit = 2000): Promise<number> {
 		const requestedLimit = Math.max(1, Math.floor(limit));
 		const rows = (

--- a/sdk/packages/core/src/session/services/persistence-service.ts
+++ b/sdk/packages/core/src/session/services/persistence-service.ts
@@ -120,13 +120,19 @@ export class UnifiedSessionPersistenceService {
 			}),
 			prompt: input.prompt,
 		});
+		const status: SessionStatus = input.status ?? "running";
+		const terminal = !isNonTerminalSessionStatus(status);
+		const endedAt = terminal ? (input.endedAt ?? nowIso()) : undefined;
+		const exitCode = terminal ? (input.exitCode ?? 0) : undefined;
 		const manifest = {
 			version: 1 as const,
 			session_id: sessionId,
 			source: input.source,
 			pid: input.pid,
 			started_at: startedAt,
-			status: "running" as const,
+			...(endedAt ? { ended_at: endedAt } : {}),
+			...(exitCode !== undefined ? { exit_code: exitCode } : {}),
+			status,
 			interactive: input.interactive,
 			provider: input.provider,
 			model: input.model,
@@ -146,9 +152,9 @@ export class UnifiedSessionPersistenceService {
 			source: input.source,
 			pid: input.pid,
 			startedAt,
-			endedAt: null,
-			exitCode: null,
-			status: "running",
+			endedAt: endedAt ?? null,
+			exitCode: exitCode ?? null,
+			status,
 			statusLock: 0,
 			interactive: input.interactive,
 			provider: input.provider,
@@ -538,7 +544,7 @@ export class UnifiedSessionPersistenceService {
 	 * dedup markers — use this instead.
 	 */
 	async listSessionMetadata(
-		limit = 100_000,
+		limit = Number.MAX_SAFE_INTEGER,
 	): Promise<Array<{ sessionId: string; metadata?: Record<string, unknown> }>> {
 		const rows = await this.adapter.listSessions({
 			limit: Math.max(1, Math.floor(limit)),


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — internal feature (importing session history from other coding agents into the desktop app).

### Description

Lets people switching to Cline bring their conversation history with them: the desktop app scans the machine for local session stores from **Claude Code**, **Codex**, and **opencode**, shows a picker with real titles/timestamps/workspaces, and translates each conversation into a native Cline session that lists, renders, and resumes like one of ours. Reachable from the Sessions page header, Settings → General, and as an onboarding step that only appears when there's actually history to import.

#### Why this was cheap: no new intermediate format

Cline's at-rest transcript (`<id>.messages.json`) is Anthropic-native — `user`/`assistant` messages with `text`/`thinking`/`tool_use`/`tool_result` blocks. Claude Code's session files are *already exactly that shape*, and Codex/opencode both collapse onto the same four block types. So the "IR" is just `MessageWithMetadata[]`, and the writer is the existing `CoreSessionService` path (`createRootSessionWithArtifacts` → `persistSessionMessages` → status flip) — no hand-written DB rows or manifests. Prior art: the legacy VS Code migration's `legacyApiHistoryToSdkMessages` does the same kind of conversion.

#### Architecture

- **`@cline/core`** — `src/services/session-import/`: `SessionImportService` (discover + import + idempotency) with one adapter per tool behind a common interface, plus a sanitizer that guarantees replayability.
- **Sidecar** — two commands: `list_importable_sessions` → `{ installedTools, sessions }`, and `import_sessions { selections }` which imports sequentially (per-session transactional — one bad file fails one item) and broadcasts `session_import_progress` events.
- **Webview** — `ImportSessionsDialog` (scan → grouped picker → live progress → summary), entry points in Sessions header + Settings → General, an onboarding step, and a `session_import_progress` subscription in `use-session-history` so history refreshes regardless of which surface started the import. Wire types are mirrored in `webview/lib/session-import.ts` so the client bundle never imports node-only core code.

#### Format landmines (all discovered against real stores, not docs)

These are the things that would have silently produced broken imports:

- **Claude Code** (`~/.claude/projects/<flattened-cwd>/<uuid>.jsonl`): the log is a **tree**, not a list — message edits/retries branch via `parentUuid`, so the adapter walks the parent chain back from the newest leaf. Crucially the chain passes through non-conversation lines (`attachment`, `system`, meta), so every uuid-bearing line participates in the walk (a naive user/assistant-only walk collapsed a 123-message session to 1). One API turn streams across several assistant lines sharing `message.id` and gets merged back into one message. Sidechains (subagents), meta lines, slash-command wrappers (`<command-name>`, `<local-command-stdout>`, …) are excluded; titles come from `ai-title` lines; `<synthetic>` model = local error notice, not API output.
- **Codex** (`~/.codex/sessions/**/rollout-*.jsonl`): real user prompts live in `user_message` **event_msg** lines — the user-role `response_item`s are injected AGENTS.md/environment context you do *not* want in history (there's a fallback for old rollouts without user_message events). `function_call`/`function_call_output` pair by `call_id` (`arguments` is a JSON *string*). **Resuming a thread writes a new rollout file re-embedding the original session id**, so one logical session spans several files — discovery dedupes to the file with the most conversation. `token_count` events arrive while the assistant turn is still accumulating, so metrics stamp at flush time. Titles come free from `~/.codex/session_index.jsonl`.
- **opencode** (`~/.local/share/opencode/opencode.db`): live WAL sqlite — the adapter snapshots db+wal+shm to a temp dir and reads the copy, never touching the live handle. Inline `tool` parts carry both call and result and are split into `tool_use` + a following `tool_result` user message to preserve the structure providers expect. `synthetic: true` parts (injected context) and child (subagent) sessions are skipped. Assistant rows carry `providerID/modelID/tokens/cost` verbatim → `modelInfo`/`metrics`.

#### Replay correctness (imports must survive being sent to a provider)

"Continue this conversation in Cline" replays the history, so every import runs through a sanitizer:
- every `tool_use` gets a matching `tool_result` (orphans get a `[import] Tool result was not captured…` placeholder — providers hard-400 otherwise);
- orphaned `tool_result`s and empty text blocks drop (the empty-block class of bug is what caused the Vercel all-empty-message 400s, #13204);
- thinking signatures / encrypted reasoning strip — they only validate against the original provider session.

Foreign tool *names* (`Bash`, `exec_command`, …) are kept as-is: they're history, not callable tools, and the transcript renderer's `classifyTool` already fuzzy-matches them onto sensible icons with an `"other"` fallback.

#### History-visibility gates (how an imported session avoids being filtered or deleted)

Synthesized sessions must satisfy gates scattered across discovery and the webview, all handled by the writer: a `sessions.db` row must exist (discovery `rm -rf`s session dirs without one!); session id keeps the `${epochMs}_${nanoid5}` shape using the **source** start time so history sorts chronologically, and never contains `__`; provider/model non-empty and not `"unknown"`; empty cwd falls back to the shared chat workspace; terminal status from birth (`completed`/`ended_at`/`exit_code 0` — non-terminal rows with pid 0 get reconciled to `failed`); ≥1 message; explicit `metadata.title`; and **no** `metadata.checkpoint` (fabricated checkpoint refs would surface restore buttons pointing at git refs that don't exist).

Two non-obvious writer details: `resolveMetadataWithTitle` stomps `metadata.title` with a prompt-derived title during creation, so the source tool's title is restored via `updateSession({title})` afterwards; and `updateSessionStatus` doesn't touch the manifest, so the manifest is rewritten with terminal status + source-era `ended_at`.

Idempotency rides on `metadata.importedFrom = { tool, sourceSessionId, sourcePath, importedAt }` — re-scans badge already-imported sessions (disabled rows) instead of duplicating them.

#### UX notes

- Dialog: sessions grouped per tool with collapsible sections (collapsed headers keep count + selected count; filtering forces sections open so matches can't hide), global Select All with indeterminate state operating on the visible/filtered set, text filter over title/folder/first-prompt, live progress bar fed by the broadcast events, per-failure error messages in the summary, and overlay-click dismissal blocked mid-import.
- Onboarding: the import step scans once on entry and **silently auto-advances** when there's nothing (new) to import or the scan fails — only people with actual history ever see it. After a successful import, "Start building" completes onboarding directly; skip/nothing-found paths still get the "You're all set" screen.

#### Debugging journey / gotchas worth remembering

- **`e.trim is not a function` crash**: `formatRelativeTime()` takes a string (`parseTimestamp` calls `.trim()`), and the dialog passed numeric `updatedAtMs`. It shipped because **the webview is never typechecked**: `tsconfig.dev.json` excludes `webview/`, and `next.config.mjs` sets `typescript.ignoreBuildErrors: true` (the webview's own tsconfig currently has ~64 pre-existing errors, presumably why). Burning those down and re-enabling enforcement would be a worthwhile follow-up PR.
- **Header/search clipped by the dialog**: the dialog grid's default auto column track sizes to *min-content*, and `break-words` affects layout but not intrinsic sizing — so one unbreakable URL in a Codex title made the column wider than the fixed 620px dialog and `overflow-hidden` clipped the header/search. Fixed with `grid-cols-[minmax(0,1fr)]`. Bonus find: the primitive's `sm:max-w-lg` survives tailwind-merge across variants and was silently capping the dialog at 512px.
- **Onboarding looped to the done screen after importing**: the scan effect depended on an inline callback recreated every parent render — and importing itself re-renders the shell via the history refresh — so the step re-scanned after import, found zero remaining (Select All), and hit the nothing-to-import auto-advance. Scan now runs exactly once per step entry.
- Codex fan-out/duplicate session ids also show up when the same prompt is run multiple times (benchmark-style), not just resume — the richest-file dedupe handles both.

### Test Procedure

- **Unit tests** (`sdk/packages/core/src/services/session-import/session-import.test.ts`, 7 tests): synthetic fixtures per tool covering the branched Claude Code DAG walk + turn merge + sidechain/meta exclusion, Codex injected-context filtering + tool pairing + resumed-rollout dedupe + token_count stamping, opencode tool-part splitting + child-session/synthetic filtering, sanitizer repair (orphaned tool_use → placeholder, orphaned results/empty text dropped, signatures stripped), and an end-to-end service test asserting every visibility gate on the written row/manifest/messages plus re-discovery badging.
- **Bulk validation against real stores** (this machine has real Claude Code, Codex, and opencode histories): imported a 43-session sample spread across sizes and all three tools into an isolated `CLINE_DATA_DIR` — 43/43 imported with all invariants passing (tool pairing, no empty blocks, no leaked signatures, ids present, modelInfo/metrics stamped), re-discovery marked exactly 43 as already imported.
- **Live e2e over the real WebSocket transport**: scan (~1,300 sessions after dedupe) → import → session appears in `list_discovered_sessions` (the exact feed the history UI renders) → `read_session_messages` parses → re-scan badges it.
- **Manual browser testing** of the dialog (both entry points), the onboarding step via Settings → Replay (which is how the rescan-loop bug was found), and resumed an imported session end-to-end.
- CI-equivalent checks locally: core `tsc` build clean, `vitest` suite green, biome clean, `next build` green, plus a manual `tsc` pass over the webview confirming the new files add zero errors.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Tested in browser dev mode inside a sandbox (no screenshot tooling available there); the import dialog and onboarding step are quick to see live: Sessions → Import, and Settings → General → New user experience → Replay.

### Additional Notes

- Follow-ups deliberately left out of this PR: CLI `cline history import` (near-free on top of the core service), tool-name aliasing so imported transcripts get Cline's rich tool cards instead of generic ones, opencode legacy file-store support (pre-sqlite versions), import telemetry counts, and the webview typecheck cleanup mentioned above.
- Related internal work: cline/internal-examples#18 adds agent *skills* with Python parsers for the same three formats (search/export, not import). Its parsing matched what's on disk here and was used as a cross-check; worth keeping the two in sync on format knowledge.


### Review follow-ups (post-first-pass)

Changes made after a fresh-eyes review, Greptile's pass, and an independent review agent — all pushed as separate commits:

- **Imported sessions resume on the user's configured provider.** Opening a history session adopts the row's provider/model (`use-chat-session`: `session.provider || prev.provider`). Rows were stamped with the *source tool's* provider — `openai` for Codex (Cline's id is `openai-native`), whatever opencode reported — so "continue this in Cline" failed on first send for anyone without that provider configured. The dialog now passes the app's current model selection (`lastProvider`/`lastModelByProvider`) and the service stamps it on the row; the source provider/model are preserved in `metadata.importedFrom.sourceProvider/sourceModel` and per-message `modelInfo` stays accurate. A half-specified target is ignored rather than pairing a Cline provider with a foreign model id.
- **Created terminal, marked imported last** (Greptile P1s + a cross-process race the review agent confirmed). Rows were created `running`/pid-0 and flipped to `completed` afterwards; the hub daemon's stale-session reconciler runs against the same SQLite DB and, in that window, flips such rows to `failed` and stamps `terminal_marker` metadata. `createRootSessionWithArtifacts` now accepts `status`/`endedAt`/`exitCode`, so imports are created completed with the source session's end time. The `importedFrom` marker is written as the **final** step, so a session whose later writes failed — even if the rollback delete also fails — can never claim the source and block a retry.
- **Rollback + unbounded dedupe** (Greptile P1s). Any write failure after creation deletes the half-written session. Dedup markers were read through `listSessions`, which caps at 2,000 rows; a new `listSessionMetadata()` (ids + metadata for every row, no manifest reads/reconciliation) feeds them, and idempotency is also enforced at import time — a request for an already-imported source resolves to the existing session (`alreadyImported: true`) instead of writing a copy.
- **Tool-result consolidation.** The sanitizer put placeholder results in a separate user message from the real ones; Anthropic requires a turn's results in the *immediately* following message. Incomplete/split spans are now rebuilt as one consolidated results message (tool_use order, placeholders for missing ids) plus a follow-up with any other blocks, mirroring the legacy migration sanitizer.
- **Batch performance.** Codex `convert()` re-walked and re-read every rollout per imported session (O(sessions × files)); opencode copied its whole WAL db per session. Adapters now cache once per batch (session-id → richest-file index; single db snapshot) and release via `dispose()`.

Tests: 12 import tests (added: resume stamping, rollback, marker-last under double failure, import-time dedupe, result consolidation); 138 across the session persistence suites; real-store bulk validation still 44/44 with all invariants passing.
