### PR TITLE
feat(webview): drag-to-reorder and inline-edit queued prompts

### DIFF
--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -14,6 +14,10 @@ service TaskService {
   rpc cancelTask(EmptyRequest) returns (Empty);
   // Cancels a queued prompt by ID
   rpc cancelQueuedPrompt(StringRequest) returns (Empty);
+  // Updates a queued prompt's content (and optionally delivery) by ID
+  rpc updateQueuedPrompt(UpdateQueuedPromptRequest) returns (Empty);
+  // Reorders a queued prompt to the given queue position (drag-and-drop)
+  rpc reorderQueuedPrompt(ReorderQueuedPromptRequest) returns (Empty);
   // Cancels the currently running background command
   rpc cancelBackgroundCommand(EmptyRequest) returns (Empty);
   // Detaches the running foreground terminal command ("Proceed While Running"):
@@ -54,6 +58,19 @@ message NewTaskRequest {
   repeated string images = 3;
   repeated string files = 4;
   optional Settings task_settings = 5;
+}
+
+// Request message for updating a queued prompt (content edit / delivery change)
+message UpdateQueuedPromptRequest {
+  string prompt_id = 1;
+  optional string prompt = 2;
+  optional string delivery = 3;
+}
+
+// Request message for reordering a queued prompt to an explicit queue position
+message ReorderQueuedPromptRequest {
+  string prompt_id = 1;
+  int32 position = 2;
 }
 
 // Request message for toggling task favorite status

--- a/apps/vscode/src/core/controller/task/reorderQueuedPrompt.ts
+++ b/apps/vscode/src/core/controller/task/reorderQueuedPrompt.ts
@@ -1,0 +1,25 @@
+import { Empty } from "@shared/proto/cline/common"
+import { ReorderQueuedPromptRequest } from "@shared/proto/cline/task"
+import { Logger } from "@/shared/services/Logger"
+import { Controller } from ".."
+
+/**
+ * Reorders a queued prompt to an explicit queue position for the active SDK session.
+ * Used by drag-and-drop reordering of queued messages in the chat UI.
+ *
+ * @param controller The controller instance
+ * @param request The reorder request containing the prompt ID and target position
+ * @returns Empty response
+ */
+export async function reorderQueuedPrompt(
+	controller: Controller,
+	request: ReorderQueuedPromptRequest,
+): Promise<Empty> {
+	try {
+		await controller.reorderQueuedPrompt(request.promptId, request.position)
+		return Empty.create()
+	} catch (error) {
+		Logger.error("Error in reorderQueuedPrompt handler:", error)
+		throw error
+	}
+}

--- a/apps/vscode/src/core/controller/task/updateQueuedPrompt.ts
+++ b/apps/vscode/src/core/controller/task/updateQueuedPrompt.ts
@@ -1,0 +1,28 @@
+import { Empty } from "@shared/proto/cline/common"
+import { UpdateQueuedPromptRequest } from "@shared/proto/cline/task"
+import { Logger } from "@/shared/services/Logger"
+import { Controller } from ".."
+
+/**
+ * Updates a queued prompt's content (and optionally delivery) for the active SDK session.
+ *
+ * @param controller The controller instance
+ * @param request The update request containing the prompt ID and optional new content
+ * @returns Empty response
+ */
+export async function updateQueuedPrompt(
+	controller: Controller,
+	request: UpdateQueuedPromptRequest,
+): Promise<Empty> {
+	try {
+		await controller.updateQueuedPrompt({
+			promptId: request.promptId,
+			prompt: request.prompt ?? undefined,
+			delivery: request.delivery ?? undefined,
+		})
+		return Empty.create()
+	} catch (error) {
+		Logger.error("Error in updateQueuedPrompt handler:", error)
+		throw error
+	}
+}

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -1458,6 +1458,62 @@ export class Controller {
 		}
 		await this.postStateToWebview()
 	}
+	async updateQueuedPrompt(input: {
+		promptId: string
+		prompt?: string
+		delivery?: string
+	}): Promise<void> {
+		const trimmedPromptId = input.promptId.trim()
+		if (!trimmedPromptId) {
+			Logger.warn("[SdkController] updateQueuedPrompt: Missing prompt id")
+			return
+		}
+
+		const activeSession = this.sessions.getActiveSession()
+		if (!activeSession) {
+			Logger.warn("[SdkController] updateQueuedPrompt: No active session")
+			return
+		}
+
+		const delivery =
+			input.delivery === "queue" || input.delivery === "steer" ? input.delivery : undefined
+		const trimmedPrompt = input.prompt?.trim()
+		const result = await activeSession.sdkHost.pendingPrompts("update", {
+			sessionId: activeSession.sessionId,
+			promptId: trimmedPromptId,
+			...(trimmedPrompt !== undefined ? { prompt: trimmedPrompt } : {}),
+			...(delivery ? { delivery } : {}),
+		})
+		if (!result.updated) {
+			Logger.warn(`[SdkController] updateQueuedPrompt: Prompt not found: ${trimmedPromptId}`)
+		}
+		await this.postStateToWebview()
+	}
+
+	async reorderQueuedPrompt(promptId: string, position: number): Promise<void> {
+		const trimmedPromptId = promptId.trim()
+		if (!trimmedPromptId) {
+			Logger.warn("[SdkController] reorderQueuedPrompt: Missing prompt id")
+			return
+		}
+
+		const activeSession = this.sessions.getActiveSession()
+		if (!activeSession) {
+			Logger.warn("[SdkController] reorderQueuedPrompt: No active session")
+			return
+		}
+
+		const normalizedPosition = Number.isFinite(position) ? Math.max(0, Math.floor(position)) : 0
+		const result = await activeSession.sdkHost.pendingPrompts("update", {
+			sessionId: activeSession.sessionId,
+			promptId: trimmedPromptId,
+			position: normalizedPosition,
+		})
+		if (!result.updated) {
+			Logger.warn(`[SdkController] reorderQueuedPrompt: Prompt not found: ${trimmedPromptId}`)
+		}
+		await this.postStateToWebview()
+	}
 
 	/**
 	 * Manually compact (condense) the active task's conversation. Triggered by

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.test.tsx
@@ -4,15 +4,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { QueuedPrompts } from "./QueuedPrompts"
 
 const cancelQueuedPromptMock = vi.hoisted(() => vi.fn())
+const updateQueuedPromptMock = vi.hoisted(() => vi.fn())
+const reorderQueuedPromptMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/services/grpc-client", () => ({
 	TaskServiceClient: {
 		cancelQueuedPrompt: (request: unknown) => cancelQueuedPromptMock(request),
+		updateQueuedPrompt: (request: unknown) => updateQueuedPromptMock(request),
+		reorderQueuedPrompt: (request: unknown) => reorderQueuedPromptMock(request),
 	},
 }))
 
 vi.mock("@shared/proto/cline/common", () => ({
 	StringRequest: {
+		create: (request: unknown) => request,
+	},
+}))
+
+vi.mock("@shared/proto/cline/task", () => ({
+	UpdateQueuedPromptRequest: {
+		create: (request: unknown) => request,
+	},
+	ReorderQueuedPromptRequest: {
 		create: (request: unknown) => request,
 	},
 }))
@@ -32,10 +45,23 @@ const queuedPrompts: QueuedPrompt[] = [
 	},
 ]
 
+function makeDataTransfer(): DataTransfer {
+	return {
+		effectAllowed: "",
+		dropEffect: "move",
+		setData: vi.fn(),
+		getData: vi.fn(),
+	} as unknown as DataTransfer
+}
+
 describe("QueuedPrompts", () => {
 	beforeEach(() => {
 		cancelQueuedPromptMock.mockReset()
+		updateQueuedPromptMock.mockReset()
+		reorderQueuedPromptMock.mockReset()
 		cancelQueuedPromptMock.mockResolvedValue({})
+		updateQueuedPromptMock.mockResolvedValue({})
+		reorderQueuedPromptMock.mockResolvedValue({})
 	})
 
 	it("cancels a queued prompt from the row action", async () => {
@@ -49,6 +75,37 @@ describe("QueuedPrompts", () => {
 		expect(cancelButtons[0]).toBeDisabled()
 
 		await waitFor(() => expect(cancelButtons[0]).not.toBeDisabled())
+	})
+
+	it("edits a queued prompt and persists the change", async () => {
+		render(<QueuedPrompts items={queuedPrompts} />)
+
+		fireEvent.click(screen.getAllByRole("button", { name: "Edit queued message" })[0])
+		const input = screen.getByDisplayValue("First queued message")
+		fireEvent.change(input, { target: { value: "Edited first message" } })
+		fireEvent.click(screen.getByRole("button", { name: "Save queued message" }))
+
+		await waitFor(() =>
+			expect(updateQueuedPromptMock).toHaveBeenCalledWith({
+				promptId: "prompt-1",
+				prompt: "Edited first message",
+			}),
+		)
+	})
+
+	it("reorders a queued prompt via drag and drop", async () => {
+		render(<QueuedPrompts items={queuedPrompts} />)
+
+		const rows = screen.getAllByTitle("Drag to reorder").map((handle) => handle.closest("div")!)
+		fireEvent.dragStart(rows[0], { dataTransfer: makeDataTransfer() })
+		fireEvent.drop(rows[1], { dataTransfer: makeDataTransfer() })
+
+		await waitFor(() =>
+			expect(reorderQueuedPromptMock).toHaveBeenCalledWith({
+				promptId: "prompt-1",
+				position: 1,
+			}),
+		)
 	})
 
 	it("does not render an empty queue", () => {

--- a/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/chat-view/components/layout/QueuedPrompts.tsx
@@ -1,5 +1,6 @@
 import type { QueuedPrompt } from "@shared/ExtensionMessage"
 import { StringRequest } from "@shared/proto/cline/common"
+import { ReorderQueuedPromptRequest, UpdateQueuedPromptRequest } from "@shared/proto/cline/task"
 import { useState } from "react"
 import { TaskServiceClient } from "@/services/grpc-client"
 
@@ -33,6 +34,11 @@ interface QueuedPromptsProps {
 
 export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 	const [cancellingIds, setCancellingIds] = useState<Set<string>>(() => new Set())
+	const [mutatingIds, setMutatingIds] = useState<Set<string>>(() => new Set())
+	const [draggingId, setDraggingId] = useState<string | null>(null)
+	const [overId, setOverId] = useState<string | null>(null)
+	const [editingId, setEditingId] = useState<string | null>(null)
+	const [editValue, setEditValue] = useState("")
 
 	if (items.length === 0) {
 		return null
@@ -53,6 +59,73 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 			})
 	}
 
+	const startEdit = (item: QueuedPrompt) => {
+		setEditingId(item.id)
+		setEditValue(item.prompt)
+	}
+
+	const saveEdit = async (item: QueuedPrompt) => {
+		const prompt = editValue.trim()
+		if (!prompt || editingId !== item.id) {
+			setEditingId(null)
+			return
+		}
+		setMutatingIds((current) => new Set(current).add(item.id))
+		try {
+			await TaskServiceClient.updateQueuedPrompt(
+				UpdateQueuedPromptRequest.create({ promptId: item.id, prompt }),
+			)
+		} catch (error) {
+			console.error("Failed to update queued prompt:", error)
+		} finally {
+			setMutatingIds((current) => {
+				const next = new Set(current)
+				next.delete(item.id)
+				return next
+			})
+			setEditingId(null)
+		}
+	}
+
+	const handleDrop = async (targetId: string) => {
+		const sourceId = draggingId
+		setDraggingId(null)
+		setOverId(null)
+		if (!sourceId || sourceId === targetId) {
+			return
+		}
+		const fromIndex = items.findIndex((item) => item.id === sourceId)
+		let toIndex = items.findIndex((item) => item.id === targetId)
+		if (fromIndex < 0 || toIndex < 0) {
+			return
+		}
+		// Compute the final queue index the source would land at after removal.
+		const list = [...items]
+		const [moved] = list.splice(fromIndex, 1)
+		if (!moved) {
+			return
+		}
+		if (toIndex > fromIndex) {
+			toIndex -= 1
+		}
+		list.splice(toIndex, 0, moved)
+		const finalIndex = list.findIndex((item) => item.id === sourceId)
+		setMutatingIds((current) => new Set(current).add(sourceId))
+		try {
+			await TaskServiceClient.reorderQueuedPrompt(
+				ReorderQueuedPromptRequest.create({ promptId: sourceId, position: finalIndex }),
+			)
+		} catch (error) {
+			console.error("Failed to reorder queued prompt:", error)
+		} finally {
+			setMutatingIds((current) => {
+				const next = new Set(current)
+				next.delete(sourceId)
+				return next
+			})
+		}
+	}
+
 	return (
 		<div className="mx-3 mt-2.5 mb-2.5 rounded-xs border border-editor-group-border bg-code/70 px-2.5 py-2 shadow-xs">
 			<div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-description">
@@ -64,17 +137,79 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 					const attachments = attachmentLabel(item.attachmentCount)
 					const isSteer = item.delivery === "steer"
 					const isCancelling = cancellingIds.has(item.id)
+					const isMutating = mutatingIds.has(item.id)
+					const isEditing = editingId === item.id
+					const isDragging = draggingId === item.id
+					const isOver = overId === item.id
 					// The prompt text renders in spans whose line boxes are 5 spacing units tall
 					// (the global `span { @apply leading-5 }` base style), so every control in the
 					// row is sized/offset against that same 5-unit first line to stay vertically
 					// centered with it: the dot ((5 - 1.5) / 2 units), the h-5 badges, and the
-					// size-5 (26px) cancel button pulled in by -my-1.5 ((5u - size-5) / 2).
+					// size-5 (26px) icon buttons pulled in by -my-1.5 ((5u - size-5) / 2).
 					return (
 						<div
-							className="flex items-start gap-2 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs"
-							key={item.id}>
+							className={`flex items-start gap-1.5 rounded-[3px] bg-input-background/40 px-2 py-1.5 text-xs ${
+								isDragging ? "opacity-40" : ""
+							} ${isOver ? "bg-input-background ring-1 ring-inset ring-editor-foreground/40" : ""} ${
+								isEditing ? "cursor-default" : "cursor-grab active:cursor-grabbing"
+							}`}
+							draggable={!isEditing && !isMutating && !isCancelling}
+							key={item.id}
+							onDragEnd={() => {
+								setDraggingId(null)
+								setOverId(null)
+							}}
+							onDragLeave={() => {
+								if (overId === item.id) {
+									setOverId(null)
+								}
+							}}
+							onDragOver={(event) => {
+								event.preventDefault()
+								event.dataTransfer.dropEffect = "move"
+								if (overId !== item.id) {
+									setOverId(item.id)
+								}
+							}}
+							onDragStart={(event) => {
+								setDraggingId(item.id)
+								event.dataTransfer.effectAllowed = "move"
+								event.dataTransfer.setData("text/plain", item.id)
+							}}
+							onDrop={(event) => {
+								event.preventDefault()
+								void handleDrop(item.id)
+							}}>
+							<span
+								aria-hidden="true"
+								className="codicon codicon-gripper mt-1.75 shrink-0 select-none text-description/50"
+								title="Drag to reorder"
+							/>
 							<span aria-hidden="true" className="mt-1.75 size-1.5 shrink-0 rounded-full bg-description/70" />
-							<span className="min-w-0 flex-1 break-words text-foreground">{truncatePrompt(item.prompt)}</span>
+							{isEditing ? (
+								<input
+									autoFocus
+									className="min-w-0 flex-1 rounded-[3px] border border-editor-foreground/40 bg-input-background px-1.5 py-0.5 text-foreground outline-none"
+									onBlur={() => {
+										if (editingId === item.id) {
+											void saveEdit(item)
+										}
+									}}
+									onChange={(event) => setEditValue(event.target.value)}
+									onKeyDown={(event) => {
+										if (event.key === "Enter") {
+											void saveEdit(item)
+										} else if (event.key === "Escape") {
+											setEditingId(null)
+										}
+									}}
+									value={editValue}
+								/>
+							) : (
+								<span className="min-w-0 flex-1 break-words text-foreground" title={item.prompt}>
+									{truncatePrompt(item.prompt)}
+								</span>
+							)}
 							{isSteer && (
 								<span className="flex h-5 shrink-0 items-center rounded-[3px] border border-editor-group-border px-1.5 text-[10px] leading-none text-description">
 									Steer
@@ -85,15 +220,50 @@ export function QueuedPrompts({ items = [] }: QueuedPromptsProps) {
 									{attachments}
 								</span>
 							)}
-							<button
-								aria-label="Cancel queued message"
-								className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-								disabled={isCancelling}
-								onClick={() => cancelQueuedPrompt(item.id)}
-								title="Cancel queued message"
-								type="button">
-								<span aria-hidden="true" className="codicon codicon-close text-[12px]" />
-							</button>
+							{isMutating || isCancelling ? (
+								<span
+									aria-hidden="true"
+									className="codicon codicon-loading codicon-modifier-animated -my-1.5 size-5 shrink-0 text-description"
+								/>
+							) : isEditing ? (
+								<>
+									<button
+										aria-label="Save queued message"
+										className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground"
+										onClick={() => void saveEdit(item)}
+										title="Save"
+										type="button">
+										<span aria-hidden="true" className="codicon codicon-check text-[12px]" />
+									</button>
+									<button
+										aria-label="Cancel edit"
+										className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground"
+										onClick={() => setEditingId(null)}
+										title="Cancel edit"
+										type="button">
+										<span aria-hidden="true" className="codicon codicon-close text-[12px]" />
+									</button>
+								</>
+							) : (
+								<>
+									<button
+										aria-label="Edit queued message"
+										className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground"
+										onClick={() => startEdit(item)}
+										title="Edit queued message"
+										type="button">
+										<span aria-hidden="true" className="codicon codicon-edit text-[12px]" />
+									</button>
+									<button
+										aria-label="Cancel queued message"
+										className="-my-1.5 flex size-5 shrink-0 items-center justify-center rounded-[3px] text-description hover:bg-toolbar-hover-background hover:text-foreground"
+										onClick={() => cancelQueuedPrompt(item.id)}
+										title="Cancel queued message"
+										type="button">
+										<span aria-hidden="true" className="codicon codicon-close text-[12px]" />
+									</button>
+								</>
+							)}
 						</div>
 					)
 				})}

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -288,6 +288,12 @@ export interface PendingPromptsUpdateInput {
 	prompt?: string;
 	mode?: AgentMode;
 	delivery?: "queue" | "steer";
+	/**
+	 * Target index within the pending-prompt queue (0-based, clamped). When set,
+	 * the prompt is moved to this position instead of using the delivery-based
+	 * auto-reordering. Used by drag-and-drop reordering in the chat UI.
+	 */
+	position?: number;
 }
 
 export interface PendingPromptsDeleteInput {

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.test.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.test.ts
@@ -104,6 +104,56 @@ describe("PendingPromptService", () => {
 		expect(removed.prompts.map((prompt) => prompt.prompt)).toEqual(["keep"]);
 	});
 
+	it("reorders a prompt to an explicit position via drag-and-drop", () => {
+		const service = new PendingPromptService();
+		const state = createState();
+
+		service.enqueue(state, { prompt: "first", delivery: "queue" });
+		service.enqueue(state, { prompt: "second", delivery: "queue" });
+		service.enqueue(state, { prompt: "third", delivery: "queue" });
+		const queued = service.list(state);
+		const secondId = queued[1]?.id;
+		const thirdId = queued[2]?.id;
+
+		// Move "second" to the end (position 2).
+		const moved = service.update(state, {
+			sessionId: "sess-1",
+			promptId: secondId ?? "",
+			position: 2,
+		});
+		expect(moved.updated).toBe(true);
+		expect(moved.prompts.map((prompt) => prompt.prompt)).toEqual([
+			"first",
+			"third",
+			"second",
+		]);
+
+		// Move "third" to the front (position 0).
+		const movedFront = service.update(state, {
+			sessionId: "sess-1",
+			promptId: thirdId ?? "",
+			position: 0,
+		});
+		expect(movedFront.prompts.map((prompt) => prompt.prompt)).toEqual([
+			"third",
+			"first",
+			"second",
+		]);
+
+		// Positions are clamped to the valid range.
+		const clamped = service.update(state, {
+			sessionId: "sess-1",
+			promptId: thirdId ?? "",
+			position: 99,
+		});
+		expect(clamped.updated).toBe(true);
+		expect(clamped.prompts.map((prompt) => prompt.prompt)).toEqual([
+			"first",
+			"second",
+			"third",
+		]);
+	});
+
 	it("normalizes edited prompt text and rejects empty prompts", () => {
 		const service = new PendingPromptService();
 		const state = createState();

--- a/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
+++ b/sdk/packages/core/src/runtime/turn-queue/pending-prompt-service.ts
@@ -98,7 +98,14 @@ export class PendingPromptService {
 			delivery,
 		};
 		state.pendingPrompts.splice(index, 1);
-		insertUpdatedPrompt(state, next, index, existing.delivery);
+		if (input.position !== undefined) {
+			// Explicit drag-and-drop reorder: place at the requested index
+			// (clamped), overriding the delivery-based auto-reordering.
+			const target = Math.max(0, Math.min(input.position, state.pendingPrompts.length));
+			state.pendingPrompts.splice(target, 0, next);
+		} else {
+			insertUpdatedPrompt(state, next, index, existing.delivery);
+		}
 		return {
 			sessionId: input.sessionId,
 			prompts: snapshotPrompts(state),


### PR DESCRIPTION
Queued (pending) prompts in the chat view can now be reordered by drag-and-drop and edited inline before they are sent to the agent. Adds updateQueuedPrompt / reorderQueuedPrompt RPCs (proto + SDK core position support) and the webview UI with tests.