### PR TITLE
Desktop marketplace: show detail panel only on item click, left-align detail content

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
@@ -28,12 +28,12 @@ import {
 import { cn } from "@/lib/utils";
 
 /**
- * Marketplace explorer: a two-pane master/detail directory in the spirit of
- * an IDE extensions panel. The left rail lists every catalog entry grouped by
- * primitive maturity (Skills, then MCP, then plugins); the right pane is a
- * full detail page for the selected entry with the catalog's metadata
- * (author, license, verified state, tags, install command, env setup) and
- * links out to the entry's homepage and repository.
+ * Marketplace explorer: a master/detail directory in the spirit of an IDE
+ * extensions panel. Initially the catalog list fills the view, grouped by
+ * primitive maturity (Skills, then MCP, then plugins); clicking an entry
+ * opens a detail panel with the catalog's metadata (author, license,
+ * verified state, tags, install command, env setup) and links out to the
+ * entry's homepage and repository.
  */
 
 /** Ordered most-mature first: skills > MCP servers > plugins. */
@@ -368,10 +368,12 @@ function MetaCell({
 function DetailPane({
 	directory,
 	entry,
+	onClose,
 	onSelectTag,
 }: {
 	directory: MarketplaceDirectory;
 	entry: MarketplaceEntry;
+	onClose: () => void;
 	onSelectTag: (tag: string) => void;
 }) {
 	const meta = TYPE_META[entry.type];
@@ -392,7 +394,7 @@ function DetailPane({
 
 	return (
 		<ScrollArea className="h-full min-w-0 flex-1">
-			<div className="mx-auto grid max-w-3xl gap-6 px-8 py-8 max-[900px]:px-5">
+			<div className="grid max-w-3xl gap-6 px-8 py-8 max-[900px]:px-5">
 				<div className="flex items-start gap-5">
 					<div className="min-w-0 flex-1">
 						<div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -466,6 +468,16 @@ function DetailPane({
 							</output>
 						) : null}
 					</div>
+					<Button
+						aria-label="Close details"
+						className="shrink-0 text-muted-foreground"
+						onClick={onClose}
+						size="icon"
+						type="button"
+						variant="ghost"
+					>
+						<X className="size-4" />
+					</Button>
 				</div>
 
 				<div className="grid grid-cols-3 gap-4 rounded-xl border bg-card p-4 max-[720px]:grid-cols-2">
@@ -650,9 +662,7 @@ export function MarketplaceExplorerView() {
 
 	const selectedEntry = useMemo(() => {
 		const flat = groups.flatMap((group) => group.entries);
-		return (
-			flat.find((entry) => entryKey(entry) === selectedKey) ?? flat[0] ?? null
-		);
+		return flat.find((entry) => entryKey(entry) === selectedKey) ?? null;
 	}, [groups, selectedKey]);
 
 	const typeCounts = useMemo(() => {
@@ -684,7 +694,14 @@ export function MarketplaceExplorerView() {
 
 	return (
 		<div className="flex h-full min-h-0 min-w-0">
-			<aside className="flex w-85 shrink-0 flex-col border-r max-[900px]:w-72">
+			<aside
+				className={cn(
+					"flex flex-col",
+					selectedEntry
+						? "w-85 shrink-0 border-r max-[900px]:w-72"
+						: "min-w-0 flex-1",
+				)}
+			>
 				<div className="grid gap-2.5 border-b p-3">
 					<div className="relative">
 						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -814,13 +831,10 @@ export function MarketplaceExplorerView() {
 				<DetailPane
 					directory={directory}
 					entry={selectedEntry}
+					onClose={() => setSelectedKey(null)}
 					onSelectTag={setSelectedTag}
 				/>
-			) : (
-				<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-					Select an entry to see details.
-				</div>
-			)}
+			) : null}
 		</div>
 	);
 }

--- a/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
@@ -1,10 +1,8 @@
 import {
 	ArrowUpRight,
 	BadgeCheck,
-	Github,
 	Globe,
 	Puzzle,
-	Scale,
 	Search,
 	Server,
 	Trash2,
@@ -31,9 +29,8 @@ import { cn } from "@/lib/utils";
  * Marketplace explorer: a master/detail directory in the spirit of an IDE
  * extensions panel. Initially the catalog list fills the view, grouped by
  * primitive maturity (Skills, then MCP, then plugins); clicking an entry
- * opens a detail panel with the catalog's metadata (author, license,
- * verified state, tags, install command, env setup) and links out to the
- * entry's homepage and repository.
+ * opens a detail panel with the catalog's metadata (author, verified state,
+ * tags, install command, env setup) and a link out to the entry's homepage.
  */
 
 /** Ordered most-mature first: skills > MCP servers > plugins. */
@@ -381,6 +378,9 @@ function DetailPane({
 	const state = directory.actionStates.get(key);
 	const installed = directory.installedKeys.has(key);
 	const busy = isBusy(state);
+	// Homepage is usually the entry's docs/product page; the repo is the
+	// fallback since many entries set both to the same GitHub URL anyway.
+	const learnMoreUrl = entry.homepage ?? entry.repo;
 	const requiredEnv =
 		entry.install.env?.filter((env) => env.required !== false) ?? [];
 	const optionalEnv =
@@ -430,27 +430,15 @@ function DetailPane({
 								{installed && !busy ? <Trash2 className="size-4" /> : null}
 								{actionLabelFor(state, installed, directory.installedReady)}
 							</Button>
-							{entry.homepage ? (
+							{learnMoreUrl ? (
 								<Button
-									onClick={() => void openExternalUrl(entry.homepage as string)}
+									onClick={() => void openExternalUrl(learnMoreUrl)}
 									size="sm"
 									type="button"
 									variant="outline"
 								>
 									<Globe className="size-4" />
 									Learn more
-									<ArrowUpRight className="size-3.5 text-muted-foreground" />
-								</Button>
-							) : null}
-							{entry.repo ? (
-								<Button
-									onClick={() => void openExternalUrl(entry.repo as string)}
-									size="sm"
-									type="button"
-									variant="outline"
-								>
-									<Github className="size-4" />
-									Repository
 									<ArrowUpRight className="size-3.5 text-muted-foreground" />
 								</Button>
 							) : null}
@@ -480,7 +468,7 @@ function DetailPane({
 					</Button>
 				</div>
 
-				<div className="grid grid-cols-3 gap-4 rounded-xl border bg-card p-4 max-[720px]:grid-cols-2">
+				<div className="grid grid-cols-2 gap-4 rounded-xl border bg-card p-4">
 					{entry.author ? (
 						<MetaCell
 							icon={User}
@@ -493,11 +481,6 @@ function DetailPane({
 							value={entry.author.name}
 						/>
 					) : null}
-					<MetaCell
-						icon={Scale}
-						label="License"
-						value={entry.license ?? "Not specified"}
-					/>
 					<MetaCell icon={meta.icon} label="Type" value={meta.plural} />
 				</div>
 

--- a/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
@@ -643,10 +643,15 @@ export function MarketplaceExplorerView() {
 		[filteredEntries],
 	);
 
-	const selectedEntry = useMemo(() => {
-		const flat = groups.flatMap((group) => group.entries);
-		return flat.find((entry) => entryKey(entry) === selectedKey) ?? null;
-	}, [groups, selectedKey]);
+	// Resolved against the full catalog so an open panel stays open while the
+	// list is filtered, rather than closing and reopening as filters change.
+	const selectedEntry = useMemo(
+		() =>
+			directory.catalog?.entries.find(
+				(entry) => entryKey(entry) === selectedKey,
+			) ?? null,
+		[directory.catalog?.entries, selectedKey],
+	);
 
 	const typeCounts = useMemo(() => {
 		const counts = new Map<MarketplacePrimitiveType, number>();


### PR DESCRIPTION
### Description

Fixes up the desktop Marketplace explorer layout:

- The initial view now shows only the catalog list, filling the full width. The detail panel no longer auto-opens on the first entry.
- Clicking a listing opens the detail panel alongside the list; a close button in the panel header returns to the full-width list.
- The listing detail content is now left aligned instead of centered (removed the `mx-auto` on the detail column).
- Removed the License cell from the metadata card (now just Author and Type).
- Collapsed the "Learn more" + "Repository" buttons into a single "Learn more" that opens `homepage`, falling back to `repo`. In the current catalog, 52 of the 139 entries with both fields point at the identical URL, so the two buttons were often duplicates; where they differ, `homepage` is the more specific docs/product page.

Initial view (no panel):

![Marketplace initial view: full-width list, no detail panel](https://cursor.com/artifacts/c/art-e819678e-d71a-464b-8452-cf03015c463a)

After clicking an entry (left-aligned detail panel, single Learn more, no License):

![Marketplace detail panel after clicking an entry](https://cursor.com/artifacts/c/art-8eba7e54-8973-4311-a107-3503c6a4d039)

### Test Procedure

Ran the app headless (`dev:sidecar` + `dev:web`) and verified in a browser under Customize > Marketplace: initial view has no detail panel, clicking an entry opens the panel with left-aligned content, clicking another entry updates it, the close button hides it again, only Install and Learn more buttons appear, and Learn more opens the entry's homepage. Also ran `tsc --noEmit` and Biome on the changed file.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Code
- [ ] 🔥 Performance Improvements
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Desktop app only (`apps/examples/desktop-app`); no changes to the VS Code extension marketplace.