### PR TITLE
fix(cli): route desktop approvals with request session

### DIFF
--- a/apps/cli/src/utils/approval.test.ts
+++ b/apps/cli/src/utils/approval.test.ts
@@ -1,0 +1,65 @@
+import type { ToolApprovalRequest } from "@cline/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getActiveCliSession: vi.fn(() => undefined),
+	requestDesktopToolApproval: vi.fn(
+		async (
+			_request: ToolApprovalRequest,
+			options?: { approvalDir?: string; sessionId?: string },
+		) => {
+			if (!options?.approvalDir || !options.sessionId) {
+				return {
+					approved: false,
+					reason: "Desktop tool approval IPC is not configured",
+				};
+			}
+			return { approved: true };
+		},
+	),
+}));
+
+vi.mock("@cline/core", () => ({
+	requestDesktopToolApproval: mocks.requestDesktopToolApproval,
+}));
+
+vi.mock("./output", () => ({
+	c: { dim: "", green: "", reset: "", yellow: "" },
+	getActiveCliSession: mocks.getActiveCliSession,
+	write: vi.fn(),
+}));
+
+import { requestToolApproval } from "./approval";
+
+const request: ToolApprovalRequest = {
+	sessionId: "session-from-request",
+	agentId: "agent-1",
+	conversationId: "conversation-1",
+	iteration: 0,
+	toolCallId: "tool-call-1",
+	toolName: "execute_command",
+	input: { command: "pwd" },
+	policy: { autoApprove: false },
+};
+
+describe("requestToolApproval", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.clearAllMocks();
+	});
+
+	it("routes a first-turn desktop approval with the request session ID", async () => {
+		vi.stubEnv("CLINE_TOOL_APPROVAL_MODE", "desktop");
+		vi.stubEnv("CLINE_TOOL_APPROVAL_DIR", "/tmp/cline-approvals");
+
+		await expect(requestToolApproval(request)).resolves.toEqual({
+			approved: true,
+		});
+
+		expect(mocks.getActiveCliSession).not.toHaveBeenCalled();
+		expect(mocks.requestDesktopToolApproval).toHaveBeenCalledWith(request, {
+			approvalDir: "/tmp/cline-approvals",
+			sessionId: request.sessionId,
+		});
+	});
+});

--- a/apps/cli/src/utils/approval.ts
+++ b/apps/cli/src/utils/approval.ts
@@ -5,7 +5,7 @@ import {
 	USER_REJECTED_TOOL_REASON,
 } from "@cline/shared";
 import { truncate } from "./helpers";
-import { c, getActiveCliSession, write } from "./output";
+import { c, write } from "./output";
 
 const SHOW_TERMINAL_CURSOR = "\x1b[?25h";
 
@@ -57,9 +57,8 @@ async function requestDesktopToolApprovalFromCore(
 			});
 	}
 	const requester = await cachedDesktopApprovalRequester;
-	const sessionId = getActiveCliSession()?.manifest.session_id;
 	const approvalDir = process.env.CLINE_TOOL_APPROVAL_DIR?.trim();
-	return requester(request, { approvalDir, sessionId });
+	return requester(request, { approvalDir, sessionId: request.sessionId });
 }
 
 // =============================================================================


### PR DESCRIPTION
### Related Issue

**Issue:** #13763

### Description

Desktop approval routing used the global active CLI session, but one-shot sessions only populate that global after the initial Core turn returns. A first-turn tool call could therefore have no session ID even though its ToolApprovalRequest already carries the owning session.

This passes request.sessionId to the desktop approval requester and removes the timing dependency on global CLI state. Approval policy and explicit user approval behavior are unchanged.

### Test Procedure

- Added a regression with desktop approval mode enabled and no active global CLI session. It fails on the old implementation with Desktop tool approval IPC is not configured and passes when the request session ID is forwarded.
- Verified the real CLI wrapper with the built Core IPC in a fresh process: it created the request artifact under first-turn-session, consumed an approval decision, and returned approved.
- `bun -F @cline/cli test:unit -- src/utils/approval.test.ts`: 1 passed
- `bun -F @cline/cli test:unit`: 137 files, 1159 tests passed
- `bun -F @cline/cli typecheck`: passed
- Biome check on both changed files: passed
- pre-commit gitleaks scan: no leaks
- `git diff --check`: passed

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable; this changes headless CLI approval routing and has no UI delta.