### PR TITLE
fix(core): resolve TS2352 casts failing typecheck in session-import tests

### DIFF
--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -39,6 +39,11 @@ function jsonl(lines: unknown[]): string {
 	return `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`;
 }
 
+/** Message content as loosely-typed blocks for assertions on raw fields. */
+function blocks(message: { content: unknown }): Array<Record<string, unknown>> {
+	return message.content as Array<Record<string, unknown>>;
+}
+
 // ---------------------------------------------------------------------------
 // Claude Code fixtures
 // ---------------------------------------------------------------------------
@@ -382,10 +387,7 @@ describe("CodexImportAdapter", () => {
 		);
 		expect(types).toEqual(["thinking", "tool_use"]);
 
-		const toolResultMsg = converted.messages[2];
-		const toolResult = (
-			toolResultMsg.content as Array<Record<string, unknown>>
-		)[0];
+		const toolResult = blocks(converted.messages[2])[0];
 		expect(toolResult.type).toBe("tool_result");
 		expect(toolResult.tool_use_id).toBe("call_1");
 		expect(toolResult.name).toBe("exec_command");
@@ -603,9 +605,7 @@ describe("OpencodeImportAdapter", () => {
 			"thinking",
 			"tool_use",
 		]);
-		const toolResult = (
-			converted.messages[2].content as Array<Record<string, unknown>>
-		)[0];
+		const toolResult = blocks(converted.messages[2])[0];
 		expect(toolResult.tool_use_id).toBe("call_a");
 		expect(toolResult.content).toBe("edited");
 
@@ -650,7 +650,7 @@ describe("sanitizeImportedMessages", () => {
 			"assistant",
 			"user",
 		]);
-		const repair = sanitized[2].content as Array<Record<string, unknown>>;
+		const repair = blocks(sanitized[2]);
 		expect(repair[0].type).toBe("tool_result");
 		expect(repair[0].tool_use_id).toBe("t1");
 		expect(repair[0].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
@@ -694,14 +694,14 @@ describe("sanitizeImportedMessages", () => {
 			"user",
 			"assistant",
 		]);
-		const consolidated = sanitized[2].content as Array<Record<string, unknown>>;
+		const consolidated = blocks(sanitized[2]);
 		expect(consolidated.map((block) => block.tool_use_id)).toEqual([
 			"a",
 			"b",
 			"c",
 		]);
 		expect(consolidated[2].content).toBe(IMPORT_MISSING_TOOL_RESULT_TEXT);
-		const leftovers = sanitized[3].content as Array<Record<string, unknown>>;
+		const leftovers = blocks(sanitized[3]);
 		expect(leftovers).toEqual([{ type: "text", text: "also do this next" }]);
 	});
 });


### PR DESCRIPTION
### Related Issue

**Issue:** N/A. Fixes the failing `Quality Checks` typecheck on #13744.

### Description

`@cline/core:typecheck` fails on `saoudrizwan/session-import` with five `TS2352` errors in `session-import.test.ts`:

```
Conversion of type 'string | ContentBlock[]' to type 'Record<string, unknown>[]' may be a mistake ...
  Type 'RedactedThinkingContent' is not comparable to type 'Record<string, unknown>'.
```

tsc will not cast the `ContentBlock` union directly to `Record<string, unknown>[]`. The five assertion sites that did this now go through a small `blocks()` helper in the test file that widens via `unknown`. No assertion logic changed, and no source files are touched.

For context: `main` typechecks clean, and the other recent `Quality Checks` failures on other branches are unrelated (biome lint on `feat/cloud-session-*`, a Windows `bash.test.ts` failure on `dpc/unify-command-backgrounding`). This one is specific to the test file added in #13744.

### Test Procedure

From `sdk/packages/core`, the same commands CI runs:

- `bun tsc -p tsconfig.dev.json --noEmit` now exits 0 (previously 5 errors, all in this file)
- `vitest run src/services/session-import/` - 12/12 pass
- `biome check` on the file is clean

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Targets `saoudrizwan/session-import` rather than `main` since the test file only exists on that branch. Once merged there, #13744's Quality Checks should go green.