### PR TITLE
fix(vscode): honor Azure API version in SDK sessions and mirror it to providers.json

### DIFF
--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -16,6 +16,7 @@ import {
 	normalizeProviderReasoningSettings,
 	normalizeSdkBaseUrl,
 	resolveApiKey,
+	resolveAzureProviderConfig,
 	updateHistoryItem,
 } from "./cline-session-factory"
 import { parseProviderId } from "./model-catalog/provider-id"
@@ -508,6 +509,121 @@ describe("buildSessionConfig", () => {
 			providerId: "asksage",
 			baseUrl: "https://asksage.migrated.example/server",
 		})
+	})
+
+	it("forwards Azure settings from legacy state and mirrors them into providers.json", async () => {
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "gpt-5.6-terra",
+			openAiApiKey: "azure-key",
+			openAiBaseUrl: "https://example.openai.azure.com/openai/deployments/gpt-5.6-terra",
+			azureApiVersion: "2025-01-01-preview",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		// Without this the SDK gateway never appends ?api-version= to Azure
+		// deployment URLs and Azure rejects every request with
+		// "Resource not found" (#13655).
+		expect(config.providerConfig).toMatchObject({
+			providerId: "openai-compatible",
+			azure: { apiVersion: "2025-01-01-preview" },
+		})
+		expect(mocks.providerSettingsManager.saveProviderSettings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: "openai-compatible",
+				azure: { apiVersion: "2025-01-01-preview" },
+			}),
+			{ setLastUsed: false },
+		)
+	})
+
+	it("falls back to the providers.json Azure settings when legacy state has none", async () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "openai-compatible") {
+				return undefined
+			}
+			return {
+				provider: "openai-compatible",
+				apiKey: "azure-key",
+				baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-5.6-terra",
+				azure: { apiVersion: "2025-04-01-preview", useIdentity: true },
+			} as any
+		})
+		mocks.stateManager.getApiConfiguration.mockReturnValue({
+			actModeApiProvider: "openai",
+			actModeOpenAiModelId: "gpt-5.6-terra",
+		} as any)
+
+		const config = await buildSessionConfig({ cwd: "/tmp/workspace" })
+
+		expect(config.providerConfig).toMatchObject({
+			providerId: "openai-compatible",
+			azure: { apiVersion: "2025-04-01-preview", useIdentity: true },
+		})
+		expect(mocks.providerSettingsManager.saveProviderSettings).not.toHaveBeenCalled()
+	})
+
+	it("treats a blank legacy Azure API version as unset and keeps the stored value", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "openai-compatible") {
+				return undefined
+			}
+			return {
+				provider: "openai-compatible",
+				azure: { apiVersion: "2025-04-01-preview" },
+			} as any
+		})
+
+		expect(resolveAzureProviderConfig({ azureApiVersion: "   " } as any)).toEqual({
+			azure: { apiVersion: "2025-04-01-preview" },
+		})
+		expect(mocks.providerSettingsManager.saveProviderSettings).not.toHaveBeenCalled()
+	})
+
+	it("merges legacy Azure fields over the stored azure block when mirroring", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "openai-compatible") {
+				return undefined
+			}
+			return {
+				provider: "openai-compatible",
+				apiKey: "stored-key",
+				model: "gpt-5.6-terra",
+				azure: { apiVersion: "2024-06-01", useIdentity: true },
+			} as any
+		})
+
+		const resolved = resolveAzureProviderConfig({ azureApiVersion: "2025-01-01-preview" } as any)
+
+		expect(resolved).toEqual({ azure: { apiVersion: "2025-01-01-preview", useIdentity: true } })
+		// The mirror must preserve unrelated stored fields (key, model, ...).
+		expect(mocks.providerSettingsManager.saveProviderSettings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: "openai-compatible",
+				apiKey: "stored-key",
+				model: "gpt-5.6-terra",
+				azure: { apiVersion: "2025-01-01-preview", useIdentity: true },
+			}),
+			{ setLastUsed: false },
+		)
+	})
+
+	it("does not rewrite providers.json when the stored Azure settings already match", () => {
+		mocks.providerSettingsManager.getProviderSettings.mockImplementation((providerId?: string) => {
+			if (providerId !== "openai-compatible") {
+				return undefined
+			}
+			return {
+				provider: "openai-compatible",
+				azure: { apiVersion: "2025-01-01-preview" },
+			} as any
+		})
+
+		const resolved = resolveAzureProviderConfig({ azureApiVersion: "2025-01-01-preview" } as any)
+
+		expect(resolved).toEqual({ azure: { apiVersion: "2025-01-01-preview" } })
+		expect(mocks.providerSettingsManager.saveProviderSettings).not.toHaveBeenCalled()
 	})
 
 	it("forwards the regional API line from legacy state so the gateway can route to the regional endpoint", async () => {

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -104,6 +104,9 @@ beforeEach(() => {
 	mocks.providerSettingsManager.getFilePath.mockReturnValue(path.join(tempDir, "settings", "providers.json"))
 	mocks.providerSettingsManager.getLastUsedProviderSettings.mockReturnValue(undefined)
 	mocks.providerSettingsManager.getProviderSettings.mockReturnValue(undefined)
+	// clearAllMocks keeps implementations: re-pin the default so a test that
+	// swaps in a real manager cannot leak it into later tests.
+	mocks.getProviderSettingsManager.mockImplementation(() => mocks.providerSettingsManager)
 })
 
 afterEach(() => {
@@ -607,6 +610,44 @@ describe("buildSessionConfig", () => {
 			}),
 			{ setLastUsed: false },
 		)
+	})
+
+	it("mirrors Azure settings through the real ProviderSettingsManager (schema round-trip)", async () => {
+		// The mocked-manager tests above cannot catch a mirror payload that the
+		// real ProviderSettingsSchema.parse would reject (the resolver swallows
+		// save failures), so exercise the real manager against a temp file.
+		// Import by relative path: the "@cline/core" specifier is aliased to an
+		// in-memory stub in vitest.config.ts, which validates nothing.
+		const { ProviderSettingsManager } = await import(
+			"../../../../sdk/packages/core/src/services/storage/provider-settings-manager"
+		)
+		const realManager = new ProviderSettingsManager({
+			filePath: path.join(tempDir, "settings", "providers.json"),
+		})
+		// Reporter's #13655 state: entry written by the CLI onboarding (key,
+		// base URL, model) but no azure block.
+		realManager.saveProviderSettings(
+			{
+				provider: "openai-compatible",
+				apiKey: "azure-key",
+				model: "gpt-5.6-terra",
+				baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-5.6-terra",
+			},
+			{ setLastUsed: false },
+		)
+		mocks.getProviderSettingsManager.mockReturnValue(realManager as never)
+
+		const resolved = resolveAzureProviderConfig({ azureApiVersion: "2025-01-01-preview" } as any)
+
+		expect(resolved).toEqual({ azure: { apiVersion: "2025-01-01-preview" } })
+		const persisted = realManager.getProviderSettings("openai-compatible")
+		expect(persisted).toMatchObject({
+			provider: "openai-compatible",
+			apiKey: "azure-key",
+			model: "gpt-5.6-terra",
+			baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-5.6-terra",
+			azure: { apiVersion: "2025-01-01-preview" },
+		})
 	})
 
 	it("does not rewrite providers.json when the stored Azure settings already match", () => {

--- a/apps/vscode/src/sdk/cline-session-factory.test.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.test.ts
@@ -616,11 +616,11 @@ describe("buildSessionConfig", () => {
 		// The mocked-manager tests above cannot catch a mirror payload that the
 		// real ProviderSettingsSchema.parse would reject (the resolver swallows
 		// save failures), so exercise the real manager against a temp file.
-		// Import by relative path: the "@cline/core" specifier is aliased to an
-		// in-memory stub in vitest.config.ts, which validates nothing.
-		const { ProviderSettingsManager } = await import(
-			"../../../../sdk/packages/core/src/services/storage/provider-settings-manager"
-		)
+		// Import the built package by file path: the bare "@cline/core"
+		// specifier is aliased to an in-memory stub in vitest.config.ts (which
+		// validates nothing), and importing SDK *source* would pull it into
+		// this project's tsc program (TS6059: outside rootDir).
+		const { ProviderSettingsManager } = await import("../../node_modules/@cline/core/dist/index.js")
 		const realManager = new ProviderSettingsManager({
 			filePath: path.join(tempDir, "settings", "providers.json"),
 		})
@@ -648,6 +648,11 @@ describe("buildSessionConfig", () => {
 			baseUrl: "https://example.openai.azure.com/openai/deployments/gpt-5.6-terra",
 			azure: { apiVersion: "2025-01-01-preview" },
 		})
+		// Assert on the file, not just the manager: the in-memory vitest stub
+		// would satisfy the manager-level assertions too, but only the real
+		// manager persists to disk.
+		const onDisk = JSON.parse(fs.readFileSync(path.join(tempDir, "settings", "providers.json"), "utf8"))
+		expect(onDisk.providers["openai-compatible"].settings.azure).toEqual({ apiVersion: "2025-01-01-preview" })
 	})
 
 	it("does not rewrite providers.json when the stored Azure settings already match", () => {

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -613,6 +613,55 @@ export function resolveVertexProviderConfig(config: ApiConfiguration): Pick<Prov
 	}
 }
 
+/**
+ * Resolve Azure OpenAI settings (API version / Entra ID auth) for the OpenAI
+ * Compatible provider. The webview saves them only to legacy state
+ * (`azureApiVersion` / `azureIdentity`); the providers.json `azure` block is
+ * the fallback for entries written by the CLI onboarding or the one-shot
+ * legacy migration. Without this mapping the SDK gateway never appends
+ * `?api-version=` to Azure deployment URLs and Azure rejects every request
+ * with "Resource not found" (#13655).
+ *
+ * Values resolved from legacy state are also mirrored into providers.json so
+ * the CLI — which reads only providers.json — sees the same Azure
+ * configuration the extension uses. The legacy migration never updates
+ * existing entries, so this mirror is the only ongoing sync for these fields.
+ */
+export function resolveAzureProviderConfig(config: ApiConfiguration): Pick<ProviderSettings, "azure"> | undefined {
+	const apiVersion = config.azureApiVersion?.trim() || undefined
+	const useIdentity = typeof config.azureIdentity === "boolean" ? config.azureIdentity : undefined
+
+	let stored: ProviderSettings | undefined
+	try {
+		stored = getProviderSettingsManager().getProviderSettings("openai-compatible")
+	} catch {
+		Logger.warn("[SessionFactory] Failed to read OpenAI Compatible Azure settings from providers.json")
+	}
+
+	if (apiVersion === undefined && useIdentity === undefined) {
+		return stored?.azure ? { azure: stored.azure } : undefined
+	}
+
+	const azure: NonNullable<ProviderSettings["azure"]> = {
+		...(stored?.azure ?? {}),
+		...(apiVersion !== undefined ? { apiVersion } : {}),
+		...(useIdentity !== undefined ? { useIdentity } : {}),
+	}
+
+	if (stored?.azure?.apiVersion !== azure.apiVersion || stored?.azure?.useIdentity !== azure.useIdentity) {
+		try {
+			getProviderSettingsManager().saveProviderSettings(
+				{ ...(stored ?? {}), provider: "openai-compatible", azure },
+				{ setLastUsed: false },
+			)
+		} catch {
+			Logger.warn("[SessionFactory] Failed to mirror Azure settings into providers.json")
+		}
+	}
+
+	return { azure }
+}
+
 type OllamaProviderConfig = {
 	modelInfo?: { id: string; name: string; contextWindow: number }
 	timeoutMs?: number
@@ -787,6 +836,7 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	let vertexProviderConfig: Pick<ProviderSettings, "gcp" | "region"> | undefined
 	let sapProviderConfig: SapProviderConfig | undefined
 	let ollamaProviderConfig: ReturnType<typeof resolveOllamaProviderConfig> | undefined
+	let azureProviderConfig: Pick<ProviderSettings, "azure"> | undefined
 
 	try {
 		const stateManager = StateManager.get()
@@ -832,6 +882,12 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 
 			if (providerId === "ollama") {
 				ollamaProviderConfig = resolveOllamaProviderConfig(apiConfig, modelId)
+			}
+
+			// The OpenAI Compatible provider is spelled "openai" after the
+			// legacy fold above; keep the SDK spelling as a defensive alias.
+			if (providerId === "openai" || providerId === "openai-compatible") {
+				azureProviderConfig = resolveAzureProviderConfig(apiConfig)
 			}
 
 			Logger.log(
@@ -994,6 +1050,10 @@ export async function buildSessionConfig(input: SessionConfigInput): Promise<Cor
 	// proxy/CA-aware fetch — can never be clobbered if those types gain matching keys.
 	const providerConfig = {
 		...(cloudProviderConfig ?? {}),
+		// Only spread when defined: an explicit `azure: undefined` key would
+		// clobber the providers.json azure block core merges in downstream
+		// (buildProviderConfig spreads this session config over stored settings).
+		...(azureProviderConfig ?? {}),
 		providerId: sdkProviderId,
 		modelId,
 		...(apiKey ? { apiKey } : {}),

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
 			// here, so subpath imports fail with "Cannot find package". Keep the more
 			// specific subpath alias(es) before the bare package alias.
 			"@cline/shared/storage": path.resolve(__dirname, "node_modules/@cline/shared/dist/storage/index.js"),
+			"@cline/shared/db": path.resolve(__dirname, "node_modules/@cline/shared/dist/db/index.js"),
 			"@cline/shared": path.resolve(__dirname, "node_modules/@cline/shared/dist/index.js"),
 			vscode: path.resolve(__dirname, "src/test/vscode-vitest-stub.ts"),
 			"@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
Fixes #13655 ([CLINE-3101](https://linear.app/cline-bot/issue/CLINE-3101)) — Azure AI Foundry deployments failing with "Resource not found" on the SDK architecture (CLI, VS Code Next, JetBrains).

## Root cause

The request path is fine: when `azure.apiVersion` is present in the resolved provider config, the gateway's OpenAI-compatible vendor appends `?api-version=` to Azure deployment URLs (verified against the released CLI 3.0.60 binary with a mock Azure endpoint). What's broken is that the value never gets there when Azure is configured through the extension GUI:

- The webview's **Azure API Version / Identity** fields (OpenAI Compatible provider) are saved only to legacy StateManager keys (`azureApiVersion` / `azureIdentity`).
- The SDK session factory (`cline-session-factory.ts`) resolves structured options from legacy state for Bedrock, Vertex, SAP, and Ollama — but had no Azure handling at all, so SDK sessions hit the Azure deployment URL without `api-version` and Azure answers "Resource not found".
- Nothing syncs those fields into the shared `~/.cline/data/settings/providers.json` either (the one-shot legacy migration never updates existing entries), so the CLI — which reads only providers.json — fails the same way after a user configures Azure in the extension. This is exactly the issue's repro: *"Setup Azure AI Foundry config with extension → open CLI → failed"*. The earlier fix in #11359 worked because the reporter re-entered the API version through the CLI onboarding, which does write providers.json.

## Fix

`resolveAzureProviderConfig` in the SDK session factory, following the existing dual-source pattern (`resolveBaseUrl` / `resolveApiKey`):

- Resolve `azureApiVersion` / `azureIdentity` from legacy state, falling back to the providers.json `azure` block (entries written by CLI onboarding or the legacy migration), and pass them as `providerConfig.azure`. Core already forwards that to the gateway as `options.apiVersion` for OpenAI-compatible clients.
- Mirror values resolved from legacy state into providers.json (merged over the stored `azure` block, other fields preserved, no write when unchanged) so the CLI sees the same Azure configuration the extension uses. Since this runs at session build, existing users are healed on their next task in the extension without re-editing settings.

Precedence note: legacy state wins over providers.json, matching how the base URL and API key already resolve in this file — the webview field is the value the extension user sees, and the mirror keeps the CLI consistent with it.

The key is only spread into the session provider config when defined, so a session config without Azure values can never clobber a providers.json `azure` block during core's stored-settings merge.

## Testing

- 5 new unit tests in `cline-session-factory.test.ts` covering: legacy-state resolution + mirror write, providers.json fallback (no write), blank legacy value treated as unset, merge over stored `useIdentity` with unrelated fields preserved, and no rewrite when values already match. Full suite: 82/82 passing.
- Verified the downstream path end-to-end with the released CLI 3.0.60 binary against a mock Azure endpoint: with `azure.apiVersion` in providers.json the request goes to `/openai/deployments/<deployment>/chat/completions?api-version=...`; without it the query parameter is missing (the reported failure).
- `check-types`, `lint`, and biome format clean.