### PR TITLE
feat(core): integrate Langfuse with OpenTelemetry

### DIFF
--- a/LANGFUSE.md
+++ b/LANGFUSE.md
@@ -1,0 +1,109 @@
+# Langfuse and OpenTelemetry
+
+## Goal
+
+Cline emits AI SDK traces through its existing OpenTelemetry provider and OTLP
+exporter. The OpenTelemetry backend stores the Langfuse credentials and
+forwards selected traces to Langfuse. Direct `@cline/llms` consumers retain a
+standalone Langfuse integration.
+
+## Modes
+
+`createConfiguredTelemetryHandle` supports three modes:
+
+```ts
+// Default for Cline: credentials live in the OTel backend.
+createConfiguredTelemetryHandle({
+  ...otelConfig,
+  langfuse: { mode: "collector" },
+});
+
+// Optional direct application-to-Langfuse export.
+createConfiguredTelemetryHandle({
+  ...otelConfig,
+  langfuse: { mode: "direct", publicKey, secretKey, baseUrl },
+});
+
+// No Langfuse instrumentation.
+createConfiguredTelemetryHandle({ ...otelConfig, langfuse: false });
+```
+
+Collector mode is the default when `langfuse` is omitted. It registers the AI
+SDK 7 Langfuse integration but does not install a local
+`LangfuseSpanProcessor`. AI SDK spans flow through the normal Cline OTLP
+exporter. When Cline telemetry is disabled, Langfuse instrumentation is also
+disabled, including the standalone environment fallback.
+
+Direct mode constructs a `LangfuseSpanProcessor` before the immutable OTel SDK
+2.x tracer provider is created. The client provider owns its flush and
+shutdown. Standalone `@cline/llms` uses an isolated provider only when it has
+not been configured by a Cline host.
+
+## Credential ownership
+
+In collector mode, no Langfuse credentials are present in the Cline process,
+session configuration, runtime context, RPC payloads, or model requests. The
+OTel backend stores:
+
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_BASE_URL`
+
+It exports traces over OTLP/HTTP to
+`<LANGFUSE_BASE_URL>/api/public/otel` using:
+
+```yaml
+headers:
+  Authorization: "Basic ${env:LANGFUSE_BASIC_AUTH}"
+  x-langfuse-ingestion-version: "4"
+```
+
+`LANGFUSE_BASIC_AUTH` is the Base64 encoding of
+`<public-key>:<secret-key>`. It remains a secret even though it is encoded.
+
+## Ownership rules
+
+| Runtime | Provider owner | Langfuse export | Shutdown owner |
+| --- | --- | --- | --- |
+| Cline collector mode | Client/core | OTel backend | Client/core |
+| Cline direct mode | Client/core | Injected Langfuse processor | Client/core |
+| Standalone `@cline/llms` | `@cline/llms` | Isolated Langfuse provider | `@cline/llms` |
+| Embedding application | Application | Application-composed processor | Application |
+
+Only the provider owner may flush or shut it down. The LLM request path must
+never inspect, mutate, replace, flush, or shut down an ambient global provider.
+
+## Backend configuration
+
+An OpenTelemetry Collector can fan traces out to the existing destination and
+Langfuse:
+
+```yaml
+exporters:
+  otlphttp/primary:
+    endpoint: ${env:PRIMARY_OTEL_ENDPOINT}
+  otlphttp/langfuse:
+    endpoint: https://us.cloud.langfuse.com/api/public/otel
+    headers:
+      Authorization: "Basic ${env:LANGFUSE_BASIC_AUTH}"
+      x-langfuse-ingestion-version: "4"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/primary, otlphttp/langfuse]
+```
+
+Use collector filters carefully. Langfuse needs the relevant root span to
+reconstruct the trace, so filtering parent spans can orphan AI SDK model-call
+spans.
+
+## Content policy
+
+Prompt, response, tool-input, and tool-output capture is separate from
+transport configuration. Enabling collector or direct mode must not by itself
+authorize content capture. Operational metadata such as model, usage, cost,
+latency, finish reason, session, conversation, and run identifiers should be
+handled independently from content-bearing fields.

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -460,6 +460,27 @@ Design implication:
 - logging is injectable and transport-agnostic, allowing host environments (CLI, VS Code, browser) to wire their own backends
 - do not hardcode logging calls; accept a `logger?: BasicLogger` parameter instead
 
+### 6.1 OpenTelemetry and Langfuse ownership
+
+`@cline/core` is the composition root for Cline's process-wide OpenTelemetry
+provider. `createConfiguredTelemetryHandle` constructs that provider with both
+the configured OTLP processors and any additional processors. In Langfuse
+collector mode, it activates AI SDK 7 instrumentation but installs no local
+Langfuse exporter; the normal OTLP pipeline forwards spans and the backend owns
+the Langfuse credential. Direct mode instead obtains a `LangfuseSpanProcessor`
+from `@cline/llms` and installs it during provider construction.
+
+Direct `@cline/llms` consumers retain a standalone fallback. It creates an
+isolated Langfuse tracer provider and owns that provider's flush and shutdown.
+An LLM request never mutates or shuts down an ambient global provider.
+
+Design implication:
+
+- provider owners compose span processors before constructing an OpenTelemetry SDK 2.x provider
+- collector-mode Langfuse credentials remain in the OTel backend and are never present in the client or request metadata
+- only the provider owner may flush or shut down the provider
+- telemetry opt-out prevents creation and activation of the Cline-hosted Langfuse integration
+
 ### 7. Storage Adapters
 
 Stateful persistence should be isolated behind adapter/service layers.

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -779,6 +779,7 @@ export {
 export type { ITelemetryAdapter } from "./services/telemetry/ITelemetryAdapter";
 export {
 	type ConfiguredTelemetryHandle,
+	type CreateConfiguredTelemetryHandleOptions,
 	type CreateOpenTelemetryTelemetryServiceOptions,
 	createConfiguredTelemetryHandle,
 	createConfiguredTelemetryService,
@@ -917,6 +918,16 @@ export async function loadOpenTelemetryAdapter() {
 	return import("./services/telemetry/index.js");
 }
 export { Agent, createAgentRuntime } from "@cline/agents";
+export {
+	activateLangfuseTelemetry,
+	createLangfuseTelemetryIntegration,
+	disableLangfuseTelemetry,
+	hasLangfuseTelemetryConfig,
+	type LangfuseCollectorTelemetryConfig,
+	type LangfuseDirectTelemetryConfig,
+	type LangfuseTelemetryConfig,
+	type LangfuseTelemetryIntegration,
+} from "@cline/llms";
 export {
 	createCompactionStateAwarePrepareTurn,
 	createContextCompactionPrepareTurn,

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as llms from "@cline/llms";
 import type { BasicLogger } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeGlobalSettings } from "../global-settings";
@@ -160,6 +161,10 @@ describe("createOpenTelemetryTelemetryService", () => {
 	});
 
 	it("uses the existing OTLP pipeline without a local Langfuse processor in collector mode", async () => {
+		const activateLangfuseTelemetry = vi.spyOn(
+			llms,
+			"activateLangfuseTelemetry",
+		);
 		const handle = createConfiguredTelemetryHandle({
 			metadata: {
 				extension_version: "1.2.3",
@@ -175,6 +180,7 @@ describe("createOpenTelemetryTelemetryService", () => {
 		});
 
 		expect(handle.provider?.tracerProvider).not.toBeNull();
+		expect(activateLangfuseTelemetry).toHaveBeenCalledTimes(1);
 		expect(
 			(
 				handle.provider as unknown as {
@@ -182,6 +188,29 @@ describe("createOpenTelemetryTelemetryService", () => {
 				}
 			).options.additionalSpanProcessors,
 		).toEqual([]);
+		await handle.dispose();
+	});
+
+	it("does not activate Langfuse collector mode without a trace pipeline", async () => {
+		const activateLangfuseTelemetry = vi.spyOn(
+			llms,
+			"activateLangfuseTelemetry",
+		);
+		const handle = createConfiguredTelemetryHandle({
+			metadata: {
+				extension_version: "1.2.3",
+				cline_type: "cli",
+				platform: "terminal",
+				platform_version: process.version,
+				os_type: process.platform,
+				os_version: "unknown",
+			},
+			enabled: true,
+			langfuse: { mode: "collector" },
+		});
+
+		expect(handle.provider?.tracerProvider).toBeNull();
+		expect(activateLangfuseTelemetry).not.toHaveBeenCalled();
 		await handle.dispose();
 	});
 

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.test.ts
@@ -5,6 +5,7 @@ import type { BasicLogger } from "@cline/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeGlobalSettings } from "../global-settings";
 import {
+	createConfiguredTelemetryHandle,
 	createConfiguredTelemetryService,
 	createOpenTelemetryTelemetryService,
 	OpenTelemetryProvider,
@@ -130,6 +131,58 @@ describe("createOpenTelemetryTelemetryService", () => {
 		const span = provider.getTracer("test").startSpan("verify.tracing");
 		span.end();
 		await provider.dispose();
+	});
+
+	it("constructs the tracer provider with an injected span processor", async () => {
+		const shutdown = vi.fn(async () => undefined);
+		const processor = {
+			onStart: vi.fn(),
+			onEnd: vi.fn(),
+			forceFlush: vi.fn(async () => undefined),
+			shutdown,
+		};
+		const { provider } = createOpenTelemetryTelemetryService({
+			metadata: {
+				extension_version: "1.2.3",
+				cline_type: "cli",
+				platform: "terminal",
+				platform_version: process.version,
+				os_type: process.platform,
+				os_version: "unknown",
+			},
+			enabled: true,
+			additionalSpanProcessors: [processor],
+		});
+
+		expect(provider.tracerProvider).not.toBeNull();
+		await provider.dispose();
+		expect(shutdown).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the existing OTLP pipeline without a local Langfuse processor in collector mode", async () => {
+		const handle = createConfiguredTelemetryHandle({
+			metadata: {
+				extension_version: "1.2.3",
+				cline_type: "cli",
+				platform: "terminal",
+				platform_version: process.version,
+				os_type: process.platform,
+				os_version: "unknown",
+			},
+			enabled: true,
+			tracesExporter: "console",
+			langfuse: { mode: "collector" },
+		});
+
+		expect(handle.provider?.tracerProvider).not.toBeNull();
+		expect(
+			(
+				handle.provider as unknown as {
+					options: { additionalSpanProcessors?: unknown[] };
+				}
+			).options.additionalSpanProcessors,
+		).toEqual([]);
+		await handle.dispose();
 	});
 
 	it("does not create an OTEL provider when disabled", () => {

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
@@ -1,3 +1,9 @@
+import {
+	activateLangfuseTelemetry,
+	createLangfuseTelemetryIntegration,
+	disableLangfuseTelemetry,
+	type LangfuseTelemetryConfig,
+} from "@cline/llms";
 import type {
 	BasicLogger,
 	ITelemetryService,
@@ -125,6 +131,13 @@ export interface OpenTelemetryProviderOptions
 	logMaxQueueSize?: number;
 	logBatchSize?: number;
 	logBatchTimeoutMs?: number;
+	/**
+	 * Host-owned span processors installed when the tracer provider is created.
+	 * OpenTelemetry SDK 2.x providers are immutable after construction, so
+	 * integrations such as Langfuse must be composed here rather than attached
+	 * lazily by the request path.
+	 */
+	additionalSpanProcessors?: readonly SpanProcessor[];
 }
 
 export interface CreateOpenTelemetryTelemetryServiceOptions
@@ -272,9 +285,6 @@ export class OpenTelemetryProvider {
 		resource: ReturnType<typeof resourceFromAttributes>,
 	): NodeTracerProvider | null {
 		const exporters = normalizeExporters(this.options.tracesExporter);
-		if (exporters.length === 0) {
-			return null;
-		}
 
 		const traceEndpoint =
 			this.options.otlpTracesEndpoint ?? this.options.otlpEndpoint;
@@ -293,6 +303,7 @@ export class OpenTelemetryProvider {
 				processors.push(processor);
 			}
 		}
+		processors.push(...(this.options.additionalSpanProcessors ?? []));
 		if (processors.length === 0) {
 			return null;
 		}
@@ -431,6 +442,16 @@ export interface ConfiguredTelemetryHandle {
 	emitProviderCreated?: () => void;
 }
 
+export interface CreateConfiguredTelemetryHandleOptions
+	extends CreateOpenTelemetryTelemetryServiceOptions {
+	/**
+	 * Langfuse transport. Omit for the Cline default (`collector`), select
+	 * `direct` to construct a local processor, or use `false` to disable AI SDK
+	 * Langfuse instrumentation explicitly.
+	 */
+	langfuse?: LangfuseTelemetryConfig | false;
+}
+
 /**
  * Builds a {@link ConfiguredTelemetryHandle} so hosts (CLI, VS Code, hub
  * daemon) share one canonical flush/dispose implementation. Without a
@@ -438,10 +459,39 @@ export interface ConfiguredTelemetryHandle {
  * to drift; this factory keeps the lifecycle uniform across hosts.
  */
 export function createConfiguredTelemetryHandle(
-	options: CreateOpenTelemetryTelemetryServiceOptions,
+	options: CreateConfiguredTelemetryHandleOptions,
 ): ConfiguredTelemetryHandle {
+	// This is the Cline composition root for process-wide telemetry. Resolve
+	// Langfuse credentials here so its processor is present when the immutable
+	// OTel SDK 2.x provider is constructed. The same bundled @cline/llms module
+	// later instruments AI SDK calls, avoiding cross-bundle singleton drift.
+	const { langfuse: langfuseConfig, ...telemetryOptions } = options;
+	const langfuseEnabled =
+		telemetryOptions.enabled === true &&
+		!isTelemetryOptedOutGlobally() &&
+		langfuseConfig !== false;
+	if (!langfuseEnabled) {
+		disableLangfuseTelemetry();
+	}
+	const collectorMode =
+		langfuseEnabled &&
+		(langfuseConfig === undefined || langfuseConfig.mode === "collector");
+	const langfuse =
+		langfuseEnabled && langfuseConfig && langfuseConfig.mode === "direct"
+			? createLangfuseTelemetryIntegration(langfuseConfig)
+			: undefined;
+	const configuredOptions: CreateOpenTelemetryTelemetryServiceOptions = {
+		...telemetryOptions,
+		additionalSpanProcessors: [
+			...(telemetryOptions.additionalSpanProcessors ?? []),
+			...(langfuse ? [langfuse.spanProcessor] : []),
+		],
+	};
 	const { telemetry, provider, emitProviderCreated } =
-		createConfiguredTelemetryService(options);
+		createConfiguredTelemetryService(configuredOptions);
+	if (provider && (langfuse || collectorMode)) {
+		activateLangfuseTelemetry();
+	}
 
 	const flush = async (): Promise<void> => {
 		const candidate = provider as
@@ -465,7 +515,7 @@ export function createConfiguredTelemetryHandle(
 		provider,
 		flush,
 		dispose,
-		...(options.deferProviderCreatedEvent && emitProviderCreated
+		...(telemetryOptions.deferProviderCreatedEvent && emitProviderCreated
 			? { emitProviderCreated }
 			: {}),
 	};

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
@@ -489,7 +489,7 @@ export function createConfiguredTelemetryHandle(
 	};
 	const { telemetry, provider, emitProviderCreated } =
 		createConfiguredTelemetryService(configuredOptions);
-	if (provider && (langfuse || collectorMode)) {
+	if (provider?.tracerProvider && (langfuse || collectorMode)) {
 		activateLangfuseTelemetry();
 	}
 

--- a/sdk/packages/core/src/services/telemetry/index.ts
+++ b/sdk/packages/core/src/services/telemetry/index.ts
@@ -14,6 +14,7 @@ export {
 } from "./OpenTelemetryAdapter";
 export {
 	type ConfiguredTelemetryHandle,
+	type CreateConfiguredTelemetryHandleOptions,
 	type CreateOpenTelemetryTelemetryServiceOptions,
 	createConfiguredTelemetryHandle,
 	createConfiguredTelemetryService,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -134,7 +134,17 @@ export {
 	type ClineWebSearchResult,
 	createCline,
 } from "./providers/vendors/cline";
-export { disposeLangfuseTelemetry } from "./services/langfuse-telemetry";
+export {
+	activateLangfuseTelemetry,
+	createLangfuseTelemetryIntegration,
+	disableLangfuseTelemetry,
+	disposeLangfuseTelemetry,
+	hasLangfuseTelemetryConfig,
+	type LangfuseCollectorTelemetryConfig,
+	type LangfuseDirectTelemetryConfig,
+	type LangfuseTelemetryConfig,
+	type LangfuseTelemetryIntegration,
+} from "./services/langfuse-telemetry";
 export {
 	type AudioTranscriptionRequest,
 	type AudioTranscriptionResult,

--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -1,76 +1,67 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { registerDisposableSpy, registerTelemetrySpy, telemetryStartSpy } =
-	vi.hoisted(() => ({
-		registerDisposableSpy: vi.fn(),
-		registerTelemetrySpy: vi.fn(),
-		telemetryStartSpy: vi.fn(),
-	}));
+const mocks = vi.hoisted(() => ({
+	registerDisposable: vi.fn(),
+	registerTelemetry: vi.fn(),
+	telemetryStart: vi.fn(),
+	setTracerProvider: vi.fn(),
+	forceFlush: vi.fn(async () => undefined),
+	shutdown: vi.fn(async () => undefined),
+	processorConstructor: vi.fn(),
+	providerConstructor: vi.fn(),
+}));
+
+vi.mock("@cline/shared", () => ({
+	registerDisposable: mocks.registerDisposable,
+}));
 
 vi.mock("ai", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("ai")>();
 	return {
 		...actual,
-		registerTelemetry: (
-			...integrations: Parameters<typeof actual.registerTelemetry>
-		) => {
-			registerTelemetrySpy(...integrations);
-			actual.registerTelemetry(...integrations);
+		registerTelemetry: (...integrations: unknown[]) => {
+			mocks.registerTelemetry(...integrations);
+			actual.registerTelemetry(...(integrations as never));
 		},
 	};
 });
 
-vi.mock("@langfuse/vercel-ai-sdk", () => ({
-	LangfuseVercelAiSdkIntegration: class MockLangfuseVercelAiSdkIntegration {
-		onStart = telemetryStartSpy;
+vi.mock("@langfuse/otel", () => ({
+	LangfuseSpanProcessor: class MockLangfuseSpanProcessor {
+		constructor(config: unknown) {
+			mocks.processorConstructor(config);
+		}
 	},
 }));
 
-const {
-	addSpanProcessorSpy,
-	forceFlushSpy,
-	shutdownSpy,
-	getDelegateSpy,
-	getTracerProviderSpy,
-	registeredGlobalProvider,
-} = vi.hoisted(() => ({
-	addSpanProcessorSpy: vi.fn(),
-	forceFlushSpy: vi.fn(async () => undefined),
-	shutdownSpy: vi.fn(async () => undefined),
-	getDelegateSpy: vi.fn(),
-	getTracerProviderSpy: vi.fn(),
-	registeredGlobalProvider: { current: undefined as unknown },
+vi.mock("@langfuse/tracing", () => ({
+	propagateAttributes: async (_attributes: unknown, callback: () => unknown) =>
+		await callback(),
+	setLangfuseTracerProvider: mocks.setTracerProvider,
 }));
 
-class MockNodeTracerProvider {
-	// Mirrors OpenTelemetry's registerGlobal semantics: the first
-	// registration wins and later ones are silently ignored.
-	register = vi.fn(() => {
-		registeredGlobalProvider.current ??= this;
-	});
-}
-
-vi.mock("@cline/shared", () => ({
-	registerDisposable: registerDisposableSpy,
-}));
-
-vi.mock("@langfuse/otel", () => ({
-	LangfuseSpanProcessor: class MockLangfuseSpanProcessor {},
-}));
-
-vi.mock("@opentelemetry/api", () => ({
-	trace: {
-		getTracerProvider: getTracerProviderSpy,
+vi.mock("@langfuse/vercel-ai-sdk", () => ({
+	LangfuseVercelAiSdkIntegration: class MockIntegration {
+		onStart = mocks.telemetryStart;
 	},
 }));
 
 vi.mock("@opentelemetry/sdk-trace-node", () => ({
-	NodeTracerProvider: MockNodeTracerProvider,
+	NodeTracerProvider: class MockNodeTracerProvider {
+		forceFlush = mocks.forceFlush;
+		shutdown = mocks.shutdown;
+		constructor(config: unknown) {
+			mocks.providerConstructor(config);
+		}
+	},
 }));
 
 import { generateText } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 import {
+	activateLangfuseTelemetry,
+	createLangfuseTelemetryIntegration,
+	disableLangfuseTelemetry,
 	disposeLangfuseTelemetry,
 	ensureLangfuseTelemetry,
 	resetLangfuseTelemetryForTests,
@@ -79,25 +70,7 @@ import {
 describe("langfuse telemetry", () => {
 	beforeEach(() => {
 		resetLangfuseTelemetryForTests();
-		registerDisposableSpy.mockReset();
-		registerTelemetrySpy.mockReset();
-		telemetryStartSpy.mockReset();
-		addSpanProcessorSpy.mockReset();
-		forceFlushSpy.mockReset();
-		forceFlushSpy.mockResolvedValue(undefined);
-		shutdownSpy.mockReset();
-		shutdownSpy.mockResolvedValue(undefined);
-		getDelegateSpy.mockReset();
-		getDelegateSpy.mockReturnValue({
-			constructor: { name: "NodeTracerProvider" },
-			forceFlush: forceFlushSpy,
-			shutdown: shutdownSpy,
-		});
-		registeredGlobalProvider.current = undefined;
-		getTracerProviderSpy.mockReturnValue({
-			addSpanProcessor: addSpanProcessorSpy,
-			getDelegate: getDelegateSpy,
-		});
+		for (const mock of Object.values(mocks)) mock.mockClear();
 		process.env.LANGFUSE_BASE_URL = "https://langfuse.example";
 		process.env.LANGFUSE_PUBLIC_KEY = "public-key";
 		process.env.LANGFUSE_SECRET_KEY = "secret-key";
@@ -110,102 +83,58 @@ describe("langfuse telemetry", () => {
 		resetLangfuseTelemetryForTests();
 	});
 
-	it("enables telemetry for non-cline providers when langfuse config is available", async () => {
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-
-		expect(registerDisposableSpy).toHaveBeenCalledTimes(1);
-		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledWith(expect.any(Object));
+	it("creates a processor for a host-owned provider without creating a provider", () => {
+		const integration = createLangfuseTelemetryIntegration();
+		expect(integration?.spanProcessor).toBeDefined();
+		expect(mocks.processorConstructor).toHaveBeenCalledWith({
+			baseUrl: "https://langfuse.example",
+			publicKey: "public-key",
+			secretKey: "secret-key",
+		});
+		expect(mocks.providerConstructor).not.toHaveBeenCalled();
 	});
 
-	it("flushes before shutdown during disposal", async () => {
+	it("activates shared-provider AI SDK telemetry only once", () => {
+		activateLangfuseTelemetry();
+		activateLangfuseTelemetry();
+		expect(mocks.registerTelemetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("creates and owns an isolated provider for standalone use", async () => {
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		expect(mocks.providerConstructor).toHaveBeenCalledTimes(1);
+		expect(mocks.setTracerProvider).toHaveBeenCalledWith(expect.any(Object));
+		expect(mocks.registerDisposable).toHaveBeenCalledTimes(1);
+
 		await disposeLangfuseTelemetry();
-
-		expect(forceFlushSpy).toHaveBeenCalledTimes(1);
-		expect(shutdownSpy).toHaveBeenCalledTimes(1);
-		expect(forceFlushSpy.mock.invocationCallOrder[0]).toBeLessThan(
-			shutdownSpy.mock.invocationCallOrder[0],
-		);
+		expect(mocks.forceFlush).toHaveBeenCalledTimes(1);
+		expect(mocks.shutdown).toHaveBeenCalledTimes(1);
+		expect(mocks.setTracerProvider).toHaveBeenLastCalledWith(null);
 	});
 
-	it("recognizes a directly registered tracer provider", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			addSpanProcessor: addSpanProcessorSpy,
-		});
-
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
-		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+	it("does not use the standalone fallback after a host disables telemetry", async () => {
+		disableLangfuseTelemetry();
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
+		expect(mocks.providerConstructor).not.toHaveBeenCalled();
+		expect(mocks.registerTelemetry).not.toHaveBeenCalled();
 	});
 
-	it("registers its own provider when minification renames the proxy provider", async () => {
-		// Simulates the compiled release binary: the ProxyTracerProvider and
-		// its no-op delegate carry mangled constructor names, expose no
-		// addSpanProcessor, and only reflect a registration through
-		// getDelegate.
-		getTracerProviderSpy.mockReturnValue({
-			constructor: { name: "Zt" },
-			getDelegate: () =>
-				registeredGlobalProvider.current ?? { constructor: { name: "Qn" } },
-		});
-
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
-		expect(registeredGlobalProvider.current).toBeInstanceOf(
-			MockNodeTracerProvider,
-		);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+	it("does not dispose a host-owned provider", async () => {
+		activateLangfuseTelemetry();
+		await disposeLangfuseTelemetry();
+		expect(mocks.forceFlush).not.toHaveBeenCalled();
+		expect(mocks.shutdown).not.toHaveBeenCalled();
 	});
 
-	it("attaches to an already registered tracer provider through its delegate", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({ addSpanProcessor: addSpanProcessorSpy }),
-		});
-
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
-		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("disables telemetry when a foreign provider owns the slot and accepts no processors", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({
-				forceFlush: forceFlushSpy,
-				shutdown: shutdownSpy,
-			}),
-		});
-
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
-	});
-
-	it("disables telemetry when the global slot rejects the registration", async () => {
-		// The delegate never reflects the attempted registration, matching an
-		// API whose global slot is stuck with an inert owner.
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({ constructor: { name: "SomethingInert" } }),
-		});
-
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
-	});
-
-	it("connects an AI SDK 7 call to the registered telemetry integration", async () => {
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
-
+	it("connects an AI SDK 7 call to the registered integration", async () => {
+		activateLangfuseTelemetry();
 		await generateText({
 			model: new MockLanguageModelV4({
 				doGenerate: {
 					content: [{ type: "text", text: "hello" }],
 					finishReason: { unified: "stop", raw: "stop" },
 					usage: {
-						inputTokens: {
-							total: 1,
-							noCache: 1,
-							cacheRead: 0,
-							cacheWrite: 0,
-						},
+						inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
 						outputTokens: { total: 1, text: 1, reasoning: 0 },
 					},
 					warnings: [],
@@ -214,7 +143,6 @@ describe("langfuse telemetry", () => {
 			prompt: "say hello",
 			telemetry: { isEnabled: true },
 		});
-
-		expect(telemetryStartSpy).toHaveBeenCalled();
+		expect(mocks.telemetryStart).toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -1,13 +1,31 @@
-type MutableTracerProvider = {
-	addSpanProcessor?: (spanProcessor: unknown) => void;
-	getDelegate?: () => unknown;
+import { registerDisposable } from "@cline/shared";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import {
+	propagateAttributes,
+	setLangfuseTracerProvider,
+} from "@langfuse/tracing";
+import { LangfuseVercelAiSdkIntegration } from "@langfuse/vercel-ai-sdk";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { registerTelemetry } from "ai";
+
+export type LangfuseDirectTelemetryConfig = {
+	mode: "direct";
+	baseUrl?: string;
+	publicKey?: string;
+	secretKey?: string;
 };
 
-type LangfuseTelemetryConfig = {
-	baseUrl: string;
-	publicKey: string;
-	secretKey: string;
+export type LangfuseCollectorTelemetryConfig = {
+	mode: "collector";
 };
+
+export type LangfuseTelemetryConfig =
+	| LangfuseDirectTelemetryConfig
+	| LangfuseCollectorTelemetryConfig;
+
+type ResolvedLangfuseTelemetryConfig = Required<
+	Omit<LangfuseDirectTelemetryConfig, "mode">
+>;
 
 export type LangfuseTraceAttributes = {
 	userId?: string;
@@ -17,159 +35,104 @@ export type LangfuseTraceAttributes = {
 	traceName?: string;
 };
 
+/** A Langfuse processor ready for a host-owned OpenTelemetry provider. */
+export interface LangfuseTelemetryIntegration {
+	readonly spanProcessor: LangfuseSpanProcessor;
+}
+
+const LANGFUSE_DEBUG_ENV = "CLINE_DEBUG_LANGFUSE";
+type LangfuseTelemetryState = "unconfigured" | "active" | "disabled";
+let langfuseTelemetryState: LangfuseTelemetryState = "unconfigured";
+let standaloneTracerProvider: NodeTracerProvider | undefined;
+let aiSdkIntegrationRegistered = false;
+let standaloneDisposableRegistered = false;
+
+function readLangfuseTelemetryConfig(
+	config?: LangfuseDirectTelemetryConfig,
+): ResolvedLangfuseTelemetryConfig | undefined {
+	const baseUrl =
+		config?.baseUrl?.trim() || process.env.LANGFUSE_BASE_URL?.trim();
+	const publicKey =
+		config?.publicKey?.trim() || process.env.LANGFUSE_PUBLIC_KEY?.trim();
+	const secretKey =
+		config?.secretKey?.trim() || process.env.LANGFUSE_SECRET_KEY?.trim();
+	if (!baseUrl || !publicKey || !secretKey) return undefined;
+	return { baseUrl, publicKey, secretKey };
+}
+
+export function hasLangfuseTelemetryConfig(
+	config?: LangfuseDirectTelemetryConfig,
+): boolean {
+	return readLangfuseTelemetryConfig(config) !== undefined;
+}
+
 /**
- * Set Langfuse trace-level attributes for the duration of an SDK operation.
- * Runtime context is useful observation metadata, but Langfuse's Sessions and
- * Users views are indexed from propagated trace attributes instead.
+ * Creates the Langfuse part of an OTel pipeline without claiming the global
+ * provider. Cline hosts install this processor while constructing their
+ * existing provider.
  */
+export function createLangfuseTelemetryIntegration(
+	config?: LangfuseDirectTelemetryConfig,
+): LangfuseTelemetryIntegration | undefined {
+	const resolved = readLangfuseTelemetryConfig(config);
+	if (!resolved) return undefined;
+	return { spanProcessor: new LangfuseSpanProcessor(resolved) };
+}
+
+/**
+ * Activate AI SDK telemetry after either a direct processor or a collector
+ * export path has been configured by the host.
+ */
+export function activateLangfuseTelemetry(): void {
+	langfuseTelemetryState = "active";
+	if (!aiSdkIntegrationRegistered) {
+		registerTelemetry(new LangfuseVercelAiSdkIntegration());
+		aiSdkIntegrationRegistered = true;
+	}
+}
+
+/** Prevent standalone discovery when the Cline host disabled telemetry. */
+export function disableLangfuseTelemetry(): void {
+	langfuseTelemetryState = "disabled";
+}
+
 export async function withLangfuseTraceAttributes<T>(
 	enabled: boolean,
 	attributes: LangfuseTraceAttributes,
 	callback: () => T | Promise<T>,
 ): Promise<T> {
-	if (!enabled) {
-		return await callback();
-	}
-
-	const { propagateAttributes } = await import("@langfuse/tracing");
+	if (!enabled) return await callback();
 	return await propagateAttributes(attributes, callback);
 }
 
-const LANGFUSE_DEBUG_ENV = "CLINE_DEBUG_LANGFUSE";
-
-let langfuseTelemetryReady: boolean | undefined;
-let langfuseTelemetryInitPromise: Promise<boolean> | undefined;
-
-function readLangfuseTelemetryConfig(): LangfuseTelemetryConfig | undefined {
-	const env = process?.env;
-	const baseUrl = env?.LANGFUSE_BASE_URL?.trim();
-	const publicKey = env?.LANGFUSE_PUBLIC_KEY?.trim();
-	const secretKey = env?.LANGFUSE_SECRET_KEY?.trim();
-
-	if (!baseUrl || !publicKey || !secretKey) {
-		return undefined;
-	}
-
-	return {
-		baseUrl,
-		publicKey,
-		secretKey,
-	};
-}
-
-export function hasLangfuseTelemetryConfig(): boolean {
-	return readLangfuseTelemetryConfig() !== undefined;
-}
-
+/**
+ * Standalone fallback for direct `@cline/llms` use. Full Cline hosts activate
+ * their injected integration first, so this never creates a competing provider
+ * in those processes.
+ */
 export async function ensureLangfuseTelemetry(
 	_providerId: string,
 ): Promise<boolean> {
-	if (!hasLangfuseTelemetryConfig()) {
-		return false;
-	}
-
-	if (langfuseTelemetryReady !== undefined) {
-		debugLangfuse(`cached readiness=${String(langfuseTelemetryReady)}`);
-		return langfuseTelemetryReady;
-	}
-
-	if (!langfuseTelemetryInitPromise) {
-		langfuseTelemetryInitPromise = initializeLangfuseTelemetry();
-	}
-
-	langfuseTelemetryReady = await langfuseTelemetryInitPromise;
-	debugLangfuse(`initialized readiness=${String(langfuseTelemetryReady)}`);
-	return langfuseTelemetryReady;
-}
-
-async function initializeLangfuseTelemetry(): Promise<boolean> {
-	// Register for cleanup once, when initialization begins.
-	const { registerDisposable } = await import("@cline/shared");
-	registerDisposable(disposeLangfuseTelemetry);
-	const config = readLangfuseTelemetryConfig();
-	if (!config) {
-		return false;
-	}
+	if (langfuseTelemetryState === "active") return true;
+	if (langfuseTelemetryState === "disabled") return false;
+	const integration = createLangfuseTelemetryIntegration();
+	if (!integration) return false;
 
 	try {
-		// Give Langfuse and any other OTEL exporter a stable resource identity.
-		// Respect an explicitly configured service name from the host.
 		if (!process.env.OTEL_SERVICE_NAME?.trim()) {
 			process.env.OTEL_SERVICE_NAME = "cline-sdk";
 		}
-		const [
-			{ LangfuseSpanProcessor },
-			{ LangfuseVercelAiSdkIntegration },
-			{ registerTelemetry },
-			{ trace },
-			{ NodeTracerProvider },
-		] = await Promise.all([
-			import("@langfuse/otel"),
-			import("@langfuse/vercel-ai-sdk"),
-			import("ai"),
-			import("@opentelemetry/api"),
-			import("@opentelemetry/sdk-trace-node"),
-		]);
-
-		const spanProcessor = new LangfuseSpanProcessor({
-			baseUrl: config.baseUrl,
-			publicKey: config.publicKey,
-			secretKey: config.secretKey,
+		const provider = new NodeTracerProvider({
+			spanProcessors: [integration.spanProcessor],
 		});
-		debugLangfuse(`creating span processor baseUrl=${config.baseUrl}`);
-
-		const tracerProvider = trace.getTracerProvider() as MutableTracerProvider;
-		if (typeof tracerProvider?.addSpanProcessor === "function") {
-			tracerProvider.addSpanProcessor(spanProcessor);
-			const hasDelegate = hasActiveTracerDelegate(trace);
-			if (hasDelegate) {
-				registerTelemetry(new LangfuseVercelAiSdkIntegration());
-			}
-			debugLangfuse(
-				`attached processor to existing tracer provider delegateReady=${String(hasDelegate)}`,
-			);
-			return hasDelegate;
+		setLangfuseTracerProvider(provider);
+		standaloneTracerProvider = provider;
+		activateLangfuseTelemetry();
+		if (!standaloneDisposableRegistered) {
+			registerDisposable(disposeLangfuseTelemetry);
+			standaloneDisposableRegistered = true;
 		}
-
-		// Class names are unreliable here: release binaries are minified, which
-		// renames classes like ProxyTracerProvider, so all provider detection
-		// below is structural (method presence, object identity) instead of
-		// comparing constructor names.
-		const existingDelegate =
-			typeof tracerProvider?.getDelegate === "function"
-				? tracerProvider.getDelegate()
-				: undefined;
-		if (isRecordingTracerProvider(existingDelegate)) {
-			// Another provider already owns the global slot, so registering our
-			// own would be rejected. Attach to it when it accepts processors.
-			const delegate = existingDelegate as MutableTracerProvider;
-			if (typeof delegate.addSpanProcessor === "function") {
-				delegate.addSpanProcessor(spanProcessor);
-				registerTelemetry(new LangfuseVercelAiSdkIntegration());
-				debugLangfuse("attached processor to registered tracer delegate");
-				return true;
-			}
-			debugLangfuse(
-				"tracer provider slot already owned; disabling Langfuse export",
-			);
-			return false;
-		}
-
-		const nodeTracerProvider = new NodeTracerProvider({
-			spanProcessors: [spanProcessor],
-		} as unknown as ConstructorParameters<typeof NodeTracerProvider>[0]);
-		nodeTracerProvider.register();
-		if (!isRegisteredGlobalTracerProvider(trace, nodeTracerProvider)) {
-			debugLangfuse(
-				"tracer provider registration was not accepted; disabling Langfuse export",
-			);
-			// Shut the orphaned provider down so its span processor does not
-			// keep buffering spans that can never be exported.
-			await nodeTracerProvider.shutdown?.();
-			return false;
-		}
-		registerTelemetry(new LangfuseVercelAiSdkIntegration());
-		debugLangfuse("registered NodeTracerProvider delegateReady=true");
+		debugLangfuse("initialized isolated standalone tracer provider");
 		return true;
 	} catch (error) {
 		debugLangfuse(
@@ -179,94 +142,17 @@ async function initializeLangfuseTelemetry(): Promise<boolean> {
 	}
 }
 
-function hasActiveTracerDelegate(traceApi: {
-	getTracerProvider: () => unknown;
-}): boolean {
-	const tracerProvider = traceApi.getTracerProvider() as MutableTracerProvider;
-	if (typeof tracerProvider.getDelegate !== "function") {
-		// Some runtimes expose the registered tracer provider directly rather
-		// than through OpenTelemetry's ProxyTracerProvider. A direct provider
-		// has no delegate to inspect, but its addSpanProcessor API is sufficient
-		// evidence that it can receive and export spans.
-		return typeof tracerProvider.addSpanProcessor === "function";
-	}
-
-	return isRecordingTracerProvider(tracerProvider.getDelegate());
-}
-
-/**
- * Distinguishes a recording tracer provider from OpenTelemetry's no-op
- * fallback without relying on constructor names, which minified release
- * builds rename. Real SDK providers expose lifecycle methods the no-op
- * provider lacks.
- */
-function isRecordingTracerProvider(provider: unknown): boolean {
-	if (!provider || typeof provider !== "object") {
-		return false;
-	}
-	const candidate = provider as {
-		addSpanProcessor?: unknown;
-		forceFlush?: unknown;
-		shutdown?: unknown;
-	};
-	return (
-		typeof candidate.addSpanProcessor === "function" ||
-		typeof candidate.forceFlush === "function" ||
-		typeof candidate.shutdown === "function"
-	);
-}
-
-/**
- * Confirms the OpenTelemetry API accepted a provider registration. The API
- * silently keeps the previous owner when the global slot is taken, so the
- * only reliable signal is identity: the global provider (or its proxy
- * delegate) must be the exact instance that was just registered.
- */
-function isRegisteredGlobalTracerProvider(
-	traceApi: { getTracerProvider: () => unknown },
-	provider: unknown,
-): boolean {
-	const globalProvider = traceApi.getTracerProvider() as
-		| MutableTracerProvider
-		| null
-		| undefined;
-	if (globalProvider === provider) {
-		return true;
-	}
-	return (
-		typeof globalProvider?.getDelegate === "function" &&
-		globalProvider.getDelegate() === provider
-	);
-}
-
-async function flushLangfuseTelemetry(): Promise<void> {
-	try {
-		const { trace } = await import("@opentelemetry/api");
-		const tracerProvider = trace.getTracerProvider() as {
-			getDelegate?: () => {
-				forceFlush?: () => Promise<void>;
-			};
-		};
-		await tracerProvider.getDelegate?.()?.forceFlush?.();
-		debugLangfuse("forceFlush completed");
-	} catch (error) {
-		debugLangfuse(
-			`forceFlush failed error=${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-}
-
+/** Dispose only the provider created by the standalone fallback. */
 export async function disposeLangfuseTelemetry(): Promise<void> {
+	const provider = standaloneTracerProvider;
+	standaloneTracerProvider = undefined;
+	if (!provider) return;
 	try {
-		await flushLangfuseTelemetry();
-		const { trace } = await import("@opentelemetry/api");
-		const tracerProvider = trace.getTracerProvider() as {
-			getDelegate?: () => {
-				shutdown?: () => Promise<void>;
-			};
-		};
-		await tracerProvider.getDelegate?.()?.shutdown?.();
-		debugLangfuse("shutdown completed");
+		await provider.forceFlush();
+		await provider.shutdown();
+		setLangfuseTracerProvider(null);
+		langfuseTelemetryState = "unconfigured";
+		debugLangfuse("standalone provider shutdown completed");
 	} catch (error) {
 		debugLangfuse(
 			`shutdown failed error=${error instanceof Error ? error.message : String(error)}`,
@@ -275,22 +161,21 @@ export async function disposeLangfuseTelemetry(): Promise<void> {
 }
 
 export function debugLangfuse(message: string): void {
-	if (!isLangfuseDebugEnabled()) {
-		return;
-	}
+	if (!isLangfuseDebugEnabled()) return;
 	console.warn(`[langfuse-debug] ${message}`);
 }
 
 function isLangfuseDebugEnabled(): boolean {
 	const raw = process.env[LANGFUSE_DEBUG_ENV];
-	if (!raw) {
-		return false;
-	}
+	if (!raw) return false;
 	const normalized = raw.trim().toLowerCase();
 	return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 export function resetLangfuseTelemetryForTests(): void {
-	langfuseTelemetryReady = undefined;
-	langfuseTelemetryInitPromise = undefined;
+	langfuseTelemetryState = "unconfigured";
+	standaloneTracerProvider = undefined;
+	aiSdkIntegrationRegistered = false;
+	standaloneDisposableRegistered = false;
+	setLangfuseTracerProvider(null);
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds first-class Langfuse observability to the SDK's existing OpenTelemetry architecture.

Cline defaults to collector mode: AI SDK 7 Langfuse instrumentation emits through the existing client-owned OTel provider and OTLP exporter, while the OTel backend owns the Langfuse API key and forwards selected spans. Direct mode remains available by injecting a `LangfuseSpanProcessor`, and standalone `@cline/llms` retains an isolated provider fallback.

The integration observes telemetry opt-out, avoids mutating or shutting down an ambient global provider, adds explicit provider ownership and transport types, and documents the collector topology and credentials.

### Test Procedure

- Ran `bun run build:sdk` from `sdk/`.
- Ran the complete `@cline/llms` test suite: 783 passed, 4 skipped.
- Ran focused core OpenTelemetry provider tests: 13 passed.
- Ran the CLI typecheck.
- Ran Biome and `git diff --check` while developing the change.
- Rebased the branch on the latest `origin/main` and repeated the build and tests.

The primary risk is telemetry lifecycle and routing. Tests cover injected processor construction, collector mode without a local Langfuse processor, standalone ownership, opt-out suppression, flush/shutdown behavior, and AI SDK 7 integration registration.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this change has no UI.

### Additional Notes

The OTel backend must configure an OTLP/HTTP Langfuse exporter with `Authorization: Basic <base64(public-key:secret-key)>` and `x-langfuse-ingestion-version: 4`. Langfuse credentials are not required in Cline when using the default collector mode.
