### PR TITLE
fix(desktop): keep the scheduled-task report visible when a finished run collapses

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-messages.test.tsx
@@ -331,6 +331,61 @@ describe("ChatMessages tool disclosures", () => {
 		expect(container.textContent).not.toContain("Scheduled task completed");
 	});
 
+	it("keeps the scheduled-task report visible when the run collapses", async () => {
+		// A follow-up prompt settles the scheduled run's span and folds its
+		// working rows into the work summary; the submit_and_exit row is the
+		// run's final report and must stay visible below it.
+		const summary = "All feeds healthy.";
+		await renderMessages([
+			{
+				id: "user-schedule",
+				sessionId: "session-1",
+				role: "user",
+				content: "Check the feeds",
+				createdAt: 1_000,
+			},
+			{
+				id: "tool-read",
+				sessionId: "session-1",
+				role: "tool",
+				content: JSON.stringify({
+					toolName: "read_files",
+					input: { paths: ["feeds.json"] },
+					result: {},
+				}),
+				createdAt: 2_000,
+			},
+			{
+				id: "tool-submit",
+				sessionId: "session-1",
+				role: "tool",
+				content: JSON.stringify({
+					toolName: "submit_and_exit",
+					input: { summary, verified: true },
+					result: summary,
+				}),
+				createdAt: 3_000,
+			},
+			{
+				id: "user-followup",
+				sessionId: "session-1",
+				role: "user",
+				content: "Thanks!",
+				createdAt: 9_000,
+			},
+		]);
+
+		// The working rows folded into a collapsed work summary…
+		const workTrigger = container.querySelector(
+			"button.cline-chat-work-trigger",
+		);
+		expect(workTrigger?.getAttribute("aria-expanded")).toBe("false");
+		// …but the report row did not fold with them: it stays visible and
+		// expanded outside the summary.
+		expect(container.textContent).toContain("Scheduled task completed");
+		expect(container.textContent).toContain(summary);
+	});
+
 	it("renders consecutive tool calls as individual rows", async () => {
 		const tools: ChatMessage[] = [
 			{

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
@@ -420,6 +420,116 @@ describe("collapseCompletedWork", () => {
 		expect(work.durationMilliseconds).toBe(4_000);
 	});
 
+	function makeSubmitTool(id: string, createdAt: number): ChatMessage {
+		return makeMessage({
+			id,
+			role: "tool",
+			content: JSON.stringify({
+				toolName: "submit_and_exit",
+				input: { summary: "Report ready." },
+				result: "Report ready.",
+			}),
+			createdAt,
+		});
+	}
+
+	it("keeps a trailing submit_and_exit row visible as the collapsed run's answer", () => {
+		// Scheduled runs end on submit_and_exit — its row carries the final
+		// report, so it must not fold into the work summary.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 2_000),
+				makeSubmitTool("submit", 5_000),
+			],
+			true,
+		);
+
+		expect(items.map((item) => item.type)).toEqual([
+			"message",
+			"work",
+			"tools",
+		]);
+		const work = items[1];
+		if (work?.type !== "work") throw new Error("expected work item");
+		expect(work.toolCallCount).toBe(1);
+		expect(work.durationMilliseconds).toBe(4_000);
+		const submit = items[2];
+		if (submit?.type !== "tools") throw new Error("expected tools item");
+		expect(submit.messages.map((message) => message.id)).toEqual(["submit"]);
+	});
+
+	it("keeps the submit_and_exit row visible once a later user message exists", () => {
+		// A follow-up prompt in a finished scheduled session settles the run's
+		// span; the report row must survive the collapse instead of hiding
+		// inside the work summary.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 2_000),
+				makeSubmitTool("submit", 5_000),
+				makeMessage({
+					id: "u2",
+					role: "user",
+					content: "thanks, one more thing",
+					createdAt: 9_000,
+				}),
+			],
+			false,
+		);
+
+		expect(items.map((item) => item.type)).toEqual([
+			"message",
+			"work",
+			"tools",
+			"message",
+		]);
+		const submit = items[2];
+		if (submit?.type !== "tools") throw new Error("expected tools item");
+		expect(submit.messages.map((message) => message.id)).toEqual(["submit"]);
+	});
+
+	it("keeps a live run's trailing submit_and_exit with its working rows", () => {
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeMessage({
+					id: "r1",
+					reasoning: "wrapping up",
+					createdAt: 1_500,
+				}),
+				makeTool("t1", 2_000),
+				makeSubmitTool("submit", 3_000),
+			],
+			false,
+		);
+
+		expect(items.map((item) => item.type)).toEqual(["message", "run"]);
+		const run = items[1];
+		if (run?.type !== "run") throw new Error("expected run item");
+		const tools = run.items.at(-1);
+		if (tools?.type !== "tools") throw new Error("expected tools item");
+		expect(tools.messages.map((message) => message.id)).toEqual([
+			"t1",
+			"submit",
+		]);
+	});
+
 	it("measures duration from the first working row when no user message precedes it", () => {
 		const items = collapse(
 			[

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.test.ts
@@ -530,6 +530,114 @@ describe("collapseCompletedWork", () => {
 		]);
 	});
 
+	it("treats a mid-run submit_and_exit as ordinary work", () => {
+		// Only a submit the run actually ended on is its deliverable; one
+		// followed by more work folds with everything else.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeSubmitTool("submit", 2_000),
+				makeTool("t1", 3_000),
+				makeMessage({ id: "a1", content: "Done.", createdAt: 5_000 }),
+			],
+			true,
+		);
+
+		expect(items.map((item) => item.type)).toEqual([
+			"message",
+			"work",
+			"message",
+		]);
+		const work = items[1];
+		if (work?.type !== "work") throw new Error("expected work item");
+		expect(work.toolCallCount).toBe(2);
+	});
+
+	it("prefers trailing assistant text over an earlier submit as the answer", () => {
+		// When the model narrates after submitting, the narration is the
+		// answer and the run folds exactly as it did before the submit
+		// special-case existed.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 2_000),
+				makeSubmitTool("submit", 3_000),
+				makeMessage({ id: "a1", content: "All wrapped up.", createdAt: 4_000 }),
+			],
+			true,
+		);
+
+		expect(items.map((item) => item.type)).toEqual([
+			"message",
+			"work",
+			"message",
+		]);
+		const work = items[1];
+		if (work?.type !== "work") throw new Error("expected work item");
+		expect(work.toolCallCount).toBe(2);
+		const answer = items[2];
+		if (answer?.type !== "message") throw new Error("expected message item");
+		expect(answer.message.id).toBe("a1");
+	});
+
+	it("detects submit_and_exit from message meta when the content is not JSON", () => {
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 2_000),
+				makeMessage({
+					id: "submit-meta",
+					role: "tool",
+					content: "not-json",
+					meta: { toolName: "submit_and_exit" },
+					createdAt: 3_000,
+				}),
+			],
+			true,
+		);
+
+		expect(items.map((item) => item.type)).toEqual([
+			"message",
+			"work",
+			"tools",
+		]);
+	});
+
+	it("does not treat other trailing tool calls as the run's answer", () => {
+		// A finished tail ending on an ordinary tool call still reads as an
+		// interrupted run: rows stay visible, nothing collapses.
+		const items = collapse(
+			[
+				makeMessage({
+					id: "u1",
+					role: "user",
+					content: "go",
+					createdAt: 1_000,
+				}),
+				makeTool("t1", 2_000),
+				makeTool("t2", 3_000),
+			],
+			true,
+		);
+
+		expect(items.map((item) => item.type)).toEqual(["message", "tools"]);
+	});
+
 	it("measures duration from the first working row when no user message precedes it", () => {
 		const items = collapse(
 			[

--- a/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
+++ b/apps/examples/desktop-app/webview/components/views/chat/messages/group-messages.ts
@@ -1,5 +1,6 @@
 import type { AgentMessageRole } from "@cline/ui/components/agent-chat";
 import type { ChatMessage } from "@/lib/chat-schema";
+import { parseToolPayload } from "./tool-summaries";
 
 export type ChatRenderItem =
 	| {
@@ -174,6 +175,18 @@ function maxFiniteTimestamp(
 	return max;
 }
 
+/**
+ * A `submit_and_exit` call carries the run's final report (scheduled tasks
+ * end with it), so a run that ends on one treats that row as its deliverable
+ * — it must stay visible when the working rows fold into a work summary.
+ */
+function isSubmitAndExitMessage(message: ChatMessage): boolean {
+	if (message.role !== "tool") return false;
+	const toolName =
+		message.meta?.toolName || parseToolPayload(message.content)?.toolName;
+	return toolName?.toLowerCase() === "submit_and_exit";
+}
+
 function firstMessageId(item: ChatRenderItem): string | undefined {
 	if (item.type === "tools") return item.messages[0]?.id;
 	if (item.type === "message") {
@@ -185,7 +198,8 @@ function firstMessageId(item: ChatRenderItem): string | undefined {
 /**
  * Folds each finished run's working rows (tool calls, thinking traces,
  * intermediate narration) into a single expandable `work` item, keeping the
- * run's final answer — the assistant text the run ended on — visible after it.
+ * run's final answer — the assistant text or submit_and_exit report the run
+ * ended on — visible after it.
  * Working rows that stay visible (live stream, tool-less runs, tails that
  * never produced an answer) are grouped into a `run` item instead, so they
  * share one tight rhythm and hold their position when the collapse happens.
@@ -215,15 +229,33 @@ export function collapseCompletedWork(
 
 	const flushSpan = (nextIndex: number) => {
 		if (span.length === 0) return;
-		// "Done" means assistant text not followed by more tool calls: that
-		// message is the run's answer and stays visible below the summary.
+		// "Done" means the run ended on its deliverable: assistant text not
+		// followed by more tool calls, or a submit_and_exit call carrying the
+		// run's final report. That item is the run's answer and stays visible
+		// below the summary.
 		const last = span.at(-1);
-		const answer =
+		let answer: ChatRenderItem | undefined;
+		let workRows = span;
+		if (
 			last?.type === "message" &&
 			last.message.role === "assistant" &&
 			last.message.content.trim()
-				? last
-				: undefined;
+		) {
+			answer = last;
+			workRows = span.slice(0, -1);
+		} else if (last?.type === "tools") {
+			const lastToolMessage = last.messages.at(-1);
+			if (lastToolMessage && isSubmitAndExitMessage(lastToolMessage)) {
+				answer = { type: "tools", messages: [lastToolMessage] };
+				workRows =
+					last.messages.length > 1
+						? [
+								...span.slice(0, -1),
+								{ type: "tools", messages: last.messages.slice(0, -1) },
+							]
+						: span.slice(0, -1);
+			}
+		}
 		// A span is settled once a later user message exists. The trailing span
 		// settles only when the session stopped running AND the run actually
 		// ended on an answer — a cancelled or failed tail keeps its rows
@@ -231,7 +263,7 @@ export function collapseCompletedWork(
 		const complete =
 			nextIndex <= lastUserIndex ||
 			(collapseTrailingRun && answer !== undefined);
-		const collapsed = complete && answer ? span.slice(0, -1) : span;
+		const collapsed = complete && answer ? workRows : span;
 		const toolCallCount = collapsed.reduce(
 			(count, item) =>
 				item.type === "tools" ? count + item.messages.length : count,
@@ -242,8 +274,11 @@ export function collapseCompletedWork(
 			// Not collapsed: group the working rows (everything but a trailing
 			// answer-looking message) so they render with the tight in-run
 			// rhythm instead of full transcript spacing. Pure prose spans have
-			// no tool work to group and keep normal spacing.
-			const body = answer ? span.slice(0, -1) : span;
+			// no tool work to group and keep normal spacing. A trailing submit
+			// row stays inside the group here — it only pops out once the run
+			// actually collapses.
+			const messageAnswer = answer?.type === "message" ? answer : undefined;
+			const body = messageAnswer ? span.slice(0, -1) : span;
 			const firstBody = body[0];
 			const hasToolWork = body.some((item) => item.type === "tools");
 			if (body.length >= 2 && hasToolWork && firstBody !== undefined) {
@@ -252,8 +287,8 @@ export function collapseCompletedWork(
 					id: firstMessageId(firstBody) ?? "run",
 					items: body,
 				});
-				if (answer) {
-					out.push(answer);
+				if (messageAnswer) {
+					out.push(messageAnswer);
 				}
 			} else {
 				out.push(...span);


### PR DESCRIPTION
## Problem

A finished scheduled session surfaces its final report through the auto-expanded "Scheduled task completed" row (the `submit_and_exit` call, added in #13612). But `collapseCompletedWork` only treats a trailing assistant text message as the run's answer. A scheduled run ends on the `submit_and_exit` tool row instead, so as soon as the run's span settles (for example a follow-up prompt lands in that session), the entire run, report row included, folds into the collapsed "Worked for Xs and made N tool calls" summary. The final report silently disappears from the transcript.

Before (report nowhere to be found; it is hiding inside the collapsed "Worked for" row):

![Before: scheduled task report hidden](https://cursor.com/artifacts/c/art-0342967d-e3b6-406e-b61d-eba5a509cb38)

## Fix

`collapseCompletedWork` now treats a trailing `submit_and_exit` tool row as the run's deliverable, the same way it treats trailing assistant text:

- When a run collapses into a work summary, the submit row is split out of the collapsed span and stays visible (and auto-expanded) below the "Worked for" row.
- A finished trailing scheduled run now also collapses into the intended "prompt, work summary, answer" reading instead of leaving every working row expanded.
- Live and interrupted runs are unchanged: the submit row stays inside the run group until the run actually collapses.
- Only a submit the run actually ended on is treated as the deliverable; a mid-run submit, or one followed by trailing assistant narration, folds exactly as before.

After (same transcript; the report stays visible below the collapsed work summary, and the summary's tool-call count no longer includes the submit call):

![After: scheduled task report visible](https://cursor.com/artifacts/c/art-13265369-0eb0-4ef9-bb69-80ac1b0bf116)

Expanding the work row shows only the working rows, with no duplicate of the report:

![After: expanded work row with no duplicate report](https://cursor.com/artifacts/c/art-e050d8a8-a90d-4cd9-af9d-1231bf857319)

## Regression coverage for other tool calls

Verified the collapse pipeline is unchanged for ordinary runs, both in tests and manually in the app:

- An ordinary completed run (read/edit/command tools ending in assistant text) still collapses into "Worked for ... and made N tool calls" with the answer visible, and expands back into thought/read/edit-diff/command rows.

![Regression: normal run still collapses with answer visible](https://cursor.com/artifacts/c/art-00626e99-9a6d-4a31-8988-d144d1569cca)

![Regression: expanded work row shows tool rows and diff](https://cursor.com/artifacts/c/art-4d6e162f-cd8a-42f7-823e-8cec98224012)

- A cancelled run that ended mid-work keeps all rows visible with no collapse, as before.

![Regression: cancelled run stays expanded](https://cursor.com/artifacts/c/art-802fe29f-9b4b-4a49-b9b1-f2edf109f535)

## Testing

- New `collapseCompletedWork` unit tests: trailing submit kept visible on collapse, kept visible after a later user message, kept inside the run group while live, mid-run submit folds as ordinary work, trailing assistant text still wins as the answer, meta-based tool-name detection, and ordinary trailing tool calls never treated as an answer.
- New `ChatMessages` render test: with a follow-up message after the run, the work summary is collapsed while "Scheduled task completed" and the report text stay visible.
- Full desktop webview vitest suite passes: 615 tests across 57 files, plus `bun run typecheck`.
- Manually verified in the headless desktop app (sidecar + Next dev) with seeded transcripts: the scheduled session before/after the fix, an ordinary multi-tool completed run, a cancelled run, and pre-existing real sessions.