### PR TITLE
refactor(cli): make 'cline hub upgrade' use the shared replacement policy

### DIFF
--- a/apps/cli/src/commands/hub.test.ts
+++ b/apps/cli/src/commands/hub.test.ts
@@ -3,17 +3,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const {
 	mockClearHubDiscovery,
 	mockEnsureDetachedHubServer,
-	mockLocalHubHasNoActiveSessions,
 	mockProbeHubServer,
 	mockReadHubDiscovery,
 	mockRequestHubDrain,
 	mockResolveProductionHubOwnerContext,
 	mockResolveSharedHubOwnerContext,
 	mockStopLocalHubServerGracefully,
+	mockUpgradeManagedHub,
 } = vi.hoisted(() => ({
 	mockClearHubDiscovery: vi.fn(),
 	mockEnsureDetachedHubServer: vi.fn(),
-	mockLocalHubHasNoActiveSessions: vi.fn(),
 	mockProbeHubServer: vi.fn(),
 	mockReadHubDiscovery: vi.fn(),
 	mockRequestHubDrain: vi.fn(),
@@ -26,18 +25,19 @@ const {
 		discoveryPath: "/tmp/cline-data/locks/hub/owners/hub-owner.json",
 	})),
 	mockStopLocalHubServerGracefully: vi.fn(),
+	mockUpgradeManagedHub: vi.fn(),
 }));
 
 vi.mock("@cline/core", () => ({
 	clearHubDiscovery: mockClearHubDiscovery,
 	ensureDetachedHubServer: mockEnsureDetachedHubServer,
-	localHubHasNoActiveSessions: mockLocalHubHasNoActiveSessions,
 	probeHubServer: mockProbeHubServer,
 	readHubDiscovery: mockReadHubDiscovery,
 	requestHubDrain: mockRequestHubDrain,
 	resolveProductionHubOwnerContext: mockResolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext: mockResolveSharedHubOwnerContext,
 	stopLocalHubServerGracefully: mockStopLocalHubServerGracefully,
+	upgradeManagedHub: mockUpgradeManagedHub,
 }));
 
 import { version as cliVersion } from "../../package.json";
@@ -172,57 +172,73 @@ describe("createHubCommand", () => {
 		});
 	});
 
-	it("replaces an idle hub with upgrade --wait 0 instead of skipping the idle check", async () => {
-		mockReadHubDiscovery.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
-			authToken: "token",
-		});
-		mockRequestHubDrain.mockResolvedValue(true);
-		mockLocalHubHasNoActiveSessions.mockResolvedValue(true);
-		mockStopLocalHubServerGracefully.mockResolvedValue(true);
-		mockEnsureDetachedHubServer.mockResolvedValue({
-			url: "ws://127.0.0.1:25463/hub",
+	it("delegates upgrade to the shared replacement policy with the wait window and endpoint flags", async () => {
+		mockUpgradeManagedHub.mockResolvedValue({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:26000/hub",
 			authToken: "new-token",
+			activeSessionCount: 0,
 		});
 
 		const { cmd, output, errors, exitCode } = createCommand();
-		await cmd.parseAsync(["upgrade", "--wait", "0"], { from: "user" });
+		await cmd.parseAsync(["--port", "26000", "upgrade", "--wait", "7"], {
+			from: "user",
+		});
 
 		expect(errors).toEqual([]);
 		expect(exitCode()).toBe(0);
-		expect(mockLocalHubHasNoActiveSessions).toHaveBeenCalled();
-		expect(mockStopLocalHubServerGracefully).toHaveBeenCalled();
-		expect(mockEnsureDetachedHubServer).toHaveBeenCalled();
-		// The drain was never lifted manually: the drained hub was replaced.
-		expect(mockRequestHubDrain).toHaveBeenCalledTimes(1);
+		expect(mockUpgradeManagedHub).toHaveBeenCalledWith(
+			expect.objectContaining({
+				waitForIdleMs: 7_000,
+				reason: "cline hub upgrade",
+				endpoint: expect.objectContaining({ port: 26000 }),
+			}),
+		);
 		expect(JSON.parse(output[0] || "")).toEqual({
 			upgraded: true,
-			url: "ws://127.0.0.1:25463/hub",
+			url: "ws://127.0.0.1:26000/hub",
 		});
 	});
 
-	it("un-drains the hub when upgrade aborts because sessions are still active", async () => {
-		mockReadHubDiscovery.mockResolvedValue({
+	it("reports failure without replacing when the hub stays busy through the wait window", async () => {
+		mockUpgradeManagedHub.mockResolvedValue({
+			outcome: "still_busy",
 			url: "ws://127.0.0.1:25463/hub",
-			authToken: "token",
+			activeSessionCount: 2,
 		});
-		mockRequestHubDrain.mockResolvedValue(true);
-		mockLocalHubHasNoActiveSessions.mockResolvedValue(false);
 
 		const { cmd, errors, exitCode } = createCommand();
 		await cmd.parseAsync(["upgrade", "--wait", "0"], { from: "user" });
 
 		expect(exitCode()).toBe(1);
 		expect(errors[0]).toContain("still serving sessions");
-		expect(mockStopLocalHubServerGracefully).not.toHaveBeenCalled();
-		expect(mockEnsureDetachedHubServer).not.toHaveBeenCalled();
-		expect(mockRequestHubDrain).toHaveBeenCalledTimes(2);
-		expect(mockRequestHubDrain).toHaveBeenLastCalledWith(
-			"ws://127.0.0.1:25463/hub",
-			"token",
-			"cline hub upgrade aborted",
-			{ off: true },
+	});
+
+	it("refuses to downgrade a hub newer than this CLI", async () => {
+		mockUpgradeManagedHub.mockResolvedValue({
+			outcome: "hub_not_older",
+			url: "ws://127.0.0.1:25463/hub",
+		});
+
+		const { cmd, errors, exitCode } = createCommand();
+		await cmd.parseAsync(["upgrade"], { from: "user" });
+
+		expect(exitCode()).toBe(1);
+		expect(errors[0]).toContain("newer than this CLI");
+	});
+
+	it("surfaces upgrade errors (refused drain, unstoppable hub) with a non-zero exit", async () => {
+		mockUpgradeManagedHub.mockRejectedValue(
+			new Error(
+				"The running Cline Hub at ws://127.0.0.1:25463/hub did not accept a drain request, so it was not replaced.",
+			),
 		);
+
+		const { cmd, errors, exitCode } = createCommand();
+		await cmd.parseAsync(["upgrade"], { from: "user" });
+
+		expect(exitCode()).toBe(1);
+		expect(errors[0]).toContain("did not accept a drain request");
 	});
 
 	it("rejects a non-numeric upgrade --wait instead of treating it as an expired deadline", async () => {
@@ -239,7 +255,7 @@ describe("createHubCommand", () => {
 		await expect(
 			cmd.parseAsync(["upgrade", "--wait", "soon"], { from: "user" }),
 		).rejects.toThrow("--wait requires a non-negative number of seconds.");
-		expect(mockRequestHubDrain).not.toHaveBeenCalled();
+		expect(mockUpgradeManagedHub).not.toHaveBeenCalled();
 	});
 
 	it("passes the selected owner to graceful stop", async () => {

--- a/apps/cli/src/commands/hub.test.ts
+++ b/apps/cli/src/commands/hub.test.ts
@@ -196,8 +196,26 @@ describe("createHubCommand", () => {
 		);
 		expect(JSON.parse(output[0] || "")).toEqual({
 			upgraded: true,
+			outcome: "replaced",
 			url: "ws://127.0.0.1:26000/hub",
 		});
+	});
+
+	it.each([
+		{ outcome: "already_current", upgraded: false },
+		{ outcome: "started", upgraded: true },
+	])("reports $outcome with upgraded: $upgraded", async ({ outcome, upgraded }) => {
+		const url = "ws://127.0.0.1:25463/hub";
+		mockUpgradeManagedHub.mockResolvedValue({ outcome, url });
+
+		const { cmd, output, errors, exitCode } = createCommand();
+		await cmd.parseAsync(["upgrade"], { from: "user" });
+
+		expect(exitCode()).toBe(0);
+		expect(errors).toEqual([]);
+		expect(output.map((line) => JSON.parse(line))).toEqual([
+			{ upgraded, outcome, url },
+		]);
 	});
 
 	it("reports failure without replacing when the hub stays busy through the wait window", async () => {

--- a/apps/cli/src/commands/hub.ts
+++ b/apps/cli/src/commands/hub.ts
@@ -1,13 +1,13 @@
 import {
 	clearHubDiscovery,
 	ensureDetachedHubServer,
-	localHubHasNoActiveSessions,
 	probeHubServer,
 	readHubDiscovery,
 	requestHubDrain,
 	resolveProductionHubOwnerContext,
 	resolveSharedHubOwnerContext,
 	stopLocalHubServerGracefully,
+	upgradeManagedHub,
 } from "@cline/core";
 import { formatUptime, resolveClineBuildEnv } from "@cline/shared";
 import { Command, InvalidArgumentError } from "commander";
@@ -216,61 +216,36 @@ export function createHubCommand(
 					port?: number;
 					pathname?: string;
 				}>();
-				const owner = resolveCliHubOwnerContext();
-				const discovery = await readHubDiscovery(owner.discoveryPath);
-				if (discovery?.url) {
-					const drained = await requestHubDrain(
-						discovery.url,
-						discovery.authToken,
-						"cline hub upgrade",
-					).catch(() => false);
-					// An aborted upgrade must hand the hub back: leaving it
-					// draining refuses all new mutating work until a restart.
-					const undrain = async (): Promise<void> => {
-						if (!drained) {
-							return;
-						}
-						await requestHubDrain(
-							discovery.url,
-							discovery.authToken,
-							"cline hub upgrade aborted",
-							{ off: true },
-						).catch(() => false);
-					};
-					try {
-						const deadline = Date.now() + cmdOptions.wait * 1_000;
-						let idle = false;
-						// Check at least once so --wait 0 still observes an idle hub.
-						for (;;) {
-							idle = await localHubHasNoActiveSessions(
-								discovery.url,
-								discovery.authToken,
-							).catch(() => true);
-							if (idle || Date.now() >= deadline) {
-								break;
-							}
-							await new Promise((resolve) => setTimeout(resolve, 1_000));
-						}
-						if (!idle) {
-							await undrain();
-							io.writeErr(
-								"Hub is still serving sessions after the wait window; not replacing it. Re-run with a longer --wait, or finish the sessions first.",
-							);
-							fail();
-							return;
-						}
-						await stopHubServer(opts.cwd);
-					} catch (error) {
-						await undrain();
-						throw error;
-					}
-				}
-				const { url } = await ensureDetachedHubServer(opts.cwd, {
-					host: opts.host,
-					port: opts.port,
-					pathname: opts.pathname,
+				// One replacement policy for every surface: upgradeManagedHub
+				// carries the build-order gate (never downgrade a newer hub) and
+				// the accepted-drain requirement that this command's original
+				// inline implementation lacked. Endpoint flags only shape the
+				// replacement daemon; discovery still follows the owner context.
+				const result = await upgradeManagedHub({
+					workspaceRoot: opts.cwd,
+					waitForIdleMs: cmdOptions.wait * 1_000,
+					reason: "cline hub upgrade",
+					endpoint: {
+						host: opts.host,
+						port: opts.port,
+						pathname: opts.pathname,
+					},
 				});
-				io.writeln(JSON.stringify({ upgraded: true, url }));
+				if (result.outcome === "still_busy") {
+					io.writeErr(
+						"Hub is still serving sessions after the wait window; not replacing it. Re-run with a longer --wait, or finish the sessions first.",
+					);
+					fail();
+					return;
+				}
+				if (result.outcome === "hub_not_older") {
+					io.writeErr(
+						"The running hub is newer than this CLI, so it was not replaced. Run 'cline update' instead.",
+					);
+					fail();
+					return;
+				}
+				io.writeln(JSON.stringify({ upgraded: true, url: result.url }));
 			}),
 		);
 

--- a/apps/cli/src/commands/hub.ts
+++ b/apps/cli/src/commands/hub.ts
@@ -200,7 +200,7 @@ export function createHubCommand(
 	hub
 		.command("upgrade")
 		.description(
-			"Drain, wait for the hub to go idle, stop it, and start a fresh one",
+			"Upgrade the hub after draining active sessions; leave a hub already on this build at the requested endpoint running",
 		)
 		.option(
 			"--wait <seconds>",
@@ -245,7 +245,13 @@ export function createHubCommand(
 					fail();
 					return;
 				}
-				io.writeln(JSON.stringify({ upgraded: true, url: result.url }));
+				io.writeln(
+					JSON.stringify({
+						upgraded: result.outcome !== "already_current",
+						outcome: result.outcome,
+						url: result.url,
+					}),
+				);
 			}),
 		);
 

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1180,6 +1180,84 @@ describe("upgradeManagedHub", () => {
 		expect(createHubServerUrl).toHaveBeenCalledWith("127.0.0.1", 26000, "/hub");
 	});
 
+	it("moves a same-build hub to a requested endpoint through the drain-first path", async () => {
+		readHubDiscovery
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				authToken: "old-token",
+				pid: 12345,
+			})
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:26000/hub",
+				authToken: "new-token",
+			});
+		probeHubServer
+			// A compatible, current-build hub - but not where the caller asked.
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:25463/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+				pid: 12345,
+			})
+			// The retire wait: the old hub is gone.
+			.mockResolvedValueOnce(undefined)
+			// The ensure probe of the replacement at the requested endpoint.
+			.mockResolvedValueOnce({
+				url: "ws://127.0.0.1:26000/hub",
+				protocolVersion: "v1",
+				buildId: "current-build",
+			});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({
+			workspaceRoot: "/workspace",
+			endpoint: { port: 26000 },
+			waitForIdleMs: 0,
+		});
+
+		expect(result).toEqual({
+			outcome: "replaced",
+			url: "ws://127.0.0.1:26000/hub",
+			authToken: "new-token",
+			activeSessionCount: 0,
+		});
+		// The move went through the same drain-first ladder as a build upgrade.
+		expect(requestHubDrain).toHaveBeenCalledWith(
+			"ws://127.0.0.1:25463/hub",
+			"old-token",
+			"hub upgrade requested",
+		);
+		expect(requestHubShutdown).toHaveBeenCalled();
+	});
+
+	it("refuses to move a newer hub even when an endpoint override is given", async () => {
+		readHubDiscovery.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "newer-hub-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:25463/hub",
+			protocolVersion: "v1",
+			buildId: "newer-build",
+			buildEpochMs: 2_000_000,
+		});
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({
+			endpoint: { port: 26000 },
+			force: true,
+		});
+
+		expect(result).toEqual({
+			outcome: "hub_not_older",
+			url: "ws://127.0.0.1:25463/hub",
+			authToken: "newer-hub-token",
+		});
+		expect(requestHubDrain).not.toHaveBeenCalled();
+		expect(requestHubShutdown).not.toHaveBeenCalled();
+	});
+
 	it("un-drains and reports failure when the old hub survives the retire ladder", async () => {
 		queryHubSessionActivity.mockResolvedValue({
 			activeSessionCount: 1,

--- a/sdk/packages/core/src/hub/daemon/index.test.ts
+++ b/sdk/packages/core/src/hub/daemon/index.test.ts
@@ -1153,6 +1153,33 @@ describe("upgradeManagedHub", () => {
 		});
 	});
 
+	it("passes endpoint overrides through to the replacement daemon", async () => {
+		readHubDiscovery.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+			url: "ws://127.0.0.1:26000/hub",
+			authToken: "new-token",
+		});
+		probeHubServer.mockResolvedValueOnce({
+			url: "ws://127.0.0.1:26000/hub",
+			protocolVersion: "v1",
+			buildId: "current-build",
+		});
+		verifyHubConnection.mockResolvedValue(true);
+
+		const { upgradeManagedHub } = await import(".");
+		const result = await upgradeManagedHub({
+			workspaceRoot: "/workspace",
+			endpoint: { host: "127.0.0.1", port: 26000 },
+		});
+
+		expect(result).toEqual({
+			outcome: "started",
+			url: "ws://127.0.0.1:26000/hub",
+			authToken: "new-token",
+		});
+		// The override shaped the expected replacement endpoint.
+		expect(createHubServerUrl).toHaveBeenCalledWith("127.0.0.1", 26000, "/hub");
+	});
+
 	it("un-drains and reports failure when the old hub survives the retire ladder", async () => {
 		queryHubSessionActivity.mockResolvedValue({
 			activeSessionCount: 1,

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -733,6 +733,13 @@ const HUB_UPGRADE_IDLE_POLL_MS = 500;
 export interface UpgradeManagedHubOptions {
 	workspaceRoot?: string;
 	/**
+	 * Endpoint overrides for the replacement hub, passed through to
+	 * `ensureDetachedHubServer` (the `cline hub upgrade --host/--port/
+	 * --pathname` flags). Discovery of the currently running hub still
+	 * follows the owner context, matching the command's historical behavior.
+	 */
+	endpoint?: HubEndpointOverrides;
+	/**
 	 * How long to wait, after draining, for the hub's live sessions to finish
 	 * before replacing it (`force`) or giving up (`still_busy`).
 	 */
@@ -814,7 +821,10 @@ export async function upgradeManagedHub(
 		? await safeProbeHubServer(discovered.url, discovered.authToken)
 		: undefined;
 	if (!live?.url) {
-		const ensured = await ensureDetachedHubServer(workspaceRoot);
+		const ensured = await ensureDetachedHubServer(
+			workspaceRoot,
+			options.endpoint ?? {},
+		);
 		return { outcome: "started", ...ensured };
 	}
 	const record = {
@@ -909,7 +919,10 @@ export async function upgradeManagedHub(
 			`The running Cline Hub at ${record.url} could not be stopped. Run 'cline doctor fix' to stop stale hub daemons, then try again.`,
 		);
 	}
-	const ensured = await ensureDetachedHubServer(workspaceRoot);
+	const ensured = await ensureDetachedHubServer(
+		workspaceRoot,
+		options.endpoint ?? {},
+	);
 	return {
 		outcome: "replaced",
 		...ensured,

--- a/sdk/packages/core/src/hub/daemon/index.ts
+++ b/sdk/packages/core/src/hub/daemon/index.ts
@@ -737,6 +737,9 @@ export interface UpgradeManagedHubOptions {
 	 * `ensureDetachedHubServer` (the `cline hub upgrade --host/--port/
 	 * --pathname` flags). Discovery of the currently running hub still
 	 * follows the owner context, matching the command's historical behavior.
+	 * An override also narrows `already_current`: a same-build hub at a
+	 * different endpoint is replaced at the requested one rather than
+	 * reported as current at its old address.
 	 */
 	endpoint?: HubEndpointOverrides;
 	/**
@@ -761,7 +764,8 @@ export type UpgradeManagedHubOutcome =
 	| "replaced"
 	/** No live hub was found; a current-build hub was started. */
 	| "started"
-	/** The running hub already matches this build; nothing to do. */
+	/** The running hub already matches this build - and the requested
+	 * endpoint, when one is overridden; nothing to do. */
 	| "already_current"
 	/**
 	 * The running hub is newer than (or unorderable against) this build.
@@ -832,14 +836,36 @@ export async function upgradeManagedHub(
 		authToken: live.authToken ?? discovered?.authToken,
 		pid: live.pid ?? discovered?.pid,
 	};
-	if (getManagedHubCompatibility(live).compatible) {
+	// With an explicit endpoint override, "already current" also requires the
+	// hub to be listening where the caller asked: `cline hub upgrade --port`
+	// has always meant "a current-build hub at THIS endpoint", so a same-build
+	// hub elsewhere goes through the drain-first replacement below instead of
+	// being reported as upgraded at its old address.
+	const requestedEndpoint = options.endpoint ?? {};
+	const hasEndpointOverride =
+		requestedEndpoint.host !== undefined ||
+		requestedEndpoint.port !== undefined ||
+		requestedEndpoint.pathname !== undefined;
+	let liveAtRequestedEndpoint = true;
+	if (hasEndpointOverride) {
+		const resolved = resolveHubEndpointOptions(requestedEndpoint);
+		liveAtRequestedEndpoint =
+			live.url ===
+			createHubServerUrl(resolved.host, resolved.port, resolved.pathname);
+	}
+	const compatible = getManagedHubCompatibility(live).compatible;
+	if (compatible && liveAtRequestedEndpoint) {
 		return {
 			outcome: "already_current",
 			url: live.url,
 			authToken: record.authToken,
 		};
 	}
-	if (compareHubBuilds(resolveHubBuildIdentity(), live) <= 0) {
+	// A hub this build is not strictly newer than is never replaced for build
+	// reasons, endpoint override or not - it may belong to a newer install.
+	// A same-build hub at the wrong endpoint is this install's own to move,
+	// so it falls through to the replacement path.
+	if (!compatible && compareHubBuilds(resolveHubBuildIdentity(), live) <= 0) {
 		return {
 			outcome: "hub_not_older",
 			url: live.url,


### PR DESCRIPTION
### Related Issue

Post-merge review follow-up (item 3) on #13727: https://github.com/cline/cline/pull/13727#issuecomment-5506848714

### Description

`cline hub upgrade` kept its own inline drain → wait → stop → restart implementation, which lacked the safety rules #13727 added to `upgradeManagedHub`: no build-order gate (it could downgrade a Hub newer than the CLI) and no requirement that the drain be accepted before retirement. The TUI's Esc reminder points users straight at this command, so the weaker policy was the recommended one.

The command now delegates to `upgradeManagedHub`, and the shared policy gains an `endpoint` option so `--host/--port/--pathname` still shape the replacement daemon while discovery of the running Hub keeps following the owner context (the command's historical behavior). Outcome mapping: `still_busy` exits non-zero with the existing message; `hub_not_older` exits non-zero telling the user to run `cline update` instead; drain-refused/unstoppable errors propagate with their actionable messages.

Behavior changes (intended, per the review): the command now refuses to downgrade a newer Hub and refuses to replace a Hub that does not accept the drain. A compatible Hub already on this build at the requested endpoint is left running. Successful JSON includes `outcome` (`replaced`, `started`, or `already_current`), with `upgraded: false` for `already_current` and `upgraded: true` for `replaced` or `started`. The command help documents this no-op behavior.

### Test Procedure

- `apps/cli`: rewritten `hub.test.ts` upgrade suite (delegation with wait window + endpoint flags, still_busy, hub_not_older, propagated errors, --wait validation, and truthful JSON for already_current/started/replaced) — 11 tests passing
- `sdk/packages/core`: daemon suite + new endpoint-passthrough test — 28 tests
- Typechecks clean in both packages

### Type of Change

- [x] ♻️ Refactor Changes
- [x] 🐛 Bug fix (the command could previously downgrade a newer Hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)