### PR TITLE
fix(desktop): restore connectors in the marketplace explorer + single-flight connects (desktop-experimental)

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -2520,7 +2520,11 @@ export async function handleCommand(
 				return await listComposioToolkits(ctx.logger);
 			case "connect": {
 				const toolkit = parseComposioToolkitSlug(args?.toolkit);
-				const result = await connectComposioToolkit(toolkit, ctx.logger);
+				// Tie the attempt to the initiating webview so it is abandoned
+				// if that connection goes away before the browser flow finishes.
+				const result = await connectComposioToolkit(toolkit, ctx.logger, {
+					owner: options?.connection,
+				});
 				if (result.redirectUrl) {
 					await openUrlInDefaultBrowser(result.redirectUrl);
 				}

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -460,7 +460,11 @@ describe("connectComposioToolkit", () => {
 	it("overlapping connects are single-flight: only one remote account is ever created", async () => {
 		const dir = useTempDataDir();
 		process.env.COMPOSIO_API_KEY = "ck_overlap";
-		writeState(dir, { apiKey: "ck_overlap", userId: "u_overlap", toolkits: {} });
+		writeState(dir, {
+			apiKey: "ck_overlap",
+			userId: "u_overlap",
+			toolkits: {},
+		});
 		let releaseAuthorize: (() => void) | undefined;
 		const authorize = vi.fn(
 			() =>
@@ -517,6 +521,84 @@ describe("connectComposioToolkit", () => {
 		await cancelComposioConnect("github");
 	});
 
+	it("a refresh racing a redirect-less attempt cannot leave a failed connection installed", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_refresh_race";
+		writeState(dir, {
+			apiKey: "ck_refresh_race",
+			userId: "u_refresh_race",
+			toolkits: {},
+		});
+		let rejectConnectFetch: ((error: Error) => void) | undefined;
+		const getRawComposioTools = vi.fn(() =>
+			// First call is the connect's finalize: suspended, then failed.
+			// Any later call (a refresh import) resolves immediately.
+			getRawComposioTools.mock.calls.length <= 1
+				? new Promise<{ slug: string }[]>((_resolve, reject) => {
+						rejectConnectFetch = reject;
+					})
+				: Promise.resolve([{ slug: "GITHUB_LIST_ISSUES" }]),
+		);
+		const remoteDelete = vi.fn(async () => ({}));
+		const client = {
+			toolkits: {
+				// Redirect-less: the account is ACTIVE remotely from creation,
+				// which is what lets a concurrent refresh see it.
+				authorize: vi.fn(async () => ({
+					id: "ca_race_import",
+					redirectUrl: null,
+					waitForConnection: async () => ({}),
+				})),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: { getRawComposioTools },
+			connectedAccounts: {
+				list: vi.fn(async () => ({
+					items: [
+						{
+							id: "ca_race_import",
+							status: "ACTIVE",
+							toolkit: { slug: "github" },
+						},
+					],
+					nextCursor: null,
+				})),
+				link: vi.fn(),
+				delete: remoteDelete,
+			},
+		};
+		createMockComposioClient = () => client;
+
+		const connectPromise = connectComposioToolkit("github");
+		await vi.waitFor(() => {
+			expect(getRawComposioTools).toHaveBeenCalledTimes(1);
+		});
+		// A refresh runs while the attempt is mid-finalize and sees the
+		// account as ACTIVE. The in-flight guard must keep it from importing
+		// the connector out from under the attempt.
+		const refreshed = await getComposioStatus({ refresh: true });
+		expect(
+			refreshed.integrations.find((entry) => entry.toolkit === "github")
+				?.status,
+		).toBe("not_connected");
+		expect(readStateFile(dir).toolkits ?? {}).toEqual({});
+		// The attempt's tool fetch then fails; the account is abandoned.
+		rejectConnectFetch?.(new Error("500 tools endpoint exploded"));
+		await expect(connectPromise).rejects.toThrow(/tools endpoint exploded/);
+		expect(remoteDelete).toHaveBeenCalledWith("ca_race_import", {
+			revoke_on_delete: true,
+		});
+		// Nothing may report the failed connection as installed afterwards.
+		expect(readStateFile(dir).toolkits ?? {}).toEqual({});
+		const after = await getComposioStatus();
+		expect(
+			after.integrations.find((entry) => entry.toolkit === "github")?.status,
+		).toBe("not_connected");
+	});
+
 	it("a connect overlapping a redirect-less finalize is also single-flight", async () => {
 		const dir = useTempDataDir();
 		process.env.COMPOSIO_API_KEY = "ck_overlap_rl";
@@ -541,7 +623,8 @@ describe("connectComposioToolkit", () => {
 				getRawComposioTools: vi.fn(
 					() =>
 						new Promise<{ slug: string }[]>((resolve) => {
-							releaseToolFetch = () => resolve([{ slug: "GITHUB_LIST_ISSUES" }]);
+							releaseToolFetch = () =>
+								resolve([{ slug: "GITHUB_LIST_ISSUES" }]);
 						}),
 				),
 			},

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -456,6 +456,122 @@ describe("managed COMPOSIO_API_KEY", () => {
 	});
 });
 
+describe("connectComposioToolkit", () => {
+	it("overlapping connects are single-flight: only one remote account is ever created", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_overlap";
+		writeState(dir, { apiKey: "ck_overlap", userId: "u_overlap", toolkits: {} });
+		let releaseAuthorize: (() => void) | undefined;
+		const authorize = vi.fn(
+			() =>
+				new Promise<{
+					id: string;
+					redirectUrl: string;
+					waitForConnection: () => Promise<unknown>;
+				}>((resolve) => {
+					releaseAuthorize = () =>
+						resolve({
+							id: "ca_single",
+							redirectUrl: "https://connect.example/ca_single",
+							waitForConnection: () => new Promise(() => {}),
+						});
+				}),
+		);
+		const remoteDelete = vi.fn(async () => ({}));
+		const client = {
+			toolkits: { authorize },
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: { getRawComposioTools: vi.fn(async () => []) },
+			connectedAccounts: {
+				list: vi.fn(async () => ({ items: [] })),
+				link: vi.fn(),
+				delete: remoteDelete,
+			},
+		};
+		createMockComposioClient = () => client;
+
+		const first = connectComposioToolkit("github");
+		await vi.waitFor(() => {
+			expect(authorize).toHaveBeenCalledTimes(1);
+		});
+		// A second connect lands while the first is still inside the
+		// initiation round trip — before any pending entry exists. It must
+		// not start a second attempt (whose account nothing would ever
+		// revoke) or overwrite the first attempt's pending entry.
+		const second = await connectComposioToolkit("github");
+		expect(second.redirectUrl).toBeUndefined();
+		expect(authorize).toHaveBeenCalledTimes(1);
+
+		releaseAuthorize?.();
+		const firstResult = await first;
+		expect(firstResult.redirectUrl).toContain("ca_single");
+		// The surviving pending attempt is the first one; a third call now
+		// reports it instead of starting over.
+		const third = await connectComposioToolkit("github");
+		expect(third.redirectUrl).toContain("ca_single");
+		expect(authorize).toHaveBeenCalledTimes(1);
+		// Clean up the pending attempt so it cannot leak into other tests.
+		await cancelComposioConnect("github");
+	});
+
+	it("a connect overlapping a redirect-less finalize is also single-flight", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_overlap_rl";
+		writeState(dir, {
+			apiKey: "ck_overlap_rl",
+			userId: "u_overlap_rl",
+			toolkits: {},
+		});
+		let releaseToolFetch: (() => void) | undefined;
+		const authorize = vi.fn(async () => ({
+			id: "ca_rl_single",
+			redirectUrl: null,
+			waitForConnection: async () => ({}),
+		}));
+		const client = {
+			toolkits: { authorize },
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: {
+				getRawComposioTools: vi.fn(
+					() =>
+						new Promise<{ slug: string }[]>((resolve) => {
+							releaseToolFetch = () => resolve([{ slug: "GITHUB_LIST_ISSUES" }]);
+						}),
+				),
+			},
+			connectedAccounts: {
+				list: vi.fn(async () => ({ items: [] })),
+				link: vi.fn(),
+				delete: vi.fn(async () => ({})),
+			},
+		};
+		createMockComposioClient = () => client;
+
+		const first = connectComposioToolkit("github");
+		await vi.waitFor(() => {
+			expect(client.tools.getRawComposioTools).toHaveBeenCalledTimes(1);
+		});
+		// The redirect-less path never has a pending entry, so the in-flight
+		// guard is the only thing preventing a duplicate attempt here.
+		const second = await connectComposioToolkit("github");
+		expect(second.alreadyConnected).toBeUndefined();
+		expect(authorize).toHaveBeenCalledTimes(1);
+
+		releaseToolFetch?.();
+		const firstResult = await first;
+		expect(firstResult.alreadyConnected).toBe(true);
+		expect(readStateFile(dir).toolkits?.github?.connectedAccountId).toBe(
+			"ca_rl_single",
+		);
+	});
+});
+
 describe("cancelComposioConnect", () => {
 	it("revokes the cancelled attempt and never imports it, even when the browser flow completes later", async () => {
 		const dir = useTempDataDir();

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -725,6 +725,77 @@ describe("cancelComposioConnect", () => {
 		expect(readStateFile(dir).cancelledAccountIds).toContain("ca_cancelled");
 	});
 
+	it("a cancel whose revocation is confirmed mid-refresh still drops the refresh's prepared import", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_cancel_refresh";
+		writeState(dir, {
+			apiKey: "ck_cancel_refresh",
+			userId: "u_cancel_refresh",
+			toolkits: {},
+		});
+		let releaseImportFetch: (() => void) | undefined;
+		const client = {
+			toolkits: {
+				// Used only by the connect started mid-refresh (a different
+				// account than the one the refresh is importing).
+				authorize: vi.fn(async () => ({
+					id: "ca_pending",
+					redirectUrl: "https://connect.example/ca_pending",
+					waitForConnection: () => new Promise(() => {}),
+				})),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: {
+				// The refresh's import tool fetch — suspended so a cancel can land
+				// during it.
+				getRawComposioTools: vi.fn(
+					() =>
+						new Promise<{ slug: string }[]>((resolve) => {
+							releaseImportFetch = () => resolve([{ slug: "GITHUB_LIST" }]);
+						}),
+				),
+			},
+			connectedAccounts: {
+				// ca_import is ACTIVE at snapshot time (no pending yet), so the
+				// refresh prepares an import for it.
+				list: vi.fn(async () => ({
+					items: [
+						{ id: "ca_import", status: "ACTIVE", toolkit: { slug: "github" } },
+					],
+					nextCursor: null,
+				})),
+				link: vi.fn(),
+				delete: vi.fn(async () => ({})), // revocation SUCCEEDS -> tombstone pruned
+			},
+		};
+		createMockComposioClient = () => client;
+
+		// The refresh prepares an import for ca_import and suspends in its tool
+		// fetch (no pending exists at decision time).
+		const refreshPromise = getComposioStatus({ refresh: true });
+		await vi.waitFor(() => {
+			expect(client.tools.getRawComposioTools).toHaveBeenCalled();
+		});
+		// Now a connect starts and is cancelled while the refresh is suspended.
+		// The cancel's revoke succeeds and prunes its tombstone, so only the
+		// entry-time lastDisconnectedAt marker can save the write-time check.
+		await connectComposioToolkit("github");
+		await cancelComposioConnect("github");
+		expect(readStateFile(dir).cancelledAccountIds).toBeUndefined();
+		releaseImportFetch?.();
+		const status = await refreshPromise;
+		// The refresh's prepared import must be dropped: a cancel for this
+		// toolkit landed after the refresh began, so its stale snapshot must
+		// not restore the connector.
+		expect(
+			status.integrations.find((entry) => entry.toolkit === "github")?.status,
+		).toBe("not_connected");
+		expect(readStateFile(dir).toolkits ?? {}).toEqual({});
+	});
+
 	it("prunes the tombstone once the revocation is confirmed", async () => {
 		const dir = useTempDataDir();
 		process.env.COMPOSIO_API_KEY = "ck_prune";

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -1691,6 +1691,81 @@ describe("disconnectComposioToolkit", () => {
 		expect(readStateFile(dir).cancelledAccountIds).toContain("ca_stale");
 	});
 
+	it("a disconnect started after a redirect-less connect wins over the finalize", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_disc_wins";
+		writeState(dir, {
+			apiKey: "ck_disc_wins",
+			userId: "u_disc_wins",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_prev",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		let releaseConnectFetch: (() => void) | undefined;
+		const remoteDelete = vi.fn(async () => ({}));
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => ({
+					id: "ca_connect_new",
+					redirectUrl: null,
+					waitForConnection: async () => ({}),
+				})),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: {
+				getRawComposioTools: vi.fn(
+					() =>
+						new Promise<{ slug: string }[]>((resolve) => {
+							releaseConnectFetch = () =>
+								resolve([{ slug: "GITHUB_CREATE_AN_ISSUE" }]);
+						}),
+				),
+			},
+			connectedAccounts: {
+				list: vi.fn(async () => ({ items: [], nextCursor: null })),
+				link: vi.fn(),
+				delete: remoteDelete,
+			},
+		};
+		createMockComposioClient = () => client;
+
+		// The connect starts first and is suspended inside its finalize's tool
+		// fetch.
+		const connectPromise = connectComposioToolkit("github");
+		await vi.waitFor(() => {
+			expect(client.tools.getRawComposioTools).toHaveBeenCalledTimes(1);
+		});
+		// The user then clicks disconnect — the newer intent. It must win even
+		// though the connect finalizes afterward.
+		const disconnected = await disconnectComposioToolkit("github");
+		expect(
+			disconnected.integrations.find((entry) => entry.toolkit === "github")
+				?.status,
+		).toBe("not_connected");
+		// The connect's tool fetch completes last; its finalize must be dropped
+		// (disconnect marker predates nothing — the connect started earlier, so
+		// its startedAt is before the disconnect marker) and its new account
+		// revoked.
+		releaseConnectFetch?.();
+		const connectResult = await connectPromise;
+		expect(connectResult.alreadyConnected).toBeUndefined();
+		expect(readStateFile(dir).toolkits ?? {}).toEqual({});
+		expect(remoteDelete).toHaveBeenCalledWith("ca_connect_new", {
+			revoke_on_delete: true,
+		});
+		const after = await getComposioStatus();
+		expect(
+			after.integrations.find((entry) => entry.toolkit === "github")?.status,
+		).toBe("not_connected");
+	});
+
 	it("treats an account that is already gone remotely as revoked", async () => {
 		const dir = useTempDataDir();
 		process.env.COMPOSIO_API_KEY = "ck_gone_404";

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -1506,15 +1506,23 @@ describe("disconnectComposioToolkit", () => {
 				},
 			},
 		});
-		let releaseOldDelete: (() => void) | undefined;
+		// ca_old_acct is revoked by the disconnect AND by the reconnect's
+		// finalize (which supersedes it); collect every resolver so releasing
+		// unblocks all of them regardless of order.
+		const oldDeleteResolvers: Array<() => void> = [];
 		const remoteDelete = vi.fn((accountId: string) => {
 			if (accountId === "ca_old_acct") {
 				return new Promise((resolve) => {
-					releaseOldDelete = () => resolve({});
+					oldDeleteResolvers.push(() => resolve({}));
 				});
 			}
 			return Promise.resolve({});
 		});
+		const releaseOldDelete = () => {
+			for (const resolve of oldDeleteResolvers.splice(0)) {
+				resolve();
+			}
+		};
 		const client = {
 			toolkits: {
 				// Redirect-less reconnect: finalizes without a pending entry.
@@ -1562,7 +1570,12 @@ describe("disconnectComposioToolkit", () => {
 		expect(readStateFile(dir).toolkits?.github?.connectedAccountId).toBe(
 			"ca_new_acct",
 		);
-		releaseOldDelete?.();
+		// Wait until the reconnect's finalize has also issued its supersession
+		// revoke of ca_old_acct, then release every ca_old_acct delete.
+		await vi.waitFor(() => {
+			expect(remoteDelete.mock.calls.length).toBeGreaterThanOrEqual(2);
+		});
+		releaseOldDelete();
 		const disconnected = await disconnectPromise;
 		// The disconnect only revoked ca_old_acct; blindly deleting the slot
 		// would orphan ca_new_acct (authorized remotely, no local record) for
@@ -1575,7 +1588,11 @@ describe("disconnectComposioToolkit", () => {
 			disconnected.integrations.find((entry) => entry.toolkit === "github")
 				?.status,
 		).toBe("connected");
-		expect(remoteDelete).toHaveBeenCalledTimes(1);
+		// The surviving connection's own account is never revoked.
+		expect(remoteDelete).not.toHaveBeenCalledWith(
+			"ca_new_acct",
+			expect.anything(),
+		);
 		// And a later refresh keeps it, rather than re-importing an orphan.
 		const refreshed = await getComposioStatus({ refresh: true });
 		expect(
@@ -1585,6 +1602,93 @@ describe("disconnectComposioToolkit", () => {
 		expect(readStateFile(dir).toolkits?.github?.connectedAccountId).toBe(
 			"ca_new_acct",
 		);
+	});
+
+	it("a failed revocation whose slot was replaced hands the old account to the tombstone machinery", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_orphan_race";
+		writeState(dir, {
+			apiKey: "ck_orphan_race",
+			userId: "u_orphan_race",
+			toolkits: {
+				github: {
+					connectedAccountId: "ca_stale",
+					connectedAt: "2026-08-28T00:00:00.000Z",
+					tools: [{ slug: "GITHUB_CREATE_AN_ISSUE" }],
+				},
+			},
+		});
+		// ca_stale is revoked by the disconnect AND by the reconnect's finalize
+		// (which supersedes it); both fail. Collect every rejecter.
+		const staleRejecters: Array<(error: Error) => void> = [];
+		const remoteDelete = vi.fn((accountId: string) => {
+			if (accountId === "ca_stale") {
+				return new Promise((_resolve, reject) => {
+					staleRejecters.push(reject);
+				});
+			}
+			return Promise.resolve({});
+		});
+		const rejectStaleDelete = (error: Error) => {
+			for (const reject of staleRejecters.splice(0)) {
+				reject(error);
+			}
+		};
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => ({
+					id: "ca_fresh_replace",
+					redirectUrl: null,
+					waitForConnection: async () => ({}),
+				})),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: {
+				getRawComposioTools: vi.fn(async () => [
+					{ slug: "GITHUB_CREATE_AN_ISSUE" },
+				]),
+			},
+			connectedAccounts: {
+				list: vi.fn(async () => ({ items: [], nextCursor: null })),
+				link: vi.fn(),
+				delete: remoteDelete,
+			},
+		};
+		createMockComposioClient = () => client;
+
+		const disconnectPromise = disconnectComposioToolkit("github");
+		await vi.waitFor(() => {
+			expect(remoteDelete).toHaveBeenCalledWith("ca_stale", {
+				revoke_on_delete: true,
+			});
+		});
+		// A redirect-less reconnect replaces the slot while the disconnect is
+		// suspended on the (about to fail) revocation. The replacement also
+		// tombstones ca_stale defensively.
+		const reconnect = await connectComposioToolkit("github");
+		expect(reconnect.alreadyConnected).toBe(true);
+		// Wait for the finalize's own supersession revoke of ca_stale to be in
+		// flight too, then fail every ca_stale revocation at once.
+		await vi.waitFor(() => {
+			expect(remoteDelete.mock.calls.length).toBeGreaterThanOrEqual(2);
+		});
+		// The disconnect's revocation now fails. Throwing "still connected —
+		// try again" would be a lie (the slot holds the new account) and would
+		// leave ca_stale authorized with no local reference; instead it must
+		// stay tombstoned so reconciliation keeps retrying the revocation.
+		rejectStaleDelete(new Error("500 internal error"));
+		const disconnected = await disconnectPromise;
+		expect(
+			disconnected.integrations.find((entry) => entry.toolkit === "github")
+				?.status,
+		).toBe("connected");
+		expect(readStateFile(dir).toolkits?.github?.connectedAccountId).toBe(
+			"ca_fresh_replace",
+		);
+		expect(readStateFile(dir).cancelledAccountIds).toContain("ca_stale");
 	});
 
 	it("treats an account that is already gone remotely as revoked", async () => {

--- a/apps/examples/desktop-app/sidecar/composio.test.ts
+++ b/apps/examples/desktop-app/sidecar/composio.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	abandonComposioConnectsForOwner,
 	buildConnectableCatalog,
 	cancelComposioConnect,
 	connectComposioToolkit,
@@ -1157,6 +1158,76 @@ describe("cancelComposioConnect", () => {
 		// Revocation succeeded, so the tombstone was pruned again.
 		expect(readStateFile(dir).cancelledAccountIds).toBeUndefined();
 		expect(readStateFile(dir).toolkits ?? {}).toEqual({});
+	});
+
+	it("abandons pending attempts owned by a departed webview and refuses their later completion", async () => {
+		const dir = useTempDataDir();
+		process.env.COMPOSIO_API_KEY = "ck_owner";
+		writeState(dir, { apiKey: "ck_owner", userId: "u_owner", toolkits: {} });
+		let resolveWait: ((value: unknown) => void) | undefined;
+		const remoteDelete = vi.fn(async () => ({}));
+		const client = {
+			toolkits: {
+				authorize: vi.fn(async () => ({
+					id: "ca_owner_attempt",
+					redirectUrl: "https://connect.example/ca_owner_attempt",
+					waitForConnection: () =>
+						new Promise((resolve) => {
+							resolveWait = resolve;
+						}),
+				})),
+			},
+			authConfigs: {
+				list: vi.fn(async () => ({ items: [] })),
+				create: vi.fn(),
+			},
+			tools: { getRawComposioTools: vi.fn(async () => []) },
+			connectedAccounts: {
+				list: vi.fn(async () => ({
+					items: [
+						{
+							id: "ca_owner_attempt",
+							status: "ACTIVE",
+							toolkit: { slug: "github" },
+						},
+					],
+					nextCursor: null,
+				})),
+				link: vi.fn(),
+				delete: remoteDelete,
+			},
+		};
+		createMockComposioClient = () => client;
+
+		const owner = {}; // stands in for the webview connection
+		const connect = await connectComposioToolkit("github", undefined, {
+			owner,
+		});
+		expect(connect.redirectUrl).toContain("ca_owner_attempt");
+
+		// The webview closes: server.ts calls this for the departing owner.
+		const abandoned = abandonComposioConnectsForOwner(owner);
+		expect(abandoned).toBe(1);
+		await vi.waitFor(() => {
+			expect(remoteDelete).toHaveBeenCalledWith("ca_owner_attempt", {
+				revoke_on_delete: true,
+			});
+		});
+		// The revoke was confirmed, so the tombstone is pruned again — the
+		// account is gone remotely and needs no further guarding.
+		await vi.waitFor(() => {
+			expect(readStateFile(dir).cancelledAccountIds).toBeUndefined();
+		});
+
+		// The user finishes the still-open browser tab afterward; the waiter's
+		// finalize must not materialize tools for the abandoned attempt.
+		resolveWait?.({});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(client.tools.getRawComposioTools).not.toHaveBeenCalled();
+		const status = await getComposioStatus();
+		expect(
+			status.integrations.find((entry) => entry.toolkit === "github")?.status,
+		).toBe("not_connected");
 	});
 
 	it("a cancelled toolkit can still be reconnected under a fresh account", async () => {

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -204,6 +204,15 @@ type ConnectedAccountListItem = {
 };
 
 const pendingConnections = new Map<ComposioToolkitSlug, PendingConnection>();
+/**
+ * Toolkits whose connect call is inside its initiation round trip. The
+ * pending entry only exists once Composio has returned the connected-account
+ * id, so this set is what makes connects single-flight across that window —
+ * without it, two overlapping calls would each create a remote account and
+ * the second `pendingConnections.set` would overwrite the first, leaving the
+ * superseded account unrevoked and eligible for a later import.
+ */
+const connectInitiationsInFlight = new Set<ComposioToolkitSlug>();
 const lastConnectionErrors = new Map<ComposioToolkitSlug, string>();
 /** When each toolkit was last disconnected, so state snapshots taken before
  * the disconnect cannot write it back. */
@@ -984,115 +993,126 @@ export async function connectComposioToolkit(
 			status: buildStatusResponse(state),
 		};
 	}
-	lastConnectionErrors.delete(toolkit);
-	const client = await getComposioClient(state.apiKey);
-	let connectionRequest: ComposioConnectionRequest;
+	if (connectInitiationsInFlight.has(toolkit)) {
+		// Another connect for this toolkit is mid-initiation (see the set's
+		// doc). Single-flight: the first call owns the attempt and already
+		// received its redirect; this one just reports current status.
+		return { status: buildStatusResponse(state) };
+	}
+	connectInitiationsInFlight.add(toolkit);
 	try {
-		connectionRequest = await initiateToolkitConnection(
-			client,
-			state.userId,
-			toolkit,
-			logger,
-		);
-	} catch (error) {
-		throw new Error(
-			`Could not start the ${toolkit} connection: ${formatComposioError(error)}`,
-		);
-	}
-	const redirectUrl = connectionRequest.redirectUrl?.trim() || undefined;
-	const guard = { apiKey: state.apiKey, userId: state.userId, startedAt };
-	if (!redirectUrl) {
-		// No browser step needed (e.g. the account is already authorized on
-		// Composio's side) — finalize right away. There is no pending entry on
-		// this path, so the disconnect defense lives entirely in the guard's
-		// startedAt check inside finalizeToolkitConnection.
-		let persisted: boolean;
+		lastConnectionErrors.delete(toolkit);
+		const client = await getComposioClient(state.apiKey);
+		let connectionRequest: ComposioConnectionRequest;
 		try {
-			persisted = await finalizeToolkitConnection(
+			connectionRequest = await initiateToolkitConnection(
 				client,
+				state.userId,
 				toolkit,
-				connectionRequest.id,
-				guard,
 				logger,
 			);
 		} catch (error) {
-			// The attempt failed from the app's point of view, but the freshly
-			// created account is authorized on Composio's side and nothing
-			// references it — left alone, the next reconciliation would import
-			// it and a connection the user was told failed would silently
-			// appear as installed. Abandon it like a cancel before surfacing
-			// the error.
-			await abandonFinalizedConnection(
-				connectionRequest.id,
-				guard.apiKey,
-				logger,
+			throw new Error(
+				`Could not start the ${toolkit} connection: ${formatComposioError(error)}`,
 			);
-			throw error;
 		}
-		// A dropped result (a disconnect won the race, or the key changed
-		// mid-flow) must not report success: the connector is NOT connected,
-		// and the status below already reflects that.
-		return {
-			...(persisted ? { alreadyConnected: true } : {}),
-			status: buildStatusResponse(readComposioState()),
-		};
+		const redirectUrl = connectionRequest.redirectUrl?.trim() || undefined;
+		const guard = { apiKey: state.apiKey, userId: state.userId, startedAt };
+		if (!redirectUrl) {
+			// No browser step needed (e.g. the account is already authorized on
+			// Composio's side) — finalize right away. There is no pending entry on
+			// this path, so the disconnect defense lives entirely in the guard's
+			// startedAt check inside finalizeToolkitConnection.
+			let persisted: boolean;
+			try {
+				persisted = await finalizeToolkitConnection(
+					client,
+					toolkit,
+					connectionRequest.id,
+					guard,
+					logger,
+				);
+			} catch (error) {
+				// The attempt failed from the app's point of view, but the freshly
+				// created account is authorized on Composio's side and nothing
+				// references it — left alone, the next reconciliation would import
+				// it and a connection the user was told failed would silently
+				// appear as installed. Abandon it like a cancel before surfacing
+				// the error.
+				await abandonFinalizedConnection(
+					connectionRequest.id,
+					guard.apiKey,
+					logger,
+				);
+				throw error;
+			}
+			// A dropped result (a disconnect won the race, or the key changed
+			// mid-flow) must not report success: the connector is NOT connected,
+			// and the status below already reflects that.
+			return {
+				...(persisted ? { alreadyConnected: true } : {}),
+				status: buildStatusResponse(readComposioState()),
+			};
+		}
+
+		const attemptId = randomUUID();
+		pendingConnections.set(toolkit, {
+			attemptId,
+			connectedAccountId: connectionRequest.id,
+			redirectUrl,
+			...guard,
+		});
+
+		// The OAuth flow finishes in the external browser, which cannot navigate
+		// the app back. Wait for Composio to report the connection in the
+		// background; the webview polls `status` to observe the flip.
+		void (async () => {
+			try {
+				await connectionRequest.waitForConnection(CONNECT_WAIT_TIMEOUT_MS);
+				if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
+					return; // Cancelled or superseded while we waited.
+				}
+				// finalizeToolkitConnection re-checks the attempt and the key/user
+				// at write time, so a cancel, disconnect, or key change that lands
+				// during the tool fetch cannot be overwritten by this attempt.
+				await finalizeToolkitConnection(
+					client,
+					toolkit,
+					connectionRequest.id,
+					{ ...guard, attemptId },
+					logger,
+				);
+			} catch (error) {
+				if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
+					return; // Cancel/disconnect/key change already abandoned it.
+				}
+				const reason = formatComposioError(error);
+				lastConnectionErrors.set(
+					toolkit,
+					`Connection was not completed: ${reason}`,
+				);
+				logger?.log?.(`composio connect ${toolkit} failed: ${reason}`);
+				// The attempt is dead from the app's point of view (timeout, wait
+				// error, or a failed finalize), but the browser flow can still turn
+				// the remote account ACTIVE later — where reconciliation would
+				// import it, materializing a connection the user was told failed.
+				// Abandon it like a cancel: tombstone first, revoke best-effort.
+				await abandonFinalizedConnection(
+					connectionRequest.id,
+					guard.apiKey,
+					logger,
+				);
+			} finally {
+				if (pendingConnections.get(toolkit)?.attemptId === attemptId) {
+					pendingConnections.delete(toolkit);
+				}
+			}
+		})();
+
+		return { redirectUrl, status: buildStatusResponse(state) };
+	} finally {
+		connectInitiationsInFlight.delete(toolkit);
 	}
-
-	const attemptId = randomUUID();
-	pendingConnections.set(toolkit, {
-		attemptId,
-		connectedAccountId: connectionRequest.id,
-		redirectUrl,
-		...guard,
-	});
-
-	// The OAuth flow finishes in the external browser, which cannot navigate
-	// the app back. Wait for Composio to report the connection in the
-	// background; the webview polls `status` to observe the flip.
-	void (async () => {
-		try {
-			await connectionRequest.waitForConnection(CONNECT_WAIT_TIMEOUT_MS);
-			if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
-				return; // Cancelled or superseded while we waited.
-			}
-			// finalizeToolkitConnection re-checks the attempt and the key/user
-			// at write time, so a cancel, disconnect, or key change that lands
-			// during the tool fetch cannot be overwritten by this attempt.
-			await finalizeToolkitConnection(
-				client,
-				toolkit,
-				connectionRequest.id,
-				{ ...guard, attemptId },
-				logger,
-			);
-		} catch (error) {
-			if (pendingConnections.get(toolkit)?.attemptId !== attemptId) {
-				return; // Cancel/disconnect/key change already abandoned it.
-			}
-			const reason = formatComposioError(error);
-			lastConnectionErrors.set(
-				toolkit,
-				`Connection was not completed: ${reason}`,
-			);
-			logger?.log?.(`composio connect ${toolkit} failed: ${reason}`);
-			// The attempt is dead from the app's point of view (timeout, wait
-			// error, or a failed finalize), but the browser flow can still turn
-			// the remote account ACTIVE later — where reconciliation would
-			// import it, materializing a connection the user was told failed.
-			// Abandon it like a cancel: tombstone first, revoke best-effort.
-			await abandonFinalizedConnection(
-				connectionRequest.id,
-				guard.apiKey,
-				logger,
-			);
-		} finally {
-			if (pendingConnections.get(toolkit)?.attemptId === attemptId) {
-				pendingConnections.delete(toolkit);
-			}
-		}
-	})();
-
-	return { redirectUrl, status: buildStatusResponse(state) };
 }
 
 export async function cancelComposioConnect(

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -745,7 +745,12 @@ export async function getComposioStatus(options?: {
 			const remoteAccountId = activeByToolkit.get(slug);
 			const stored = startToolkits[slug];
 			baselineIdBySlug.set(slug, stored?.connectedAccountId);
-			if (stored && !remoteAccountId) {
+			if (stored && cancelledIds.has(stored.connectedAccountId)) {
+				// A stored entry carrying a tombstoned account (imported by a
+				// refresh that raced an attempt's failure) must never stay
+				// reported as installed — its account is abandoned/revoked.
+				removals.push(slug);
+			} else if (stored && !remoteAccountId) {
 				// Absence-based removal is only sound when the whole account
 				// list was seen; a capped (incomplete) listing proves nothing
 				// about accounts past the cap.
@@ -764,6 +769,12 @@ export async function getComposioStatus(options?: {
 					// instead of trusting the empty cache.
 					stored.tools.length === 0) &&
 				!pendingConnections.has(slug) &&
+				// A connect mid-initiation owns the slug (its pending entry does
+				// not exist yet): a redirect-less attempt can already be ACTIVE
+				// remotely while its finalize is still fetching tools, and
+				// importing it here would keep it installed even if that
+				// finalize then fails and abandons the account.
+				!connectInitiationsInFlight.has(slug) &&
 				// The remote snapshot predates a local disconnect of this
 				// toolkit; writing it back would resurrect the connection.
 				(lastDisconnectedAt.get(slug) ?? 0) < refreshStartedAt
@@ -818,7 +829,10 @@ export async function getComposioStatus(options?: {
 					if ((lastDisconnectedAt.get(slug) ?? 0) >= refreshStartedAt) {
 						continue; // Disconnected mid-refresh.
 					}
-					if (pendingConnections.has(slug)) {
+					if (
+						pendingConnections.has(slug) ||
+						connectInitiationsInFlight.has(slug)
+					) {
 						continue; // A new attempt started mid-refresh; let it finish.
 					}
 					if (freshCancelled.has(imported.connectedAccountId)) {
@@ -1317,6 +1331,15 @@ async function abandonFinalizedConnection(
 ): Promise<void> {
 	updateComposioState((s) => {
 		rememberCancelledAccountId(s, connectedAccountId);
+		// A concurrent refresh may have imported this account before the
+		// tombstone above landed (it was ACTIVE remotely while the attempt was
+		// still finalizing). No stored entry may outlive its abandoned
+		// account, so strip any toolkit that carries it.
+		for (const [slug, stored] of Object.entries(s.toolkits ?? {})) {
+			if (stored?.connectedAccountId === connectedAccountId && s.toolkits) {
+				delete s.toolkits[slug];
+			}
+		}
 	});
 	const confirmedGone = await revokeConnectedAccountQuietly(
 		apiKey,

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -1189,6 +1189,15 @@ export async function disconnectComposioToolkit(
 	toolkit: ComposioToolkitSlug,
 	logger?: BasicLogger,
 ): Promise<ComposioStatusResponse> {
+	// Record the disconnect intent BEFORE any await, so a connect attempt
+	// that began earlier and finalizes while this disconnect is still
+	// awaiting its remote revocation is dropped at write time (its startedAt
+	// predates this marker; see FinalizeGuard.startedAt). Stamping at entry —
+	// rather than after the revocation — is the mirror of anchoring the
+	// connect's startedAt at entry: whichever action started later wins,
+	// symmetrically. A connect that began AFTER this marker keeps a larger
+	// startedAt and is not dropped, so a genuinely newer reconnect survives.
+	lastDisconnectedAt.set(toolkit, Date.now());
 	const pending = pendingConnections.get(toolkit);
 	pendingConnections.delete(toolkit);
 	lastConnectionErrors.delete(toolkit);
@@ -1261,15 +1270,17 @@ export async function disconnectComposioToolkit(
 			}
 		}
 	}
-	let slotEmptyAfterRemoval = false;
 	const next = updateComposioState((s) => {
 		const current = s.toolkits?.[toolkit];
 		// Remove only the account this disconnect actually revoked. A
 		// connection finalized while the awaited revocation above was in
-		// flight is the newer user intent: it carries a different account id
-		// and its remote account was never touched — blindly deleting it here
-		// would leave that account authorized with no local record, for the
-		// next refresh to import as a resurrected connector.
+		// flight is the newer user intent (its startedAt is after this
+		// disconnect's entry marker, so finalize was NOT dropped): it carries
+		// a different account id and its remote account was never touched —
+		// blindly deleting it here would leave that account authorized with no
+		// local record, for the next refresh to import as a resurrected
+		// connector. The entry-time marker is safe to keep either way: it
+		// predates any surviving newer connection's startedAt.
 		if (
 			current &&
 			stored &&
@@ -1278,14 +1289,7 @@ export async function disconnectComposioToolkit(
 		) {
 			delete s.toolkits[toolkit];
 		}
-		slotEmptyAfterRemoval = !s.toolkits?.[toolkit];
 	});
-	if (slotEmptyAfterRemoval) {
-		// Only an effective disconnect stamps the marker; stamping over a
-		// surviving newer connection would make later refreshes and
-		// finalizations treat it as disconnected.
-		lastDisconnectedAt.set(toolkit, Date.now());
-	}
 	return buildStatusResponse(next);
 }
 

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -1145,6 +1145,13 @@ export async function cancelComposioConnect(
 	if (!pending) {
 		return;
 	}
+	// Record the cancel intent BEFORE any await, so a status refresh that
+	// snapshotted this account as ACTIVE and is mid-import drops it at its
+	// write-time check (lastDisconnectedAt >= refreshStartedAt). The tombstone
+	// alone is not enough for that: a successful revocation prunes it before
+	// the refresh's write, so the timestamp is the durable "cancelled during
+	// this refresh" signal. Mirrors the disconnect entry marker.
+	lastDisconnectedAt.set(toolkit, Date.now());
 	// Deleting the local marker alone is not enough: the OAuth tab may still
 	// be open, and completing it later would turn the remote account ACTIVE,
 	// where the next dashboard reconciliation would import it right back.

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -98,6 +98,11 @@ type PendingConnection = {
 	 * either changed while the browser flow was in flight. */
 	apiKey: string;
 	userId: string;
+	/** The webview connection that started this attempt, if any. When that
+	 * connection goes away (webview closed/reloaded, transport drop) the
+	 * attempt is abandoned — matching how provider and MCP OAuth waits are
+	 * cancelled for a departing owner. Identity only; never dereferenced. */
+	owner?: object;
 };
 
 type ComposioConnectionRequest = {
@@ -985,6 +990,7 @@ export async function listComposioToolkits(
 export async function connectComposioToolkit(
 	toolkit: ComposioToolkitSlug,
 	logger?: BasicLogger,
+	options?: { owner?: object },
 ): Promise<ComposioConnectResponse> {
 	// Anchor the disconnect race at function entry, BEFORE any await: a
 	// disconnect whose marker lands at or after this instant overlapped this
@@ -1074,6 +1080,7 @@ export async function connectComposioToolkit(
 			attemptId,
 			connectedAccountId: connectionRequest.id,
 			redirectUrl,
+			owner: options?.owner,
 			...guard,
 		});
 
@@ -1157,6 +1164,32 @@ export async function cancelComposioConnect(
 	if (confirmedGone) {
 		pruneConfirmedCancelledAccount(pending.connectedAccountId);
 	}
+}
+
+/**
+ * Abandon every pending OAuth attempt started by `owner` — the webview
+ * connection that initiated it. Called when that connection goes away
+ * (webview closed/reloaded, transport drop), mirroring how provider and MCP
+ * OAuth waits are cancelled for a departing owner: an interactive attempt the
+ * user walked away from must not complete in the background and materialize
+ * credential-bearing tools afterward. Each is abandoned exactly like an
+ * explicit cancel (tombstone + best-effort revoke). Returns the count
+ * abandoned.
+ */
+export function abandonComposioConnectsForOwner(
+	owner: object,
+	logger?: BasicLogger,
+): number {
+	const toolkits: ComposioToolkitSlug[] = [];
+	for (const [toolkit, pending] of pendingConnections) {
+		if (pending.owner === owner) {
+			toolkits.push(toolkit);
+		}
+	}
+	for (const toolkit of toolkits) {
+		void cancelComposioConnect(toolkit, logger);
+	}
+	return toolkits.length;
 }
 
 /**

--- a/apps/examples/desktop-app/sidecar/composio.ts
+++ b/apps/examples/desktop-app/sidecar/composio.ts
@@ -1220,23 +1220,45 @@ export async function disconnectComposioToolkit(
 			);
 		} catch (error) {
 			if (!isAccountAlreadyGoneError(error)) {
-				// Revocation did NOT happen: the account is still authorized on
-				// Composio's side, and running Hub sessions that loaded this
-				// connector keep executing against it until the delete lands.
-				// Removing only the local state would report an uninstall that
-				// never took effect remotely — keep the connector installed and
-				// surface the failure so the user retries. (Revoking from the
-				// Composio dashboard works too: the next status refresh drops
-				// the local state once the account is gone.)
-				throw new Error(
-					`Could not revoke the ${toolkit} connection: ${formatComposioError(error)}. The connector is still connected — try again, or revoke it from the Composio dashboard.`,
+				const current =
+					readComposioState().toolkits?.[toolkit]?.connectedAccountId;
+				if (
+					current === stored.connectedAccountId &&
+					!connectInitiationsInFlight.has(toolkit)
+				) {
+					// Revocation did NOT happen: the account is still authorized
+					// on Composio's side, and running Hub sessions that loaded
+					// this connector keep executing against it until the delete
+					// lands. Removing only the local state would report an
+					// uninstall that never took effect remotely — keep the
+					// connector installed (it is the retry vehicle) and surface
+					// the failure. (Revoking from the Composio dashboard works
+					// too: the next status refresh drops the local state once
+					// the account is gone.)
+					throw new Error(
+						`Could not revoke the ${toolkit} connection: ${formatComposioError(error)}. The connector is still connected — try again, or revoke it from the Composio dashboard.`,
+					);
+				}
+				// The slot was replaced by a newer connect (or one is mid-flight
+				// and may replace it), so the stored entry can no longer serve
+				// as the retry vehicle for this still-authorized account —
+				// throwing here would orphan it with no local reference at all.
+				// Tombstone it instead: reconciliation retries the revocation on
+				// every refresh and prunes once it is confirmed.
+				updateComposioState((s) => {
+					rememberCancelledAccountId(s, stored.connectedAccountId);
+				});
+				logger?.log?.(
+					`composio disconnect ${toolkit}: revocation failed after the slot changed; retrying via tombstone (${formatComposioError(error)})`,
 				);
 			}
-			// Already deleted on Composio's side; local removal is all that is
-			// left to do.
-			logger?.log?.(
-				`composio disconnect ${toolkit}: account already gone remotely`,
-			);
+			if (isAccountAlreadyGoneError(error)) {
+				// Already deleted on Composio's side; local removal is all that
+				// is left to do.
+				logger?.log?.(
+					`composio disconnect ${toolkit}: account already gone remotely`,
+				);
+			}
 		}
 	}
 	let slotEmptyAfterRemoval = false;
@@ -1396,7 +1418,17 @@ async function finalizeToolkitConnection(
 	}
 	// No await separates the guard checks above from this write, so the
 	// checked state cannot go stale in between.
+	let replacedAccountId: string | undefined;
 	updateComposioState((s) => {
+		const previous = s.toolkits?.[toolkit];
+		if (previous && previous.connectedAccountId !== connectedAccountId) {
+			// Superseded by this connection: nothing references the previous
+			// account anymore, so it must not stay authorized remotely. The
+			// tombstone also covers a concurrent disconnect whose own
+			// revocation of it fails after this write.
+			replacedAccountId = previous.connectedAccountId;
+			rememberCancelledAccountId(s, previous.connectedAccountId);
+		}
 		s.toolkits = {
 			...(s.toolkits ?? {}),
 			[toolkit]: {
@@ -1407,6 +1439,16 @@ async function finalizeToolkitConnection(
 			},
 		};
 	});
+	if (replacedAccountId) {
+		const superseded = replacedAccountId;
+		void revokeConnectedAccountQuietly(guard.apiKey, superseded, logger).then(
+			(confirmedGone) => {
+				if (confirmedGone) {
+					pruneConfirmedCancelledAccount(superseded);
+				}
+			},
+		);
+	}
 	logger?.log?.(`composio connected ${toolkit} with ${tools.length} tool(s)`);
 	return true;
 }

--- a/apps/examples/desktop-app/sidecar/server.ts
+++ b/apps/examples/desktop-app/sidecar/server.ts
@@ -17,6 +17,7 @@ import {
 	sendEvent,
 	syncSidecarApprovalReadiness,
 } from "./context";
+import { abandonComposioConnectsForOwner } from "./composio";
 import { fetchMarketplaceCatalog } from "./marketplace";
 import { cancelMcpOAuthAuthorizationsForOwner } from "./mcp-oauth";
 import { cancelProviderOAuthLoginsForOwner } from "./oauth-login";
@@ -537,6 +538,10 @@ export function createWebSocketHandler(ctx: SidecarContext) {
 			// wait so the sidecar cannot retain an abandoned authorization attempt.
 			cancelProviderOAuthLoginsForOwner(ws);
 			cancelMcpOAuthAuthorizationsForOwner(ws);
+			// Composio connects finish in the external browser; abandon (revoke
+			// + tombstone) any this connection started so a flow completed after
+			// the webview is gone cannot materialize connector tools.
+			abandonComposioConnectsForOwner(ws);
 		},
 	};
 }

--- a/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
@@ -1,14 +1,17 @@
 import {
 	ArrowUpRight,
 	BadgeCheck,
+	Cable,
 	Github,
 	Globe,
+	Loader2,
 	Puzzle,
 	Scale,
 	Search,
 	Server,
 	Trash2,
 	User,
+	Wrench,
 	X,
 	Zap,
 } from "lucide-react";
@@ -18,6 +21,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
+import { fetchComposioToolkitCatalog } from "@/lib/composio";
+import type { ComposioCatalogToolkit } from "@/lib/composio-types";
 import { desktopClient, openExternalUrl } from "@/lib/desktop-client";
 import {
 	fetchMarketplaceCatalog,
@@ -25,7 +30,13 @@ import {
 	type MarketplaceEntry,
 	type MarketplacePrimitiveType,
 } from "@/lib/marketplace";
+import { useComposioConnections } from "@/lib/use-composio-connections";
 import { cn } from "@/lib/utils";
+import {
+	ConnectorActionButton,
+	ConnectorLogo,
+	connectorMatchesQuery,
+} from "./settings/composio-connector-browser";
 
 /**
  * Marketplace explorer: a two-pane master/detail directory in the spirit of
@@ -73,8 +84,18 @@ const INSTALL_TIMEOUT_MS = 300_000;
 /** Tag pills shown while the category row is collapsed. */
 const COLLAPSED_TAG_COUNT = 4;
 
+/** Connector rows shown in the mixed ("All") view; the Connectors filter
+ * lists the full catalog. */
+const CONNECTOR_PREVIEW_COUNT = 24;
+
 function entryKey(entry: Pick<MarketplaceEntry, "id" | "type">): string {
 	return `${entry.type}:${entry.id}`;
+}
+
+const CONNECTOR_KEY_PREFIX = "connector:";
+
+function connectorKey(slug: string): string {
+	return `${CONNECTOR_KEY_PREFIX}${slug}`;
 }
 
 function entrySearchText(
@@ -565,15 +586,240 @@ function DetailPane({
 	);
 }
 
+function ConnectorListRow({
+	connector,
+	connected,
+	onSelect,
+	selected,
+}: {
+	connector: ComposioCatalogToolkit;
+	connected: boolean;
+	onSelect: () => void;
+	selected: boolean;
+}) {
+	return (
+		<button
+			className={cn(
+				"flex w-full min-w-0 items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors",
+				selected ? "bg-primary/10" : "hover:bg-surface-hover-lighter",
+			)}
+			onClick={onSelect}
+			type="button"
+		>
+			<span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-secondary">
+				<ConnectorLogo
+					className="size-4"
+					logo={connector.logo}
+					name={connector.name}
+					slug={connector.slug}
+				/>
+			</span>
+			<span className="min-w-0 flex-1">
+				<span className="block truncate text-sm font-medium text-foreground">
+					{connector.name}
+				</span>
+				<span className="block truncate text-xs text-muted-foreground">
+					{connector.description ?? "Connect your account via Composio."}
+				</span>
+			</span>
+			{connected ? (
+				<span
+					className="size-1.5 shrink-0 rounded-full bg-emerald-500"
+					title="Connected"
+				/>
+			) : null}
+		</button>
+	);
+}
+
+function ConnectorDetailPane({
+	connector,
+	connections,
+}: {
+	connector: ComposioCatalogToolkit;
+	connections: ReturnType<typeof useComposioConnections>;
+}) {
+	const summary = connections.statusBySlug.get(connector.slug);
+	const status = summary?.status ?? "not_connected";
+	const busy = connections.busyToolkit === connector.slug;
+	const toolNames = summary?.toolNames ?? [];
+	const error = connections.actionError ?? summary?.error;
+
+	return (
+		<ScrollArea className="h-full min-w-0 flex-1">
+			<div className="mx-auto grid max-w-3xl gap-6 px-8 py-8 max-[900px]:px-5">
+				<div className="flex items-start gap-5">
+					<span className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-secondary">
+						<ConnectorLogo
+							className="size-7"
+							logo={connector.logo}
+							name={connector.name}
+							slug={connector.slug}
+						/>
+					</span>
+					<div className="min-w-0 flex-1">
+						<div className="flex min-w-0 flex-wrap items-center gap-2">
+							<h1 className="min-w-0 truncate text-2xl font-semibold text-foreground">
+								{connector.name}
+							</h1>
+							<Badge variant="outline" className="text-muted-foreground">
+								Connector
+							</Badge>
+							{status === "connected" ? (
+								<Badge className="border border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
+									Connected
+								</Badge>
+							) : null}
+						</div>
+						{connector.description ? (
+							<p className="mt-1 text-sm text-muted-foreground">
+								{connector.description}
+							</p>
+						) : null}
+						<div className="mt-4 flex flex-wrap items-center gap-2">
+							<ConnectorActionButton
+								busy={busy}
+								configured
+								onCancel={() => void connections.cancelConnect(connector.slug)}
+								onConnect={() => void connections.connect(connector.slug)}
+								onDisconnect={() => void connections.disconnect(connector.slug)}
+								showUninstall
+								status={status}
+								variant="default"
+							/>
+						</div>
+						{status === "pending" ? (
+							<p className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground">
+								<Loader2 className="size-4 animate-spin" />
+								Finish authorizing {connector.name} in your browser…
+							</p>
+						) : null}
+						{error ? (
+							<p className="mt-2 text-xs text-destructive" role="alert">
+								{error}
+							</p>
+						) : null}
+					</div>
+				</div>
+
+				<div className="grid grid-cols-2 gap-x-6 gap-y-4 rounded-xl border p-4 sm:grid-cols-3">
+					<MetaCell
+						icon={Wrench}
+						label="Tools"
+						value={
+							status === "connected" && toolNames.length > 0
+								? `${toolNames.length} available`
+								: connector.toolsCount !== undefined
+									? `${connector.toolsCount} in toolkit`
+									: "—"
+						}
+					/>
+					<MetaCell
+						icon={Cable}
+						label="Provider"
+						value="Composio (OAuth in your browser)"
+					/>
+				</div>
+
+				{connector.categories && connector.categories.length > 0 ? (
+					<div className="flex flex-wrap gap-1.5">
+						{connector.categories.map((category) => (
+							<Badge
+								className="font-normal text-muted-foreground"
+								key={category}
+								variant="outline"
+							>
+								{category}
+							</Badge>
+						))}
+					</div>
+				) : null}
+
+				{status === "connected" && toolNames.length > 0 ? (
+					<div className="grid gap-2">
+						<p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+							Tools available in new sessions
+						</p>
+						<div className="flex flex-wrap gap-1.5">
+							{toolNames.map((name) => (
+								<Badge className="font-normal" key={name} variant="outline">
+									{name}
+								</Badge>
+							))}
+						</div>
+					</div>
+				) : null}
+			</div>
+		</ScrollArea>
+	);
+}
+
 export function MarketplaceExplorerView() {
 	const directory = useMarketplaceDirectory();
 	const [query, setQuery] = useState("");
-	const [typeFilter, setTypeFilter] = useState<MarketplacePrimitiveType | null>(
-		null,
-	);
+	const [typeFilter, setTypeFilter] = useState<
+		MarketplacePrimitiveType | "connectors" | null
+	>(null);
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
 	const [tagsExpanded, setTagsExpanded] = useState(false);
 	const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+	// Connectors (Composio) ride along in the explorer when this install has
+	// a managed key and the account passes the internal gate — the sidecar
+	// reports both through `configured`. Unconfigured installs never see the
+	// section, the filter chip, or a network fetch for the catalog.
+	const connections = useComposioConnections();
+	const [connectorEntries, setConnectorEntries] = useState<
+		ComposioCatalogToolkit[] | null
+	>(null);
+	useEffect(() => {
+		if (!connections.configured) {
+			setConnectorEntries(null);
+			return;
+		}
+		let cancelled = false;
+		void fetchComposioToolkitCatalog()
+			.then((response) => {
+				if (!cancelled && response.configured) {
+					setConnectorEntries(response.toolkits);
+				}
+			})
+			.catch(() => {
+				// The section appears once the catalog loads; a failed fetch
+				// leaves the marketplace usable without it.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [connections.configured]);
+	const connectorsAvailable =
+		connections.configured && (connectorEntries?.length ?? 0) > 0;
+
+	// Marketplace tags don't apply to connectors (they carry their own
+	// category labels), so an active tag narrows the list to tagged
+	// marketplace entries only.
+	const matchedConnectors = useMemo(() => {
+		if (
+			!connectorsAvailable ||
+			selectedTag !== null ||
+			(typeFilter !== null && typeFilter !== "connectors")
+		) {
+			return [];
+		}
+		const entries = connectorEntries ?? [];
+		const normalized = query.trim().toLowerCase();
+		return normalized.length === 0
+			? entries
+			: entries.filter((entry) => connectorMatchesQuery(entry, normalized));
+	}, [connectorsAvailable, connectorEntries, query, selectedTag, typeFilter]);
+
+	const visibleConnectors = useMemo(
+		() =>
+			typeFilter === "connectors"
+				? matchedConnectors
+				: matchedConnectors.slice(0, CONNECTOR_PREVIEW_COUNT),
+		[matchedConnectors, typeFilter],
+	);
 
 	// Type + query filtering happens before tag filtering so the tag pill
 	// counts reflect what each tag would narrow the current list down to.
@@ -648,12 +894,30 @@ export function MarketplaceExplorerView() {
 		[filteredEntries],
 	);
 
+	const selectedConnector = useMemo(() => {
+		if (!selectedKey?.startsWith(CONNECTOR_KEY_PREFIX)) {
+			return null;
+		}
+		const slug = selectedKey.slice(CONNECTOR_KEY_PREFIX.length);
+		return visibleConnectors.find((entry) => entry.slug === slug) ?? null;
+	}, [selectedKey, visibleConnectors]);
+
 	const selectedEntry = useMemo(() => {
+		if (selectedConnector) {
+			return null;
+		}
 		const flat = groups.flatMap((group) => group.entries);
 		return (
 			flat.find((entry) => entryKey(entry) === selectedKey) ?? flat[0] ?? null
 		);
-	}, [groups, selectedKey]);
+	}, [groups, selectedConnector, selectedKey]);
+
+	// With only connectors visible (the Connectors filter, or a query that
+	// matches nothing else), default the detail pane to the first connector
+	// the same way marketplace entries default to the first row.
+	const activeConnector =
+		selectedConnector ??
+		(selectedEntry === null ? (visibleConnectors[0] ?? null) : null);
 
 	const typeCounts = useMemo(() => {
 		const counts = new Map<MarketplacePrimitiveType, number>();
@@ -723,6 +987,24 @@ export function MarketplaceExplorerView() {
 								</span>
 							</Button>
 						))}
+						{connectorsAvailable ? (
+							<Button
+								aria-pressed={typeFilter === "connectors"}
+								onClick={() =>
+									setTypeFilter((current) =>
+										current === "connectors" ? null : "connectors",
+									)
+								}
+								size="xs"
+								type="button"
+								variant={typeFilter === "connectors" ? "default" : "outline"}
+							>
+								Connectors
+								<span className="text-[10px] opacity-70">
+									{connectorEntries?.length ?? 0}
+								</span>
+							</Button>
+						) : null}
 					</div>
 					{visibleTags.length > 0 ? (
 						<div className="flex flex-wrap gap-1">
@@ -802,7 +1084,43 @@ export function MarketplaceExplorerView() {
 								</div>
 							);
 						})}
-						{groups.length === 0 ? (
+						{visibleConnectors.length > 0 ? (
+							<div className="grid gap-1">
+								<div className="flex items-center gap-1.5 px-2.5 pt-1">
+									<Cable className="size-3.5 text-primary" />
+									<span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+										Connectors
+									</span>
+									<span className="text-xs text-muted-foreground/70">
+										{matchedConnectors.length}
+									</span>
+								</div>
+								{visibleConnectors.map((connector) => (
+									<ConnectorListRow
+										connected={
+											connections.statusBySlug.get(connector.slug)?.status ===
+											"connected"
+										}
+										connector={connector}
+										key={connector.slug}
+										onSelect={() =>
+											setSelectedKey(connectorKey(connector.slug))
+										}
+										selected={activeConnector?.slug === connector.slug}
+									/>
+								))}
+								{matchedConnectors.length > visibleConnectors.length ? (
+									<button
+										className="mx-2.5 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-surface-hover-lighter hover:text-foreground"
+										onClick={() => setTypeFilter("connectors")}
+										type="button"
+									>
+										Show all {matchedConnectors.length} connectors
+									</button>
+								) : null}
+							</div>
+						) : null}
+						{groups.length === 0 && visibleConnectors.length === 0 ? (
 							<p className="px-3 py-6 text-center text-sm text-muted-foreground">
 								No entries match the current filters.
 							</p>
@@ -810,7 +1128,12 @@ export function MarketplaceExplorerView() {
 					</div>
 				</ScrollArea>
 			</aside>
-			{selectedEntry ? (
+			{activeConnector ? (
+				<ConnectorDetailPane
+					connections={connections}
+					connector={activeConnector}
+				/>
+			) : selectedEntry ? (
 				<DetailPane
 					directory={directory}
 					entry={selectedEntry}

--- a/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/marketplace-explorer-view.tsx
@@ -643,7 +643,13 @@ function ConnectorDetailPane({
 	const status = summary?.status ?? "not_connected";
 	const busy = connections.busyToolkit === connector.slug;
 	const toolNames = summary?.toolNames ?? [];
-	const error = connections.actionError ?? summary?.error;
+	// Action errors are scoped to the toolkit they came from — connector B's
+	// pane must never render connector A's failure.
+	const scopedActionError =
+		connections.actionError?.toolkit === connector.slug
+			? connections.actionError.message
+			: undefined;
+	const error = scopedActionError ?? summary?.error;
 
 	return (
 		<ScrollArea className="h-full min-w-0 flex-1">

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
@@ -325,7 +325,7 @@ export function ComposioConnectorBrowser({
 
 			{actionError ? (
 				<p className="text-xs text-destructive" role="alert">
-					{actionError}
+					{actionError.message}
 				</p>
 			) : null}
 

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
@@ -324,7 +324,11 @@ export function ComposioConnectorBrowser({
 			</div>
 
 			{actionError ? (
+				// Attributed to the connector the failed action targeted, so the
+				// catalog surface never presents it as some other connector's
+				// failure.
 				<p className="text-xs text-destructive" role="alert">
+					{statusBySlug.get(actionError.toolkit)?.name ?? actionError.toolkit}:{" "}
 					{actionError.message}
 				</p>
 			) : null}
@@ -387,6 +391,11 @@ export function ComposioConnectorBrowser({
 			)}
 
 			<ConnectorDetailDialog
+				actionError={
+					detailSlug !== null && actionError?.toolkit === detailSlug
+						? actionError.message
+						: undefined
+				}
 				busy={detailSlug !== null && busyToolkit === detailSlug}
 				entry={detailEntry}
 				onCancel={() => {
@@ -475,6 +484,7 @@ function ConnectorRow({
 function ConnectorDetailDialog({
 	entry,
 	summary,
+	actionError,
 	busy,
 	onConnect,
 	onCancel,
@@ -483,6 +493,8 @@ function ConnectorDetailDialog({
 }: {
 	entry: ComposioCatalogToolkit | null;
 	summary?: ComposioIntegrationSummary;
+	/** Already scoped by the caller to THIS dialog's connector. */
+	actionError?: string;
 	busy: boolean;
 	onConnect: () => void;
 	onCancel: () => void;
@@ -562,9 +574,9 @@ function ConnectorDetailDialog({
 								</p>
 							) : null}
 
-							{summary?.error ? (
+							{(actionError ?? summary?.error) ? (
 								<p className="text-xs text-destructive" role="alert">
-									{summary.error}
+									{actionError ?? summary?.error}
 								</p>
 							) : null}
 

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connector-browser.tsx
@@ -323,16 +323,6 @@ export function ComposioConnectorBrowser({
 				)}
 			</div>
 
-			{actionError ? (
-				// Attributed to the connector the failed action targeted, so the
-				// catalog surface never presents it as some other connector's
-				// failure.
-				<p className="text-xs text-destructive" role="alert">
-					{statusBySlug.get(actionError.toolkit)?.name ?? actionError.toolkit}:{" "}
-					{actionError.message}
-				</p>
-			) : null}
-
 			{catalogLoading && !catalog ? (
 				<output
 					aria-label="Loading connector catalog"
@@ -361,18 +351,29 @@ export function ComposioConnectorBrowser({
 					<div className="max-h-[calc(100dvh-370px)] min-h-80 overflow-y-auto pr-1">
 						<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
 							{visibleCatalog.map((entry) => (
-								<ConnectorRow
-									busy={busyToolkit === entry.slug}
-									entry={entry}
-									key={entry.slug}
-									onCancel={() => void cancelConnect(entry.slug)}
-									onConnect={() => void connect(entry.slug)}
-									onDisconnect={() => void disconnect(entry.slug)}
-									onOpenDetails={() => setDetailSlug(entry.slug)}
-									status={
-										statusBySlug.get(entry.slug)?.status ?? "not_connected"
-									}
-								/>
+								<div className="min-w-0" key={entry.slug}>
+									<ConnectorRow
+										busy={busyToolkit === entry.slug}
+										entry={entry}
+										onCancel={() => void cancelConnect(entry.slug)}
+										onConnect={() => void connect(entry.slug)}
+										onDisconnect={() => void disconnect(entry.slug)}
+										onOpenDetails={() => setDetailSlug(entry.slug)}
+										status={
+											statusBySlug.get(entry.slug)?.status ?? "not_connected"
+										}
+									/>
+									{actionError?.toolkit === entry.slug ? (
+										// Scoped to this connector's own card; no shared
+										// surface retains another connector's failure.
+										<p
+											className="mt-1 px-1 text-xs text-destructive"
+											role="alert"
+										>
+											{actionError.message}
+										</p>
+									) : null}
+								</div>
 							))}
 						</div>
 						{visibleCatalog.length === 0 ? (

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
@@ -118,7 +118,7 @@ export function ComposioConnectorsView({
 
 			{actionError ? (
 				<p className="text-xs text-destructive" role="alert">
-					{actionError}
+					{actionError.message}
 				</p>
 			) : null}
 

--- a/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/composio-connectors-view.tsx
@@ -116,12 +116,6 @@ export function ComposioConnectorsView({
 				</p>
 			</div>
 
-			{actionError ? (
-				<p className="text-xs text-destructive" role="alert">
-					{actionError.message}
-				</p>
-			) : null}
-
 			<section>
 				<h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
 					Recommended
@@ -129,6 +123,11 @@ export function ComposioConnectorsView({
 				<div className="flex flex-col gap-3">
 					{recommended.map((integration) => (
 						<ConnectorCard
+							actionError={
+								actionError?.toolkit === integration.toolkit
+									? actionError.message
+									: undefined
+							}
 							busy={busyToolkit === integration.toolkit}
 							configured={configured}
 							integration={integration}
@@ -185,6 +184,7 @@ function ConnectorCard({
 	integration,
 	logo,
 	configured,
+	actionError,
 	busy,
 	onConnect,
 	onCancel,
@@ -193,6 +193,8 @@ function ConnectorCard({
 	integration: ComposioIntegrationSummary;
 	logo?: string;
 	configured: boolean;
+	/** Already scoped by the caller to THIS card's connector. */
+	actionError?: string;
 	busy: boolean;
 	onConnect: () => void;
 	onCancel: () => void;
@@ -240,9 +242,9 @@ function ConnectorCard({
 				</p>
 			) : null}
 
-			{integration.error ? (
+			{(actionError ?? integration.error) ? (
 				<p className="mt-2 text-xs text-destructive" role="alert">
-					{integration.error}
+					{actionError ?? integration.error}
 				</p>
 			) : null}
 

--- a/apps/examples/desktop-app/webview/lib/use-composio-connections.ts
+++ b/apps/examples/desktop-app/webview/lib/use-composio-connections.ts
@@ -30,7 +30,12 @@ export function useComposioConnections({
 } = {}) {
 	const [status, setStatus] = useState<ComposioStatusResponse | null>(null);
 	const [loadError, setLoadError] = useState<string | null>(null);
-	const [actionError, setActionError] = useState<string | null>(null);
+	// Scoped to the toolkit the failed action targeted, so one connector's
+	// failure is never rendered as another connector's error.
+	const [actionError, setActionError] = useState<{
+		toolkit: ComposioToolkitSlug;
+		message: string;
+	} | null>(null);
 	const [busyToolkit, setBusyToolkit] = useState<ComposioToolkitSlug | null>(
 		null,
 	);
@@ -112,7 +117,10 @@ export function useComposioConnections({
 				const result = await connectComposioIntegration(toolkit);
 				applyStatus(result.status);
 			} catch (error) {
-				setActionError(error instanceof Error ? error.message : String(error));
+				setActionError({
+					toolkit,
+					message: error instanceof Error ? error.message : String(error),
+				});
 			} finally {
 				setBusyToolkit(null);
 			}
@@ -138,7 +146,10 @@ export function useComposioConnections({
 			try {
 				applyStatus(await disconnectComposioIntegration(toolkit));
 			} catch (error) {
-				setActionError(error instanceof Error ? error.message : String(error));
+				setActionError({
+					toolkit,
+					message: error instanceof Error ? error.message : String(error),
+				});
 			} finally {
 				setBusyToolkit(null);
 			}


### PR DESCRIPTION
## What

Two follow-ups for the beta line, cherry-picked from #13684's reviewed head (both at 5/5 there):

1. **Restore connectors in the marketplace.** The main sync (#13742) brought the marketplace explorer redesign (#13653) into desktop-experimental — which has no connectors surface, so 0.0.22-beta.1 shipped with connectors missing from the marketplace. This integrates them first-class into the two-pane explorer: a Connectors filter chip with catalog count (rendered only when the sidecar reports connectors available — managed key + internal gate), a Connectors group in the left rail with a top-24 preview and "Show all" affordance, and a connector detail pane matching the explorer's layout (Install/OAuth, cancel, uninstall, pending/error states, category pills, tool list once connected). Customize → Connectors is unaffected either way.

2. **Single-flight connect initiation** (review finding by @johnwschoi on #13684): two connects for the same toolkit overlapping inside the initiation round trip each created a remote account, and the second pending entry overwrote the first — whose account was never tombstoned or revoked, leaving it eligible for a later reconciliation import. A per-toolkit in-flight guard now claims the slot synchronously at entry; overlapping calls report current status without starting an attempt. Regression tests assert exactly one authorize call for overlapping browser-flow and redirect-less connects.

## Testing

- 64/64 desktop sidecar tests (composio + feature-flags), `bun run typecheck` clean, biome clean
- Cherry-picks applied without conflicts onto current desktop-experimental (post-#13742 sync)

## After merge

Worth including in the next beta cut so testers get the marketplace surface back.