### PR TITLE
fix(hub): never prompt about a hub running the same core version

### DIFF
--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.test.ts
@@ -11,6 +11,15 @@ type DiscoveryMockOptions = {
 	 * settles under this file's fake timers.
 	 */
 	activity?: { activeSessionCount: number; participantClientCount: number };
+	/**
+	 * This client's own build identity; omitted keeps the real resolution
+	 * (env-driven buildId/epoch plus the actual core package version).
+	 */
+	selfIdentity?: {
+		buildId?: string;
+		buildEpochMs?: number;
+		coreVersion?: string;
+	};
 };
 
 function mockDiscovery(options: DiscoveryMockOptions): void {
@@ -38,6 +47,9 @@ function mockDiscovery(options: DiscoveryMockOptions): void {
 		return {
 			...actual,
 			resolveHubBuildId: () => options.expectedBuildId ?? "current-build",
+			...(options.selfIdentity
+				? { resolveHubBuildIdentity: () => options.selfIdentity }
+				: {}),
 			readHubDiscovery: vi.fn(async () => options.record),
 			probeHubServer: vi.fn(async () => options.probe),
 		};
@@ -60,6 +72,93 @@ describe("checkManagedHubBuildMismatch", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();
 		vi.resetModules();
+	});
+
+	// Two artifacts of the same release cut from different commits never share
+	// a build fingerprint or epoch (e.g. desktop-v0.0.22 and cli-v3.0.61 both
+	// bundling core 0.0.82). Neither side can act on that - "update" installs
+	// nothing newer - so neither direction may prompt.
+	it("does not prompt for a same-release hub with a different fingerprint (hub built earlier)", async () => {
+		mockDiscovery({
+			expectedBuildId: "desktop-fingerprint",
+			selfIdentity: {
+				buildId: "desktop-fingerprint",
+				buildEpochMs: 2_000,
+				coreVersion: "0.0.82",
+			},
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "cli-fingerprint",
+				buildEpochMs: 1_000,
+				coreVersion: "0.0.82",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		// Without the same-release rule this would classify as outdated_hub.
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("does not prompt for a same-release hub with a different fingerprint (hub built later)", async () => {
+		mockDiscovery({
+			expectedBuildId: "desktop-fingerprint",
+			selfIdentity: {
+				buildId: "desktop-fingerprint",
+				buildEpochMs: 1_000,
+				coreVersion: "0.0.82",
+			},
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "cli-fingerprint",
+				buildEpochMs: 2_000,
+				coreVersion: "0.0.82",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		// Without the same-release rule this would classify as build_mismatch.
+		await expect(checkManagedHubBuildMismatch()).resolves.toBeUndefined();
+	});
+
+	it("still prompts across genuinely different releases", async () => {
+		mockDiscovery({
+			expectedBuildId: "desktop-fingerprint",
+			selfIdentity: {
+				buildId: "desktop-fingerprint",
+				buildEpochMs: 1_000,
+				coreVersion: "0.0.82",
+			},
+			record: liveRecord,
+			probe: {
+				protocolVersion: "v1",
+				buildId: "cli-fingerprint",
+				buildEpochMs: 2_000,
+				coreVersion: "0.0.83",
+				host: "127.0.0.1",
+				port: 59999,
+				url: "ws://127.0.0.1:59999/hub",
+			},
+		});
+		const { checkManagedHubBuildMismatch } = await import(
+			"./managed-hub-build-watcher"
+		);
+
+		await expect(checkManagedHubBuildMismatch()).resolves.toMatchObject({
+			reason: "build_mismatch",
+			hubCoreVersion: "0.0.83",
+		});
 	});
 
 	it("reports a live hub running a newer build", async () => {

--- a/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
+++ b/sdk/packages/core/src/hub/client/managed-hub-build-watcher.ts
@@ -143,12 +143,29 @@ export async function checkManagedHubBuildMismatch(): Promise<
 	if (compatibility.reason === "unsupported_protocol") {
 		return report("unsupported_protocol");
 	}
+	// Two independently built artifacts of the same release never share a
+	// build fingerprint: a CLI and a desktop app cut from different commits
+	// at the same core version carry different buildIds and build epochs, so
+	// they disagree forever. That disagreement is not user-actionable in
+	// either direction - "update" would install nothing newer, and the
+	// prompt loops until the next release happens to align the fingerprints.
+	// Same core version therefore never prompts; the fingerprint keeps its
+	// role in the reuse/retire total order, where its antisymmetry matters,
+	// but it does not drive prompts on its own.
+	const self = resolveHubBuildIdentity();
+	if (
+		self.coreVersion &&
+		healthy.coreVersion &&
+		self.coreVersion === healthy.coreVersion
+	) {
+		return undefined;
+	}
 	// Only a Hub this client is strictly newer than gets the "older Hub" copy;
 	// that is the case the retire path defers while sessions are live. A newer
 	// Hub - or one that carries too little metadata to order, where updating
 	// this client is what supplies the missing ordering - is a client-update
 	// prompt as before.
-	if (compareHubBuilds(resolveHubBuildIdentity(), healthy) > 0) {
+	if (compareHubBuilds(self, healthy) > 0) {
 		return await withHubSessionActivity(
 			report("outdated_hub"),
 			record.authToken,


### PR DESCRIPTION
### Related Issue

Production follow-up to #13727.

### Description

**Incident:** after cutting `cli-v3.0.61` and `desktop-v0.0.22` — both bundling core **0.0.82**, but from different commits (`595f1dbf` vs `be59305d`) — every desktop user with the CLI installed gets the **"Cline Hub was updated"** dialog on every launch and on every webview reconnect (e.g. switching sessions). "Update and restart" reports *"No app update is available to download yet"* forever, because the app already is the latest release.

**Root cause:** packaged buildIds are source fingerprints, so two same-version releases cut from different commits can never match on buildId, and their build epochs always order one above the other. The mismatch watcher prompted on that fingerprint disagreement even though it is not user-actionable in either direction.

**Fix:** `checkManagedHubBuildMismatch` returns nothing when the hub's `coreVersion` equals this client's own — suppressing both the `build_mismatch` ("update the app") and `outdated_hub` ("update the hub") prompts for same-release pairs. This silences the desktop dialog, the sidecar startup check, and the TUI toast, since all three source from this check. The fingerprint keeps its role in the reuse/retire total order (where its antisymmetry prevents the #13145 kill loop); it no longer drives prompts on its own. Genuinely different releases (e.g. hub on 0.0.83, app on 0.0.82) still prompt.

### Test Procedure

- 3 new watcher tests: same-release suppression with the hub built earlier (would have been `outdated_hub`) and later (would have been `build_mismatch`), plus a genuine cross-release mismatch still prompting — 15/15 pass
- Core typecheck clean

Releasing this in a desktop cut gives current v0.0.22 users an actionable update, and after updating they stop being prompted for same-release fingerprint skew permanently.

Before

<img width="1024" height="440" alt="image" src="https://github.com/user-attachments/assets/1fcbf8fd-6dda-46c0-8863-c4eb6167b594" />

<img width="1036" height="476" alt="image" src="https://github.com/user-attachments/assets/653d1e49-d1f6-43c9-ade1-35506c4bf980" />


### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
