### PR TITLE
Add v2 frame schema and v1-to-v2 framer (Phase 1)

### DIFF
--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -457,6 +457,30 @@ Producer validator on. Trace generator derived from the tables;
 property-test: every generated legal v1-input sequence yields legal v2
 output.
 
+**Phase 1 status: implemented.** `@cline/shared` carries
+`stream-frames.ts` (the v2 frame schema and `validateFrameStream` with
+its own violation codes), `agent-event-framer.ts` (the pure v1→v2
+framer), and `v1-trace-generator.ts` (a seeded generator derived from
+the v1 tables). `@cline/core` carries `runtime-frame-adapter.ts`, a
+wrapper over `RuntimeEventAdapter` whose v1 output is asserted identical
+to the plain adapter's (test-locked, `durationMs` normalized — it is
+wall-clock per instance). The property loop — 200 seeds of legal v1
+traces framed and validated — is green, as are the per-wart pins
+(open+close for W2, force-close for W3, notices for recoverable errors,
+one outcome spelling for P6). Schema decisions settled at writing
+time: a v1 *run* is a v2 *turn*; v1 *iterations* become turn-scoped
+notices (`iteration_started`/`iteration_finished` carrying iteration,
+hadToolCalls, toolCallCount); finish reasons map
+completed/max_iterations/mistake_limit → `completed`, `aborted` →
+`interrupted`, `error` → the error outcome (synthesizing the StreamError
+the missing error event would have carried); `bumpEpoch()` is the host's
+conversation fence, called by the host (Phase 3 wiring), never by the
+run; a session-scoped close frame is not emitted by the framer — it is
+a host-level concern (also Phase 3). The first frame consumer (CLI
+port) lands in Phase 2; until then the framer/validator are exercised by
+tests, and the wrapper exists so the producer side of the contract is
+pinned before any consumer ports.
+
 **Phase 2 — assembler + first consumer.** Implement the assembler
 (`@cline/core`). Port the **CLI terminal renderer** first (smallest,
 lowest risk: `apps/cli/src/utils/events.ts`), then ACP. Differential

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -502,6 +502,10 @@ export {
 	type RuntimeOAuthResolution,
 	RuntimeOAuthTokenManager,
 } from "./runtime/orchestration/runtime-oauth-token-manager";
+export {
+	type RuntimeFrameAdapterOptions,
+	RuntimeFrameAdapter,
+} from "./runtime/orchestration/runtime-frame-adapter";
 export type {
 	BuiltRuntime,
 	RuntimeBuilder,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
@@ -5,6 +5,7 @@
  * consumer changes" proof of the migration.
  */
 import type {
+	AgentEvent,
 	AgentMessage,
 	AgentRuntimeEvent,
 	AgentRuntimeStateSnapshot,
@@ -153,11 +154,11 @@ describe("RuntimeFrameAdapter — dual-emit", () => {
 		// durationMs is wall-clock per adapter instance (tool-started to
 		// tool-finished); normalize it so the identity check compares
 		// structure, not sub-millisecond scheduling.
-		const normalize = (event: Record<string, unknown>): Record<string, unknown> => {
+		const normalize = (event: AgentEvent): Record<string, unknown> => {
 			if (event.type === "content_end" && event.contentType === "tool") {
 				return { ...event, durationMs: "normalized" };
 			}
-			return event;
+			return { ...event };
 		};
 
 		const dualEvents = [];
@@ -176,7 +177,7 @@ describe("RuntimeFrameAdapter — dual-emit", () => {
 		);
 		// The normalized field is still a real measured duration.
 		const toolEnd = dualEvents.find(
-			(event) =>
+			(event): event is Extract<AgentEvent, { type: "content_end" }> =>
 				event.type === "content_end" && event.contentType === "tool",
 		);
 		expect(typeof toolEnd?.durationMs).toBe("number");

--- a/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Phase 1 dual-emit guarantee: `RuntimeFrameAdapter`'s v1 output is
+ * byte-identical to the plain `RuntimeEventAdapter`, and its frame
+ * output is legal per `validateFrameStream`. This is the "no existing
+ * consumer changes" proof of the migration.
+ */
+import type {
+	AgentMessage,
+	AgentRuntimeEvent,
+	AgentRuntimeStateSnapshot,
+	AgentToolCallPart,
+	AgentUsage,
+} from "@cline/shared";
+import { validateFrameStream } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { RuntimeEventAdapter } from "./runtime-event-adapter";
+import { RuntimeFrameAdapter } from "./runtime-frame-adapter";
+
+function makeSnapshot(): AgentRuntimeStateSnapshot {
+	return {
+		agentId: "agent_test",
+		runId: "run_test",
+		status: "running",
+		iteration: 1,
+		messages: [],
+		pendingToolCalls: [],
+		usage: {
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			totalCost: 0,
+		},
+	};
+}
+
+function toolCall(toolCallId: string): AgentToolCallPart {
+	return {
+		type: "tool-call",
+		toolCallId,
+		toolName: "read_file",
+		input: { path: "/tmp/x" },
+	};
+}
+
+function usage(overrides: Partial<AgentUsage> = {}): AgentUsage {
+	return {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		totalCost: 0,
+		...overrides,
+	};
+}
+
+function toolResultMessage(toolCallId: string): AgentMessage {
+	return {
+		id: "m_tool",
+		role: "tool",
+		createdAt: 0,
+		content: [
+			{
+				type: "tool-result",
+				toolCallId,
+				toolName: "read_file",
+				output: "ok",
+			},
+		],
+	};
+}
+
+const RUN: readonly AgentRuntimeEvent[] = [
+	{ type: "run-started", snapshot: makeSnapshot() },
+	{ type: "turn-started", snapshot: makeSnapshot(), iteration: 1 },
+	{
+		type: "assistant-text-delta",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		text: "He",
+		accumulatedText: "He",
+	},
+	{
+		type: "assistant-text-delta",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		text: "llo",
+		accumulatedText: "Hello",
+	},
+	{
+		type: "tool-started",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		toolCall: toolCall("call_1"),
+	},
+	{
+		type: "tool-updated",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		toolCall: toolCall("call_1"),
+		update: { p: 1 },
+	},
+	{
+		type: "tool-finished",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		toolCall: toolCall("call_1"),
+		message: toolResultMessage("call_1"),
+	},
+	{
+		type: "assistant-message",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		message: {
+			id: "m",
+			role: "assistant",
+			createdAt: 0,
+			content: [{ type: "text", text: "Hello" }],
+		},
+		finishReason: "stop",
+	},
+	{
+		type: "usage-updated",
+		snapshot: makeSnapshot(),
+		usage: usage({ inputTokens: 10, outputTokens: 5 }),
+	},
+	{
+		type: "turn-finished",
+		snapshot: makeSnapshot(),
+		iteration: 1,
+		toolCallCount: 1,
+	},
+	{
+		type: "run-finished",
+		snapshot: makeSnapshot(),
+		result: {
+			agentId: "agent_test",
+			runId: "run_test",
+			status: "completed",
+			iterations: 1,
+			outputText: "Hello",
+			messages: [],
+			usage: usage({ inputTokens: 10, outputTokens: 5 }),
+		},
+	},
+];
+
+describe("RuntimeFrameAdapter — dual-emit", () => {
+	it("v1 events are identical to the plain adapter; frames are legal", () => {
+		const plain = new RuntimeEventAdapter();
+		const dual = new RuntimeFrameAdapter();
+
+		// durationMs is wall-clock per adapter instance (tool-started to
+		// tool-finished); normalize it so the identity check compares
+		// structure, not sub-millisecond scheduling.
+		const normalize = (event: Record<string, unknown>): Record<string, unknown> => {
+			if (event.type === "content_end" && event.contentType === "tool") {
+				return { ...event, durationMs: "normalized" };
+			}
+			return event;
+		};
+
+		const dualEvents = [];
+		const plainEvents = [];
+		const frames = [];
+		for (const runtimeEvent of RUN) {
+			const { events, frames: f } = dual.translateWithFrames(
+				runtimeEvent,
+			);
+			dualEvents.push(...events);
+			frames.push(...f);
+			plainEvents.push(...plain.translate(runtimeEvent));
+		}
+		expect(dualEvents.map(normalize)).toEqual(
+			plainEvents.map(normalize),
+		);
+		// The normalized field is still a real measured duration.
+		const toolEnd = dualEvents.find(
+			(event) =>
+				event.type === "content_end" && event.contentType === "tool",
+		);
+		expect(typeof toolEnd?.durationMs).toBe("number");
+
+		const validation = validateFrameStream(frames);
+		expect(validation.violations).toEqual([]);
+		expect(validation.openBlocks).toEqual([]);
+		expect(validation.openTurnId).toBeUndefined();
+	});
+
+	it("reset() fences open scopes with interrupted and the next run opens a new turn with continued seq", () => {
+		const dual = new RuntimeFrameAdapter();
+		const allFrames = [];
+
+		// Open a turn and a tool, then fence the run mid-flight.
+		const first = dual.translateWithFrames({
+			type: "turn-started",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+		});
+		allFrames.push(...first.frames);
+		const second = dual.translateWithFrames({
+			type: "tool-started",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+			toolCall: toolCall("call_1"),
+		});
+		allFrames.push(...second.frames);
+
+		const fenced = dual.reset();
+		const fencedCloses = fenced.filter((frame) => frame.kind === "close");
+		expect(fencedCloses).toHaveLength(2); // tool block, then turn
+		expect(
+			fencedCloses.every((close) => close.outcome.kind === "interrupted"),
+		).toBe(true);
+		allFrames.push(...fenced);
+
+		// The next run's events open a fresh turn; no old-turn frames leak.
+		const next = dual.translateWithFrames({
+			type: "turn-started",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+		});
+		const openTurns = next.frames.filter(
+			(frame) => frame.kind === "open" && frame.openKind === "turn",
+		);
+		expect(openTurns).toHaveLength(1);
+		allFrames.push(...next.frames);
+
+		const validation = validateFrameStream(allFrames);
+		expect(validation.violations).toEqual([]);
+		expect(validation.openBlocks).toEqual([]);
+		// The new run is legitimately mid-flight: turn-2 is open, and
+		// turn-1's tool closed during the fence (zero violations proves
+		// the fence close matched its open).
+		expect(validation.openTurnId).toBe("turn-2");
+	});
+});

--- a/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * Dual-emit wrapper for the v1→v2 migration (Phase 1 of the agent event
+ * stream v2 design). Wraps — does not modify — `RuntimeEventAdapter`:
+ * every v1 consumer keeps its byte-identical event stream, and v2
+ * consumers get frames produced from the same adapter output by the
+ * shared `AgentEventFramer`.
+ *
+ * The first frame consumer (the CLI port) lands in Phase 2; this class
+ * exists now so the producer side of the contract is pinned by tests
+ * before any consumer ports.
+ */
+import type { AgentEvent, AgentRuntimeEvent } from "@cline/shared";
+import { AgentEventFramer, type StreamFrame } from "@cline/shared";
+import { RuntimeEventAdapter } from "./runtime-event-adapter";
+
+export interface RuntimeFrameAdapterOptions {
+	/** Passed to the framer; defaults to ["root"]. */
+	agentPath?: string[];
+	/** Passed to the framer; defaults to 0. */
+	startEpoch?: number;
+}
+
+export class RuntimeFrameAdapter extends RuntimeEventAdapter {
+	private readonly framer: AgentEventFramer;
+
+	constructor(options: RuntimeFrameAdapterOptions = {}) {
+		super();
+		this.framer = new AgentEventFramer({
+			...(options.agentPath !== undefined
+				? { agentPath: options.agentPath }
+				: {}),
+			...(options.startEpoch !== undefined
+				? { startEpoch: options.startEpoch }
+				: {}),
+		});
+	}
+
+	/**
+	 * The host's conversation fence (task switch, cancel, reinit).
+	 */
+	bumpEpoch(): void {
+		this.framer.bumpEpoch();
+	}
+
+	/**
+	 * Run boundary. The parent's reset() clears its v1 bookkeeping; the
+	 * framer's open scopes — which can only exist when the host fences a
+	 * run that never reached a v1 terminal — are closed with
+	 * `interrupted` here, and the frames are returned so the host can
+	 * flush them before the next run's events. A host cancel boundary
+	 * should also call bumpEpoch().
+	 */
+	override reset(): StreamFrame[] {
+		super.reset();
+		return this.framer.fence();
+	}
+
+	/**
+	 * Translate one runtime event into both representations. The
+	 * `events` array is exactly what the plain adapter returns — that
+	 * equality is asserted by test, not by convention.
+	 */
+	translateWithFrames(
+		event: AgentRuntimeEvent,
+	): { events: AgentEvent[]; frames: StreamFrame[] } {
+		const events = this.translate(event);
+		return { events, frames: this.frameEvents(events) };
+	}
+
+	/** Frame already-translated v1 events (e.g. replayed history). */
+	frameEvents(events: readonly AgentEvent[]): StreamFrame[] {
+		return this.framer.frameAll(events);
+	}
+}

--- a/sdk/packages/shared/src/agents/agent-event-framer.test.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Phase 1 tests: framer wart-fixes, and the closed property loop —
+ * generateLegalV1Trace → AgentEventFramer → validateFrameStream must
+ * be zero-violation for every seed.
+ */
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "./types";
+import { validateAgentEventStream } from "./stream-grammar";
+import { AgentEventFramer } from "./agent-event-framer";
+import { validateFrameStream, type StreamFrame } from "./stream-frames";
+import { generateLegalV1Trace } from "./v1-trace-generator";
+
+// ---------------------------------------------------------------------------
+// v1 fixtures (same shapes as stream-grammar.test.ts)
+// ---------------------------------------------------------------------------
+
+const iterStart = (iteration = 1): AgentEvent => ({
+	type: "iteration_start",
+	iteration,
+});
+const textStart = (text: string): AgentEvent => ({
+	type: "content_start",
+	contentType: "text",
+	text,
+});
+const textEnd = (text: string): AgentEvent => ({
+	type: "content_end",
+	contentType: "text",
+	text,
+});
+const toolOpen = (toolCallId: string, input: unknown): AgentEvent => ({
+	type: "content_start",
+	contentType: "tool",
+	toolCallId,
+	toolName: "read_file",
+	input,
+});
+const toolUpdate = (toolCallId: string): AgentEvent => ({
+	type: "content_update",
+	contentType: "tool",
+	toolCallId,
+	update: { p: 1 },
+});
+const toolClose = (toolCallId: string, error?: string): AgentEvent => ({
+	type: "content_end",
+	contentType: "tool",
+	toolCallId,
+	toolName: "read_file",
+	output: "ok",
+	...(error !== undefined ? { error } : {}),
+});
+const done = (reason = "completed"): AgentEvent => ({
+	type: "done",
+	reason,
+	text: "ok",
+	iterations: 1,
+});
+const errorEvent = (recoverable: boolean): AgentEvent => ({
+	type: "error",
+	error: new Error("boom"),
+	iteration: 1,
+	recoverable,
+});
+
+const kindsOf = (frames: StreamFrame[]): string[] =>
+	frames.map((frame) =>
+		frame.kind === "open" ? `open:${frame.openKind}` : frame.kind,
+	);
+
+// ---------------------------------------------------------------------------
+// Property loop: v1 tables → framer → v2 tables
+// ---------------------------------------------------------------------------
+
+describe("closed loop: legal v1 trace → frames → zero violations", () => {
+	it("holds for 200 deterministic seeds", () => {
+		for (let seed = 1; seed <= 200; seed += 1) {
+			const trace = generateLegalV1Trace(seed, { maxEvents: 60 });
+			const v1 = validateAgentEventStream(trace);
+			expect(v1.violations).toEqual([]);
+
+			const framer = new AgentEventFramer();
+			const frames = framer.frameAll(trace);
+			const v2 = validateFrameStream(frames);
+			expect(
+				v2.violations,
+				`seed ${seed} framed with violations`,
+			).toEqual([]);
+			expect(v2.openBlocks).toEqual([]);
+			expect(v2.openTurnId).toBeUndefined();
+		}
+	});
+
+	it("seq increases by exactly one per frame across the stream", () => {
+		for (let seed = 1; seed <= 50; seed += 1) {
+			const frames = new AgentEventFramer().frameAll(
+				generateLegalV1Trace(seed, { maxEvents: 60 }),
+			);
+			for (let i = 1; i < frames.length; i += 1) {
+				expect(frames[i].seq).toBe(frames[i - 1].seq + 1);
+			}
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Framer wart-fixes
+// ---------------------------------------------------------------------------
+
+describe("framer wart-fixes", () => {
+	it("W1: text deltas frame as one open plus deltas, then a close with the final", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			textStart("He"),
+			textStart("llo"),
+			textEnd("Hello"),
+			done(),
+		]);
+		expect(kindsOf(frames)).toEqual([
+			"open:turn",
+			"notice",
+			"open:text",
+			"delta",
+			"delta",
+			"close",
+			"close",
+		]);
+		const close = frames[5];
+		if (close.kind !== "close") {
+			throw new Error("expected close");
+		}
+		expect(close.final).toEqual({ type: "text", text: "Hello" });
+	});
+
+	it("W2: a final with no deltas frames as open+close, never close-without-open", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			textEnd("done"),
+			done(),
+		]);
+		expect(validateFrameStream(frames).violations).toEqual([]);
+		expect(kindsOf(frames)).toEqual([
+			"open:turn",
+			"notice",
+			"open:text",
+			"close",
+			"close",
+		]);
+	});
+
+	it("W3 + P3: terminal mid-tool force-closes with interrupted, and close carries the open's input", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			toolOpen("call_1", { path: "/tmp/x" }),
+			errorEvent(false),
+		]);
+		const toolClose = frames.find(
+			(frame) => frame.kind === "close" && frame.scope.blockId === "call_1",
+		);
+		if (toolClose === undefined || toolClose.kind !== "close") {
+			throw new Error("expected tool close");
+		}
+		expect(toolClose.outcome).toEqual({ kind: "interrupted" });
+		expect(toolClose.final).toEqual({
+			type: "tool",
+			input: { path: "/tmp/x" },
+		});
+		const turnClose = frames[frames.length - 1];
+		if (turnClose.kind !== "close") {
+			throw new Error("expected turn close");
+		}
+		expect(turnClose.outcome).toMatchObject({ kind: "error" });
+		expect(validateFrameStream(frames).violations).toEqual([]);
+	});
+
+	it("W4: a recoverable error is a notice and the turn closes exactly once", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			errorEvent(true),
+			textStart("still going"),
+			textEnd("recovered"),
+			done(),
+		]);
+		const closes = frames.filter(
+			(frame) => frame.kind === "close" && frame.scope.blockId === undefined,
+		);
+		expect(closes).toHaveLength(1);
+		expect(
+			frames.some(
+				(frame) => frame.kind === "notice" && frame.noticeType === "recovery",
+			),
+		).toBe(true);
+	});
+
+	it("P6: done(reason:'error') without an error event frames as the error outcome", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			textEnd("partial"),
+			done("error"),
+		]);
+		const turnClose = frames[frames.length - 1];
+		if (turnClose.kind !== "close") {
+			throw new Error("expected turn close");
+		}
+		expect(turnClose.outcome).toEqual({
+			kind: "error",
+			error: { code: "run_failed", message: "ok" },
+		});
+	});
+
+	it("aborted maps to interrupted; max_iterations maps to completed", () => {
+		const aborted = new AgentEventFramer().frameAll([
+			iterStart(1),
+			done("aborted"),
+		]);
+		let close = aborted[aborted.length - 1];
+		if (close.kind !== "close") {
+			throw new Error("expected close");
+		}
+		expect(close.outcome).toEqual({ kind: "interrupted" });
+
+		const capped = new AgentEventFramer().frameAll([
+			iterStart(1),
+			done("max_iterations"),
+		]);
+		close = capped[capped.length - 1];
+		if (close.kind !== "close") {
+			throw new Error("expected close");
+		}
+		expect(close.outcome).toEqual({ kind: "completed" });
+	});
+
+	it("epoch changes only via bumpEpoch; seq continues across turns", () => {
+		const framer = new AgentEventFramer();
+		const first = framer.frameAll([iterStart(1), done()]);
+		framer.bumpEpoch();
+		const second = framer.frameAll([iterStart(1), done()]);
+		expect(first.every((frame) => frame.epoch === 0)).toBe(true);
+		expect(second.every((frame) => frame.epoch === 1)).toBe(true);
+		expect(second[0].seq).toBe(first[first.length - 1].seq + 1);
+		expect(second[0].kind).toBe("open");
+	});
+
+	it("a tool error frames the error outcome on the block close", () => {
+		const frames = new AgentEventFramer().frameAll([
+			iterStart(1),
+			toolOpen("call_1", {}),
+			toolUpdate("call_1"),
+			toolClose("call_1", "boom"),
+			done(),
+		]);
+		const toolCloseFrame = frames.find(
+			(frame) => frame.kind === "close" && frame.scope.blockId === "call_1",
+		);
+		if (toolCloseFrame === undefined || toolCloseFrame.kind !== "close") {
+			throw new Error("expected tool close");
+		}
+		expect(toolCloseFrame.outcome).toEqual({
+			kind: "error",
+			error: { code: "tool_error", message: "boom" },
+		});
+	});
+});

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -1,0 +1,563 @@
+/**
+ * AgentEvent → v2 Frame framer. Phase 1 of the agent event stream v2
+ * design (`agent-event-stream-design.md`).
+ *
+ * The framer is the producer-side instance of the v2 tables: its state
+ * is exactly the v1 tables' state (open iteration, open tools, current
+ * text/reasoning), and its output is validated by `validateFrameStream`
+ * derived from the v2 tables. It fixes the warts by construction:
+ *
+ * - W1: text/reasoning `content_start`-per-delta becomes one `open` plus
+ *   `delta`s (start means start).
+ * - W2: `content_end` with no prior deltas becomes open+close — never a
+ *   close without an open.
+ * - W3: at the turn terminal, dangling blocks are force-closed with
+ *   `interrupted` before the turn close.
+ * - W4/P6: the terminal has one spelling — a single turn close whose
+ *   outcome says what happened; recoverable errors are notices.
+ * - P3: tool close carries the input captured at open.
+ *
+ * Scope mapping (design: "decide at schema writing"): a v1 *run* is a
+ * v2 *turn* (the unit the design's turn-end semantics describe); v1
+ * *iterations* become turn-scoped notices carrying their metadata
+ * (consumers used iteration boundaries as stream-reset bookkeeping,
+ * which block closes make unnecessary). A session-level close frame is
+ * not emitted here — it is a host-level concern wired in Phase 3.
+ *
+ * `seq` is monotonic for the framer's lifetime and survives turns, so
+ * resume can request "everything after seq N". `epoch` changes only
+ * via `bumpEpoch()` — the host's conversation fence (task switch,
+ * cancel, reinit), never the run itself.
+ */
+import type { AgentEvent, AgentFinishReason } from "./types";
+import {
+	FRAME_SCHEMA_VERSION,
+	type FrameBody,
+	type StreamError,
+	type StreamFrame,
+	type Outcome,
+} from "./stream-frames";
+
+export interface AgentEventFramerOptions {
+	/** Root agent first, owning agent last. Defaults to ["root"]. */
+	agentPath?: string[];
+	/** Starting epoch. Defaults to 0; use `bumpEpoch()` thereafter. */
+	startEpoch?: number;
+}
+
+interface OpenTool {
+	input: unknown;
+}
+
+export class AgentEventFramer {
+	private readonly agentPath: string[];
+	private epoch: number;
+	private seq = 0;
+	private turnCounter = 0;
+	private blockCounter = 0;
+	private currentTurnId: string | undefined;
+	private currentTextBlock: string | undefined;
+	private currentReasoningBlock: string | undefined;
+	private readonly openTools = new Map<string, OpenTool>();
+
+	constructor(options: AgentEventFramerOptions = {}) {
+		this.agentPath = options.agentPath ?? ["root"];
+		this.epoch = options.startEpoch ?? 0;
+	}
+
+	/** Host's conversation fence: task switch, cancel, reinit. */
+	bumpEpoch(): void {
+		this.epoch += 1;
+	}
+
+	/** Frames emitted so far (resumable-after-N cursor). */
+	get lastSeq(): number {
+		return this.seq;
+	}
+
+	/** Frame a single v1 event into zero or more v2 frames. */
+	frameEvent(event: AgentEvent): StreamFrame[] {
+		const out: StreamFrame[] = [];
+		switch (event.type) {
+			case "iteration_start": {
+				const turnId = this.ensureTurn(out);
+				this.emit(out, this.turnScope(turnId), {
+					kind: "notice",
+					noticeType: "iteration_started",
+					iteration: event.iteration,
+				});
+				break;
+			}
+			case "iteration_end": {
+				const turnId = this.ensureTurn(out);
+				this.emit(out, this.turnScope(turnId), {
+					kind: "notice",
+					noticeType: "iteration_finished",
+					iteration: event.iteration,
+					hadToolCalls: event.hadToolCalls,
+					toolCallCount: event.toolCallCount,
+				});
+				break;
+			}
+			case "content_start": {
+				const turnId = this.ensureTurn(out);
+				if (event.contentType === "text") {
+					if (this.currentTextBlock === undefined) {
+						this.currentTextBlock = this.nextBlockId();
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentTextBlock),
+							{
+								kind: "open",
+								openKind: "text",
+								start: { blockId: this.currentTextBlock },
+							},
+						);
+					}
+					if (event.text !== undefined && event.text !== "") {
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentTextBlock),
+							{
+								kind: "delta",
+								payload: { type: "text", text: event.text },
+							},
+						);
+					}
+					break;
+				}
+				if (event.contentType === "reasoning") {
+					if (this.currentReasoningBlock === undefined) {
+						this.currentReasoningBlock = this.nextBlockId();
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentReasoningBlock),
+							{
+								kind: "open",
+								openKind: "reasoning",
+								start: {
+									blockId: this.currentReasoningBlock,
+									redacted: event.redacted === true,
+								},
+							},
+						);
+					}
+					if (event.reasoning !== undefined && event.reasoning !== "") {
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentReasoningBlock),
+							{
+								kind: "delta",
+								payload: {
+									type: "reasoning",
+									reasoning: event.reasoning,
+								},
+							},
+						);
+					}
+					break;
+				}
+				if (event.contentType === "tool") {
+					const blockId =
+						event.toolCallId === undefined
+							? this.nextBlockId()
+							: event.toolCallId;
+					// A missing toolCallId is v1-illegal (the v1 validator
+					// flags it); we still frame it deterministically, and
+					// the v2 tables flag the result.
+					this.openTools.set(blockId, { input: event.input });
+					this.emit(out, this.blockScope(turnId, blockId), {
+						kind: "open",
+						openKind: "tool",
+						start: {
+							blockId,
+							toolName: event.toolName ?? "unknown",
+							input: event.input,
+							...(event.execution !== undefined
+								? { execution: event.execution }
+								: {}),
+						},
+					});
+					break;
+				}
+				// media: the v1 adapter never emits a media content_start.
+				break;
+			}
+			case "content_update": {
+				const turnId = this.ensureTurn(out);
+				const blockId = event.toolCallId ?? this.nextBlockId();
+				this.emit(out, this.blockScope(turnId, blockId), {
+					kind: "delta",
+					payload: { type: "tool", update: event.update },
+				});
+				break;
+			}
+			case "content_end": {
+				const turnId = this.ensureTurn(out);
+				if (event.contentType === "tool") {
+					const blockId =
+						event.toolCallId === undefined
+							? this.nextBlockId()
+							: event.toolCallId;
+					const tool = this.openTools.get(blockId);
+					this.openTools.delete(blockId);
+					this.emit(out, this.blockScope(turnId, blockId), {
+						kind: "close",
+						outcome: event.error
+							? {
+									kind: "error",
+									error: {
+										code: "tool_error",
+										message: event.error,
+									},
+								}
+							: { kind: "completed" },
+						final: {
+							type: "tool",
+							input: tool?.input,
+							...(event.output !== undefined
+								? { output: event.output }
+								: {}),
+							...(event.durationMs !== undefined
+								? { durationMs: event.durationMs }
+								: {}),
+						},
+					});
+					break;
+				}
+				if (event.contentType === "text") {
+					// W2 fix: a final with no streamed deltas frames as
+					// open+close, never a close without an open.
+					if (this.currentTextBlock === undefined) {
+						this.currentTextBlock = this.nextBlockId();
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentTextBlock),
+							{
+								kind: "open",
+								openKind: "text",
+								start: { blockId: this.currentTextBlock },
+							},
+						);
+					}
+					this.emit(
+						out,
+						this.blockScope(turnId, this.currentTextBlock),
+						{
+							kind: "close",
+							outcome: { kind: "completed" },
+							final: { type: "text", text: event.text ?? "" },
+						},
+					);
+					this.currentTextBlock = undefined;
+					break;
+				}
+				if (event.contentType === "reasoning") {
+					if (this.currentReasoningBlock === undefined) {
+						this.currentReasoningBlock = this.nextBlockId();
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentReasoningBlock),
+							{
+								kind: "open",
+								openKind: "reasoning",
+								start: {
+									blockId: this.currentReasoningBlock,
+									// redacted lives on the deltas, not the final;
+									// a synthesized open defaults false.
+									redacted: false,
+								},
+							},
+						);
+					}
+					this.emit(
+						out,
+						this.blockScope(turnId, this.currentReasoningBlock),
+						{
+							kind: "close",
+							outcome: { kind: "completed" },
+							final: {
+								type: "reasoning",
+								reasoning: event.reasoning ?? "",
+							},
+						},
+					);
+					this.currentReasoningBlock = undefined;
+					break;
+				}
+				if (event.contentType === "media") {
+					// Media arrives whole: open + close, no deltas.
+					const blockId = this.nextBlockId();
+					this.emit(out, this.blockScope(turnId, blockId), {
+						kind: "open",
+						openKind: "media",
+						start: { blockId },
+					});
+					this.emit(out, this.blockScope(turnId, blockId), {
+						kind: "close",
+						outcome: { kind: "completed" },
+						...(event.media !== undefined
+							? { final: { type: "media", media: event.media } }
+							: {}),
+					});
+					break;
+				}
+				break;
+			}
+			case "notice": {
+				const turnId = this.ensureTurn(out);
+				this.emit(out, this.turnScope(turnId), {
+					kind: "notice",
+					noticeType: event.noticeType,
+					message: event.message,
+					...(event.displayRole !== undefined
+						? { displayRole: event.displayRole }
+						: {}),
+					...(event.reason !== undefined ? { reason: event.reason } : {}),
+				});
+				break;
+			}
+			case "usage": {
+				const turnId = this.ensureTurn(out);
+				this.emit(out, this.turnScope(turnId), {
+					kind: "usage",
+					inputTokens: event.inputTokens,
+					outputTokens: event.outputTokens,
+					...(event.cacheReadTokens !== undefined
+						? { cacheReadTokens: event.cacheReadTokens }
+						: {}),
+					...(event.cacheWriteTokens !== undefined
+						? { cacheWriteTokens: event.cacheWriteTokens }
+						: {}),
+					...(event.cost !== undefined ? { cost: event.cost } : {}),
+					totalInputTokens: event.totalInputTokens,
+					totalOutputTokens: event.totalOutputTokens,
+					...(event.totalCacheReadTokens !== undefined
+						? { totalCacheReadTokens: event.totalCacheReadTokens }
+						: {}),
+					...(event.totalCacheWriteTokens !== undefined
+						? { totalCacheWriteTokens: event.totalCacheWriteTokens }
+						: {}),
+					...(event.totalCost !== undefined
+						? { totalCost: event.totalCost }
+						: {}),
+				});
+				break;
+			}
+			case "error": {
+				if (event.recoverable) {
+					// W4/P6 fix: in-run errors are notices, not terminals.
+					const turnId = this.ensureTurn(out);
+					this.emit(out, this.turnScope(turnId), {
+						kind: "notice",
+						noticeType: "recovery",
+						message: toStreamErrorMessage(event.error),
+					});
+					break;
+				}
+				this.closeTurn(out, {
+					kind: "error",
+					error: toStreamError(event.error, event.errorClass),
+				});
+				break;
+			}
+			case "done": {
+				this.closeTurn(out, finishReasonToOutcome(event));
+				break;
+			}
+			default: {
+				const _exhaustive: never = event;
+				void _exhaustive;
+			}
+		}
+		return out;
+	}
+
+	/** Frame a sequence of v1 events. */
+	frameAll(events: readonly AgentEvent[]): StreamFrame[] {
+		const out: StreamFrame[] = [];
+		for (const event of events) {
+			out.push(...this.frameEvent(event));
+		}
+		return out;
+	}
+
+	/**
+	 * Close any open scopes without a v1 terminal event — the run was
+	 * fenced by the host (crash recovery, reinit), not ended by the
+	 * agent. Children close with `interrupted`, the turn closes with
+	 * `interrupted`. Emits nothing when the stream is already clean.
+	 * Does NOT bump the epoch: that is the host's conversation-fence
+	 * decision (see bumpEpoch).
+	 */
+	fence(): StreamFrame[] {
+		const out: StreamFrame[] = [];
+		if (this.currentTurnId === undefined) {
+			return out;
+		}
+		this.closeTurn(out, { kind: "interrupted" });
+		return out;
+	}
+
+	// -------------------------------------------------------------------------
+	// Scope helpers
+	// -------------------------------------------------------------------------
+
+	private turnScope(turnId: string): StreamFrame["scope"] {
+		return { agentPath: this.agentPath, turnId };
+	}
+
+	private blockScope(
+		turnId: string,
+		blockId: string,
+	): StreamFrame["scope"] {
+		return { agentPath: this.agentPath, turnId, blockId };
+	}
+
+	private emit(
+		out: StreamFrame[],
+		scope: StreamFrame["scope"],
+		body: FrameBody,
+	): void {
+		this.seq += 1;
+		const frame: StreamFrame = {
+			v: FRAME_SCHEMA_VERSION,
+			epoch: this.epoch,
+			seq: this.seq,
+			scope,
+			...body,
+		};
+		out.push(frame);
+	}
+
+	/** Lazily open the turn at the first turn-scoped event of a run. */
+	private ensureTurn(out: StreamFrame[]): string {
+		if (this.currentTurnId === undefined) {
+			this.turnCounter += 1;
+			this.currentTurnId = `turn-${this.turnCounter}`;
+			this.emit(out, this.turnScope(this.currentTurnId), {
+				kind: "open",
+				openKind: "turn",
+				start: { turnId: this.currentTurnId },
+			});
+		}
+		return this.currentTurnId;
+	}
+
+	private nextBlockId(): string {
+		this.blockCounter += 1;
+		return `blk-${this.blockCounter}`;
+	}
+
+	/** Close every open block with `interrupted` (W3: force-close). */
+	private forceCloseChildren(out: StreamFrame[]): void {
+		if (this.currentTurnId === undefined) {
+			return;
+		}
+		if (this.currentTextBlock !== undefined) {
+			this.emit(
+				out,
+				this.blockScope(this.currentTurnId, this.currentTextBlock),
+				{ kind: "close", outcome: { kind: "interrupted" } },
+			);
+			this.currentTextBlock = undefined;
+		}
+		if (this.currentReasoningBlock !== undefined) {
+			this.emit(
+				out,
+				this.blockScope(this.currentTurnId, this.currentReasoningBlock),
+				{ kind: "close", outcome: { kind: "interrupted" } },
+			);
+			this.currentReasoningBlock = undefined;
+		}
+		for (const [toolCallId, tool] of this.openTools) {
+			this.emit(
+				out,
+				this.blockScope(this.currentTurnId, toolCallId),
+				{
+					kind: "close",
+					outcome: { kind: "interrupted" },
+					final: { type: "tool", input: tool.input },
+				},
+			);
+			this.openTools.delete(toolCallId);
+		}
+	}
+
+	/** One spelling of turn end (W4/P6): children first, then the close. */
+	private closeTurn(out: StreamFrame[], outcome: Outcome): void {
+		const turnId = this.ensureTurn(out);
+		this.forceCloseChildren(out);
+		this.emit(out, this.turnScope(turnId), {
+			kind: "close",
+			outcome,
+		});
+		this.currentTurnId = undefined;
+	}
+}
+
+// =============================================================================
+// v1 → v2 mappers (module scope: pure, no framer state)
+// =============================================================================
+
+/**
+ * P7 fix: the structured, serializable error shape. `details` would keep
+ * structured provider payloads when the Error carries them (the VSCode
+ * translator currently reconstructs these by string parsing).
+ */
+function toStreamError(
+	error: unknown,
+	providerErrorClass?: string,
+): StreamError {
+	if (error instanceof Error) {
+		return {
+			code: error.name || "Error",
+			message: error.message,
+			...(providerErrorClass !== undefined ? { providerErrorClass } : {}),
+		};
+	}
+	return {
+		code: "Error",
+		message: String(error),
+		...(providerErrorClass !== undefined ? { providerErrorClass } : {}),
+	};
+}
+
+function toStreamErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Finish reasons map onto the one Outcome spelling (design: Frame kinds).
+ * `max_iterations` and `mistake_limit` are legitimate run completions;
+ * `aborted` (user cancel) is `interrupted`; `error` is the error outcome
+ * (v1's done(reason:"error")-without-an-error-event case synthesizes
+ * the StreamError the missing event would have carried).
+ */
+function finishReasonToOutcome(
+	event: Extract<AgentEvent, { type: "done" }>,
+): Outcome {
+	const reason: AgentFinishReason = event.reason;
+	switch (reason) {
+		case "completed":
+		case "max_iterations":
+		case "mistake_limit":
+			return { kind: "completed" };
+		case "aborted":
+			return { kind: "interrupted" };
+		case "error":
+			return {
+				kind: "error",
+				error: {
+					code: "run_failed",
+					message: event.text || "Run failed",
+				},
+			};
+		default: {
+			const _exhaustive: never = reason;
+			void _exhaustive;
+			return { kind: "completed" };
+		}
+	}
+}
+

--- a/sdk/packages/shared/src/agents/index.ts
+++ b/sdk/packages/shared/src/agents/index.ts
@@ -1,2 +1,5 @@
 export * from "./types";
 export * from "./stream-grammar";
+export * from "./stream-frames";
+export * from "./agent-event-framer";
+export * from "./v1-trace-generator";

--- a/sdk/packages/shared/src/agents/stream-frames.test.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the v2 frame tables (`validateFrameStream`). The
+ * framer-level loop tests live in agent-event-framer.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	FRAME_SCHEMA_VERSION,
+	SEQ_NOT_INCREASING,
+	TURN_CLOSE_WITH_OPEN_CHILDREN,
+	TURN_CLOSE_WITHOUT_OPEN,
+	TURN_OVERLAP,
+	BLOCK_CLOSE_WITHOUT_OPEN,
+	validateFrameStream,
+	type StreamFrame,
+} from "./stream-frames";
+
+const base = { v: FRAME_SCHEMA_VERSION, epoch: 0 } as const;
+let seq = 0;
+const frame = (body: Record<string, unknown>, scope: Record<string, unknown> = {}): StreamFrame =>
+	({
+		...base,
+		seq: (seq += 1),
+		scope: { agentPath: ["root"], ...scope },
+		...body,
+	}) as StreamFrame;
+
+const openTurn = (): StreamFrame =>
+	frame({ kind: "open", openKind: "turn", start: { turnId: "turn-1" } }, { turnId: "turn-1" });
+const closeTurn = (turnId = "turn-1"): StreamFrame =>
+	frame({ kind: "close", outcome: { kind: "completed" } }, { turnId });
+
+describe("v2 frame tables", () => {
+	it("accepts a minimal legal stream", () => {
+		const result = validateFrameStream([openTurn(), closeTurn()]);
+		expect(result.violations).toEqual([]);
+		expect(result.openBlocks).toEqual([]);
+	});
+
+	it("flags overlapping turns, double close, and seq regression", () => {
+		const overlap = validateFrameStream([openTurn(), openTurn()]);
+		expect(overlap.violations[0]?.code).toBe(TURN_OVERLAP);
+
+		const doubleClose = validateFrameStream([
+			openTurn(),
+			closeTurn(),
+			closeTurn(),
+		]);
+		expect(doubleClose.violations[0]?.code).toBe(TURN_CLOSE_WITHOUT_OPEN);
+
+		seq = 0;
+		const regressed = validateFrameStream([
+			openTurn(),
+			{ ...openTurn(), seq: 1 },
+		]);
+		expect(
+			regressed.violations.some((v) => v.code === SEQ_NOT_INCREASING),
+		).toBe(true);
+	});
+
+	it("flags a turn close with an open child, and a block close without open", () => {
+		const withChild = validateFrameStream([
+			openTurn(),
+			frame(
+				{ kind: "open", openKind: "text", start: { blockId: "b1" } },
+				{ turnId: "turn-1", blockId: "b1" },
+			),
+			closeTurn(),
+		]);
+		expect(withChild.violations[0]?.code).toBe(
+			TURN_CLOSE_WITH_OPEN_CHILDREN,
+		);
+		expect(withChild.openBlocks).toEqual(["b1"]);
+
+		const orphanClose = validateFrameStream([
+			openTurn(),
+			frame({ kind: "close", outcome: { kind: "completed" } }, {
+				turnId: "turn-1",
+				blockId: "ghost",
+			}),
+		]);
+		expect(orphanClose.violations[0]?.code).toBe(BLOCK_CLOSE_WITHOUT_OPEN);
+	});
+});

--- a/sdk/packages/shared/src/agents/stream-frames.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.ts
@@ -1,0 +1,441 @@
+/**
+ * v2 frame schema — the wire representation of the agent event stream.
+ *
+ * Design: `@cline/core/docs/agent-event-stream-design.md`. A frame is a
+ * scoped, sequenced lifecycle/payload datum: every frame names exactly
+ * one scope (session, turn, or block), and the per-scope projections of
+ * a frame stream each form a small regular language (see
+ * `validateFrameStream`).
+ *
+ * `epoch` is the conversation/replica fence (task switch, cancel,
+ * reinit) — bumped by the host via the framer's `bumpEpoch()`, never by
+ * the run itself. `seq` is monotonic per producer stream and survives
+ * runs, so reconnect/resume can request "everything after seq N".
+ */
+export const FRAME_SCHEMA_VERSION = 2;
+
+// =============================================================================
+// Scope address
+// =============================================================================
+
+export interface FrameScope {
+	/** Root agent first, owning agent last (e.g. ["root", "agent-3f"]). */
+	agentPath: string[];
+	/** Present on turn- and block-scoped frames. */
+	turnId?: string;
+	/** Present on block-scoped frames. For tools this is the toolCallId. */
+	blockId?: string;
+}
+
+// =============================================================================
+// Errors and outcomes
+// =============================================================================
+
+/**
+ * Structured, serializable error (design P7). Replaces the JS `Error`
+ * that `AgentErrorEvent` carries, which cannot cross a wire and which
+ * every serializing boundary currently flattens differently.
+ */
+export interface StreamError {
+	code: string;
+	message: string;
+	/** Provider error classification when known (AgentErrorEvent.errorClass). */
+	providerErrorClass?: string;
+	/** Structured provider details when available (e.g. a JSON error body). */
+	details?: unknown;
+}
+
+/** Handle to out-of-stream work (design: scope tree, "detach"). */
+export interface ResourceRef {
+	/** What kind of thing survives the scope (a log file, a runId). */
+	kind: "file" | "run";
+	/** Where to find it: a path, an id in another subsystem. */
+	ref: string;
+}
+
+export type Outcome =
+	| { kind: "completed" }
+	| { kind: "error"; error: StreamError }
+	| { kind: "interrupted" }
+	| { kind: "detached"; resource: ResourceRef };
+
+// =============================================================================
+// Frame bodies (discriminated on `kind`)
+// =============================================================================
+
+export interface TurnStart {
+	turnId: string;
+}
+
+export interface TextStart {
+	blockId: string;
+}
+
+export interface ReasoningStart {
+	blockId: string;
+	/** Whether this block's reasoning is redacted (from content_start). */
+	redacted: boolean;
+}
+
+export interface ToolStart {
+	blockId: string;
+	toolName: string;
+	input: unknown;
+	/** Where a model tool is executed; absent for ordinary local tools. */
+	execution?: "client" | "provider";
+}
+
+export interface MediaStart {
+	blockId: string;
+}
+
+export type OpenBody =
+	| { kind: "open"; openKind: "turn"; start: TurnStart }
+	| { kind: "open"; openKind: "text"; start: TextStart }
+	| { kind: "open"; openKind: "reasoning"; start: ReasoningStart }
+	| { kind: "open"; openKind: "tool"; start: ToolStart }
+	| { kind: "open"; openKind: "media"; start: MediaStart };
+
+export type DeltaBody =
+	| { kind: "delta"; payload: { type: "text"; text: string } }
+	| { kind: "delta"; payload: { type: "reasoning"; reasoning: string } }
+	| { kind: "delta"; payload: { type: "tool"; update: unknown } };
+
+/**
+ * Authoritative final content. Always carries the open's data for tools
+ * (input), so consumers never carry state from open to close (design P3).
+ * Absent on turn closes, which carry only the outcome.
+ */
+export type CloseFinal =
+	| { type: "text"; text: string }
+	| { type: "reasoning"; reasoning: string }
+	| { type: "tool"; input: unknown; output?: unknown; error?: StreamError; durationMs?: number }
+	| { type: "media"; media: unknown };
+
+export interface CloseBody {
+	kind: "close";
+	outcome: Outcome;
+	final?: CloseFinal;
+}
+
+/** Turn-scoped notices: recovery, status, and the v1 iteration markers. */
+export interface NoticeBody {
+	kind: "notice";
+	noticeType:
+		| "recovery"
+		| "stop"
+		| "status"
+		| "iteration_started"
+		| "iteration_finished";
+	/** Iteration number for the iteration_* markers. */
+	iteration?: number;
+	hadToolCalls?: boolean;
+	toolCallCount?: number;
+	message?: string;
+	displayRole?: "system" | "status";
+	reason?: string;
+}
+
+export interface UsageBody {
+	kind: "usage";
+	/** Delta usage for the turn so far (v1 `usage` event fields). */
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+	cost?: number;
+	totalInputTokens: number;
+	totalOutputTokens: number;
+	totalCacheReadTokens?: number;
+	totalCacheWriteTokens?: number;
+	totalCost?: number;
+}
+
+/**
+ * Namespaced, typed data attached to a scope by a non-agent producer
+ * (approval coordinator, checkpoint tracker). Closed union at schema
+ * level; unknown namespaces decode as `{ ns: "unknown", raw }`.
+ * Emitted from Phase 2+; declared here so the wire contract is total.
+ */
+export type AnnotationBody =
+	| { kind: "annotation"; ns: "approval"; body: Record<string, unknown> }
+	| { kind: "annotation"; ns: "checkpoint"; body: Record<string, unknown> }
+	| { kind: "annotation"; ns: "hook"; body: Record<string, unknown> }
+	| { kind: "annotation"; ns: "unknown"; raw: unknown };
+
+/** Session-scoped list of open scopes, sent on attach/reconnect. Phase 2+. */
+export interface SnapshotBody {
+	kind: "snapshot";
+	openScopes: Array<{
+		scope: FrameScope;
+		openKind: "turn" | "text" | "reasoning" | "tool" | "media" | "agent" | "run";
+		start: unknown;
+	}>;
+}
+
+export type FrameBody =
+	| OpenBody
+	| DeltaBody
+	| CloseBody
+	| NoticeBody
+	| UsageBody
+	| AnnotationBody
+	| SnapshotBody;
+
+// =============================================================================
+// Envelope + frame
+// =============================================================================
+
+export interface FrameEnvelope {
+	v: typeof FRAME_SCHEMA_VERSION;
+	epoch: number;
+	seq: number;
+	scope: FrameScope;
+}
+
+export type StreamFrame = FrameEnvelope & FrameBody;
+
+// =============================================================================
+// Validator — per-scope projections of a frame stream
+// =============================================================================
+
+/** Frame seq must strictly increase; the stream is resumable after seq N. */
+export const SEQ_NOT_INCREASING = "seq-not-increasing";
+/** Epoch may not decrease within one stream. */
+export const EPOCH_REGRESSION = "epoch-regression";
+/** Wrong schema version. */
+export const BAD_VERSION = "bad-version";
+/** open(turn) while another turn is open. */
+export const TURN_OVERLAP = "turn-overlap";
+/** close(turn) with no matching open turn (also covers the double close). */
+export const TURN_CLOSE_WITHOUT_OPEN = "turn-close-without-open";
+/** close(turn) while child blocks of the turn are still open. */
+export const TURN_CLOSE_WITH_OPEN_CHILDREN = "turn-close-with-open-children";
+/** A block frame addressed to a turn that is not open. */
+export const BLOCK_WITHOUT_TURN = "block-without-turn";
+/** open(block) for a blockId that is already open. */
+export const BLOCK_OPEN_WHILE_OPEN = "block-open-while-open";
+/** delta for a blockId that is not open. */
+export const BLOCK_DELTA_WITHOUT_OPEN = "block-delta-without-open";
+/** close(block) for a blockId that is not open. */
+export const BLOCK_CLOSE_WITHOUT_OPEN = "block-close-without-open";
+/** Turn-scoped notice/usage with no open turn at that address. */
+export const TURN_FRAME_WITHOUT_TURN = "turn-frame-without-turn";
+/** Any frame after the session close. */
+export const AFTER_SESSION_END = "after-session-end";
+/** Annotation addressed to a scope never seen in this stream. */
+export const ANNOTATION_UNKNOWN_SCOPE = "annotation-unknown-scope";
+/** Address does not match the frame kind (missing turnId/blockId). */
+export const BAD_SCOPE_ADDRESS = "bad-scope-address";
+
+export type FrameViolationCode =
+	| typeof SEQ_NOT_INCREASING
+	| typeof EPOCH_REGRESSION
+	| typeof BAD_VERSION
+	| typeof TURN_OVERLAP
+	| typeof TURN_CLOSE_WITHOUT_OPEN
+	| typeof TURN_CLOSE_WITH_OPEN_CHILDREN
+	| typeof BLOCK_WITHOUT_TURN
+	| typeof BLOCK_OPEN_WHILE_OPEN
+	| typeof BLOCK_DELTA_WITHOUT_OPEN
+	| typeof BLOCK_CLOSE_WITHOUT_OPEN
+	| typeof TURN_FRAME_WITHOUT_TURN
+	| typeof AFTER_SESSION_END
+	| typeof ANNOTATION_UNKNOWN_SCOPE
+	| typeof BAD_SCOPE_ADDRESS;
+
+export interface FrameViolation {
+	code: FrameViolationCode;
+	/** Index of the offending frame in the input. */
+	index: number;
+	/** Discriminant of the offending frame. */
+	kind: StreamFrame["kind"];
+	detail?: string;
+}
+
+export interface FrameValidationResult {
+	violations: FrameViolation[];
+	/** Blocks still open (empty for a well-formed terminated stream). */
+	openBlocks: string[];
+	openTurnId?: string;
+	/** True when a session-scoped close frame was seen. */
+	sessionEnded: boolean;
+	frameCount: number;
+}
+
+/**
+ * Validate a frame stream against the v2 tables.
+ *
+ * Like the v1 validator (`stream-grammar.ts`), this is a fold over
+ * per-scope projections: every frame names exactly one scope, and each
+ * scope's projection is a small regular language. A prefix is legal;
+ * `openBlocks`/`openTurnId` report dangling scopes for debugging and
+ * for reconnect snapshots. There is no wart registry in v2 — warts were
+ * v1's structural deviations, and v2 makes them unrepresentable.
+ */
+export function validateFrameStream(
+	frames: readonly StreamFrame[],
+): FrameValidationResult {
+	const violations: FrameViolation[] = [];
+	const violation = (
+		index: number,
+		frame: StreamFrame,
+		code: FrameViolationCode,
+		detail?: string,
+	): void => {
+		violations.push({ code, index, kind: frame.kind, detail });
+	};
+
+	let lastSeq = 0;
+	let lastEpoch = 0;
+	let sessionEnded = false;
+	let openTurnId: string | undefined;
+	const openBlocks = new Map<string, string>(); // blockId -> owning turnId
+	const knownBlocks = new Set<string>();
+	const knownTurns = new Set<string>();
+
+	for (let index = 0; index < frames.length; index += 1) {
+		const frame = frames[index];
+		if (frame.v !== FRAME_SCHEMA_VERSION) {
+			violation(index, frame, BAD_VERSION);
+			continue;
+		}
+		if (frame.epoch < lastEpoch) {
+			violation(index, frame, EPOCH_REGRESSION);
+		}
+		lastEpoch = Math.max(lastEpoch, frame.epoch);
+		if (frame.seq <= lastSeq) {
+			violation(index, frame, SEQ_NOT_INCREASING);
+		}
+		lastSeq = Math.max(lastSeq, frame.seq);
+
+		if (sessionEnded) {
+			violation(index, frame, AFTER_SESSION_END);
+			continue;
+		}
+
+		const turnId = frame.scope.turnId;
+		const blockId = frame.scope.blockId;
+
+		switch (frame.kind) {
+			case "open": {
+				if (frame.openKind === "turn") {
+					if (turnId === undefined || blockId !== undefined) {
+						violation(index, frame, BAD_SCOPE_ADDRESS);
+						break;
+					}
+					if (openTurnId !== undefined) {
+						violation(index, frame, TURN_OVERLAP, turnId);
+						break;
+					}
+					openTurnId = turnId;
+					knownTurns.add(turnId);
+					break;
+				}
+				if (turnId === undefined || blockId === undefined) {
+					violation(index, frame, BAD_SCOPE_ADDRESS);
+					break;
+				}
+				if (openTurnId !== turnId) {
+					violation(index, frame, BLOCK_WITHOUT_TURN, blockId);
+					break;
+				}
+				if (openBlocks.has(blockId)) {
+					violation(index, frame, BLOCK_OPEN_WHILE_OPEN, blockId);
+					break;
+				}
+				openBlocks.set(blockId, turnId);
+				knownBlocks.add(blockId);
+				break;
+			}
+			case "delta": {
+				if (turnId === undefined || blockId === undefined) {
+					violation(index, frame, BAD_SCOPE_ADDRESS);
+					break;
+				}
+				if (openTurnId !== turnId || !openBlocks.has(blockId)) {
+					violation(index, frame, BLOCK_DELTA_WITHOUT_OPEN, blockId);
+				}
+				break;
+			}
+			case "close": {
+				if (blockId !== undefined) {
+					if (openBlocks.get(blockId) !== turnId) {
+						violation(index, frame, BLOCK_CLOSE_WITHOUT_OPEN, blockId);
+						break;
+					}
+					openBlocks.delete(blockId);
+					break;
+				}
+				if (turnId !== undefined) {
+					if (openTurnId !== turnId) {
+						violation(index, frame, TURN_CLOSE_WITHOUT_OPEN, turnId);
+						break;
+					}
+					const stragglers = [...openBlocks.entries()]
+						.filter(([, owner]) => owner === turnId)
+						.map(([id]) => id);
+					if (stragglers.length > 0) {
+						violation(
+							index,
+							frame,
+							TURN_CLOSE_WITH_OPEN_CHILDREN,
+							stragglers.join(","),
+						);
+					}
+					openTurnId = undefined;
+					break;
+				}
+				sessionEnded = true;
+				break;
+			}
+			case "notice":
+			case "usage": {
+				if (turnId === undefined) {
+					// Session-scoped notices are legal; usage is turn-scoped.
+					if (frame.kind === "usage") {
+						violation(index, frame, BAD_SCOPE_ADDRESS);
+					}
+					break;
+				}
+				if (openTurnId !== turnId) {
+					violation(index, frame, TURN_FRAME_WITHOUT_TURN, turnId);
+				}
+				break;
+			}
+			case "annotation": {
+				// Legal on open or closed scopes, but the scope must be one
+				// this stream has seen (late annotations target real scopes).
+				if (blockId !== undefined) {
+					if (!knownBlocks.has(blockId)) {
+						violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, blockId);
+					}
+				} else if (turnId !== undefined && !knownTurns.has(turnId)) {
+					violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, turnId);
+				}
+				break;
+			}
+			case "snapshot": {
+				// Session-scoped; contents are the producer's live set and
+				// are diffed by the assembler, not validated here.
+				if (turnId !== undefined || blockId !== undefined) {
+					violation(index, frame, BAD_SCOPE_ADDRESS);
+				}
+				break;
+			}
+			default: {
+				const _exhaustive: never = frame;
+				void _exhaustive;
+			}
+		}
+	}
+
+	return {
+		violations,
+		openBlocks: [...openBlocks.keys()],
+		openTurnId,
+		sessionEnded,
+		frameCount: frames.length,
+	};
+}
+

--- a/sdk/packages/shared/src/agents/v1-trace-generator.ts
+++ b/sdk/packages/shared/src/agents/v1-trace-generator.ts
@@ -1,0 +1,225 @@
+/**
+ * Deterministic legal-trace generator for the v1 AgentEvent grammar.
+ *
+ * Derived from the same tables as `validateAgentEventStream` (stream-
+ * grammar.ts): every emitted trace is v1-legal by construction, and the
+ * property test closes the loop — generate → frame → validateFrameStream
+ * must be zero-violation. A seeded LCG keeps runs reproducible without
+ * adding a dependency; seeds are the test's identity, so a failure can
+ * be replayed exactly.
+ */
+import type { AgentEvent } from "./types";
+
+/** Small deterministic PRNG (LCG) — reproducibility over quality. */
+class Lcg {
+	private state: number;
+	constructor(seed: number) {
+		this.state = (seed * 2654435761) % 2147483647 || 1;
+	}
+	next(): number {
+		this.state = (this.state * 48271) % 2147483647;
+		return this.state;
+	}
+	pick<T>(items: readonly T[]): T {
+		return items[this.next() % items.length];
+	}
+}
+
+const TEXTS = ["He", "llo", " wo", "rld", "!"];
+
+export interface GenerateOptions {
+	/** Upper bound on emitted events; traces may end earlier (terminal). */
+	maxEvents?: number;
+}
+
+/**
+ * Generate a random v1-legal trace. Covers the warts deliberately: text
+ * deltas (W1), finals with no deltas (W2), terminals with dangling
+ * scopes (W3), recoverable errors (W4), and every finish reason.
+ */
+export function generateLegalV1Trace(
+	seed: number,
+	options: GenerateOptions = {},
+): AgentEvent[] {
+	const maxEvents = options.maxEvents ?? 48;
+	const rng = new Lcg(seed);
+	const out: AgentEvent[] = [];
+
+	let iterationOpen: number | undefined;
+	let lastEndedIteration = 0;
+	let nextTool = 1;
+	const openTools: string[] = [];
+	let terminated = false;
+
+	const iterationStart = (): void => {
+		iterationOpen = lastEndedIteration + 1;
+		out.push({ type: "iteration_start", iteration: iterationOpen });
+	};
+	const iterationEnd = (): void => {
+		lastEndedIteration = iterationOpen ?? lastEndedIteration;
+		out.push({
+			type: "iteration_end",
+			iteration: iterationOpen ?? 0,
+			hadToolCalls: openTools.length > 0,
+			toolCallCount: 1,
+		});
+		iterationOpen = undefined;
+	};
+
+	while (out.length < maxEvents && !terminated) {
+		const moves: Array<() => void> = [];
+		if (iterationOpen === undefined) {
+			moves.push(iterationStart);
+		} else {
+			// Deltas are the most common real events — weight them.
+			moves.push(
+				(): void => {
+					out.push({
+						type: "content_start",
+						contentType: "text",
+						text: rng.pick(TEXTS),
+					});
+				},
+				(): void => {
+					out.push({
+						type: "content_start",
+						contentType: "text",
+						text: rng.pick(TEXTS),
+					});
+				},
+				(): void => {
+					out.push({
+						type: "content_start",
+						contentType: "reasoning",
+						reasoning: rng.pick(TEXTS),
+						redacted: rng.next() % 4 === 0,
+					});
+				},
+				(): void => {
+					out.push({
+						type: "content_end",
+						contentType: "text",
+						text: "final text",
+					});
+				},
+				(): void => {
+					out.push({
+						type: "content_end",
+						contentType: "reasoning",
+						reasoning: "final reasoning",
+					});
+				},
+				(): void => {
+					const toolCallId = `call_${nextTool}`;
+					nextTool += 1;
+					openTools.push(toolCallId);
+					out.push({
+						type: "content_start",
+						contentType: "tool",
+						toolCallId,
+						toolName: "read_file",
+						input: { path: "/tmp/x" },
+					});
+				},
+				(): void => {
+					out.push({ type: "notice", noticeType: "status", message: "t" });
+				},
+				(): void => {
+					out.push({
+						type: "usage",
+						inputTokens: 1,
+						outputTokens: 1,
+						totalInputTokens: 1,
+						totalOutputTokens: 1,
+					});
+				},
+				(): void => {
+					// W4: recoverable in-run error.
+					out.push({
+						type: "error",
+						error: new Error("transient"),
+						iteration: iterationOpen ?? 0,
+						recoverable: true,
+					});
+				},
+				(): void => {
+					// Terminal. W3 occurs when tools are still open.
+					if (rng.next() % 2 === 0) {
+						out.push({
+							type: "done",
+							reason: rng.pick([
+								"completed",
+								"max_iterations",
+								"aborted",
+								"mistake_limit",
+								"error",
+							] as const),
+							text: "done",
+							iterations: 1,
+						});
+					} else {
+						out.push({
+							type: "error",
+							error: new Error("fatal"),
+							iteration: iterationOpen ?? 0,
+							recoverable: false,
+						});
+					}
+					terminated = true;
+				},
+				(): void => {
+					// Close the iteration when no tool is open (v1 requires
+					// tools closed before iteration_end); otherwise close a
+					// tool instead.
+					if (openTools.length === 0) {
+						iterationEnd();
+					} else {
+						const index = rng.next() % openTools.length;
+						const [toolCallId] = openTools.splice(index, 1);
+						out.push({
+							type: "content_end",
+							contentType: "tool",
+							toolCallId,
+							toolName: "read_file",
+							output: "ok",
+						});
+					}
+				},
+			);
+			if (openTools.length > 0) {
+				moves.push(
+					(): void => {
+						out.push({
+							type: "content_update",
+							contentType: "tool",
+							toolCallId: rng.pick(openTools),
+							update: { p: 1 },
+						});
+					},
+					(): void => {
+						const index = rng.next() % openTools.length;
+						const [toolCallId] = openTools.splice(index, 1);
+						out.push({
+							type: "content_end",
+							contentType: "tool",
+							toolCallId,
+							toolName: "read_file",
+							output: "ok",
+							...(rng.next() % 5 === 0 ? { error: "boom" } : {}),
+						});
+					},
+				);
+			}
+		}
+		moves[Math.floor(rng.next() % moves.length)]();
+	}
+
+	// A trace that reaches the bound without a terminal is a legal
+	// prefix, but the property loop asserts full-turn closure; end every
+	// generated trace deterministically so seeds are stable and the
+	// closed-loop assertion is unconditional.
+	if (!terminated) {
+		out.push({ type: "done", reason: "completed", text: "done", iterations: 1 });
+	}
+	return out;
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

PR 1 of the stack (#13759) made the v1 event stream's grammar explicit: transition tables, a validator, and a wart registry counting the four known deviations (start-as-delta, final-without-deltas, dangling-at-terminal, terminal-ambiguity). This PR defines what they were deviating *from*, and produces it.

Three additive pieces, no behavior change to any existing producer or consumer:

- **v2 frame schema** (`@cline/shared/src/agents/stream-frames.ts`): scoped, sequenced frames — every frame addresses exactly one scope (session/turn/block) and carries the producer's `(epoch, seq)`; bodies are `open`/`delta`/`close`/`notice`/`usage` (+ `annotation`/`snapshot` declared for later phases); a structured, serializable `StreamError` replaces the JS `Error` that currently gets flattened differently at every wire; `validateFrameStream` checks the per-scope projections.
- **Framer** (`agent-event-framer.ts`): pure v1→v2 translation that fixes the warts by construction — one `open` per text/reasoning block (start means start), open+close for finals with no deltas, children force-closed with `interrupted` before the turn close, recoverable errors as notices, and one spelling of turn end (`completed`/`error`/`interrupted`). Scope decisions settled at schema-writing time: a v1 run is a v2 turn; v1 iterations become turn-scoped notices; `bumpEpoch()` is the host's conversation fence, never the run's.
- **Proof machinery**: a seeded trace generator derived from the v1 tables, and a 200-seed property loop — every legal v1 trace frames to a zero-violation v2 stream with all scopes closed. `@cline/core` gains `RuntimeFrameAdapter` (dual-emit wrapper) whose v1 output is test-locked identical to the plain adapter's, and whose `reset()` fences mid-flight scopes — closing the gap where a host reset without a v1 terminal would leak open scopes into the next run.

The first frame consumer (the CLI port) lands in Phase 2/PR 3; until then the framer and wrapper are exercised by the property loop and the dual-emit identity test, and `RuntimeFrameAdapter` is exported from `@cline/core` ready for that port.

### Test Procedure

Pure addition; the risks are a bad table (false violation) or the framer disagreeing with the tables. Both are covered by the closed loop and the identity test:

```
cd sdk/packages/shared && bun run test:unit
# 410 passed — includes the 200-seed property loop
# (generator → framer → validateFrameStream = zero violations, all scopes
# closed), per-wart pins, and the v2 validator table tests.

cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime/
# 344 passed — includes RuntimeFrameAdapter's dual-emit identity test
# (v1 events identical to the plain adapter, durationMs normalized — it is
# wall-clock per instance) and the reset()-fence test.

bun run build:sdk   # all six packages build against the new exports
```

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stacked on #13759 (Phase 0: the v1 grammar tables). PR 3 (Phase 2) adds the assembler and ports the CLI terminal renderer — the first consumer. The design doc (`sdk/packages/core/docs/agent-event-stream-design.md`, updated here with the Phase 1 status and the settled schema decisions) carries the full plan and the verification strategy. Review this PR with #13759's tables in view: the property loop is the machine-checkable statement that the v2 tables are the v1 tables' intended meaning.
