### PR TITLE
Add ClineMessage sinks for the frame stream (VSCode translator tranche 1)

### DIFF
--- a/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Differential parity: the frame path (frame → assemble →
+ * FrameMessageBridge) must produce the same ClineMessages as the v1
+ * translator (translateAgentEvent) for the core agent-event surface.
+ *
+ * Both paths mint message ids from identically-seeded counters, so any
+ * behavioral divergence shows up as a row difference — content, order,
+ * or ts. Generated traces cover the grammar's legal shapes (including
+ * the warts); handcrafted traces pin the edges the generator cannot
+ * aim at.
+ *
+ * Traces exercising surfaces not yet ported to the bridge (terminal
+ * error rows, compaction dividers, tool-specific renderings) are
+ * excluded here — the switchover checklist in the design doc maps each
+ * to the pinned v1 translator tests that gate its port.
+ */
+
+import { StreamAssembler } from "@cline/core/frames"
+import { type AgentEvent, AgentEventFramer, generateLegalV1Trace } from "@cline/shared"
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { describe, expect, it } from "vitest"
+import { FrameMessageBridge } from "./frame-message-bridge"
+import { MessageIdMinter } from "./message-id-minter"
+import { MessageTranslatorState, translateAgentEvent } from "./message-translator"
+
+/** The v1 oracle: the production translator, unchanged. */
+function v1Messages(events: readonly AgentEvent[], mode: "plan" | "act" = "act"): ClineMessage[] {
+	const state = new MessageTranslatorState(new MessageIdMinter(), undefined, () => mode)
+	const out: ClineMessage[] = []
+	for (const event of events) {
+		out.push(...translateAgentEvent(event, state))
+	}
+	return out
+}
+
+/** The v2 path: frame → assemble → bridge sinks. */
+function v2Messages(events: readonly AgentEvent[], mode: "plan" | "act" = "act"): ClineMessage[] {
+	const minter = new MessageIdMinter()
+	const bridge = new FrameMessageBridge({ nextTs: () => minter.nextId(), getUiMode: () => mode })
+	const assembler = new StreamAssembler(bridge)
+	assembler.pushAll(new AgentEventFramer().frameAll(events))
+	return bridge.takeMessages()
+}
+
+function expectParity(events: readonly AgentEvent[], mode?: "plan" | "act"): void {
+	const v1 = v1Messages(events, mode)
+	const v2 = v2Messages(events, mode)
+	expect(v2).toEqual(v1)
+}
+
+describe("FrameMessageBridge differential parity", () => {
+	it("generated traces: frame path equals v1 translator output", () => {
+		const traces: AgentEvent[][] = []
+		for (let seed = 1; traces.length < 100; seed += 1) {
+			const events = generateLegalV1Trace(seed, { maxEvents: 40 })
+			// Terminal non-recoverable errors emit the not-yet-ported
+			// api_req_failed pair in v1 — excluded surface.
+			if (events.some((e) => e.type === "error" && e.recoverable !== true)) {
+				continue
+			}
+			// Concurrently open tools: v1 reuses one streamingToolTs across
+			// them (their partial rows collide in the message store); the
+			// bridge gives each tool block its own identity — intended
+			// divergence, whitelisted like the CLI's done(error) case.
+			let openTools = 0
+			let concurrent = false
+			for (const e of events) {
+				if (e.type === "content_start" && e.contentType === "tool") openTools += 1
+				if (e.type === "content_end" && e.contentType === "tool") openTools -= 1
+				if (openTools > 1) concurrent = true
+			}
+			// Text/reasoning blocks left open across an iteration boundary:
+			// v1's iteration_start reset() re-mints the streaming ts while
+			// the framer keeps one block open — the real adapter closes
+			// content within its iteration, so this shape is unmodeled in
+			// the tables; excluded (see the design doc's framer note).
+			let textOpen = false
+			let reasoningOpen = false
+			let danglingAtBoundary = false
+			for (const e of events) {
+				if (e.type === "content_start" && e.contentType === "text") textOpen = true
+				if (e.type === "content_end" && e.contentType === "text") textOpen = false
+				if (e.type === "content_start" && e.contentType === "reasoning") reasoningOpen = true
+				if (e.type === "content_end" && e.contentType === "reasoning") reasoningOpen = false
+				if (e.type === "iteration_start" || e.type === "iteration_end") {
+					if (textOpen || reasoningOpen) danglingAtBoundary = true
+				}
+			}
+			if (danglingAtBoundary) {
+				continue
+			}
+			if (concurrent) {
+				continue
+			}
+			traces.push(events)
+		}
+		expect(traces.length).toBe(100)
+		for (const events of traces) {
+			const v1 = v1Messages(events)
+			const v2 = v2Messages(events)
+			expect(v2).toEqual(v1)
+		}
+	})
+
+	it("streaming text finalizes and retags as completion (act mode)", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_start", contentType: "text", text: "He", accumulated: "He" },
+			{ type: "content_start", contentType: "text", text: "llo", accumulated: "Hello" },
+			{ type: "content_end", contentType: "text", text: "Hello" },
+			{ type: "iteration_end", iteration: 1, hadToolCalls: false, toolCallCount: 0 },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("plan mode retags as plan_completion_result", () => {
+		expectParity(
+			[
+				{ type: "iteration_start", iteration: 1 },
+				{ type: "content_end", contentType: "text", text: "the plan" },
+				{ type: "done", text: "", reason: "completed", iterations: 1 },
+			],
+			"plan",
+		)
+	})
+
+	it("max_iterations and mistake_limit complete the turn but never retag", () => {
+		for (const reason of ["max_iterations", "mistake_limit"] as const) {
+			expectParity([
+				{ type: "iteration_start", iteration: 1 },
+				{ type: "content_end", contentType: "text", text: "partial answer" },
+				{ type: "done", text: "", reason, iterations: 3 },
+			])
+		}
+	})
+
+	it("tool activity drops the retag candidate; later text re-records it", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "first" },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "read_file",
+				input: { path: "/tmp/x" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "read_file", output: "ok" },
+			{ type: "content_end", contentType: "text", text: "second" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+})
+
+describe("FrameMessageBridge differential parity (edges)", () => {
+	it("reasoning streams accumulated text and finalizes", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_start", contentType: "reasoning", reasoning: "th" },
+			{ type: "content_start", contentType: "reasoning", reasoning: "inking" },
+			{ type: "content_end", contentType: "reasoning", reasoning: "thinking" },
+			{ type: "content_end", contentType: "text", text: "answer" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("interleaved reasoning and text keep separate rows", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_start", contentType: "text", text: "a", accumulated: "a" },
+			{ type: "content_start", contentType: "reasoning", reasoning: "r" },
+			{ type: "content_start", contentType: "text", text: "b", accumulated: "ab" },
+			{ type: "content_end", contentType: "reasoning", reasoning: "r" },
+			{ type: "content_end", contentType: "text", text: "ab" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("final without streamed deltas (W2) still renders the final row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "whole answer" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("aborted turn with dangling tool and text is silent for the dangling blocks (W3)", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_start", contentType: "text", text: "ha", accumulated: "ha" },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "read_file",
+				input: { path: "/tmp/x" },
+			},
+			{ type: "content_update", contentType: "tool", toolCallId: "c1", update: { p: 1 } },
+			{ type: "done", text: "", reason: "aborted", iterations: 1 },
+		])
+	})
+
+	it("tool close with error renders the tool row plus an error row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "read_file",
+				input: { path: "/tmp/x" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "read_file", error: "boom" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("iteration markers emit api_req_started; usage fills the cost row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "x" },
+			{
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+				cacheReadTokens: 4,
+				cacheWriteTokens: 2,
+				cost: 0.5,
+				totalInputTokens: 10,
+				totalOutputTokens: 5,
+			},
+			{ type: "iteration_end", iteration: 1, hadToolCalls: false, toolCallCount: 0 },
+			{ type: "iteration_start", iteration: 2 },
+			{ type: "content_end", contentType: "text", text: "y" },
+			{ type: "done", text: "", reason: "completed", iterations: 2 },
+		])
+	})
+
+	it("status and plain notices render as info rows; internal ones are dropped", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "notice", noticeType: "status", message: "t" },
+			{ type: "notice", noticeType: "status", message: "compaction-budget-adjusted" },
+			{ type: "notice", noticeType: "stop", message: "note text" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("recoverable errors emit nothing and the turn continues", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "error", error: new Error("transient"), iteration: 1, recoverable: true },
+			{ type: "content_end", contentType: "text", text: "still fine" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("consecutive text blocks each mint their own row identity", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_start", contentType: "text", text: "a", accumulated: "a" },
+			{ type: "content_end", contentType: "text", text: "a" },
+			{ type: "content_start", contentType: "text", text: "b", accumulated: "b" },
+			{ type: "content_end", contentType: "text", text: "b" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("empty final text never becomes a retag candidate", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "   " },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+})

--- a/apps/vscode/src/sdk/frame-message-bridge.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.ts
@@ -1,0 +1,338 @@
+/**
+ * FrameMessageBridge — ClineMessage sinks for the v2 frame stream
+ * (`sdk/packages/core/docs/agent-event-stream-design.md`).
+ *
+ * Implements the assembler's consumer API so the frame path produces the
+ * same ClineMessages as the v1 translator (`message-translator.ts`) for
+ * the core agent-event surface: streaming text/reasoning rows, generic
+ * tool rows, usage, iteration markers, notices, and turn terminals
+ * (including the completion retag). Parity with v1 is differential-test
+ * locked (frame-message-bridge.differential.test.ts): both paths mint
+ * message ids at identical points, so the produced rows must be equal.
+ *
+ * Ordering rules are the assembler's, not this file's: sinks receive
+ * updates only between their open and close, children close before the
+ * turn, and a force-close (interrupted) is silent — matching v1, where a
+ * dangling block simply never got its content_end (W3).
+ *
+ * Not yet ported (the switchover checklist in the design doc, each gated
+ * by its pinned v1 translator tests): error-terminal rows
+ * (reshapeErrorForWebview + api_req_failed), compaction dividers, and the
+ * tool-specific renderings (completion, command, MCP, read_files /
+ * apply_patch splits, ask_question suppression, spawn_agent aggregation,
+ * approval-coordinator interactions). Until the switchover PR, v1 remains
+ * the production ClineMessage source and this bridge runs shadow-only —
+ * its output is drained and discarded by SdkFrameStream.
+ */
+
+import type { SessionConsumer, StreamDiagnostic, TurnConsumer } from "@cline/core/frames"
+import type { CloseFinal, NoticeBody, Outcome, UsageBody } from "@cline/shared"
+import type { ClineApiReqInfo, ClineMessage } from "@shared/ExtensionMessage"
+import { Logger } from "@shared/services/Logger"
+import {
+	isCompletionTool,
+	normalizeUsageEvent,
+	parseCompactionNoticeMetadata,
+	sdkToolToClineSayTool,
+	toDisplaySayTool,
+} from "./message-translator"
+
+/** Retained diagnostics, newest last, bounded for a long session. */
+const MAX_RETAINED_DIAGNOSTICS = 100
+
+/**
+ * Status notices that are internal diagnostics with no user-facing copy —
+ * the same suppression set as the v1 translator (kept in sync with the
+ * `emitStatusNotice` call sites in sdk/packages/core/src/extensions/context/compaction.ts).
+ */
+const INTERNAL_STATUS_NOTICES = new Set(["compaction-budget-adjusted"])
+
+export interface FrameMessageBridgeDeps {
+	/** Mint a ClineMessage ts — the same authority the v1 state uses. */
+	nextTs: () => number
+	/** UI mode for the completion retag's say kind; undefined means act. */
+	getUiMode?: () => "plan" | "act" | "yolo" | undefined
+	/** Working directory for tool-path relativization. */
+	getCwd?: () => string | undefined
+}
+
+/**
+ * Session-level sink: mints rows for notices/usage and delegates turn
+ * bodies to per-turn consumers that hold the turn-scoped retag state.
+ */
+export class FrameMessageBridge implements SessionConsumer {
+	private messages: ClineMessage[] = []
+	diagnostics: Array<{ code: string; detail?: string; seq?: number }> = []
+
+	/** Minting/config access shared with this file's turn consumers. */
+	readonly deps: FrameMessageBridgeDeps
+
+	constructor(deps: FrameMessageBridgeDeps) {
+		this.deps = deps
+	}
+
+	/** Drain produced messages (the shadow runner discards them until switchover). */
+	takeMessages(): ClineMessage[] {
+		const out = this.messages
+		this.messages = []
+		return out
+	}
+
+	onTurn(): TurnConsumer {
+		return new BridgeTurnConsumer(this)
+	}
+
+	onSessionNotice(notice: NoticeBody): void {
+		// Session-scope notices render as info rows, mirroring the v1
+		// translator's notice default wherever the notice fires.
+		this.push({
+			ts: this.deps.nextTs(),
+			type: "say",
+			say: "info",
+			text: notice.message ?? "",
+			partial: false,
+		})
+	}
+
+	onIdle(): void {
+		// Quiescence is a host-lifecycle signal (rebuild scheduler), not a
+		// chat row; the switchover wiring subscribes to it separately.
+	}
+
+	onDiagnostic(diagnostic: StreamDiagnostic): void {
+		this.diagnostics.push({
+			code: diagnostic.code,
+			seq: diagnostic.seq,
+			detail: diagnostic.detail,
+		})
+		if (this.diagnostics.length > MAX_RETAINED_DIAGNOSTICS) {
+			this.diagnostics.shift()
+		}
+		Logger.warn(
+			`[FrameMessageBridge] ${diagnostic.code}${diagnostic.detail ? ` ${diagnostic.detail}` : ""} (seq ${diagnostic.seq ?? "?"})`,
+		)
+	}
+
+	/** Visible to the turn consumers in this file. */
+	push(message: ClineMessage): void {
+		this.messages.push(message)
+	}
+}
+
+/** Per-turn state: the completion-retag candidate, v1's turn-scoped rule. */
+class BridgeTurnConsumer implements TurnConsumer {
+	private turnFinalText: { ts: number; text: string } | undefined
+	private attemptCompletionSeen = false
+
+	constructor(private readonly bridge: FrameMessageBridge) {}
+
+	onText(): ReturnType<TurnConsumer["onText"]> {
+		const ts = this.bridge.deps.nextTs()
+		const turn = this
+		let accumulated = ""
+		const bridge = this.bridge
+		return {
+			onDelta(text: string): void {
+				accumulated += text
+				bridge.push({ ts, type: "say", say: "text", text: accumulated, partial: true })
+			},
+			onAnnotation(): void {},
+			onClose(outcome: Outcome, final: { text: string }): void {
+				// A force-close is silent: v1 never saw a content_end for a
+				// dangling text block (W3), so neither does this path.
+				if (outcome.kind === "interrupted") {
+					return
+				}
+				bridge.push({ ts, type: "say", say: "text", text: final.text, partial: false })
+				if (final.text.trim()) {
+					turn.recordTurnFinalText(ts, final.text)
+				}
+			},
+		}
+	}
+
+	onReasoning(): ReturnType<TurnConsumer["onReasoning"]> {
+		const ts = this.bridge.deps.nextTs()
+		let accumulated = ""
+		const bridge = this.bridge
+		return {
+			onDelta(reasoning: string): void {
+				accumulated += reasoning
+				bridge.push({ ts, type: "say", say: "reasoning", text: accumulated, reasoning: accumulated, partial: true })
+			},
+			onAnnotation(): void {},
+			onClose(outcome: Outcome, final: { reasoning: string }): void {
+				if (outcome.kind === "interrupted") {
+					return
+				}
+				bridge.push({
+					ts,
+					type: "say",
+					say: "reasoning",
+					text: final.reasoning,
+					reasoning: final.reasoning,
+					partial: false,
+				})
+			},
+		}
+	}
+
+	onTool(start: { toolName: string; input?: unknown }): ReturnType<TurnConsumer["onTool"]> {
+		// Tool activity after a text block means that text wasn't the
+		// turn-final response — drop the retag candidate (v1 rule).
+		this.turnFinalText = undefined
+		if (isCompletionTool(start.toolName)) {
+			this.attemptCompletionSeen = true
+		}
+		const ts = this.bridge.deps.nextTs()
+		const cwd = this.bridge.deps.getCwd?.()
+		this.bridge.push({
+			ts,
+			type: "say",
+			say: "tool",
+			text: JSON.stringify(toDisplaySayTool(sdkToolToClineSayTool(start.toolName, start.input), cwd)),
+			partial: true,
+		})
+		const bridge = this.bridge
+		return {
+			onProgress(): void {
+				// v1 ignores content_update for generic tools; the partial
+				// row from the open is the running state until close.
+			},
+			onAnnotation(): void {},
+			onClose(outcome: Outcome, final: CloseFinal): void {
+				if (outcome.kind === "interrupted") {
+					// v1 W3 silence: a dangling tool never got its content_end.
+					return
+				}
+				if (final.type !== "tool") {
+					return
+				}
+				const input = final.input ?? start.input
+				const sayTool = toDisplaySayTool(sdkToolToClineSayTool(start.toolName, input), cwd)
+				bridge.push({ ts, type: "say", say: "tool", text: JSON.stringify(sayTool), partial: false })
+				if (outcome.kind === "error") {
+					bridge.push({
+						ts: bridge.deps.nextTs(),
+						type: "say",
+						say: "error",
+						text: outcome.error.message,
+						partial: false,
+					})
+				}
+			},
+		}
+	}
+
+	onMedia(): void {
+		// The v1 adapter never emits media content events.
+	}
+
+	onSubAgent(): TurnConsumer | null {
+		// Main chat renders sub-agents via the spawn_agent tool rows (P5's
+		// structural pruning — replaces v1's timing-based suppression).
+		return null
+	}
+
+	onNotice(notice: NoticeBody): void {
+		switch (notice.noticeType) {
+			case "iteration_started": {
+				// v1's iteration_start: an api_req_started row per API
+				// request (spinner + cost display placeholder).
+				this.bridge.push({
+					ts: this.bridge.deps.nextTs(),
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ request: undefined } satisfies ClineApiReqInfo),
+					partial: false,
+				})
+				return
+			}
+			case "iteration_finished": {
+				// v1's iteration_end emits nothing.
+				return
+			}
+			case "recovery": {
+				// Recoverable errors are in-run notices, not turn outcomes;
+				// any tool failure is already inline on its tool row (v1
+				// parity — see the war-story comment in the v1 error case).
+				Logger.warn(`[FrameMessageBridge] Recoverable agent error (run continues): ${notice.message ?? ""}`)
+				return
+			}
+			case "status": {
+				const compaction = parseCompactionNoticeMetadata(notice.metadata)
+				if (compaction) {
+					// Compaction dividers are not yet ported (switchover
+					// checklist); log so the gap is visible in shadow runs.
+					Logger.warn(`[FrameMessageBridge] Compaction notice not yet ported (phase: ${compaction.status})`)
+					return
+				}
+				if (INTERNAL_STATUS_NOTICES.has(notice.message ?? "")) {
+					return
+				}
+				break
+			}
+			default:
+				break
+		}
+		// Non-status notices (and unrecognized status ones) are info rows —
+		// a future notice surfaces as its raw slug instead of vanishing.
+		this.bridge.push({
+			ts: this.bridge.deps.nextTs(),
+			type: "say",
+			say: "info",
+			text: notice.message ?? "",
+			partial: false,
+		})
+	}
+
+	onUsage(usage: UsageBody): void {
+		const normalized = normalizeUsageEvent(usage)
+		const apiReqInfo: ClineApiReqInfo = {
+			tokensIn: normalized.tokensIn,
+			tokensOut: normalized.tokensOut,
+			cacheWrites: normalized.cacheWrites,
+			cacheReads: normalized.cacheReads,
+			cost: normalized.totalCost,
+		}
+		this.bridge.push({
+			ts: this.bridge.deps.nextTs(),
+			type: "say",
+			say: "api_req_started",
+			text: JSON.stringify(apiReqInfo),
+			partial: false,
+		})
+	}
+
+	onClose(outcome: Outcome): void {
+		// v1 retags only on done(reason:"completed") exactly —
+		// max_iterations/mistake_limit turns keep their plain text.
+		const completedExactly = outcome.kind === "completed" && (outcome.finishReason ?? "completed") === "completed"
+		if (completedExactly && !this.attemptCompletionSeen) {
+			// Inferred completion feedback: retag the turn's final text row
+			// in place (same ts) for the legacy done visual.
+			const finalText = this.turnFinalText
+			this.turnFinalText = undefined
+			if (finalText) {
+				this.bridge.push({
+					ts: finalText.ts,
+					type: "say",
+					say: this.bridge.deps.getUiMode?.() === "plan" ? "plan_completion_result" : "completion_result",
+					text: finalText.text,
+					partial: false,
+				})
+			}
+			return
+		}
+		if (outcome.kind === "error") {
+			// Terminal error rows (api_req_failed pair) are not yet ported —
+			// the switchover checklist; logged so the gap is visible.
+			Logger.warn(`[FrameMessageBridge] Terminal error outcome rows not yet ported: ${outcome.error.message}`)
+		}
+		this.turnFinalText = undefined
+	}
+
+	private recordTurnFinalText(ts: number, text: string): void {
+		this.turnFinalText = { ts, text }
+	}
+}

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -84,7 +84,7 @@ export interface TranslationResult {
 
 type NormalizedUsage = NonNullable<TranslationResult["usage"]>
 
-function normalizeUsageEvent(usageEvent: {
+export function normalizeUsageEvent(usageEvent: {
 	inputTokens?: number
 	outputTokens?: number
 	cacheReadTokens?: number
@@ -551,7 +551,7 @@ const FILESYSTEM_PATH_TOOLS: ReadonlySet<ClineSayTool["tool"]> = new Set([
  * display behavior that was lost in the SDK migration (the SDK works with
  * absolute paths). Display-only — executors receive the raw tool input.
  */
-function toDisplaySayTool(sayTool: ClineSayTool, cwd: string | undefined): ClineSayTool {
+export function toDisplaySayTool(sayTool: ClineSayTool, cwd: string | undefined): ClineSayTool {
 	if (!cwd || !FILESYSTEM_PATH_TOOLS.has(sayTool.tool)) {
 		return sayTool
 	}
@@ -651,7 +651,7 @@ function relativizePatchPaths(patch: string | undefined, cwd: string): string | 
  *   ask_question/ask_followup_question → (not a visual tool — handled by askQuestion executor in SdkController)
  *   MCP tools (serverName__toolName)   → (handled before reaching sdkToolToClineSayTool — emitted as say="use_mcp_server")
  */
-function sdkToolToClineSayTool(toolName: string, input?: unknown): ClineSayTool {
+export function sdkToolToClineSayTool(toolName: string, input?: unknown): ClineSayTool {
 	// Parse input if it's a string (some SDK tools pass stringified JSON)
 	const parsedInput = parseToolInput(input)
 
@@ -857,7 +857,7 @@ function parseToolInput(input: unknown): Record<string, unknown> | undefined {
  * but still present in persisted transcripts) and the SDK's built-in `submit_and_exit`
  * (DefaultToolNames.SUBMIT_AND_EXIT, lifecycle.completesRun=true).
  */
-function isCompletionTool(toolName: string): boolean {
+export function isCompletionTool(toolName: string): boolean {
 	return toolName === "submit_and_exit" || toolName === "attempt_completion"
 }
 
@@ -1265,7 +1265,7 @@ function finalizeDanglingCompaction(
 	messages.push(buildCompactionMessage({ status, mode: "auto" }, ts))
 }
 
-function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): ClineMessage[] {
+export function translateAgentEvent(event: AgentEvent, state: MessageTranslatorState): ClineMessage[] {
 	const messages: ClineMessage[] = []
 
 	switch (event.type) {

--- a/apps/vscode/src/sdk/sdk-frame-stream.test.ts
+++ b/apps/vscode/src/sdk/sdk-frame-stream.test.ts
@@ -76,9 +76,11 @@ describe("SdkFrameStream", () => {
 				agentId: "agent-a",
 			}),
 		)
-		// Child frames routed structurally (P5): the child's own turn is open.
-		expect(stream.openScopes().turnPaths).toContain("root/agent-a")
-		expect(stream.openScopes().turnPaths).toContain("root")
+		// The bridge is a renderer (P5): sub-agent streams are pruned
+		// silently and deliberately, so the child's scopes never open.
+		// Routing itself is verified by the ABSENCE of orphan diagnostics —
+		// an unrouted child frame would diagnose as an orphan block.
+		expect(stream.openScopes().turnPaths).toEqual(["root"])
 		expect(stream.streamDiagnostics).toEqual([])
 	})
 

--- a/apps/vscode/src/sdk/sdk-frame-stream.ts
+++ b/apps/vscode/src/sdk/sdk-frame-stream.ts
@@ -12,77 +12,24 @@
  * `minter.bumpEpoch()` (cancel / reinit / task-switch boundaries)
  * makes any later straggler frame stale for every frame consumer.
  *
- * The assembler's consumer here is a stream-health monitor (design,
- * verification gate 4): legal streams are silent; repairs are logged
- * and retained for debugging. The translator port (Phase 3c part 2)
- * replaces this consumer with the real ClineMessage sinks — the frame
- * source and fence wiring stay as built here.
+ * The assembler's consumer here is the FrameMessageBridge — the
+ * ClineMessage sinks that will replace the v1 translator at switchover.
+ * Until then it runs shadow-only: its rows are drained and discarded
+ * (parity with the v1 translator is differential-test locked), while its
+ * diagnostics are logged and retained exactly as the health monitor's
+ * were (legal streams stay silent; repairs surface as warnings).
  */
 
 import type { CoreSessionEvent } from "@cline/core"
-import { projectSessionEvent, type SessionConsumer, StreamAssembler, type TurnConsumer } from "@cline/core/frames"
+import { projectSessionEvent, StreamAssembler } from "@cline/core/frames"
 import { type FrameSequencer, SessionFramer, type StreamFrame } from "@cline/shared"
-import { Logger } from "@/shared/services/Logger"
+import { FrameMessageBridge } from "./frame-message-bridge"
 import { MessageIdMinter } from "./message-id-minter"
-
-/** Retained diagnostics, newest last, bounded for a long session. */
-const MAX_RETAINED_DIAGNOSTICS = 100
-
-class StreamHealthMonitor implements SessionConsumer {
-	diagnostics: Array<{ code: string; detail?: string; seq?: number }> = []
-	turnCount = 0
-
-	onTurn(): TurnConsumer {
-		this.turnCount += 1
-		return this.makeConsumer()
-	}
-
-	/** Observe sub-agent streams, not prune them: a health monitor
-	 * wants their scopes tracked (and cascade-closed) like the lead's. */
-	private makeConsumer(): TurnConsumer {
-		return {
-			onText: () => ({ onDelta: () => {}, onAnnotation: () => {}, onClose: () => {} }),
-			onReasoning: () => ({
-				onDelta: () => {},
-				onAnnotation: () => {},
-				onClose: () => {},
-			}),
-			onTool: () => ({
-				onProgress: () => {},
-				onAnnotation: () => {},
-				onClose: () => {},
-			}),
-			onMedia: () => {},
-			onSubAgent: () => this.makeConsumer(),
-			onNotice: () => {},
-			onUsage: () => {},
-			onClose: () => {},
-		}
-	}
-
-	onSessionNotice(): void {}
-
-	onIdle(): void {}
-
-	onDiagnostic(diagnostic: { code: string; seq?: number; detail?: string }): void {
-		this.diagnostics.push({
-			code: diagnostic.code,
-			seq: diagnostic.seq,
-			detail: diagnostic.detail,
-		})
-		if (this.diagnostics.length > MAX_RETAINED_DIAGNOSTICS) {
-			this.diagnostics.shift()
-		}
-		Logger.warn(
-			`[SdkFrameStream] ${diagnostic.code}${diagnostic.detail ? ` ${diagnostic.detail}` : ""} (seq ${diagnostic.seq ?? "?"})`,
-		)
-	}
-}
 
 export class SdkFrameStream {
 	private readonly framer: SessionFramer
 	private readonly assembler: StreamAssembler
-	private readonly monitor = new StreamHealthMonitor()
+	private readonly bridge: FrameMessageBridge
 
 	constructor(minter: MessageIdMinter) {
 		// Frames sample the minter's id counter — the same authority that
@@ -100,7 +47,12 @@ export class SdkFrameStream {
 			},
 		}
 		this.framer = new SessionFramer({ sequencer })
-		this.assembler = new StreamAssembler(this.monitor)
+		this.bridge = new FrameMessageBridge({
+			// Same id authority as the v1 translator state; the retag/cwd
+			// getters are wired at switchover (shadow rows are discarded).
+			nextTs: () => minter.nextId(),
+		})
+		this.assembler = new StreamAssembler(this.bridge)
 	}
 
 	/** Feed one CoreSessionEvent: project to agent paths, frame, push. */
@@ -133,10 +85,13 @@ export class SdkFrameStream {
 		detail?: string
 		seq?: number
 	}> {
-		return this.monitor.diagnostics
+		return this.bridge.diagnostics
 	}
 
 	private pushFrames(frames: readonly StreamFrame[]): void {
 		this.assembler.pushAll(frames)
+		// Shadow run: the v1 translator remains the production ClineMessage
+		// source, so the bridge's rows are drained and discarded here.
+		this.bridge.takeMessages()
 	}
 }

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -583,11 +583,52 @@ pending-prompt delivery windows (`pending_prompt_submitted` sets
 running BEFORE any turn frames exist), so the assembler's idle edge
 would fire between queued turns and let the scheduler rebuild
 mid-delivery; blocked until pending-prompts become frames (Phase 3d's
-scope). **Remaining (part 2):** the translator sinks port —
-MessageTranslatorState's parser fields delete, ClineMessage mapping
-becomes sink implementations, sub-agent suppression (P5's heuristic)
-becomes `onSubAgent → null` plus a SubagentStatusRow consumer, and
-the health monitor is replaced by the real sinks.
+scope).
+
+**Phase 3c part 2 status: implemented (first tranche, differential
+parity).** `apps/vscode/src/sdk/frame-message-bridge.ts` implements the
+assembler's consumer API and produces ClineMessages for the core
+agent-event surface: streaming text/reasoning rows (accumulated
+partials, authoritatively-final closes), generic tool rows (partial at
+open, final with the open's input at close, error rows), usage
+api_req_started rows, iteration markers, notices (internal ones
+suppressed, others info rows), and turn terminals with the completion
+retag. `SdkFrameStream`'s consumer is now the bridge (the monitor's
+diagnostics behavior moved onto it) — v1 remains the production
+ClineMessage source, so the bridge runs shadow-only: SdkFrameStream
+drains and discards its rows until the switchover PR. Parity is
+differential-locked (`frame-message-bridge.differential.test.ts`):
+generated traces plus handcrafted edges through both the v1 translator
+and frame→assemble→bridge must produce equal ClineMessages, including
+ts (both paths mint from identically-seeded counters). Three contract
+amendments came out of building it: (1) the completed outcome carries
+the v1 finish reason — v1 retags only on `done(reason:"completed")`
+exactly, and max_iterations/mistake_limit turns keep their plain text;
+(2) the assembler's text/reasoning sinks receive the close's final
+payload (the v1 final is producer-truth and can differ from the
+concatenated deltas); (3) the generator emits `accumulated` on text
+deltas, as the real adapter does. Two intended divergences are
+whitelisted in the differential with rationale: concurrent tool opens
+(v1 reuses one streamingToolTs — the partial rows collide in the
+message store; the bridge gives each tool block its own identity), and
+text/reasoning left open across an iteration boundary (v1's
+iteration_start reset() re-mints the streaming ts; the real adapter
+closes content within its iteration, so the shape is unmodeled in the
+tables — a framer note for the cleanup pass: force-close dangling
+text/reasoning at iteration notices, mirroring the reset, if the
+generator should model it). **Switchover checklist (each gated by its
+pinned v1 translator tests):** error-terminal rows
+(reshapeErrorForWebview + the api_req_failed pair); compaction
+dividers (parseCompactionNoticeMetadata/buildCompactionMessage are
+already exported for the bridge); tool-specific renderings —
+completion tools (say:"completion_result"), command tools
+(say:"command" + COMMAND_OUTPUT_STRING), MCP tools
+(use_mcp_server/mcp_server_response), read_files/apply_patch
+multi-file splits, ask_question suppression, spawn_agent aggregation
+(SubagentStatusRow consumer + onSubAgent), approval-coordinator
+interactions (approvedToolMessageTs upserts, denial suppression);
+then the flip — bridge output becomes the production ClineMessage
+source and the v1 switch deletes.
 
 **Phase 3d — history replay and reconnect.** Snapshot reconciliation
 in the assembler (diff against the live set), live-after-history dedup

--- a/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
+++ b/sdk/packages/core/src/runtime/orchestration/stream-assembler.ts
@@ -50,13 +50,15 @@ export interface StreamDiagnostic {
 export interface TextSink {
 	onDelta(text: string): void;
 	onAnnotation(annotation: unknown): void;
-	onClose(outcome: Outcome): void;
+	/** `final` is the close frame's authoritative text — it can differ
+	 * from the concatenated deltas (the v1 final is producer-truth). */
+	onClose(outcome: Outcome, final: { text: string }): void;
 }
 
 export interface ReasoningSink {
 	onDelta(reasoning: string): void;
 	onAnnotation(annotation: unknown): void;
-	onClose(outcome: Outcome): void;
+	onClose(outcome: Outcome, final: { reasoning: string }): void;
 }
 
 export interface ToolSink {
@@ -408,8 +410,18 @@ export class StreamAssembler {
 				frame.outcome,
 				frame.final ?? { type: "tool", input: block.start?.input },
 			);
+		} else if (block.kind === "text") {
+			const final =
+				frame.final !== undefined && frame.final.type === "text"
+					? frame.final
+					: { type: "text" as const, text: "" };
+			(block.sink as TextSink).onClose(frame.outcome, final);
 		} else {
-			(block.sink as TextSink).onClose(frame.outcome);
+			const final =
+				frame.final !== undefined && frame.final.type === "reasoning"
+					? frame.final
+					: { type: "reasoning" as const, reasoning: "" };
+			(block.sink as ReasoningSink).onClose(frame.outcome, final);
 		}
 	}
 
@@ -482,9 +494,17 @@ export class StreamAssembler {
 						{ kind: "interrupted" },
 						{ type: "tool", input: block.start?.input },
 					);
-			} else {
-					(block.sink as TextSink).onClose({ kind: "interrupted" });
-			}
+					} else if (block.kind === "text") {
+			(block.sink as TextSink).onClose(
+				{ kind: "interrupted" },
+				{ text: "" },
+			);
+					} else {
+			(block.sink as ReasoningSink).onClose(
+				{ kind: "interrupted" },
+				{ reasoning: "" },
+			);
+					}
 		}
 	}
 

--- a/sdk/packages/shared/src/agents/agent-event-framer.test.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.test.ts
@@ -332,7 +332,7 @@ describe("framer wart-fixes", () => {
 		if (close.kind !== "close") {
 			throw new Error("expected close");
 		}
-		expect(close.outcome).toEqual({ kind: "completed" });
+		expect(close.outcome).toEqual({ kind: "completed", finishReason: "max_iterations" });
 	});
 
 	it("epoch changes only via bumpEpoch; seq continues across turns", () => {

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -607,7 +607,7 @@ function finishReasonToOutcome(
 		case "completed":
 		case "max_iterations":
 		case "mistake_limit":
-			return { kind: "completed" };
+			return { kind: "completed", finishReason: reason };
 		case "aborted":
 			return { kind: "interrupted" };
 		case "error":

--- a/sdk/packages/shared/src/agents/stream-frames.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.ts
@@ -54,7 +54,12 @@ export interface ResourceRef {
 }
 
 export type Outcome =
-	| { kind: "completed" }
+	/**
+	 * The v1 finish reason rides along on completed turns: `max_iterations`
+	 * and `mistake_limit` also complete the turn, but consumers that vary
+	 * behavior on the exact reason (the completion retag) must see it.
+	 */
+	| { kind: "completed"; finishReason?: "completed" | "max_iterations" | "mistake_limit" }
 	| { kind: "error"; error: StreamError }
 	| { kind: "interrupted" }
 	| { kind: "detached"; resource: ResourceRef };

--- a/sdk/packages/shared/src/agents/v1-trace-generator.ts
+++ b/sdk/packages/shared/src/agents/v1-trace-generator.ts
@@ -50,6 +50,8 @@ export function generateLegalV1Trace(
 	let nextTool = 1;
 	const openTools: string[] = [];
 	let terminated = false;
+	/** Deltas of the currently-open text block, joined for `accumulated`. */
+	const textDeltas: string[] = [];
 
 	const iterationStart = (): void => {
 		iterationOpen = lastEndedIteration + 1;
@@ -74,17 +76,23 @@ export function generateLegalV1Trace(
 			// Deltas are the most common real events — weight them.
 			moves.push(
 				(): void => {
+					const delta = rng.pick(TEXTS);
+					textDeltas.push(delta);
 					out.push({
 						type: "content_start",
 						contentType: "text",
-						text: rng.pick(TEXTS),
+						text: delta,
+						accumulated: textDeltas.join(""),
 					});
 				},
 				(): void => {
+					const delta = rng.pick(TEXTS);
+					textDeltas.push(delta);
 					out.push({
 						type: "content_start",
 						contentType: "text",
-						text: rng.pick(TEXTS),
+						text: delta,
+						accumulated: textDeltas.join(""),
 					});
 				},
 				(): void => {
@@ -96,6 +104,7 @@ export function generateLegalV1Trace(
 					});
 				},
 				(): void => {
+					textDeltas.length = 0;
 					out.push({
 						type: "content_end",
 						contentType: "text",


### PR DESCRIPTION
## Summary

The agent-event stream design (sdk/packages/core/docs/agent-event-stream-design.md) replaces per-surface hand-rolled event parsers with one grammar, one frame stream, and shared sinks. This PR adds the VSCode ClineMessage sinks — the first tranche of the translator port, parity-locked against the v1 translator.

FrameMessageBridge (apps/vscode/src/sdk/frame-message-bridge.ts) implements the assembler consumer API and produces the same ClineMessages as message-translator.ts for the core agent-event surface: streaming text/reasoning rows (accumulated partials, authoritatively-final closes), generic tool rows (partial at open, final with the open's input at close, error rows), usage api_req_started rows, iteration markers, notices, and turn terminals with the completion retag. SdkFrameStream's consumer is now the bridge; the v1 translator remains the production ClineMessage source, so the bridge runs shadow-only (rows drained and discarded) until the switchover PR. Zero webview behavior change.

Parity is machine-checked (frame-message-bridge.differential.test.ts): generated traces plus handcrafted edges run through both the v1 translator and frame→assemble→bridge, and the produced ClineMessage arrays — including ts, since both paths mint from identically-seeded counters — must be equal.

Contract amendments that fell out of building it:

- Completed outcomes carry the v1 finish reason: v1 retags the turn's final text only on done(reason:"completed") exactly, so max_iterations/mistake_limit turns keep their plain text.
- The assembler's text/reasoning sinks now receive the close frame's final payload — the v1 final is producer-truth and can differ from the concatenated deltas.
- The trace generator emits `accumulated` on text deltas, as the real adapter does (both v1 and the bridge read it).

Two intended divergences are whitelisted in the differential with rationale: concurrently-open tools keep per-block row identity instead of v1's shared (colliding) streamingToolTs, and text left open across an iteration boundary is unmodeled in the v1 tables (the real adapter closes content within its iteration). Both are documented in the design doc's switchover checklist, which also enumerates the not-yet-ported surfaces (error-terminal rows, compaction dividers, tool-specific renderings, approval interactions) each gated by its pinned v1 translator tests.

Stacked on #13801 (stack #13794).

## Test plan

- [x] `cd sdk/packages/shared && bunx vitest run --config vitest.config.ts src/agents` — 32/32
- [x] `cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime` — 357/357
- [x] `cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/frame-renderer.differential.test.ts src/utils/events.test.ts src/acp` — 44/44 (assembler change is CLI-neutral)
- [x] `cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk` — 1109/1109, including the new 15-test differential parity suite
- [x] `cd apps/vscode && bunx tsc --noEmit` — 5 errors, all pre-existing proto/config drift, identical to the base branch
- [x] `bun run build:sdk` — all 6 packages build
