### PR TITLE
Port the ACP forwarder onto the frame stream (Phase 3b)

### DIFF
--- a/apps/cli/src/acp/acpAgent.ts
+++ b/apps/cli/src/acp/acpAgent.ts
@@ -62,9 +62,9 @@ import {
 } from "./organizations";
 import { requestAcpToolApproval } from "./permissions";
 import { replaySessionHistory } from "./session-load";
+import { AcpStreamForwarder } from "./frame-forwarder";
 import {
 	describeAgentError,
-	forwardAgentEvent,
 	sendConfigOptionUpdate,
 	sendCurrentModeUpdate,
 	sendSessionInfoUpdate,
@@ -726,6 +726,10 @@ export class AcpAgent implements Agent {
 			session.pendingInitialMessages = undefined;
 		}
 
+		// v2 frame stream (Phase 3b): ACP updates are emitted from
+		// assembler sinks; the v1 translator stays as the differential
+		// reference in session-updates.ts.
+		const streamForwarder = new AcpStreamForwarder(this.conn, acpSessionId);
 		session.unsubscribe = subscribeToAgentEvents(
 			sessionManager,
 			(event: AgentEvent) => {
@@ -736,7 +740,7 @@ export class AcpAgent implements Agent {
 							? event.error
 							: new Error(describeAgentError(event.error));
 				}
-				forwardAgentEvent(this.conn, acpSessionId, event);
+				streamForwarder.pushEvent(event);
 			},
 		);
 

--- a/apps/cli/src/acp/frame-forwarder.differential.test.ts
+++ b/apps/cli/src/acp/frame-forwarder.differential.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Differential harness: the v1 ACP translator (session-updates.ts
+ * reference) vs the frame path (SessionFramer → StreamAssembler →
+ * AcpStreamForwarder) must emit identical SessionUpdate sequences for
+ * every trace.
+ */
+import type { AgentEvent } from "@cline/core";
+import { generateLegalV1Trace } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { AcpStreamForwarder } from "./frame-forwarder";
+import { forwardAgentEvent } from "./session-updates";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+interface Capture {
+	updates: Array<{ sessionId: string; update: SessionUpdate }>;
+}
+
+const makeCapture = (): Capture & {
+	sessionUpdate(params: {
+		sessionId: string;
+		update: SessionUpdate;
+	}): Promise<unknown>;
+} => {
+	const capture: Capture & {
+		sessionUpdate(params: {
+			sessionId: string;
+			update: SessionUpdate;
+		}): Promise<unknown>;
+	} = {
+		updates: [],
+		sessionUpdate(params) {
+			this.updates.push(params);
+			return Promise.resolve({});
+		},
+	};
+	return capture;
+};
+
+function renderV1(trace: AgentEvent[]): SessionUpdate[] {
+	const capture = makeCapture();
+	for (const event of trace) {
+		forwardAgentEvent(capture, "s1", event);
+	}
+	return capture.updates.map((entry) => entry.update);
+}
+
+function renderV2(trace: AgentEvent[]): SessionUpdate[] {
+	const capture = makeCapture();
+	const forwarder = new AcpStreamForwarder(capture, "s1");
+	for (const event of trace) {
+		forwarder.pushEvent(event);
+	}
+	return capture.updates.map((entry) => entry.update);
+}
+
+describe("ACP forwarder differential — v1 reference vs frame path", () => {
+	it("generated traces emit identical SessionUpdate sequences", () => {
+		for (let seed = 1; seed <= 100; seed += 1) {
+			const trace = generateLegalV1Trace(seed, { maxEvents: 60 });
+			expect(renderV1(trace), `seed ${seed}`).toEqual(renderV2(trace));
+		}
+	});
+
+	it("handcrafted edges emit identical sequences: media, tool error, empty reasoning", () => {
+		const trace: AgentEvent[] = [
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "reasoning",
+				redacted: true,
+			},
+			{
+				type: "content_start",
+				contentType: "text",
+				text: "Answer",
+			},
+			{
+				type: "content_end",
+				contentType: "text",
+				text: "Answer",
+			},
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "t1",
+				toolName: "run_commands",
+				input: { command: "ls" },
+			},
+			{
+				type: "content_end",
+				contentType: "tool",
+				toolCallId: "t1",
+				toolName: "run_commands",
+				error: "boom",
+			},
+			{
+				type: "content_end",
+				contentType: "media",
+				media: {
+					id: "m1",
+					modality: "image",
+					mediaType: "image/png",
+					source: { type: "base64", data: "aGk=" },
+				} as never,
+			},
+			{
+				type: "done",
+				reason: "completed",
+				text: "ok",
+				iterations: 1,
+			},
+		];
+		const v1 = renderV1(trace);
+		const v2 = renderV2(trace);
+		expect(v1).toEqual(v2);
+		// The sequence is what v1 produced: the "Answer" text chunk, the
+		// pending tool_call, the failed update, the image chunk — no
+		// thought chunk (the redacted marker is empty and skipped), no
+		// done artifact.
+		expect(v2).toHaveLength(4);
+		expect(v2[0]).toMatchObject({ sessionUpdate: "agent_message_chunk" });
+		expect(v2[1]).toMatchObject({ sessionUpdate: "tool_call", status: "pending" });
+		expect(v2[2]).toMatchObject({
+			sessionUpdate: "tool_call_update",
+			status: "failed",
+		});
+		expect(v2[3]).toMatchObject({ sessionUpdate: "agent_message_chunk" });
+	});
+});

--- a/apps/cli/src/acp/frame-forwarder.differential.test.ts
+++ b/apps/cli/src/acp/frame-forwarder.differential.test.ts
@@ -9,7 +9,7 @@ import { generateLegalV1Trace } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { AcpStreamForwarder } from "./frame-forwarder";
 import { forwardAgentEvent } from "./session-updates";
-import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { AgentSideConnection, SessionUpdate } from "@agentclientprotocol/sdk";
 
 interface Capture {
 	updates: Array<{ sessionId: string; update: SessionUpdate }>;
@@ -39,7 +39,9 @@ const makeCapture = (): Capture & {
 function renderV1(trace: AgentEvent[]): SessionUpdate[] {
 	const capture = makeCapture();
 	for (const event of trace) {
-		forwardAgentEvent(capture, "s1", event);
+		// v1 takes the full connection type; the capture is the structural
+		// slice it actually calls (the same cast session-updates.test.ts uses).
+		forwardAgentEvent(capture as unknown as AgentSideConnection, "s1", event);
 	}
 	return capture.updates.map((entry) => entry.update);
 }

--- a/apps/cli/src/acp/frame-forwarder.ts
+++ b/apps/cli/src/acp/frame-forwarder.ts
@@ -25,17 +25,14 @@ import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import type { AgentEvent } from "@cline/core";
 import {
 	StreamAssembler,
-	type CloseFinal,
 	type MediaFinal,
-	type Outcome,
-	type ReasoningStart,
 	type SessionConsumer,
 	type TextSink,
 	type ReasoningSink,
 	type ToolSink,
 	type TurnConsumer,
 } from "@cline/core";
-import { SessionFramer } from "@cline/shared";
+import { type CloseFinal, type Outcome, SessionFramer } from "@cline/shared";
 import { buildToolTitle, mapToolKind } from "./tool-utils";
 
 /** Structural slice of AgentSideConnection the forwarder needs —

--- a/apps/cli/src/acp/frame-forwarder.ts
+++ b/apps/cli/src/acp/frame-forwarder.ts
@@ -1,0 +1,189 @@
+/**
+ * ACP forwarder on the v2 frame stream (Phase 3b of the agent event
+ * stream design). Implements the assembler's consumer API; each sink
+ * emits the ACP SessionUpdate notifications the v1 translator emitted,
+ * with stream structure owned by the assembler instead of implied by
+ * event ordering.
+ *
+ * Fidelity contract (differential-tested against the v1
+ * `forwardAgentEvent` reference in session-updates.ts):
+ * - Empty text/reasoning deltas are skipped (v1 skipped empty chunks).
+ * - Tool opens emit `tool_call` (pending) with title/kind/rawInput;
+ *   closes emit `tool_call_update` with completed/failed and
+ *   rawOutput (error message preferred, as in v1).
+ * - Interrupted tool closes are silent: v1 never observed a dangling
+ *   tool close, and an interrupted tool has no result to report.
+ * - Errors, iterations, usage, and turn closes emit nothing (v1
+ *   ignored them); recoverable errors arrive as notices and stay
+ *   silent here.
+ * - Media arrives whole and maps to image or text chunks (v1 logic).
+ * - Sub-agent distinction: none — the ACP subscription delivers plain
+ *   AgentEvents and v1 forwarded them all as top-level chunks, so the
+ *   forwarder frames everything on the root path.
+ */
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { AgentEvent } from "@cline/core";
+import {
+	StreamAssembler,
+	type CloseFinal,
+	type MediaFinal,
+	type Outcome,
+	type ReasoningStart,
+	type SessionConsumer,
+	type TextSink,
+	type ReasoningSink,
+	type ToolSink,
+	type TurnConsumer,
+} from "@cline/core";
+import { SessionFramer } from "@cline/shared";
+import { buildToolTitle, mapToolKind } from "./tool-utils";
+
+/** Structural slice of AgentSideConnection the forwarder needs —
+ * tests pass a capture; production passes the real connection. */
+export interface AcpSessionUpdateSender {
+	sessionUpdate(params: {
+		sessionId: string;
+		update: SessionUpdate;
+	}): Promise<unknown>;
+}
+
+export class AcpStreamForwarder implements SessionConsumer {
+	private readonly sender: AcpSessionUpdateSender;
+	private readonly sessionId: string;
+	private readonly framer = new SessionFramer();
+	private readonly assembler: StreamAssembler;
+
+	constructor(sender: AcpSessionUpdateSender, sessionId: string) {
+		this.sender = sender;
+		this.sessionId = sessionId;
+		this.assembler = new StreamAssembler(this);
+	}
+
+	/** Frame and forward one agent event (the subscription callback). */
+	pushEvent(event: AgentEvent): void {
+		this.assembler.pushAll(this.framer.frameEvent(event));
+	}
+
+	private send(update: SessionUpdate): void {
+		void this.sender.sessionUpdate({ sessionId: this.sessionId, update });
+	}
+
+	onTurn = (): TurnConsumer => ({
+		onText: (): TextSink => ({
+			onDelta: (text: string): void => {
+				if (text !== "") {
+					this.send({
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text },
+					});
+				}
+			},
+			onAnnotation: (): void => {},
+			onClose: (): void => {
+				// v1 did not re-send final text (deltas already streamed).
+			},
+		}),
+		onReasoning: (): ReasoningSink => ({
+			onDelta: (reasoning: string): void => {
+				if (reasoning !== "") {
+					this.send({
+						sessionUpdate: "agent_thought_chunk",
+						content: { type: "text", text: reasoning },
+					});
+				}
+			},
+			onAnnotation: (): void => {},
+			onClose: (): void => {},
+		}),
+		onTool: (start: {
+			blockId: string;
+			toolName: string;
+			input: unknown;
+		}): ToolSink => {
+			// v1 emitted the pending tool_call at content_start; the open
+			// is that moment on the frame stream.
+			this.send({
+				sessionUpdate: "tool_call",
+				toolCallId: start.blockId,
+				title: buildToolTitle(start.toolName, start.input),
+				kind: mapToolKind(start.toolName),
+				status: "pending",
+				rawInput: start.input,
+			});
+			return {
+				onProgress: (): void => {
+					// v1 did not forward tool progress updates.
+				},
+				onAnnotation: (): void => {},
+				onClose: (outcome: Outcome, final: CloseFinal): void => {
+					if (outcome.kind === "interrupted" || outcome.kind === "detached") {
+						return;
+					}
+					if (outcome.kind === "error") {
+						this.send({
+							sessionUpdate: "tool_call_update",
+							toolCallId: start.blockId,
+							status: "failed",
+							rawOutput: outcome.error.message,
+						});
+						return;
+					}
+					this.send({
+						sessionUpdate: "tool_call_update",
+						toolCallId: start.blockId,
+						status: "completed",
+						rawOutput: final.type === "tool" ? final.output : undefined,
+					});
+				},
+			};
+		},
+		onMedia: (media: MediaFinal): void => {
+			const generated = media.media as {
+				modality: string;
+				mediaType: string;
+				source: { type: string; data?: string; url?: string };
+			};
+			if (generated.modality === "image" && generated.source.type === "base64") {
+				this.send({
+					sessionUpdate: "agent_message_chunk",
+					content: {
+						type: "image",
+						data: generated.source.data ?? "",
+						mimeType: generated.mediaType,
+					},
+				});
+				return;
+			}
+			this.send({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: `[Generated ${generated.modality}: ${generated.mediaType}]`,
+				},
+			});
+		},
+		onSubAgent: (): null => null,
+		onNotice: (): void => {
+			// v1 ignored notices and recoverable errors.
+		},
+		onUsage: (): void => {},
+		onClose: (): void => {
+			// v1 ignored done/error terminals.
+		},
+	});
+
+	// The tool_call (pending) is emitted at open — v1 emitted it at
+	// content_start — so the forwarder sends it when the sink is created,
+	// which happens in onTool. Wrap creation to send the pending update.
+	onSessionNotice(): void {}
+
+	onIdle(): void {}
+
+	onDiagnostic(diagnostic: { code: string; detail?: string }): void {
+		// Protocol-visible repairs would corrupt the client stream;
+		// diagnostics go to the process console.
+		console.error(
+			`[acp stream] ${diagnostic.code}${diagnostic.detail ? ` ${diagnostic.detail}` : ""}`,
+		);
+	}
+}

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -539,11 +539,31 @@ now route structurally, deleting the v1 timing heuristic's premise (P5):
 into the producer envelope (the CLI's SessionFramer already carries
 it); port `SdkSessionRebuildScheduler` to `onIdle`.
 
-**Phase 3c — VSCode translator.** Port message-translator onto the
-assembler. MessageTranslatorState's parser fields delete; ClineMessage
-mapping remains as sink implementations; sub-agent suppression (P5's
-heuristic) becomes `onSubAgent → null` plus a SubagentStatusRow
-consumer.
+**Phase 3b status: implemented (ACP port; fence and scheduler moved to
+3c).** The ACP forwarder (`apps/cli/src/acp/frame-forwarder.ts`) is
+the second frame consumer: `AcpStreamForwarder` implements the
+assembler's consumer API, and `acpAgent.ts`'s subscription now frames
+via `SessionFramer` instead of calling the v1 `forwardAgentEvent` —
+which stays in `session-updates.ts` as the differential reference
+(its own test suite unchanged). The differential harness proves
+byte-identical `SessionUpdate` sequences across 100 generated traces
+plus handcrafted edges (media, tool error, redacted marker).
+Fidelity notes: empty text/reasoning deltas skipped; interrupted tool
+closes silent (v1 never observed dangling closes); errors, iterations,
+usage, and turn closes emit nothing, exactly as v1; diagnostics go to
+the process console, never the protocol stream. **Scope correction**:
+"epoch fence into the producer" and "rebuild scheduler on `onIdle`"
+moved to 3c — both are VSCode host wiring that would be dead code
+until the translator consumes frames.
+
+**Phase 3c — VSCode wiring and translator.** Port message-translator
+onto the assembler. MessageTranslatorState's parser fields delete;
+ClineMessage mapping remains as sink implementations; sub-agent
+suppression (P5's heuristic) becomes `onSubAgent → null` plus a
+SubagentStatusRow consumer. Also the host wiring moved from 3b: the
+epoch fence from SdkController into the producer envelope
+(`RuntimeFrameAdapter.bumpEpoch` at cancel/reinit boundaries), and
+`SdkSessionRebuildScheduler` onto the assembler's `onIdle`.
 
 **Phase 3d — history replay and reconnect.** Snapshot reconciliation
 in the assembler (diff against the live set), live-after-history dedup
@@ -618,8 +638,8 @@ revertable without reverting its ancestors' behavior changes:
 | 2 | `dpc/event-stream-phase1` | v2 frame schema, structured StreamError, dual-emit in RuntimeEventAdapter, trace generator + property tests. | 1 |
 | 3 | `dpc/event-stream-phase2` | Assembler (`@cline/core`), CLI terminal port, differential replay harness. (ACP port moved to PR 5, Phase 3b.) | 2 |
 | 4 | `dpc/event-stream-demux` | Phase 3a: multiplexed framing (SessionFramer, shared sequencer), address-keyed validator, tree-aware assembler with `onSubAgent` pruning, session-event projector. | 3 |
-| 5 | `dpc/event-stream-phase3b` | Phase 3b: epoch fence into the producer, ACP port, rebuild scheduler on `onIdle`. | 4 |
-| 6 | `dpc/event-stream-phase3c` | Phase 3c: VSCode translator sinks; P5 heuristic becomes `onSubAgent → null`. | 5 |
+| 5 | `dpc/event-stream-phase3b` | Phase 3b: ACP port (second frame consumer, differential-tested). | 4 |
+| 6 | `dpc/event-stream-phase3c` | Phase 3c: VSCode translator sinks, epoch fence into producer, rebuild scheduler on `onIdle`; P5 heuristic becomes `onSubAgent → null`. | 5 |
 | 7 | `dpc/event-stream-phase3d` | Phase 3d: history replay/reconnect, snapshot reconciliation. | 6 |
 | 8 | `dpc/event-stream-phase4a` | Desktop sidecar forwards frames verbatim (v1 re-encoding deletes). | 7 |
 | 9 | `dpc/event-stream-phase4b` | Desktop webview sinks (`use-chat-session`). | 8 |


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

The CLI terminal renderer became the first frame consumer in Phase 2. This PR ports the second: the ACP connection. `acpAgent.ts`'s event subscription now frames events via `SessionFramer` and drives `AcpStreamForwarder` — an assembler consumer whose sinks emit the ACP `SessionUpdate` notifications — replacing the v1 `forwardAgentEvent` call.

Fidelity is differential-proven: the v1 translator stays in `session-updates.ts` as the reference (its own test suite unchanged), and the new harness compares the two paths' emitted `SessionUpdate` sequences exactly — 100 generated traces plus handcrafted edges (base64 media, tool error, redacted-empty reasoning). Byte-identical, with the fidelity decisions documented in the forwarder:

- empty text/reasoning deltas skipped (v1 skipped empty chunks);
- interrupted tool closes silent — v1 never observed a dangling tool close, and an interrupted tool has no result to report;
- errors, iterations, usage, and turn closes emit nothing, exactly as v1;
- stream diagnostics go to the process console, never the protocol stream.

One scope correction, recorded in the design doc: "epoch fence into the producer" and "rebuild scheduler on `onIdle`" move from 3b to 3c — both are VSCode host wiring that would be dead code until the translator consumes frames. The stacked plan table reflects it.

### Test Procedure

```
cd apps/cli && bunx vitest run --config vitest.config.ts src/acp/
# 26 passed — the differential harness (v1 vs frame path, exact SessionUpdate
# sequence equality) plus the unchanged v1 reference suite.

cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/ src/runtime/
# CLI suites unchanged and green (the terminal renderer's harness is unaffected).

bun -F @cline/cli build   # green
```

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stacked on #13798 (Phase 3a) → #13796 → #13766 → #13759; review in that order. With this PR both CLI-app consumers (terminal renderer, ACP) run on the frame stream. Next: Phase 3c — the VSCode wiring and translator port, the largest remaining piece.
