### PR TITLE
Add stream assembler and port the CLI renderer to frames (Phase 2)

### DIFF
--- a/apps/cli/src/utils/agent-renderer-v1.reference.ts
+++ b/apps/cli/src/utils/agent-renderer-v1.reference.ts
@@ -1,0 +1,214 @@
+/**
+ * v1 inline CLI renderer — the differential-test reference, extracted
+ * verbatim from the pre-Phase-2 `handleEvent` (apps/cli/src/utils/
+ * events.ts). NOT used by production; it exists so the differential
+ * harness can prove the frame-path renderer byte-for-byte parity.
+ * Deleted in Phase 5 when the migration is complete.
+ */
+import type { AgentEvent } from "@cline/core";
+import {
+	formatCompactionDividerLabel,
+	parseCompactionNoticeMetadata,
+} from "../tui/utils/compaction-status";
+import { formatCliErrorMessage } from "./cline-pass-errors";
+import { materializeGeneratedMedia } from "./generated-media";
+import { formatToolInput, formatToolOutput } from "./helpers";
+import { c } from "./output";
+import type { RendererConfig, RendererIo } from "./frame-renderer";
+
+const HOOK = "⎿ ";
+
+function formatResultLines(text: string, maxLines = 5): string[] {
+	const lines = text.split("\n");
+	if (lines.length <= maxLines) return lines;
+	return [...lines.slice(0, maxLines), `... ${lines.length - maxLines} more lines`];
+}
+
+export class V1ReferenceRenderer {
+	private activeInlineStream: "text" | "reasoning" | undefined;
+	private inlineStreamHasOutput = false;
+	private shouldPrefixNextTextWithBlankLine = false;
+
+	constructor(
+		private readonly config: RendererConfig,
+		private readonly io: RendererIo,
+	) {}
+
+	private closeInlineStreamIfNeeded(): void {
+		if (!this.inlineStreamHasOutput) {
+			return;
+		}
+		this.io.write("\n");
+		this.activeInlineStream = undefined;
+		this.inlineStreamHasOutput = false;
+	}
+
+	handleEvent(event: AgentEvent): void {
+		switch (event.type) {
+			case "iteration_start":
+				this.closeInlineStreamIfNeeded();
+				break;
+
+			case "iteration_end":
+				this.closeInlineStreamIfNeeded();
+				break;
+
+			case "content_start":
+				switch (event.contentType) {
+					case "text":
+						if (this.activeInlineStream !== "text") {
+							this.closeInlineStreamIfNeeded();
+							if (this.shouldPrefixNextTextWithBlankLine) {
+								this.io.write("\n");
+								this.shouldPrefixNextTextWithBlankLine = false;
+							}
+							this.activeInlineStream = "text";
+						}
+						this.io.write(event.text ?? "");
+						this.inlineStreamHasOutput = true;
+						break;
+					case "reasoning":
+						if (this.activeInlineStream !== "reasoning") {
+							this.closeInlineStreamIfNeeded();
+							this.io.write(`${c.dim}[thinking] ${c.reset}`);
+							this.activeInlineStream = "reasoning";
+							this.inlineStreamHasOutput = true;
+						}
+						if (event.redacted && !event.reasoning) {
+							this.io.write(`${c.dim}[redacted]${c.reset}`);
+							this.inlineStreamHasOutput = true;
+							break;
+						}
+						this.io.write(`${c.dim}${event.reasoning ?? ""}${c.reset}`);
+						this.inlineStreamHasOutput = true;
+						break;
+					case "tool": {
+						this.closeInlineStreamIfNeeded();
+						const toolName = event.toolName ?? "unknown_tool";
+						const inputStr = formatToolInput(toolName, event.input);
+						if (toolName === "ask_question") {
+							break;
+						}
+						this.io.write(
+							`${c.cyan}[${toolName}]${c.reset}${inputStr ? ` ${inputStr}` : ""}\n`,
+						);
+						break;
+					}
+				}
+				break;
+
+			case "content_end":
+				switch (event.contentType) {
+					case "text":
+					case "reasoning":
+						this.closeInlineStreamIfNeeded();
+						break;
+					case "tool":
+						this.closeInlineStreamIfNeeded();
+						if (event.toolName === "ask_question") {
+							break;
+						}
+						if (event.error) {
+							this.io.write(
+								`   ${c.gray}${HOOK}${c.reset}${c.red}error: ${event.error}${c.reset}\n`,
+							);
+						} else {
+							const outputStr = formatToolOutput(event.output);
+							if (outputStr) {
+								const lines = formatResultLines(outputStr);
+								for (let i = 0; i < lines.length; i++) {
+									const prefix = i === 0 ? HOOK : "  ";
+									this.io.write(
+										`   ${c.gray}${prefix}${c.reset}${c.dim}${lines[i]}${c.reset}\n`,
+									);
+								}
+							} else {
+								this.io.write(
+									`   ${c.gray}${HOOK}${c.reset}${c.green}ok${c.reset}\n`,
+								);
+							}
+						}
+						this.shouldPrefixNextTextWithBlankLine = false;
+						break;
+					case "media": {
+						this.closeInlineStreamIfNeeded();
+						const media = event.media;
+						if (!media) break;
+						const saved = materializeGeneratedMedia(media);
+						if (saved) {
+							this.io.write(
+								`${c.dim}[generated ${media.modality}]${c.reset} ${saved.path}\n`,
+							);
+						} else if (media.source.type === "url") {
+							this.io.write(
+								`${c.dim}[generated ${media.modality}]${c.reset} ${media.source.url}\n`,
+							);
+						} else if (media.source.type === "artifact") {
+							this.io.write(
+								`${c.dim}[generated ${media.modality}]${c.reset} artifact:${media.source.artifactId}\n`,
+							);
+						} else {
+							this.io.write(
+								`${c.dim}[generated ${media.modality}]${c.reset} ${media.mediaType} could not be saved\n`,
+							);
+						}
+						break;
+					}
+				}
+				break;
+
+			case "done": {
+				this.closeInlineStreamIfNeeded();
+				if (this.config.verbose) {
+					const iterations = event.iterations;
+					const label = event.reason === "aborted" ? "aborted" : "finished";
+					this.io.write(
+						`\n${c.dim}── ${label} (${iterations} iterations) ──${c.reset}\n`,
+					);
+				}
+				this.activeInlineStream = undefined;
+				this.inlineStreamHasOutput = false;
+				this.shouldPrefixNextTextWithBlankLine = false;
+				break;
+			}
+			case "error":
+				this.closeInlineStreamIfNeeded();
+				if (!event.recoverable || this.config.verbose) {
+					this.io.writeErr(
+						formatCliErrorMessage(event.error, {
+							modelId: this.config.modelId,
+						}),
+					);
+				}
+				break;
+			case "notice":
+				if (event.displayRole === "status") {
+					this.closeInlineStreamIfNeeded();
+					const label = this.statusLabel(event);
+					if (label) {
+						this.io.write(`\n${c.dim}[status]${c.reset} ${label}\n`);
+					}
+				}
+				break;
+		}
+	}
+
+	private statusLabel(event: AgentEvent): string | undefined {
+		if (event.type !== "notice" || event.displayRole !== "status") {
+			return undefined;
+		}
+		const compaction = parseCompactionNoticeMetadata(event.metadata);
+		if (compaction) {
+			return formatCompactionDividerLabel({ kind: "compaction", ...compaction });
+		}
+		switch (event.reason) {
+			case "auto_compaction":
+				return "auto-compacting";
+			case "manual_compaction":
+				return "compacting";
+			case "compaction_budget_emergency":
+				return "context budget adjusted";
+		}
+		return event.message.trim() || undefined;
+	}
+}

--- a/apps/cli/src/utils/events.test.ts
+++ b/apps/cli/src/utils/events.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	handleEvent,
 	handleTeamEvent,
+	resetAgentEventStreamForTesting,
 	resolveStatusNoticeLabel,
 } from "./events";
 import { setCurrentOutputMode } from "./output";
@@ -47,6 +48,7 @@ describe("handleEvent text formatting", () => {
 	let errorOutput = "";
 
 	beforeEach(() => {
+		resetAgentEventStreamForTesting();
 		output = "";
 		errorOutput = "";
 		setCurrentOutputMode("text");

--- a/apps/cli/src/utils/events.ts
+++ b/apps/cli/src/utils/events.ts
@@ -1,49 +1,92 @@
 import type { AgentEvent, TeamEvent } from "@cline/core";
-import {
-	formatCompactionDividerLabel,
-	parseCompactionNoticeMetadata,
-} from "../tui/utils/compaction-status";
-import { formatCliErrorMessage } from "./cline-pass-errors";
-import { materializeGeneratedMedia } from "./generated-media";
-import { formatToolInput, formatToolOutput, truncate } from "./helpers";
-import {
-	c,
-	emitJsonLine,
-	getCurrentOutputMode,
-	write,
-	writeErr,
-} from "./output";
+import { StreamAssembler } from "@cline/core";
+import { AgentEventFramer, type StreamFrame } from "@cline/shared";
+import { truncate } from "./helpers";
+import { c, emitJsonLine, getCurrentOutputMode, write, writeErr } from "./output";
+import { CliFrameRenderer, resolveFrameStatusLabel } from "./frame-renderer";
 import type { Config } from "./types";
 
 // =============================================================================
-// Inline stream state
+// Agent event stream (v2 frames)
 // =============================================================================
+//
+// The inline CLI renderer now consumes v2 frames: every v1 event is
+// framed (AgentEventFramer) and parsed (StreamAssembler) into the
+// CliFrameRenderer, whose sinks hold only visual state. The v1 switch
+// and its module-level parser state are gone from production; the
+// extracted v1 logic lives in agent-renderer-v1.reference.ts as the
+// differential-test baseline and is deleted in Phase 5.
+//
+// The framer/assembler/renderer are per-process singletons: one
+// terminal, one stream. JSON mode is unchanged — it emits the v1
+// event verbatim, which is the machine contract.
 
-let activeInlineStream: "text" | "reasoning" | undefined;
-let inlineStreamHasOutput = false;
-let shouldPrefixNextTextWithBlankLine = false;
+let stream: {
+	framer: AgentEventFramer;
+	assembler: StreamAssembler;
+	renderer: CliFrameRenderer;
+} | undefined;
 
-// Prefix for result rows
-const HOOK = "⎿ ";
-const TEAM_RUN_ACTIVE_SUFFIX = `${c.dim} ...${c.reset}`;
-
-export function resolveStatusNoticeLabel(
-	event: AgentEvent,
-): string | undefined {
-	if (event.type !== "notice" || event.displayRole !== "status") {
-		return undefined;
+function ensureStream(config: Config): {
+	framer: AgentEventFramer;
+	assembler: StreamAssembler;
+	renderer: CliFrameRenderer;
+} {
+	if (stream === undefined) {
+		const renderer = new CliFrameRenderer(
+			{ verbose: config.verbose, modelId: config.modelId },
+			{ write, writeErr },
+		);
+		stream = {
+			framer: new AgentEventFramer(),
+			assembler: new StreamAssembler(renderer),
+			renderer,
+		};
 	}
-	const compaction = parseCompactionNoticeMetadata(event.metadata);
-	if (compaction) {
-		return formatCompactionDividerLabel({ kind: "compaction", ...compaction });
+	return stream;
+}
+
+export function handleEvent(event: AgentEvent, config: Config): void {
+	if (getCurrentOutputMode() === "json") {
+		emitJsonLine("stdout", { type: "agent_event", event });
+		return;
 	}
-	return resolveNonCompactionStatusLabel(event);
+	const { framer, assembler } = ensureStream(config);
+	const frames: StreamFrame[] = framer.frameEvent(event);
+	assembler.pushAll(frames);
+}
+
+/** Kept for external callers (hooks.ts) and the team handler below. */
+export function closeInlineStreamIfNeeded(): void {
+	stream?.renderer.closeInlineStreamIfNeeded();
 }
 
 /**
- * Label for a status notice already known not to be a compaction notice.
- * Callers that have parsed the compaction metadata themselves use this to
- * avoid re-parsing.
+ * v1-event adapter over the frame-path label logic, kept for callers
+ * holding v1 notice events (the existing tests and any external user).
+ */
+export function resolveStatusNoticeLabel(
+	event: AgentEvent,
+): string | undefined {
+	if (event.type !== "notice") {
+		return undefined;
+	}
+	return resolveFrameStatusLabel({
+		kind: "notice",
+		noticeType: event.noticeType,
+		...(event.message !== undefined ? { message: event.message } : {}),
+		...(event.displayRole !== undefined
+			? { displayRole: event.displayRole }
+			: {}),
+		...(event.reason !== undefined ? { reason: event.reason } : {}),
+		...(event.metadata !== undefined ? { metadata: event.metadata } : {}),
+	});
+}
+
+/**
+ * Label for a status notice already known not to be a compaction
+ * notice. Kept for the TUI (use-agent-events.ts), which parses
+ * compaction metadata itself; ports to the frame path in Phase 3+.
  */
 export function resolveNonCompactionStatusLabel(
 	event: AgentEvent,
@@ -62,189 +105,12 @@ export function resolveNonCompactionStatusLabel(
 	return event.message.trim() || undefined;
 }
 
-export function closeInlineStreamIfNeeded(): void {
-	if (!inlineStreamHasOutput) {
-		return;
-	}
-	write("\n");
-	activeInlineStream = undefined;
-	inlineStreamHasOutput = false;
+/** Test seam: drop the per-process stream so a fresh one is built. */
+export function resetAgentEventStreamForTesting(): void {
+	stream = undefined;
 }
 
-// Used by team events that arrive while the lead agent is mid-stream. Ends the
-// current visual line so the team event prints cleanly, but keeps
-// activeInlineStream set so the next text chunk continues on a new line without
-// re-emitting any prefix.
-function breakLineIfStreaming(): void {
-	if (activeInlineStream === "text" && inlineStreamHasOutput) {
-		write("\n");
-		inlineStreamHasOutput = false;
-	}
-}
-
-// =============================================================================
-// Agent event handler
-// =============================================================================
-
-function formatResultLines(text: string, maxLines = 5): string[] {
-	const lines = text.split("\n");
-	if (lines.length <= maxLines) return lines;
-	return [
-		...lines.slice(0, maxLines),
-		`... ${lines.length - maxLines} more lines`,
-	];
-}
-
-export function handleEvent(event: AgentEvent, config: Config): void {
-	if (getCurrentOutputMode() === "json") {
-		emitJsonLine("stdout", { type: "agent_event", event });
-		return;
-	}
-
-	switch (event.type) {
-		case "iteration_start":
-			closeInlineStreamIfNeeded();
-			break;
-
-		case "iteration_end":
-			closeInlineStreamIfNeeded();
-			break;
-
-		case "content_start":
-			switch (event.contentType) {
-				case "text":
-					if (activeInlineStream !== "text") {
-						closeInlineStreamIfNeeded();
-						if (shouldPrefixNextTextWithBlankLine) {
-							write("\n");
-							shouldPrefixNextTextWithBlankLine = false;
-						}
-						activeInlineStream = "text";
-					}
-					write(event.text ?? "");
-					inlineStreamHasOutput = true;
-					break;
-				case "reasoning":
-					if (activeInlineStream !== "reasoning") {
-						closeInlineStreamIfNeeded();
-						write(`${c.dim}[thinking] ${c.reset}`);
-						activeInlineStream = "reasoning";
-						inlineStreamHasOutput = true;
-					}
-					if (event.redacted && !event.reasoning) {
-						write(`${c.dim}[redacted]${c.reset}`);
-						inlineStreamHasOutput = true;
-						break;
-					}
-					write(`${c.dim}${event.reasoning ?? ""}${c.reset}`);
-					inlineStreamHasOutput = true;
-					break;
-				case "tool": {
-					closeInlineStreamIfNeeded();
-					const toolName = event.toolName ?? "unknown_tool";
-					const inputStr = formatToolInput(toolName, event.input);
-					if (toolName === "ask_question") {
-						break;
-					}
-					write(
-						`${c.cyan}[${toolName}]${c.reset}${inputStr ? ` ${inputStr}` : ""}\n`,
-					);
-					break;
-				}
-			}
-			break;
-
-		case "content_end":
-			switch (event.contentType) {
-				case "text":
-				case "reasoning":
-					closeInlineStreamIfNeeded();
-					break;
-				case "tool":
-					closeInlineStreamIfNeeded();
-					if (event.toolName === "ask_question") {
-						break;
-					}
-					if (event.error) {
-						write(
-							`   ${c.gray}${HOOK}${c.reset}${c.red}error: ${event.error}${c.reset}\n`,
-						);
-					} else {
-						const outputStr = formatToolOutput(event.output);
-						if (outputStr) {
-							const lines = formatResultLines(outputStr);
-							for (let i = 0; i < lines.length; i++) {
-								const prefix = i === 0 ? HOOK : "  ";
-								write(
-									`   ${c.gray}${prefix}${c.reset}${c.dim}${lines[i]}${c.reset}\n`,
-								);
-							}
-						} else {
-							write(`   ${c.gray}${HOOK}${c.reset}${c.green}ok${c.reset}\n`);
-						}
-					}
-					shouldPrefixNextTextWithBlankLine = false;
-					break;
-				case "media": {
-					closeInlineStreamIfNeeded();
-					const media = event.media;
-					if (!media) break;
-					const saved = materializeGeneratedMedia(media);
-					if (saved) {
-						write(
-							`${c.dim}[generated ${media.modality}]${c.reset} ${saved.path}\n`,
-						);
-					} else if (media.source.type === "url") {
-						write(
-							`${c.dim}[generated ${media.modality}]${c.reset} ${media.source.url}\n`,
-						);
-					} else if (media.source.type === "artifact") {
-						write(
-							`${c.dim}[generated ${media.modality}]${c.reset} artifact:${media.source.artifactId}\n`,
-						);
-					} else {
-						write(
-							`${c.dim}[generated ${media.modality}]${c.reset} ${media.mediaType} could not be saved\n`,
-						);
-					}
-					break;
-				}
-			}
-			break;
-
-		case "done": {
-			closeInlineStreamIfNeeded();
-			if (config.verbose) {
-				const iterations = event.iterations;
-				const label = event.reason === "aborted" ? "aborted" : "finished";
-				write(
-					`\n${c.dim}── ${label} (${iterations} iterations) ──${c.reset}\n`,
-				);
-			}
-			activeInlineStream = undefined;
-			inlineStreamHasOutput = false;
-			shouldPrefixNextTextWithBlankLine = false;
-			break;
-		}
-		case "error":
-			closeInlineStreamIfNeeded();
-			if (!event.recoverable || config.verbose) {
-				writeErr(
-					formatCliErrorMessage(event.error, { modelId: config.modelId }),
-				);
-			}
-			break;
-		case "notice":
-			if (event.displayRole === "status") {
-				closeInlineStreamIfNeeded();
-				const label = resolveStatusNoticeLabel(event);
-				if (label) {
-					write(`\n${c.dim}[status]${c.reset} ${label}\n`);
-				}
-			}
-			break;
-	}
-}
+const TEAM_RUN_ACTIVE_SUFFIX = `${c.dim} ...${c.reset}`;
 
 // =============================================================================
 // Team event handler
@@ -261,8 +127,8 @@ export function handleTeamEvent(event: TeamEvent): void {
 		return;
 	}
 
-	breakLineIfStreaming();
-	if (activeInlineStream !== "text") {
+	stream?.renderer.breakLineIfStreaming();
+	if (!stream?.renderer.isActiveTextStream()) {
 		closeInlineStreamIfNeeded();
 	}
 

--- a/apps/cli/src/utils/frame-renderer.differential.test.ts
+++ b/apps/cli/src/utils/frame-renderer.differential.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Differential harness: the v1 inline CLI renderer (reference) vs the
+ * v2 frame path (framer → assembler → CliFrameRenderer) must produce
+ * byte-identical output for every trace, except the whitelisted P6
+ * fix: `done(reason:"error")` now renders as an error instead of v1's
+ * fake "finished" banner.
+ */
+import { generateLegalV1Trace, AgentEventFramer } from "@cline/shared";
+import type { AgentEvent } from "@cline/core";
+import { StreamAssembler } from "@cline/core";
+import { describe, expect, it } from "vitest";
+import { V1ReferenceRenderer } from "./agent-renderer-v1.reference";
+import { CliFrameRenderer } from "./frame-renderer";
+
+interface Output {
+	out: string[];
+	err: string[];
+}
+
+function makeIo(output: Output) {
+	return {
+		write: (text: string): void => {
+			output.out.push(text);
+		},
+		writeErr: (text: string): void => {
+			output.err.push(text);
+		},
+	};
+}
+
+function renderV1(
+	trace: AgentEvent[],
+	config: { verbose: boolean },
+): Output {
+	const output: Output = { out: [], err: [] };
+	const renderer = new V1ReferenceRenderer(config, makeIo(output));
+	for (const event of trace) {
+		renderer.handleEvent(event);
+	}
+	return output;
+}
+
+function renderV2(
+	trace: AgentEvent[],
+	config: { verbose: boolean },
+): Output {
+	const output: Output = { out: [], err: [] };
+	const renderer = new CliFrameRenderer(config, makeIo(output));
+	const framer = new AgentEventFramer();
+	const assembler = new StreamAssembler(renderer);
+	for (const event of trace) {
+		assembler.pushAll(framer.frameEvent(event));
+	}
+	return output;
+}
+
+const hasDoneError = (trace: AgentEvent[]): boolean =>
+	trace.some((event) => event.type === "done" && event.reason === "error");
+
+describe("CLI renderer differential — v1 reference vs frame path", () => {
+	for (const verbose of [false, true]) {
+		it(`generated traces render identically (verbose=${verbose})`, () => {
+			for (let seed = 1; seed <= 100; seed += 1) {
+				const trace = generateLegalV1Trace(seed, { maxEvents: 60 });
+				const v1 = renderV1(trace, { verbose });
+				const v2 = renderV2(trace, { verbose });
+				if (hasDoneError(trace)) {
+					// Whitelisted P6 fix: the run's failure is now an error,
+					// not a fake "finished" banner.
+					expect(v2.err.length).toBeGreaterThan(v1.err.length);
+					continue;
+				}
+				expect(v1.out, `seed ${seed} stdout`).toEqual(v2.out);
+				expect(v1.err, `seed ${seed} stderr`).toEqual(v2.err);
+			}
+		});
+	}
+
+	it("handcrafted edges render identically: ask_question, redacted reasoning, tool error, status notice", () => {
+		const trace: AgentEvent[] = [
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "reasoning",
+				redacted: true,
+			},
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "q1",
+				toolName: "ask_question",
+				input: { question: "hi" },
+			},
+			{
+				type: "content_end",
+				contentType: "tool",
+				toolCallId: "q1",
+				toolName: "ask_question",
+			},
+			{
+				type: "content_start",
+				contentType: "text",
+				text: "Answer",
+			},
+			{
+				type: "content_end",
+				contentType: "text",
+				text: "Answer",
+			},
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "t1",
+				toolName: "run_command",
+				input: { command: "ls" },
+			},
+			{
+				type: "content_end",
+				contentType: "tool",
+				toolCallId: "t1",
+				toolName: "run_command",
+				output: "a\nb\nc",
+			},
+			{
+				type: "notice",
+				noticeType: "status",
+				displayRole: "status",
+				reason: "auto_compaction",
+				message: "compacting",
+			},
+			{
+				type: "done",
+				reason: "completed",
+				text: "done",
+				iterations: 2,
+			},
+		];
+		const v1 = renderV1(trace, { verbose: true });
+		const v2 = renderV2(trace, { verbose: true });
+		expect(v1.out).toEqual(v2.out);
+		expect(v1.err).toEqual(v2.err);
+		// Substrings avoid the ANSI resets between segments.
+		expect(v2.out.join("")).toContain("[thinking]");
+		expect(v2.out.join("")).toContain("auto-compacting");
+		expect(v2.out.join("")).toContain("── finished (2 iterations) ──");
+		// ask_question renders nothing in both.
+		expect(v2.out.join("")).not.toContain("ask_question");
+	});
+
+	it("recoverable errors: identical in both modes", () => {
+		const trace: AgentEvent[] = [
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "error",
+				error: new Error("transient"),
+				iteration: 1,
+				recoverable: true,
+			},
+			{
+				type: "content_start",
+				contentType: "text",
+				text: "recovered",
+			},
+			{
+				type: "content_end",
+				contentType: "text",
+				text: "recovered",
+			},
+			{
+				type: "done",
+				reason: "completed",
+				text: "ok",
+				iterations: 1,
+			},
+		];
+		for (const verbose of [false, true]) {
+			const v1 = renderV1(trace, { verbose });
+			const v2 = renderV2(trace, { verbose });
+			expect(v1.out).toEqual(v2.out);
+			expect(v1.err).toEqual(v2.err);
+		}
+	});
+});

--- a/apps/cli/src/utils/frame-renderer.ts
+++ b/apps/cli/src/utils/frame-renderer.ts
@@ -24,7 +24,6 @@ import type {
 	NoticeBody,
 	Outcome,
 	ReasoningStart,
-	TextStart,
 	ToolStart,
 } from "@cline/shared";
 import type {

--- a/apps/cli/src/utils/frame-renderer.ts
+++ b/apps/cli/src/utils/frame-renderer.ts
@@ -1,0 +1,318 @@
+/**
+ * CLI terminal renderer on the v2 frame stream (Phase 2 of the agent
+ * event stream design). Implements the assembler's consumer API; the
+ * hand-rolled v1 parser state (activeInlineStream etc.) collapses to
+ * per-renderer visual state, and stream structure is the assembler's
+ * job.
+ *
+ * Fidelity notes (differential-tested against the v1 reference):
+ * - Text block closes ignore the final text: v1 streamed text via
+ *   deltas only, and finals with no deltas printed nothing — the v1
+ *   quirk is preserved deliberately.
+ * - Recoverable errors arrive as `recovery` notices; the verbose-only
+ *   display rule is v1's.
+ * - One intended divergence (the P6 fix, whitelisted in the
+ *   differential test): `done(reason:"error")` renders as an error
+ *   rather than v1's fake "finished" banner.
+ */
+import {
+	formatCompactionDividerLabel,
+	parseCompactionNoticeMetadata,
+} from "../tui/utils/compaction-status";
+import type {
+	CloseFinal,
+	NoticeBody,
+	Outcome,
+	ReasoningStart,
+	TextStart,
+	ToolStart,
+} from "@cline/shared";
+import type {
+	MediaFinal,
+	SessionConsumer,
+	TextSink,
+	ReasoningSink,
+	ToolSink,
+	TurnConsumer,
+} from "@cline/core";
+import { formatCliErrorMessage } from "./cline-pass-errors";
+import { materializeGeneratedMedia } from "./generated-media";
+import { formatToolInput, formatToolOutput } from "./helpers";
+import { c } from "./output";
+
+const HOOK = "⎿ ";
+
+export interface RendererIo {
+	write: (text: string) => void;
+	writeErr: (text: string) => void;
+}
+
+export interface RendererConfig {
+	verbose: boolean;
+	modelId?: string;
+}
+
+function formatResultLines(
+	text: string,
+	maxLines = 5,
+): string[] {
+	const lines = text.split("\n");
+	if (lines.length <= maxLines) return lines;
+	return [
+		...lines.slice(0, maxLines),
+		`... ${lines.length - maxLines} more lines`,
+	];
+}
+
+/** Status label for a notice frame (mirrors the v1 label helpers). */
+export function resolveFrameStatusLabel(
+	frame: NoticeBody,
+): string | undefined {
+	if (frame.displayRole !== "status") {
+		return undefined;
+	}
+	const compaction = frame.metadata
+		? parseCompactionNoticeMetadata(frame.metadata)
+		: undefined;
+	if (compaction) {
+		return formatCompactionDividerLabel({
+			kind: "compaction",
+			...compaction,
+		});
+	}
+	switch (frame.reason) {
+		case "auto_compaction":
+			return "auto-compacting";
+		case "manual_compaction":
+			return "compacting";
+		case "compaction_budget_emergency":
+			return "context budget adjusted";
+	}
+	return frame.message?.trim() || undefined;
+}
+
+export class CliFrameRenderer implements SessionConsumer {
+	private readonly config: RendererConfig;
+	private readonly io: RendererIo;
+	private activeInlineStream: "text" | "reasoning" | undefined;
+	private inlineStreamHasOutput = false;
+
+	constructor(config: RendererConfig, io: RendererIo) {
+		this.config = config;
+		this.io = io;
+	}
+
+	/** v1's exported close helper, kept for external callers (hooks). */
+	closeInlineStreamIfNeeded(): void {
+		if (!this.inlineStreamHasOutput) {
+			return;
+		}
+		this.io.write("\n");
+		this.activeInlineStream = undefined;
+		this.inlineStreamHasOutput = false;
+	}
+
+	/** Team-handler probe: is a text stream visually open? */
+	isActiveTextStream(): boolean {
+		return this.activeInlineStream === "text";
+	}
+
+	/** v1's breakLineIfStreaming: end the visual line but keep the
+	 * text stream active so the next chunk continues without a prefix. */
+	breakLineIfStreaming(): void {
+		if (this.activeInlineStream === "text" && this.inlineStreamHasOutput) {
+			this.io.write("\n");
+			this.inlineStreamHasOutput = false;
+		}
+	}
+
+	private closeInline(): void {
+		this.closeInlineStreamIfNeeded();
+	}
+
+	onTurn = (): TurnConsumer => ({
+		onText: (): TextSink => {
+			return {
+				onDelta: (text: string): void => {
+					if (this.activeInlineStream !== "text") {
+						this.closeInline();
+						this.activeInlineStream = "text";
+					}
+					this.io.write(text);
+					this.inlineStreamHasOutput = true;
+				},
+				onAnnotation: (): void => {},
+				onClose: (): void => {
+					// v1 printed nothing for a text final (deltas only).
+					this.closeInline();
+				},
+			};
+		},
+		onReasoning: (start: ReasoningStart): ReasoningSink => {
+			this.closeInline();
+			return {
+				onDelta: (reasoning: string): void => {
+					if (this.activeInlineStream !== "reasoning") {
+						this.closeInline();
+						this.io.write(`${c.dim}[thinking] ${c.reset}`);
+						this.activeInlineStream = "reasoning";
+						this.inlineStreamHasOutput = true;
+					}
+					if (reasoning === "" && start.redacted) {
+						this.io.write(`${c.dim}[redacted]${c.reset}`);
+						this.inlineStreamHasOutput = true;
+						return;
+					}
+					this.io.write(`${c.dim}${reasoning}${c.reset}`);
+					this.inlineStreamHasOutput = true;
+				},
+				onAnnotation: (): void => {},
+				onClose: (): void => {
+					this.closeInline();
+				},
+			};
+		},
+		onTool: (start: ToolStart): ToolSink => {
+			this.closeInline();
+			if (start.toolName !== "ask_question") {
+				const inputStr = formatToolInput(start.toolName, start.input);
+				this.io.write(
+					`${c.cyan}[${start.toolName}]${c.reset}${inputStr ? ` ${inputStr}` : ""}\n`,
+				);
+			}
+			return {
+				onProgress: (): void => {
+					// v1's inline CLI did not render tool progress.
+				},
+				onAnnotation: (): void => {},
+				onClose: (outcome: Outcome, final: CloseFinal): void => {
+					this.closeInline();
+					if (start.toolName === "ask_question") {
+						return;
+					}
+					if (outcome.kind === "interrupted") {
+						// v1 printed nothing for a tool that never closed
+						// (W3 dangling); the force-close must stay silent
+						// too, or an interrupted tool would render "ok".
+						return;
+					}
+					if (outcome.kind === "detached") {
+						// Detached work survives the stream as a resource
+						// handle; the block itself has no final output to
+						// render. No producer emits this yet (Phase 3+).
+						return;
+					}
+					if (outcome.kind === "error") {
+						this.io.write(
+							`   ${c.gray}${HOOK}${c.reset}${c.red}error: ${outcome.error.message}${c.reset}\n`,
+						);
+						return;
+					}
+					const output =
+						final.type === "tool" ? formatToolOutput(final.output) : "";
+					if (output) {
+						const lines = formatResultLines(output);
+						for (let i = 0; i < lines.length; i++) {
+							const prefix = i === 0 ? HOOK : "  ";
+							this.io.write(
+								`   ${c.gray}${prefix}${c.reset}${c.dim}${lines[i]}${c.reset}\n`,
+							);
+						}
+					} else {
+						this.io.write(
+							`   ${c.gray}${HOOK}${c.reset}${c.green}ok${c.reset}\n`,
+						);
+					}
+				},
+			};
+		},
+		onMedia: (media: MediaFinal): void => {
+			this.closeInline();
+			const generated = media.media as {
+				modality: string;
+				mediaType: string;
+				source: { type: string; url?: string; artifactId?: string };
+			};
+			const saved = materializeGeneratedMedia(media.media as never);
+			if (saved) {
+				this.io.write(
+					`${c.dim}[generated ${generated.modality}]${c.reset} ${saved.path}\n`,
+				);
+			} else if (generated.source.type === "url") {
+				this.io.write(
+					`${c.dim}[generated ${generated.modality}]${c.reset} ${generated.source.url}\n`,
+				);
+			} else if (generated.source.type === "artifact") {
+				this.io.write(
+					`${c.dim}[generated ${generated.modality}]${c.reset} artifact:${generated.source.artifactId}\n`,
+				);
+			} else {
+				this.io.write(
+					`${c.dim}[generated ${generated.modality}]${c.reset} ${generated.mediaType} could not be saved\n`,
+				);
+			}
+		},
+		onSubAgent: (): null => null,
+		onNotice: (notice: NoticeBody): void => {
+			if (
+				notice.noticeType === "iteration_started" ||
+				notice.noticeType === "iteration_finished"
+			) {
+				this.closeInline();
+				return;
+			}
+			if (notice.noticeType === "recovery") {
+				// v1 closed the inline stream on every error event, even
+				// recoverable ones whose message was suppressed.
+				this.closeInline();
+				if (this.config.verbose && notice.message) {
+					this.io.writeErr(
+						formatCliErrorMessage(notice.message, {
+							modelId: this.config.modelId,
+						}),
+					);
+				}
+				return;
+			}
+			if (notice.displayRole === "status") {
+				this.closeInline();
+				const label = resolveFrameStatusLabel(notice);
+				if (label) {
+					this.io.write(`\n${c.dim}[status]${c.reset} ${label}\n`);
+				}
+			}
+		},
+		onUsage: (): void => {
+			// v1's inline renderer did not render usage.
+		},
+		onClose: (outcome: Outcome, iterations?: number): void => {
+			this.closeInline();
+			if (this.config.verbose && iterations !== undefined) {
+				const label =
+					outcome.kind === "interrupted" ? "aborted" : "finished";
+				this.io.write(
+					`\n${c.dim}── ${label} (${iterations} iterations) ──${c.reset}\n`,
+				);
+			}
+			if (outcome.kind === "error") {
+				this.io.writeErr(
+					formatCliErrorMessage(outcome.error.message, {
+						modelId: this.config.modelId,
+					}),
+				);
+			}
+			this.activeInlineStream = undefined;
+			this.inlineStreamHasOutput = false;
+		},
+	});
+
+	onSessionNotice(): void {}
+
+	onIdle(): void {}
+
+	onDiagnostic(diagnostic: { code: string; detail?: string }): void {
+		this.io.writeErr(
+			`${c.dim}[stream] ${diagnostic.code}${diagnostic.detail ? ` ${diagnostic.detail}` : ""}${c.reset}\n`,
+		);
+	}
+}

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -481,11 +481,34 @@ port) lands in Phase 2; until then the framer/validator are exercised by
 tests, and the wrapper exists so the producer side of the contract is
 pinned before any consumer ports.
 
-**Phase 2 — assembler + first consumer.** Implement the assembler
-(`@cline/core`). Port the **CLI terminal renderer** first (smallest,
-lowest risk: `apps/cli/src/utils/events.ts`), then ACP. Differential
-test: replay recorded sessions through old and new paths, compare
-rendered output.
+**Phase 2 status: implemented (CLI port; ACP moved).** `@cline/core`
+carries `stream-assembler.ts` — the consumer-side instance of the v2
+tables: push-based consumer API (SessionConsumer/TurnConsumer/sinks),
+delivery contract (seq order, close-last, children-before-turn-close),
+the live set, repairs (stale-epoch drop, orphan drop, force-close)
+reported via `onDiagnostic`, and the `onIdle` quiescence edge. Its tests
+extend the property loop (100 seeds: zero diagnostics, one idle per
+turn) and pin each repair. The CLI terminal renderer
+(`apps/cli/src/utils/events.ts`) is the first frame consumer: the v1
+switch and its module-level parser state are gone; `handleEvent` frames
+via `AgentEventFramer` and drives `CliFrameRenderer` sinks. Fidelity is
+proven two ways: the new differential harness (100 seeds × 2 verbosity
+modes, byte-identical stdout/stderr, plus handcrafted edges —
+ask_question, redacted reasoning, tool errors, status notices) and the
+pre-existing `events.test.ts` behavioral suite, which now runs against
+the frame path unchanged. The harness whitelists exactly one intended
+divergence (P6 made visible: `done(reason:"error")` renders as an
+error, not v1's fake "finished" banner). Framer amendments forced by
+rendering fidelity: `NoticeBody.metadata` (compaction labels),
+turn-close `iterations` (verbose run summary), an empty delta for
+redacted-with-no-text reasoning (the `[redacted]` marker moment), and
+id-less tool open/close pairing (type-legal v1 input). The old v1
+renderer lives as `agent-renderer-v1.reference.ts`, the differential
+baseline, deleted in Phase 5. JSON mode is byte-identical and
+untouched. **ACP port moved to the next PR**: `session-updates.ts` is
+a separate surface with its own wiring; delivering the CLI port +
+harness first keeps this PR's risk surface small, and the assembler
+API is now proven by a real consumer before the second port.
 
 **Phase 3 — VSCode.** Port message-translator onto the assembler.
 MessageTranslatorState's parser fields delete; ClineMessage mapping

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -506,6 +506,27 @@ export {
 	type RuntimeFrameAdapterOptions,
 	RuntimeFrameAdapter,
 } from "./runtime/orchestration/runtime-frame-adapter";
+export {
+	DIAG_AFTER_SESSION_END,
+	DIAG_ANNOTATION_UNROUTED,
+	DIAG_BLOCK_OPEN_WHILE_OPEN,
+	DIAG_ORPHAN_BLOCK_FRAME,
+	DIAG_SNAPSHOT_UNROUTED,
+	DIAG_STALE_EPOCH,
+	DIAG_TURN_CLOSE_WITHOUT_OPEN,
+	DIAG_TURN_OPEN_WHILE_OPEN,
+	StreamAssembler,
+} from "./runtime/orchestration/stream-assembler";
+export type {
+	MediaFinal,
+	ReasoningSink,
+	SessionConsumer,
+	StreamDiagnostic,
+	TextSink,
+	ToolSink,
+	TurnConsumer,
+	TurnObserver,
+} from "./runtime/orchestration/stream-assembler";
 export type {
 	BuiltRuntime,
 	RuntimeBuilder,

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Assembler delivery-contract tests: callback order, repair behavior,
+ * diagnostics, and the idle edge. The property loop extends Phase 1's
+ * generator → framer → validator chain with the assembler: every legal
+ * v1 trace must drive the consumer with zero diagnostics and complete
+ * scope closure.
+ */
+import {
+	generateLegalV1Trace,
+	AgentEventFramer,
+	validateFrameStream,
+	type StreamFrame,
+} from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import {
+	DIAG_ORPHAN_BLOCK_FRAME,
+	DIAG_STALE_EPOCH,
+	DIAG_TURN_CLOSE_WITHOUT_OPEN,
+	StreamAssembler,
+	type SessionConsumer,
+	type TextSink,
+	type ToolSink,
+	type TurnConsumer,
+} from "./stream-assembler";
+
+interface RecordedEvent {
+	call: string;
+	detail?: string;
+}
+
+/** Consumer that records every callback in order. */
+class RecordingConsumer implements SessionConsumer {
+	events: RecordedEvent[] = [];
+	idleCount = 0;
+	diagnostics: string[] = [];
+
+	private record = (call: string, detail?: string): void => {
+		this.events.push({ call, detail });
+	};
+
+	onTurn(): TurnConsumer {
+		this.record("turn:open");
+		return {
+			onText: (): TextSink => {
+				this.record("text:open");
+				return {
+					onDelta: (text: string): void => {
+						this.record("text:delta", text);
+					},
+					onAnnotation: (): void => {
+						this.record("text:annotation");
+					},
+					onClose: (outcome: { kind: string }): void => {
+						this.record("text:close", outcome.kind);
+					},
+				};
+			},
+			onReasoning: (): TextSink => {
+				this.record("reasoning:open");
+				return {
+					onDelta: (reasoning: string): void => {
+						this.record("reasoning:delta", reasoning);
+					},
+					onAnnotation: (): void => {
+						this.record("reasoning:annotation");
+					},
+					onClose: (outcome: { kind: string }): void => {
+						this.record("reasoning:close", outcome.kind);
+					},
+				};
+			},
+			onTool: (): ToolSink => {
+				this.record("tool:open");
+				return {
+					onProgress: (): void => {
+						this.record("tool:progress");
+					},
+					onAnnotation: (): void => {
+						this.record("tool:annotation");
+					},
+					onClose: (outcome: { kind: string }): void => {
+						this.record("tool:close", outcome.kind);
+					},
+				};
+			},
+			onMedia: (): void => {
+				this.record("media");
+			},
+			onSubAgent: (): null => null,
+			onNotice: (): void => {
+				this.record("notice");
+			},
+			onUsage: (): void => {
+				this.record("usage");
+			},
+			onClose: (outcome: { kind: string }, iterations?: number): void => {
+				this.record("turn:close", `${outcome.kind}:${iterations ?? "-"}`);
+			},
+		};
+	}
+
+	onSessionNotice(): void {
+		this.record("session:notice");
+	}
+
+	onIdle(): void {
+		this.idleCount += 1;
+	}
+
+	onDiagnostic(diagnostic: { code: string }): void {
+		this.diagnostics.push(diagnostic.code);
+	}
+}
+
+describe("assembler — property loop over legal traces", () => {
+	it("delivers every frame with zero diagnostics and reaches idle once per turn", () => {
+		for (let seed = 1; seed <= 100; seed += 1) {
+			const frames = new AgentEventFramer().frameAll(
+				generateLegalV1Trace(seed, { maxEvents: 60 }),
+			);
+			expect(validateFrameStream(frames).violations, `seed ${seed}`).toEqual(
+				[],
+			);
+			const consumer = new RecordingConsumer();
+			const assembler = new StreamAssembler(consumer);
+			assembler.pushAll(frames);
+			expect(consumer.diagnostics, `seed ${seed} diagnostics`).toEqual([]);
+			const turnCloses = consumer.events.filter((event) =>
+				event.call.startsWith("turn:close"),
+			);
+			expect(consumer.idleCount, `seed ${seed}`).toBe(turnCloses.length);
+			expect(assembler.openScopes().blocks).toEqual([]);
+			expect(assembler.openScopes().turnId).toBeUndefined();
+		}
+	});
+
+	it("closes every child sink before its turn close (delivery rule 3)", () => {
+		for (let seed = 1; seed <= 100; seed += 1) {
+			const frames = new AgentEventFramer().frameAll(
+				generateLegalV1Trace(seed, { maxEvents: 60 }),
+			);
+			const consumer = new RecordingConsumer();
+			new StreamAssembler(consumer).pushAll(frames);
+			let turnClosed = false;
+			for (const event of consumer.events) {
+				if (event.call === "turn:open") {
+					turnClosed = false;
+				} else if (event.call.startsWith("turn:close")) {
+					turnClosed = true;
+				} else if (turnClosed && !event.call.endsWith("annotation")) {
+					throw new Error(
+						`seed ${seed}: ${event.call} delivered after turn close`,
+					);
+				}
+			}
+		}
+	});
+});
+
+describe("assembler — repairs and diagnostics", () => {
+	it("drops stale-epoch frames with a diagnostic", () => {
+		const consumer = new RecordingConsumer();
+		const assembler = new StreamAssembler(consumer);
+		const framer = new AgentEventFramer();
+		const run1 = framer.frameAll([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "done", reason: "completed", text: "ok", iterations: 1 },
+		]);
+		assembler.pushAll(run1);
+		framer.bumpEpoch();
+		assembler.pushAll(
+			framer.frameAll([
+				{ type: "iteration_start", iteration: 1 },
+				{ type: "done", reason: "completed", text: "ok", iterations: 1 },
+			]),
+		);
+		expect(consumer.diagnostics).toEqual([]);
+		const opensBefore = consumer.events.filter(
+			(event) => event.call === "turn:open",
+		).length;
+		expect(opensBefore).toBe(2);
+
+		// Replay the epoch-0 frames after the assembler has seen epoch 1:
+		// the fenced-conversation straggler scenario. Every frame drops.
+		assembler.pushAll(run1);
+		expect(consumer.diagnostics).toContain(DIAG_STALE_EPOCH);
+		expect(
+			consumer.events.filter((event) => event.call === "turn:open").length,
+		).toBe(opensBefore);
+	});
+
+	it("drops orphan block frames and double turn closes with diagnostics", () => {
+		const consumer = new RecordingConsumer();
+		const assembler = new StreamAssembler(consumer);
+		assembler.pushAll(
+			new AgentEventFramer().frameAll([
+				{ type: "iteration_start", iteration: 1 },
+				{ type: "done", reason: "completed", text: "ok", iterations: 1 },
+			]),
+		);
+		expect(consumer.diagnostics).toEqual([]);
+
+		// A close for a block that never opened, under the closed turn.
+		assembler.push({
+			v: 2,
+			epoch: 0,
+			seq: 50,
+			scope: { agentPath: ["root"], turnId: "turn-1", blockId: "ghost" },
+			kind: "close",
+			outcome: { kind: "completed" },
+		});
+		expect(consumer.diagnostics).toContain(DIAG_ORPHAN_BLOCK_FRAME);
+
+		// A second turn close on the already-closed turn.
+		assembler.push({
+			v: 2,
+			epoch: 0,
+			seq: 51,
+			scope: { agentPath: ["root"], turnId: "turn-1" },
+			kind: "close",
+			outcome: { kind: "completed" },
+		});
+		expect(consumer.diagnostics).toContain(DIAG_TURN_CLOSE_WITHOUT_OPEN);
+	});
+});

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
@@ -17,6 +17,7 @@ import {
 	DIAG_STALE_EPOCH,
 	DIAG_TURN_CLOSE_WITHOUT_OPEN,
 	StreamAssembler,
+	type ReasoningSink,
 	type SessionConsumer,
 	type TextSink,
 	type ToolSink,
@@ -55,7 +56,7 @@ class RecordingConsumer implements SessionConsumer {
 					},
 				};
 			},
-			onReasoning: (): TextSink => {
+			onReasoning: (): ReasoningSink => {
 				this.record("reasoning:open");
 				return {
 					onDelta: (reasoning: string): void => {

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
@@ -1,0 +1,412 @@
+/**
+ * Stream assembler — Phase 2 of the agent event stream v2 design
+ * (`docs/agent-event-stream-design.md`). The consumer-side instance of
+ * the v2 tables: parses `StreamFrame`s into the push-based consumer
+ * API, so a consumer implements rendering only and ordering rules are
+ * unrepresentable in its code (you cannot handle an update for a block
+ * you were never handed).
+ *
+ * Delivery contract (test-locked):
+ * 1. Callbacks fire in frame order.
+ * 2. `onClose` is the last non-annotation call on a sink; annotations
+ *    may arrive later (post-close annotations target real scopes).
+ * 3. Every child sink's `onClose` fires before its turn's `onClose`.
+ * 4. On a violating frame the assembler repairs to the nearest legal
+ *    state (drops stale-epoch frames, drops orphan block frames,
+ *    force-closes open children before a turn close) and reports via
+ *    `onDiagnostic`; legal streams produce zero diagnostics.
+ * 5. `onIdle` fires exactly once per transition to quiescence (no open
+ *    turn and no open run scopes).
+ *
+ * Scope mapping follows the Phase 1 decisions: a v1 run is a v2 turn;
+ * iterations are turn-scoped notices; media arrives whole (open then
+ * close, delivered as `onMedia`). The assembler is per-agent-stream —
+ * one instance per consumer per `agentPath`.
+ */
+import type {
+	CloseFinal,
+	NoticeBody,
+	Outcome,
+	ReasoningStart,
+	StreamFrame,
+	TextStart,
+	ToolStart,
+	UsageBody,
+} from "@cline/shared";
+
+// =============================================================================
+// Consumer API
+// =============================================================================
+
+/** Diagnostics: repairs and unsupported routes. Not violations — the
+ * stream was made legal; the consumer is told what happened. */
+export interface StreamDiagnostic {
+	code: string;
+	seq?: number;
+	detail?: string;
+}
+
+export interface TextSink {
+	onDelta(text: string): void;
+	onAnnotation(annotation: unknown): void;
+	onClose(outcome: Outcome): void;
+}
+
+export interface ReasoningSink {
+	onDelta(reasoning: string): void;
+	onAnnotation(annotation: unknown): void;
+	onClose(outcome: Outcome): void;
+}
+
+export interface ToolSink {
+	onProgress(update: unknown): void;
+	onAnnotation(annotation: unknown): void;
+	onClose(outcome: Outcome, final: CloseFinal): void;
+}
+
+/** Media arrives whole; the assembler delivers the close's final. */
+export interface MediaFinal {
+	media: unknown;
+}
+
+/** Observer for sub-agent streams; null from `onSubAgent` prunes the
+ * subtree (Phase 3 wires real sub-agent frames; the hook exists now so
+ * the consumer API is total). */
+export interface TurnObserver {
+	onNotice(notice: NoticeBody): void;
+	onUsage(usage: UsageBody): void;
+	onClose(outcome: Outcome): void;
+}
+
+export interface TurnConsumer {
+	onText(start: TextStart): TextSink;
+	onReasoning(start: ReasoningStart): ReasoningSink;
+	onTool(start: ToolStart): ToolSink;
+	onMedia(media: MediaFinal): void;
+	onSubAgent(start: { agentId: string }): TurnObserver | null;
+	onNotice(notice: NoticeBody): void;
+	onUsage(usage: UsageBody): void;
+	onClose(outcome: Outcome, iterations?: number): void;
+}
+
+export interface SessionConsumer {
+	onTurn(start: { turnId: string }): TurnConsumer;
+	onSessionNotice(notice: NoticeBody): void;
+	/** Edge-triggered: no open turn and no open run scopes. */
+	onIdle(): void;
+	onDiagnostic(diagnostic: StreamDiagnostic): void;
+}
+
+// =============================================================================
+// Assembler
+// =============================================================================
+
+interface OpenBlock {
+	kind: "text" | "reasoning" | "tool" | "media";
+	turnId: string;
+	sink: TextSink | ReasoningSink | ToolSink | undefined;
+	/** Tool opens carry the input the force-close final needs. */
+	start?: ToolStart;
+}
+
+export const DIAG_STALE_EPOCH = "stale-epoch";
+export const DIAG_ORPHAN_BLOCK_FRAME = "orphan-block-frame";
+export const DIAG_TURN_CLOSE_WITHOUT_OPEN = "turn-close-without-open";
+export const DIAG_TURN_OPEN_WHILE_OPEN = "turn-open-while-open";
+export const DIAG_ANNOTATION_UNROUTED = "annotation-unrouted";
+export const DIAG_SNAPSHOT_UNROUTED = "snapshot-unrouted";
+export const DIAG_AFTER_SESSION_END = "after-session-end";
+export const DIAG_BLOCK_OPEN_WHILE_OPEN = "block-open-while-open";
+
+export class StreamAssembler {
+	private readonly consumer: SessionConsumer;
+	private epoch: number | undefined;
+	private ended = false;
+	private idleNotified = false;
+	private openTurn: { turnId: string; consumer: TurnConsumer } | undefined;
+	private readonly openBlocks = new Map<string, OpenBlock>();
+	private openRunCount = 0;
+
+	constructor(consumer: SessionConsumer) {
+		this.consumer = consumer;
+	}
+
+	/** Frames still open — the live set, derived from the routing table. */
+	openScopes(): { turnId?: string; blocks: string[] } {
+		return {
+			turnId: this.openTurn?.turnId,
+			blocks: [...this.openBlocks.keys()],
+		};
+	}
+
+	push(frame: StreamFrame): void {
+		if (this.ended) {
+			this.diagnose(DIAG_AFTER_SESSION_END, frame);
+			return;
+		}
+		if (this.epoch === undefined) {
+			this.epoch = frame.epoch;
+		} else if (frame.epoch < this.epoch) {
+			// Stale frame from a fenced conversation: dropped, not merged.
+			this.diagnose(DIAG_STALE_EPOCH, frame);
+			return;
+		}
+		this.epoch = frame.epoch;
+
+		const turnId = frame.scope.turnId;
+		const blockId = frame.scope.blockId;
+
+		switch (frame.kind) {
+			case "open": {
+				if (frame.openKind === "turn") {
+					this.openTurnFrame(frame, turnId);
+				} else {
+					this.openBlockFrame(frame, turnId, blockId);
+				}
+				break;
+			}
+			case "delta": {
+				const block =
+					blockId !== undefined ? this.openBlocks.get(blockId) : undefined;
+				if (block === undefined || block.turnId !== turnId) {
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockId);
+					break;
+				}
+				if (block.sink === undefined) {
+					break;
+				}
+				if (block.kind === "text") {
+					(block.sink as TextSink).onDelta(
+						frame.payload.type === "text" ? frame.payload.text : "",
+					);
+				} else if (block.kind === "reasoning") {
+					(block.sink as ReasoningSink).onDelta(
+						frame.payload.type === "reasoning" ? frame.payload.reasoning : "",
+					);
+				} else if (block.kind === "tool") {
+					(block.sink as ToolSink).onProgress(
+						frame.payload.type === "tool" ? frame.payload.update : undefined,
+					);
+				}
+				break;
+			}
+			case "close": {
+				if (blockId !== undefined) {
+					this.closeBlockFrame(frame, turnId, blockId);
+				} else {
+					this.closeTurnFrame(frame, turnId);
+				}
+				break;
+			}
+			case "notice": {
+				if (turnId === undefined) {
+					this.consumer.onSessionNotice(frame);
+					break;
+				}
+				const noticeTurn = this.openTurn;
+				if (noticeTurn !== undefined && noticeTurn.turnId === turnId) {
+					noticeTurn.consumer.onNotice(frame);
+				} else {
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnId);
+				}
+				break;
+			}
+			case "usage": {
+				const usageTurn = this.openTurn;
+				if (usageTurn !== undefined && usageTurn.turnId === turnId) {
+					usageTurn.consumer.onUsage(frame);
+				} else {
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnId);
+				}
+				break;
+			}
+			case "annotation": {
+				const block =
+					blockId !== undefined ? this.openBlocks.get(blockId) : undefined;
+				if (block?.sink !== undefined) {
+					(block.sink as ToolSink).onAnnotation(frame);
+				} else {
+					this.diagnose(DIAG_ANNOTATION_UNROUTED, frame);
+				}
+				break;
+			}
+			case "snapshot": {
+				// Reconnect reconciliation is Phase 3; until then snapshots
+				// are reported, not applied.
+				this.diagnose(DIAG_SNAPSHOT_UNROUTED, frame);
+				break;
+			}
+			default: {
+				const _exhaustive: never = frame;
+				void _exhaustive;
+			}
+		}
+	}
+
+	pushAll(frames: readonly StreamFrame[]): void {
+		for (const frame of frames) {
+			this.push(frame);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	private diagnose(code: string, frame: StreamFrame, detail?: string): void {
+		this.consumer.onDiagnostic({ code, seq: frame.seq, detail });
+	}
+
+	private openTurnFrame(frame: StreamFrame, turnId: string | undefined): void {
+		if (this.openTurn !== undefined) {
+			// Repair: close the abandoned turn as interrupted, then open
+			// the new one.
+			this.closeChildren(this.openTurn.turnId);
+			this.openTurn.consumer.onClose({ kind: "interrupted" });
+			this.diagnose(DIAG_TURN_OPEN_WHILE_OPEN, frame, this.openTurn.turnId);
+			this.openTurn = undefined;
+		}
+		if (turnId === undefined) {
+			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, "(missing turnId)");
+			return;
+		}
+		this.openTurn = { turnId, consumer: this.consumer.onTurn({ turnId }) };
+		this.idleNotified = false;
+	}
+
+	private openBlockFrame(
+		frame: StreamFrame & { kind: "open" },
+		turnId: string | undefined,
+		blockId: string | undefined,
+	): void {
+		if (
+			this.openTurn === undefined ||
+			this.openTurn.turnId !== turnId ||
+			blockId === undefined
+		) {
+			this.diagnose(
+				DIAG_ORPHAN_BLOCK_FRAME,
+				frame,
+				blockId ?? turnId ?? "(unaddressed)",
+			);
+			return;
+		}
+		if (this.openBlocks.has(blockId)) {
+			this.diagnose(DIAG_BLOCK_OPEN_WHILE_OPEN, frame, blockId);
+			return;
+		}
+		const consumer = this.openTurn.consumer;
+		if (frame.openKind === "text") {
+			this.openBlocks.set(blockId, {
+				kind: "text",
+				turnId,
+				sink: consumer.onText(frame.start),
+			});
+		} else if (frame.openKind === "reasoning") {
+			this.openBlocks.set(blockId, {
+				kind: "reasoning",
+				turnId,
+				sink: consumer.onReasoning(frame.start),
+			});
+		} else if (frame.openKind === "tool") {
+			this.openBlocks.set(blockId, {
+				kind: "tool",
+				turnId,
+				sink: consumer.onTool(frame.start),
+				start: frame.start,
+			});
+		} else {
+			// Media arrives whole: the open is bookkeeping so the close
+			// matches; no sink is created.
+			this.openBlocks.set(blockId, { kind: "media", turnId, sink: undefined });
+		}
+	}
+
+	private closeBlockFrame(
+		frame: StreamFrame & { kind: "close" },
+		turnId: string | undefined,
+		blockId: string,
+	): void {
+		const block = this.openBlocks.get(blockId);
+		if (block === undefined || block.turnId !== turnId) {
+			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockId);
+			return;
+		}
+		this.openBlocks.delete(blockId);
+		if (block.kind === "media") {
+			if (frame.final !== undefined && this.openTurn?.turnId === turnId) {
+				this.openTurn.consumer.onMedia({
+					media: (frame.final as { media: unknown }).media,
+				});
+			}
+			return;
+		}
+		if (block.sink === undefined) {
+			return;
+		}
+		if (block.kind === "tool") {
+			(block.sink as ToolSink).onClose(
+				frame.outcome,
+				frame.final ?? { type: "tool", input: block.start?.input },
+			);
+		} else {
+			(block.sink as TextSink).onClose(frame.outcome);
+		}
+	}
+
+	private closeTurnFrame(
+		frame: StreamFrame & { kind: "close" },
+		turnId: string | undefined,
+	): void {
+		if (turnId === undefined) {
+			// Session-scoped close: repair everything, then end.
+			this.ended = true;
+			if (this.openTurn !== undefined) {
+				this.closeChildren(this.openTurn.turnId);
+				this.openTurn.consumer.onClose({ kind: "interrupted" });
+				this.openTurn = undefined;
+			}
+			this.notifyIdle();
+			return;
+		}
+		if (this.openTurn === undefined || this.openTurn.turnId !== turnId) {
+			this.diagnose(DIAG_TURN_CLOSE_WITHOUT_OPEN, frame, turnId);
+			return;
+		}
+		this.closeChildren(turnId);
+		this.openTurn.consumer.onClose(frame.outcome, frame.iterations);
+		this.openTurn = undefined;
+		this.notifyIdle();
+	}
+
+	/** Force-close children of the turn (delivery contract rule 3). */
+	private closeChildren(turnId: string): void {
+		for (const [blockId, block] of [...this.openBlocks.entries()]) {
+			if (block.turnId !== turnId) {
+				continue;
+			}
+			this.openBlocks.delete(blockId);
+			if (block.sink === undefined) {
+				continue;
+			}
+			if (block.kind === "tool") {
+				(block.sink as ToolSink).onClose(
+					{ kind: "interrupted" },
+					{ type: "tool", input: block.start?.input },
+				);
+			} else {
+				(block.sink as TextSink).onClose({ kind: "interrupted" });
+			}
+		}
+	}
+
+	private notifyIdle(): void {
+		if (
+			!this.idleNotified &&
+			this.openTurn === undefined &&
+			this.openRunCount === 0
+		) {
+			this.idleNotified = true;
+			this.consumer.onIdle();
+		}
+	}
+}
+

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -59,6 +59,9 @@ export class AgentEventFramer {
 	private currentTextBlock: string | undefined;
 	private currentReasoningBlock: string | undefined;
 	private readonly openTools = new Map<string, OpenTool>();
+	/** Open tool blocks minted for toolCallId-less (v1-illegal) opens;
+	 * closes without ids pair with the most recent one. */
+	private readonly unnamedToolStack: string[] = [];
 
 	constructor(options: AgentEventFramerOptions = {}) {
 		this.agentPath = options.agentPath ?? ["root"];
@@ -154,17 +157,31 @@ export class AgentEventFramer {
 								},
 							},
 						);
+					} else if (event.redacted) {
+						// v1 marks redacted-with-no-text with a [redacted]
+						// token at this exact stream position; the empty
+						// delta preserves that moment for consumers.
+						this.emit(
+							out,
+							this.blockScope(turnId, this.currentReasoningBlock),
+							{
+								kind: "delta",
+								payload: { type: "reasoning", reasoning: "" },
+							},
+						);
 					}
 					break;
 				}
 				if (event.contentType === "tool") {
-					const blockId =
-						event.toolCallId === undefined
-							? this.nextBlockId()
-							: event.toolCallId;
-					// A missing toolCallId is v1-illegal (the v1 validator
-					// flags it); we still frame it deterministically, and
-					// the v2 tables flag the result.
+					let blockId: string;
+					if (event.toolCallId === undefined) {
+						// v1-illegal but type-legal input; pair id-less
+						// closes with the most recent id-less open.
+						blockId = this.nextBlockId();
+						this.unnamedToolStack.push(blockId);
+					} else {
+						blockId = event.toolCallId;
+					}
 					this.openTools.set(blockId, { input: event.input });
 					this.emit(out, this.blockScope(turnId, blockId), {
 						kind: "open",
@@ -197,7 +214,7 @@ export class AgentEventFramer {
 				if (event.contentType === "tool") {
 					const blockId =
 						event.toolCallId === undefined
-							? this.nextBlockId()
+							? (this.unnamedToolStack.pop() ?? this.nextBlockId())
 							: event.toolCallId;
 					const tool = this.openTools.get(blockId);
 					this.openTools.delete(blockId);
@@ -314,6 +331,9 @@ export class AgentEventFramer {
 						? { displayRole: event.displayRole }
 						: {}),
 					...(event.reason !== undefined ? { reason: event.reason } : {}),
+					...(event.metadata !== undefined
+						? { metadata: event.metadata }
+						: {}),
 				});
 				break;
 			}
@@ -362,7 +382,11 @@ export class AgentEventFramer {
 				break;
 			}
 			case "done": {
-				this.closeTurn(out, finishReasonToOutcome(event));
+				this.closeTurn(
+					out,
+					finishReasonToOutcome(event),
+					event.iterations,
+				);
 				break;
 			}
 			default: {
@@ -485,12 +509,17 @@ export class AgentEventFramer {
 	}
 
 	/** One spelling of turn end (W4/P6): children first, then the close. */
-	private closeTurn(out: StreamFrame[], outcome: Outcome): void {
+	private closeTurn(
+		out: StreamFrame[],
+		outcome: Outcome,
+		iterations?: number,
+	): void {
 		const turnId = this.ensureTurn(out);
 		this.forceCloseChildren(out);
 		this.emit(out, this.turnScope(turnId), {
 			kind: "close",
 			outcome,
+			...(iterations !== undefined ? { iterations } : {}),
 		});
 		this.currentTurnId = undefined;
 	}

--- a/sdk/packages/shared/src/agents/stream-frames.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.ts
@@ -116,6 +116,12 @@ export interface CloseBody {
 	kind: "close";
 	outcome: Outcome;
 	final?: CloseFinal;
+	/**
+	 * Turn closes only: the run's iteration count (from the v1 `done`
+	 * event). Consumers render run summaries from it; block closes
+	 * never carry it.
+	 */
+	iterations?: number;
 }
 
 /** Turn-scoped notices: recovery, status, and the v1 iteration markers. */
@@ -134,6 +140,9 @@ export interface NoticeBody {
 	message?: string;
 	displayRole?: "system" | "status";
 	reason?: string;
+	/** Producer metadata (e.g. compaction status payloads) that
+	 * consumers parse for rich labels. */
+	metadata?: Record<string, unknown>;
 }
 
 export interface UsageBody {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

PR 1 (#13759) made the v1 event grammar explicit; PR 2 (#13766) defined the v2 frame schema and the v1→v2 framer with a 200-seed property loop. This PR adds the consumer side and the first real frame consumer.

- **Assembler** (`@cline/core`, `stream-assembler.ts`): parses v2 frames into the push-based consumer API (`SessionConsumer.onTurn → TurnConsumer` with text/reasoning/tool sinks). Ordering rules become unrepresentable in consumer code — you cannot handle an update for a block you were never handed. The delivery contract is test-locked: callbacks in frame order, every child closed before its turn close, violations repaired (stale-epoch frames dropped, orphan block frames dropped, children force-closed) and reported via `onDiagnostic` instead of becoming rendering glitches, and `onIdle` fires exactly once per quiescence edge.
- **CLI terminal renderer ported** (`apps/cli/src/utils/events.ts`): the v1 switch and its module-level parser state (`activeInlineStream` etc.) are deleted from production; `handleEvent` frames via `AgentEventFramer` and drives `CliFrameRenderer` sinks, which hold visual state only. JSON mode (`--output json`) is byte-identical and untouched.
- **Differential harness**: 100 generated traces × both verbosity modes render byte-identically through the old (reference) and new paths, plus handcrafted edges (ask_question, redacted reasoning, tool errors, status/compaction notices). Exactly one intended divergence, whitelisted: `done(reason:"error")` now renders as an error instead of v1's fake "finished" banner — the P6 wart made visible.
- **A second oracle**: the pre-existing `events.test.ts` behavioral suite now runs against the frame path with no fixture changes.

The old v1 renderer is kept as `agent-renderer-v1.reference.ts`, the differential baseline, deleted in Phase 5. ACP port moves to the next PR (noted in the design doc) so this PR's risk surface is one consumer, proven.

### Test Procedure

```
cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime/orchestration/
# assembler contract suite: property loop (100 seeds, zero diagnostics,
# one idle per turn), repairs (stale epoch, orphan frames, double close)

cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/ src/runtime/
# 304 passed — includes the differential harness and the pre-existing
# events.test.ts behavioral suite running against the frame path

bun run build:sdk && bun -F @cline/cli build   # all green
```

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stacked on #13766 (Phase 1), on #13759 (Phase 0) — review in that order; the tables in PR 1 are the vocabulary for this PR's contract tests. Next in the stack: the ACP port, then VSCode. The design doc (`sdk/packages/core/docs/agent-event-stream-design.md`) carries the full plan, the Phase 2 status, and the verification strategy.
