### PR TITLE
Add agent-path demultiplexing to the frame stream (Phase 3a)

### DIFF
--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -510,17 +510,50 @@ a separate surface with its own wiring; delivering the CLI port +
 harness first keeps this PR's risk surface small, and the assembler
 API is now proven by a real consumer before the second port.
 
-**Phase 3 — VSCode.** Port message-translator onto the assembler.
-MessageTranslatorState's parser fields delete; ClineMessage mapping
-remains as sink implementations. Move the epoch fence from SdkController
-into the producer envelope. Port `SdkSessionRebuildScheduler` to
-`onIdle`. This is the largest phase; the translator's existing tests
-become sink tests.
+**Phase 3 (decomposed during execution — the VSCode translator port
+was too large for one PR, and the demux layer turned out to be design
+work rather than porting).**
+
+**Phase 3a status: implemented (agent-path demux).** Sub-agent events
+now route structurally, deleting the v1 timing heuristic's premise (P5):
+- `@cline/shared`: `AgentEventFramer` accepts an injectable
+  `FrameSequencer`, and a `SessionFramer` facade frames multiplexed
+  agent paths (root `frameEvent`, `frameRoutedEvent(agentPath, event)`)
+  under one session-wide (epoch, seq) — the design's "one counter
+  across all scopes" invariant holds for interleaved streams. The
+  validator is address-keyed (path/turn/block), so two agents minting
+  their own `turn-1` stay independent.
+- `@cline/core`: the assembler routes by agent path, resolves
+  sub-agents through `TurnConsumer.onSubAgent` (now returning a full
+  TurnConsumer — sub-agent streams carry their own blocks; the doc's
+  minimal TurnObserver was upgraded), prunes silently on null (P5),
+  and force-closes child streams (deepest first) before the spawning
+  turn's close. `session-event-projector.ts` attributes
+  `CoreSessionEvent`s by parentAgentId (child path) and teamAgentId
+  (teammate path), flagging unattributable events instead of guessing.
+- Remaining, sequenced: **3b** epoch fence into the producer +
+  rebuild-scheduler on `onIdle` (small); **3c** VSCode translator
+  sinks; **3d** history replay/reconnect (snapshot reconciliation).
+
+**Phase 3b — host wiring.** Move the epoch fence from SdkController
+into the producer envelope (the CLI's SessionFramer already carries
+it); port `SdkSessionRebuildScheduler` to `onIdle`.
+
+**Phase 3c — VSCode translator.** Port message-translator onto the
+assembler. MessageTranslatorState's parser fields delete; ClineMessage
+mapping remains as sink implementations; sub-agent suppression (P5's
+heuristic) becomes `onSubAgent → null` plus a SubagentStatusRow
+consumer.
+
+**Phase 3d — history replay and reconnect.** Snapshot reconciliation
+in the assembler (diff against the live set), live-after-history dedup
+by (scopeId, seq).
 
 **Phase 4 — desktop.** Sidecar forwards frames verbatim (the
 `chat_text`/`chat_done` re-encoding in `sidecar/context.ts` deletes);
-`use-chat-session.ts` becomes sinks + React state. Largest line-count
-deletion.
+`use-chat-session.ts` becomes sinks + React state. Likely split into
+two PRs (sidecar forwarding; webview sinks) by the same reasoning that
+decomposed Phase 3.
 
 **Phase 5 — ratchet.** CI check: no `switch`/`if` over raw
 `AgentEvent.type` outside the assembler package and the (legacy) hub
@@ -583,10 +616,14 @@ revertable without reverting its ancestors' behavior changes:
 |---|---|---|---|
 | 1 | `dpc/event-stream-phase0` | Design doc + v1 tables, validator, wart registry, adapter grammar tests. No behavior change. | — |
 | 2 | `dpc/event-stream-phase1` | v2 frame schema, structured StreamError, dual-emit in RuntimeEventAdapter, trace generator + property tests. | 1 |
-| 3 | `dpc/event-stream-phase2` | Assembler (`@cline/core`), CLI terminal + ACP ports, differential replay harness. | 2 |
-| 4 | `dpc/event-stream-phase3` | VSCode translator port, epoch fence into producer, rebuild scheduler on `onIdle`. | 3 |
-| 5 | `dpc/event-stream-phase4` | Desktop: sidecar forwards frames, `use-chat-session` becomes sinks. | 3 |
-| 6 | `dpc/event-stream-phase5` | CI ratchet + deletion of superseded v1 consumer paths. | 4, 5 |
+| 3 | `dpc/event-stream-phase2` | Assembler (`@cline/core`), CLI terminal port, differential replay harness. (ACP port moved to PR 5, Phase 3b.) | 2 |
+| 4 | `dpc/event-stream-demux` | Phase 3a: multiplexed framing (SessionFramer, shared sequencer), address-keyed validator, tree-aware assembler with `onSubAgent` pruning, session-event projector. | 3 |
+| 5 | `dpc/event-stream-phase3b` | Phase 3b: epoch fence into the producer, ACP port, rebuild scheduler on `onIdle`. | 4 |
+| 6 | `dpc/event-stream-phase3c` | Phase 3c: VSCode translator sinks; P5 heuristic becomes `onSubAgent → null`. | 5 |
+| 7 | `dpc/event-stream-phase3d` | Phase 3d: history replay/reconnect, snapshot reconciliation. | 6 |
+| 8 | `dpc/event-stream-phase4a` | Desktop sidecar forwards frames verbatim (v1 re-encoding deletes). | 7 |
+| 9 | `dpc/event-stream-phase4b` | Desktop webview sinks (`use-chat-session`). | 8 |
+| 10 | `dpc/event-stream-phase5` | CI ratchet + deletion of superseded v1 consumer paths and the v1 reference renderer. | 9 |
 
 Review stays manageable because PR 1 is additive-only (this PR), PRs 2-3
 are producer/plumbing with property tests doing the checking, and the

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -513,10 +513,13 @@ export {
 	DIAG_ORPHAN_BLOCK_FRAME,
 	DIAG_SNAPSHOT_UNROUTED,
 	DIAG_STALE_EPOCH,
+	DIAG_SUBAGENT_WITHOUT_TURN,
 	DIAG_TURN_CLOSE_WITHOUT_OPEN,
 	DIAG_TURN_OPEN_WHILE_OPEN,
 	StreamAssembler,
 } from "./runtime/orchestration/stream-assembler";
+export type { ProjectedAgentEvent } from "./runtime/orchestration/session-event-projector";
+export { projectSessionEvent } from "./runtime/orchestration/session-event-projector";
 export type {
 	MediaFinal,
 	ReasoningSink,
@@ -525,8 +528,8 @@ export type {
 	TextSink,
 	ToolSink,
 	TurnConsumer,
-	TurnObserver,
 } from "./runtime/orchestration/stream-assembler";
+
 export type {
 	BuiltRuntime,
 	RuntimeBuilder,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-frame-adapter.test.ts
@@ -185,7 +185,7 @@ describe("RuntimeFrameAdapter — dual-emit", () => {
 		const validation = validateFrameStream(frames);
 		expect(validation.violations).toEqual([]);
 		expect(validation.openBlocks).toEqual([]);
-		expect(validation.openTurnId).toBeUndefined();
+		expect(validation.openTurns).toEqual([]);
 	});
 
 	it("reset() fences open scopes with interrupted and the next run opens a new turn with continued seq", () => {
@@ -233,6 +233,6 @@ describe("RuntimeFrameAdapter — dual-emit", () => {
 		// The new run is legitimately mid-flight: turn-2 is open, and
 		// turn-1's tool closed during the fence (zero violations proves
 		// the fence close matched its open).
-		expect(validation.openTurnId).toBe("turn-2");
+		expect(validation.openTurns).toEqual(["root/turn-2"]);
 	});
 });

--- a/sdk/packages/core/src/runtime/orchestration/session-event-projector.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-event-projector.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the session-event projector (Phase 3a): the explicit
+ * routing rule that replaces the v1 timing heuristic (P5).
+ */
+import { describe, expect, it } from "vitest";
+import { projectSessionEvent } from "./session-event-projector";
+import type { CoreSessionEvent } from "../../types/events";
+
+const agentEvent = (overrides: Record<string, unknown> = {}) =>
+	({ type: "content_start", contentType: "text", text: "hi", ...overrides }) as never;
+
+const sessionEvent = (
+	payloadOverrides: Record<string, unknown>,
+	eventOverrides: Record<string, unknown> = {},
+): CoreSessionEvent =>
+	({
+		type: "agent_event",
+		payload: {
+			sessionId: "s1",
+			event: agentEvent(eventOverrides),
+			...payloadOverrides,
+		},
+	}) as never;
+
+describe("session-event projector", () => {
+	it("routes sub-agent events (parentAgentId) to the child path", () => {
+		const [projected] = projectSessionEvent(
+			sessionEvent({}, { parentAgentId: "root", agentId: "agent-a" }),
+		);
+		expect(projected.agentPath).toEqual(["root", "agent-a"]);
+		expect(projected.unattributed).toBe(false);
+	});
+
+	it("routes teammate events (teamAgentId) to their own path", () => {
+		const [projected] = projectSessionEvent(
+			sessionEvent({ teamAgentId: "worker-1", teamRole: "teammate" }),
+		);
+		expect(projected.agentPath).toEqual(["root", "worker-1"]);
+		expect(projected.unattributed).toBe(false);
+	});
+
+	it("routes plain lead events to the root path", () => {
+		const [projected] = projectSessionEvent(sessionEvent({}));
+		expect(projected.agentPath).toEqual(["root"]);
+		expect(projected.unattributed).toBe(false);
+	});
+
+	it("flags events with an agentId but no attribution as unattributed (the P5 hole, visible)", () => {
+		const [projected] = projectSessionEvent(
+			sessionEvent({}, { agentId: "agent-a" }),
+		);
+		expect(projected.agentPath).toEqual(["root"]);
+		expect(projected.unattributed).toBe(true);
+	});
+
+	it("projects non-agent session events to nothing", () => {
+		expect(
+			projectSessionEvent({ type: "ended", payload: { sessionId: "s1", reason: "", ts: 0 } } as never),
+		).toEqual([]);
+	});
+});

--- a/sdk/packages/core/src/runtime/orchestration/session-event-projector.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-event-projector.ts
@@ -1,0 +1,79 @@
+/**
+ * Session-event projector — Phase 3a of the agent event stream v2
+ * design (`docs/agent-event-stream-design.md`). Replaces the v1
+ * consumer-side *timing heuristic* (message-translator.ts:2023: "while
+ * spawn_agent calls are in flight we also suppress every non-spawn
+ * event" — P5) with an explicit routing rule at the producer boundary:
+ * every agent event is attributed to an agent path before framing.
+ *
+ * Rules (deterministic, test-locked):
+ * - `parentAgentId` set → the event belongs to the child stream
+ *   `["root", <agentId>]` — sub-agent events route structurally, so
+ *   consumers prune subtrees via `onSubAgent → null`, never by timing.
+ * - `teamAgentId` set (teammates) → `["root", <teamAgentId>]` — a
+ *   session-scoped sibling stream keyed by team membership. (agentPath
+ *   is a routing key, not a reporting line; "root" prefix denotes
+ *   "session-level", not parenthood.)
+ * - Neither → the root stream, and `unattributed` flags the case where
+ *   the event carried an `agentId` we could not place (older adapters
+ *   emit sub-agent events without parentAgentId — the exact hole the
+ *   v1 heuristic papered over). Visible to callers; never folklore.
+ *
+ * Deeper chains (a sub-agent spawning agents) resolve one level at a
+ * time as events carry their own parentAgentId; today the SDK emits
+ * single-level chains.
+ */
+import type { CoreSessionEvent } from "../../types/events";
+import type { AgentEvent } from "@cline/shared";
+
+export interface ProjectedAgentEvent {
+	/** Agent path (root first) the event belongs to. */
+	agentPath: string[];
+	/** The agent event itself. */
+	event: AgentEvent;
+	/**
+	 * True when the event could not be attributed beyond the root
+	 * stream (no parentAgentId, no teamAgentId, but it carried an
+	 * agentId). The P5 hole, made visible instead of guessed at.
+	 */
+	unattributed: boolean;
+}
+
+/** Project one CoreSessionEvent; non-agent events project to nothing. */
+export function projectSessionEvent(
+	event: CoreSessionEvent,
+): ProjectedAgentEvent[] {
+	if (event.type !== "agent_event") {
+		return [];
+	}
+	const agentEvent: AgentEvent = event.payload.event;
+	const parentAgentId = agentEvent.parentAgentId ?? undefined;
+	const agentId = agentEvent.agentId ?? undefined;
+	const teamAgentId = event.payload.teamAgentId;
+
+	if (parentAgentId !== undefined && agentId !== undefined) {
+		return [
+			{
+				agentPath: ["root", agentId],
+				event: agentEvent,
+				unattributed: false,
+			},
+		];
+	}
+	if (teamAgentId !== undefined) {
+		return [
+			{
+				agentPath: ["root", teamAgentId],
+				event: agentEvent,
+				unattributed: false,
+			},
+		];
+	}
+	return [
+		{
+			agentPath: ["root"],
+			event: agentEvent,
+			unattributed: agentId !== undefined,
+		},
+	];
+}

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.test.ts
@@ -8,6 +8,7 @@
 import {
 	generateLegalV1Trace,
 	AgentEventFramer,
+	SessionFramer,
 	validateFrameStream,
 	type StreamFrame,
 } from "@cline/shared";
@@ -15,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
 	DIAG_ORPHAN_BLOCK_FRAME,
 	DIAG_STALE_EPOCH,
+	DIAG_SUBAGENT_WITHOUT_TURN,
 	DIAG_TURN_CLOSE_WITHOUT_OPEN,
 	StreamAssembler,
 	type ReasoningSink,
@@ -131,7 +133,7 @@ describe("assembler — property loop over legal traces", () => {
 			);
 			expect(consumer.idleCount, `seed ${seed}`).toBe(turnCloses.length);
 			expect(assembler.openScopes().blocks).toEqual([]);
-			expect(assembler.openScopes().turnId).toBeUndefined();
+			expect(assembler.openScopes().turnPaths).toEqual([]);
 		}
 	});
 
@@ -222,5 +224,178 @@ describe("assembler — repairs and diagnostics", () => {
 			outcome: { kind: "completed" },
 		});
 		expect(consumer.diagnostics).toContain(DIAG_TURN_CLOSE_WITHOUT_OPEN);
+	});
+});
+
+describe("assembler — sub-agent routing (Phase 3a)", () => {
+	/** Consumer with per-path event logs and a prunable sub-agent. */
+	class SubAgentConsumer implements SessionConsumer {
+		events: string[] = [];
+		idleCount = 0;
+		diagnostics: string[] = [];
+		pruneChildren = false;
+		subAgentConsumed = false;
+
+		onTurn(): TurnConsumer {
+			this.events.push("turn:open");
+			return this.makeConsumer("root");
+		}
+
+		private makeConsumer(path: string): TurnConsumer {
+			const self = this;
+			return {
+				onText: (): TextSink => {
+					self.events.push(`${path}:text:open`);
+					return {
+						onDelta: (text: string): void => {
+							self.events.push(`${path}:text:delta`);
+							void text;
+						},
+						onAnnotation: (): void => {},
+						onClose: (): void => {
+							self.events.push(`${path}:text:close`);
+						},
+					};
+				},
+				onReasoning: (): ReasoningSink => {
+					return {
+						onDelta: (): void => {},
+						onAnnotation: (): void => {},
+						onClose: (): void => {},
+					};
+				},
+				onTool: (): ToolSink => {
+					self.events.push(`${path}:tool:open`);
+					return {
+						onProgress: (): void => {},
+						onAnnotation: (): void => {},
+						onClose: (outcome: { kind: string }): void => {
+							self.events.push(`${path}:tool:close:${outcome.kind}`);
+						},
+					};
+				},
+				onMedia: (): void => {},
+				onSubAgent: (): TurnConsumer | null => {
+					if (self.pruneChildren) {
+						return null;
+					}
+					self.subAgentConsumed = true;
+					return self.makeConsumer("child");
+				},
+				onNotice: (): void => {},
+				onUsage: (): void => {},
+				onClose: (outcome: { kind: string }): void => {
+					self.events.push(`${path}:turn:close:${outcome.kind}`);
+				},
+			};
+		}
+
+		onSessionNotice(): void {}
+		onIdle(): void {
+			this.idleCount += 1;
+		}
+		onDiagnostic(diagnostic: { code: string }): void {
+			this.diagnostics.push(diagnostic.code);
+		}
+	}
+
+	const push = (
+		assembler: StreamAssembler,
+		frames: readonly StreamFrame[],
+	): void => {
+		assembler.pushAll(frames);
+	};
+
+	it("routes child frames to onSubAgent's consumer; pruning drops them silently", () => {
+		// Routed: the child stream renders via its own consumer.
+		const consumer = new SubAgentConsumer();
+		const assembler = new StreamAssembler(consumer);
+		const framer = new SessionFramer();
+		push(assembler, framer.frameEvent({ type: "iteration_start", iteration: 1 }));
+		push(
+			assembler,
+			framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "content_start",
+				contentType: "text",
+				text: "child text",
+			}),
+		);
+		expect(consumer.subAgentConsumed).toBe(true);
+		expect(consumer.events).toContain("child:text:delta");
+		expect(consumer.diagnostics).toEqual([]);
+
+		// Pruned: same input, consumer says null — nothing reaches it and
+		// nothing is diagnosed (P5: pruning is deliberate, not a fault).
+		const pruner = new SubAgentConsumer();
+		pruner.pruneChildren = true;
+		const prunerAssembler = new StreamAssembler(pruner);
+		const framer2 = new SessionFramer();
+		push(
+			prunerAssembler,
+			framer2.frameEvent({ type: "iteration_start", iteration: 1 }),
+		);
+		push(
+			prunerAssembler,
+			framer2.frameRoutedEvent(["root", "agent-a"], {
+				type: "content_start",
+				contentType: "text",
+				text: "child text",
+			}),
+		);
+		expect(pruner.subAgentConsumed).toBe(false);
+		expect(pruner.diagnostics).toEqual([]);
+		expect(pruner.events).not.toContain("child:text:delta");
+	});
+
+	it("closing the parent turn force-closes the child stream first (rule 3)", () => {
+		const consumer = new SubAgentConsumer();
+		const assembler = new StreamAssembler(consumer);
+		const framer = new SessionFramer();
+		const frames = [
+			...framer.frameEvent({ type: "iteration_start", iteration: 1 }),
+			...framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "iteration_start",
+				iteration: 1,
+			}),
+			...framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "content_start",
+				contentType: "text",
+				text: "working",
+			}),
+		];
+		assembler.pushAll(frames);
+		// Parent completes while the child is mid-flight.
+		assembler.pushAll(
+			framer.frameEvent({
+				type: "done",
+				reason: "completed",
+				text: "ok",
+				iterations: 1,
+			}),
+		);
+		expect(consumer.diagnostics).toEqual([]);
+		const childClose = consumer.events.indexOf("child:turn:close:interrupted");
+		const parentClose = consumer.events.indexOf("root:turn:close:completed");
+		expect(childClose).toBeGreaterThanOrEqual(0);
+		expect(parentClose).toBeGreaterThan(childClose);
+		// The child's open text block closed before its turn.
+		const childTextClose = consumer.events.indexOf("child:text:close");
+		expect(childTextClose).toBeGreaterThan(-1);
+		expect(childTextClose).toBeLessThan(childClose);
+	});
+
+	it("child frames with no parent turn open are diagnosed, not guessed", () => {
+		const consumer = new SubAgentConsumer();
+		const assembler = new StreamAssembler(consumer);
+		const framer = new SessionFramer();
+		assembler.pushAll(
+			framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "content_start",
+				contentType: "text",
+				text: "orphan child",
+			}),
+		);
+		expect(consumer.diagnostics).toContain(DIAG_SUBAGENT_WITHOUT_TURN);
+		expect(consumer.subAgentConsumed).toBe(false);
 	});
 });

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
@@ -1,27 +1,28 @@
 /**
- * Stream assembler — Phase 2 of the agent event stream v2 design
+ * Stream assembler — Phase 2/3a of the agent event stream v2 design
  * (`docs/agent-event-stream-design.md`). The consumer-side instance of
  * the v2 tables: parses `StreamFrame`s into the push-based consumer
  * API, so a consumer implements rendering only and ordering rules are
- * unrepresentable in its code (you cannot handle an update for a block
- * you were never handed).
+ * unrepresentable in its code.
  *
  * Delivery contract (test-locked):
  * 1. Callbacks fire in frame order.
- * 2. `onClose` is the last non-annotation call on a sink; annotations
- *    may arrive later (post-close annotations target real scopes).
- * 3. Every child sink's `onClose` fires before its turn's `onClose`.
+ * 2. `onClose` is the last non-annotation call on a sink.
+ * 3. Every child sink's `onClose` fires before its turn's `onClose`,
+ *    and every sub-agent stream closes before the spawning turn's
+ *    `onClose` (scope tree rule 3).
  * 4. On a violating frame the assembler repairs to the nearest legal
- *    state (drops stale-epoch frames, drops orphan block frames,
- *    force-closes open children before a turn close) and reports via
- *    `onDiagnostic`; legal streams produce zero diagnostics.
- * 5. `onIdle` fires exactly once per transition to quiescence (no open
- *    turn and no open run scopes).
+ *    state and reports via `onDiagnostic`. Pruning is NOT a violation:
+ *    `onSubAgent` returning null drops that subtree's frames silently
+ *    (design P5 — structural pruning replaces the v1 timing heuristic).
+ * 5. `onIdle` fires exactly once per transition to quiescence.
  *
- * Scope mapping follows the Phase 1 decisions: a v1 run is a v2 turn;
- * iterations are turn-scoped notices; media arrives whole (open then
- * close, delivered as `onMedia`). The assembler is per-agent-stream —
- * one instance per consumer per `agentPath`.
+ * Address-keyed (Phase 3a): turns and blocks are keyed by full scope
+ * address, so multiplexed agent streams — each minting their own
+ * `turn-1` — route independently. Sub-agent streams get their consumer
+ * from the spawning turn's `onSubAgent`; their turn opens are scope
+ * bookkeeping (no callback — `onSubAgent` was the callback), and their
+ * blocks/notices flow to that consumer.
  */
 import type {
 	CloseFinal,
@@ -69,21 +70,21 @@ export interface MediaFinal {
 	media: unknown;
 }
 
-/** Observer for sub-agent streams; null from `onSubAgent` prunes the
- * subtree (Phase 3 wires real sub-agent frames; the hook exists now so
- * the consumer API is total). */
-export interface TurnObserver {
-	onNotice(notice: NoticeBody): void;
-	onUsage(usage: UsageBody): void;
-	onClose(outcome: Outcome): void;
-}
-
+/**
+ * Consumer for one agent stream. Sub-agents return one from
+ * `TurnConsumer.onSubAgent` (a full TurnConsumer, not the design doc's
+ * minimal TurnObserver: sub-agent streams carry their own text and
+ * tool blocks); the root stream's consumer comes from
+ * `SessionConsumer.onTurn` per turn.
+ */
 export interface TurnConsumer {
 	onText(start: TextStart): TextSink;
 	onReasoning(start: ReasoningStart): ReasoningSink;
 	onTool(start: ToolStart): ToolSink;
 	onMedia(media: MediaFinal): void;
-	onSubAgent(start: { agentId: string }): TurnObserver | null;
+	/** Null prunes the subtree — its frames are dropped, silently and
+	 * deliberately (design P5). */
+	onSubAgent(start: { agentId: string }): TurnConsumer | null;
 	onNotice(notice: NoticeBody): void;
 	onUsage(usage: UsageBody): void;
 	onClose(outcome: Outcome, iterations?: number): void;
@@ -92,7 +93,7 @@ export interface TurnConsumer {
 export interface SessionConsumer {
 	onTurn(start: { turnId: string }): TurnConsumer;
 	onSessionNotice(notice: NoticeBody): void;
-	/** Edge-triggered: no open turn and no open run scopes. */
+	/** Edge-triggered: no open turn (any path) and no open run scopes. */
 	onIdle(): void;
 	onDiagnostic(diagnostic: StreamDiagnostic): void;
 }
@@ -103,38 +104,49 @@ export interface SessionConsumer {
 
 interface OpenBlock {
 	kind: "text" | "reasoning" | "tool" | "media";
-	turnId: string;
+	blockKey: string;
 	sink: TextSink | ReasoningSink | ToolSink | undefined;
 	/** Tool opens carry the input the force-close final needs. */
 	start?: ToolStart;
+}
+
+interface OpenTurn {
+	turnId: string;
+	consumer: TurnConsumer;
 }
 
 export const DIAG_STALE_EPOCH = "stale-epoch";
 export const DIAG_ORPHAN_BLOCK_FRAME = "orphan-block-frame";
 export const DIAG_TURN_CLOSE_WITHOUT_OPEN = "turn-close-without-open";
 export const DIAG_TURN_OPEN_WHILE_OPEN = "turn-open-while-open";
+export const DIAG_SUBAGENT_WITHOUT_TURN = "subagent-without-turn";
 export const DIAG_ANNOTATION_UNROUTED = "annotation-unrouted";
 export const DIAG_SNAPSHOT_UNROUTED = "snapshot-unrouted";
 export const DIAG_AFTER_SESSION_END = "after-session-end";
 export const DIAG_BLOCK_OPEN_WHILE_OPEN = "block-open-while-open";
+
+const ROOT = "root";
 
 export class StreamAssembler {
 	private readonly consumer: SessionConsumer;
 	private epoch: number | undefined;
 	private ended = false;
 	private idleNotified = false;
-	private openTurn: { turnId: string; consumer: TurnConsumer } | undefined;
+	/** pathKey -> open turn (one per agent path). */
+	private readonly openTurns = new Map<string, OpenTurn>();
+	/** blockKey (path/turn/block) -> open block. */
 	private readonly openBlocks = new Map<string, OpenBlock>();
-	private openRunCount = 0;
+	/** pathKey -> sub-agent consumer; null = pruned subtree. */
+	private readonly subAgents = new Map<string, TurnConsumer | null>();
 
 	constructor(consumer: SessionConsumer) {
 		this.consumer = consumer;
 	}
 
-	/** Frames still open — the live set, derived from the routing table. */
-	openScopes(): { turnId?: string; blocks: string[] } {
+	/** Scopes still open — the live set, derived from the routing tables. */
+	openScopes(): { turnPaths: string[]; blocks: string[] } {
 		return {
-			turnId: this.openTurn?.turnId,
+			turnPaths: [...this.openTurns.keys()],
 			blocks: [...this.openBlocks.keys()],
 		};
 	}
@@ -147,29 +159,39 @@ export class StreamAssembler {
 		if (this.epoch === undefined) {
 			this.epoch = frame.epoch;
 		} else if (frame.epoch < this.epoch) {
-			// Stale frame from a fenced conversation: dropped, not merged.
 			this.diagnose(DIAG_STALE_EPOCH, frame);
 			return;
 		}
 		this.epoch = frame.epoch;
 
+		const pathKey = frame.scope.agentPath.join("/");
+		if (pathKey !== ROOT && !this.routeSubAgent(pathKey, frame)) {
+			// Unroutable (diagnostic already emitted) or pruned (silent).
+			return;
+		}
+
 		const turnId = frame.scope.turnId;
 		const blockId = frame.scope.blockId;
+		const turnKey = turnId !== undefined ? `${pathKey}/${turnId}` : undefined;
+		const blockKey =
+			turnKey !== undefined && blockId !== undefined
+				? `${turnKey}/${blockId}`
+				: undefined;
 
 		switch (frame.kind) {
 			case "open": {
 				if (frame.openKind === "turn") {
-					this.openTurnFrame(frame, turnId);
+					this.openTurnFrame(pathKey, turnId, frame);
 				} else {
-					this.openBlockFrame(frame, turnId, blockId);
+					this.openBlockFrame(frame, pathKey, turnKey, blockKey);
 				}
 				break;
 			}
 			case "delta": {
 				const block =
-					blockId !== undefined ? this.openBlocks.get(blockId) : undefined;
-				if (block === undefined || block.turnId !== turnId) {
-					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockId);
+					blockKey !== undefined ? this.openBlocks.get(blockKey) : undefined;
+				if (block === undefined) {
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockKey);
 					break;
 				}
 				if (block.sink === undefined) {
@@ -191,38 +213,38 @@ export class StreamAssembler {
 				break;
 			}
 			case "close": {
-				if (blockId !== undefined) {
-					this.closeBlockFrame(frame, turnId, blockId);
+				if (blockKey !== undefined) {
+					this.closeBlockFrame(frame, blockKey);
 				} else {
-					this.closeTurnFrame(frame, turnId);
+					this.closeTurnFrame(frame, pathKey, turnId);
 				}
 				break;
 			}
 			case "notice": {
-				if (turnId === undefined) {
+				if (turnKey === undefined) {
 					this.consumer.onSessionNotice(frame);
 					break;
 				}
-				const noticeTurn = this.openTurn;
+				const noticeTurn = this.openTurns.get(pathKey);
 				if (noticeTurn !== undefined && noticeTurn.turnId === turnId) {
 					noticeTurn.consumer.onNotice(frame);
 				} else {
-					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnId);
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnKey);
 				}
 				break;
 			}
 			case "usage": {
-				const usageTurn = this.openTurn;
+				const usageTurn = this.openTurns.get(pathKey);
 				if (usageTurn !== undefined && usageTurn.turnId === turnId) {
 					usageTurn.consumer.onUsage(frame);
 				} else {
-					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnId);
+					this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, turnKey);
 				}
 				break;
 			}
 			case "annotation": {
 				const block =
-					blockId !== undefined ? this.openBlocks.get(blockId) : undefined;
+					blockKey !== undefined ? this.openBlocks.get(blockKey) : undefined;
 				if (block?.sink !== undefined) {
 					(block.sink as ToolSink).onAnnotation(frame);
 				} else {
@@ -231,7 +253,7 @@ export class StreamAssembler {
 				break;
 			}
 			case "snapshot": {
-				// Reconnect reconciliation is Phase 3; until then snapshots
+				// Reconnect reconciliation is Phase 3b; until then snapshots
 				// are reported, not applied.
 				this.diagnose(DIAG_SNAPSHOT_UNROUTED, frame);
 				break;
@@ -255,92 +277,131 @@ export class StreamAssembler {
 		this.consumer.onDiagnostic({ code, seq: frame.seq, detail });
 	}
 
-	private openTurnFrame(frame: StreamFrame, turnId: string | undefined): void {
-		if (this.openTurn !== undefined) {
+	/** Resolve (or prune) the consumer for a non-root agent path. Returns
+	 * true when frames for the path may be processed. */
+	private routeSubAgent(pathKey: string, frame: StreamFrame): boolean {
+		if (this.subAgents.has(pathKey)) {
+			return this.subAgents.get(pathKey) !== null;
+		}
+		const segments = pathKey.split("/");
+		const agentId = segments[segments.length - 1];
+		const parentKey = segments.slice(0, -1).join("/");
+		const parent = this.openTurns.get(parentKey);
+		if (parent === undefined) {
+			this.diagnose(DIAG_SUBAGENT_WITHOUT_TURN, frame, pathKey);
+			return false;
+		}
+		const child = parent.consumer.onSubAgent({ agentId });
+		this.subAgents.set(pathKey, child);
+		return child !== null;
+	}
+
+	private openTurnFrame(
+		pathKey: string,
+		turnId: string | undefined,
+		frame: StreamFrame,
+	): void {
+		if (this.openTurns.has(pathKey)) {
 			// Repair: close the abandoned turn as interrupted, then open
-			// the new one.
-			this.closeChildren(this.openTurn.turnId);
-			this.openTurn.consumer.onClose({ kind: "interrupted" });
-			this.diagnose(DIAG_TURN_OPEN_WHILE_OPEN, frame, this.openTurn.turnId);
-			this.openTurn = undefined;
+			// the new one on this path.
+			this.closePathTurn(pathKey, { kind: "interrupted" });
+			this.diagnose(DIAG_TURN_OPEN_WHILE_OPEN, frame, pathKey);
 		}
 		if (turnId === undefined) {
 			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, "(missing turnId)");
 			return;
 		}
-		this.openTurn = { turnId, consumer: this.consumer.onTurn({ turnId }) };
+		const consumer =
+			pathKey === ROOT
+				? this.consumer.onTurn({ turnId })
+				: this.subAgents.get(pathKey);
+		if (consumer === undefined || consumer === null) {
+			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, pathKey);
+			return;
+		}
+		this.openTurns.set(pathKey, { turnId, consumer });
 		this.idleNotified = false;
 	}
 
 	private openBlockFrame(
 		frame: StreamFrame & { kind: "open" },
-		turnId: string | undefined,
-		blockId: string | undefined,
+		pathKey: string,
+		turnKey: string | undefined,
+		blockKey: string | undefined,
 	): void {
+		const turn = this.openTurns.get(pathKey);
 		if (
-			this.openTurn === undefined ||
-			this.openTurn.turnId !== turnId ||
-			blockId === undefined
+			turn === undefined ||
+			turnKey === undefined ||
+			blockKey === undefined ||
+			turn.turnId !== frame.scope.turnId
 		) {
 			this.diagnose(
 				DIAG_ORPHAN_BLOCK_FRAME,
 				frame,
-				blockId ?? turnId ?? "(unaddressed)",
+				blockKey ?? turnKey ?? "(unaddressed)",
 			);
 			return;
 		}
-		if (this.openBlocks.has(blockId)) {
-			this.diagnose(DIAG_BLOCK_OPEN_WHILE_OPEN, frame, blockId);
+		if (this.openBlocks.has(blockKey)) {
+			this.diagnose(DIAG_BLOCK_OPEN_WHILE_OPEN, frame, blockKey);
 			return;
 		}
-		const consumer = this.openTurn.consumer;
+		const consumer = turn.consumer;
 		if (frame.openKind === "text") {
-			this.openBlocks.set(blockId, {
+			this.openBlocks.set(blockKey, {
 				kind: "text",
-				turnId,
+				blockKey,
 				sink: consumer.onText(frame.start),
 			});
 		} else if (frame.openKind === "reasoning") {
-			this.openBlocks.set(blockId, {
+			this.openBlocks.set(blockKey, {
 				kind: "reasoning",
-				turnId,
+				blockKey,
 				sink: consumer.onReasoning(frame.start),
 			});
 		} else if (frame.openKind === "tool") {
-			this.openBlocks.set(blockId, {
+			this.openBlocks.set(blockKey, {
 				kind: "tool",
-				turnId,
+				blockKey,
 				sink: consumer.onTool(frame.start),
 				start: frame.start,
 			});
 		} else {
 			// Media arrives whole: the open is bookkeeping so the close
 			// matches; no sink is created.
-			this.openBlocks.set(blockId, { kind: "media", turnId, sink: undefined });
+			this.openBlocks.set(blockKey, {
+				kind: "media",
+				blockKey,
+				sink: undefined,
+			});
 		}
 	}
 
 	private closeBlockFrame(
 		frame: StreamFrame & { kind: "close" },
-		turnId: string | undefined,
-		blockId: string,
+		blockKey: string,
 	): void {
-		const block = this.openBlocks.get(blockId);
-		if (block === undefined || block.turnId !== turnId) {
-			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockId);
+		const block = this.openBlocks.get(blockKey);
+		if (block === undefined) {
+			this.diagnose(DIAG_ORPHAN_BLOCK_FRAME, frame, blockKey);
 			return;
 		}
-		this.openBlocks.delete(blockId);
+		this.openBlocks.delete(blockKey);
 		if (block.kind === "media") {
-			if (frame.final !== undefined && this.openTurn?.turnId === turnId) {
-				this.openTurn.consumer.onMedia({
-					media: (frame.final as { media: unknown }).media,
-				});
+			if (frame.final !== undefined) {
+				const pathSegments = blockKey.split("/");
+				const turn = this.openTurns.get(
+					pathSegments.slice(0, -2).join("/"),
+				);
+				turn?.consumer.onMedia({
+						media: (frame.final as { media: unknown }).media,
+					});
 			}
 			return;
 		}
 		if (block.sink === undefined) {
-			return;
+				return;
 		}
 		if (block.kind === "tool") {
 			(block.sink as ToolSink).onClose(
@@ -354,59 +415,83 @@ export class StreamAssembler {
 
 	private closeTurnFrame(
 		frame: StreamFrame & { kind: "close" },
+		pathKey: string,
 		turnId: string | undefined,
 	): void {
 		if (turnId === undefined) {
 			// Session-scoped close: repair everything, then end.
 			this.ended = true;
-			if (this.openTurn !== undefined) {
-				this.closeChildren(this.openTurn.turnId);
-				this.openTurn.consumer.onClose({ kind: "interrupted" });
-				this.openTurn = undefined;
+			for (const openPath of [...this.openTurns.keys()].sort(
+				(a, b) => b.length - a.length,
+			)) {
+				this.closePathTurn(openPath, { kind: "interrupted" });
 			}
 			this.notifyIdle();
 			return;
 		}
-		if (this.openTurn === undefined || this.openTurn.turnId !== turnId) {
-			this.diagnose(DIAG_TURN_CLOSE_WITHOUT_OPEN, frame, turnId);
+		const turn = this.openTurns.get(pathKey);
+		if (turn === undefined || turn.turnId !== turnId) {
+			this.diagnose(DIAG_TURN_CLOSE_WITHOUT_OPEN, frame, pathKey);
 			return;
 		}
-		this.closeChildren(turnId);
-		this.openTurn.consumer.onClose(frame.outcome, frame.iterations);
-		this.openTurn = undefined;
+		this.closePathTurn(pathKey, frame.outcome, frame.iterations);
 		this.notifyIdle();
 	}
 
-	/** Force-close children of the turn (delivery contract rule 3). */
-	private closeChildren(turnId: string): void {
-		for (const [blockId, block] of [...this.openBlocks.entries()]) {
-			if (block.turnId !== turnId) {
+	/** Close the path's open turn: its blocks, its sub-agents (deep
+	 * first), then the turn's own onClose (delivery rule 3). */
+	private closePathTurn(
+		pathKey: string,
+		outcome: Outcome,
+		iterations?: number,
+	): void {
+		const turn = this.openTurns.get(pathKey);
+		if (turn === undefined) {
+			return;
+		}
+		this.closeBlocksOfTurn(pathKey, turn.turnId);
+		// Sub-agent streams spawned under this turn close first, deepest
+		// paths first so nested spawns unwind inside-out.
+		for (const childPath of [...this.openTurns.keys()]
+			.filter((key) => key.startsWith(`${pathKey}/`))
+			.sort((a, b) => b.length - a.length)) {
+			this.closePathTurn(childPath, { kind: "interrupted" });
+		}
+		// Registrations are per-spawn: a later spawn re-asks onSubAgent.
+		for (const key of [...this.subAgents.keys()]) {
+			if (key === pathKey || key.startsWith(`${pathKey}/`)) {
+				this.subAgents.delete(key);
+			}
+		}
+		turn.consumer.onClose(outcome, iterations);
+		this.openTurns.delete(pathKey);
+	}
+
+	private closeBlocksOfTurn(pathKey: string, turnId: string): void {
+		const prefix = `${pathKey}/${turnId}/`;
+		for (const [blockKey, block] of [...this.openBlocks.entries()]) {
+			if (!blockKey.startsWith(prefix)) {
 				continue;
 			}
-			this.openBlocks.delete(blockId);
+			this.openBlocks.delete(blockKey);
 			if (block.sink === undefined) {
-				continue;
-			}
+					continue;
+				}
 			if (block.kind === "tool") {
-				(block.sink as ToolSink).onClose(
-					{ kind: "interrupted" },
-					{ type: "tool", input: block.start?.input },
-				);
+					(block.sink as ToolSink).onClose(
+						{ kind: "interrupted" },
+						{ type: "tool", input: block.start?.input },
+					);
 			} else {
-				(block.sink as TextSink).onClose({ kind: "interrupted" });
+					(block.sink as TextSink).onClose({ kind: "interrupted" });
 			}
 		}
 	}
 
 	private notifyIdle(): void {
-		if (
-			!this.idleNotified &&
-			this.openTurn === undefined &&
-			this.openRunCount === 0
-		) {
+		if (!this.idleNotified && this.openTurns.size === 0) {
 			this.idleNotified = true;
 			this.consumer.onIdle();
 		}
 	}
 }
-

--- a/sdk/packages/shared/src/agents/agent-event-framer.test.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "./types";
 import { validateAgentEventStream } from "./stream-grammar";
-import { AgentEventFramer } from "./agent-event-framer";
+import { AgentEventFramer, SessionFramer } from "./agent-event-framer";
 import { validateFrameStream, type StreamFrame } from "./stream-frames";
 import { generateLegalV1Trace } from "./v1-trace-generator";
 
@@ -67,6 +67,112 @@ const kindsOf = (frames: StreamFrame[]): string[] =>
 		frame.kind === "open" ? `open:${frame.openKind}` : frame.kind,
 	);
 
+describe("SessionFramer — multiplexed agent paths", () => {
+	it("interleaved root and child streams share one strictly-increasing seq and validate cleanly", () => {
+		const framer = new SessionFramer();
+		const rootTrace = generateLegalV1Trace(11, { maxEvents: 30 });
+		const childTrace = generateLegalV1Trace(12, { maxEvents: 30 });
+		const frames = [];
+		// Round-robin interleave: path-independence is the point.
+		for (let i = 0; i < Math.max(rootTrace.length, childTrace.length); i += 1) {
+			if (rootTrace[i] !== undefined) {
+				frames.push(...framer.frameEvent(rootTrace[i]));
+			}
+			if (childTrace[i] !== undefined) {
+				frames.push(
+					...framer.frameRoutedEvent(["root", "agent-a"], childTrace[i]),
+				);
+			}
+		}
+		for (let i = 1; i < frames.length; i += 1) {
+			expect(frames[i].seq).toBe(frames[i - 1].seq + 1);
+		}
+		const validation = validateFrameStream(frames);
+		expect(validation.violations).toEqual([]);
+		expect(validation.openBlocks).toEqual([]);
+		expect(validation.openTurns).toEqual([]);
+	});
+
+	it("frameEvent on the root path matches a standalone AgentEventFramer", () => {
+		const trace = generateLegalV1Trace(13, { maxEvents: 20 });
+		const sessionFramer = new SessionFramer();
+		const standalone = new AgentEventFramer();
+		expect(sessionFramer.frameAll(trace)).toEqual(standalone.frameAll(trace));
+	});
+
+	it("a parent turn close emits descendant closes first (scope tree rule 3, producer-side)", () => {
+		const framer = new SessionFramer();
+		const frames = [
+			...framer.frameEvent({ type: "iteration_start", iteration: 1 }),
+			...framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "iteration_start",
+				iteration: 1,
+			}),
+			...framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "content_start",
+				contentType: "text",
+				text: "working",
+			}),
+			// Parent completes while the child is mid-flight.
+			...framer.frameEvent({
+				type: "done",
+				reason: "completed",
+				text: "ok",
+				iterations: 1,
+			}),
+		];
+		const validation = validateFrameStream(frames);
+		expect(validation.violations).toEqual([]);
+		// The producer closed the child — nothing dangles for the
+		// assembler to repair.
+		expect(validation.openTurns).toEqual([]);
+		expect(validation.openBlocks).toEqual([]);
+		// Child closes precede the parent turn close.
+		const closes = frames
+			.map((frame, index) => ({ frame, index }))
+			.filter(({ frame }) => frame.kind === "close");
+		const parentTurnClose = closes.find(
+			({ frame }) =>
+				frame.kind === "close" &&
+				frame.scope.agentPath.join("/") === "root" &&
+				frame.scope.blockId === undefined,
+		);
+		const childCloses = closes.filter(
+			({ frame }) =>
+				frame.kind === "close" &&
+				frame.scope.agentPath.join("/") === "root/agent-a",
+		);
+		expect(childCloses.length).toBeGreaterThan(0);
+		for (const child of childCloses) {
+			expect(child.index).toBeLessThan(parentTurnClose?.index ?? -1);
+		}
+	});
+
+	it("fence closes every path and bumpEpoch applies to all paths", () => {
+		const framer = new SessionFramer();
+		const allFrames = [];
+		allFrames.push(
+			...framer.frameEvent({ type: "iteration_start", iteration: 1 }),
+		);
+		allFrames.push(
+			...framer.frameRoutedEvent(["root", "agent-a"], {
+				type: "iteration_start",
+				iteration: 1,
+			}),
+		);
+		const fenced = framer.fence();
+		// Two turns closed: root and agent-a.
+		expect(fenced.filter((frame) => frame.kind === "close")).toHaveLength(2);
+		const validation = validateFrameStream([...allFrames, ...fenced]);
+		expect(validation.violations).toEqual([]);
+		expect(validation.openTurns).toEqual([]);
+
+		framer.bumpEpoch();
+		const next = framer.frameEvent({ type: "iteration_start", iteration: 1 });
+		expect(next.every((frame) => frame.epoch === 1)).toBe(true);
+	});
+});
+
 // ---------------------------------------------------------------------------
 // Property loop: v1 tables → framer → v2 tables
 // ---------------------------------------------------------------------------
@@ -86,7 +192,7 @@ describe("closed loop: legal v1 trace → frames → zero violations", () => {
 				`seed ${seed} framed with violations`,
 			).toEqual([]);
 			expect(v2.openBlocks).toEqual([]);
-			expect(v2.openTurnId).toBeUndefined();
+			expect(v2.openTurns).toEqual([]);
 		}
 	});
 

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -43,6 +43,41 @@ export interface AgentEventFramerOptions {
 	agentPath?: string[];
 	/** Starting epoch. Defaults to 0; use `bumpEpoch()` thereafter. */
 	startEpoch?: number;
+	/** Shared (epoch, seq) source. When provided (SessionFramer), this
+	 * framer stamps frames from the session-wide sequence so interleaved
+	 * agent streams keep one resumable counter; epoch changes then go
+	 * through the sequencer's owner, not this framer. */
+	sequencer?: FrameSequencer;
+}
+
+/** The session-wide (epoch, seq) authority. One per session, shared by
+ * every per-agent-path framer (design: "one counter across all scopes"). */
+export interface FrameSequencer {
+	epoch(): number;
+	nextSeq(): number;
+	lastSeq(): number;
+	bumpEpoch(): void;
+}
+
+class InternalFrameSequencer implements FrameSequencer {
+	private epochValue: number;
+	private seqValue = 0;
+	constructor(startEpoch: number) {
+		this.epochValue = startEpoch;
+	}
+	epoch(): number {
+		return this.epochValue;
+	}
+	nextSeq(): number {
+		this.seqValue += 1;
+		return this.seqValue;
+	}
+	lastSeq(): number {
+		return this.seqValue;
+	}
+	bumpEpoch(): void {
+		this.epochValue += 1;
+	}
 }
 
 interface OpenTool {
@@ -51,8 +86,7 @@ interface OpenTool {
 
 export class AgentEventFramer {
 	private readonly agentPath: string[];
-	private epoch: number;
-	private seq = 0;
+	private readonly sequencer: FrameSequencer;
 	private turnCounter = 0;
 	private blockCounter = 0;
 	private currentTurnId: string | undefined;
@@ -65,17 +99,20 @@ export class AgentEventFramer {
 
 	constructor(options: AgentEventFramerOptions = {}) {
 		this.agentPath = options.agentPath ?? ["root"];
-		this.epoch = options.startEpoch ?? 0;
+		this.sequencer =
+			options.sequencer ??
+			new InternalFrameSequencer(options.startEpoch ?? 0);
 	}
 
-	/** Host's conversation fence: task switch, cancel, reinit. */
+	/** Host's conversation fence: task switch, cancel, reinit. With an
+	 * external sequencer this must be called on the owning SessionFramer. */
 	bumpEpoch(): void {
-		this.epoch += 1;
+		this.sequencer.bumpEpoch();
 	}
 
 	/** Frames emitted so far (resumable-after-N cursor). */
 	get lastSeq(): number {
-		return this.seq;
+		return this.sequencer.lastSeq();
 	}
 
 	/** Frame a single v1 event into zero or more v2 frames. */
@@ -443,11 +480,10 @@ export class AgentEventFramer {
 		scope: StreamFrame["scope"],
 		body: FrameBody,
 	): void {
-		this.seq += 1;
 		const frame: StreamFrame = {
 			v: FRAME_SCHEMA_VERSION,
-			epoch: this.epoch,
-			seq: this.seq,
+			epoch: this.sequencer.epoch(),
+			seq: this.sequencer.nextSeq(),
 			scope,
 			...body,
 		};
@@ -589,4 +625,95 @@ function finishReasonToOutcome(
 		}
 	}
 }
+
+// =============================================================================
+// SessionFramer — multiplexed framing across agent paths
+// =============================================================================
+
+/**
+ * The session-level framer (Phase 3a): routes each agent's events to a
+ * per-path `AgentEventFramer` while all paths share one (epoch, seq)
+ * authority, so interleaved agent streams keep a single resumable
+ * counter (design: "one counter across all scopes"). The root path is
+ * `["root"]`; deeper paths (sub-agents, teammates) come from the
+ * session-event projector. `frameEvent` is the root-path entry point
+ * and behaves exactly like a standalone AgentEventFramer.
+ */
+export class SessionFramer {
+	private readonly sequencer: FrameSequencer;
+	private readonly streams = new Map<string, AgentEventFramer>();
+
+	constructor(options: { startEpoch?: number } = {}) {
+		// Reuse the framer's internal sequencer through a root instance:
+		// one authority, owned here.
+		this.sequencer = new InternalFrameSequencer(options.startEpoch ?? 0);
+	}
+
+	/** Frame an event for the root agent (same as AgentEventFramer). */
+	frameEvent(event: AgentEvent): StreamFrame[] {
+		return this.frameRoutedEvent(["root"], event);
+	}
+
+	/** Frame a sequence of root-agent events. */
+	frameAll(events: readonly AgentEvent[]): StreamFrame[] {
+		const out: StreamFrame[] = [];
+		for (const event of events) {
+			out.push(...this.frameEvent(event));
+		}
+		return out;
+	}
+
+	/** Frame an event for the agent at `agentPath` (root first). */
+	frameRoutedEvent(agentPath: string[], event: AgentEvent): StreamFrame[] {
+		const pathKey = agentPath.join("/");
+		// Scope tree rule 3 (design, Grammar): when this event closes the
+		// path's turn, the producer emits descendant agents' closes first
+		// — deepest first — instead of leaving them for the consumer's
+		// assembler to repair. Emitted BEFORE framing the event so the
+		// shared sequencer stamps in emission order.
+		const closesTurn =
+			event.type === "done" ||
+			(event.type === "error" && !event.recoverable);
+		const out: StreamFrame[] = [];
+		if (closesTurn) {
+			for (const key of [...this.streams.keys()]
+				.filter((candidate) => candidate.startsWith(`${pathKey}/`))
+				.sort((a, b) => b.length - a.length)) {
+				out.push(...this.streams.get(key)?.fence() ?? []);
+			}
+		}
+		out.push(...this.streamFor(agentPath).frameEvent(event));
+		return out;
+	}
+
+	/** Close open scopes on every path (host fence without a terminal). */
+	fence(): StreamFrame[] {
+		const out: StreamFrame[] = [];
+		for (const framer of this.streams.values()) {
+			out.push(...framer.fence());
+		}
+		return out;
+	}
+
+	/** The host's conversation fence: task switch, cancel, reinit. */
+	bumpEpoch(): void {
+		this.sequencer.bumpEpoch();
+	}
+
+	/** Frames emitted so far across all paths (resumable-after-N). */
+	get lastSeq(): number {
+		return this.sequencer.lastSeq();
+	}
+
+	private streamFor(agentPath: string[]): AgentEventFramer {
+		const key = agentPath.join("/");
+		let framer = this.streams.get(key);
+		if (framer === undefined) {
+			framer = new AgentEventFramer({ agentPath, sequencer: this.sequencer });
+			this.streams.set(key, framer);
+		}
+		return framer;
+	}
+}
+
 

--- a/sdk/packages/shared/src/agents/stream-frames.test.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.test.ts
@@ -69,7 +69,7 @@ describe("v2 frame tables", () => {
 		expect(withChild.violations[0]?.code).toBe(
 			TURN_CLOSE_WITH_OPEN_CHILDREN,
 		);
-		expect(withChild.openBlocks).toEqual(["b1"]);
+		expect(withChild.openBlocks).toEqual(["root/turn-1/b1"]);
 
 		const orphanClose = validateFrameStream([
 			openTurn(),

--- a/sdk/packages/shared/src/agents/stream-frames.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.ts
@@ -264,9 +264,10 @@ export interface FrameViolation {
 
 export interface FrameValidationResult {
 	violations: FrameViolation[];
-	/** Blocks still open (empty for a well-formed terminated stream). */
+	/** Blocks still open (address keys: path#turn#block). */
 	openBlocks: string[];
-	openTurnId?: string;
+	/** Turns still open, one per agent path (address keys: path#turn). */
+	openTurns: string[];
 	/** True when a session-scoped close frame was seen. */
 	sessionEnded: boolean;
 	frameCount: number;
@@ -276,11 +277,13 @@ export interface FrameValidationResult {
  * Validate a frame stream against the v2 tables.
  *
  * Like the v1 validator (`stream-grammar.ts`), this is a fold over
- * per-scope projections: every frame names exactly one scope, and each
- * scope's projection is a small regular language. A prefix is legal;
- * `openBlocks`/`openTurnId` report dangling scopes for debugging and
- * for reconnect snapshots. There is no wart registry in v2 — warts were
- * v1's structural deviations, and v2 makes them unrepresentable.
+ * per-scope projections — keyed by full scope address (agentPath,
+ * turnId, blockId), because multiplexed agent streams each mint their
+ * own `turn-1` and several turns can be open at once (one per agent
+ * path). A prefix is legal; `openBlocks`/`openTurns` report dangling
+ * scopes for debugging and reconnect snapshots. There is no wart
+ * registry in v2 — warts were v1's structural deviations, and v2
+ * makes them unrepresentable.
  */
 export function validateFrameStream(
 	frames: readonly StreamFrame[],
@@ -298,10 +301,12 @@ export function validateFrameStream(
 	let lastSeq = 0;
 	let lastEpoch = 0;
 	let sessionEnded = false;
-	let openTurnId: string | undefined;
-	const openBlocks = new Map<string, string>(); // blockId -> owning turnId
-	const knownBlocks = new Set<string>();
+	// turnKey: `${agentPath joined}/${turnId}` -> turnId
+	const openTurns = new Map<string, string>();
 	const knownTurns = new Set<string>();
+	// blockKey: `${agentPath joined}/${turnId}/${blockId}` -> turnKey
+	const openBlocks = new Map<string, string>();
+	const knownBlocks = new Set<string>();
 
 	for (let index = 0; index < frames.length; index += 1) {
 		const frame = frames[index];
@@ -323,8 +328,15 @@ export function validateFrameStream(
 			continue;
 		}
 
+		const path = frame.scope.agentPath.join("/");
 		const turnId = frame.scope.turnId;
 		const blockId = frame.scope.blockId;
+		const turnKey =
+			turnId !== undefined ? `${path}/${turnId}` : undefined;
+		const blockKey =
+			turnId !== undefined && blockId !== undefined
+				? `${path}/${turnId}/${blockId}`
+				: undefined;
 
 		switch (frame.kind) {
 			case "open": {
@@ -333,66 +345,67 @@ export function validateFrameStream(
 						violation(index, frame, BAD_SCOPE_ADDRESS);
 						break;
 					}
-					if (openTurnId !== undefined) {
-						violation(index, frame, TURN_OVERLAP, turnId);
+					const key = `${path}/${turnId}`;
+					if (openTurns.has(key)) {
+						violation(index, frame, TURN_OVERLAP, key);
 						break;
 					}
-					openTurnId = turnId;
-					knownTurns.add(turnId);
+					openTurns.set(key, turnId);
+					knownTurns.add(key);
 					break;
 				}
-				if (turnId === undefined || blockId === undefined) {
+				if (turnKey === undefined || blockKey === undefined) {
 					violation(index, frame, BAD_SCOPE_ADDRESS);
 					break;
 				}
-				if (openTurnId !== turnId) {
-					violation(index, frame, BLOCK_WITHOUT_TURN, blockId);
+				if (!openTurns.has(turnKey)) {
+					violation(index, frame, BLOCK_WITHOUT_TURN, blockKey);
 					break;
 				}
-				if (openBlocks.has(blockId)) {
-					violation(index, frame, BLOCK_OPEN_WHILE_OPEN, blockId);
+				if (openBlocks.has(blockKey)) {
+					violation(index, frame, BLOCK_OPEN_WHILE_OPEN, blockKey);
 					break;
 				}
-				openBlocks.set(blockId, turnId);
-				knownBlocks.add(blockId);
+				openBlocks.set(blockKey, turnKey);
+				knownBlocks.add(blockKey);
 				break;
 			}
 			case "delta": {
-				if (turnId === undefined || blockId === undefined) {
+				if (blockKey === undefined) {
 					violation(index, frame, BAD_SCOPE_ADDRESS);
 					break;
 				}
-				if (openTurnId !== turnId || !openBlocks.has(blockId)) {
-					violation(index, frame, BLOCK_DELTA_WITHOUT_OPEN, blockId);
+				if (openBlocks.get(blockKey) !== turnKey) {
+					violation(index, frame, BLOCK_DELTA_WITHOUT_OPEN, blockKey);
 				}
 				break;
 			}
 			case "close": {
 				if (blockId !== undefined) {
-					if (openBlocks.get(blockId) !== turnId) {
-						violation(index, frame, BLOCK_CLOSE_WITHOUT_OPEN, blockId);
+					if (blockKey === undefined || openBlocks.get(blockKey) !== turnKey) {
+						violation(index, frame, BLOCK_CLOSE_WITHOUT_OPEN, blockKey ?? blockId);
 						break;
 					}
-					openBlocks.delete(blockId);
+					openBlocks.delete(blockKey);
 					break;
 				}
 				if (turnId !== undefined) {
-					if (openTurnId !== turnId) {
-						violation(index, frame, TURN_CLOSE_WITHOUT_OPEN, turnId);
+					if (turnKey === undefined || !openTurns.has(turnKey)) {
+						violation(index, frame, TURN_CLOSE_WITHOUT_OPEN, turnKey ?? turnId);
 						break;
 					}
 					const stragglers = [...openBlocks.entries()]
-						.filter(([, owner]) => owner === turnId)
-						.map(([id]) => id);
+						.filter(([, owner]) => owner === turnKey)
+						.map(([key]) => key);
 					if (stragglers.length > 0) {
 						violation(
 							index,
 							frame,
 							TURN_CLOSE_WITH_OPEN_CHILDREN,
-							stragglers.join(","),
-						);
+								stragglers.join(","),
+							);
 					}
-					openTurnId = undefined;
+					openTurns.delete(turnKey);
 					break;
 				}
 				sessionEnded = true;
@@ -407,20 +420,20 @@ export function validateFrameStream(
 					}
 					break;
 				}
-				if (openTurnId !== turnId) {
-					violation(index, frame, TURN_FRAME_WITHOUT_TURN, turnId);
+				if (turnKey === undefined || !openTurns.has(turnKey)) {
+					violation(index, frame, TURN_FRAME_WITHOUT_TURN, turnKey);
 				}
 				break;
 			}
 			case "annotation": {
 				// Legal on open or closed scopes, but the scope must be one
 				// this stream has seen (late annotations target real scopes).
-				if (blockId !== undefined) {
-					if (!knownBlocks.has(blockId)) {
-						violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, blockId);
+				if (blockKey !== undefined) {
+					if (!knownBlocks.has(blockKey)) {
+						violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, blockKey);
 					}
-				} else if (turnId !== undefined && !knownTurns.has(turnId)) {
-					violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, turnId);
+				} else if (turnKey !== undefined && !knownTurns.has(turnKey)) {
+					violation(index, frame, ANNOTATION_UNKNOWN_SCOPE, turnKey);
 				}
 				break;
 			}
@@ -442,9 +455,8 @@ export function validateFrameStream(
 	return {
 		violations,
 		openBlocks: [...openBlocks.keys()],
-		openTurnId,
+		openTurns: [...openTurns.keys()],
 		sessionEnded,
 		frameCount: frames.length,
 	};
 }
-


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

PRs 1-3 built the grammar, the frame schema/framer, and the assembler with the CLI as the first consumer. One gap remained before the VSCode port: sub-agent events. In v1, consumers demultiplex them by *timing* — the translator suppresses all non-spawn events while a spawn_agent call is in flight (design P5), which eats legitimate parent output. This PR replaces the heuristic with structural routing.

- **Multiplexed framing** (`@cline/shared`): `AgentEventFramer` accepts an injectable `FrameSequencer`, and a `SessionFramer` facade frames interleaved agent paths (root, sub-agents, teammates) under one session-wide `(epoch, seq)` — the design's "one counter across all scopes" invariant holds across streams. When a path's turn closes, the producer emits descendant agents' closes first, deepest-first (scope tree rule 3) — nothing dangles for consumers to repair.
- **Address-keyed validator**: turns and blocks key by full scope address, so two agents each minting `turn-1` stay independent, and several turns can be open at once (one per agent path).
- **Tree-aware assembler** (`@cline/core`): routes frames by agent path; a sub-agent's consumer comes from the spawning turn's `onSubAgent` (a full `TurnConsumer` — sub-agent streams carry their own blocks; the design doc's minimal `TurnObserver` was upgraded). Returning `null` prunes the subtree — silently and deliberately: P5's suppression becomes a structural decision, not a fault. The assembler retains force-close cascades as repair for producers that don't emit them.
- **Session-event projector**: attributes `CoreSessionEvent`s by `parentAgentId` (child path) and `teamAgentId` (teammate path); events that carry an `agentId` but no attribution are flagged `unattributed` instead of guessed at — the exact hole the v1 heuristic papered over, now visible.

The stacked plan is decomposed accordingly (in the design doc): Phase 3 becomes 3a (this PR) / 3b host wiring + ACP / 3c VSCode translator / 3d history replay; Phase 4 splits in two. Ten PRs total, same merge discipline.

### Test Procedure

```
cd sdk/packages/shared && bun run test:unit
# 413 passed — includes interleaved multiplex framing (shared seq strictly
# +1 across agents, zero violations), SessionFramer parity with a standalone
# framer, and the producer-side cascade test (child closes precede the
# parent turn close).

cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime/orchestration/
# 169 passed — assembler sub-agent routing, silent pruning (zero diagnostics),
# force-close cascade (child turn closes before the parent's), orphan-child
# diagnosis, and the projector's five attribution rules.

bun run build:sdk   # all six packages build
```

All pre-existing suites pass with only assertion-shape updates (the validator result now reports `openTurns[]` instead of `openTurnId`).

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stacked on #13796 (Phase 2) → #13766 (Phase 1) → #13759 (Phase 0); review in that order. Next: Phase 3b (epoch fence into the producer, ACP port, rebuild scheduler on `onIdle`). Nothing here changes any shipped behavior — the CLI's frame path benefits from the same rules, and its differential harness still passes byte-identically.
