### PR TITLE
fix(cli): show the keep-Hub reminder toast when the outdated-hub dialog is dismissed

### DIFF
--- a/apps/cli/src/tui/root.tsx
+++ b/apps/cli/src/tui/root.tsx
@@ -610,6 +610,12 @@ function App(props: TuiProps) {
 				})
 				.then(async (update) => {
 					if (!update) {
+						// choice() resolves undefined on Esc; it does not reject.
+						showToast(
+							"The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish.",
+							"info",
+						);
+						refocusTextareaRef.current();
 						return;
 					}
 					showToast("Updating the Cline Hub…", "info");
@@ -642,10 +648,6 @@ function App(props: TuiProps) {
 					refocusTextareaRef.current();
 				})
 				.catch(() => {
-					showToast(
-						"The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish.",
-						"info",
-					);
 					refocusTextareaRef.current();
 				});
 			return;


### PR DESCRIPTION
### Related Issue

Follow-up to #13727 (targets `bee/hub-update-flow`).

### Description

In the new `outdated_hub` handler in `apps/cli/src/tui/root.tsx`, the "The running Cline Hub stays on the older version. Run 'cline hub upgrade' once its sessions finish." toast lived in `.catch()`. `@opentui-ui/dialog`'s `choice()` resolves `undefined` on `dismiss()`/Esc rather than rejecting, so that branch never ran and pressing Esc closed the dialog silently.

This moves the toast (and the textarea refocus) into the falsy branch of `.then()`, matching how the existing `unsupported_protocol` handler in the same file already does it.

### Test Procedure

Reproduced with tuistory against an old-build hub (`CLINE_HUB_BUILD_ID=old-build CLINE_HUB_BUILD_EPOCH_MS=1000`, `CLINE_BUILD_ENV=production`) kept busy by an old-build TUI, then a new-build TUI with `CLINE_HUB_BUILD_WATCH_INTERVAL_MS=2000`:

- Unfixed PR code: dialog appears, Esc closes it, no toast within 10s.
- With this change: dialog appears, Esc closes it, the reminder toast renders and the hub stays `old-build` / `draining:false`.

![Reminder toast after pressing Esc](https://cursor.com/artifacts/c/art-27157c0e-e7a5-4276-ac5e-ea7ce2e023fc)

Note the toast is clipped to one line by the existing `Toast` component (`maxWidth 44`, unchanged here); that affects all of the longer hub toasts in #13727 and is worth a separate follow-up.

`bunx biome check` and `tsc --noEmit` clean for `apps/cli`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)