### PR TITLE
Wire the v2 frame stream into the VSCode host (Phase 3c part 1)

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -75,6 +75,7 @@ import { SdkCompactionCoordinator } from "./sdk-compaction-coordinator"
 import { SdkDiffEditCoordinator } from "./sdk-diff-edit-coordinator"
 import { SdkFollowupCoordinator } from "./sdk-followup-coordinator"
 import { SdkForegroundCommandCoordinator } from "./sdk-foreground-command-coordinator"
+import { SdkFrameStream } from "./sdk-frame-stream"
 import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
 import { SdkMcpCoordinator } from "./sdk-mcp-coordinator"
 import { SdkMessageCoordinator, type SessionEventListener } from "./sdk-message-coordinator"
@@ -167,6 +168,7 @@ export class Controller {
 	// SDK session state and the coordinators that drive it.
 	private messageTranslatorState: MessageTranslatorState
 	private turnStateTracker!: TurnStateTracker
+	private readonly frameStream: SdkFrameStream
 	private messages: SdkMessageCoordinator
 	private sessions: SdkSessionLifecycle
 	private sessionRebuilds: SdkSessionRebuildScheduler
@@ -341,6 +343,10 @@ export class Controller {
 		void this.getWorkspaceRoot()
 		// Authoritative UI-mode tracker, sharing the one id/seq/epoch authority.
 		this.turnStateTracker = new TurnStateTracker(this.messageTranslatorState.getMinter())
+		// v2 frame stream (Phase 3c part 1): producer-envelope tap sharing the
+		// minter's (epoch, seq) authority; health-monitored until the translator
+		// port (part 2) replaces the consumer with ClineMessage sinks.
+		this.frameStream = new SdkFrameStream(this.messageTranslatorState.getMinter())
 		this.messages = new SdkMessageCoordinator({
 			getTask: () => this.task,
 			// Stamp seq/epoch on every message flowing to the webview from the shared authority.
@@ -394,6 +400,9 @@ export class Controller {
 				this.sessionEvents.handleSessionEvent(event).catch((err) => {
 					Logger.error("[SdkController] Failed to handle session event:", err)
 				})
+				// Dual-run frame tap (Phase 3c part 1): same events, framed and
+				// health-monitored; the fence sites call fenceAndFlush().
+				this.frameStream?.handleSessionEvent(event)
 			},
 			onDidBecomeIdle: () => this.handleSessionBecameIdle(),
 			beforeStartSession: () => this.ensureRemoteConfigForSessionStart(),
@@ -603,6 +612,7 @@ export class Controller {
 			// turn carry the old epoch and are dropped by the webview. The resumable phase is set
 			// in SdkController.cancelTask before this runs.
 			raiseCancelFence: () => {
+				this.frameStream?.fenceAndFlush()
 				this.messageTranslatorState.clearApprovedToolMessageTs()
 				this.messageTranslatorState.getMinter().bumpEpoch()
 			},
@@ -2220,6 +2230,9 @@ export class Controller {
 	 * and is dropped by the webview. Order matters: bump synchronously here, before any await.
 	 */
 	resetMessageTranslatorAndFence(): void {
+		// Frame stream: close open scopes at the current epoch; the bump below
+		// fences later stragglers for every frame consumer (design P4).
+		this.frameStream?.fenceAndFlush()
 		this.messageTranslatorState.reset()
 		this.messageTranslatorState.getMinter().bumpEpoch()
 	}

--- a/apps/vscode/src/sdk/sdk-frame-stream.test.ts
+++ b/apps/vscode/src/sdk/sdk-frame-stream.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the VSCode producer-envelope tap (Phase 3c part 1): the
+ * frame stream shares the minter's (epoch, seq) authority, the fence
+ * flows through the envelope, and legal streams produce no diagnostics.
+ */
+import type { CoreSessionEvent } from "@cline/core"
+import { describe, expect, it, vi } from "vitest"
+import { Logger } from "@/shared/services/Logger"
+import { MessageIdMinter } from "./message-id-minter"
+import { SdkFrameStream } from "./sdk-frame-stream"
+
+const agentEvent = (overrides: Record<string, unknown> = {}) =>
+	({ type: "content_start", contentType: "text", text: "hi", ...overrides }) as never
+
+const sessionEvent = (
+	eventOverrides: Record<string, unknown> = {},
+	payloadOverrides: Record<string, unknown> = {},
+): CoreSessionEvent =>
+	({
+		type: "agent_event",
+		payload: { sessionId: "s1", event: agentEvent(eventOverrides), ...payloadOverrides },
+	}) as never
+
+describe("SdkFrameStream", () => {
+	it("samples the minter's counter: frame seq equals minter.nextId values", () => {
+		const minter = new MessageIdMinter(100)
+		const stream = new SdkFrameStream(minter)
+		stream.handleSessionEvent(sessionEvent({ type: "iteration_start", iteration: 1 }))
+		const firstId = minter.nextId()
+		stream.handleSessionEvent(sessionEvent())
+		// The next frame stamped after our manual nextId() must be greater,
+		// and strictly increasing across frames (shared counter, one order).
+		const secondId = minter.nextId()
+		expect(secondId).toBeGreaterThan(firstId)
+		expect(stream.streamDiagnostics).toEqual([])
+	})
+
+	it("carries the epoch fence in the envelope: fenceAndFlush closes scopes, bump fences stragglers", () => {
+		const minter = new MessageIdMinter()
+		const stream = new SdkFrameStream(minter)
+		// Open a turn and a tool block mid-flight.
+		stream.handleSessionEvent(sessionEvent({ type: "iteration_start", iteration: 1 }))
+		stream.handleSessionEvent(
+			sessionEvent({ type: "content_start", contentType: "tool", toolCallId: "t1", toolName: "read_file" }),
+		)
+		expect(stream.openScopes().blocks).toHaveLength(1)
+
+		// Host fence (as wired in resetMessageTranslatorAndFence / raiseCancelFence):
+		// flush closes at the current epoch, then the minter bump fences stragglers.
+		stream.fenceAndFlush()
+		minter.bumpEpoch()
+		expect(stream.openScopes().turnPaths).toEqual([])
+		expect(stream.openScopes().blocks).toEqual([])
+
+		// A straggler event from the cancelled turn (old epoch semantics):
+		// the framer now stamps with the NEW epoch, so within this stream it
+		// opens a fresh turn — the stale-epoch drop is the CONSUMER's rule;
+		// here we assert the envelope's promise: post-fence frames carry the
+		// new epoch, never the old one.
+		const before = minter.epoch
+		stream.handleSessionEvent(sessionEvent({ type: "iteration_start", iteration: 1 }))
+		expect(minter.epoch).toBe(before)
+		expect(stream.openScopes().turnPaths).toHaveLength(1)
+	})
+
+	it("routes sub-agent events to their own path via the projector", () => {
+		const minter = new MessageIdMinter()
+		const stream = new SdkFrameStream(minter)
+		stream.handleSessionEvent(sessionEvent({ type: "iteration_start", iteration: 1 }))
+		stream.handleSessionEvent(
+			sessionEvent({
+				type: "content_start",
+				contentType: "text",
+				text: "child",
+				parentAgentId: "root",
+				agentId: "agent-a",
+			}),
+		)
+		// Child frames routed structurally (P5): the child's own turn is open.
+		expect(stream.openScopes().turnPaths).toContain("root/agent-a")
+		expect(stream.openScopes().turnPaths).toContain("root")
+		expect(stream.streamDiagnostics).toEqual([])
+	})
+
+	it("legal streams produce no diagnostics; repairs are logged", () => {
+		const warn = vi.spyOn(Logger, "warn").mockImplementation(() => {})
+		const minter = new MessageIdMinter()
+		const stream = new SdkFrameStream(minter)
+		stream.handleSessionEvent(sessionEvent({ type: "iteration_start", iteration: 1 }))
+		stream.handleSessionEvent(sessionEvent({ type: "done", reason: "completed", text: "ok", iterations: 1 }))
+		expect(stream.streamDiagnostics).toEqual([])
+		expect(warn).not.toHaveBeenCalled()
+		// Malformed: a block close with no open block (v1-illegal input).
+		stream.handleSessionEvent(
+			sessionEvent({
+				type: "content_end",
+				contentType: "tool",
+				toolCallId: "ghost",
+				toolName: "read_file",
+			}),
+		)
+		expect(stream.streamDiagnostics.length).toBeGreaterThan(0)
+		expect(warn).toHaveBeenCalled()
+		warn.mockRestore()
+	})
+})

--- a/apps/vscode/src/sdk/sdk-frame-stream.ts
+++ b/apps/vscode/src/sdk/sdk-frame-stream.ts
@@ -1,0 +1,142 @@
+/**
+ * SdkFrameStream — Phase 3c part 1 of the agent event stream v2 design
+ * (`sdk/packages/core/docs/agent-event-stream-design.md`): the producer
+ * envelope wired into the VSCode host.
+ *
+ * The (epoch, seq) authority is the host's existing `MessageIdMinter`
+ * — frames sample the SAME counter that stamps ClineMessage ids, so
+ * frame seq, message ids, and state-snapshot versions share one total
+ * order (the minter's documented rationale). The epoch fence therefore
+ * already lives in the envelope: `fenceAndFlush()` emits closes for
+ * open scopes at the CURRENT epoch, and the caller's existing
+ * `minter.bumpEpoch()` (cancel / reinit / task-switch boundaries)
+ * makes any later straggler frame stale for every frame consumer.
+ *
+ * The assembler's consumer here is a stream-health monitor (design,
+ * verification gate 4): legal streams are silent; repairs are logged
+ * and retained for debugging. The translator port (Phase 3c part 2)
+ * replaces this consumer with the real ClineMessage sinks — the frame
+ * source and fence wiring stay as built here.
+ */
+
+import type { CoreSessionEvent } from "@cline/core"
+import { projectSessionEvent, type SessionConsumer, StreamAssembler, type TurnConsumer } from "@cline/core/frames"
+import { type FrameSequencer, SessionFramer, type StreamFrame } from "@cline/shared"
+import { Logger } from "@/shared/services/Logger"
+import { MessageIdMinter } from "./message-id-minter"
+
+/** Retained diagnostics, newest last, bounded for a long session. */
+const MAX_RETAINED_DIAGNOSTICS = 100
+
+class StreamHealthMonitor implements SessionConsumer {
+	diagnostics: Array<{ code: string; detail?: string; seq?: number }> = []
+	turnCount = 0
+
+	onTurn(): TurnConsumer {
+		this.turnCount += 1
+		return this.makeConsumer()
+	}
+
+	/** Observe sub-agent streams, not prune them: a health monitor
+	 * wants their scopes tracked (and cascade-closed) like the lead's. */
+	private makeConsumer(): TurnConsumer {
+		return {
+			onText: () => ({ onDelta: () => {}, onAnnotation: () => {}, onClose: () => {} }),
+			onReasoning: () => ({
+				onDelta: () => {},
+				onAnnotation: () => {},
+				onClose: () => {},
+			}),
+			onTool: () => ({
+				onProgress: () => {},
+				onAnnotation: () => {},
+				onClose: () => {},
+			}),
+			onMedia: () => {},
+			onSubAgent: () => this.makeConsumer(),
+			onNotice: () => {},
+			onUsage: () => {},
+			onClose: () => {},
+		}
+	}
+
+	onSessionNotice(): void {}
+
+	onIdle(): void {}
+
+	onDiagnostic(diagnostic: { code: string; seq?: number; detail?: string }): void {
+		this.diagnostics.push({
+			code: diagnostic.code,
+			seq: diagnostic.seq,
+			detail: diagnostic.detail,
+		})
+		if (this.diagnostics.length > MAX_RETAINED_DIAGNOSTICS) {
+			this.diagnostics.shift()
+		}
+		Logger.warn(
+			`[SdkFrameStream] ${diagnostic.code}${diagnostic.detail ? ` ${diagnostic.detail}` : ""} (seq ${diagnostic.seq ?? "?"})`,
+		)
+	}
+}
+
+export class SdkFrameStream {
+	private readonly framer: SessionFramer
+	private readonly assembler: StreamAssembler
+	private readonly monitor = new StreamHealthMonitor()
+
+	constructor(minter: MessageIdMinter) {
+		// Frames sample the minter's id counter — the same authority that
+		// stamps ClineMessage identity — so one total order covers both.
+		let lastSeq = 0
+		const sequencer: FrameSequencer = {
+			epoch: () => minter.epoch,
+			nextSeq: () => {
+				lastSeq = minter.nextId()
+				return lastSeq
+			},
+			lastSeq: () => lastSeq,
+			bumpEpoch: () => {
+				minter.bumpEpoch()
+			},
+		}
+		this.framer = new SessionFramer({ sequencer })
+		this.assembler = new StreamAssembler(this.monitor)
+	}
+
+	/** Feed one CoreSessionEvent: project to agent paths, frame, push. */
+	handleSessionEvent(event: CoreSessionEvent): void {
+		for (const projected of projectSessionEvent(event)) {
+			const frames = this.framer.frameRoutedEvent(projected.agentPath, projected.event)
+			this.pushFrames(frames)
+		}
+	}
+
+	/**
+	 * Host fence (cancel / reinit / task switch): emit closes for open
+	 * scopes at the CURRENT epoch. The caller's existing
+	 * `minter.bumpEpoch()` then fences later stragglers — the envelope
+	 * carries the fence (design P4), so the translator's private
+	 * straggler-dropping becomes every frame consumer's stale-epoch drop.
+	 */
+	fenceAndFlush(): void {
+		this.pushFrames(this.framer.fence())
+	}
+
+	/** Scopes still open — the live set, for debugging and state views. */
+	openScopes(): { turnPaths: string[]; blocks: string[] } {
+		return this.assembler.openScopes()
+	}
+
+	/** Retained stream-health diagnostics (legal streams stay empty). */
+	get streamDiagnostics(): ReadonlyArray<{
+		code: string
+		detail?: string
+		seq?: number
+	}> {
+		return this.monitor.diagnostics
+	}
+
+	private pushFrames(frames: readonly StreamFrame[]): void {
+		this.assembler.pushAll(frames)
+	}
+}

--- a/apps/vscode/test-setup.js
+++ b/apps/vscode/test-setup.js
@@ -202,16 +202,48 @@ Module.prototype.require = function (id) {
 		}
 	}
 
+	if (id === "@cline/core/frames") {
+		// SdkController constructs the frame stream at load; the integration
+		// tests never feed it events, so an inert assembler suffices.
+		class StreamAssembler {
+			constructor(_consumer) {}
+			push() {}
+			pushAll() {}
+			openScopes() {
+				return { turnPaths: [], blocks: [] }
+			}
+		}
+		return {
+			StreamAssembler,
+			projectSessionEvent: () => [],
+		}
+	}
+
 	if (id === "@cline/shared") {
 		// Mirrors USER_REJECTED_TOOL_REASON / TOOL_REJECTION_SUFFIX in
 		// sdk/packages/shared/src/llms/tools.ts (the ESM-only real package
 		// cannot be required from this CommonJS test host).
+		// SessionFramer pairs with the inert StreamAssembler above: constructed
+		// by SdkController's frame stream at load, never fed by these tests.
+		class SessionFramer {
+			constructor(_options) {}
+			frameEvent() {
+				return []
+			}
+			frameRoutedEvent() {
+				return []
+			}
+			fence() {
+				return []
+			}
+		}
 		return {
 			buildClineSystemPrompt: () => "",
 			USER_REJECTED_TOOL_REASON: "This tool call was rejected by the user and not executed.",
 			TOOL_REJECTION_SUFFIX: "NOT a tool or system failure. Clarify with user before proceeding.",
 			createTool: (tool) => tool,
 			formatDisplayUserInput: (input) => (typeof input === "string" ? input : JSON.stringify(input)),
+			SessionFramer,
 		}
 	}
 

--- a/apps/vscode/tsconfig.test.json
+++ b/apps/vscode/tsconfig.test.json
@@ -49,6 +49,9 @@
 			],
 			"@cline/shared/*": [
 				"./node_modules/@cline/shared/dist/*"
+			],
+			"@cline/core/frames": [
+				"./node_modules/@cline/core/dist/frames"
 			]
 		},
 		"types": [

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
 	},
 	resolve: {
 		alias: {
+			"@cline/core/frames": path.resolve(__dirname, "node_modules/@cline/core/dist/frames.js"),
 			"@cline/core": path.resolve(__dirname, "src/test/cline-core-vitest-stub.ts"),
 			"@cline/llms": path.resolve(__dirname, "node_modules/@cline/llms/dist/index.js"),
 			// Map @cline/shared subpath exports explicitly. The bare "@cline/shared"

--- a/sdk/packages/core/bun.mts
+++ b/sdk/packages/core/bun.mts
@@ -54,6 +54,13 @@ const builds: Parameters<typeof Bun.build>[0][] = [
 		...buildConfig,
 	},
 	{
+		// Pure frame toolkit (assembler + projector) as a cheap subpath
+		// export for consumers and test harnesses.
+		entrypoints: ["./src/frames.ts"],
+		outdir: "./dist",
+		...buildConfig,
+	},
+	{
 		entrypoints: ["./src/hub/index.ts"],
 		outdir: "./dist/hub",
 		...buildConfig,

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -556,14 +556,38 @@ the process console, never the protocol stream. **Scope correction**:
 moved to 3c — both are VSCode host wiring that would be dead code
 until the translator consumes frames.
 
-**Phase 3c — VSCode wiring and translator.** Port message-translator
-onto the assembler. MessageTranslatorState's parser fields delete;
-ClineMessage mapping remains as sink implementations; sub-agent
-suppression (P5's heuristic) becomes `onSubAgent → null` plus a
-SubagentStatusRow consumer. Also the host wiring moved from 3b: the
-epoch fence from SdkController into the producer envelope
-(`RuntimeFrameAdapter.bumpEpoch` at cancel/reinit boundaries), and
-`SdkSessionRebuildScheduler` onto the assembler's `onIdle`.
+**Phase 3c — VSCode wiring and translator (split during execution
+into wiring and translator-sinks PRs).**
+
+**Phase 3c part 1 status: implemented (producer envelope wiring).**
+`apps/vscode/src/sdk/sdk-frame-stream.ts` is the host's frame tap: a
+`SessionFramer` whose (epoch, seq) authority IS the existing
+`MessageIdMinter` — frames sample the same counter that stamps
+ClineMessage ids, so one total order covers both (the minter's
+documented rationale, extended to frames). SdkController feeds every
+CoreSessionEvent through it (dual-run, parallel to the v1 coordinator),
+and both fence sites (`resetMessageTranslatorAndFence`,
+`raiseCancelFence`) call `fenceAndFlush()` before the minter bump —
+the epoch fence now lives in the envelope (P4): open scopes close at
+the current epoch, and any later straggler frame is stale for every
+frame consumer. The assembler's consumer is a stream-health monitor
+(verification gate 4): legal streams are silent; repairs are logged
+and retained for debugging. A health monitor must OBSERVE sub-agents,
+not prune them — its `onSubAgent` returns a consumer, unlike
+rendering consumers. Enabling plumbing: `@cline/core` gains a pure
+`./frames` subpath export (assembler + projector, mirroring
+`@cline/shared/storage`) so the vscode test harness can alias around
+the heavy main index. **Deferred with rationale:** the rebuild
+scheduler's `onIdle` port — session-lifecycle `isRunning` encodes
+pending-prompt delivery windows (`pending_prompt_submitted` sets
+running BEFORE any turn frames exist), so the assembler's idle edge
+would fire between queued turns and let the scheduler rebuild
+mid-delivery; blocked until pending-prompts become frames (Phase 3d's
+scope). **Remaining (part 2):** the translator sinks port —
+MessageTranslatorState's parser fields delete, ClineMessage mapping
+becomes sink implementations, sub-agent suppression (P5's heuristic)
+becomes `onSubAgent → null` plus a SubagentStatusRow consumer, and
+the health monitor is replaced by the real sinks.
 
 **Phase 3d — history replay and reconnect.** Snapshot reconciliation
 in the assembler (diff against the live set), live-after-history dedup
@@ -639,11 +663,12 @@ revertable without reverting its ancestors' behavior changes:
 | 3 | `dpc/event-stream-phase2` | Assembler (`@cline/core`), CLI terminal port, differential replay harness. (ACP port moved to PR 5, Phase 3b.) | 2 |
 | 4 | `dpc/event-stream-demux` | Phase 3a: multiplexed framing (SessionFramer, shared sequencer), address-keyed validator, tree-aware assembler with `onSubAgent` pruning, session-event projector. | 3 |
 | 5 | `dpc/event-stream-phase3b` | Phase 3b: ACP port (second frame consumer, differential-tested). | 4 |
-| 6 | `dpc/event-stream-phase3c` | Phase 3c: VSCode translator sinks, epoch fence into producer, rebuild scheduler on `onIdle`; P5 heuristic becomes `onSubAgent → null`. | 5 |
-| 7 | `dpc/event-stream-phase3d` | Phase 3d: history replay/reconnect, snapshot reconciliation. | 6 |
-| 8 | `dpc/event-stream-phase4a` | Desktop sidecar forwards frames verbatim (v1 re-encoding deletes). | 7 |
-| 9 | `dpc/event-stream-phase4b` | Desktop webview sinks (`use-chat-session`). | 8 |
-| 10 | `dpc/event-stream-phase5` | CI ratchet + deletion of superseded v1 consumer paths and the v1 reference renderer. | 9 |
+| 6 | `dpc/event-stream-phase3c-wiring` | Phase 3c part 1: producer envelope in SdkController — minter-backed frame stream, fence in the envelope, health monitor; `@cline/core/frames` subpath. | 5 |
+| 7 | `dpc/event-stream-phase3c-sinks` | Phase 3c part 2: VSCode translator sinks; P5 heuristic becomes `onSubAgent → null`; health monitor replaced by ClineMessage sinks. | 6 |
+| 8 | `dpc/event-stream-phase3d` | Phase 3d: history replay/reconnect, snapshot reconciliation. | 7 |
+| 9 | `dpc/event-stream-phase4a` | Desktop sidecar forwards frames verbatim (v1 re-encoding deletes). | 8 |
+| 10 | `dpc/event-stream-phase4b` | Desktop webview sinks (`use-chat-session`). | 9 |
+| 11 | `dpc/event-stream-phase5` | CI ratchet + deletion of superseded v1 consumer paths and the v1 reference renderer. | 10 |
 
 Review stays manageable because PR 1 is additive-only (this PR), PRs 2-3
 are producer/plumbing with property tests doing the checking, and the

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -34,6 +34,10 @@
 		"./services/feature-flags/posthog": {
 			"types": "./dist/services/feature-flags/posthog.d.ts",
 			"import": "./dist/services/feature-flags/posthog.js"
+		},
+		"./frames": {
+			"types": "./dist/frames.d.ts",
+			"import": "./dist/frames.js"
 		}
 	},
 	"scripts": {

--- a/sdk/packages/core/src/frames.ts
+++ b/sdk/packages/core/src/frames.ts
@@ -1,0 +1,31 @@
+/**
+ * The pure frame-toolkit surface of @cline/core: the stream assembler,
+ * the session-event projector, and their types. Deliberately free of
+ * the heavy index's imports (node services, hub transports) so
+ * consumers — and test harnesses aliasing around the main entry — can
+ * load it cheaply. Mirrors the subpath-export pattern of
+ * `@cline/shared/storage`.
+ */
+export {
+	DIAG_AFTER_SESSION_END,
+	DIAG_ANNOTATION_UNROUTED,
+	DIAG_BLOCK_OPEN_WHILE_OPEN,
+	DIAG_ORPHAN_BLOCK_FRAME,
+	DIAG_SNAPSHOT_UNROUTED,
+	DIAG_STALE_EPOCH,
+	DIAG_SUBAGENT_WITHOUT_TURN,
+	DIAG_TURN_CLOSE_WITHOUT_OPEN,
+	DIAG_TURN_OPEN_WHILE_OPEN,
+	StreamAssembler,
+} from "./runtime/orchestration/stream-assembler"
+export type {
+	MediaFinal,
+	ReasoningSink,
+	SessionConsumer,
+	StreamDiagnostic,
+	TextSink,
+	ToolSink,
+	TurnConsumer,
+} from "./runtime/orchestration/stream-assembler"
+export type { ProjectedAgentEvent } from "./runtime/orchestration/session-event-projector"
+export { projectSessionEvent } from "./runtime/orchestration/session-event-projector"

--- a/sdk/packages/core/tsconfig.build.json
+++ b/sdk/packages/core/tsconfig.build.json
@@ -11,6 +11,7 @@
 	},
 	"include": [
 		"src/index.ts",
+		"src/frames.ts",
 		"src/hub/index.ts",
 		"src/hub/daemon/entry.ts",
 		"src/services/telemetry/index.ts",

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -643,10 +643,17 @@ export class SessionFramer {
 	private readonly sequencer: FrameSequencer;
 	private readonly streams = new Map<string, AgentEventFramer>();
 
-	constructor(options: { startEpoch?: number } = {}) {
-		// Reuse the framer's internal sequencer through a root instance:
-		// one authority, owned here.
-		this.sequencer = new InternalFrameSequencer(options.startEpoch ?? 0);
+	constructor(options: {
+		startEpoch?: number;
+		/** External (epoch, seq) authority — e.g. the VSCode host's
+		 * MessageIdMinter, so frames and ClineMessages share one
+		 * counter (design: "one counter across all scopes"). When
+		 * provided, epoch changes go through the owner, not here. */
+		sequencer?: FrameSequencer;
+	} = {}) {
+		this.sequencer =
+			options.sequencer ??
+			new InternalFrameSequencer(options.startEpoch ?? 0);
 	}
 
 	/** Frame an event for the root agent (same as AgentEventFramer). */


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Phases 1-3b built the frame stream and ported both CLI consumers. This PR wires the producer envelope into the VSCode host — the prerequisite for the translator port (Phase 3c part 2), and the piece that moves the epoch fence out of consumer folklore and into the protocol (design P4).

- **`SdkFrameStream`** (`apps/vscode/src/sdk/sdk-frame-stream.ts`): the host's frame tap. Its `(epoch, seq)` authority is the *existing* `MessageIdMinter` — frames sample the same counter that stamps ClineMessage ids, so one total order covers messages, state snapshots, and frames (the minter's documented rationale, extended). SdkController feeds every `CoreSessionEvent` through it alongside the v1 coordinator (dual-run); sub-agent events route structurally via the Phase 3a projector.
- **The fence lives in the envelope now**: both fence sites (`resetMessageTranslatorAndFence`, `raiseCancelFence`) call `fenceAndFlush()` before the minter bump — open scopes close at the current epoch, and any straggler frame after the bump is stale for *every* frame consumer. The translator's private straggler-dropping becomes the protocol's rule.
- **Stream-health monitor** (verification gate 4): the assembler's consumer logs and retains repairs — legal streams are silent, producer bugs surface as `[SdkFrameStream]` warnings instead of rendering glitches. A monitor observes sub-agents rather than pruning them.
- **Enabling plumbing**: `@cline/core` gains a pure `./frames` subpath export (assembler + projector, mirroring `@cline/shared/storage`) so the vscode test harness can alias around the heavy main index.

Two honest scope notes, both recorded in the design doc: the rebuild-scheduler `onIdle` port is **deferred with rationale** — session-lifecycle `isRunning` encodes pending-prompt delivery windows, so the assembler's idle edge would fire between queued turns until pending-prompts become frames (Phase 3d); and one consequence to be aware of — frame seqs consume the minter's id space, so ClineMessage ids become non-contiguous (the minter's contract is uniqueness + monotonicity, which holds; nothing reads ids as positions).

### Test Procedure

```
cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk/
# 1094 passed (70 files) — includes the 4 new SdkFrameStream tests
# (minter counter sharing, fence-then-bump semantics, structural sub-agent
# routing, legal-stream silence + repair logging) and the entire
# message-translator suite unchanged.

bun -F @cline/core build   # dist/frames.js + dist/frames.d.ts emitted
```

`tsc --noEmit` on the app: the one new-file error was resolved by emitting `frames.d.ts`; the 5 remaining errors are pre-existing proto-regeneration errors, identical without this change (`bun run protos` refreshes them in the repo's own `check-types` flow).

### Type of Change

-   [x] ♻️ Refactor Changes
-   [x] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Stacked on #13800 → #13798 → #13796 → #13766 → #13759; review in that order. This PR changes no user-visible behavior — the tap is parallel to the v1 path, and the full sdk suite passes unchanged. Next: Phase 3c part 2, the translator sinks port (MessageTranslatorState's parser fields delete; P5's suppression heuristic becomes `onSubAgent → null`).
