### PR TITLE
fix(vscode): persist meaningful tasks before clear can drop history

### DIFF
--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -237,6 +237,95 @@ describe("SdkTaskStartCoordinator", () => {
 	})
 })
 
+it("persists durable history before clear can erase a prompted task (#13781)", async () => {
+	const { coordinator, options, sdkHost, historyStore, durableHistoryIds } = makeCoordinator()
+
+	const sessionId = await coordinator.initTask("ship the fix")
+	expect(sessionId).toEqual(expect.any(String))
+	expect(sdkHost.ensureSessionPersisted).toHaveBeenCalledWith(sessionId, { prompt: "ship the fix" })
+	expect(sdkHost.ensureSessionPersisted.mock.invocationCallOrder[0]).toBeLessThan(
+		options.taskHistory.updateTaskHistoryItem.mock.invocationCallOrder[0],
+	)
+	expect(durableHistoryIds.has(sessionId!)).toBe(true)
+	expect(historyStore.get(sessionId!)?.task).toBe("ship the fix")
+
+	// Immediate New Task / clear before first model token: durable row remains exactly once.
+	await options.clearTask()
+	expect([...historyStore.keys()]).toEqual([sessionId])
+})
+
+it("keeps exactly one history entry after immediate close of a prompted task", async () => {
+	const { coordinator, options, historyStore, sdkHost } = makeCoordinator()
+	const sessionId = await coordinator.initTask("close me next")
+	expect(sdkHost.ensureSessionPersisted).toHaveBeenCalledOnce()
+	// Simulate Close Task disposing the active session without waiting for send.
+	await options.clearTask()
+	expect(historyStore.size).toBe(1)
+	expect(historyStore.get(sessionId!)?.id).toBe(sessionId)
+})
+
+it("still sends the first turn after early persistence (no normal-path regression)", async () => {
+	const { coordinator, options, sdkHost } = makeCoordinator()
+	const sessionId = await coordinator.initTask("normal path")
+	expect(sdkHost.ensureSessionPersisted).toHaveBeenCalledOnce()
+	expect(options.sessions.fireAndForgetSend).toHaveBeenCalledWith(
+		sdkHost,
+		sessionId,
+		"resolved: normal path",
+		undefined,
+		undefined,
+	)
+})
+
+it("does not create duplicate durable + synthetic history rows", async () => {
+	const { coordinator, historyStore, sdkHost } = makeCoordinator()
+	const sessionId = await coordinator.initTask("once only")
+	// Second early-persist call would still be the same session id; store stays size 1.
+	await sdkHost.ensureSessionPersisted(sessionId!, { prompt: "once only" })
+	expect(historyStore.size).toBe(1)
+	expect([...historyStore.keys()]).toEqual([sessionId])
+})
+
+it("does not materialize durable history for a truly empty task/session", async () => {
+	const { coordinator, options, sdkHost, historyStore, durableHistoryIds } = makeCoordinator()
+	const sessionId = await coordinator.initTask("   ")
+	expect(sessionId).toEqual(expect.any(String))
+	expect(sdkHost.ensureSessionPersisted).not.toHaveBeenCalled()
+	expect(options.sessions.fireAndForgetSend).not.toHaveBeenCalled()
+	// update may be attempted, but without durable id it does not land in History.
+	expect(historyStore.size).toBe(0)
+	expect(durableHistoryIds.size).toBe(0)
+})
+
+it("does not fabricate successful history when startup fails", async () => {
+	const { coordinator, options, sdkHost, historyStore } = makeCoordinator()
+	options.sessions.startNewSession.mockRejectedValue(new Error("session start failed"))
+	const sessionId = await coordinator.initTask("do something")
+	expect(sessionId).toBeUndefined()
+	expect(sdkHost.ensureSessionPersisted).not.toHaveBeenCalled()
+	expect(options.taskHistory.updateTaskHistoryItem).not.toHaveBeenCalled()
+	expect(historyStore.size).toBe(0)
+})
+
+it("proves the durable row exists at the corrected lifecycle boundary before send", async () => {
+	const { coordinator, options, sdkHost, durableHistoryIds } = makeCoordinator()
+	const sessionId = await coordinator.initTask("boundary proof")
+	expect(durableHistoryIds.has(sessionId!)).toBe(true)
+	expect(sdkHost.ensureSessionPersisted.mock.invocationCallOrder[0]).toBeLessThan(
+		options.sessions.fireAndForgetSend.mock.invocationCallOrder[0],
+	)
+	expect(options.taskHistory.updateTaskHistoryItem.mock.invocationCallOrder[0]).toBeLessThan(
+		options.sessions.fireAndForgetSend.mock.invocationCallOrder[0],
+	)
+})
+
+it("persists attachment-only tasks without waiting for model output", async () => {
+	const { coordinator, sdkHost, historyStore } = makeCoordinator()
+	const sessionId = await coordinator.initTask("", ["shot.png"], undefined)
+	expect(sdkHost.ensureSessionPersisted).toHaveBeenCalledWith(sessionId, { prompt: "" })
+	expect(historyStore.size).toBe(1)
+})
+
 function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 	const state: { task?: { taskId: string } } = {}
 	const config = input.config ?? {
@@ -256,9 +345,15 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		readMessages: vi.fn().mockResolvedValue([{ role: "user", content: "hello" }]),
 		dispose: vi.fn().mockResolvedValue(undefined),
 	}
+	const durableHistoryIds = new Set<string>()
 	const sdkHost = {
 		send: vi.fn(),
+		ensureSessionPersisted: vi.fn(async (sessionId: string) => {
+			durableHistoryIds.add(sessionId)
+			return true
+		}),
 	}
+	const historyStore = new Map<string, HistoryItem>()
 	const options = {
 		stateManager: {
 			getGlobalSettingsKey: vi.fn(() => input.mode ?? "act"),
@@ -277,7 +372,14 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		taskHistory: {
 			findHistoryItem: vi.fn(() => (input.hasHistoryItem === false ? undefined : historyItem)),
 			updateTaskHistory: vi.fn().mockResolvedValue([]),
-			updateTaskHistoryItem: vi.fn().mockResolvedValue(undefined),
+			updateTaskHistoryItem: vi.fn(async (item: HistoryItem) => {
+				// Mirrors production: update is a no-op until a durable session row exists.
+				if (!durableHistoryIds.has(item.id)) {
+					return
+				}
+				historyStore.set(item.id, item)
+			}),
+			listDurableHistory: () => [...historyStore.values()],
 		},
 		sessionConfigBuilder: {
 			build: vi.fn().mockResolvedValue(config),
@@ -343,6 +445,9 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 		options,
 		state,
 		tempHost,
+		sdkHost,
+		durableHistoryIds,
+		historyStore,
 	}
 }
 

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.test.ts
@@ -326,6 +326,52 @@ it("persists attachment-only tasks without waiting for model output", async () =
 	expect(historyStore.size).toBe(1)
 })
 
+it("does not fabricate history or send when ensureSessionPersisted throws after start (#13781)", async () => {
+	const { coordinator, options, state, sdkHost, historyStore } = makeCoordinator()
+	const persistError = new Error("materialize failed")
+	sdkHost.ensureSessionPersisted.mockRejectedValue(persistError)
+
+	const sessionId = await coordinator.initTask("persist then explode")
+
+	expect(sessionId).toBeUndefined()
+	expect(options.sessions.startNewSession).toHaveBeenCalledOnce()
+	expect(sdkHost.ensureSessionPersisted).toHaveBeenCalledOnce()
+	expect(options.sessions.fireAndForgetSend).not.toHaveBeenCalled()
+	expect(options.taskHistory.updateTaskHistoryItem).not.toHaveBeenCalled()
+	expect(historyStore.size).toBe(0)
+	expect(options.captureProviderApiError).toHaveBeenCalledWith({
+		sessionId: expect.any(String),
+		error: persistError,
+		providerId: "anthropic",
+		modelId: "model",
+		errorType: PROVIDER_FAILURE_ERROR_TYPE.TASK_INIT,
+		failurePhase: PROVIDER_FAILURE_PHASE.PREFLIGHT,
+	})
+	expect(options.messages.appendAndEmit).toHaveBeenCalledWith(
+		[
+			expect.objectContaining({
+				type: "say",
+				say: "error",
+				text: expect.stringContaining("materialize failed"),
+			}),
+		],
+		expect.objectContaining({
+			type: "status",
+			payload: expect.objectContaining({ status: "error" }),
+		}),
+	)
+	// Early streaming post + post-error post (handleInitError path).
+	expect(options.postStateToWebview).toHaveBeenCalled()
+
+	// CURRENT BEHAVIOR (#13781 evidence): clearTask runs once at init start only.
+	// After startNewSession succeeded and ensureSessionPersisted threw, production
+	// catch does NOT call clearTask again — so createAndSetTask's resident task
+	// may remain on state. Document, do not "fix" with product cleanup here.
+	expect(options.clearTask).toHaveBeenCalledOnce()
+	expect(state.task).toBeDefined()
+	expect(state.task?.taskId).toEqual(expect.any(String))
+})
+
 function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 	const state: { task?: { taskId: string } } = {}
 	const config = input.config ?? {
@@ -348,7 +394,7 @@ function makeCoordinator(input: Partial<MakeCoordinatorInput> = {}) {
 	const durableHistoryIds = new Set<string>()
 	const sdkHost = {
 		send: vi.fn(),
-		ensureSessionPersisted: vi.fn(async (sessionId: string) => {
+		ensureSessionPersisted: vi.fn(async (sessionId: string, _options?: { prompt?: string }) => {
 			durableHistoryIds.add(sessionId)
 			return true
 		}),

--- a/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-task-start-coordinator.ts
@@ -140,6 +140,20 @@ export class SdkTaskStartCoordinator {
 				taskSessionId = startResult.sessionId
 			}
 
+			const hasMeaningfulUserInput = Boolean(prompt?.trim() || images?.length || files?.length)
+			// Lazy start intentionally skips durable History for empty sessions. A real
+			// prompt/attachment task must get a durable row before clear/close can erase
+			// the only synthetic representation (#13781). Do this before the first send
+			// and before History update, without waiting for model output.
+			if (hasMeaningfulUserInput && sdkHost.ensureSessionPersisted) {
+				const persisted = await sdkHost.ensureSessionPersisted(taskSessionId, {
+					prompt: prompt ?? "",
+				})
+				if (!persisted) {
+					Logger.warn(`[SdkController] Failed to materialize durable history for session ${taskSessionId} before send`)
+				}
+			}
+
 			const newHistoryItem = this.options.createHistoryItemFromSession(
 				taskSessionId,
 				prompt ?? "",
@@ -149,7 +163,7 @@ export class SdkTaskStartCoordinator {
 			await this.options.taskHistory.updateTaskHistoryItem(newHistoryItem)
 			await this.options.postStateToWebview()
 
-			if (prompt?.trim() || images?.length || files?.length) {
+			if (hasMeaningfulUserInput) {
 				Logger.log(`[SdkController] Sending prompt to session: ${taskSessionId}`)
 				const resolvedTask = await this.options.resolveContextMentions(prompt || "")
 				this.options.sessions.fireAndForgetSend(sdkHost, taskSessionId, resolvedTask, images, files)

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -54,6 +54,11 @@ export interface SdkSessionHost {
 			title?: string | null
 		},
 	): Promise<{ updated: boolean }>
+	/**
+	 * Persist a lazy in-memory session into History before clear/close can erase it.
+	 * Optional: hosts without resident sessions may omit this.
+	 */
+	ensureSessionPersisted?(sessionId: string, options?: { prompt?: string }): Promise<boolean>
 	handleHookEvent(payload: HookEventPayload): Promise<void>
 	pendingPrompts(action: "list", input: PendingPromptsListInput): Promise<SessionPendingPrompt[]>
 	pendingPrompts(action: "update", input: PendingPromptsUpdateInput): Promise<PendingPromptMutationResult>

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -302,6 +302,13 @@ export class VscodeSessionHost implements SdkSessionHost {
 		return this.inner.update(sessionId, updates)
 	}
 
+	async ensureSessionPersisted(sessionId: string, options?: { prompt?: string }): Promise<boolean> {
+		if (!this.inner.ensureSessionPersisted) {
+			return false
+		}
+		return this.inner.ensureSessionPersisted(sessionId, options)
+	}
+
 	async handleHookEvent(payload: HookEventPayload): Promise<void> {
 		return this.inner.ingestHookEvent(payload)
 	}

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -496,6 +496,16 @@ export class ClineCore {
 	 */
 	update: RuntimeHost["updateSession"] = (...args) =>
 		this.host.updateSession(...args);
+
+	ensureSessionPersisted: NonNullable<RuntimeHost["ensureSessionPersisted"]> = (
+		sessionId,
+		options,
+	) => {
+		if (!this.host.ensureSessionPersisted) {
+			return Promise.resolve(false);
+		}
+		return this.host.ensureSessionPersisted(sessionId, options);
+	};
 	/**
 	 * Stores the compacted working-context state for an existing session.
 	 */

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -1288,6 +1288,138 @@ describe("LocalRuntimeHost", () => {
 		expect(sessionService.persistSessionMessages).not.toHaveBeenCalled();
 	});
 
+	describe("ensureSessionPersisted (#13781 early materialization seam)", () => {
+		function makeLazyHost(sessionId: string) {
+			const manifest = createManifest(sessionId);
+			const sessionService = {
+				ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+				createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+					manifestPath: "/tmp/manifest.json",
+					messagesPath: "/tmp/messages.json",
+					manifest,
+				}),
+				persistSessionMessages: vi.fn(),
+				updateSessionStatus: vi.fn().mockResolvedValue({
+					updated: true,
+					endedAt: "2026-01-01T00:00:05.000Z",
+				}),
+				writeSessionManifest: vi.fn(),
+				listSessions: vi.fn().mockResolvedValue([]),
+				deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+			};
+			const runtimeBuilder = {
+				build: vi.fn().mockReturnValue({
+					tools: [],
+					teamRuntime: undefined,
+					teamRestoredFromPersistence: false,
+					shutdown: vi.fn(),
+				}),
+			};
+			const agent = {
+				run: vi.fn().mockResolvedValue(createResult()),
+				continue: vi.fn().mockResolvedValue(createResult()),
+				getMessages: vi.fn().mockReturnValue([]),
+				getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+				getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+				abort: vi.fn(),
+				subscribeEvents: vi.fn().mockReturnValue(() => {}),
+				canStartRun: vi.fn().mockReturnValue(true),
+				shutdown: vi.fn().mockResolvedValue(undefined),
+			};
+			const manager = new RuntimeHostUnderTest({
+				distinctId,
+				sessionService: sessionService as never,
+				runtimeBuilder: runtimeBuilder as never,
+				createAgent: () => agent as never,
+			});
+			return { manager, sessionService };
+		}
+
+		it("materializes a lazy interactive session with the ensure prompt (title/first-prompt)", async () => {
+			const sessionId = "sess-ensure-persist";
+			const { manager, sessionService } = makeLazyHost(sessionId);
+
+			await manager.startSession(
+				normalizeStartInput({
+					config: createConfig({ sessionId }),
+					interactive: true,
+				}),
+			);
+
+			// Empty lazy start alone must not create durable artifacts.
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).not.toHaveBeenCalled();
+
+			const persisted = await manager.ensureSessionPersisted(sessionId, {
+				prompt: "meaningful prompt",
+			});
+
+			expect(persisted).toBe(true);
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).toHaveBeenCalledOnce();
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sessionId,
+					prompt: "meaningful prompt",
+				}),
+			);
+		});
+
+		it("is idempotent once artifacts already exist", async () => {
+			const sessionId = "sess-ensure-idempotent";
+			const { manager, sessionService } = makeLazyHost(sessionId);
+
+			await manager.startSession(
+				normalizeStartInput({
+					config: createConfig({ sessionId }),
+					interactive: true,
+				}),
+			);
+
+			await expect(
+				manager.ensureSessionPersisted(sessionId, { prompt: "first ensure" }),
+			).resolves.toBe(true);
+			await expect(
+				manager.ensureSessionPersisted(sessionId, { prompt: "second ensure" }),
+			).resolves.toBe(true);
+
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).toHaveBeenCalledOnce();
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sessionId,
+					prompt: "first ensure",
+				}),
+			);
+		});
+
+		it("returns false for unknown session ids without materializing", async () => {
+			const sessionId = "sess-ensure-known";
+			const { manager, sessionService } = makeLazyHost(sessionId);
+
+			await manager.startSession(
+				normalizeStartInput({
+					config: createConfig({ sessionId }),
+					interactive: true,
+				}),
+			);
+
+			await expect(manager.ensureSessionPersisted("unknown-id")).resolves.toBe(
+				false,
+			);
+			expect(
+				sessionService.createRootSessionWithArtifacts,
+			).not.toHaveBeenCalled();
+		});
+	});
+
 	it("readLiveSessionMessages serves in-memory messages for resident sessions before persistence", async () => {
 		const sessionId = "sess-live-messages";
 		const manifest = createManifest(sessionId);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -923,7 +923,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		// conversation. Brand-new empty sessions stay lazy.
 		if (initialMessages.length > 0 && !resumedArtifacts) {
 			try {
-				await this.ensureSessionPersisted(active);
+				await this.materializeSessionArtifacts(active);
 				await this.invoke<void>(
 					"persistSessionMessages",
 					sessionId,
@@ -1693,7 +1693,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		if (!session.artifacts && !session.pendingPrompt) {
 			session.pendingPrompt = prompt;
 		}
-		await this.ensureSessionPersisted(session);
+		await this.materializeSessionArtifacts(session);
 		// A seeded session (fork, checkpoint restore, missing-session
 		// recovery) materializes at start, before any prompt exists, so its
 		// row is created promptless. Backfill it with the first user prompt,
@@ -1791,7 +1791,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		// session seeded with in-memory history, the entire conversation.
 		if (messages.length > 0) {
 			try {
-				await this.ensureSessionPersisted(session);
+				await this.materializeSessionArtifacts(session);
 				await this.invoke<void>(
 					"persistSessionMessages",
 					session.sessionId,
@@ -2109,7 +2109,26 @@ export class LocalRuntimeHost implements RuntimeHost {
 
 	// ── Session lifecycle ───────────────────────────────────────────────
 
-	private async ensureSessionPersisted(session: ActiveSession): Promise<void> {
+	async ensureSessionPersisted(
+		sessionId: string,
+		options?: { prompt?: string },
+	): Promise<boolean> {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			return false;
+		}
+		if (session.artifacts) {
+			return true;
+		}
+		const prompt = options?.prompt?.trim();
+		if (prompt && !session.pendingPrompt) {
+			session.pendingPrompt = prompt;
+		}
+		await this.materializeSessionArtifacts(session);
+		return session.artifacts !== undefined;
+	}
+
+	private async materializeSessionArtifacts(session: ActiveSession): Promise<void> {
 		if (session.artifacts) return;
 		const workspacePath = resolveWorkspacePath(session.config);
 		session.artifacts = (await this.invoke("createRootSessionWithArtifacts", {

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -402,6 +402,16 @@ export interface RuntimeHost {
 		sessionId: string,
 	): Promise<LlmsProviders.MessageWithMetadata[]>;
 	dispatchHookEvent(payload: HookEventPayload): Promise<void>;
+	/**
+	 * Materialize a durable History row for an already-started in-memory lazy
+	 * session that has a meaningful user prompt and/or attachments.
+	 * Does not start a model turn. No-op when the session is unknown or already
+	 * persisted. Optional so hub/remote hosts without resident sessions can omit it.
+	 */
+	ensureSessionPersisted?(
+		sessionId: string,
+		options?: { prompt?: string },
+	): Promise<boolean>;
 	subscribe(
 		listener: (event: CoreSessionEvent) => void,
 		options?: RuntimeHostSubscribeOptions,


### PR DESCRIPTION
## Summary

Fixes #13781.

A newly-created task can currently exist only as an in-memory/synthetic History entry until the first turn reaches the runtime persistence boundary. If the user immediately creates a new task or closes the current one before that happens, the synthetic entry is removed before a durable row exists.

This change keeps empty sessions lazy, but materializes a durable session for tasks with meaningful user input (prompt and/or attachments) immediately after `startNewSession` and before the History update / first send.

## Details

- adds an optional `RuntimeHost.ensureSessionPersisted(sessionId, { prompt? })` seam
- `LocalRuntimeHost` reuses the existing session artifact materialization path
- threads the seam through `ClineCore` / VS Code session hosts
- `SdkTaskStartCoordinator` invokes it only for meaningful user input
- does not wait for model output and does not add timers
- empty/whitespace-only sessions remain lazy
- repeated ensure is idempotent; unknown session IDs return `false`

The existing init-failure behavior is intentionally unchanged: if persistence itself throws after `startNewSession`, the task-init error path runs, no send or successful History update occurs, and this PR does not add a second `clearTask()` teardown path without separate race/cleanup proof.

## Verification

- `sdk-task-start-coordinator.test.ts`: 19 passed
- `sdk-task-history.test.ts`: 38 passed
- `LocalRuntimeHost` ensure/lazy-session focused tests: 4 passed
- `@cline/core` typecheck: pass
- VS Code TypeScript checks: pass
- Biome checks on changed VS Code files: pass

The branch is rebased onto current `main` (`4ae53292d398d44dc7d92d8b99f5ac75196c7b34`).