### PR TITLE
feat(ui): support read-only pending controls

### DIFF
--- a/sdk/packages/ui/README.md
+++ b/sdk/packages/ui/README.md
@@ -80,14 +80,17 @@ welcome surfaces. It supports bot-only and grid-only compositions and becomes
 static when reduced motion is requested.
 
 `AgentApprovalCard` is controlled presentation; the host owns approval state
-and submits its callbacks.
+and submits its callbacks. Its `readOnly` mode keeps context visible while
+disabling decisions.
 
 `AgentAskQuestion` keeps option selection locally and submits explicitly. The
 host owns pending answers, errors, and response transport. Multiple-choice
 items set `multiple: true` and provide `onAnswers` for array submission.
+`readOnly` keeps questions visible without accepting or focusing answers.
 
 `AgentPromptQueue` renders queued prompts and reports edit, remove, and steer
-actions to the host.
+actions to the host. `readOnly` preserves queue disclosure while disabling
+those mutations.
 
 The token entry point has no React, Tailwind, font-package, or desktop runtime
 dependency. Apps provide Inter and Geist Mono themselves, which

--- a/sdk/packages/ui/components/agent-approval-card.tsx
+++ b/sdk/packages/ui/components/agent-approval-card.tsx
@@ -11,6 +11,7 @@ export interface AgentApprovalCardProps {
 	meta?: ReactNode;
 	onApprove: () => void;
 	onReject: () => void;
+	readOnly?: boolean;
 	responding?: AgentApprovalAction;
 	title: ReactNode;
 }
@@ -34,11 +35,13 @@ export function AgentApprovalCard({
 	meta,
 	onApprove,
 	onReject,
+	readOnly = false,
 	responding,
 	title,
 }: AgentApprovalCardProps) {
 	const titleId = useId();
 	const isPending = responding !== undefined;
+	const actionsDisabled = isPending || readOnly;
 
 	return (
 		<section
@@ -75,7 +78,7 @@ export function AgentApprovalCard({
 			<div className="cline-ui-agent-approval-card__actions">
 				<button
 					className="cline-ui-agent-approval-card__button cline-ui-agent-approval-card__button--approve inline-flex h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-cline-ui-md border-0 bg-cline-ui-primary px-3 font-cline-ui-medium text-cline-ui-primary-foreground transition-[color,background-color,border-color,box-shadow] duration-150 ease-[ease] [&:hover]:bg-cline-ui-primary/90 focus-visible:outline-3 focus-visible:outline-cline-ui-ring/50 focus-visible:outline-offset-0 disabled:pointer-events-none disabled:opacity-50"
-					disabled={isPending}
+					disabled={actionsDisabled}
 					onClick={onApprove}
 					type="button"
 				>
@@ -90,7 +93,7 @@ export function AgentApprovalCard({
 				</button>
 				<button
 					className="cline-ui-agent-approval-card__button cline-ui-agent-approval-card__button--reject inline-flex h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-cline-ui-md border border-cline-ui-border bg-cline-ui-background px-3 font-cline-ui-medium text-cline-ui-foreground shadow-xs transition-[color,background-color,border-color,box-shadow] duration-150 ease-[ease] [&:hover]:bg-cline-ui-accent [&:hover]:text-cline-ui-accent-foreground focus-visible:outline-3 focus-visible:outline-cline-ui-ring/50 focus-visible:outline-offset-0 disabled:pointer-events-none disabled:opacity-50 cline-ui-dark:border-cline-ui-input cline-ui-dark:bg-cline-ui-input/30 cline-ui-dark:[&:hover]:bg-cline-ui-input/50"
-					disabled={isPending}
+					disabled={actionsDisabled}
 					onClick={onReject}
 					type="button"
 				>

--- a/sdk/packages/ui/components/agent-ask-question.tsx
+++ b/sdk/packages/ui/components/agent-ask-question.tsx
@@ -25,6 +25,7 @@ export interface AgentAskQuestionProps {
 	pendingAnswers?: Readonly<
 		Record<string, string | readonly string[] | undefined>
 	>;
+	readOnly?: boolean;
 }
 
 function optionLabel(index: number) {
@@ -58,6 +59,7 @@ export function AgentAskQuestion({
 	onAnswer,
 	onAnswers,
 	pendingAnswers = {},
+	readOnly = false,
 }: AgentAskQuestionProps) {
 	const [selections, setSelections] = useState<
 		Readonly<Record<string, readonly string[]>>
@@ -91,6 +93,7 @@ export function AgentAskQuestion({
 				const canSubmit =
 					selected.length > 0 && (!item.multiple || Boolean(onAnswers));
 				const selectOption = (option: string) => {
+					if (readOnly) return;
 					setSelections((current) => {
 						const currentSelection = current[item.id] ?? [];
 						const nextSelection = item.multiple
@@ -103,14 +106,20 @@ export function AgentAskQuestion({
 					});
 				};
 				const submit = () => {
-					if (!canSubmit) return;
+					if (!canSubmit || readOnly) return;
 					if (item.multiple) onAnswers?.(item.id, selected);
 					else onAnswer(item.id, selected[0] as string);
 				};
 				const handleOptionKeyDown = (
 					event: ReactKeyboardEvent<HTMLFieldSetElement>,
 				) => {
-					if (isPending || event.altKey || event.ctrlKey || event.metaKey)
+					if (
+						isPending ||
+						readOnly ||
+						event.altKey ||
+						event.ctrlKey ||
+						event.metaKey
+					)
 						return;
 
 					const optionButtons = Array.from(
@@ -187,9 +196,11 @@ export function AgentAskQuestion({
 							{options.map((option, index) => (
 								<Button
 									aria-pressed={selected.includes(option)}
-									autoFocus={itemIndex === 0 && index === 0 && !isPending}
+									autoFocus={
+										itemIndex === 0 && index === 0 && !isPending && !readOnly
+									}
 									className="cline-ui-agent-ask-question__option h-auto min-h-9.5 w-full max-w-full justify-start gap-3 rounded-cline-ui-md p-2 text-left text-cline-ui-sm"
-									disabled={isPending}
+									disabled={isPending || readOnly}
 									key={option}
 									onClick={() => selectOption(option)}
 									size="sm"
@@ -221,7 +232,7 @@ export function AgentAskQuestion({
 							) : null}
 							<Button
 								className="cline-ui-agent-ask-question__submit"
-								disabled={!canSubmit || isPending}
+								disabled={!canSubmit || isPending || readOnly}
 								onClick={submit}
 								size="sm"
 								tone="neutral"

--- a/sdk/packages/ui/components/agent-prompt-queue.tsx
+++ b/sdk/packages/ui/components/agent-prompt-queue.tsx
@@ -14,6 +14,7 @@ export interface AgentPromptQueueProps {
 	onEdit: (id: string, prompt: string) => Promise<void> | void;
 	onRemove: (id: string) => Promise<void> | void;
 	onSteer: (id: string) => Promise<void> | void;
+	readOnly?: boolean;
 }
 
 type IconName =
@@ -103,6 +104,7 @@ export function AgentPromptQueue({
 	onEdit,
 	onRemove,
 	onSteer,
+	readOnly = false,
 }: AgentPromptQueueProps) {
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editingValue, setEditingValue] = useState("");
@@ -122,7 +124,7 @@ export function AgentPromptQueue({
 	const submitEdit = useCallback(
 		async (item: AgentPromptQueueItem) => {
 			const prompt = editingValue.trim();
-			if (!prompt || pendingId) return;
+			if (!prompt || pendingId || readOnly) return;
 			setActionError(null);
 			setPendingId(item.id);
 			try {
@@ -139,12 +141,12 @@ export function AgentPromptQueue({
 				setPendingId(null);
 			}
 		},
-		[cancelEdit, editingValue, onEdit, pendingId],
+		[cancelEdit, editingValue, onEdit, pendingId, readOnly],
 	);
 
 	const runAction = useCallback(
 		async (item: AgentPromptQueueItem, action: "steer" | "remove") => {
-			if (pendingId) return;
+			if (pendingId || readOnly) return;
 			setActionError(null);
 			setPendingId(item.id);
 			try {
@@ -159,7 +161,7 @@ export function AgentPromptQueue({
 				setPendingId(null);
 			}
 		},
-		[onRemove, onSteer, pendingId],
+		[onRemove, onSteer, pendingId, readOnly],
 	);
 
 	useEffect(() => {
@@ -225,12 +227,16 @@ export function AgentPromptQueue({
 										aria-label="Edit queued prompt"
 										className="cline-ui-agent-prompt-queue__editor block min-h-8 w-full resize-none rounded-cline-ui-md border border-cline-ui-border bg-cline-ui-background px-2 py-1.5 text-cline-ui-foreground text-cline-ui-xs leading-4 outline-none focus:border-[color-mix(in_oklab,var(--cline-ui-primary)_50%,transparent)] focus:shadow-[0_0_0_1px_color-mix(in_oklab,var(--cline-ui-primary)_20%,transparent)]"
 										disabled={isPending}
-										onChange={(event) => setEditingValue(event.target.value)}
+										onChange={(event) => {
+											if (!readOnly) setEditingValue(event.target.value);
+										}}
 										onKeyDown={(event) => {
 											if (event.key === "Escape") {
 												event.preventDefault();
 												cancelEdit();
+												return;
 											}
+											if (readOnly) return;
 											if (
 												event.key === "Enter" &&
 												!event.shiftKey &&
@@ -241,6 +247,7 @@ export function AgentPromptQueue({
 											}
 										}}
 										rows={1}
+										readOnly={readOnly}
 										value={editingValue}
 									/>
 								) : (
@@ -276,7 +283,9 @@ export function AgentPromptQueue({
 										<button
 											aria-label="Save queued prompt"
 											className={ACTION_CLASS_NAME}
-											disabled={isBusy || editingValue.trim().length === 0}
+											disabled={
+												isBusy || readOnly || editingValue.trim().length === 0
+											}
 											onClick={() => void submitEdit(item)}
 											type="button"
 										>
@@ -298,7 +307,7 @@ export function AgentPromptQueue({
 											<button
 												aria-label="Steer queued prompt"
 												className={ACTION_CLASS_NAME}
-												disabled={isBusy}
+												disabled={isBusy || readOnly}
 												onClick={() => void runAction(item, "steer")}
 												title="Steer next"
 												type="button"
@@ -309,7 +318,7 @@ export function AgentPromptQueue({
 										<button
 											aria-label="Edit queued prompt"
 											className={ACTION_CLASS_NAME}
-											disabled={isBusy}
+											disabled={isBusy || readOnly}
 											onClick={() => {
 												setEditingId(item.id);
 												setEditingValue(item.prompt);
@@ -321,7 +330,7 @@ export function AgentPromptQueue({
 										<button
 											aria-label="Remove queued prompt"
 											className={ACTION_CLASS_NAME}
-											disabled={isBusy}
+											disabled={isBusy || readOnly}
 											onClick={() => void runAction(item, "remove")}
 											type="button"
 										>

--- a/sdk/packages/ui/tests/agent-approval-card.test.tsx
+++ b/sdk/packages/ui/tests/agent-approval-card.test.tsx
@@ -93,4 +93,30 @@ describe("AgentApprovalCard", () => {
 			"true",
 		);
 	});
+
+	it("keeps approval context visible without accepting decisions when read-only", async () => {
+		const onApprove = vi.fn();
+		const onReject = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentApprovalCard
+					detail="bun test"
+					onApprove={onApprove}
+					onReject={onReject}
+					readOnly
+					title="Run command"
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(container.textContent).toContain("bun test");
+		expect([...buttons].every((button) => button.disabled)).toBe(true);
+		await act(async () => {
+			buttons[0]?.click();
+			buttons[1]?.click();
+		});
+		expect(onApprove).not.toHaveBeenCalled();
+		expect(onReject).not.toHaveBeenCalled();
+	});
 });

--- a/sdk/packages/ui/tests/agent-approval-card.test.tsx
+++ b/sdk/packages/ui/tests/agent-approval-card.test.tsx
@@ -95,14 +95,12 @@ describe("AgentApprovalCard", () => {
 	});
 
 	it("keeps approval context visible without accepting decisions when read-only", async () => {
-		const onApprove = vi.fn();
-		const onReject = vi.fn();
 		await act(async () =>
 			root.render(
 				<AgentApprovalCard
 					detail="bun test"
-					onApprove={onApprove}
-					onReject={onReject}
+					onApprove={vi.fn()}
+					onReject={vi.fn()}
 					readOnly
 					title="Run command"
 				/>,
@@ -112,11 +110,5 @@ describe("AgentApprovalCard", () => {
 		const buttons = container.querySelectorAll("button");
 		expect(container.textContent).toContain("bun test");
 		expect([...buttons].every((button) => button.disabled)).toBe(true);
-		await act(async () => {
-			buttons[0]?.click();
-			buttons[1]?.click();
-		});
-		expect(onApprove).not.toHaveBeenCalled();
-		expect(onReject).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -385,7 +385,6 @@ describe("AgentAskQuestion", () => {
 	});
 
 	it("keeps questions visible without focusing or accepting answers when read-only", async () => {
-		const onAnswer = vi.fn();
 		await act(async () =>
 			root.render(
 				<AgentAskQuestion
@@ -396,7 +395,7 @@ describe("AgentAskQuestion", () => {
 							question: "Continue this task?",
 						},
 					]}
-					onAnswer={onAnswer}
+					onAnswer={vi.fn()}
 					readOnly
 				/>,
 			),
@@ -406,10 +405,5 @@ describe("AgentAskQuestion", () => {
 		expect(container.textContent).toContain("Continue this task?");
 		expect([...buttons].every((button) => button.disabled)).toBe(true);
 		expect([...buttons]).not.toContain(document.activeElement);
-		await act(async () => {
-			buttons[0]?.click();
-			buttons[2]?.click();
-		});
-		expect(onAnswer).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/ui/tests/agent-ask-question.test.tsx
+++ b/sdk/packages/ui/tests/agent-ask-question.test.tsx
@@ -383,4 +383,33 @@ describe("AgentAskQuestion", () => {
 		await act(async () => buttons[2]?.click());
 		expect(onAnswer).toHaveBeenCalledWith("request-1", "Second");
 	});
+
+	it("keeps questions visible without focusing or accepting answers when read-only", async () => {
+		const onAnswer = vi.fn();
+		await act(async () =>
+			root.render(
+				<AgentAskQuestion
+					items={[
+						{
+							id: "request-1",
+							options: ["Continue", "Stop"],
+							question: "Continue this task?",
+						},
+					]}
+					onAnswer={onAnswer}
+					readOnly
+				/>,
+			),
+		);
+
+		const buttons = container.querySelectorAll("button");
+		expect(container.textContent).toContain("Continue this task?");
+		expect([...buttons].every((button) => button.disabled)).toBe(true);
+		expect([...buttons]).not.toContain(document.activeElement);
+		await act(async () => {
+			buttons[0]?.click();
+			buttons[2]?.click();
+		});
+		expect(onAnswer).not.toHaveBeenCalled();
+	});
 });

--- a/sdk/packages/ui/tests/agent-prompt-queue.test.tsx
+++ b/sdk/packages/ui/tests/agent-prompt-queue.test.tsx
@@ -240,4 +240,72 @@ describe("AgentPromptQueue", () => {
 		);
 		expect(container.childElementCount).toBe(0);
 	});
+
+	it("keeps queue disclosure available while read-only actions stay disabled", async () => {
+		const onEdit = vi.fn();
+		const onRemove = vi.fn();
+		const onSteer = vi.fn();
+		const renderQueue = (readOnly: boolean) =>
+			root.render(
+				<AgentPromptQueue
+					items={[{ id: "one", prompt: "Queued context", steer: false }]}
+					onEdit={onEdit}
+					onRemove={onRemove}
+					onSteer={onSteer}
+					readOnly={readOnly}
+				/>,
+			);
+		await act(async () => renderQueue(false));
+
+		const toggle = container.querySelector<HTMLButtonElement>(
+			"button[aria-expanded]",
+		);
+		await act(async () => toggle?.click());
+		await act(async () =>
+			container
+				.querySelector<HTMLButtonElement>('[aria-label="Edit queued prompt"]')
+				?.click(),
+		);
+		await act(async () => renderQueue(true));
+
+		const editor = container.querySelector<HTMLTextAreaElement>(
+			'[aria-label="Edit queued prompt"]',
+		);
+		expect(toggle?.disabled).toBe(false);
+		expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+		expect(editor?.readOnly).toBe(true);
+		expect(
+			container.querySelector<HTMLButtonElement>(
+				'[aria-label="Save queued prompt"]',
+			)?.disabled,
+		).toBe(true);
+
+		await act(async () =>
+			editor?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+			),
+		);
+		expect(onEdit).not.toHaveBeenCalled();
+		await act(async () =>
+			container
+				.querySelector<HTMLButtonElement>(
+					'[aria-label="Cancel editing queued prompt"]',
+				)
+				?.click(),
+		);
+		expect(container.textContent).toContain("Queued context");
+		const actionButtons = container.querySelectorAll<HTMLButtonElement>(
+			".cline-ui-agent-prompt-queue__action",
+		);
+		expect([...actionButtons].every((button) => button.disabled)).toBe(true);
+		await act(async () => {
+			actionButtons.forEach((button) => {
+				button.click();
+			});
+			await Promise.resolve();
+		});
+		expect(onEdit).not.toHaveBeenCalled();
+		expect(onRemove).not.toHaveBeenCalled();
+		expect(onSteer).not.toHaveBeenCalled();
+	});
 });

--- a/sdk/packages/ui/tests/agent-prompt-queue.test.tsx
+++ b/sdk/packages/ui/tests/agent-prompt-queue.test.tsx
@@ -243,15 +243,13 @@ describe("AgentPromptQueue", () => {
 
 	it("keeps queue disclosure available while read-only actions stay disabled", async () => {
 		const onEdit = vi.fn();
-		const onRemove = vi.fn();
-		const onSteer = vi.fn();
 		const renderQueue = (readOnly: boolean) =>
 			root.render(
 				<AgentPromptQueue
 					items={[{ id: "one", prompt: "Queued context", steer: false }]}
 					onEdit={onEdit}
-					onRemove={onRemove}
-					onSteer={onSteer}
+					onRemove={vi.fn()}
+					onSteer={vi.fn()}
 					readOnly={readOnly}
 				/>,
 			);
@@ -298,14 +296,5 @@ describe("AgentPromptQueue", () => {
 			".cline-ui-agent-prompt-queue__action",
 		);
 		expect([...actionButtons].every((button) => button.disabled)).toBe(true);
-		await act(async () => {
-			actionButtons.forEach((button) => {
-				button.click();
-			});
-			await Promise.resolve();
-		});
-		expect(onEdit).not.toHaveBeenCalled();
-		expect(onRemove).not.toHaveBeenCalled();
-		expect(onSteer).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- add an optional readOnly mode to AgentApprovalCard, AgentAskQuestion, and AgentPromptQueue
- keep approval, question, and queued-prompt context visible while disabling host mutations
- preserve queue expand/collapse and local edit cancellation; prevent answer autofocus and keyboard selection

This is the shared UI primitive needed for clients such as Desktop and Core Platform to render pending context safely during transport loss. Consumer wiring and package publication are intentionally out of scope.

## Validation

- bun -F @cline/ui test: 151 tests passed
- bun -F @cline/ui typecheck
- bun -F @cline/ui test:package
- Biome check on all changed TypeScript files
- git diff --check

## Risk

Low. The API is additive and defaults to the existing interactive behavior.