### PR TITLE
fix: stop child-stdin EPIPE and the SAP SDK's winston handler from killing the host process

### DIFF
--- a/.changeset/child-stdin-epipe-crash.md
+++ b/.changeset/child-stdin-epipe-crash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Stop the core process from dying 3 seconds after a hook or MCP server exits without reading its input. The pending stdin write failed with EPIPE and escaped as an uncaught exception, and a winston handler pulled in by the SAP AI Core provider turned that into `process.exit(1)` -- surfaced on JetBrains as "cline-core exited unexpectedly with code 1" after submitting a prompt with URL content.

--- a/apps/vscode/src/core/hooks/HookProcess.ts
+++ b/apps/vscode/src/core/hooks/HookProcess.ts
@@ -283,6 +283,16 @@ export class HookProcess extends EventEmitter {
 							reject(spawnError)
 						})
 
+						// A hook that exits (or closes stdin) before draining its input
+						// fails the still-pending write asynchronously with EPIPE (EOF on
+						// Windows). That surfaces on the stdin stream, not the child, so
+						// without a listener it escapes as an uncaught exception on the
+						// host process. The "close" handler already reports how the hook
+						// ended; the write failure itself only needs to be absorbed.
+						this.childProcess.stdin?.on("error", (error) => {
+							Logger.debug(`Hook '${this.scriptPath}' stopped reading its input: ${error.message}`)
+						})
+
 						// Send input to the process
 						try {
 							this.childProcess.stdin?.write(inputJson)

--- a/apps/vscode/src/core/hooks/HookProcess.ts
+++ b/apps/vscode/src/core/hooks/HookProcess.ts
@@ -195,6 +195,12 @@ export class HookProcess extends EventEmitter {
 						})
 
 						let didEmitEmptyLine = false
+						// Set when delivering the input failed (see the stdin "error"
+						// listener below); appended to failure messages so a hook that
+						// never read its input is diagnosable from the error alone.
+						let inputFailure: string | undefined
+						const withInputFailure = (message: string) =>
+							inputFailure ? `${message} The hook stopped reading its input before it was fully delivered (${inputFailure}).` : message
 
 						// Set up timeout
 						this.timeoutHandle = setTimeout(() => {
@@ -202,7 +208,9 @@ export class HookProcess extends EventEmitter {
 								this.childProcess.kill("SIGTERM")
 								reject(
 									new Error(
-										`Hook execution timed out after ${this.timeoutMs}ms. The hook script at '${this.scriptPath}' took too long to complete.`,
+										withInputFailure(
+											`Hook execution timed out after ${this.timeoutMs}ms. The hook script at '${this.scriptPath}' took too long to complete.`,
+										),
 									),
 								)
 							}
@@ -255,7 +263,7 @@ export class HookProcess extends EventEmitter {
 							if (code === 0) {
 								resolve()
 							} else {
-								reject(new Error(`Hook exited with code ${code}${signal ? `, signal ${signal}` : ""}`))
+								reject(new Error(withInputFailure(`Hook exited with code ${code}${signal ? `, signal ${signal}` : ""}`)))
 							}
 						})
 
@@ -287,9 +295,13 @@ export class HookProcess extends EventEmitter {
 						// fails the still-pending write asynchronously with EPIPE (EOF on
 						// Windows). That surfaces on the stdin stream, not the child, so
 						// without a listener it escapes as an uncaught exception on the
-						// host process. The "close" handler already reports how the hook
-						// ended; the write failure itself only needs to be absorbed.
+						// host process. It is deliberately not treated as a failure of the
+						// run: a hook is free to ignore its input, and a hook that exits 0
+						// without reading must still count as success. The "close" handler
+						// stays the single source of truth for the outcome; the failure is
+						// only recorded so timeout/exit errors can explain it.
 						this.childProcess.stdin?.on("error", (error) => {
+							inputFailure = error.message
 							Logger.debug(`Hook '${this.scriptPath}' stopped reading its input: ${error.message}`)
 						})
 

--- a/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
@@ -238,3 +238,46 @@ describe("HookProcess spawn failures", () => {
 		},
 	)
 })
+
+describe("HookProcess stdin failures", () => {
+	let tempDir: string
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hookprocess-stdin-test-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	it("fails open when the hook exits without reading a large input", async () => {
+		const hookBasePath = path.join(tempDir, "UserPromptSubmit")
+		await writeHookScriptForPlatform(hookBasePath, `#!/usr/bin/env node\nprocess.exit(3)\n`)
+		const scriptPath = process.platform === "win32" ? `${hookBasePath}.ps1` : hookBasePath
+
+		// An input larger than the pipe buffer leaves part of the write pending
+		// when the hook exits. That failure lands on the stdin stream, not the
+		// child; unguarded it escapes as an uncaught exception and kills the
+		// whole host process instead of failing this one hook.
+		const uncaught: unknown[] = []
+		const onUncaught = (error: unknown) => {
+			uncaught.push(error)
+		}
+		process.on("uncaughtException", onUncaught)
+		try {
+			const hookProcess = new HookProcess(scriptPath, 15000)
+			const input = JSON.stringify({ userPromptSubmit: { prompt: "x".repeat(1_000_000) } })
+			try {
+				await hookProcess.run(input)
+				throw new Error("Expected hook run to fail")
+			} catch (error: any) {
+				error.message.should.match(/Hook exited with code 3/)
+			}
+			// Give a late pipe error a chance to surface before asserting.
+			await new Promise((resolve) => setTimeout(resolve, 200))
+			uncaught.should.be.empty()
+		} finally {
+			process.off("uncaughtException", onUncaught)
+		}
+	}, 15000)
+})

--- a/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "bun:test"
+import type { EventEmitter } from "events"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
@@ -260,7 +261,7 @@ describe("HookProcess stdin failures", () => {
 		// child; unguarded it escapes as an uncaught exception and kills the
 		// whole host process instead of failing this one hook.
 		const uncaught: unknown[] = []
-		const onUncaught = (error: unknown) => {
+		const onUncaught: NodeJS.UncaughtExceptionListener = (error) => {
 			uncaught.push(error)
 		}
 		process.on("uncaughtException", onUncaught)
@@ -280,7 +281,9 @@ describe("HookProcess stdin failures", () => {
 			await new Promise((resolve) => setTimeout(resolve, 200))
 			uncaught.should.be.empty()
 		} finally {
-			process.off("uncaughtException", onUncaught)
+			// Through the plain EventEmitter type: bun-types merges extra
+			// overloads into `process` that break resolution of this call.
+			;(process as unknown as EventEmitter).removeListener("uncaughtException", onUncaught)
 		}
 	}, 15000)
 

--- a/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hookprocess.test.ts
@@ -272,6 +272,9 @@ describe("HookProcess stdin failures", () => {
 				throw new Error("Expected hook run to fail")
 			} catch (error: any) {
 				error.message.should.match(/Hook exited with code 3/)
+				// stdin's failure is emitted before the child's "close", so the exit
+				// error can say the input never arrived.
+				error.message.should.match(/stopped reading its input before it was fully delivered/)
 			}
 			// Give a late pipe error a chance to surface before asserting.
 			await new Promise((resolve) => setTimeout(resolve, 200))
@@ -279,5 +282,16 @@ describe("HookProcess stdin failures", () => {
 		} finally {
 			process.off("uncaughtException", onUncaught)
 		}
+	}, 15000)
+
+	it("still succeeds when a hook ignores a large input and exits 0", async () => {
+		const hookBasePath = path.join(tempDir, "TaskStart")
+		await writeHookScriptForPlatform(hookBasePath, `#!/usr/bin/env node\nconsole.log("{}")\n`)
+		const scriptPath = process.platform === "win32" ? `${hookBasePath}.ps1` : hookBasePath
+
+		// Ignoring stdin is legitimate hook behavior; a failed input delivery
+		// must not turn a successful hook into a failed one.
+		const hookProcess = new HookProcess(scriptPath, 15000)
+		await hookProcess.run(JSON.stringify({ taskStart: { blob: "x".repeat(1_000_000) } }))
 	}, 15000)
 })

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -133,11 +133,50 @@ process.stdin.on("data", (chunk) => {
 });
 `;
 
+// Answers initialize normally, then exits the moment a tools/call request
+// starts arriving -- without draining stdin. A request body larger than the
+// pipe buffer is then still partly queued on the client side when the reader
+// disappears, which is how a stdin write fails asynchronously with EPIPE.
+const EXIT_ON_CALL_SERVER_SCRIPT = `
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+	const text = chunk.toString("utf8");
+	if (text.includes('"tools/call"')) {
+		process.exit(0);
+	}
+	buffer += text;
+	let idx;
+	while ((idx = buffer.indexOf("\\n")) >= 0) {
+		const line = buffer.slice(0, idx).trim();
+		buffer = buffer.slice(idx + 1);
+		if (!line) continue;
+		let msg;
+		try {
+			msg = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (msg.id === undefined || msg.method !== "initialize") continue;
+		const result = {
+			protocolVersion: "2024-11-05",
+			capabilities: {},
+			serverInfo: { name: "fake", version: "0.0.0" },
+		};
+		process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\\n");
+	}
+});
+`;
+
 let tempRoot: string;
 
 beforeAll(() => {
 	tempRoot = mkdtempSync(join(tmpdir(), "mcp-client-test-"));
 	writeFileSync(join(tempRoot, "fake-server.js"), FAKE_SERVER_SCRIPT, "utf8");
+	writeFileSync(
+		join(tempRoot, "exit-on-call-server.js"),
+		EXIT_ON_CALL_SERVER_SCRIPT,
+		"utf8",
+	);
 	writeFileSync(
 		join(tempRoot, "framed-server.js"),
 		FRAMED_SERVER_SCRIPT,
@@ -159,6 +198,7 @@ function fakeServerRegistration(options: {
 	delayMs: number;
 	initDelayMs?: number;
 	pidFile?: string;
+	script?: string;
 }): McpServerRegistration {
 	return {
 		name: "fake-server",
@@ -170,7 +210,7 @@ function fakeServerRegistration(options: {
 				process.platform === "win32"
 					? `"${process.execPath}"`
 					: process.execPath,
-			args: [join(tempRoot, "fake-server.js")],
+			args: [join(tempRoot, options.script ?? "fake-server.js")],
 			env: {
 				FAKE_MCP_DELAY_MS: String(options.delayMs),
 				...(options.initDelayMs === undefined
@@ -559,4 +599,33 @@ describe("default connect budget", () => {
 			HUB_DEFAULT_COMMAND_TIMEOUT_MS / 2,
 		);
 	});
+});
+
+describe("mcp client stdin failures", () => {
+	it("fails the request instead of crashing when the server exits mid-write", async () => {
+		const uncaught: unknown[] = [];
+		const onUncaught = (error: unknown) => {
+			uncaught.push(error);
+		};
+		process.on("uncaughtException", onUncaught);
+		const factory = createDefaultMcpServerClientFactory();
+		const client = await factory(
+			fakeServerRegistration({ delayMs: 0, script: "exit-on-call-server.js" }),
+		);
+		try {
+			await client.connect();
+			await expect(
+				client.callTool({
+					name: "anything",
+					arguments: { blob: "x".repeat(1_000_000) },
+				}),
+			).rejects.toThrow(/MCP process/);
+			// Give a late pipe error a chance to surface before asserting.
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			expect(uncaught).toEqual([]);
+		} finally {
+			process.off("uncaughtException", onUncaught);
+			await client.disconnect();
+		}
+	}, 30_000);
 });

--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -604,7 +604,7 @@ describe("default connect budget", () => {
 describe("mcp client stdin failures", () => {
 	it("fails the request instead of crashing when the server exits mid-write", async () => {
 		const uncaught: unknown[] = [];
-		const onUncaught = (error: unknown) => {
+		const onUncaught: NodeJS.UncaughtExceptionListener = (error) => {
 			uncaught.push(error);
 		};
 		process.on("uncaughtException", onUncaught);
@@ -624,7 +624,7 @@ describe("mcp client stdin failures", () => {
 			await new Promise((resolve) => setTimeout(resolve, 200));
 			expect(uncaught).toEqual([]);
 		} finally {
-			process.off("uncaughtException", onUncaught);
+			process.removeListener("uncaughtException", onUncaught);
 			await client.disconnect();
 		}
 	}, 30_000);

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -357,6 +357,21 @@ class StdioMcpClient implements McpServerClient {
 				new Error(`MCP process error: ${toErrorMessage(error)}`),
 			);
 		});
+		// A server that dies or closes stdin while a request is still being
+		// written fails that write asynchronously on the stdin stream. Without
+		// a listener Node raises it as an uncaught exception on the host
+		// process. The "exit" handler reports the server's fate for anything
+		// still pending; the write error only needs a home.
+		child.stdin.on("error", (error) => {
+			if (this.process !== child) {
+				return;
+			}
+			this.failAllPending(
+				new Error(
+					`MCP process for "${this.registration.name}" stopped accepting input: ${toErrorMessage(error)}`,
+				),
+			);
+		});
 		child.once("exit", (code, signal) => {
 			if (this.process !== child) {
 				return;

--- a/sdk/packages/llms/src/providers/vendors/community.process-hygiene.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.process-hygiene.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+// Import for its side effects only: the assertions below are about what
+// loading this module does to the process, before any provider is built.
+import "./community";
+
+// Kept in its own file so vitest gives it a fresh module context: the
+// createSapAiCoreProviderModule tests strip the handlers again as part of
+// building a provider, which would mask a missing strip at module load.
+describe("community vendor module process hygiene", () => {
+	it("does not leave the SAP SDK's exit-on-uncaught-exception handler on the process", () => {
+		// @sap-cloud-sdk/util registers winston's ExceptionHandler at load
+		// (twice: once from the package and once from the private copy bundled
+		// into @jerome-benoit/sap-ai-provider). winston binds it as
+		// `_uncaughtException` and exits the process 3s after any uncaught
+		// exception. Importing this module must leave none of them behind.
+		const winstonHandlers = process
+			.listeners("uncaughtException")
+			.filter((listener) => listener.name === "bound _uncaughtException");
+		expect(winstonHandlers).toEqual([]);
+		const winstonRejectionHandlers = process
+			.listeners("unhandledRejection")
+			.filter((listener) => listener.name === "bound _unhandledRejection");
+		expect(winstonRejectionHandlers).toEqual([]);
+	});
+});

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -11,6 +11,31 @@ import { createDifyProvider } from "dify-ai-provider";
 import { resolveApiKey } from "../http";
 import type { ProviderFactoryResult } from "./types";
 
+// @sap-cloud-sdk/util, pulled in by the SAP provider, builds a winston logger
+// with `exceptionHandlers` at module load. That installs a process-wide
+// "uncaughtException" listener which, with winston's default exitOnError,
+// calls process.exit(1) three seconds after ANY uncaught exception in the host
+// process -- including ones the host's own handler already caught and chose to
+// survive. Libraries must never own process lifecycle (see
+// stripRogueSignalHandlers below). The SDK's disableExceptionLogger() is not
+// enough: @jerome-benoit/sap-ai-provider bundles a second, private copy of the
+// util module that no import can reach. winston registers its catchers as
+// `this._uncaughtException.bind(this)` / `this._unhandledRejection.bind(this)`,
+// so match them by that name and remove every instance.
+function stripWinstonProcessCatchers(): void {
+	for (const listener of process.listeners("uncaughtException")) {
+		if (listener.name === "bound _uncaughtException") {
+			process.removeListener("uncaughtException", listener);
+		}
+	}
+	for (const listener of process.listeners("unhandledRejection")) {
+		if (listener.name === "bound _unhandledRejection") {
+			process.removeListener("unhandledRejection", listener);
+		}
+	}
+}
+stripWinstonProcessCatchers();
+
 type SapModel = Record<PropertyKey, unknown>;
 const SAP_SERVICE_KEY_METHODS = new Set<PropertyKey>([
 	"doGenerate",
@@ -392,6 +417,9 @@ export async function createSapAiCoreProviderModule(
 			maxContentLength: Number.POSITIVE_INFINITY,
 		},
 	});
+	// The SAP SDK loads parts of itself lazily; make sure nothing it pulled in
+	// while building the provider re-armed an exit-on-uncaught handler.
+	stripWinstonProcessCatchers();
 	return {
 		operations: {
 			language: (modelId) =>


### PR DESCRIPTION
### Related Issue

**Issue:** cline/intellij-plugin#1155 (private) — Linear: [CLINE-3149](https://linear.app/cline-bot/issue/CLINE-3149/cline-cline-core-exited-unexpectedly-with-code-1-error-occurred-while)

### Description

On JetBrains, submitting a prompt with a `@https://...` mention killed cline-core: `write EPIPE` in the core log, then "cline-core exited unexpectedly with code 1" exactly 3 seconds later with nothing logged in between. Two independent bugs stack up to produce that:

1. **Unguarded child stdin writes.** `HookProcess` (apps/vscode hooks) and the SDK's stdio MCP client write to a child's stdin without an `error` listener. If the child exits before draining its input and part of the write is still queued (input larger than the pipe buffer), Node fails the write asynchronously with `EPIPE`, and with no listener that becomes an uncaught exception on the host process. The URL mention matters only because the resolved prompt (~20 KB of page content) is what pushes the hook payload past the pipe buffer. The SDK's own `subprocess-runner` already handles this correctly; both remaining writers now do the same and let the existing `close`/`exit` handling report how the child ended.

2. **A library that exits the process on uncaught exceptions.** `@sap-cloud-sdk/util`, pulled in by the SAP AI Core provider, creates a winston logger with `exceptionHandlers` at module load. winston registers a process-wide `uncaughtException` listener and, with its default `exitOnError`, calls `process.exit(1)` after a 3-second flush timer. That overrides cline-core's deliberate "log but keep running" handler, so *any* uncaught exception becomes a hard crash once the community vendor module has loaded (SAP AI Core, Claude Code, OpenAI Codex, OpenCode or Dify provider used in that process). `disableExceptionLogger()` is not sufficient: `@jerome-benoit/sap-ai-provider` bundles a second, private copy of the util module that no import can reach (which is also why the crash log shows the EPIPE printed twice in winston's format). The community module now strips winston's process catchers by their bound-method name right after the import and again after building the provider, mirroring the existing `stripRogueSignalHandlers` for opencode.

VS Code never showed this because the extension host blocks `process.exit`; the standalone core (JetBrains, CLI) has no such guard.

### Test Procedure

- New tests, each verified to fail with the corresponding guard removed:
  - `apps/vscode` `hookprocess.test.ts`: a hook that exits without reading a 1 MB input fails with "Hook exited with code 3" and no uncaught exception (without the listener: `EPIPE: broken pipe` escapes).
  - `sdk/packages/core` `client.test.ts`: an MCP server that exits as a large `tools/call` arrives rejects the request with an "MCP process ..." error and no uncaught exception (without the listener: `write EPIPE` is caught by the test's process listener).
  - `sdk/packages/llms` `community.process-hygiene.test.ts` (own file so it gets a fresh module context): importing the community module leaves no `bound _uncaughtException` / `bound _unhandledRejection` listener on the process (without the strip: two winston catchers remain).
- Full existing suites for the touched files pass: `hookprocess.test.ts` (10), `mcp/client.test.ts` (17), `community.test.ts` (7).
- `typecheck` for `@cline/llms` and `@cline/core`, biome check on all touched files.
- Reproduced the exact `WriteWrap.onWriteComplete ... stream_base_commons:87:19` frame from the report with a pending stdin write to an exiting child, and confirmed the winston `_uncaughtException` handler with its 3 s `process.exit(1)` timer in a built `cline-core.js`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Not a regression: the unguarded hook stdin write dates back to the hooks introduction (Oct 2025) and the legacy extension imported `@sap-ai-sdk/*` statically, so the winston exit handler was armed in every legacy core process. On the SDK line it only arms after one of the five community providers is used, which is what makes this report environment-dependent (the reporter has SAP AI Core configured and, presumably, a hook that exits without reading stdin).
