### PR TITLE
refactor(hub): share describeOutdatedHubSessions between CLI and desktop

### DIFF
--- a/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required-helpers.ts
@@ -15,27 +15,6 @@ export function resolveHubUpdateRequiredKeyAction(
 }
 
 /**
- * Human phrase for the live work an outdated Hub is serving, used by the
- * "Hub update required" dialog. Falls back to an unquantified phrase when the
- * Hub could not answer the activity query.
- */
-export function describeOutdatedHubSessions(counts: {
-	activeSessionCount?: number;
-	participantClientCount?: number;
-}): string {
-	const sessions = counts.activeSessionCount;
-	if (typeof sessions !== "number" || sessions <= 0) {
-		return "active sessions from other Cline clients";
-	}
-	const sessionsPhrase = `${sessions} active session${sessions === 1 ? "" : "s"}`;
-	const clients = counts.participantClientCount;
-	if (typeof clients !== "number" || clients <= 0) {
-		return sessionsPhrase;
-	}
-	return `${sessionsPhrase} from ${clients} connected Cline client${clients === 1 ? "" : "s"}`;
-}
-
-/**
  * Yolo and sandbox sessions force the local backend and never attach to the
  * shared managed Hub (see the forceLocalBackend condition in the interactive
  * session runtime), so a build mismatch on that Hub is another installation's

--- a/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
+++ b/apps/cli/src/tui/components/dialogs/hub-update-required.tsx
@@ -1,11 +1,9 @@
 // @jsxImportSource @opentui/react
+import { describeOutdatedHubSessions } from "@cline/shared";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
 import { useDialogPalette } from "../../hooks/use-theme";
-import {
-	describeOutdatedHubSessions,
-	resolveHubUpdateRequiredKeyAction,
-} from "./hub-update-required-helpers";
+import { resolveHubUpdateRequiredKeyAction } from "./hub-update-required-helpers";
 
 export interface HubUpdateRequiredDetails {
 	hubCoreVersion?: string;

--- a/apps/examples/desktop-app/README.md
+++ b/apps/examples/desktop-app/README.md
@@ -10,12 +10,17 @@ From `apps/examples/desktop-app/`:
 - `bun run dev:web` - Next.js UI only (approval-gated tools require `dev:headless` or the native app)
 - `bun run dev:sidecar` - sidecar backend only (approval-gated tools require `dev:headless` or the native app)
 - `bun run dev` - Tauri desktop dev
-- `bun run build` - build web assets
+- `bun run build:web` - build production web assets only (includes the shared UI build)
+- `bun run build` - build web assets and the sidecar binary
 - `bun run build:sidecar` - build the Bun sidecar bundle
 - `bun run build:sidecar:bin` - compile the Bun sidecar into a local binary
 - `bun run build:binary` - build desktop binary
 - `bun run package:desktop` - package the current OS desktop app into `dist/desktop/`
 - `bun run typecheck` - TypeScript check
+
+### Checking webview changes
+
+Run `bun run build:web` from this directory when changing webview imports or shared browser APIs. Type checking and Vitest do not check the production browser bundle: a valid TypeScript import can still pull Node-only modules into a client chunk. Use `@cline/shared/browser` for runtime imports in the webview; the bare `@cline/shared` source alias points to the Node entry point.
 
 ## Customizing the macOS Install Window
 

--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -10,6 +10,8 @@
 		"predev:headless": "bun run build:ui",
 		"dev:headless": "bun run scripts/dev-headless.ts",
 		"dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
+		"prebuild:web": "bun run build:ui",
+		"build:web": "next build webview",
 		"prebuild": "bun run build:ui",
 		"build": "bun run bun.mts",
 		"build:sidecar": "mkdir -p dist/sidecar && bun build ./sidecar/index.ts --outfile ./dist/sidecar/index.js --target bun",

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { describeOutdatedHubSessions } from "@cline/shared";
 import { useCallback, useEffect, useState } from "react";
 import {
 	AlertDialog,
@@ -16,10 +17,7 @@ import {
 	restartToApplyUpdate,
 } from "@/hooks/use-app-update";
 import { desktopClient } from "@/lib/desktop-client";
-import {
-	describeOutdatedHubSessions,
-	resolveHubUpdateRestartDecision,
-} from "./hub-update-required-helpers";
+import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
 
 type HubBuildMismatchPayload = {
 	hubBuildId?: string;

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { describeOutdatedHubSessions } from "@cline/shared";
+import { describeOutdatedHubSessions } from "@cline/shared/browser";
 import { useCallback, useEffect, useState } from "react";
 import {
 	AlertDialog,

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -1,40 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	describeOutdatedHubSessions,
-	resolveHubUpdateRestartDecision,
-} from "./hub-update-required-helpers";
-
-describe("describeOutdatedHubSessions", () => {
-	it("quantifies sessions and clients when the hub reported both", () => {
-		expect(
-			describeOutdatedHubSessions({
-				activeSessionCount: 2,
-				participantClientCount: 1,
-			}),
-		).toBe("2 active sessions from 1 connected Cline client");
-		expect(
-			describeOutdatedHubSessions({
-				activeSessionCount: 1,
-				participantClientCount: 3,
-			}),
-		).toBe("1 active session from 3 connected Cline clients");
-	});
-
-	it("omits the client clause when participant ids were unavailable", () => {
-		expect(
-			describeOutdatedHubSessions({
-				activeSessionCount: 4,
-				participantClientCount: 0,
-			}),
-		).toBe("4 active sessions");
-	});
-
-	it("falls back to an unquantified phrase when the hub could not answer", () => {
-		expect(describeOutdatedHubSessions({})).toBe(
-			"active sessions from other Cline clients",
-		);
-	});
-});
+import { resolveHubUpdateRestartDecision } from "./hub-update-required-helpers";
 
 describe("resolveHubUpdateRestartDecision", () => {
 	it("restarts only once an update is staged", () => {

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -5,27 +5,6 @@ export type HubUpdateRestartDecision =
 	| { action: "stay"; hint: string };
 
 /**
- * Human phrase for the live work an outdated Hub is serving, used by the
- * blocking "Hub update required" dialog. Falls back to an unquantified
- * phrase when the Hub could not answer the activity query.
- */
-export function describeOutdatedHubSessions(counts: {
-	activeSessionCount?: number;
-	participantClientCount?: number;
-}): string {
-	const sessions = counts.activeSessionCount;
-	if (typeof sessions !== "number" || sessions <= 0) {
-		return "active sessions from other Cline clients";
-	}
-	const sessionsPhrase = `${sessions} active session${sessions === 1 ? "" : "s"}`;
-	const clients = counts.participantClientCount;
-	if (typeof clients !== "number" || clients <= 0) {
-		return sessionsPhrase;
-	}
-	return `${sessionsPhrase} from ${clients} connected Cline client${clients === 1 ? "" : "s"}`;
-}
-
-/**
  * Decide what "Update and restart" should do after an on-demand updater
  * check. Restart only when an update is actually staged - relaunching the
  * same version would bring the mismatch dialog straight back without

--- a/sdk/packages/shared/src/hub.test.ts
+++ b/sdk/packages/shared/src/hub.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { HubCommandInput } from "./hub";
 import {
+	describeOutdatedHubSessions,
 	HUB_CAPABILITIES,
 	isHubProtocolCompatible,
 	readHubScheduleMode,
@@ -88,6 +89,38 @@ describe("readHubScheduleMode", () => {
 	])("rejects a present invalid mode: %s", (mode) => {
 		expect(() => readHubScheduleMode({ mode }, "yolo")).toThrow(
 			"mode must be one of: act, plan, yolo",
+		);
+	});
+});
+
+describe("describeOutdatedHubSessions", () => {
+	it("quantifies sessions and clients when the hub reported both", () => {
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 2,
+				participantClientCount: 1,
+			}),
+		).toBe("2 active sessions from 1 connected Cline client");
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 1,
+				participantClientCount: 3,
+			}),
+		).toBe("1 active session from 3 connected Cline clients");
+	});
+
+	it("omits the client clause when participant ids were unavailable", () => {
+		expect(
+			describeOutdatedHubSessions({
+				activeSessionCount: 4,
+				participantClientCount: 0,
+			}),
+		).toBe("4 active sessions");
+	});
+
+	it("falls back to an unquantified phrase when the hub could not answer", () => {
+		expect(describeOutdatedHubSessions({})).toBe(
+			"active sessions from other Cline clients",
 		);
 	});
 });

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -1000,3 +1000,25 @@ export interface HubUIShowWindowPayload {
 	windowId?: string;
 	focus?: boolean;
 }
+
+/**
+ * Human phrase for the live work an outdated Hub is serving, used by the
+ * "Hub update required" surfaces in the CLI and the desktop app - the two
+ * must read identically, which is why the copy lives here. Falls back to an
+ * unquantified phrase when the Hub could not answer the activity query.
+ */
+export function describeOutdatedHubSessions(counts: {
+	activeSessionCount?: number;
+	participantClientCount?: number;
+}): string {
+	const sessions = counts.activeSessionCount;
+	if (typeof sessions !== "number" || sessions <= 0) {
+		return "active sessions from other Cline clients";
+	}
+	const sessionsPhrase = `${sessions} active session${sessions === 1 ? "" : "s"}`;
+	const clients = counts.participantClientCount;
+	if (typeof clients !== "number" || clients <= 0) {
+		return sessionsPhrase;
+	}
+	return `${sessionsPhrase} from ${clients} connected Cline client${clients === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
### Related Issue

Post-merge review follow-up (item 4) on #13727: https://github.com/cline/cline/pull/13727#issuecomment-5506848714

### Description

`describeOutdatedHubSessions` existed word for word in the CLI TUI (`apps/cli/.../hub-update-required-helpers.ts`) and the desktop webview (`apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts`), with tests only on the desktop copy. Both surfaces must read identically, so the copy now lives once in `@cline/shared` (`src/hub.ts`, exported on both the node and browser surfaces, which the webview already imports elsewhere). The test suite moved to `sdk/packages/shared/src/hub.test.ts`; the CLI now imports from `@cline/shared` and the desktop webview from `@cline/shared/browser` and the local copies are deleted.

### Test Procedure

Validated after review fix (1fc536ef1):

- `bun run build:sdk` — passed.
- Shared: `bun run test:unit src/hub.test.ts src/index.browser.test.ts` — 15 tests passed.
- Desktop: `bun run build:web` — production Next.js build and static export passed. This new command builds the shared UI and webview without packaging the sidecar; documented in the desktop README.
- Desktop: `bun run typecheck` — passed.
- Desktop: `bun x vitest run webview/components/hub-update-required-helpers.test.ts --config vitest.config.ts` — 8 tests passed.
- CLI: `bun test src/tui/components/dialogs/hub-update-required.test.ts` — 5 tests passed.

Production bundling matters here: type checking and unit tests do not catch Node-only modules entering the client chunk through the bare shared source alias.

### Type of Change

- [x] ♻️ Refactor Changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)