### PR TITLE
fix(vscode): honor disabled rule toggles in SDK sessions

### DIFF
--- a/apps/vscode/src/core/context/instructions/user-instructions/__tests__/frontmatter.test.ts
+++ b/apps/vscode/src/core/context/instructions/user-instructions/__tests__/frontmatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "bun:test"
 import { expect } from "chai"
-import { parseYamlFrontmatter } from "../frontmatter"
+import { parseYamlFrontmatter, updateUserInstructionMarkdownDisabledState } from "../frontmatter"
 
 describe("parseYamlFrontmatter", () => {
 	it("returns original content when no frontmatter", () => {
@@ -67,5 +67,30 @@ describe("parseYamlFrontmatter", () => {
 		expect(result.parseError).to.equal(undefined)
 		expect(result.data).to.deep.equal({ name: "my-skill", description: "A test skill" })
 		expect(result.body.trim()).to.equal("# my-skill\nThis is a test skill.")
+	})
+})
+
+describe("updateUserInstructionMarkdownDisabledState", () => {
+	it("adds disabled frontmatter when a rule is toggled off", () => {
+		const output = updateUserInstructionMarkdownDisabledState("Follow this rule", false)
+		expect(output).to.equal("---\ndisabled: true\n---\nFollow this rule")
+	})
+
+	it("preserves existing frontmatter fields when disabling", () => {
+		const input = ["---", "paths:", "  - src/**", "---", "Scoped rule"].join("\n")
+		const output = updateUserInstructionMarkdownDisabledState(input, false)
+		expect(output).to.contain("disabled: true")
+		expect(output).to.contain("paths:")
+		expect(output).to.contain("Scoped rule")
+	})
+
+	it("removes disabled frontmatter when a rule is toggled back on", () => {
+		const input = ["---", "disabled: true", "---", "Follow this rule"].join("\n")
+		expect(updateUserInstructionMarkdownDisabledState(input, true)).to.equal("Follow this rule")
+	})
+
+	it("leaves malformed frontmatter untouched", () => {
+		const input = ["---", "paths: [invalid", "---", "Rule body"].join("\n")
+		expect(updateUserInstructionMarkdownDisabledState(input, false)).to.equal(input)
 	})
 })

--- a/apps/vscode/src/core/context/instructions/user-instructions/__tests__/rule-loading.test.ts
+++ b/apps/vscode/src/core/context/instructions/user-instructions/__tests__/rule-loading.test.ts
@@ -3,7 +3,29 @@ import { expect } from "chai"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
+import { setRuleDisabledInFrontmatter } from "../cline-rules"
+import { parseYamlFrontmatter } from "../frontmatter"
 import { getRuleFilesTotalContentWithMetadata } from "../rule-helpers"
+
+describe("rule toggle frontmatter persistence", () => {
+	it("keeps the SDK disabled flag in sync when a file-backed rule is toggled", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "cline-rule-toggle-test-"))
+		try {
+			const rulePath = path.join(tmp, "project-rule.md")
+			await fs.writeFile(rulePath, "Follow this rule")
+
+			expect(await setRuleDisabledInFrontmatter(rulePath, false)).to.equal(true)
+			const disabled = parseYamlFrontmatter(await fs.readFile(rulePath, "utf-8"))
+			expect(disabled.data.disabled).to.equal(true)
+			expect(disabled.body).to.equal("Follow this rule")
+
+			expect(await setRuleDisabledInFrontmatter(rulePath, true)).to.equal(true)
+			expect(await fs.readFile(rulePath, "utf-8")).to.equal("Follow this rule")
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true })
+		}
+	})
+})
 
 describe("rule loading with paths frontmatter", () => {
 	it("filters rules by evaluationContext.paths", async () => {

--- a/apps/vscode/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/apps/vscode/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -1,8 +1,33 @@
 import { synchronizeRuleToggles } from "@core/context/instructions/user-instructions/rule-helpers"
 import { ensureRulesDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { ClineRulesToggles } from "@shared/cline-rules"
+import * as fs from "fs/promises"
 import path from "path"
 import { Controller } from "@/core/controller"
+import { Logger } from "@/shared/services/Logger"
+import { updateUserInstructionMarkdownDisabledState } from "./frontmatter"
+
+/**
+ * Persist a rule's UI toggle in the frontmatter consumed by the SDK rules
+ * loader. The legacy rule loader reads extension state, while the SDK loader
+ * reads `disabled` from the rule document itself.
+ */
+export async function setRuleDisabledInFrontmatter(rulePath: string, enabled: boolean): Promise<boolean> {
+	if (!rulePath) {
+		return false
+	}
+	try {
+		const content = await fs.readFile(rulePath, "utf-8")
+		const updated = updateUserInstructionMarkdownDisabledState(content, enabled)
+		if (updated !== content) {
+			await fs.writeFile(rulePath, updated)
+		}
+		return true
+	} catch (error) {
+		Logger.warn(`Failed to update rule frontmatter at ${rulePath}:`, error)
+		return false
+	}
+}
 
 export async function refreshClineRulesToggles(
 	controller: Controller,

--- a/apps/vscode/src/core/context/instructions/user-instructions/frontmatter.ts
+++ b/apps/vscode/src/core/context/instructions/user-instructions/frontmatter.ts
@@ -57,3 +57,38 @@ export function parseYamlFrontmatter(markdown: string): FrontmatterParseResult {
 		return { data: {}, body: normalizedMarkdown, hadFrontmatter: true, parseError: message }
 	}
 }
+
+/**
+ * Update the `disabled` frontmatter flag shared by SDK-backed user
+ * instructions (rules, skills, and workflows).
+ *
+ * - enabled=false sets `disabled: true`.
+ * - enabled=true removes `disabled` and a stale `enabled: false`.
+ * - malformed frontmatter is left untouched so a toggle cannot corrupt it.
+ */
+export function updateUserInstructionMarkdownDisabledState(content: string, enabled: boolean): string {
+	const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(content)
+
+	if (!hadFrontmatter && enabled) {
+		return content
+	}
+
+	if (parseError) {
+		return content
+	}
+
+	if (enabled) {
+		delete data.disabled
+		if (data.enabled === false) {
+			delete data.enabled
+		}
+		if (Object.keys(data).length === 0) {
+			return body
+		}
+	} else {
+		data.disabled = true
+	}
+
+	const yamlText = yaml.dump(data, { schema: yaml.JSON_SCHEMA }).trimEnd()
+	return `---\n${yamlText}\n---\n${body}`
+}

--- a/apps/vscode/src/core/context/instructions/user-instructions/skills.ts
+++ b/apps/vscode/src/core/context/instructions/user-instructions/skills.ts
@@ -3,10 +3,9 @@ import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
 import type { SkillContent, SkillMetadata } from "@shared/skills"
 import { fileExistsAtPath, isDirectory } from "@utils/fs"
 import * as fs from "fs/promises"
-import * as yaml from "js-yaml"
 import * as path from "path"
 import { Logger } from "@/shared/services/Logger"
-import { parseYamlFrontmatter } from "./frontmatter"
+import { parseYamlFrontmatter, updateUserInstructionMarkdownDisabledState } from "./frontmatter"
 
 /**
  * Update the `disabled` frontmatter flag of a SKILL.md document.
@@ -26,38 +25,7 @@ import { parseYamlFrontmatter } from "./frontmatter"
  * frontmatter (nothing to clear).
  */
 export function updateSkillMarkdownDisabledState(content: string, enabled: boolean): string {
-	const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(content)
-
-	if (!hadFrontmatter && enabled) {
-		return content
-	}
-
-	// parseYamlFrontmatter fails open on malformed YAML: it returns data={} and
-	// body=<full original content> (frontmatter block included). Serializing here
-	// would prepend a second `---` block and corrupt the file, so leave it
-	// untouched and let the user fix the frontmatter.
-	if (parseError) {
-		return content
-	}
-
-	if (enabled) {
-		delete data.disabled
-		if (data.enabled === false) {
-			delete data.enabled
-		}
-		if (Object.keys(data).length === 0) {
-			return body
-		}
-		return serializeSkillFrontmatter(data, body)
-	}
-
-	data.disabled = true
-	return serializeSkillFrontmatter(data, body)
-}
-
-function serializeSkillFrontmatter(data: Record<string, unknown>, body: string): string {
-	const yamlText = yaml.dump(data, { schema: yaml.JSON_SCHEMA }).trimEnd()
-	return `---\n${yamlText}\n---\n${body}`
+	return updateUserInstructionMarkdownDisabledState(content, enabled)
 }
 
 /**

--- a/apps/vscode/src/core/controller/file/__tests__/toggleClineRule.test.ts
+++ b/apps/vscode/src/core/controller/file/__tests__/toggleClineRule.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { RuleScope, ToggleClineRuleRequest } from "@shared/proto/cline/file"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { parseYamlFrontmatter } from "@/core/context/instructions/user-instructions/frontmatter"
+import { toggleClineRule } from "../toggleClineRule"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+	await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+function createController() {
+	const globalToggles: Record<string, boolean> = {}
+	const localToggles: Record<string, boolean> = {}
+	const remoteToggles: Record<string, boolean> = {}
+
+	return {
+		controller: {
+			stateManager: {
+				getGlobalSettingsKey: () => globalToggles,
+				getWorkspaceStateKey: () => localToggles,
+				getGlobalStateKey: () => remoteToggles,
+				setGlobalState: () => undefined,
+				setWorkspaceState: () => undefined,
+			},
+		},
+		localToggles,
+	}
+}
+
+describe("toggleClineRule", () => {
+	it("persists local rule state for the SDK loader", async () => {
+		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cline-toggle-rule-test-"))
+		temporaryDirectories.push(directory)
+		const rulePath = path.join(directory, "project-rule.md")
+		await fs.writeFile(rulePath, "Follow this rule")
+		const { controller, localToggles } = createController()
+
+		await toggleClineRule(
+			controller as never,
+			ToggleClineRuleRequest.create({ scope: RuleScope.LOCAL, rulePath, enabled: false }),
+		)
+
+		expect(localToggles[rulePath]).toBe(false)
+		expect(parseYamlFrontmatter(await fs.readFile(rulePath, "utf-8")).data.disabled).toBe(true)
+	})
+})

--- a/apps/vscode/src/core/controller/file/toggleClineRule.ts
+++ b/apps/vscode/src/core/controller/file/toggleClineRule.ts
@@ -1,3 +1,4 @@
+import { setRuleDisabledInFrontmatter } from "@core/context/instructions/user-instructions/cline-rules"
 import { getWorkspaceBasename } from "@core/workspace"
 import type { ToggleClineRuleRequest } from "@shared/proto/cline/file"
 import { RuleScope, ToggleClineRules } from "@shared/proto/cline/file"
@@ -45,6 +46,13 @@ export async function toggleClineRule(controller: Controller, request: ToggleCli
 		}
 		default:
 			throw new Error(`Invalid scope: ${scope}`)
+	}
+
+	// The SDK rule loader reads the document's `disabled` frontmatter flag,
+	// whereas the legacy loader reads the extension's toggle state. Keep both
+	// representations in sync for file-backed global and workspace rules.
+	if (scope !== RuleScope.REMOTE) {
+		await setRuleDisabledInFrontmatter(rulePath, enabled)
 	}
 
 	// Track rule toggle telemetry with current task context


### PR DESCRIPTION
### Related Issue

**Issue:** #13717

### Description

The VS Code rule toggle only updated the extension state used by the legacy rule loader. Next sessions load rules through the SDK watcher instead, which reads the `disabled` field from each rule document's YAML frontmatter. As a result, a file-backed rule could remain in the model's system prompt after the user toggled it off.

This change keeps both representations in sync:

- file-backed global and workspace rule toggles now persist `disabled: true` when disabled and remove it when re-enabled;
- the rule and skill paths share one frontmatter transformation, preserving the existing skill behavior;
- malformed frontmatter is left untouched instead of risking document corruption;
- remote rules retain their existing rematerialization path and are not treated as local files.

### Test Procedure

- Added a controller regression test proving a local toggle updates both extension state and the rule file consumed by the SDK.
- Added an on-disk round-trip test for disabling and re-enabling a rule.
- Added frontmatter tests for existing fields, re-enabling, and malformed YAML.
- Ran the complete VS Code unit suite: 75 files, 1,089 tests passed.
- Ran the VS Code TypeScript checks, including the compatibility and webview configurations.
- Ran `bun run build:sdk` successfully.
- Ran `bun run lint`; all 1,233 checked files passed.
- Ran Biome formatting/checks on the changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this fixes how the existing toggle state is consumed by SDK-backed sessions and does not change the UI.

### Additional Notes

The write is best-effort, matching the existing skill-toggle behavior. Extension state remains the source used by legacy sessions, so the change preserves compatibility with both loaders during the migration.

---

**Maintainer note:** also fixes #13695 (same bug, community report from the 4.1.16 combined build). Linear: [CLINE-3120](https://linear.app/cline-bot/issue/CLINE-3120).