### PR TITLE
Add v1 agent event stream grammar and validator (Phase 0)

### DIFF
--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -1,0 +1,549 @@
+# Agent event stream v2 — scoped frames, one assembler
+
+Status: DRAFT for review. Nothing here is implemented.
+
+## Problem
+
+Every surface that renders an agent session (VSCode webview, CLI terminal,
+CLI TUI, ACP, hub clients, desktop app) consumes the same underlying event
+stream, but the stream's structure — which events form a block, which block
+an update belongs to, how a turn ends — is not part of the contract. It is
+re-derived by hand in each consumer as mutable parser state. The result is
+five independent stream assemblers, each with its own ordering folklore,
+its own straggler defenses, and its own bugs.
+
+This document proposes: (1) a versioned frame schema that makes stream
+structure explicit (scope addresses, sequence numbers, one spelling of every
+lifecycle transition); (2) a single shared assembler ("demux") that parses
+frames into typed object lifecycles, so consumers implement rendering only;
+(3) validators and a trace generator derived from the same transition tables,
+so malformed streams fail at the producer and translators are property-tested.
+
+TypeScript is the first-class target. The schema is language-neutral JSON so
+the Go consumers (core-platform) can generate types from it later, but no Go
+work is in scope here.
+
+## Specific problems this removes
+
+Each claim names the code that exists today and what deletes it. These are
+falsifiable; check the citations.
+
+**P1 — Five hand-rolled assemblers.** Each of these maintains private state
+whose only purpose is reconstructing stream structure:
+
+| Consumer | Parser state | Lines |
+|---|---|---|
+| `apps/vscode/src/sdk/message-translator.ts` | `MessageTranslatorState`: `streamingTextTs`, `streamingToolTs`, `streamingToolInput`, `streamingToolName`, `openCompactionTs`, `pendingToolUses` | 2,799 |
+| `apps/cli/src/utils/events.ts` | `activeInlineStream` mode variable | 357 |
+| `apps/cli/src/tui/hooks/use-agent-events.ts` | per-toolCallId entry tracking | 438 |
+| `apps/examples/desktop-app/webview/hooks/use-chat-session.ts` | `pendingStreamTextRef`, `pendingStreamReasoningRef`, `pendingToolOutputRef`, stale-stream poller | 3,208 |
+| core-platform `dashboard/.../useHubChat.ts` | own reimplementation | 1,980 |
+
+After: one assembler in the SDK; each consumer is a `TurnConsumer`
+implementation containing rendering logic only. The parser state above is
+deleted, not moved. Honest sizing: these files also contain rendering
+logic, which stays. The deletions are the parser-state fields, the
+buffering/staleness machinery, and the structural `switch`es — roughly a
+third to a half of each file, not the whole file. `useHubChat.ts` is out
+of scope for this plan (core-platform) and listed to show the recurring
+cost of each new surface.
+
+**P2 — `content_end` duplicates deltas, discovered three times.** The rule
+"final text on `content_end` repeats the streamed deltas" is documented
+independently at `apps/examples/desktop-app/sidecar/context.ts:310`,
+core-platform `agentsession/streamer.go:147`, and handled again inside the
+hub `session-event-projector.ts`. After: the frame schema states which frame
+carries authoritative final text; the assembler applies it once
+(`onBlockClose` carries the final content); the three private discoveries
+delete.
+
+**P3 — Tool input carried from start to end by hand.**
+`content_end(tool)` does not carry the tool input, so consumers save it at
+`content_start` and join at `content_end`: `streamingToolInput` in
+MessageTranslatorState, `pendingToolUses` map in the same file's history
+path (`message-translator.ts:2323`), and equivalents in the TUI and hub.
+After: `ToolSink.close(result)` delivers the input captured at open. The
+join happens once, in the assembler.
+
+**P4 — Straggler fencing invented twice.** VSCode: epoch/seq minter, bumped
+before abort so stale events are dropped (`SdkController.ts:602-608`,
+`2216-2317`; straggler special case in
+`sdk-session-event-coordinator.ts:107-117`). Desktop: settled-epoch check
+and unmatched-tool-end dropping (`use-chat-session.ts:1716, 1777-1781`).
+After: `(epoch, seq)` is stamped by the producer in the frame envelope; the
+assembler drops stale frames in one place. The desktop's fence deletes
+entirely; VSCode's minter keeps its ClineMessage id-stamping role but its
+straggler-dropping role moves into the assembler.
+
+**P5 — Sub-agent demux by timing heuristic.**
+`message-translator.ts:2023-2029`: sub-agent events sometimes lack
+`parentAgentId`, so the translator suppresses *all* non-spawn events while
+any spawn_agent call is running — eating legitimate parent output. After:
+every frame carries a full scope address; the consumer prunes sub-agent
+streams structurally (`onSubAgent → null`); the heuristic and
+`hasRunningSpawnAgents()` delete.
+
+**P6 — Turn end has three spellings.** A turn may end via `done(reason)`,
+via terminal `error`, or via `done(reason:"error")` with no error event
+(`message-translator.ts:1865-1870`); recoverable errors reuse the `error`
+type but are not terminal (`:1896-1911` documents a shipped bug from this).
+The hub re-derives the mapping (`run-handlers.ts:28-31`) and needs a
+suppression flag to avoid double-publishing terminal events
+(`handlers/context.ts:69`). After: exactly one `turn_close` frame with one
+`TurnOutcome`; recoverable errors are notices inside the turn.
+
+**P7 — Errors flattened differently at every wire.** `AgentErrorEvent.error`
+is a JS `Error` (`shared/src/agents/types.ts:211`). It survives in-process
+but each serializing boundary invents a flattening: `error.message` at
+`run-handlers.ts:289` and `apps/cline-hub/src/server/agent-events.ts:137`;
+the VSCode translator reconstructs structured ClineError data out of the
+message string (`reshapeErrorForWebview`). After: the schema defines one
+structured, serializable error shape; reconstruction-by-parsing deletes.
+
+**P8 — Liveness/quiescence tracked by polling.**
+`SdkSessionRebuildScheduler` drains MCP/provider rebuilds "only while the
+session is idle" by polling `activeSession.isRunning` plus explicit
+`sessionBecameIdle()` nudges. The desktop has a stale-stream poller
+(`use-chat-session.ts:393`). After: the assembler owns the open-scope set
+(it must, to route frames) and exposes it; idle is an edge-triggered
+callback derived from the same fold that routes frames, so it cannot drift
+from what was actually delivered.
+
+## Non-goals — what this does not fix
+
+- The LLM wire-format translation family (`message-builder.ts`,
+  `ai-sdk.ts`) is a separate translation problem and is untouched.
+- ClineMessage, ACP SessionUpdate, and the TUI model remain: surfaces still
+  map assembled structure to their own output vocabulary. This proposal
+  shrinks each surface to that mapping; it does not unify output formats.
+- The hub wire protocol and core-platform Go consumers keep working
+  unchanged during all phases here; regenerating them from the schema is
+  future work. Note the hub producer also ships as an independently
+  released pod image (cloud-platform `apps/cline-core`, pinned runtime
+  versions tracking SDK nightlies), so producer/consumer version skew on
+  that wire is an operational fact — the envelope `v` field,
+  unknown-variant tolerance, and Phase 1's dual-emit are required for
+  that deployment, not defensive extras.
+- The forked desktop/hub webview UIs are a separate problem, out of scope.
+
+## Design
+
+### Scope tree
+
+A session's events form a tree of nested intervals:
+
+```
+session
+├── turn*                        (sequential within one agent's stream)
+│   ├── block*                   (text | reasoning | tool | media; tools may be concurrent)
+│   └── agent*                   (sub-agent spawned for this turn; recursive: has its own turns)
+└── detached*                    (session-scoped: async team runs, detached commands)
+```
+
+Rules:
+
+1. Every frame carries the address of exactly one scope.
+2. A scope emits frames only between its `open` and `close`.
+3. Closing a scope closes its children first (producer emits the child
+   closes; see force-close below).
+4. A scope outlives its parent only by one of two explicit means:
+   - **detach**: the scope closes with outcome `detached` and a resource
+     handle (a file path, a runId). Later activity belongs to a *new*
+     session-scoped object, not the closed scope. This is the existing
+     "Proceed While Running" behavior (`vscode-run-commands-tool.ts`)
+     generalized: the tool block closes, output goes to a named log file.
+   - **born wider**: async team runs are session-scoped from creation
+     (today's `team_progress` is already a sibling of `agent_event` in
+     `CoreSessionEvent`, not inside any turn).
+
+### Frame envelope
+
+```jsonc
+{
+  "v": 2,
+  "epoch": 7,          // conversation/replica fence; bumped on task switch, cancel, reinit
+  "seq": 1042,         // per-session monotonic, one counter across all scopes
+  "scope": {
+    "agentPath": ["root", "agent-3f"],  // root agent to owning agent; frames from
+                                        // sub-agents always carry the full path
+    "turnId": "t-12",                   // absent for session-scoped frames
+    "blockId": "b-7"                    // absent for turn/agent/session frames
+  },
+  "frame": { /* discriminated union, below */ }
+}
+```
+
+`blockId` is producer-assigned for every block, including text and
+reasoning (today only tools have IDs via `toolCallId`; text blocks are
+identified by folklore: "at most one open at a time"). For tool blocks,
+`blockId` is the `toolCallId`.
+
+`(epoch, seq)` is the producer's obligation. Frames within one scope are
+totally ordered by seq; a child scope's `open` has a higher seq than its
+parent's `open` and lower than its parent's `close`. This is what the
+VSCode minter already implements privately (P4); it moves into the
+protocol.
+
+### Frame kinds
+
+Lifecycle frames are generic over scope kind; payload frames are
+kind-specific. One level of hierarchy, no more (helpers that benefit:
+demux routing, validation, live-set tracking, recording, force-close —
+none of which inspect payloads).
+
+```
+open        { kind: "turn" | "text" | "reasoning" | "tool" | "media" | "agent" | "run",
+              start: KindStart }       // ToolStart carries toolName+input; AgentStart carries ids
+delta       { payload: KindDelta }     // text chunk, reasoning chunk, tool progress
+close       { outcome: Outcome, final: KindFinal }
+annotation  { ns: string, body: NamespacedBody }   // see Annotations
+notice      { ... }                    // in-scope, non-structural (recovery, status)
+usage       { ... }                    // turn-scoped
+snapshot    { openScopes: [...] }      // session-scoped; for attach/reconnect
+```
+
+```ts
+type Outcome =
+  | { kind: "completed" }
+  | { kind: "error"; error: StreamError }      // structured, serializable (P7)
+  | { kind: "interrupted" }                    // parent force-closed (abort/cancel)
+  | { kind: "detached"; resource: ResourceRef }
+```
+
+`close.final` carries the authoritative final content (full text, tool
+output *and the input from open*) — P2 and P3 become schema statements.
+
+`StreamError` replaces the JS `Error` in `AgentErrorEvent`: a code,
+message, provider error class, and optional structured details
+(sufficient for what `reshapeErrorForWebview` currently reconstructs by
+string parsing).
+
+### Grammar (per-scope automata)
+
+The full interleaved stream is not one automaton; each *projection onto a
+scope* is a small one. Three tables, written once, from which the
+validator, the trace generator, and the assembler's internal states are
+all derived (one source; derivations cannot drift):
+
+**Block** (project frames by blockId):
+
+| state | frame | next |
+|---|---|---|
+| — | open | streaming |
+| streaming | delta | streaming |
+| streaming | annotation, notice | streaming |
+| streaming | close | closed |
+| closed | annotation | closed (late annotations allowed; see below) |
+| closed | anything else | **violation** |
+
+**Turn** (project by turnId; block/agent opens and closes appear here as
+child events):
+
+| state | frame | next |
+|---|---|---|
+| — | open(turn) | running |
+| running | child open/delta/close, notice, usage, annotation | running |
+| running | close(turn) | closed — **violation if any child block/agent of this turn is still open** |
+| closed | annotation | closed |
+| closed | anything else | **violation** |
+
+**Session** (project session-scoped frames):
+
+| state | frame | next |
+|---|---|---|
+| attached | open(turn), open(run), snapshot, annotation | attached |
+| attached | close(session) | ended |
+
+Plus one cross-scope check per session: seq strictly increases, and every
+child `open` falls inside its parent's (open, close) seq interval.
+
+Two automata run in production, not just tests:
+
+- **Producer validator**: after the runtime adapter emits frames, assert
+  legality. In dev/test builds a violation throws; in production it logs
+  and force-repairs (emit the missing close with `interrupted`). Cost is a
+  map lookup and an enum compare per frame — cheap enough to always run.
+- **Assembler**: the consumer-side instance of the same tables. On a
+  violating frame it repairs to the nearest legal state (drop stale-epoch
+  frames; synthesize `interrupted` closes) and reports via a diagnostics
+  hook, so one buggy producer path degrades to a logged glitch instead of
+  a stuck spinner.
+
+### Consumer API (assembler output)
+
+Push-based visitor. The consumer supplies concrete sink objects; the
+assembler routes each scope's frames to the object created at that scope's
+open. Ordering rules are consequently unrepresentable in consumer code:
+you cannot handle an update for a block you were never handed, and close
+is a method on the same object. No type parameters: the kind set is
+closed, so distinct factory methods with concrete return types give exact
+typing without casts.
+
+```ts
+interface SessionConsumer {
+  onTurn(start: TurnStart): TurnConsumer
+  onRun(start: RunStart): RunSink | null          // session-scoped (async team runs)
+  onSessionNotice(notice: Notice): void
+  onIdle(): void                                   // edge-triggered; see Quiescence
+  onDiagnostic(d: StreamDiagnostic): void          // repairs, dropped frames
+}
+
+interface TurnConsumer {
+  onText(start: TextStart): TextSink
+  onReasoning(start: ReasoningStart): ReasoningSink
+  onTool(start: ToolStart): ToolSink
+  onMedia(m: MediaFinal): void                     // media arrives whole
+  onSubAgent(start: AgentStart): TurnObserver | null  // null = prune subtree (P5)
+  onNotice(notice: Notice): void
+  onUsage(usage: Usage): void
+  onClose(outcome: TurnOutcome): void              // all sinks already closed
+}
+
+interface ToolSink {
+  onProgress(update: ToolProgress): void
+  onAnnotation(a: Annotation): void
+  onClose(outcome: Outcome, final: ToolFinal): void  // final includes input from open
+}
+// TextSink / ReasoningSink analogous: onDelta, onAnnotation, onClose.
+```
+
+Delivery contract:
+
+1. Callbacks fire in seq order.
+2. `onClose` is the last non-annotation call on any sink. Annotations may
+   arrive after close (e.g. a checkpoint restore marking a completed
+   tool's edits reverted); the assembler retains routing entries until
+   session end.
+3. `TurnConsumer.onClose` fires after every child sink's `onClose`. On
+   abort the assembler synthesizes `interrupted` closes first. "What does
+   my spinner do on cancel" is therefore a guaranteed callback, replacing
+   the `!isLast || lastMessage.ask === "resume_task"` inference documented
+   in `.clinerules` (ChatRow cancelled-state pattern).
+4. The assembler exposes `openScopes(): ScopeSnapshot` — derived from the
+   same routing table, usable for debugging and state displays.
+
+The assembler sits behind the existing tee (`subscribeEvents` fan-out is
+unchanged); each consumer gets its own assembler instance and live set.
+
+### History replay and reconnect
+
+The same assembler consumes persisted history (frames are the persistence
+format for the stream layer; `messages.json` v1 remains the LLM-turn
+artifact, see messages-contract-v1.md — different layer, both stay). On
+attach/reconnect the producer sends `snapshot` first; the assembler diffs
+it against its live set and synthesizes opens/closes so the consumer sees
+only legal transitions. Live-after-history dedup is `(scopeId, seq)`
+comparison — the desktop's reconcile-delay heuristic
+(`use-chat-session.ts:70`) and its dedup folklore delete.
+
+### Annotations
+
+Cross-cutting concerns (tool approval, checkpoints, hook status) currently
+correlate with tool blocks via side tables in each consumer
+(`approvedToolMessageTsByCallId`, `deniedToolApprovalsByCallId` in
+MessageTranslatorState). These become `annotation` frames: addressed to a
+scope, ordered by seq, published by coordinators other than the agent loop.
+
+- `Annotation` is a **closed discriminated union in the schema**
+  (`{ns:"approval",...} | {ns:"checkpoint",...} | {ns:"hook",...}`).
+  Adding a namespace is a reviewed schema change. There is no open
+  `Record<string, unknown>` bag.
+- Unknown namespaces from a newer producer decode as
+  `{ns:"unknown", raw}` — ignorable, visible, not silent.
+- Storage is consumer-owned: sinks receive annotations via `onAnnotation`
+  and keep what they render. Nothing is stored on shared objects; no
+  WeakMaps.
+
+### Quiescence
+
+Definition: a session is **idle** when it has no open turn and no open
+session-scoped run. This is computable from the assembler's live set, so
+`onIdle` is an edge-triggered signal emitted when the last of those scopes
+closes (and once immediately after snapshot reconciliation if the session
+is already idle — new subscribers need the edge they missed).
+
+Current consumers of this signal, today hand-rolled:
+
+- `SdkSessionRebuildScheduler` (MCP tool reload, provider rebuild,
+  terminal mode changes): polls `activeSession.isRunning` plus manual
+  `sessionBecameIdle()` calls. Becomes an `onIdle` subscriber. Its
+  serialization of rebuilds (`runExclusive`) stays — that is scheduling
+  policy, not stream structure.
+- Desktop turn-end reconcile and notification triggers.
+- Hub `session.updated` status projections.
+
+Note `onIdle` deliberately does not distinguish *why* the session went
+idle; `TurnConsumer.onClose(outcome)` carries that. A rebuild scheduler
+does not care whether the turn completed or errored, only that nothing is
+running.
+
+## Edge cases
+
+Checked against the design; each resolves to existing frames rather than
+new mechanism.
+
+**Error truncates a turn mid-block.** Producer emits, in order:
+`close(block, interrupted)` for each open block (or `error` if the block
+itself failed), `close(turn, {kind:"error", error})`. The assembler
+guarantees this order to consumers even if a buggy producer omits the
+block closes (repair). A tool that was mid-approval gets
+`close(interrupted)`; the approval coordinator separately publishes its
+annotation. No consumer infers truncation from message adjacency again.
+
+**Abort during compaction.** Today's `openCompactionTs` survives
+`reset()` because compaction notices span iteration boundaries
+(`message-translator.ts:139-141`). In v2, compaction is a block owned by
+the turn (kind `notice` open/close or a dedicated block kind — decide at
+schema writing); abort force-closes it with `interrupted` like any block.
+The special-cased field deletes.
+
+**Cancel racing turn completion.** The done frame from the cancelled turn
+carries the old epoch; the assembler drops it; the consumer saw
+`close(turn, interrupted)` synthesized at cancel. This replaces the
+straggler special case in `sdk-session-event-coordinator.ts:107-117`.
+
+**Detached command completes during a later turn.** The completion is an
+update to a session-scoped run object (`RunSink.onClose`), ordered by seq
+— it may land mid-turn, which is legal (session scope is not nested in
+turn scope). If the producer decides to *tell the model*, that appears as
+ordinary content in a later turn; the stream layer does not conflate the
+two.
+
+**Reconnect while a tool is open.** Snapshot lists the open scopes;
+assembler opens sinks for them (start payloads are included in the
+snapshot), then live frames continue. Consumer code cannot tell the
+difference from a normal open.
+
+**Turn ends with no output (provider failed before first token).** Legal:
+`open(turn)` → `close(turn, error)`. Consumers get a turn with zero
+sinks; nothing to repair. (Matches messages-contract-v1 failure case 2.)
+
+**Approval pause mid-turn.** A tool awaiting user approval leaves its
+block and turn open, possibly for minutes. Not idle — rebuilds stay
+deferred, matching today's `isRunning` behavior. The approval request
+itself is an `annotation(ns:"approval", state:"pending")` on the tool
+block, resolved by a later annotation, so consumers render approval state
+from the sink. The response path (user's decision back to the runtime) is
+a request/reply concern, not a stream concern; the interaction
+coordinator keeps it.
+
+**Followup question ends the turn.** A turn that ends by asking the user
+something closes normally (`completed`, with the question as its final
+text or a dedicated outcome field — decide at schema writing). The
+session *is* idle while awaiting the reply; rebuild-while-waiting is
+today's behavior and stays.
+
+**Two text blocks in one turn.** Legal in v2 (each has a blockId). Today's
+folklore "at most one" becomes unnecessary; consumers that render one
+bubble per block already handle it.
+
+## Work plan
+
+Phases ship independently; each leaves every surface working.
+
+**Phase 0 — transition tables + validator against the *current* stream.**
+Write the three tables for the de-facto v1 grammar (with its warts:
+content_start-as-delta, missing blockIds, two turn-end spellings).
+Implement `validateEventStream` and run it in the RuntimeEventAdapter
+tests and on recorded fixtures. Deliverable: the warts become failing or
+explicitly-waived assertions instead of folklore. Small; no behavior
+change; do first because it is cheap verification we keep forever.
+
+**Phase 1 — schema + producer.** Define the frame schema
+(`@cline/shared`), the wart fixes (blockIds, structured error, single
+turn-close, epoch/seq in envelope), and emit v2 frames from the runtime
+adapter alongside v1 events (additive; existing consumers untouched).
+Producer validator on. Trace generator derived from the tables;
+property-test: every generated legal v1-input sequence yields legal v2
+output.
+
+**Phase 2 — assembler + first consumer.** Implement the assembler
+(`@cline/core`). Port the **CLI terminal renderer** first (smallest,
+lowest risk: `apps/cli/src/utils/events.ts`), then ACP. Differential
+test: replay recorded sessions through old and new paths, compare
+rendered output.
+
+**Phase 3 — VSCode.** Port message-translator onto the assembler.
+MessageTranslatorState's parser fields delete; ClineMessage mapping
+remains as sink implementations. Move the epoch fence from SdkController
+into the producer envelope. Port `SdkSessionRebuildScheduler` to
+`onIdle`. This is the largest phase; the translator's existing tests
+become sink tests.
+
+**Phase 4 — desktop.** Sidecar forwards frames verbatim (the
+`chat_text`/`chat_done` re-encoding in `sidecar/context.ts` deletes);
+`use-chat-session.ts` becomes sinks + React state. Largest line-count
+deletion.
+
+**Phase 5 — ratchet.** CI check: no `switch`/`if` over raw
+`AgentEvent.type` outside the assembler package and the (legacy) hub
+projector; count must not increase. Hub projector and core-platform
+regeneration are follow-on work, not part of this plan.
+
+Ordering rationale: 0 and 1 are producer-side and reversible; 2 proves
+the consumer API on the cheapest surface; 3 and 4 are the payoff and can
+be paced independently.
+
+**Phase 0 status: implemented.** `@cline/shared` now carries
+`src/agents/stream-grammar.ts` (the v1 tables, `validateAgentEventStream`,
+and the wart registry) with unit tests, and `@cline/core` carries
+`src/runtime/orchestration/runtime-event-adapter.grammar.test.ts`, which
+drives the real `RuntimeEventAdapter` through success, mid-tool-failure,
+non-streaming, and multi-iteration runs and asserts zero violations with
+exact wart counts. When Phase 1 fixes a wart, the corresponding
+expectation flips from a wart count to zero — the grammar tests are the
+migration's scoreboard.
+
+## Verification strategy (how we know nothing broke)
+
+The refactor's safety does not rely on review; it relies on these
+mechanical gates, in order:
+
+1. **Behavior freeze before behavior change.** Phase 0's validator plus
+   the existing adapter/translator test suites (37 adapter tests, the
+   message-translator suite, the messages-contract e2e tests) pin
+   today's behavior. No phase may change producer behavior until these
+   pass unchanged; they run in every PR of the stack.
+2. **Dual-run, then delete.** From Phase 1 to Phase 4 the old path stays
+   live and the new path is additive (v2 frames emitted alongside v1
+   events; a ported consumer replaces an unported one at a time). The
+   old path is deleted only in the phase after its replacement is green
+   in CI. There is never a PR where a surface has neither path.
+3. **Differential replay.** Recorded traces (existing test fixtures and
+   a set captured from real runs) replay through old and new paths;
+   outputs are compared for equality (CLI: rendered text; VSCode:
+   ClineMessage arrays). Added in Phase 2, run in CI from then on.
+4. **Grammar validation on both sides.** `validateAgentEventStream` runs
+   against producer output in tests today, and Phase 1 adds it to the
+   v2 emit path in dev builds — a producer regression becomes a thrown
+   assertion, not a downstream rendering glitch.
+5. **Wart-count ratchet.** The grammar tests pin exact wart counts.
+   Counts may decrease (wart fixed) but never increase; an increase
+   means the producer regressed structurally and CI fails.
+6. **Ratchet on raw discrimination** (Phase 5): the count of
+   `switch`/`if` over `AgentEvent.type` outside the assembler package
+   may not increase, so no new private parser can appear mid-migration.
+7. **Per-phase manual QA** via the debug harness (VSCode surfaces) and
+   `bun run cli -i` (CLI) for the one thing automation can't check:
+   that the UI feels the same.
+
+## Stacked PR plan
+
+One PR per phase, each stacked on the previous, each independently
+revertable without reverting its ancestors' behavior changes:
+
+| # | Branch | Content | Depends on |
+|---|---|---|---|
+| 1 | `dpc/event-stream-phase0` | Design doc + v1 tables, validator, wart registry, adapter grammar tests. No behavior change. | — |
+| 2 | `dpc/event-stream-phase1` | v2 frame schema, structured StreamError, dual-emit in RuntimeEventAdapter, trace generator + property tests. | 1 |
+| 3 | `dpc/event-stream-phase2` | Assembler (`@cline/core`), CLI terminal + ACP ports, differential replay harness. | 2 |
+| 4 | `dpc/event-stream-phase3` | VSCode translator port, epoch fence into producer, rebuild scheduler on `onIdle`. | 3 |
+| 5 | `dpc/event-stream-phase4` | Desktop: sidecar forwards frames, `use-chat-session` becomes sinks. | 3 |
+| 6 | `dpc/event-stream-phase5` | CI ratchet + deletion of superseded v1 consumer paths. | 4, 5 |
+
+Review stays manageable because PR 1 is additive-only (this PR), PRs 2-3
+are producer/plumbing with property tests doing the checking, and the
+two big ports (4, 5) are mechanical sink implementations reviewed against
+the delivery contract rather than re-reviewed logic.
+
+

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.grammar.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.grammar.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Grammar validation of the real producer's output — the Phase 0
+ * cross-module guarantee of the agent event stream v2 design
+ * (`docs/agent-event-stream-design.md`, Work plan).
+ *
+ * Every realistic run driven through `RuntimeEventAdapter` must validate
+ * with ZERO violations (a violation here is a producer bug or a bug in
+ * the tables) and with exactly the expected wart counts. These tests
+ * pin the de-facto v1 grammar: when Phase 1 fixes a wart (e.g. renames
+ * content_start-as-delta), the corresponding expectation here changes
+ * from wart-count to zero.
+ */
+import type {
+	AgentEvent,
+	AgentMessage,
+	AgentRuntimeEvent,
+	AgentRuntimeStateSnapshot,
+	AgentToolCallPart,
+	AgentUsage,
+} from "@cline/shared";
+import {
+	WART_DANGLING_AT_TERMINAL,
+	WART_FINAL_WITHOUT_DELTAS,
+	WART_START_AS_DELTA,
+	validateAgentEventStream,
+} from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { RuntimeEventAdapter } from "./runtime-event-adapter";
+
+function makeSnapshot(): AgentRuntimeStateSnapshot {
+	return {
+		agentId: "agent_test",
+		runId: "run_test",
+		status: "running",
+		iteration: 1,
+		messages: [],
+		pendingToolCalls: [],
+		usage: {
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			totalCost: 0,
+		},
+	};
+}
+
+function toolCall(toolCallId: string): AgentToolCallPart {
+	return {
+		type: "tool-call",
+		toolCallId,
+		toolName: "read_file",
+		input: { path: "/tmp/x" },
+	};
+}
+
+function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
+	return {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		totalCost: 0,
+		...overrides,
+	};
+}
+
+function toolResultMessage(toolCallId: string): AgentMessage {
+	return {
+		id: "m_tool",
+		role: "tool",
+		createdAt: 0,
+		content: [
+			{
+				type: "tool-result",
+				toolCallId,
+				toolName: "read_file",
+				output: "ok",
+			},
+		],
+	};
+}
+
+/** Drive the real adapter over a runtime event sequence, flattening output. */
+function translateRun(
+	runtimeEvents: readonly AgentRuntimeEvent[],
+): AgentEvent[] {
+	const adapter = new RuntimeEventAdapter();
+	const events: AgentEvent[] = [];
+	for (const runtimeEvent of runtimeEvents) {
+		events.push(...adapter.translate(runtimeEvent));
+	}
+	return events;
+}
+
+describe("RuntimeEventAdapter output — v1 grammar validation", () => {
+	it("a full streamed run with a tool call validates with zero violations", () => {
+		const events = translateRun([
+			{ type: "run-started", snapshot: makeSnapshot() },
+			{ type: "turn-started", snapshot: makeSnapshot(), iteration: 1 },
+			{
+				type: "assistant-text-delta",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				text: "He",
+				accumulatedText: "He",
+			},
+			{
+				type: "assistant-text-delta",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				text: "llo",
+				accumulatedText: "Hello",
+			},
+			{
+				type: "tool-started",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+			},
+			{
+				type: "tool-updated",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+				update: { progress: 1 },
+			},
+			{
+				type: "tool-finished",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+				message: toolResultMessage("call_1"),
+			},
+			{
+				type: "assistant-message",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				message: {
+					id: "m",
+					role: "assistant",
+					createdAt: 0,
+					content: [{ type: "text", text: "Hello" }],
+				},
+				finishReason: "stop",
+			},
+			{
+				type: "usage-updated",
+				snapshot: makeSnapshot(),
+				usage: usage({ inputTokens: 10, outputTokens: 5 }),
+			},
+			{
+				type: "turn-finished",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCallCount: 1,
+			},
+			{
+				type: "run-finished",
+				snapshot: makeSnapshot(),
+				result: {
+					agentId: "agent_test",
+					runId: "run_test",
+					status: "completed",
+					iterations: 1,
+					outputText: "Hello",
+					messages: [],
+					usage: usage({ inputTokens: 10, outputTokens: 5 }),
+				},
+			},
+		]);
+		const result = validateAgentEventStream(events);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+		// The two text deltas surface as repeated content_start — wart W1.
+		expect(result.warts).toEqual([{ id: WART_START_AS_DELTA, count: 2 }]);
+	});
+
+	it("a failure mid-tool leaves scopes dangling (W3, not a violation)", () => {
+		const events = translateRun([
+			{ type: "turn-started", snapshot: makeSnapshot(), iteration: 1 },
+			{
+				type: "tool-started",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+			},
+			{
+				type: "run-failed",
+				snapshot: makeSnapshot(),
+				error: new Error("provider exploded"),
+			},
+		]);
+		const result = validateAgentEventStream(events);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+		expect(result.warts).toEqual([
+			{ id: WART_DANGLING_AT_TERMINAL, count: 1 },
+		]);
+	});
+
+	it("a non-streaming turn produces content_end without deltas (W2)", () => {
+		const events = translateRun([
+			{ type: "turn-started", snapshot: makeSnapshot(), iteration: 1 },
+			{
+				type: "assistant-message",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				message: {
+					id: "m",
+					role: "assistant",
+					createdAt: 0,
+					content: [{ type: "text", text: "done" }],
+				},
+				finishReason: "stop",
+			},
+			{
+				type: "turn-finished",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCallCount: 0,
+			},
+			{
+				type: "run-finished",
+				snapshot: makeSnapshot(),
+				result: {
+					agentId: "agent_test",
+					runId: "run_test",
+					status: "completed",
+					iterations: 1,
+					outputText: "done",
+					messages: [],
+					usage: usage(),
+				},
+			},
+		]);
+		const result = validateAgentEventStream(events);
+		expect(result.violations).toEqual([]);
+		expect(result.warts).toEqual([
+			{ id: WART_FINAL_WITHOUT_DELTAS, count: 1 },
+		]);
+	});
+
+	it("a multi-iteration run with increasing iteration numbers validates", () => {
+		const events = translateRun([
+			{ type: "turn-started", snapshot: makeSnapshot(), iteration: 1 },
+			{
+				type: "tool-started",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+			},
+			{
+				type: "tool-finished",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCall: toolCall("call_1"),
+				message: toolResultMessage("call_1"),
+			},
+			{
+				type: "turn-finished",
+				snapshot: makeSnapshot(),
+				iteration: 1,
+				toolCallCount: 1,
+			},
+			{ type: "turn-started", snapshot: makeSnapshot(), iteration: 2 },
+			{
+				type: "assistant-message",
+				snapshot: makeSnapshot(),
+				iteration: 2,
+				message: {
+					id: "m2",
+					role: "assistant",
+					createdAt: 0,
+					content: [{ type: "text", text: "done" }],
+				},
+				finishReason: "stop",
+			},
+			{
+				type: "turn-finished",
+				snapshot: makeSnapshot(),
+				iteration: 2,
+				toolCallCount: 0,
+			},
+			{
+				type: "run-finished",
+				snapshot: makeSnapshot(),
+				result: {
+					agentId: "agent_test",
+					runId: "run_test",
+					status: "completed",
+					iterations: 2,
+					outputText: "done",
+					messages: [],
+					usage: usage(),
+				},
+			},
+		]);
+		const result = validateAgentEventStream(events);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+	});
+});

--- a/sdk/packages/shared/src/agents/index.ts
+++ b/sdk/packages/shared/src/agents/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./stream-grammar";

--- a/sdk/packages/shared/src/agents/stream-grammar.test.ts
+++ b/sdk/packages/shared/src/agents/stream-grammar.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for the v1 stream grammar validator.
+ *
+ * These tests use hand-built traces — they test the *tables*. The
+ * cross-module guarantee ("the real producer's output validates
+ * wart-only") lives in
+ * `packages/core/src/runtime/orchestration/runtime-event-adapter.grammar.test.ts`,
+ * which drives the real RuntimeEventAdapter.
+ */
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "./types";
+import {
+	AFTER_TERMINAL,
+	DOUBLE_TERMINAL,
+	ITERATION_END_WITHOUT_START,
+	ITERATION_OVERLAP,
+	ITERATION_REGRESSION,
+	CONTENT_OUTSIDE_ITERATION,
+	TOOL_END_WITHOUT_OPEN,
+	TOOL_OPEN_AT_ITERATION_END,
+	TOOL_OPEN_WHILE_OPEN,
+	TOOL_UPDATE_WITHOUT_OPEN,
+	WART_DANGLING_AT_TERMINAL,
+	WART_FINAL_WITHOUT_DELTAS,
+	WART_START_AS_DELTA,
+	WART_TERMINAL_AMBIGUITY,
+	validateAgentEventStream,
+} from "./stream-grammar";
+
+const iterStart = (iteration = 1): AgentEvent => ({
+	type: "iteration_start",
+	iteration,
+});
+const iterEnd = (iteration = 1): AgentEvent => ({
+	type: "iteration_end",
+	iteration,
+	hadToolCalls: false,
+	toolCallCount: 0,
+});
+const textStart = (text: string): AgentEvent => ({
+	type: "content_start",
+	contentType: "text",
+	text,
+});
+const textEnd = (text: string): AgentEvent => ({
+	type: "content_end",
+	contentType: "text",
+	text,
+});
+const reasoningStart = (text: string): AgentEvent => ({
+	type: "content_start",
+	contentType: "reasoning",
+	reasoning: text,
+});
+const toolOpen = (toolCallId: string): AgentEvent => ({
+	type: "content_start",
+	contentType: "tool",
+	toolName: "read_file",
+	toolCallId,
+	input: {},
+});
+const toolUpdate = (toolCallId: string): AgentEvent => ({
+	type: "content_update",
+	contentType: "tool",
+	toolCallId,
+	update: {},
+});
+const toolClose = (toolCallId: string): AgentEvent => ({
+	type: "content_end",
+	contentType: "tool",
+	toolCallId,
+	toolName: "read_file",
+	output: "ok",
+});
+const done = (reason = "completed"): AgentEvent => ({
+	type: "done",
+	reason,
+	text: "ok",
+	iterations: 1,
+});
+const errorEvent = (recoverable: boolean): AgentEvent => ({
+	type: "error",
+	error: new Error("boom"),
+	recoverable,
+});
+const notice = (): AgentEvent => ({
+	type: "notice",
+	noticeType: "status",
+	message: "thinking",
+	displayRole: "status",
+});
+const usage = (): AgentEvent => ({
+	type: "usage",
+	inputTokens: 1,
+	outputTokens: 1,
+	totalInputTokens: 1,
+	totalOutputTokens: 1,
+});
+
+describe("stream grammar — legal traces", () => {
+	it("accepts a complete streamed turn with a tool call", () => {
+		const trace = [
+			iterStart(1),
+			reasoningStart("hmm"),
+			textStart("He"),
+			textStart("llo"),
+			toolOpen("call_1"),
+			toolUpdate("call_1"),
+			toolClose("call_1"),
+			textEnd("Hello"),
+			usage(),
+			iterEnd(1),
+			done(),
+		];
+		const result = validateAgentEventStream(trace);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+		expect(result.warts).toEqual([{ id: WART_START_AS_DELTA, count: 3 }]);
+	});
+
+	it("accepts an unterminated prefix (mid-stream validation)", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			textStart("Hi"),
+		]);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(false);
+	});
+
+	it("accepts interleaved parallel tool updates", () => {
+		const trace = [
+			iterStart(1),
+			toolOpen("a"),
+			toolOpen("b"),
+			toolUpdate("b"),
+			toolUpdate("a"),
+			toolClose("b"),
+			toolClose("a"),
+			iterEnd(1),
+			done(),
+		];
+		const result = validateAgentEventStream(trace);
+		expect(result.violations).toEqual([]);
+	});
+
+	it("accepts notices and usage anywhere before the terminal", () => {
+		const trace = [
+			notice(),
+			usage(),
+			iterStart(1),
+			notice(),
+			textEnd("no deltas streamed"),
+			usage(),
+			iterEnd(1),
+			done(),
+		];
+		const result = validateAgentEventStream(trace);
+		expect(result.violations).toEqual([]);
+		// The turn produced final text with no streamed deltas — the
+		// dedup-folklore case, counted as W2 not a violation.
+		expect(result.warts).toContainEqual({
+			id: WART_FINAL_WITHOUT_DELTAS,
+			count: 1,
+		});
+	});
+});
+
+describe("stream grammar — violations", () => {
+	it("flags any event after the terminal", () => {
+		const result = validateAgentEventStream([done(), iterStart(1)]);
+		expect(result.violations).toEqual([
+			{ code: DOUBLE_TERMINAL, index: 1, eventType: "iteration_start" },
+		]);
+		expect(DOUBLE_TERMINAL).toBe("double-terminal");
+		expect(AFTER_TERMINAL).toBe("after-terminal");
+	});
+
+	it("flags overlapping iterations", () => {
+		const result = validateAgentEventStream([iterStart(1), iterStart(2)]);
+		expect(result.violations).toEqual([
+			{ code: ITERATION_OVERLAP, index: 1, eventType: "iteration_start" },
+		]);
+	});
+
+	it("flags iteration_end without an open iteration", () => {
+		const result = validateAgentEventStream([iterEnd(1)]);
+		expect(result.violations).toEqual([
+			{
+				code: ITERATION_END_WITHOUT_START,
+				index: 0,
+				eventType: "iteration_end",
+			},
+		]);
+	});
+
+	it("flags iteration regression (reuse of an ended iteration number)", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			iterEnd(1),
+			iterStart(1),
+		]);
+		expect(result.violations).toEqual([
+			{
+				code: ITERATION_REGRESSION,
+				index: 2,
+				eventType: "iteration_start",
+			},
+		]);
+	});
+
+	it("flags content outside any iteration", () => {
+		const result = validateAgentEventStream([textStart("orphan")]);
+		expect(result.violations).toEqual([
+			{
+				code: CONTENT_OUTSIDE_ITERATION,
+				index: 0,
+				eventType: "content_start",
+			},
+		]);
+	});
+
+	it("flags duplicate tool open and unknown tool updates/ends", () => {
+		const dup = validateAgentEventStream([
+			iterStart(1),
+			toolOpen("a"),
+			toolOpen("a"),
+		]);
+		expect(dup.violations[0]?.code).toBe(TOOL_OPEN_WHILE_OPEN);
+
+		const update = validateAgentEventStream([
+			iterStart(1),
+			toolUpdate("ghost"),
+		]);
+		expect(update.violations[0]?.code).toBe(TOOL_UPDATE_WITHOUT_OPEN);
+
+		const end = validateAgentEventStream([iterStart(1), toolClose("ghost")]);
+		expect(end.violations[0]?.code).toBe(TOOL_END_WITHOUT_OPEN);
+	});
+
+	it("flags a tool block still open at iteration end", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			toolOpen("a"),
+			iterEnd(1),
+		]);
+		expect(result.violations).toEqual([
+			{
+				code: TOOL_OPEN_AT_ITERATION_END,
+				index: 2,
+				eventType: "iteration_end",
+				detail: "a",
+			},
+		]);
+	});
+});
+
+describe("stream grammar — warts", () => {
+	it("counts dangling scopes at a terminal as W3, not a violation", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			toolOpen("a"),
+			errorEvent(false),
+		]);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+		expect(result.warts).toContainEqual({
+			id: WART_DANGLING_AT_TERMINAL,
+			count: 1,
+		});
+	});
+
+	it("counts recoverable in-run errors as W4, not a terminal", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			errorEvent(true),
+			textStart("still going"),
+			textEnd("recovered"),
+			iterEnd(1),
+			done(),
+		]);
+		expect(result.violations).toEqual([]);
+		expect(result.terminated).toBe(true);
+		expect(result.warts).toContainEqual({
+			id: WART_TERMINAL_AMBIGUITY,
+			count: 1,
+		});
+	});
+
+	it("counts done(reason:'error') without an error event as W4", () => {
+		const result = validateAgentEventStream([
+			iterStart(1),
+			textEnd("partial"),
+			iterEnd(1),
+			done("error"),
+		]);
+		expect(result.violations).toEqual([]);
+		expect(result.warts).toContainEqual({
+			id: WART_TERMINAL_AMBIGUITY,
+			count: 1,
+		});
+	});
+
+	it("does not treat an explicit error event followed by done as W4", () => {
+		const result = validateAgentEventStream([errorEvent(false), done()]);
+		expect(result.violations).toEqual([
+			{ code: DOUBLE_TERMINAL, index: 1, eventType: "done" },
+		]);
+	});
+});

--- a/sdk/packages/shared/src/agents/stream-grammar.ts
+++ b/sdk/packages/shared/src/agents/stream-grammar.ts
@@ -1,0 +1,392 @@
+/**
+ * v1 AgentEvent stream grammar — transition tables, validator, wart registry.
+ *
+ * Phase 0 of the agent event stream v2 design
+ * (`@cline/core/docs/agent-event-stream-design.md`). Encodes the
+ * de-facto v1 grammar produced by `RuntimeEventAdapter`: violations are
+ * producer bugs; warts are known deviations from the v2 target grammar,
+ * counted so they are explicit instead of folklore. The v2 assembler and
+ * trace generator will derive from these same tables. Structural warts
+ * a trace cannot reveal (no blockId on text, content_end(tool) carrying
+ * no input) live in the design doc, not here.
+ */
+import type { AgentEvent } from "./types";
+
+// =============================================================================
+// Violations — hard producer bugs
+// =============================================================================
+
+/** Producer emitted an event after the stream's terminal event. */
+export const AFTER_TERMINAL = "after-terminal";
+/** A second terminal event (done or non-recoverable error) in one stream. */
+export const DOUBLE_TERMINAL = "double-terminal";
+/** iteration_start while another iteration is open. */
+export const ITERATION_OVERLAP = "iteration-overlap";
+/** iteration_end with no open iteration. */
+export const ITERATION_END_WITHOUT_START = "iteration-end-without-start";
+/** iteration_start with a number not greater than the last ended iteration. */
+export const ITERATION_REGRESSION = "iteration-regression";
+/** Any content event emitted with no open iteration. */
+export const CONTENT_OUTSIDE_ITERATION = "content-outside-iteration";
+/** content_start(tool) for a toolCallId that is already open. */
+export const TOOL_OPEN_WHILE_OPEN = "tool-open-while-open";
+/** content_update(tool) for an unknown toolCallId. */
+export const TOOL_UPDATE_WITHOUT_OPEN = "tool-update-without-open";
+/** content_end(tool) for an unknown toolCallId. */
+export const TOOL_END_WITHOUT_OPEN = "tool-end-without-open";
+/** A tool block is still open when its iteration ends. */
+export const TOOL_OPEN_AT_ITERATION_END = "tool-open-at-iteration-end";
+/** A tool event arrived under a different iteration than the one it opened in. */
+export const TOOL_WRONG_ITERATION = "tool-wrong-iteration";
+
+export type StreamViolationCode =
+	| typeof AFTER_TERMINAL
+	| typeof DOUBLE_TERMINAL
+	| typeof ITERATION_OVERLAP
+	| typeof ITERATION_END_WITHOUT_START
+	| typeof ITERATION_REGRESSION
+	| typeof CONTENT_OUTSIDE_ITERATION
+	| typeof TOOL_OPEN_WHILE_OPEN
+	| typeof TOOL_UPDATE_WITHOUT_OPEN
+	| typeof TOOL_END_WITHOUT_OPEN
+	| typeof TOOL_OPEN_AT_ITERATION_END
+	| typeof TOOL_WRONG_ITERATION;
+
+export interface StreamViolation {
+	code: StreamViolationCode;
+	/** Index of the offending event in the input trace. */
+	index: number;
+	/** Discriminant of the offending event. */
+	eventType: AgentEvent["type"];
+	/** Extra identifying detail (e.g. the toolCallId involved). */
+	detail?: string;
+}
+
+// =============================================================================
+// Warts — known, accepted v1 deviations from the v2 grammar
+// =============================================================================
+
+/**
+ * W1 — "content_start" is a delta for text/reasoning: the adapter maps
+ * every assistant-text-delta / assistant-reasoning-delta to
+ * content_start, so "start" repeats and there is no content_update for
+ * streamed text. v2 renames these to deltas on an opened block.
+ */
+export const WART_START_AS_DELTA = "start-as-delta";
+/**
+ * W2 — content_end(text/reasoning) with zero prior content_start in its
+ * iteration: the "final text with no streamed deltas" case that the
+ * dedup folklore in consumers (sidecar/context.ts, streamer.go)
+ * exists to handle. v2's close frame is authoritative and unambiguous.
+ */
+export const WART_FINAL_WITHOUT_DELTAS = "final-without-deltas";
+/**
+ * W3 — scopes left open at the terminal: v1 has no force-close, so an
+ * abort or failure mid-iteration leaves the iteration and any in-flight
+ * tool blocks dangling. v2's turn close force-closes children first.
+ */
+export const WART_DANGLING_AT_TERMINAL = "dangling-at-terminal";
+/**
+ * W4 — terminal-adjacent ambiguity: an in-run recoverable error reuses
+ * the terminal "error" discriminant, or done(reason:"error") arrives
+ * with no error event. v2 has one spelling of turn end.
+ */
+export const WART_TERMINAL_AMBIGUITY = "terminal-ambiguity";
+
+export type StreamWartId =
+	| typeof WART_START_AS_DELTA
+	| typeof WART_FINAL_WITHOUT_DELTAS
+	| typeof WART_DANGLING_AT_TERMINAL
+	| typeof WART_TERMINAL_AMBIGUITY;
+
+export interface WartInfo {
+	id: StreamWartId;
+	description: string;
+	docRef: string;
+}
+
+export const V1_WARTS: readonly WartInfo[] = [
+	{
+		id: WART_START_AS_DELTA,
+		description:
+			"text/reasoning content_start repeats per delta (start means delta in v1)",
+		docRef: "agent-event-stream-design.md, P1; runtime-event-adapter.ts:202",
+	},
+	{
+		id: WART_FINAL_WITHOUT_DELTAS,
+		description:
+			"content_end(text/reasoning) with no prior content_start in the iteration",
+		docRef: "agent-event-stream-design.md, P2; sidecar/context.ts:310",
+	},
+	{
+		id: WART_DANGLING_AT_TERMINAL,
+		description:
+			"iteration or tool block still open at done/error (v1 has no force-close)",
+		docRef: "agent-event-stream-design.md, Edge cases; runtime-event-adapter.ts:276",
+	},
+	{
+		id: WART_TERMINAL_AMBIGUITY,
+		description:
+			"recoverable error reusing the terminal error discriminant, or done(reason:'error') without an error event",
+		docRef: "agent-event-stream-design.md, P6; message-translator.ts:1865",
+	},
+];
+
+export interface StreamWartObservation {
+	id: StreamWartId;
+	count: number;
+}
+
+export interface StreamValidationResult {
+	violations: StreamViolation[];
+	warts: StreamWartObservation[];
+	/** True when a terminal event was seen. */
+	terminated: boolean;
+	/** Total events inspected. */
+	eventCount: number;
+}
+
+// =============================================================================
+// Validator — fold over the v1 tables
+// =============================================================================
+
+interface OpenTool {
+	/** Iteration number the tool opened in. */
+	iteration: number;
+}
+
+/**
+ * Validate an AgentEvent trace against the v1 de-facto grammar.
+ *
+ * The input is the per-agent projection of a session's events (for
+ * RuntimeEventAdapter output, the whole stream; for multiplexed
+ * CoreSessionEvents, project by agent path first — this validator does
+ * one language-2 stream, not the demultiplex).
+ *
+ * A prefix without a terminal is legal: streaming traces may be
+ * validated at any point. Violations are producer bugs; warts are
+ * expected v1 behavior and are counted, never fatal.
+ */
+export function validateAgentEventStream(
+	events: readonly AgentEvent[],
+): StreamValidationResult {
+	const violations: StreamViolation[] = [];
+	const wartCounts = new Map<StreamWartId, number>();
+	const noteWart = (id: StreamWartId): void => {
+		wartCounts.set(id, (wartCounts.get(id) ?? 0) + 1);
+	};
+
+	let terminated = false;
+	let openIteration: number | undefined;
+	let lastEndedIteration = 0;
+	const openTools = new Map<string, OpenTool>();
+	let textStartsInIteration = 0;
+	let reasoningStartsInIteration = 0;
+	let sawTerminalError = false;
+
+	const violation = (
+		index: number,
+		event: AgentEvent,
+		code: StreamViolationCode,
+		detail?: string,
+	): void => {
+		violations.push({ code, index, eventType: event.type, detail });
+	};
+
+	for (let index = 0; index < events.length; index += 1) {
+		const event = events[index];
+		if (terminated) {
+			violation(index, event, DOUBLE_TERMINAL);
+			continue;
+		}
+
+		switch (event.type) {
+			case "iteration_start": {
+				if (openIteration !== undefined) {
+					violation(index, event, ITERATION_OVERLAP);
+				}
+				if (event.iteration <= lastEndedIteration) {
+					violation(index, event, ITERATION_REGRESSION);
+				}
+				openIteration = event.iteration;
+				textStartsInIteration = 0;
+				reasoningStartsInIteration = 0;
+				break;
+			}
+			case "iteration_end": {
+				if (openIteration === undefined) {
+					violation(index, event, ITERATION_END_WITHOUT_START);
+					break;
+				}
+				for (const [toolCallId, tool] of openTools) {
+					if (tool.iteration === openIteration) {
+						violation(
+							index,
+							event,
+							TOOL_OPEN_AT_ITERATION_END,
+							toolCallId,
+						);
+					}
+				}
+				lastEndedIteration = Math.max(lastEndedIteration, openIteration);
+				openIteration = undefined;
+				break;
+			}
+			case "content_start": {
+				if (openIteration === undefined) {
+					violation(index, event, CONTENT_OUTSIDE_ITERATION);
+					break;
+				}
+				if (event.contentType === "tool") {
+					if (event.toolCallId === undefined) {
+						violation(
+							index,
+							event,
+							TOOL_OPEN_WHILE_OPEN,
+							"(missing toolCallId)",
+						);
+						break;
+					}
+					if (openTools.has(event.toolCallId)) {
+						violation(
+							index,
+							event,
+							TOOL_OPEN_WHILE_OPEN,
+							event.toolCallId,
+						);
+						break;
+					}
+					openTools.set(event.toolCallId, {
+						iteration: openIteration,
+					});
+				} else if (event.contentType === "text") {
+					textStartsInIteration += 1;
+					noteWart(WART_START_AS_DELTA);
+				} else if (event.contentType === "reasoning") {
+					reasoningStartsInIteration += 1;
+					noteWart(WART_START_AS_DELTA);
+				}
+				// media arrives whole on content_end; the v1 adapter
+				// never emits a media content_start.
+				break;
+			}
+			case "content_update": {
+				if (openIteration === undefined) {
+					violation(index, event, CONTENT_OUTSIDE_ITERATION);
+					break;
+				}
+				const toolCallId = event.toolCallId;
+				const tool = toolCallId === undefined ? undefined : openTools.get(toolCallId);
+				if (tool === undefined) {
+					violation(
+						index,
+						event,
+						TOOL_UPDATE_WITHOUT_OPEN,
+						toolCallId ?? "(missing toolCallId)",
+					);
+					break;
+				}
+				if (tool.iteration !== openIteration) {
+					violation(
+						index,
+						event,
+						TOOL_WRONG_ITERATION,
+						event.toolCallId,
+					);
+				}
+				break;
+			}
+			case "content_end": {
+				if (openIteration === undefined) {
+					violation(index, event, CONTENT_OUTSIDE_ITERATION);
+					break;
+				}
+				if (event.contentType === "tool") {
+					const toolCallId = event.toolCallId;
+					const tool =
+						toolCallId === undefined ? undefined : openTools.get(toolCallId);
+					if (tool === undefined) {
+						violation(
+							index,
+							event,
+							TOOL_END_WITHOUT_OPEN,
+							toolCallId ?? "(missing toolCallId)",
+						);
+						break;
+					}
+					if (tool.iteration !== openIteration) {
+						violation(
+							index,
+							event,
+							TOOL_WRONG_ITERATION,
+							event.toolCallId,
+						);
+					}
+					if (toolCallId !== undefined) {
+						openTools.delete(toolCallId);
+					}
+				} else if (event.contentType === "text") {
+					if (textStartsInIteration === 0) {
+						noteWart(WART_FINAL_WITHOUT_DELTAS);
+					}
+				} else if (event.contentType === "reasoning") {
+					if (reasoningStartsInIteration === 0) {
+						noteWart(WART_FINAL_WITHOUT_DELTAS);
+					}
+				}
+				break;
+			}
+			case "notice":
+			case "usage": {
+				// Notices (status, recovery, mistake-limit) and usage
+				// deltas are legal anywhere before the terminal.
+				break;
+			}
+			case "error": {
+				if (event.recoverable) {
+					// In-run error reusing the terminal discriminant.
+					noteWart(WART_TERMINAL_AMBIGUITY);
+					break;
+				}
+				terminated = true;
+				sawTerminalError = true;
+				if (openIteration !== undefined || openTools.size > 0) {
+					noteWart(WART_DANGLING_AT_TERMINAL);
+				}
+				break;
+			}
+			case "done": {
+				terminated = true;
+				if (event.reason === "error" && !sawTerminalError) {
+					// Terminal outcome spelled as done(reason:"error")
+					// rather than an error event.
+					noteWart(WART_TERMINAL_AMBIGUITY);
+				}
+				if (openIteration !== undefined || openTools.size > 0) {
+					noteWart(WART_DANGLING_AT_TERMINAL);
+				}
+				break;
+			}
+			default: {
+				// Exhaustiveness guard: a new AgentEvent variant must
+				// be added to the tables or this assignment fails to
+				// compile — a validator that silently ignores an event
+				// kind is worse than none.
+				const _exhaustive: never = event;
+				void _exhaustive;
+			}
+		}
+	}
+
+	const warts: StreamWartObservation[] = V1_WARTS.map((wart) => ({
+		id: wart.id,
+		count: wartCounts.get(wart.id) ?? 0,
+	})).filter((wart) => wart.count > 0);
+
+	return {
+		violations,
+		warts,
+		terminated,
+		eventCount: events.length,
+	};
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Every surface that renders an agent session re-derives the event
stream's structure by hand: which events form a block, which block an
update belongs to, how a turn ends. That grammar lives as mutable
parser state in five consumers (VSCode translator, CLI, TUI, ACP, the
desktop app), and the deviations each one discovered are re-documented
per surface.

This PR makes the grammar explicit and machine-checked, with **no
behavior change to any producer or consumer**:

- `@cline/shared/src/agents/stream-grammar.ts` — the de-facto v1
  `AgentEvent` grammar as transition tables, `validateAgentEventStream`
  (violations = producer bugs), and a wart registry (W1-W4: the known
  deviations from the v2 target grammar, counted — e.g. text
  `content_start` is really a delta, scopes dangle at terminals,
  recoverable errors reuse the terminal discriminant).
- Unit tests over the tables, and a cross-module test in `@cline/core`
  that drives the real `RuntimeEventAdapter` through success,
  mid-tool-failure, non-streaming, and multi-iteration runs, asserting
  zero violations and exact wart counts.
- `sdk/packages/core/docs/agent-event-stream-design.md` — the v2 design
  (scope tree, frame schema, per-scope automata, push-based consumer
  API, annotations) with the specific duplication/drift problems it
  removes (P1-P8, cited) and the verification strategy for the
  migration.

The grammar tests are the migration scoreboard: when a later phase
fixes a wart, the corresponding expectation flips from a wart count to
zero.

### Test Procedure

Pure addition; risk is a bad table (false violation) or a silent skip.
Both are covered by running the validator against the real producer:

```
cd sdk/packages/shared && bun run test:unit
# 397 passed (includes 15 new grammar-table tests)

cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime/
# 343 passed (includes the 4 new producer-driven grammar tests and the
# 37 pre-existing RuntimeEventAdapter tests, unchanged)
```

The validator's switch over `AgentEvent` has a `never` exhaustiveness
guard, so a future event variant fails compilation rather than being
silently ignored.

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This is PR 1 of a 6-PR stacked plan (phase 1: v2 schema + dual-emit
producer; 2: assembler + CLI/ACP port; 3: VSCode port; 4: desktop;
5: CI ratchet + deletion of superseded paths). The full plan, the
falsifiable duplication claims, and the verification strategy are in
`sdk/packages/core/docs/agent-event-stream-design.md`. Follow-ups stack
on this branch.
