### PR TITLE
Hold cron reclaims after startup or system sleep to avoid duplicate sessions

### DIFF
--- a/sdk/packages/core/src/cline-core/types.ts
+++ b/sdk/packages/core/src/cline-core/types.ts
@@ -58,6 +58,7 @@ export interface ClineCoreAutomationOptions {
 	workspaceRoot?: string;
 	dbPath?: string;
 	pollIntervalMs?: number;
+	/** Effective lease is at least 4x `pollIntervalMs` so sleep detection stays reliable. */
 	claimLeaseSeconds?: number;
 	globalMaxConcurrency?: number;
 	watcherDebounceMs?: number;

--- a/sdk/packages/core/src/cron/runner/cron-runner.test.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.test.ts
@@ -396,6 +396,48 @@ describe("CronRunner", () => {
 		expect(requeued?.error).toBe("concurrency limit reached");
 	});
 
+	it("does not reclaim an expired running lease on its first tick", async () => {
+		const { handlers, calls } = fakeHandlers();
+		const upserted = store.upsertSpec({
+			externalId: "in-flight",
+			sourcePath: "in-flight.md",
+			triggerKind: "one_off",
+			sourceHash: "h",
+			parseStatus: "valid",
+			spec: {
+				triggerKind: "one_off",
+				id: "in-flight",
+				title: "In flight",
+				prompt: "Do it",
+				workspaceRoot,
+				enabled: true,
+			},
+		});
+		const run = store.enqueueRun({
+			specId: upserted.record.specId,
+			specRevision: upserted.record.revision,
+			triggerKind: "one_off",
+		});
+		// Another runner owns this run; its lease lapsed while the OS slept.
+		store.claimDueRuns({
+			nowIso: new Date(Date.now() - 60_000).toISOString(),
+			leaseMs: 1_000,
+		});
+		const runner = new CronRunner({
+			store,
+			materializer,
+			runtimeHandlers: handlers,
+			workspaceRoot,
+			specs: { cronSpecsDir: cronDir },
+		});
+		await runner.tick();
+		await runner.dispose();
+
+		expect(calls.start).toBe(0);
+		expect(store.getRun(run.runId)?.status).toBe("running");
+		expect(store.getRun(run.runId)?.attemptCount).toBe(1);
+	});
+
 	it("requeues active runs on stop and allows them to be reclaimed", async () => {
 		let aborted = 0;
 		const handlers: HubScheduleRuntimeHandlers = {

--- a/sdk/packages/core/src/cron/runner/cron-runner.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.ts
@@ -135,6 +135,7 @@ export interface CronRunnerOptions {
 	specs?: ResolveCronSpecsDirOptions;
 	logger?: BasicLogger;
 	pollIntervalMs?: number;
+	/** Effective lease is at least 4x `pollIntervalMs` so sleep detection stays reliable. */
 	claimLeaseSeconds?: number;
 	globalMaxConcurrency?: number;
 }

--- a/sdk/packages/core/src/cron/runner/cron-runner.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.ts
@@ -163,13 +163,17 @@ export class CronRunner {
 		this.materializer = options.materializer;
 		this.options = options;
 		this.limiter = new ResourceLimiter(options.globalMaxConcurrency ?? 10);
-		this.claimLeaseMs = Math.max(
-			5_000,
-			(options.claimLeaseSeconds ?? DEFAULT_CLAIM_LEASE_SECONDS) * 1000,
-		);
 		this.pollIntervalMs = Math.max(
 			2_000,
 			options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+		);
+		// Keep the lease well above the poll cadence so the sleep-gap check in
+		// tick() (half a lease) is never tripped by routine ticks, yet always
+		// tripped by a stall long enough to expire a lease.
+		this.claimLeaseMs = Math.max(
+			5_000,
+			(options.claimLeaseSeconds ?? DEFAULT_CLAIM_LEASE_SECONDS) * 1000,
+			this.pollIntervalMs * 4,
 		);
 	}
 
@@ -225,14 +229,9 @@ export class CronRunner {
 		// system sleep, so after a long gap (or on a fresh runner sharing
 		// cron.db with a live one) expired `running` rows likely still have a
 		// live owner about to renew. Hold reclaims for one lease period so we
-		// don't start a duplicate session for the same run. The threshold stays
-		// above the normal poll cadence so routine ticks never re-arm the hold.
+		// don't start a duplicate session for the same run.
 		const now = Date.now();
-		const gapThresholdMs = Math.max(
-			this.claimLeaseMs / 2,
-			this.pollIntervalMs * 2,
-		);
-		if (now - this.lastTickAtMs > gapThresholdMs) {
+		if (now - this.lastTickAtMs > this.claimLeaseMs / 2) {
 			this.holdReclaimsUntilMs = now + this.claimLeaseMs;
 		}
 		this.lastTickAtMs = now;

--- a/sdk/packages/core/src/cron/runner/cron-runner.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.ts
@@ -145,6 +145,7 @@ export class CronRunner {
 	private readonly options: CronRunnerOptions;
 	private readonly limiter: ResourceLimiter;
 	private readonly claimLeaseMs: number;
+	private readonly pollIntervalMs: number;
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private started = false;
 	private ticking = false;
@@ -166,6 +167,10 @@ export class CronRunner {
 			5_000,
 			(options.claimLeaseSeconds ?? DEFAULT_CLAIM_LEASE_SECONDS) * 1000,
 		);
+		this.pollIntervalMs = Math.max(
+			2_000,
+			options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+		);
 	}
 
 	public async start(): Promise<void> {
@@ -173,12 +178,8 @@ export class CronRunner {
 		if (this.started) return;
 		this.stopping = false;
 		this.started = true;
-		const interval = Math.max(
-			2_000,
-			this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-		);
 		await this.tick();
-		this.timer = setInterval(() => void this.tick(), interval);
+		this.timer = setInterval(() => void this.tick(), this.pollIntervalMs);
 	}
 
 	public async stop(): Promise<void> {
@@ -224,9 +225,14 @@ export class CronRunner {
 		// system sleep, so after a long gap (or on a fresh runner sharing
 		// cron.db with a live one) expired `running` rows likely still have a
 		// live owner about to renew. Hold reclaims for one lease period so we
-		// don't start a duplicate session for the same run.
+		// don't start a duplicate session for the same run. The threshold stays
+		// above the normal poll cadence so routine ticks never re-arm the hold.
 		const now = Date.now();
-		if (now - this.lastTickAtMs > this.claimLeaseMs / 2) {
+		const gapThresholdMs = Math.max(
+			this.claimLeaseMs / 2,
+			this.pollIntervalMs * 2,
+		);
+		if (now - this.lastTickAtMs > gapThresholdMs) {
 			this.holdReclaimsUntilMs = now + this.claimLeaseMs;
 		}
 		this.lastTickAtMs = now;

--- a/sdk/packages/core/src/cron/runner/cron-runner.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.ts
@@ -150,6 +150,8 @@ export class CronRunner {
 	private ticking = false;
 	private disposed = false;
 	private stopping = false;
+	private lastTickAtMs = 0;
+	private holdReclaimsUntilMs = 0;
 	private readonly activeRuns = new Map<
 		string,
 		{ claimToken: string; sessionId?: string }
@@ -218,6 +220,16 @@ export class CronRunner {
 	}
 
 	public async tick(): Promise<void> {
+		// Leases age in wall-clock time but heartbeat timers freeze during
+		// system sleep, so after a long gap (or on a fresh runner sharing
+		// cron.db with a live one) expired `running` rows likely still have a
+		// live owner about to renew. Hold reclaims for one lease period so we
+		// don't start a duplicate session for the same run.
+		const now = Date.now();
+		if (now - this.lastTickAtMs > this.claimLeaseMs / 2) {
+			this.holdReclaimsUntilMs = now + this.claimLeaseMs;
+		}
+		this.lastTickAtMs = now;
 		if (this.ticking) return;
 		this.ticking = true;
 		try {
@@ -225,6 +237,7 @@ export class CronRunner {
 			const claims = this.store.claimDueRuns({
 				nowIso: nowIso(),
 				leaseMs: this.claimLeaseMs,
+				reclaimExpiredRunning: now >= this.holdReclaimsUntilMs,
 			});
 			await Promise.allSettled(claims.map((claim) => this.executeClaim(claim)));
 		} catch (err) {

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
@@ -568,6 +568,8 @@ export interface ClaimRunOptions {
 	nowIso: string;
 	leaseMs: number;
 	limit?: number;
+	/** When false, only `queued` runs are claimed; expired `running` leases are left alone. */
+	reclaimExpiredRunning?: boolean;
 }
 
 export interface ClaimedCronRun {
@@ -1574,6 +1576,9 @@ export class SqliteCronStore {
 			new Date(referenceIso).getTime() + boundedLease,
 		).toISOString();
 		const limit = Math.max(1, Math.floor(options.limit ?? 25));
+		// "" sorts before every ISO timestamp, so no running lease can match.
+		const expiredLeaseIso =
+			options.reclaimExpiredRunning === false ? "" : referenceIso;
 		const claimed: ClaimedCronRun[] = [];
 		this.db.exec("BEGIN IMMEDIATE;");
 		try {
@@ -1593,7 +1598,7 @@ export class SqliteCronStore {
 						ORDER BY COALESCE(scheduled_for, created_at) ASC
 						LIMIT ?`,
 				)
-				.all(referenceIso, referenceIso, limit);
+				.all(expiredLeaseIso, referenceIso, limit);
 			for (const row of rows) {
 				const runId = asString(row.run_id);
 				if (!runId) continue;
@@ -1631,7 +1636,7 @@ export class SqliteCronStore {
 							referenceIso,
 							referenceIso,
 							runId,
-							referenceIso,
+							expiredLeaseIso,
 						).changes ?? 0;
 				if (changes !== 1) continue;
 				const run = this.getRun(runId);


### PR DESCRIPTION
### Related Issue

User report: a desktop app user created a scheduled task, put their computer to sleep mid-run, and came back to ~4 sessions all executing the same task.

### Description

Cron runs hold a 90s claim lease that a heartbeat renews every ~45s. The lease deadline is a wall-clock timestamp in `cron.db`, but the heartbeat is a `setInterval` that freezes while the OS sleeps. After any sleep longer than the lease, every in-flight run looks expired even though its owner is alive and about to renew. Any runner sharing `cron.db` (the hub daemon runs two: `HubScheduleService` and `CronService`) then reclaims the run on its first post-wake tick and starts a new session while the original keeps going. Each sleep/wake cycle adds another duplicate.

Fix: when a runner's tick fires after a gap longer than half a lease (timers were frozen, or the runner is brand new), it skips reclaiming expired `running` rows for one lease period. Queued runs are still claimed immediately. Genuinely orphaned runs (daemon crashed) are still recovered, just up to ~90s later.

### Test Procedure

- New test: a fresh runner does not reclaim an in-flight run whose lease looks expired.
- All 93 cron tests pass; `@cline/core` typecheck and biome are clean.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines