### PR TITLE
feat(account): link to the web app's privacy settings when the API advertises them

### DIFF
--- a/.changeset/dat-111-privacy-settings-link.md
+++ b/.changeset/dat-111-privacy-settings-link.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Link to the Cline web app's privacy settings from the Account view and General settings when the Cline API advertises a destination (`dataPrivacyPath` on `/users/me`). The link carries the originating client (VS Code or JetBrains); nothing renders when the API advertises no destination.

--- a/apps/vscode/proto/cline/account.proto
+++ b/apps/vscode/proto/cline/account.proto
@@ -75,6 +75,12 @@ message UserInfo {
   optional string email = 3;
   optional string photo_url = 4;
   optional string app_base_url = 5; // Cline app base URL
+  // Dashboard path (not a URL) of the user's privacy settings, for example
+  // "/dashboard/account?tab=privacy". Present only while the Cline API advertises
+  // it (it is feature-flagged server side); absent means there is no destination
+  // and clients render nothing. Join it with app_base_url via `new URL(path, base)`
+  // rather than string concatenation because the path carries a query string.
+  optional string data_privacy_path = 6;
 }
 
 message UserOrganization {

--- a/apps/vscode/src/sdk/auth-service.test.ts
+++ b/apps/vscode/src/sdk/auth-service.test.ts
@@ -276,6 +276,23 @@ describe("AuthService", () => {
 			expect(info.user?.displayName).toBe("Test User")
 		})
 
+		it("forwards dataPrivacyPath from /users/me so the webview can link to the web privacy settings", () => {
+			const base = createTestAuthInfo()
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo({
+				userInfo: { ...base.userInfo, dataPrivacyPath: "/dashboard/account?tab=privacy" },
+			})
+			testAccess(authService)._authenticated = true
+
+			expect(authService.getInfo().user?.dataPrivacyPath).toBe("/dashboard/account?tab=privacy")
+		})
+
+		it("leaves dataPrivacyPath unset when the API did not advertise one", () => {
+			testAccess(authService)._clineAuthInfo = createTestAuthInfo()
+			testAccess(authService)._authenticated = true
+
+			expect(authService.getInfo().user?.dataPrivacyPath).toBeUndefined()
+		})
+
 		it("returns unauthenticated state when _authenticated is false even with auth info", () => {
 			const authInfo = createTestAuthInfo()
 			testAccess(authService)._clineAuthInfo = authInfo

--- a/apps/vscode/src/sdk/auth-service.ts
+++ b/apps/vscode/src/sdk/auth-service.ts
@@ -63,6 +63,11 @@ export interface ClineAccountUserInfo {
 	organizations: ClineAccountOrganization[]
 	appBaseUrl?: string
 	subject?: string
+	/**
+	 * Dashboard path of the web privacy settings, advertised by GET /users/me only while the
+	 * server-side feature flag is on for this user. Absent means the client shows no link.
+	 */
+	dataPrivacyPath?: string
 }
 
 export interface ClineAccountOrganization {
@@ -522,6 +527,7 @@ export class AuthService {
 				email: userInfo?.email,
 				photoUrl: undefined,
 				appBaseUrl: userInfo?.appBaseUrl,
+				dataPrivacyPath: userInfo?.dataPrivacyPath,
 			})
 			return AuthState.create({ user })
 		}

--- a/apps/vscode/src/utils/env.ts
+++ b/apps/vscode/src/utils/env.ts
@@ -36,7 +36,8 @@ export async function readTextFromClipboard(): Promise<string> {
 /**
  * Opens an external URL in the default browser.
  * Uses the host bridge RPC first (VS Code's openExternal which handles remote environments).
- * Falls back to the `open` npm package if the host doesn't implement the RPC (e.g., JetBrains).
+ * Falls back to the `open` npm package if the host bridge call fails. Every shipped host,
+ * including the JetBrains plugin (EnvService.openExternal -> BrowserUtil.browse), implements the RPC.
  *
  * When CLINE_CAPTURE_BROWSER is set (debug harness mode), the URL is captured
  * to a file and/or posted to the debug harness instead of opening a real browser.
@@ -56,7 +57,7 @@ export async function openExternal(url: string): Promise<void> {
 	try {
 		await HostProvider.env.openExternal(StringRequest.create({ value: url }))
 	} catch (error) {
-		// Fallback for hosts that don't implement openExternal (e.g., JetBrains plugin)
+		// Fallback for a host whose openExternal RPC is unavailable or fails (no shipped host lacks it today)
 		Logger.warn(`Host openExternal RPC failed, falling back to 'open' package: ${error}`)
 		try {
 			const open = (await import("open")).default

--- a/apps/vscode/webview-ui/src/components/account/AccountView.tsx
+++ b/apps/vscode/webview-ui/src/components/account/AccountView.tsx
@@ -17,7 +17,7 @@ import { AccountWelcomeView } from "./AccountWelcomeView"
 import { ClinePassCard } from "./ClinePassCard"
 import { CreditBalance } from "./CreditBalance"
 import CreditsHistoryTable from "./CreditsHistoryTable"
-import { convertProtoUsageTransactions, getClineUris, getMainRole } from "./helpers"
+import { convertProtoUsageTransactions, getClineUris, getMainRole, getPrivacySettingsUrl } from "./helpers"
 import { RemoteConfigToggle } from "./RemoteConfigToggle"
 
 type AccountViewProps = {
@@ -67,7 +67,7 @@ const AccountView = ({ onDone, clineUser, organizations, activeOrganization }: A
 }
 
 const ClineAccountView = ({ clineUser, userOrganizations, activeOrganization, clineEnv }: ClineAccountViewProps) => {
-	const { email, displayName, appBaseUrl, uid } = clineUser
+	const { email, displayName, appBaseUrl, uid, dataPrivacyPath } = clineUser
 	const { remoteConfigSettings, environment } = useExtensionState()
 
 	// Determine if dropdown should be locked by remote config
@@ -231,6 +231,7 @@ const ClineAccountView = ({ clineUser, userOrganizations, activeOrganization, cl
 	}, 60000)
 
 	const clineUrl = appBaseUrl || "https://app.cline.bot"
+	const privacySettingsUrl = getPrivacySettingsUrl(clineUrl, dataPrivacyPath)
 
 	// Fetch balance on mount
 	useEffect(() => {
@@ -365,6 +366,11 @@ const ClineAccountView = ({ clineUser, userOrganizations, activeOrganization, cl
 						Log out
 					</VSCodeButton>
 				</div>
+				{privacySettingsUrl && (
+					<VSCodeButtonLink appearance="secondary" className="w-full mt-2" href={privacySettingsUrl.href}>
+						Privacy settings
+					</VSCodeButtonLink>
+				)}
 
 				<VSCodeDivider className="w-full my-6" />
 

--- a/apps/vscode/webview-ui/src/components/account/helpers.test.ts
+++ b/apps/vscode/webview-ui/src/components/account/helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest"
+import { getPrivacySettingsClient, getPrivacySettingsUrl } from "./helpers"
+
+vi.mock("@/config/platform.config", () => ({
+	PLATFORM_CONFIG: { type: 0 },
+	PlatformType: { VSCODE: 0, STANDALONE: 1 },
+}))
+
+describe("getPrivacySettingsUrl", () => {
+	it("returns undefined when the API did not advertise a path, so nothing renders", () => {
+		expect(getPrivacySettingsUrl("https://app.cline.bot", undefined)).toBeUndefined()
+		expect(getPrivacySettingsUrl("https://app.cline.bot", "")).toBeUndefined()
+	})
+
+	it("joins the advertised path with the app base URL and tags the originating client", () => {
+		const url = getPrivacySettingsUrl("https://app.cline.bot", "/dashboard/account?tab=privacy", "vscode")
+		expect(url?.href).toBe("https://app.cline.bot/dashboard/account?tab=privacy&client=vscode")
+	})
+
+	it("keeps the path's own query string on a base with a trailing slash", () => {
+		const url = getPrivacySettingsUrl("https://staging-app.cline.bot/", "/dashboard/account?tab=privacy", "jetbrains")
+		expect(url?.origin).toBe("https://staging-app.cline.bot")
+		expect(url?.pathname).toBe("/dashboard/account")
+		expect(url?.searchParams.get("tab")).toBe("privacy")
+		expect(url?.searchParams.get("client")).toBe("jetbrains")
+	})
+
+	it("defaults the client to the host this webview runs in", () => {
+		expect(getPrivacySettingsClient()).toBe("vscode")
+		const url = getPrivacySettingsUrl("https://app.cline.bot", "/dashboard/account?tab=privacy")
+		expect(url?.searchParams.get("client")).toBe("vscode")
+	})
+
+	it("returns undefined instead of throwing on an unusable base", () => {
+		expect(getPrivacySettingsUrl("not a url", "/dashboard/account?tab=privacy", "vscode")).toBeUndefined()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/account/helpers.ts
+++ b/apps/vscode/webview-ui/src/components/account/helpers.ts
@@ -1,5 +1,6 @@
 import type { UsageTransaction as ClineAccountUsageTransaction } from "@shared/ClineAccount"
 import type { UsageTransaction as ProtoUsageTransaction, UserOrganization } from "@shared/proto/cline/account"
+import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 
 export const getMainRole = (roles?: string[]) => {
 	if (!roles) {
@@ -50,6 +51,38 @@ function convertProtoUsageTransaction(protoTransaction: ProtoUsageTransaction): 
  */
 export function convertProtoUsageTransactions(protoTransactions: ProtoUsageTransaction[]): ClineAccountUsageTransaction[] {
 	return protoTransactions.map(convertProtoUsageTransaction)
+}
+
+export type PrivacySettingsClient = "vscode" | "jetbrains"
+
+/**
+ * Which client a privacy-settings link identifies itself as. The JetBrains plugin renders this same
+ * webview through the standalone host, so standalone means JetBrains here.
+ */
+export const getPrivacySettingsClient = (): PrivacySettingsClient =>
+	PLATFORM_CONFIG.type === PlatformType.STANDALONE ? "jetbrains" : "vscode"
+
+/**
+ * Builds the web app's privacy settings URL from the `dataPrivacyPath` the API advertises on
+ * GET /users/me. The path is relative and carries a query string, so it is joined with
+ * `new URL(path, base)` rather than concatenated. Returns undefined when the API advertised
+ * nothing, which is the signal to render no link at all.
+ */
+export const getPrivacySettingsUrl = (
+	base: string,
+	dataPrivacyPath: string | undefined,
+	client: PrivacySettingsClient = getPrivacySettingsClient(),
+): URL | undefined => {
+	if (!dataPrivacyPath) {
+		return undefined
+	}
+	try {
+		const url = new URL(dataPrivacyPath, base)
+		url.searchParams.set("client", client)
+		return url
+	} catch {
+		return undefined
+	}
 }
 
 export const isAdminOrOwner = (activeOrg: UserOrganization): boolean => {

--- a/apps/vscode/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
@@ -1,5 +1,7 @@
 import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { getPrivacySettingsUrl } from "@/components/account/helpers"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import PreferredLanguageSetting from "../PreferredLanguageSetting"
 import Section from "../Section"
@@ -11,6 +13,8 @@ interface GeneralSettingsSectionProps {
 
 const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionProps) => {
 	const { telemetrySetting, remoteConfigSettings } = useExtensionState()
+	const { clineUser } = useClineAuth()
+	const privacySettingsUrl = getPrivacySettingsUrl(clineUser?.appBaseUrl || "https://app.cline.bot", clineUser?.dataPrivacyPath)
 
 	return (
 		<div>
@@ -59,6 +63,18 @@ const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionP
 						</VSCodeLink>{" "}
 						for more details.
 					</p>
+					{privacySettingsUrl && (
+						<p className="text-sm mt-[5px] text-description">
+							Your data sharing and Cline Bench preferences live in your Cline account's{" "}
+							<VSCodeLink
+								className="text-inherit"
+								href={privacySettingsUrl.href}
+								style={{ fontSize: "inherit", textDecoration: "underline" }}>
+								privacy settings
+							</VSCodeLink>
+							.
+						</p>
+					)}
 				</div>
 			</Section>
 		</div>

--- a/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ClineAuthContext.tsx
@@ -12,6 +12,8 @@ export interface ClineUser {
 	displayName?: string
 	photoUrl?: string
 	appBaseUrl?: string
+	/** Dashboard path of the web privacy settings; present only when the API advertises it. */
+	dataPrivacyPath?: string
 }
 
 export interface ClineAuthContextType {


### PR DESCRIPTION
### Related Issue

**Issue:** no GitHub issue; this is Linear **DAT-111** (consolidating the data-sharing opt-out onto the Cline web app, with every other client pointing at it). Server side: cline/core-platform#3317 advertises `dataPrivacyPath` on `GET /users/me` behind the `dashboard_privacy_settings` flag, and cline/core-platform#3316 is the destination (the Privacy card on the web account page).

### Description

The web app becomes the single place where a user manages the **Help improve Cline** (data sharing) and **Contribute to Cline Bench** preferences. Editors do not get their own copy of those controls; they get a pointer.

`GET /users/me` now returns `dataPrivacyPath`, a dashboard path such as `/dashboard/account?tab=privacy`, **only while the server-side feature flag is on for that user**. Absent field means "no destination".

This PR plumbs that field end to end and renders the pointer only when it is present:

- `proto/cline/account.proto`: `UserInfo` gains `optional string data_privacy_path = 6` (documented as a path, not a URL).
- `src/sdk/auth-service.ts`: `ClineAccountUserInfo.dataPrivacyPath` flows from the API response into `getInfo()` and on to the webview.
- Webview `ClineUser` gains the same optional field.
- `components/account/helpers.ts`: `getPrivacySettingsUrl(base, path, client)` joins with `new URL(path, appBaseUrl)` (the path carries a query string, so string concatenation would be wrong) and sets `client=vscode` or `client=jetbrains`. The JetBrains plugin renders this same webview through the standalone host, which is how the client is detected; no Kotlin change is needed, only a plugin re-package release.
- `AccountView.tsx`: a secondary **Privacy settings** button under the Dashboard / Log out row.
- `GeneralSettingsSection.tsx`: one sentence under the telemetry paragraph pointing at the same URL, so someone looking for "data" settings in the editor is told where they live.
- `utils/env.ts`: two comments claimed the JetBrains plugin lacks the `openExternal` host RPC. It implements it (`EnvService.openExternal` via `BrowserUtil.browse`), so the comments now say the `open` package is only a fallback for a failed call.

Because pointer and destination are gated by the same flag evaluated against the same user, they appear and disappear together. Turning the link on or off needs no client release, and rollback is "flag off" on the backend.

### Test Procedure

Automated, all run on this branch after `bun run protos` and `bun run build:sdk`:

- `apps/vscode`: `bunx tsc --noEmit` clean; `bunx vitest run src/sdk/auth-service.test.ts` 41 passed, including two new cases (field forwarded when present, `undefined` when the API omitted it).
- `apps/vscode/webview-ui`: `bunx tsc --noEmit` clean; `bunx vitest run src/components/account/helpers.test.ts` 5 passed (join with base URL, query string preserved on a trailing-slash base, client tag, default client from the host, no throw on an unusable base, `undefined` when nothing advertised).
- `bunx biome check` on the touched files clean; `bun run lint:proto` clean.

Manual, to do at review time against a backend that has cline/core-platform#3317 with the flag **off** for the signed-in user: the Account view and General settings must be pixel-identical to `main` (no button, no sentence). Flip the flag on for that user and re-open the Account view: the button appears and opens `https://app.cline.bot/dashboard/account?tab=privacy&client=vscode` (`client=jetbrains` from the plugin). The web page scrolls to its Privacy card and acknowledges the origin.

What could break: nothing renders unless the API sends the field, so an older backend, a self-hosted backend, or the flag being off leaves both views exactly as before. The only shared code touched is the `ClineUser` type (an added optional field) and the account `UserInfo` proto (a new optional field number, wire-compatible).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included yet: the button and sentence only render against a backend that advertises `dataPrivacyPath`, which needs cline/core-platform#3317 deployed with the flag on for the test user. Placement: Account view, a full-width secondary button directly under the Dashboard / Log out row; General settings, one sentence directly under the existing telemetry paragraph, same style.

### Additional Notes

- Rollout order is documented in cline/core-platform#3321 (`docs/data-opt-out-rollout.md`); this PR is phase 6 there and can merge and ship any time before or after the flag turns on, since it renders nothing until the field arrives.
- The `client` values (`vscode`, `jetbrains`) match the allowlist the API stores as `origin_client` on preference changes (`cli` and `web` are the other two). Unknown values are dropped server-side, never rejected.
- Companion PR for the CLI account dialog follows separately.
