### PR TITLE
feat(cli): open the web app's privacy settings from the account dialog

### DIFF
--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -368,3 +368,37 @@ describe("isClineAccountCreditsErrorMessage", () => {
 		).toBe(false);
 	});
 });
+
+describe("getClinePrivacySettingsUrl", () => {
+	it("returns undefined when the API did not advertise a privacy path", async () => {
+		const { getClinePrivacySettingsUrl } = await import("./cline-account");
+		expect(
+			getClinePrivacySettingsUrl({}, "https://app.cline.bot"),
+		).toBeUndefined();
+	});
+
+	it("joins the advertised path with the app base URL and tags the CLI as the client", async () => {
+		const { getClinePrivacySettingsUrl } = await import("./cline-account");
+		expect(
+			getClinePrivacySettingsUrl(
+				{ dataPrivacyPath: "/dashboard/account?tab=privacy" },
+				"https://staging-app.cline.bot/",
+			),
+		).toBe(
+			"https://staging-app.cline.bot/dashboard/account?tab=privacy&client=cli",
+		);
+	});
+
+	it("defaults to the configured Cline environment's app base URL", async () => {
+		const { getClinePrivacySettingsUrl } = await import("./cline-account");
+		const { getClineEnvironmentConfig } = await import("@cline/shared");
+		const url = getClinePrivacySettingsUrl({
+			dataPrivacyPath: "/dashboard/account?tab=privacy",
+		});
+		expect(url).toBeDefined();
+		expect(new URL(url ?? "").origin).toBe(
+			new URL(getClineEnvironmentConfig().appBaseUrl).origin,
+		);
+		expect(new URL(url ?? "").searchParams.get("client")).toBe("cli");
+	});
+});

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -33,10 +33,36 @@ export interface ClineAccountSnapshot {
 	organizations: ClineAccountOrganization[];
 	activeOrganization: ClineAccountOrganization | null;
 	displayedBalance: number;
+	/** Web privacy settings URL; undefined when the API advertised no destination. */
+	privacySettingsUrl?: string;
 }
 
 export function formatClineCredits(value: number): string {
 	return formatCreditBalance(normalizeCreditBalance(value));
+}
+
+/**
+ * Resolve the web app's privacy settings URL from the `dataPrivacyPath` the API
+ * advertises on GET /users/me. The path is relative and carries a query string,
+ * so it is joined with `new URL(path, base)` rather than concatenated, and the
+ * link identifies this client so the dashboard can acknowledge where the user
+ * came from. Returns undefined when the API advertised nothing, which is the
+ * signal to offer no action at all.
+ */
+export function getClinePrivacySettingsUrl(
+	user: Pick<ClineAccountUser, "dataPrivacyPath">,
+	appBaseUrl: string = getClineEnvironmentConfig().appBaseUrl,
+): string | undefined {
+	if (!user.dataPrivacyPath) {
+		return undefined;
+	}
+	try {
+		const url = new URL(user.dataPrivacyPath, appBaseUrl);
+		url.searchParams.set("client", "cli");
+		return url.href;
+	} catch {
+		return undefined;
+	}
 }
 
 // FIXME: These message checks are temporary until structured error types are
@@ -231,6 +257,7 @@ export async function loadClineAccountSnapshot(input: {
 		organizations,
 		activeOrganization,
 		displayedBalance,
+		privacySettingsUrl: getClinePrivacySettingsUrl(user),
 	};
 }
 

--- a/apps/cli/src/tui/components/dialogs/account-dialog.tsx
+++ b/apps/cli/src/tui/components/dialogs/account-dialog.tsx
@@ -14,7 +14,8 @@ export type AccountDialogAction =
 	| "change-model"
 	| "change-provider"
 	| "learn-more"
-	| "login";
+	| "login"
+	| { kind: "open-url"; url: string };
 
 type AccountView = "overview" | "organizations";
 
@@ -38,7 +39,8 @@ interface AccountAction {
 		| "change-account"
 		| "change-provider"
 		| "learn-more"
-		| "login";
+		| "login"
+		| "privacy-settings";
 	label: string;
 	description: string;
 	enabled: boolean;
@@ -203,7 +205,7 @@ function OrganizationRow(props: {
 }
 
 function accountActions(snapshot: ClineAccountSnapshot): AccountAction[] {
-	return LOADED_ACTIONS.map((action) => {
+	const actions = LOADED_ACTIONS.map((action) => {
 		if (action.id !== "change-account") {
 			return action;
 		}
@@ -214,6 +216,16 @@ function accountActions(snapshot: ClineAccountSnapshot): AccountAction[] {
 				Boolean(snapshot.activeOrganization),
 		};
 	});
+	if (snapshot.privacySettingsUrl) {
+		actions.push({
+			id: "privacy-settings",
+			label: "Privacy settings",
+			description:
+				"Manage data sharing in your Cline account (opens the web app)",
+			enabled: true,
+		});
+	}
+	return actions;
 }
 
 function organizationDescription(org: ClineAccountOrganization): string {
@@ -365,11 +377,17 @@ export function AccountDialogContent(
 				resolve("change-provider");
 				return;
 			}
+			if (action.id === "privacy-settings") {
+				if (snapshot?.privacySettingsUrl) {
+					resolve({ kind: "open-url", url: snapshot.privacySettingsUrl });
+				}
+				return;
+			}
 			if (action.id === "change-account") {
 				openOrganizationView();
 			}
 		},
-		[openOrganizationView, resolve],
+		[openOrganizationView, resolve, snapshot],
 	);
 
 	const runSelectedAction = useCallback(() => {

--- a/apps/cli/src/tui/hooks/use-account-dialog.tsx
+++ b/apps/cli/src/tui/hooks/use-account-dialog.tsx
@@ -62,6 +62,15 @@ export function useAccountDialog(opts: {
 			refocusTextarea();
 			return;
 		}
+		if (
+			typeof action === "object" &&
+			action !== null &&
+			action.kind === "open-url"
+		) {
+			await open(action.url, { wait: false }).catch(() => {});
+			refocusTextarea();
+			return;
+		}
 		if (action === "login") {
 			const saved = await dialog.choice<OAuthLoginResult>({
 				style: { maxHeight: termHeight - 2 },

--- a/sdk/packages/core/src/account/types.ts
+++ b/sdk/packages/core/src/account/types.ts
@@ -14,6 +14,14 @@ export interface ClineAccountUser {
 	createdAt: string;
 	updatedAt: string;
 	organizations: ClineAccountOrganization[];
+	/**
+	 * Dashboard path (not a URL) of the web privacy settings, for example
+	 * "/dashboard/account?tab=privacy". Advertised by GET /users/me only while the
+	 * server-side feature flag is on for this user; absent means there is no
+	 * destination and clients offer nothing. Join it with the app base URL via
+	 * `new URL(path, base)` because it carries a query string.
+	 */
+	dataPrivacyPath?: string;
 }
 
 export interface UserRemoteConfigOrganization {


### PR DESCRIPTION
### Related Issue

**Issue:** no GitHub issue; this is Linear **DAT-111** (consolidating the data-sharing opt-out onto the Cline web app, with every other client pointing at it). Companion to cline/cline#13756 (VS Code and JetBrains, via the shared webview). Server side: cline/core-platform#3317 advertises `dataPrivacyPath` on `GET /users/me` behind the `dashboard_privacy_settings` flag; cline/core-platform#3316 is the destination.

### Description

The web app becomes the single place where a user manages the **Help improve Cline** (data sharing) and **Contribute to Cline Bench** preferences. The CLI does not get its own copy of those controls; it gets a pointer in the `/account` dialog.

`GET /users/me` now returns `dataPrivacyPath`, a dashboard path such as `/dashboard/account?tab=privacy`, **only while the server-side feature flag is on for that user**. Absent field means "no destination".

- `sdk/packages/core/src/account/types.ts`: `ClineAccountUser.dataPrivacyPath?: string`, documented as a path, not a URL.
- `apps/cli/src/tui/cline-account.ts`: `getClinePrivacySettingsUrl(user, appBaseUrl?)` joins the path with `new URL(path, base)` (the path carries a query string, so concatenation would be wrong), defaults the base to the configured Cline environment's `appBaseUrl` (production, staging or local), and sets `client=cli`. The account snapshot carries the result as `privacySettingsUrl`.
- `account-dialog.tsx`: a **Privacy settings** action is appended to the loaded-account actions only when the snapshot has a URL. Choosing it resolves `{ kind: "open-url", url }`.
- `use-account-dialog.tsx`: handles that action by opening the URL and refocusing the textarea, the same shape as the existing "learn more" action, so browser side effects stay in the hook.

Because the pointer and the destination are gated by the same flag evaluated against the same user, they appear and disappear together. Turning the action on or off needs no CLI release; rollback is "flag off" on the backend.

### Test Procedure

Automated, all run on this branch after `bun -F @cline/core build`:

- `sdk/packages/core`: `bun tsc -p tsconfig.dev.json --noEmit` clean.
- `apps/cli`: `bun run typecheck` clean; `bunx vitest run --config vitest.config.ts src/tui/cline-account.test.ts` 12 passed, including three new cases (`undefined` when nothing advertised, join with a trailing-slash staging base keeps `tab=privacy` and adds `client=cli`, default base is the configured environment's app URL).
- `bun biome check` on the touched files: clean apart from two pre-existing a11y warnings on the dialog's clickable rows that this PR does not touch.

Manual, at review time against a backend running cline/core-platform#3317: with the flag **off** for the signed-in user, `/account` shows exactly today's three actions. With the flag on, a fourth action **Privacy settings** appears; selecting it opens `https://app.cline.bot/dashboard/account?tab=privacy&client=cli` and the web page scrolls to its Privacy card and acknowledges the origin.

What could break: nothing is offered unless the API sends the field, so an older or self-hosted backend, or the flag being off, leaves the dialog exactly as before. The only type change is an added optional field on `ClineAccountUser`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included yet: the action only appears against a backend that advertises `dataPrivacyPath`, which needs cline/core-platform#3317 deployed with the flag on for the test user. It renders as a fourth row in the `/account` dialog, after "Change provider".

### Additional Notes

- No changeset: the repo's changesets cover the `claude-dev` extension package; the CLI and `@cline/core` are versioned separately.
- Rollout order is documented in cline/core-platform#3321 (`docs/data-opt-out-rollout.md`); this PR is phase 6 there and can merge and ship any time, since it offers nothing until the field arrives.
- `client=cli` matches the allowlist the API stores as `origin_client` on preference changes (`vscode`, `jetbrains`, `web` are the others).
