### PR TITLE
fix(desktop): show the newer-hub dialog only when an app update is staged, and persist Later

### DIFF
--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -14,11 +14,13 @@ import {
 import {
 	checkForUpdateNow,
 	restartToApplyUpdate,
+	useAppUpdateStatus,
 } from "@/hooks/use-app-update";
 import { desktopClient } from "@/lib/desktop-client";
 import {
 	describeOutdatedHubSessions,
 	resolveHubUpdateRestartDecision,
+	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
 
 type HubBuildMismatchPayload = {
@@ -37,6 +39,35 @@ type UpdatePhase = "idle" | "updating" | "restarting";
 
 /** Generous deadline: drain wait + graceful retire + fresh daemon startup. */
 const HUB_UPGRADE_TIMEOUT_MS = 60_000;
+
+/**
+ * "Later" must survive webview remounts and reconnects: the sidecar replays
+ * a pending mismatch on every new webview connection (session switches,
+ * reloads, relaunches), and in-memory dismissal state resurrected the modal
+ * each time. Storage keeps one key - a different hub build prompts again.
+ */
+const DISMISSED_MISMATCH_STORAGE_KEY = "cline.hub-mismatch-dismissed";
+
+function readPersistedDismissedKey(): string | null {
+	try {
+		return localStorage.getItem(DISMISSED_MISMATCH_STORAGE_KEY);
+	} catch {
+		return null;
+	}
+}
+
+function persistDismissedKey(key: string): void {
+	try {
+		localStorage.setItem(DISMISSED_MISMATCH_STORAGE_KEY, key);
+	} catch {
+		// Best effort: without storage the dismissal lasts this mount only.
+	}
+}
+
+// One updater kick per observed mismatch per page lifetime. Module scope
+// survives component remounts (session switches) so the update feed is not
+// re-hit every time the dialog mounts.
+let updateCheckKickedForKey: string | null = null;
 
 /**
  * Blocking prompt shown when the sidecar reports that the shared Cline Hub
@@ -58,9 +89,12 @@ export function HubUpdateRequiredDialog() {
 	const [mismatch, setMismatch] = useState<HubBuildMismatchPayload | null>(
 		null,
 	);
-	const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+	const [dismissedKey, setDismissedKey] = useState<string | null>(
+		readPersistedDismissedKey,
+	);
 	const [phase, setPhase] = useState<UpdatePhase>("idle");
 	const [updateHint, setUpdateHint] = useState<string | null>(null);
+	const updateStatus = useAppUpdateStatus();
 
 	useEffect(() => {
 		return desktopClient.subscribe("hub_build_mismatch", (payload) => {
@@ -83,6 +117,25 @@ export function HubUpdateRequiredDialog() {
 	}, []);
 
 	const mismatchKey = mismatch ? mismatchKeyOf(mismatch) : null;
+
+	// When a newer Hub appears, stage the matching app update right away (if
+	// a release exists) so the prompt can open actionable instead of waiting
+	// for the next 30s background cycle. Without a staged update the
+	// build_mismatch modal stays hidden entirely - see
+	// shouldShowHubMismatchDialog.
+	useEffect(() => {
+		if (
+			!mismatch ||
+			mismatch.reason !== "build_mismatch" ||
+			mismatchKey === null ||
+			mismatchKey === dismissedKey ||
+			updateCheckKickedForKey === mismatchKey
+		) {
+			return;
+		}
+		updateCheckKickedForKey = mismatchKey;
+		void checkForUpdateNow();
+	}, [mismatch, mismatchKey, dismissedKey]);
 
 	const handleUpdateAndRestart = useCallback(async () => {
 		setPhase("updating");
@@ -191,14 +244,18 @@ export function HubUpdateRequiredDialog() {
 		);
 	}
 
-	const open = mismatchKey !== null && mismatchKey !== dismissedKey;
+	const open =
+		mismatchKey !== null &&
+		mismatchKey !== dismissedKey &&
+		shouldShowHubMismatchDialog(mismatch?.reason, updateStatus.state);
 
 	return (
 		<AlertDialog
 			open={open}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen && phase === "idle") {
+				if (!nextOpen && phase === "idle" && mismatchKey !== null) {
 					setDismissedKey(mismatchKey);
+					persistDismissedKey(mismatchKey);
 				}
 			}}
 		>

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -21,6 +21,7 @@ import {
 	describeOutdatedHubSessions,
 	isPersistableHubMismatchKey,
 	resolveHubUpdateRestartDecision,
+	retainDismissalForIncomingMismatch,
 	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
 
@@ -110,11 +111,19 @@ export function HubUpdateRequiredDialog() {
 			if (!payload || typeof payload !== "object") {
 				return;
 			}
-			setMismatch(payload as HubBuildMismatchPayload);
+			const incoming = payload as HubBuildMismatchPayload;
+			setMismatch(incoming);
 			// A new mismatch is a fresh prompt: drop any "no update available"
 			// hint left over from a previous dialog so it reopens in its
 			// initial state instead of pre-set to "Try again".
 			setUpdateHint(null);
+			// Delivery includes replays on in-place transport reconnects, where
+			// this component never remounts: a non-persistable dismissal
+			// (unsupported_protocol) must not survive them, or the warning about
+			// a Hub the app cannot talk to stays silenced indefinitely.
+			setDismissedKey((previous) =>
+				retainDismissalForIncomingMismatch(previous, mismatchKeyOf(incoming)),
+			);
 		});
 	}, []);
 

--- a/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-dialog.tsx
@@ -19,6 +19,7 @@ import {
 import { desktopClient } from "@/lib/desktop-client";
 import {
 	describeOutdatedHubSessions,
+	isPersistableHubMismatchKey,
 	resolveHubUpdateRestartDecision,
 	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
@@ -50,7 +51,8 @@ const DISMISSED_MISMATCH_STORAGE_KEY = "cline.hub-mismatch-dismissed";
 
 function readPersistedDismissedKey(): string | null {
 	try {
-		return localStorage.getItem(DISMISSED_MISMATCH_STORAGE_KEY);
+		const key = localStorage.getItem(DISMISSED_MISMATCH_STORAGE_KEY);
+		return isPersistableHubMismatchKey(key) ? key : null;
 	} catch {
 		return null;
 	}
@@ -255,7 +257,12 @@ export function HubUpdateRequiredDialog() {
 			onOpenChange={(nextOpen) => {
 				if (!nextOpen && phase === "idle" && mismatchKey !== null) {
 					setDismissedKey(mismatchKey);
-					persistDismissedKey(mismatchKey);
+					// unsupported_protocol never persists: hub-backed features
+					// stay broken against that Hub, so its warning must return
+					// on the next reconnect or relaunch.
+					if (isPersistableHubMismatchKey(mismatchKey)) {
+						persistDismissedKey(mismatchKey);
+					}
 				}
 			}}
 		>

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -3,6 +3,7 @@ import {
 	describeOutdatedHubSessions,
 	isPersistableHubMismatchKey,
 	resolveHubUpdateRestartDecision,
+	retainDismissalForIncomingMismatch,
 	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
 
@@ -31,6 +32,35 @@ describe("shouldShowHubMismatchDialog", () => {
 		expect(isPersistableHubMismatchKey("outdated_hub:abc123")).toBe(false);
 		expect(isPersistableHubMismatchKey(null)).toBe(false);
 		expect(isPersistableHubMismatchKey("")).toBe(false);
+	});
+
+	it("reopens a dismissed protocol warning on redelivery, keeps advisory and unrelated dismissals", () => {
+		// A replayed unsupported_protocol mismatch clears its own dismissal:
+		// the app cannot talk to that Hub, so "Later" must not outlive an
+		// in-place reconnect replay.
+		expect(
+			retainDismissalForIncomingMismatch(
+				"unsupported_protocol:abc",
+				"unsupported_protocol:abc",
+			),
+		).toBeNull();
+		// The advisory newer-hub dismissal stands across replays.
+		expect(
+			retainDismissalForIncomingMismatch(
+				"build_mismatch:abc",
+				"build_mismatch:abc",
+			),
+		).toBe("build_mismatch:abc");
+		// A dismissal for a different mismatch is untouched.
+		expect(
+			retainDismissalForIncomingMismatch(
+				"build_mismatch:abc",
+				"unsupported_protocol:def",
+			),
+		).toBe("build_mismatch:abc");
+		expect(retainDismissalForIncomingMismatch(null, "build_mismatch:abc")).toBe(
+			null,
+		);
 	});
 
 	it("allows a newer-hub prompt only once an app update is staged", () => {

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -2,7 +2,39 @@ import { describe, expect, it } from "vitest";
 import {
 	describeOutdatedHubSessions,
 	resolveHubUpdateRestartDecision,
+	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
+
+describe("shouldShowHubMismatchDialog", () => {
+	it("always allows the truly-broken and blocking reasons", () => {
+		for (const state of [
+			"idle",
+			"checking",
+			"downloading",
+			"ready",
+			"error",
+			undefined,
+		] as const) {
+			expect(shouldShowHubMismatchDialog("unsupported_protocol", state)).toBe(
+				true,
+			);
+			expect(shouldShowHubMismatchDialog("outdated_hub", state)).toBe(true);
+		}
+	});
+
+	it("allows a newer-hub prompt only once an app update is staged", () => {
+		expect(shouldShowHubMismatchDialog("build_mismatch", "ready")).toBe(true);
+		for (const state of [
+			"idle",
+			"checking",
+			"downloading",
+			"error",
+			undefined,
+		] as const) {
+			expect(shouldShowHubMismatchDialog("build_mismatch", state)).toBe(false);
+		}
+	});
+});
 
 describe("describeOutdatedHubSessions", () => {
 	it("quantifies sessions and clients when the hub reported both", () => {

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	describeOutdatedHubSessions,
+	isPersistableHubMismatchKey,
 	resolveHubUpdateRestartDecision,
 	shouldShowHubMismatchDialog,
 } from "./hub-update-required-helpers";
@@ -20,6 +21,16 @@ describe("shouldShowHubMismatchDialog", () => {
 			);
 			expect(shouldShowHubMismatchDialog("outdated_hub", state)).toBe(true);
 		}
+	});
+
+	it("persists dismissals only for the advisory build_mismatch case", () => {
+		expect(isPersistableHubMismatchKey("build_mismatch:abc123")).toBe(true);
+		expect(isPersistableHubMismatchKey("unsupported_protocol:abc123")).toBe(
+			false,
+		);
+		expect(isPersistableHubMismatchKey("outdated_hub:abc123")).toBe(false);
+		expect(isPersistableHubMismatchKey(null)).toBe(false);
+		expect(isPersistableHubMismatchKey("")).toBe(false);
 	});
 
 	it("allows a newer-hub prompt only once an app update is staged", () => {

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -5,6 +5,28 @@ export type HubUpdateRestartDecision =
 	| { action: "stay"; hint: string };
 
 /**
+ * Whether a hub build mismatch may interrupt with a modal at all.
+ *
+ * - `unsupported_protocol` and `outdated_hub` always may: the first means
+ *   the app cannot talk to the Hub, the second is the blocking
+ *   replace-or-quit decision.
+ * - `build_mismatch` may only once an app update is actually staged. A
+ *   newer Hub is advisory while the wire protocol still works, and without
+ *   a staged update the modal's only exit is "no update available yet",
+ *   which loops on every launch and webview reconnect until a release
+ *   ships - so it stays silent until it can offer a real action.
+ */
+export function shouldShowHubMismatchDialog(
+	reason: string | undefined,
+	updateState: AppUpdateStatus["state"] | undefined,
+): boolean {
+	if (reason === "unsupported_protocol" || reason === "outdated_hub") {
+		return true;
+	}
+	return updateState === "ready";
+}
+
+/**
  * Human phrase for the live work an outdated Hub is serving, used by the
  * blocking "Hub update required" dialog. Falls back to an unquantified
  * phrase when the Hub could not answer the activity query.

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -39,6 +39,28 @@ export function isPersistableHubMismatchKey(key: string | null): key is string {
 }
 
 /**
+ * What a dismissal becomes when the sidecar delivers a mismatch again - it
+ * replays the pending mismatch on every webview (re)connection, including
+ * in-place transport reconnects where the dialog never remounts. A reason
+ * whose dismissal may not outlive the moment (`unsupported_protocol`: the
+ * app cannot talk to the Hub) drops its matching in-memory "Later" so the
+ * warning reopens on the replay; the advisory `build_mismatch` dismissal
+ * stands. An unrelated dismissed key is kept either way.
+ */
+export function retainDismissalForIncomingMismatch(
+	previousDismissedKey: string | null,
+	incomingKey: string,
+): string | null {
+	if (
+		previousDismissedKey === incomingKey &&
+		!isPersistableHubMismatchKey(incomingKey)
+	) {
+		return null;
+	}
+	return previousDismissedKey;
+}
+
+/**
  * Human phrase for the live work an outdated Hub is serving, used by the
  * blocking "Hub update required" dialog. Falls back to an unquantified
  * phrase when the Hub could not answer the activity query.

--- a/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
+++ b/apps/examples/desktop-app/webview/components/hub-update-required-helpers.ts
@@ -27,6 +27,18 @@ export function shouldShowHubMismatchDialog(
 }
 
 /**
+ * Only the advisory `build_mismatch` dismissal may persist across webview
+ * mounts and app relaunches. An `unsupported_protocol` Hub leaves hub-backed
+ * features broken, so that warning must return on every reconnect and
+ * relaunch - its "Later" lasts only for the current mount. Applied on both
+ * write and read, so a key persisted by any other path is ignored too.
+ * (Mismatch keys are `${reason}:${hubBuildId}`.)
+ */
+export function isPersistableHubMismatchKey(key: string | null): key is string {
+	return typeof key === "string" && key.startsWith("build_mismatch:");
+}
+
+/**
  * Human phrase for the live work an outdated Hub is serving, used by the
  * blocking "Hub update required" dialog. Falls back to an unquantified
  * phrase when the Hub could not answer the activity query.


### PR DESCRIPTION
### Related Issue

Companion to #13785 (the same-release false-positive fix). This PR hardens the genuine-skew case: a newer hub really is out (e.g. CLI ships core 0.0.83 before the desktop release exists).

### Description

Two changes to the `build_mismatch` ("Cline Hub was updated") dialog:

1. **Actionability gate**: the modal renders only when `useAppUpdateStatus()` reports a staged update (`ready`). Previously, when no desktop release existed yet, "Update and restart" dead-ended in *"No app update is available to download yet"* on every launch — an unactionable nag loop. Now the dialog stays silent until it can offer a real action. A newly observed mismatch kicks one immediate `checkForUpdateNow()` (deduped per hub build per page lifetime) so the prompt opens as soon as a release exists, and the shared 30s-polled status opens it reactively when the background updater stages one later. `unsupported_protocol` and `outdated_hub` keep their unconditional dialogs — one is truly broken, the other is the blocking consent flow.
2. **Persistent dismissal**: "Later" is stored in `localStorage` keyed by `reason:hubBuildId`. The sidecar replays a pending mismatch on every webview connection — switching sessions, reloading, relaunching — and the previous in-memory dismissal resurrected the modal each time. A different hub build still prompts.

### Test Procedure

- New `shouldShowHubMismatchDialog` unit tests (always-modal reasons under every updater state; `build_mismatch` only under `ready`) — 9/9 helper tests pass
- Desktop typecheck clean

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)