### PR TITLE
feat(desktop): group scheduled runs under their schedule in the sidebar

### DIFF
--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -330,27 +330,44 @@ describe("AgentSidebar session organization", () => {
 			scheduleName: "Daily date report",
 			scheduleRunNumber: index,
 		});
+		const sessionHistory = makeSessionHistory([run(2), run(1)], vi.fn());
+		const render = async (activeSessionId: string) => {
+			await act(async () => {
+				root.render(
+					<SidebarProvider>
+						<AgentSidebar
+							activeSessionId={activeSessionId}
+							onHome={vi.fn()}
+							onSettingsSectionChange={vi.fn()}
+							sessionHistory={sessionHistory}
+							setView={vi.fn()}
+							settingsSection="General"
+							view="chat"
+						/>
+					</SidebarProvider>,
+				);
+			});
+		};
 
-		await act(async () => {
-			root.render(
-				<SidebarProvider>
-					<AgentSidebar
-						activeSessionId="alpha-1"
-						onHome={vi.fn()}
-						onSettingsSectionChange={vi.fn()}
-						sessionHistory={makeSessionHistory([run(2), run(1)], vi.fn())}
-						setView={vi.fn()}
-						settingsSection="General"
-						view="chat"
-					/>
-				</SidebarProvider>,
-			);
-		});
-
+		await render("alpha-1");
 		expect(sessionRow("Daily date report").getAttribute("aria-expanded")).toBe(
 			"true",
 		);
 		expect(sessionIsVisible("Run 1")).toBe(true);
+
+		// The group can still be collapsed while it holds the active session,
+		// and stays collapsed across re-renders.
+		await click(sessionRow("Daily date report"));
+		await render("alpha-1");
+		expect(sessionIsVisible("Run 1")).toBe(false);
+
+		// Opening another run of the schedule (e.g. from the Schedules
+		// settings page) reopens the collapsed group so the run is visible.
+		await render("alpha-2");
+		expect(sessionRow("Daily date report").getAttribute("aria-expanded")).toBe(
+			"true",
+		);
+		expect(sessionIsVisible("Run 2")).toBe(true);
 	});
 
 	it("groups scheduled runs inside their project when sorted by project", async () => {

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.test.tsx
@@ -258,6 +258,138 @@ describe("AgentSidebar session organization", () => {
 		expect(buttonWithText("Tasks")).toBeDefined();
 	});
 
+	it("folds a schedule's runs into one collapsible row", async () => {
+		const run = (index: number) => ({
+			...makeThread("alpha", index),
+			title: "Report today's date to the user.",
+			isScheduled: true,
+			scheduleId: "sched_daily",
+			scheduleName: "Daily date report",
+			scheduleRunNumber: index,
+		});
+		const openThread = vi.fn();
+		const sessionHistory = makeSessionHistory(
+			[run(2), makeThread("beta", 1), run(1)],
+			vi.fn(),
+		);
+		(sessionHistory as { openThread: unknown }).openThread = openThread;
+
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={sessionHistory}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		// One header per schedule, named after the schedule rather than the
+		// prompt, with the run count; the runs themselves start collapsed.
+		const header = sessionRow("Daily date report");
+		expect(header.textContent).toContain("2 runs");
+		expect(header.getAttribute("aria-expanded")).toBe("false");
+		expect(header.querySelector('[aria-label="Scheduled"]')).not.toBeNull();
+		expect(sessionIsVisible("Report today's date to the user.")).toBe(false);
+		expect(sessionIsVisible("Run 2")).toBe(false);
+		// The Scheduled section counts schedules, not runs.
+		expect(buttonWithText("Scheduled").textContent).toContain("1");
+		expect(sessionIsVisible("beta session 1")).toBe(true);
+
+		await click(header);
+		expect(header.getAttribute("aria-expanded")).toBe("true");
+		expect(sessionIsVisible("Run 2")).toBe(true);
+		expect(sessionIsVisible("Run 1")).toBe(true);
+		// Nested runs don't repeat the clock the header already shows.
+		expect(
+			sessionRow("Run 1").querySelector('[aria-label="Scheduled"]'),
+		).toBeNull();
+		expect(
+			sessionRow("Run 2").compareDocumentPosition(sessionRow("Run 1")) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+
+		await click(sessionRow("Run 1"));
+		expect(openThread).toHaveBeenCalledWith("alpha-1");
+
+		await click(header);
+		expect(sessionIsVisible("Run 1")).toBe(false);
+	});
+
+	it("expands the schedule group that holds the active session", async () => {
+		const run = (index: number) => ({
+			...makeThread("alpha", index),
+			isScheduled: true,
+			scheduleId: "sched_daily",
+			scheduleName: "Daily date report",
+			scheduleRunNumber: index,
+		});
+
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId="alpha-1"
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory([run(2), run(1)], vi.fn())}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+
+		expect(sessionRow("Daily date report").getAttribute("aria-expanded")).toBe(
+			"true",
+		);
+		expect(sessionIsVisible("Run 1")).toBe(true);
+	});
+
+	it("groups scheduled runs inside their project when sorted by project", async () => {
+		const run = (index: number) => ({
+			...makeThread("alpha", index),
+			isScheduled: true,
+			scheduleId: "sched_daily",
+			scheduleName: "Daily date report",
+			scheduleRunNumber: index,
+		});
+
+		await act(async () => {
+			root.render(
+				<SidebarProvider>
+					<AgentSidebar
+						activeSessionId={null}
+						onHome={vi.fn()}
+						onSettingsSectionChange={vi.fn()}
+						sessionHistory={makeSessionHistory(
+							[run(2), makeThread("alpha", 3), run(1)],
+							vi.fn(),
+						)}
+						setView={vi.fn()}
+						settingsSection="General"
+						view="chat"
+					/>
+				</SidebarProvider>,
+			);
+		});
+		await switchToProjectSort();
+
+		const header = sessionRow("Daily date report");
+		expect(header.textContent).toContain("2 runs");
+		expect(sessionIsVisible("alpha session 3")).toBe(true);
+		expect(sessionIsVisible("Run 2")).toBe(false);
+		await click(header);
+		expect(sessionIsVisible("Run 2")).toBe(true);
+	});
+
 	it("defaults to Pinned, Scheduled, and Tasks sections sorted by time", async () => {
 		const pinned = { ...makeThread("alpha", 1), pinned: true };
 		const scheduled = { ...makeThread("beta", 1), isScheduled: true };
@@ -564,6 +696,19 @@ describe("AgentSidebar session organization", () => {
 		expect(
 			getSessionOverviewItems(thread).some(([label]) => label === "Status"),
 		).toBe(false);
+		// Scheduled runs lead with the schedule they belong to and which run
+		// this is; the row itself only says "Run N".
+		expect(
+			getSessionOverviewItems({
+				...makeThread("cline", 6),
+				isScheduled: true,
+				scheduleName: "Daily date report",
+				scheduleRunNumber: 6,
+			}).slice(0, 2),
+		).toEqual([
+			["Schedule", "Daily date report"],
+			["Run", "6"],
+		]);
 	});
 
 	it("shows the full first line of the session title", () => {

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -96,8 +96,12 @@ import {
 	getSessionSources,
 } from "@/lib/session-history";
 import {
+	groupScheduledThreads,
 	groupThreadsByProject,
 	INITIAL_VISIBLE_THREAD_COUNT,
+	type SidebarListRow,
+	type SidebarScheduleGroup,
+	scheduleRunLabel,
 	workspaceDisplayName,
 } from "@/lib/sidebar-session-organization";
 import { cn } from "@/lib/utils";
@@ -325,6 +329,12 @@ export function AgentSidebar({
 	const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(
 		() => new Set(),
 	);
+	// Explicit expand/collapse choices per schedule group. Groups without an
+	// entry default to expanded only while they hold the active session, so a
+	// run opened from elsewhere (e.g. the Schedules settings page) is visible.
+	const [scheduleGroupExpanded, setScheduleGroupExpanded] = useState<
+		Map<string, boolean>
+	>(() => new Map());
 	const [projectVisibleCounts, setProjectVisibleCounts] = useState<
 		Record<string, number>
 	>({});
@@ -537,6 +547,23 @@ export function AgentSidebar({
 			return next;
 		});
 	}, []);
+	const isScheduleGroupExpanded = useCallback(
+		(group: SidebarScheduleGroup) =>
+			scheduleGroupExpanded.get(group.id) ??
+			group.threads.some((thread) => thread.id === activeThread),
+		[activeThread, scheduleGroupExpanded],
+	);
+	const toggleScheduleGroup = useCallback(
+		(group: SidebarScheduleGroup) => {
+			const expanded = isScheduleGroupExpanded(group);
+			setScheduleGroupExpanded((current) => {
+				const next = new Map(current);
+				next.set(group.id, !expanded);
+				return next;
+			});
+		},
+		[isScheduleGroupExpanded],
+	);
 	const toggleProject = useCallback((project: string) => {
 		setCollapsedProjects((current) => {
 			const next = new Set(current);
@@ -635,13 +662,15 @@ export function AgentSidebar({
 			)}
 		</Button>
 	);
-	const threadItem = (thread: Thread) => (
+	const threadItem = (thread: Thread, options?: { nested?: boolean }) => (
 		<ThreadItem
 			editTitle={editingTitle}
 			editing={editingSessionId === thread.id}
 			hoverCardOpen={hoverCardThreadId === thread.id}
 			isActive={activeThread === thread.id}
 			key={thread.id}
+			label={options?.nested ? scheduleRunLabel(thread) : undefined}
+			nested={options?.nested}
 			onHoverCardOpenChange={(open) =>
 				setHoverCardThreadId((current) =>
 					open ? thread.id : current === thread.id ? null : current,
@@ -661,6 +690,30 @@ export function AgentSidebar({
 			thread={thread}
 			unread={unreadSessionIds.has(thread.id)}
 		/>
+	);
+	// Scheduled runs collapse into one row per schedule; everything else
+	// renders as before.
+	const listRow = (row: SidebarListRow) => {
+		if (row.kind === "thread") {
+			return threadItem(row.thread);
+		}
+		const expanded = isScheduleGroupExpanded(row);
+		return (
+			<ScheduleGroupRow
+				active={row.threads.some((thread) => thread.id === activeThread)}
+				expanded={expanded}
+				group={row}
+				key={row.id}
+				onToggle={() => toggleScheduleGroup(row)}
+				unread={row.threads.some((thread) => unreadSessionIds.has(thread.id))}
+			>
+				{row.threads.map((thread) => threadItem(thread, { nested: true }))}
+			</ScheduleGroupRow>
+		);
+	};
+	const scheduledRows = useMemo(
+		() => groupScheduledThreads(scheduledThreads),
+		[scheduledThreads],
 	);
 	const customizeSectionOpen =
 		view === "settings" &&
@@ -995,20 +1048,22 @@ export function AgentSidebar({
 																label="Pinned"
 																onToggle={() => toggleSection("pinned")}
 															>
-																{pinnedThreads.map(threadItem)}
+																{pinnedThreads.map((thread) =>
+																	threadItem(thread),
+																)}
 															</CategorySection>
 														) : null}
-														{scheduledThreads.length > 0 ? (
+														{scheduledRows.length > 0 ? (
 															<CategorySection
 																collapsed={collapsedSections.has("scheduled")}
-																count={scheduledThreads.length}
+																count={scheduledRows.length}
 																label="Scheduled"
 																onToggle={() => toggleSection("scheduled")}
 															>
-																{scheduledThreads
+																{scheduledRows
 																	.slice(0, scheduledVisibleCount)
-																	.map(threadItem)}
-																{scheduledThreads.length >
+																	.map(listRow)}
+																{scheduledRows.length >
 																scheduledVisibleCount ? (
 																	<Button
 																		className="px-2!"
@@ -1037,19 +1092,24 @@ export function AgentSidebar({
 															>
 																{taskThreads
 																	.slice(0, showMoreCount)
-																	.map(threadItem)}
+																	.map((thread) => threadItem(thread))}
 																{showTimeShowMore ? timeShowMoreButton : null}
 															</CategorySection>
 														) : null}
 													</>
 												) : (
-													taskThreads.slice(0, showMoreCount).map(threadItem)
+													taskThreads
+														.slice(0, showMoreCount)
+														.map((thread) => threadItem(thread))
 												)
 											) : (
 												projectGroups.map((project) => {
 													const visibleCount =
 														projectVisibleCounts[project.id] ??
 														INITIAL_VISIBLE_THREAD_COUNT;
+													const projectRows = groupScheduledThreads(
+														project.threads,
+													);
 													return (
 														<ProjectSection
 															collapsed={collapsedProjects.has(project.id)}
@@ -1057,10 +1117,8 @@ export function AgentSidebar({
 															label={project.label}
 															onToggle={() => toggleProject(project.id)}
 														>
-															{project.threads
-																.slice(0, visibleCount)
-																.map(threadItem)}
-															{project.threads.length > visibleCount ? (
+															{projectRows.slice(0, visibleCount).map(listRow)}
+															{projectRows.length > visibleCount ? (
 																<Button
 																	className="max-w-full pl-2!"
 																	onClick={() => showMoreForProject(project.id)}
@@ -1312,12 +1370,83 @@ function ProjectSection({
 	);
 }
 
+function ScheduleGroupRow({
+	group,
+	expanded,
+	active,
+	unread,
+	onToggle,
+	children,
+}: {
+	group: SidebarScheduleGroup;
+	expanded: boolean;
+	/** One of the runs is the open session; the header shows it while collapsed. */
+	active: boolean;
+	unread: boolean;
+	onToggle: () => void;
+	children: ReactNode;
+}) {
+	const running = group.threads.some((thread) => thread.status === "running");
+	const statusDotClass = running ? "bg-green-500" : unread ? "bg-blue-500" : "";
+	const runCount = group.threads.length;
+	return (
+		<div className="min-w-0">
+			<button
+				aria-expanded={expanded}
+				className={cn(
+					"grid h-8 w-full max-w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1 overflow-hidden rounded-md px-2 text-left text-sm font-normal",
+					active && !expanded
+						? "bg-surface-hover text-sidebar-foreground"
+						: "text-sidebar-foreground/80 hover:bg-surface-hover",
+				)}
+				onClick={onToggle}
+				title={group.label}
+				type="button"
+			>
+				<span className="flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
+					<ChevronDown
+						className={cn(
+							"size-3 shrink-0 text-muted-foreground transition-transform",
+							!expanded && "-rotate-90",
+						)}
+					/>
+					<Clock3
+						aria-label="Scheduled"
+						className="size-3 shrink-0 text-muted-foreground"
+					/>
+					<span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
+						{group.label}
+					</span>
+				</span>
+				<span className="flex shrink-0 items-center gap-1.5 text-xs tabular-nums text-muted-foreground">
+					{statusDotClass ? (
+						<span
+							aria-hidden="true"
+							className={cn("size-1.5 rounded-full", statusDotClass)}
+						/>
+					) : null}
+					<span>
+						{runCount} {runCount === 1 ? "run" : "runs"}
+					</span>
+				</span>
+			</button>
+			{expanded ? (
+				<div className="ml-4 flex min-w-0 flex-col gap-0.5 border-l border-sidebar-border/70 pl-1">
+					{children}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 function ThreadItem({
 	thread,
 	editTitle,
 	editing,
 	hoverCardOpen,
 	isActive,
+	label,
+	nested = false,
 	onClick,
 	onHoverCardOpenChange,
 	onCancelRename,
@@ -1335,6 +1464,10 @@ function ThreadItem({
 	editing: boolean;
 	hoverCardOpen: boolean;
 	isActive: boolean;
+	/** Row text when it should not be the session title (a run inside a schedule group). */
+	label?: string;
+	/** Rendered inside a schedule group: the group already shows the clock. */
+	nested?: boolean;
 	onClick: () => void;
 	onHoverCardOpenChange: (open: boolean) => void;
 	onCancelRename: () => void;
@@ -1348,6 +1481,7 @@ function ThreadItem({
 	unread: boolean;
 }) {
 	const title = normalizeTitle(thread.title);
+	const rowText = label ?? title;
 	const overviewTitle = getSessionOverviewTitle(title);
 	const pending = pendingAction !== null;
 	const statusDotClass = pending
@@ -1411,14 +1545,14 @@ function ThreadItem({
 								type="button"
 							>
 								<span className="flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
-									{thread.isScheduled ? (
+									{thread.isScheduled && !nested ? (
 										<Clock3
 											aria-label="Scheduled"
 											className="size-3 shrink-0 text-muted-foreground"
 										/>
 									) : null}
 									<span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
-										{title}
+										{rowText}
 									</span>
 								</span>
 								<span className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
@@ -1508,6 +1642,8 @@ export function getSessionOverviewItems(
 	// Updated time is already visible in the sidebar item.
 	const workspacePath = thread.workspacePath || thread.codebase;
 	const items: Array<[string, string | null | undefined, string?]> = [
+		["Schedule", thread.scheduleName],
+		["Run", thread.scheduleRunNumber ? String(thread.scheduleRunNumber) : null],
 		[
 			"Workspace",
 			workspaceDisplayName(workspacePath),

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -101,6 +101,7 @@ import {
 	INITIAL_VISIBLE_THREAD_COUNT,
 	type SidebarListRow,
 	type SidebarScheduleGroup,
+	scheduleGroupKey,
 	scheduleRunLabel,
 	workspaceDisplayName,
 } from "@/lib/sidebar-session-organization";
@@ -547,6 +548,23 @@ export function AgentSidebar({
 			return next;
 		});
 	}, []);
+	// Opening a session drops the stored choice for the group that holds it,
+	// so a run opened elsewhere is visible even if its group was collapsed
+	// earlier. Keyed on the session and group ids rather than the thread list
+	// so a history refresh doesn't undo a collapse made while it is open.
+	const activeScheduleGroupId = useMemo(() => {
+		const thread = threads.find((t) => t.id === activeThread);
+		return thread ? scheduleGroupKey(thread) : null;
+	}, [activeThread, threads]);
+	useEffect(() => {
+		if (!activeThread || !activeScheduleGroupId) return;
+		setScheduleGroupExpanded((current) => {
+			if (!current.has(activeScheduleGroupId)) return current;
+			const next = new Map(current);
+			next.delete(activeScheduleGroupId);
+			return next;
+		});
+	}, [activeThread, activeScheduleGroupId]);
 	const isScheduleGroupExpanded = useCallback(
 		(group: SidebarScheduleGroup) =>
 			scheduleGroupExpanded.get(group.id) ??

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -132,8 +132,12 @@ describe("useSessionHistory session mapping", () => {
 				}
 				if (command === "list_routine_schedules") {
 					return {
+						schedules: [{ scheduleId: "sched_daily", name: "Daily report" }],
 						activeExecutions: [{ sessionId: "cron-active" }],
-						lastExecutions: [{ sessionId: "cron-session" }, {}],
+						lastExecutions: [
+							{ sessionId: "cron-session", scheduleId: "sched_daily" },
+							{},
+						],
 					};
 				}
 				return [];
@@ -161,12 +165,55 @@ describe("useSessionHistory session mapping", () => {
 			await Promise.resolve();
 		});
 
+		// The executions list also supplies the schedule identity the session
+		// record itself lacks, so the sidebar can group it with its siblings.
 		expect(
 			current.threads.find((thread) => thread.id === "cron-session"),
-		).toMatchObject({ isScheduled: true });
+		).toMatchObject({
+			isScheduled: true,
+			scheduleId: "sched_daily",
+			scheduleName: "Daily report",
+		});
 		expect(
 			current.threads.find((thread) => thread.id === "regular-session"),
 		).toMatchObject({ isScheduled: false });
+	});
+
+	it("maps the runner's schedule provenance onto sidebar threads", async () => {
+		await act(async () => {
+			root.render(<HookHarness />);
+		});
+		await flush();
+
+		await act(async () => {
+			pendingLists[0].resolve([
+				{
+					...sessionRow("run-session"),
+					source: "core",
+					metadata: {
+						sessionHistoryOrigin: {
+							mode: "automation",
+							trigger: "hub-schedule",
+						},
+						scheduleId: "sched_daily",
+						scheduleName: "Daily report",
+						scheduleExecutionId: "crun_1",
+						scheduleRunNumber: 4,
+					},
+				},
+			]);
+			await Promise.resolve();
+		});
+
+		expect(
+			current.threads.find((thread) => thread.id === "run-session"),
+		).toMatchObject({
+			isScheduled: true,
+			startedAt: "2026-07-20T10:00:00.000Z",
+			scheduleId: "sched_daily",
+			scheduleName: "Daily report",
+			scheduleRunNumber: 4,
+		});
 	});
 });
 

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -14,6 +14,7 @@ import {
 	getSessionMetadataGitBranch,
 	getSessionMetadataIsScheduled,
 	getSessionMetadataPinned,
+	getSessionMetadataSchedule,
 	getSessionMetadataTitle,
 	getSessionSource,
 	PINNED_METADATA_KEY,
@@ -39,7 +40,19 @@ export interface SessionThread {
 	status: SessionHistoryStatus;
 	pinned?: boolean;
 	isScheduled: boolean;
+	/** Raw start timestamp; the sidebar labels un-numbered scheduled runs with it. */
+	startedAt?: string;
+	/** Schedule provenance for scheduled runs (metadata or executions list). */
+	scheduleId?: string;
+	scheduleName?: string;
+	scheduleRunNumber?: number;
 }
+
+/** What the schedule executions list knows about a session it started. */
+type ScheduledSessionLink = {
+	scheduleId?: string;
+	scheduleName?: string;
+};
 
 type SessionHookEvent = {
 	inputTokens?: number;
@@ -251,6 +264,7 @@ function inferStatusFromMessages(
 
 function toThread(session: SessionHistoryItem): SessionThread {
 	const workspacePath = (session.workspaceRoot || session.cwd).trim();
+	const schedule = getSessionMetadataSchedule(session.metadata);
 	return {
 		id: session.sessionId,
 		title: toTitle(session),
@@ -264,6 +278,10 @@ function toThread(session: SessionHistoryItem): SessionThread {
 		status: normalizeDiscoveredStatus(session.status, session.prompt),
 		pinned: getSessionMetadataPinned(session.metadata),
 		isScheduled: getSessionMetadataIsScheduled(session.metadata),
+		startedAt: session.startedAt?.trim() || undefined,
+		scheduleId: schedule.scheduleId,
+		scheduleName: schedule.scheduleName,
+		scheduleRunNumber: schedule.runNumber,
 	};
 }
 
@@ -344,6 +362,17 @@ function summarizeUsageFromMessages(messages: SessionMessage[]): {
 	return { inputTokens, outputTokens, totalCostUsd };
 }
 
+function areScheduleInfosEqual(
+	a: ReturnType<typeof getSessionMetadataSchedule>,
+	b: ReturnType<typeof getSessionMetadataSchedule>,
+): boolean {
+	return (
+		a.scheduleId === b.scheduleId &&
+		a.scheduleName === b.scheduleName &&
+		a.runNumber === b.runNumber
+	);
+}
+
 function areSessionsEquivalent(
 	current: SessionHistoryItem[],
 	next: SessionHistoryItem[],
@@ -369,6 +398,10 @@ function areSessionsEquivalent(
 				getSessionMetadataTitle(b.metadata) ||
 			getSessionMetadataPinned(a.metadata) !==
 				getSessionMetadataPinned(b.metadata) ||
+			!areScheduleInfosEqual(
+				getSessionMetadataSchedule(a.metadata),
+				getSessionMetadataSchedule(b.metadata),
+			) ||
 			a.workspaceRoot !== b.workspaceRoot ||
 			a.cwd !== b.cwd ||
 			a.provider !== b.provider ||
@@ -405,7 +438,11 @@ function areThreadsEquivalent(
 			a.totalCostUsd !== b.totalCostUsd ||
 			a.status !== b.status ||
 			a.pinned !== b.pinned ||
-			a.isScheduled !== b.isScheduled
+			a.isScheduled !== b.isScheduled ||
+			a.startedAt !== b.startedAt ||
+			a.scheduleId !== b.scheduleId ||
+			a.scheduleName !== b.scheduleName ||
+			a.scheduleRunNumber !== b.scheduleRunNumber
 		) {
 			return false;
 		}
@@ -504,14 +541,16 @@ export function useSessionHistory({
 	const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(
 		() => new Set(),
 	);
-	// Session ids that schedule executions report as their own. Scheduled runs
-	// executed by the local hub do not reliably carry the "hub-schedule"
-	// origin trigger in their session metadata (the runtime that claims the
-	// run doesn't always stamp provenance), so the metadata check alone would
-	// miss them; the executions list is the authoritative link.
-	const [scheduledSessionIds, setScheduledSessionIds] = useState<Set<string>>(
-		() => new Set(),
-	);
+	// Sessions that schedule executions report as their own, keyed by session
+	// id. Scheduled runs executed by the local hub do not reliably carry the
+	// "hub-schedule" origin trigger in their session metadata (the runtime
+	// that claims the run doesn't always stamp provenance), so the metadata
+	// check alone would miss them; the executions list is the authoritative
+	// link. It also supplies the schedule id/name for sessions recorded
+	// before the runner stamped those into metadata.
+	const [scheduledSessionLinks, setScheduledSessionLinks] = useState<
+		Map<string, ScheduledSessionLink>
+	>(() => new Map());
 	const fetchLimitRef = useRef(INITIAL_HISTORY_FETCH_LIMIT);
 	// Limit of the most recent refresh that actually returned sessions. Failed
 	// attempts roll back to this rather than to a caller-local snapshot, which
@@ -563,17 +602,36 @@ export function useSessionHistory({
 
 	useEffect(() => {
 		let cancelled = false;
-		const collectScheduledSessionIds = async () => {
+		const collectScheduledSessionLinks = async () => {
 			const response = await desktopClient
 				.invoke<{
-					activeExecutions?: Array<{ sessionId?: unknown }>;
-					lastExecutions?: Array<{ sessionId?: unknown }>;
+					schedules?: Array<{ scheduleId?: unknown; name?: unknown }>;
+					activeExecutions?: Array<{
+						sessionId?: unknown;
+						scheduleId?: unknown;
+					}>;
+					lastExecutions?: Array<{
+						sessionId?: unknown;
+						scheduleId?: unknown;
+					}>;
 				}>("list_routine_schedules")
 				.catch(() => null);
 			if (cancelled || !response) {
 				return;
 			}
-			const ids = new Set<string>();
+			const scheduleNames = new Map<string, string>();
+			for (const schedule of response.schedules ?? []) {
+				const scheduleId =
+					typeof schedule?.scheduleId === "string"
+						? schedule.scheduleId.trim()
+						: "";
+				const name =
+					typeof schedule?.name === "string" ? schedule.name.trim() : "";
+				if (scheduleId && name) {
+					scheduleNames.set(scheduleId, name);
+				}
+			}
+			const links = new Map<string, ScheduledSessionLink>();
 			for (const execution of [
 				...(response.activeExecutions ?? []),
 				...(response.lastExecutions ?? []),
@@ -582,23 +640,43 @@ export function useSessionHistory({
 					typeof execution?.sessionId === "string"
 						? execution.sessionId.trim()
 						: "";
-				if (sessionId) {
-					ids.add(sessionId);
+				if (!sessionId) {
+					continue;
 				}
+				const scheduleId =
+					typeof execution?.scheduleId === "string"
+						? execution.scheduleId.trim()
+						: "";
+				links.set(sessionId, {
+					...(scheduleId ? { scheduleId } : {}),
+					...(scheduleId && scheduleNames.has(scheduleId)
+						? { scheduleName: scheduleNames.get(scheduleId) }
+						: {}),
+				});
 			}
-			setScheduledSessionIds((current) => {
+			setScheduledSessionLinks((current) => {
 				// Merge instead of replace: the executions list is a rolling
 				// window, so ids that fell out of it are still scheduled runs.
-				const next = new Set(current);
-				for (const id of ids) {
-					next.add(id);
+				let changed = false;
+				const next = new Map(current);
+				for (const [sessionId, link] of links) {
+					const existing = next.get(sessionId);
+					if (
+						existing &&
+						existing.scheduleId === link.scheduleId &&
+						existing.scheduleName === link.scheduleName
+					) {
+						continue;
+					}
+					next.set(sessionId, link);
+					changed = true;
 				}
-				return next.size === current.size ? current : next;
+				return changed ? next : current;
 			});
 		};
-		void collectScheduledSessionIds();
+		void collectScheduledSessionLinks();
 		const interval = window.setInterval(
-			() => void collectScheduledSessionIds(),
+			() => void collectScheduledSessionLinks(),
 			2 * 60 * 1000,
 		);
 		return () => {
@@ -1484,15 +1562,33 @@ export function useSessionHistory({
 	);
 
 	const threadsWithScheduled = useMemo(() => {
-		if (scheduledSessionIds.size === 0) {
+		if (scheduledSessionLinks.size === 0) {
 			return threads;
 		}
-		return threads.map((thread) =>
-			!thread.isScheduled && scheduledSessionIds.has(thread.id)
-				? { ...thread, isScheduled: true }
-				: thread,
-		);
-	}, [scheduledSessionIds, threads]);
+		return threads.map((thread) => {
+			const link = scheduledSessionLinks.get(thread.id);
+			if (!link) {
+				return thread;
+			}
+			// Metadata stamped by the runner wins; the executions list only
+			// fills in what the session record itself doesn't carry.
+			const scheduleId = thread.scheduleId ?? link.scheduleId;
+			const scheduleName = thread.scheduleName ?? link.scheduleName;
+			if (
+				thread.isScheduled &&
+				scheduleId === thread.scheduleId &&
+				scheduleName === thread.scheduleName
+			) {
+				return thread;
+			}
+			return {
+				...thread,
+				isScheduled: true,
+				...(scheduleId ? { scheduleId } : {}),
+				...(scheduleName ? { scheduleName } : {}),
+			};
+		});
+	}, [scheduledSessionLinks, threads]);
 
 	return {
 		getSessionByThreadId,

--- a/apps/examples/desktop-app/webview/lib/session-history.ts
+++ b/apps/examples/desktop-app/webview/lib/session-history.ts
@@ -21,8 +21,23 @@ export type SessionMetadata = {
 		version?: string;
 		trigger?: string;
 	};
+	/**
+	 * Provenance the cron runner stamps onto sessions it starts (see
+	 * `buildRunSessionMetadata` in @cline/core). The sidebar groups a
+	 * schedule's runs by `scheduleId` and labels each with `scheduleRunNumber`.
+	 */
+	scheduleId?: string;
+	scheduleName?: string;
+	scheduleExecutionId?: string;
+	scheduleRunNumber?: number;
 	[key: string]: unknown;
 };
+
+export interface SessionScheduleInfo {
+	scheduleId?: string;
+	scheduleName?: string;
+	runNumber?: number;
+}
 
 export const PINNED_METADATA_KEY = "pinned";
 
@@ -119,6 +134,27 @@ export function getSessionMetadataIsScheduled(
 		typeof origin.trigger === "string" &&
 		origin.trigger.trim() === SCHEDULED_SESSION_SOURCE
 	);
+}
+
+export function getSessionMetadataSchedule(
+	metadata?: SessionMetadata,
+): SessionScheduleInfo {
+	const scheduleId =
+		typeof metadata?.scheduleId === "string" ? metadata.scheduleId.trim() : "";
+	const scheduleName =
+		typeof metadata?.scheduleName === "string"
+			? metadata.scheduleName.trim()
+			: "";
+	const runNumber = metadata?.scheduleRunNumber;
+	return {
+		...(scheduleId ? { scheduleId } : {}),
+		...(scheduleName ? { scheduleName } : {}),
+		...(typeof runNumber === "number" &&
+		Number.isInteger(runNumber) &&
+		runNumber > 0
+			? { runNumber }
+			: {}),
+	};
 }
 
 export function getSessionMetadataGitBranch(

--- a/apps/examples/desktop-app/webview/lib/sidebar-session-organization.test.ts
+++ b/apps/examples/desktop-app/webview/lib/sidebar-session-organization.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionThread } from "@/hooks/use-session-history";
 import {
+	groupScheduledThreads,
 	groupThreadsByProject,
+	scheduleRunLabel,
 	workspaceDisplayName,
 } from "./sidebar-session-organization";
 
@@ -55,6 +57,98 @@ describe("sidebar session organization", () => {
 		expect(workspaceDisplayName(path)).toBe("Chat");
 		expect(groupThreadsByProject([thread("temp", path)])[0]?.label).toBe(
 			"Chat",
+		);
+	});
+
+	it("folds scheduled runs into one group per schedule at the newest run's position", () => {
+		const scheduled = (id: string, runNumber: number) =>
+			thread(id, "/work/acme/repo", {
+				title: "Report today's date",
+				isScheduled: true,
+				scheduleId: "sched_daily",
+				scheduleName: "Daily date report",
+				scheduleRunNumber: runNumber,
+			});
+		const rows = groupScheduledThreads([
+			thread("task-1", "/work/acme/repo"),
+			scheduled("run-3", 3),
+			thread("task-2", "/work/acme/repo"),
+			scheduled("run-2", 2),
+			thread("other-1", "/work/acme/repo", {
+				isScheduled: true,
+				scheduleId: "sched_other",
+				scheduleName: "Other schedule",
+			}),
+			scheduled("run-1", 1),
+		]);
+
+		expect(
+			rows.map((row) =>
+				row.kind === "thread"
+					? row.thread.id
+					: `${row.label}[${row.threads.map((t) => t.id).join(",")}]`,
+			),
+		).toEqual([
+			"task-1",
+			"Daily date report[run-3,run-2,run-1]",
+			"task-2",
+			"Other schedule[other-1]",
+		]);
+		expect(rows[1]).toMatchObject({
+			kind: "schedule",
+			id: "schedule:sched_daily",
+		});
+	});
+
+	it("groups un-stamped scheduled runs by their shared title", () => {
+		const legacy = (id: string) =>
+			thread(id, "/work/acme/repo", {
+				title: "Report today's date to the user.",
+				isScheduled: true,
+			});
+		const rows = groupScheduledThreads([
+			legacy("legacy-2"),
+			thread("named-1", "/work/acme/repo", {
+				title: "Report today's date to the user.",
+				isScheduled: true,
+				scheduleId: "sched_daily",
+				scheduleName: "Daily date report",
+			}),
+			legacy("legacy-1"),
+		]);
+
+		// Runs with a schedule id never merge into the title-keyed group.
+		expect(
+			rows.map((row) =>
+				row.kind === "schedule"
+					? `${row.id}:${row.threads.length}`
+					: row.thread.id,
+			),
+		).toEqual([
+			"title:report today's date to the user.:2",
+			"schedule:sched_daily:1",
+		]);
+		expect(rows[0]).toMatchObject({
+			label: "Report today's date to the user.",
+		});
+	});
+
+	it("labels runs by number and falls back to the start time", () => {
+		expect(
+			scheduleRunLabel(
+				thread("a", "/ws", { isScheduled: true, scheduleRunNumber: 7 }),
+			),
+		).toBe("Run 7");
+		const dated = scheduleRunLabel(
+			thread("b", "/ws", {
+				isScheduled: true,
+				startedAt: "2026-08-31T19:31:40.834Z",
+			}),
+		);
+		expect(dated).toMatch(/Aug 31/);
+		expect(dated).not.toBe("Run");
+		expect(scheduleRunLabel(thread("c", "/ws", { isScheduled: true }))).toBe(
+			"Run",
 		);
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/sidebar-session-organization.ts
+++ b/apps/examples/desktop-app/webview/lib/sidebar-session-organization.ts
@@ -1,5 +1,9 @@
 import { isChatWorkspacePath } from "@cline/shared/browser";
-import type { SessionThread } from "@/hooks/use-session-history";
+import { normalizeTitle } from "@/components/utils";
+import {
+	parseTimestamp,
+	type SessionThread,
+} from "@/hooks/use-session-history";
 import { normalizeWorkspacePath } from "@/lib/workspace-paths";
 
 // One page of sidebar rows. Large enough to fill the sidebar on a tall
@@ -69,4 +73,88 @@ export function groupThreadsByProject(
 		workspacePath: group.workspacePath,
 		threads: group.threads,
 	}));
+}
+
+export type SidebarScheduleGroup = {
+	kind: "schedule";
+	/** Stable key: the schedule id when known, otherwise the shared title. */
+	id: string;
+	label: string;
+	/** Runs in the order they were given (newest first in the sidebar). */
+	threads: SessionThread[];
+};
+
+export type SidebarListRow =
+	| { kind: "thread"; thread: SessionThread }
+	| SidebarScheduleGroup;
+
+/**
+ * Key that decides which schedule group a thread joins. Runs stamped with a
+ * schedule id (or linked to one through the executions list) group by that
+ * id; older runs without one group by their shared title, since a schedule's
+ * sessions all start from the same prompt. Non-scheduled threads return null.
+ */
+export function scheduleGroupKey(thread: SessionThread): string | null {
+	if (!thread.isScheduled) return null;
+	const scheduleId = thread.scheduleId?.trim();
+	if (scheduleId) return `schedule:${scheduleId}`;
+	const title = normalizeTitle(thread.title).trim().toLowerCase();
+	return title ? `title:${title}` : null;
+}
+
+/**
+ * Folds every scheduled thread into one row per schedule, keeping each group
+ * at the position of its first (newest) run so the list still reads in
+ * recency order. Non-scheduled threads pass through as plain rows.
+ */
+export function groupScheduledThreads(
+	threads: readonly SessionThread[],
+): SidebarListRow[] {
+	const rows: SidebarListRow[] = [];
+	const groups = new Map<string, SidebarScheduleGroup>();
+	for (const thread of threads) {
+		const key = scheduleGroupKey(thread);
+		if (!key) {
+			rows.push({ kind: "thread", thread });
+			continue;
+		}
+		const existing = groups.get(key);
+		if (existing) {
+			existing.threads.push(thread);
+			if (!existing.label) existing.label = scheduleGroupLabel(thread);
+			continue;
+		}
+		const group: SidebarScheduleGroup = {
+			kind: "schedule",
+			id: key,
+			label: scheduleGroupLabel(thread),
+			threads: [thread],
+		};
+		groups.set(key, group);
+		rows.push(group);
+	}
+	return rows;
+}
+
+function scheduleGroupLabel(thread: SessionThread): string {
+	return thread.scheduleName?.trim() || normalizeTitle(thread.title).trim();
+}
+
+/**
+ * Label for one run inside a schedule group. Runs the runner numbered show
+ * "Run N"; older runs fall back to when they started, which is the next
+ * best way to tell them apart.
+ */
+export function scheduleRunLabel(thread: SessionThread): string {
+	if (thread.scheduleRunNumber) return `Run ${thread.scheduleRunNumber}`;
+	const started = parseTimestamp(thread.startedAt);
+	if (Number.isFinite(started)) {
+		return new Date(started).toLocaleString(undefined, {
+			month: "short",
+			day: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+		});
+	}
+	return "Run";
 }

--- a/sdk/packages/core/src/cline-core/automation.ts
+++ b/sdk/packages/core/src/cline-core/automation.ts
@@ -103,7 +103,7 @@ export function createClineCoreAutomationRuntimeHandlers(
 ): HubScheduleRuntimeHandlers {
 	const { host } = input;
 	return {
-		async startSession(request) {
+		async startSession(request, options) {
 			const cwd = (request.cwd?.trim() || request.workspaceRoot).trim();
 			const extensionContext = input.getExtensionContext();
 			const started = await host.startSession({
@@ -114,10 +114,13 @@ export function createClineCoreAutomationRuntimeHandlers(
 				// Record the spec-defined trigger source (e.g. "hub-schedule"
 				// or a custom label from spec frontmatter) as provenance; the
 				// top-level `source` is reserved for the client surface.
-				sessionMetadata: withSessionHistoryOriginMetadata(undefined, {
-					mode: "automation",
-					trigger: request.source,
-				}),
+				sessionMetadata: withSessionHistoryOriginMetadata(
+					options?.sessionMetadata,
+					{
+						mode: "automation",
+						trigger: request.source,
+					},
+				),
 				interactive: false,
 				config: {
 					providerId: normalizeProviderId(request.provider),

--- a/sdk/packages/core/src/cron/runner/cron-runner.test.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.test.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 import type { ChatStartSessionRequest, CronOneOffSpec } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DefaultToolNames } from "../../extensions/tools/constants";
-import type { HubScheduleRuntimeHandlers } from "../service/schedule-service";
+import type {
+	HubScheduleRuntimeHandlers,
+	HubScheduleStartSessionOptions,
+} from "../service/schedule-service";
 import { SqliteCronStore } from "../store/sqlite-cron-store";
 import { CronMaterializer } from "./cron-materializer";
 import { CronRunner } from "./cron-runner";
@@ -23,6 +26,7 @@ function fakeHandlers(): {
 		stop: number;
 		prompts: string[];
 		startRequests: ChatStartSessionRequest[];
+		startOptions: Array<HubScheduleStartSessionOptions | undefined>;
 	};
 } {
 	const calls = {
@@ -31,11 +35,13 @@ function fakeHandlers(): {
 		stop: 0,
 		prompts: [] as string[],
 		startRequests: [] as ChatStartSessionRequest[],
+		startOptions: [] as Array<HubScheduleStartSessionOptions | undefined>,
 	};
 	const handlers: HubScheduleRuntimeHandlers = {
-		async startSession(req) {
+		async startSession(req, options) {
 			calls.start += 1;
 			calls.startRequests.push(req);
+			calls.startOptions.push(options);
 			return { sessionId: `sess_${calls.start}` };
 		},
 		async sendSession(_sessionId, req) {
@@ -470,5 +476,59 @@ describe("CronRunner", () => {
 		});
 		expect(reclaimed).toHaveLength(1);
 		expect(reclaimed[0]?.run.runId).toBe(run.runId);
+	});
+	it("stamps schedule provenance and a stable run number onto each session", async () => {
+		const { handlers, calls } = fakeHandlers();
+		const upserted = store.upsertSpec({
+			externalId: "sched_nightly",
+			sourcePath: "nightly.cron.md",
+			triggerKind: "schedule",
+			sourceHash: "h",
+			parseStatus: "valid",
+			spec: {
+				triggerKind: "schedule",
+				id: "sched_nightly",
+				title: "Nightly report",
+				prompt: "Do it",
+				workspaceRoot,
+				enabled: true,
+				schedule: "0 2 * * *",
+				modelSelection: { providerId: "p", modelId: "m" },
+			},
+		});
+		const enqueue = () =>
+			store.enqueueRun({
+				specId: upserted.record.specId,
+				specRevision: upserted.record.revision,
+				triggerKind: "schedule",
+				scheduledFor: new Date(Date.now() - 1_000).toISOString(),
+			});
+		const runner = new CronRunner({
+			store,
+			materializer,
+			runtimeHandlers: handlers,
+			workspaceRoot,
+			specs: { cronSpecsDir: cronDir },
+			pollIntervalMs: 10_000,
+		});
+		const first = enqueue();
+		await runner.tick();
+		const second = enqueue();
+		await runner.tick();
+		await runner.dispose();
+
+		expect(calls.start).toBe(2);
+		expect(calls.startOptions[0]?.sessionMetadata).toEqual({
+			scheduleId: "sched_nightly",
+			scheduleName: "Nightly report",
+			scheduleExecutionId: first.runId,
+			scheduleRunNumber: 1,
+		});
+		expect(calls.startOptions[1]?.sessionMetadata).toEqual({
+			scheduleId: "sched_nightly",
+			scheduleName: "Nightly report",
+			scheduleExecutionId: second.runId,
+			scheduleRunNumber: 2,
+		});
 	});
 });

--- a/sdk/packages/core/src/cron/runner/cron-runner.ts
+++ b/sdk/packages/core/src/cron/runner/cron-runner.ts
@@ -121,6 +121,34 @@ async function withTimeout<T>(
 	}
 }
 
+/**
+ * Session metadata keys that identify the automation run a session belongs
+ * to. Clients (e.g. the desktop sidebar) read these to group a schedule's
+ * runs together and label each one, so they are part of the session
+ * metadata contract; keep them in sync with the readers.
+ */
+export const RUN_SESSION_METADATA_KEYS = {
+	scheduleId: "scheduleId",
+	scheduleName: "scheduleName",
+	scheduleExecutionId: "scheduleExecutionId",
+	scheduleRunNumber: "scheduleRunNumber",
+} as const;
+
+export function buildRunSessionMetadata(
+	spec: Pick<CronSpecRecord, "externalId" | "title">,
+	run: Pick<CronRunRecord, "runId">,
+	runNumber: number | undefined,
+): Record<string, unknown> {
+	return {
+		[RUN_SESSION_METADATA_KEYS.scheduleId]: spec.externalId,
+		[RUN_SESSION_METADATA_KEYS.scheduleName]: spec.title,
+		[RUN_SESSION_METADATA_KEYS.scheduleExecutionId]: run.runId,
+		...(runNumber !== undefined
+			? { [RUN_SESSION_METADATA_KEYS.scheduleRunNumber]: runNumber }
+			: {}),
+	};
+}
+
 export interface CronRunnerOptions {
 	store: SqliteCronStore;
 	materializer: CronMaterializer;
@@ -305,8 +333,16 @@ export class CronRunner {
 			releaseLeaseHeartbeat = this.startClaimLeaseHeartbeat(claim);
 			const startRequest = await this.buildStartRequest(spec);
 			phase = "starting the agent session";
-			const startResp =
-				await this.options.runtimeHandlers.startSession(startRequest);
+			const startResp = await this.options.runtimeHandlers.startSession(
+				startRequest,
+				{
+					sessionMetadata: buildRunSessionMetadata(
+						spec,
+						run,
+						this.store.getRunOrdinal(run.runId),
+					),
+				},
+			);
 			sessionId = startResp.sessionId.trim();
 			if (!sessionId) throw new Error("runtime returned empty sessionId");
 			this.activeRuns.set(run.runId, {

--- a/sdk/packages/core/src/cron/service/schedule-service.ts
+++ b/sdk/packages/core/src/cron/service/schedule-service.ts
@@ -46,8 +46,20 @@ type HubScheduleTurnResult = {
 	}>;
 };
 
+export interface HubScheduleStartSessionOptions {
+	/**
+	 * Provenance the runner knows about the automation run that is starting
+	 * this session (schedule id/name, run id, run number). Handlers merge it
+	 * into the session metadata so clients can group runs by schedule.
+	 */
+	sessionMetadata?: Record<string, unknown>;
+}
+
 export interface HubScheduleRuntimeHandlers {
-	startSession(request: ChatStartSessionRequest): Promise<{
+	startSession(
+		request: ChatStartSessionRequest,
+		options?: HubScheduleStartSessionOptions,
+	): Promise<{
 		sessionId: string;
 		startResult?: ChatStartSessionArtifacts;
 	}>;

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.test.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.test.ts
@@ -290,6 +290,39 @@ describe("SqliteCronStore: runs", () => {
 		expect(store.hasConsumedOneOffRevision(spec.specId, 1)).toBe(true);
 	});
 
+	it("numbers a spec's runs by creation order regardless of status", () => {
+		const spec = seedOneOff();
+		const other = store.upsertSpec({
+			externalId: "other",
+			sourcePath: "other.md",
+			triggerKind: "one_off",
+			sourceHash: "hash-other",
+			parseStatus: "valid",
+			spec: {
+				triggerKind: "one_off",
+				id: "other",
+				title: "Other",
+				prompt: "p",
+				workspaceRoot: "/ws",
+				enabled: true,
+			},
+		}).record;
+		const enqueue = (specId: string) =>
+			store.enqueueRun({ specId, specRevision: 1, triggerKind: "manual" });
+		const first = enqueue(spec.specId);
+		const second = enqueue(spec.specId);
+		const otherFirst = enqueue(other.specId);
+		const third = enqueue(spec.specId);
+		// A cancelled run keeps its slot so later numbers never shift.
+		store.completeRun(second.runId, { status: "cancelled" });
+
+		expect(store.getRunOrdinal(first.runId)).toBe(1);
+		expect(store.getRunOrdinal(second.runId)).toBe(2);
+		expect(store.getRunOrdinal(third.runId)).toBe(3);
+		expect(store.getRunOrdinal(otherFirst.runId)).toBe(1);
+		expect(store.getRunOrdinal("crun_missing")).toBeUndefined();
+	});
+
 	it("treats failed one-off runs as satisfying the revision", () => {
 		const spec = seedOneOff();
 		const run = store.enqueueRun({

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
@@ -1270,6 +1270,30 @@ export class SqliteCronStore {
 		return row ? runToRecord(row) : undefined;
 	}
 
+	/**
+	 * 1-based position of a run among every run ever created for its spec,
+	 * in creation order. Counts runs of every status (including cancelled and
+	 * failed ones) so the number is stable: a later cancellation never shifts
+	 * the numbers already stamped onto earlier sessions. Returns undefined
+	 * for an unknown run.
+	 */
+	public getRunOrdinal(runId: string): number | undefined {
+		const row = this.db
+			.prepare(
+				`SELECT COUNT(*) AS count
+					FROM cron_runs r
+					INNER JOIN cron_runs target ON target.run_id = ?
+					WHERE r.spec_id = target.spec_id
+						AND (
+							r.created_at < target.created_at
+							OR (r.created_at = target.created_at AND r.rowid <= target.rowid)
+						)`,
+			)
+			.get(runId) as { count?: unknown } | undefined;
+		const count = Number(row?.count ?? 0);
+		return count > 0 ? count : undefined;
+	}
+
 	public insertEventLog(
 		event: AutomationEventEnvelope,
 		options: { receivedAtIso?: string } = {},

--- a/sdk/packages/core/src/hub/daemon/runtime-handlers.ts
+++ b/sdk/packages/core/src/hub/daemon/runtime-handlers.ts
@@ -87,7 +87,7 @@ export function createLocalHubScheduleRuntimeHandlers(
 	});
 
 	return {
-		async startSession(request) {
+		async startSession(request, options) {
 			const cwd = (request.cwd?.trim() || request.workspaceRoot).trim();
 			const started = await sessionHost.startSession({
 				source: SessionSource.CORE,
@@ -95,10 +95,13 @@ export function createLocalHubScheduleRuntimeHandlers(
 				// Record the spec-defined trigger source (e.g. "hub-schedule"
 				// or a custom label from spec frontmatter) as provenance; the
 				// top-level `source` is reserved for the client surface.
-				sessionMetadata: withSessionHistoryOriginMetadata(undefined, {
-					mode: "automation",
-					trigger: request.source,
-				}),
+				sessionMetadata: withSessionHistoryOriginMetadata(
+					options?.sessionMetadata,
+					{
+						mode: "automation",
+						trigger: request.source,
+					},
+				),
 				interactive: false,
 				config: {
 					providerId: normalizeProviderId(request.provider),


### PR DESCRIPTION
### Related Issue

Follow-up to #13745. While verifying that PR against my own `cron.db`/`sessions.db`, the thing that made the duplicate-session bug hard to spot was that the sidebar's Scheduled section *always* looks like duplicates: a daily schedule produces one row per run, every row titled with the same prompt text. A user can't tell "eight legitimate runs" from "the task got duplicated" without opening each one.

### Description

Scheduled runs now fold into one collapsible row per schedule in the sidebar.

**What you see**

- The Scheduled section shows one row per schedule, named after the schedule (e.g. "Daily date report at noon") rather than the prompt's first line, with a chevron, the clock icon, and a run count ("8 runs") on the right. The section header's badge counts schedules, not runs.
- Expanding a row lists the runs as sub-items labelled "Run N" (newest first), each with its usual status dot, relative time, hover card, right-click menu (pin/rename/fork/delete), and hover trash button. The hover card leads with "Schedule: <name>" and "Run: N" since the row itself no longer shows the prompt.
- Groups start collapsed, except the one holding the currently open session (so a run opened from the Schedules settings page is visible). Toggles are remembered per group for the sidebar's lifetime.
- Green dot on the header if any run is in progress; blue if any run is unread.
- The same grouping applies inside each project when sorting by project. Pinned scheduled runs stay as individual rows in Pinned.

**How a thread knows which schedule it belongs to**

Until now the only provenance on a scheduled session was `sessionHistoryOrigin.trigger = "hub-schedule"`. So this PR also has a core half: the cron runner passes schedule provenance to the runtime handlers as a new optional second argument to `HubScheduleRuntimeHandlers.startSession`, and both handler implementations (`automation.ts`, `hub/daemon/runtime-handlers.ts`) merge it into the session metadata next to the origin trigger, the same way agenda tasks stamp `agendaTaskId`/`agendaTaskRunId`:

```ts
scheduleId          // hub schedule external id (sched_…)
scheduleName        // schedule title
scheduleExecutionId // cron run id (crun_…)
scheduleRunNumber   // 1-based position among every run created for the spec
```

The run number comes from a new `SqliteCronStore.getRunOrdinal(runId)`: a count of the spec's runs created at or before this one (ties broken by rowid). It deliberately counts runs of *every* status, including cancelled and failed ones, so the numbers are stable: a later cancellation never shifts numbers already stamped onto earlier sessions. The trade-off is that a run that never produced a session (spec disabled → cancelled) leaves a gap, which I think is the honest rendering. A reclaimed run (the #13745 scenario) keeps its number, so two sessions both labelled "Run 5" is exactly what a duplicate looks like now.

The webview resolves schedule identity in three tiers, first match wins:

1. `scheduleId`/`scheduleName`/`scheduleRunNumber` from session metadata (new sessions).
2. The `list_routine_schedules` executions list the hook already polls every 2 minutes for the is-scheduled fallback. It used to collapse to a bare `Set<sessionId>`; it now keeps `sessionId → {scheduleId, scheduleName}` (name resolved through the `schedules` array in the same response). This covers sessions recorded before this PR that are still inside the executions window, and any runtime that drops the stamped metadata (the provenance bug noted in #13573 is why the executions fallback exists at all; this keeps that safety net).
3. Shared title. A schedule's sessions all start from the same prompt, so legacy runs with neither of the above still group. Title-keyed and id-keyed groups never merge with each other, so a legacy group can sit next to a new one for the same schedule until the old runs age out.

Runs without a stamped number are labelled with their start time ("Aug 31, 12:31 PM") instead of "Run N", since that's the next best way to tell them apart. Every session in my sidebar today is in that state; once the hub daemon restarts on this code new runs get numbers.

**Why not compute the run number client-side**

The sidebar only loads the newest 50 sessions, so "index within the loaded group" would call the 12th run "Run 1". Counting from the executions endpoint doesn't work either: the sidecar fetches the newest 50 executions across all schedules and backfills one per schedule, so per-schedule history is incomplete. Stamping at run time in core is the only place the full count is cheap and correct.

**Things I chose not to do**

- No `ChatStartSessionRequest` change. Adding `sessionMetadata` there would have leaked through `ChatRunTurnRequest.config` and the hub RPC surface; a second argument on the handler is contained to the runner ↔ handler contract, and the two other consumers (`cline-hub`, `cli`, the VS Code example) all use `createLocalHubScheduleRuntimeHandlers` so they pick it up for free.
- The Schedules settings page's "Runs" list and the hub webview's sidebar are untouched. The metadata is there for them to use.
- Single-run schedules still render as a group (header + one "Run 1"). Consistency over compactness: the schedule name is more useful than the prompt text either way.

### Test Procedure

- `@cline/core`: new test in `cron-runner.test.ts` asserts two consecutive runs of a schedule spec hand the handler `scheduleId`/`scheduleName`/`scheduleExecutionId` and run numbers 1 and 2; new test in `sqlite-cron-store.test.ts` covers ordinal stability across specs and a cancelled run in the middle. Runner, store, automation, and hub-runtime-host suites pass. `tsc` is clean apart from the pre-existing unused-import error in `hub-upgrades.test.ts` on main.
- Desktop webview: new tests for `groupScheduledThreads` (id grouping keeps the newest run's position, title fallback never merges with id groups), `scheduleRunLabel` (number → date → "Run"), the sidebar (header shows schedule name + "2 runs", collapsed by default, expands on click, "Run 2" above "Run 1", no clock on nested rows, clicking a run opens it, active session auto-expands, grouping inside project sort), the hover overview leading with Schedule/Run, and the hook (metadata mapping; executions link now supplies schedule id + name). All 48 tests in the three touched files pass; the full desktop-app vitest run has 7 failures that are unrelated sidecar timeouts under load (they pass in isolation) and two `bun:test`-only script tests.
- The desktop webview is not typechecked by CI; I ran `tsc` manually against the touched files and biome is clean on every changed file.
- Manual: the browser dev stack in my container picks up the change with my real history (8 runs of one legacy schedule fold into a single "Report today's date to the user." row labelled by start time, because none of them have stamped numbers yet). Worth a look on a real Mac build with a fresh daemon to see the "Run N" labels.

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed contributor guidelines
