### PR TITLE
Port tool renderings, compaction, and error terminals into the frame bridge

### DIFF
--- a/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
@@ -53,11 +53,9 @@ describe("FrameMessageBridge differential parity", () => {
 		const traces: AgentEvent[][] = []
 		for (let seed = 1; traces.length < 100; seed += 1) {
 			const events = generateLegalV1Trace(seed, { maxEvents: 40 })
-			// Terminal non-recoverable errors emit the not-yet-ported
-			// api_req_failed pair in v1 — excluded surface.
-			if (events.some((e) => e.type === "error" && e.recoverable !== true)) {
-				continue
-			}
+			// Terminal non-recoverable errors are now a ported surface — the
+			// framer preserves plain-object and Error message shapes, so the
+			// api_req_failed pair renders identically on both paths.
 			// Concurrently open tools: v1 reuses one streamingToolTs across
 			// them (their partial rows collide in the message store); the
 			// bridge gives each tool block its own identity — intended
@@ -271,6 +269,297 @@ describe("FrameMessageBridge differential parity (edges)", () => {
 			{ type: "iteration_start", iteration: 1 },
 			{ type: "content_end", contentType: "text", text: "   " },
 			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+})
+
+describe("FrameMessageBridge differential parity (tool renderings)", () => {
+	it("attempt_completion renders the green box and suppresses the retag", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "preamble" },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "attempt_completion",
+				input: { result: "All done." },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "attempt_completion" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("submit_and_exit uses the summary field", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "submit_and_exit",
+				input: { summary: "Resolved." },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "submit_and_exit" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("command tools render the running marker and completed output", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "run_commands",
+				input: { commands: ["ls -la"] },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "run_commands", output: "total 0" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("command tools render the error output", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "execute_command",
+				input: { commands: "make" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "execute_command", error: "exit 2" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("MCP tools render use_mcp_server plus the response row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "myserver__get_data",
+				input: { query: "x" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "myserver__get_data", output: "data!" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("MCP tool errors render the response row with the error", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "myserver__get_data",
+				input: { query: "x" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "myserver__get_data", error: "timeout" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("read_files multi-file split carries paths and line ranges", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "read_files",
+				input: {
+					files: [{ path: "/src/a.ts", start_line: 3, end_line: 9 }, { path: "/src/b.ts" }, { path: "/src/c.ts" }],
+				},
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "read_files" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("read_files single file falls through to the generic row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "read_files",
+				input: { files: [{ path: "/src/a.ts" }] },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "read_files", output: "contents" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("apply_patch multi-file split renders one row per file", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Update File: /a.ts",
+			"@@",
+			"-x",
+			"+y",
+			"*** Update File: /b.ts",
+			"@@",
+			"-1",
+			"+2",
+			"*** End Patch",
+		].join("\n")
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "apply_patch",
+				input: { patch },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "apply_patch", output: "ok" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("apply_patch error falls through to the generic error rows", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "apply_patch",
+				input: { patch: "*** Begin Patch\n*** Update File: /a.ts\n@@\n-x\n+y\n*** End Patch" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "apply_patch", error: "conflict" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("ask_question is suppressed at open and close", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolCallId: "c1",
+				toolName: "ask_question",
+				input: { question: "Continue?" },
+			},
+			{ type: "content_end", contentType: "tool", toolCallId: "c1", toolName: "ask_question" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+})
+
+describe("FrameMessageBridge differential parity (compaction and errors)", () => {
+	const compactionNotice = (phase: string, extra: Record<string, unknown> = {}) => ({
+		type: "notice" as const,
+		noticeType: "status" as const,
+		message: "auto-compacting",
+		metadata: { kind: "auto_compaction", phase, ...extra },
+	})
+
+	it("compaction started then completed updates the divider in place", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			compactionNotice("started"),
+			compactionNotice("completed", { tokensBefore: 100, tokensAfter: 50, messagesBefore: 10, messagesAfter: 4 }),
+			{ type: "content_end", contentType: "text", text: "done" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("compaction skipped finalizes the divider", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			compactionNotice("started"),
+			compactionNotice("skipped"),
+			{ type: "content_end", contentType: "text", text: "done" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("a dangling compaction divider finalizes as cancelled at done", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			compactionNotice("started"),
+			{ type: "content_end", contentType: "text", text: "partial" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("a dangling compaction divider finalizes as failed at a terminal error", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			compactionNotice("started"),
+			{ type: "error", error: { message: "provider down" } as unknown as Error, iteration: 1, recoverable: false },
+		])
+	})
+
+	it("a dangling compaction divider finalizes as cancelled at done(reason:error)", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			compactionNotice("started"),
+			{ type: "done", text: "", reason: "error", iterations: 1 },
+		])
+	})
+
+	it("terminal error renders the api_req_failed pair (plain-object error)", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "error",
+				error: { message: "API rate limit exceeded" } as unknown as Error,
+				iteration: 1,
+				recoverable: false,
+			},
+		])
+	})
+
+	it("terminal error renders the pair for Error instances", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "error", error: new Error("fatal"), iteration: 1, recoverable: false },
+		])
+	})
+
+	it("terminal error reshapes insufficient-credits JSON for the ErrorRow UI", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "error",
+				error: {
+					message: JSON.stringify({ error: { code: "insufficient_credits", message: "Out of credits" } }),
+				} as unknown as Error,
+				iteration: 1,
+				recoverable: false,
+			},
+		])
+	})
+
+	it("terminal error reshapes with provider, model, and error class context", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{
+				type: "error",
+				error: { message: "boom" } as unknown as Error,
+				errorClass: "auth",
+				iteration: 1,
+				recoverable: false,
+			},
+		])
+	})
+
+	it("done(reason:error) emits no rows", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "partial answer" },
+			{ type: "done", text: "", reason: "error", iterations: 1 },
 		])
 	})
 })

--- a/apps/vscode/src/sdk/frame-message-bridge.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.ts
@@ -3,12 +3,14 @@
  * (`sdk/packages/core/docs/agent-event-stream-design.md`).
  *
  * Implements the assembler's consumer API so the frame path produces the
- * same ClineMessages as the v1 translator (`message-translator.ts`) for
- * the core agent-event surface: streaming text/reasoning rows, generic
- * tool rows, usage, iteration markers, notices, and turn terminals
- * (including the completion retag). Parity with v1 is differential-test
- * locked (frame-message-bridge.differential.test.ts): both paths mint
- * message ids at identical points, so the produced rows must be equal.
+ * same ClineMessages as the v1 translator (`message-translator.ts`):
+ * streaming text/reasoning rows, tool rows (generic, completion, command,
+ * MCP, read_files/apply_patch multi-file splits, ask_question
+ * suppression), usage, iteration markers, notices including compaction
+ * dividers, and turn terminals (completion retag, terminal error rows
+ * with ErrorRow reshaping). Parity with v1 is differential-test locked
+ * (frame-message-bridge.differential.test.ts): both paths mint message
+ * ids at identical points, so the produced rows must be equal.
  *
  * Ordering rules are the assembler's, not this file's: sinks receive
  * updates only between their open and close, children close before the
@@ -16,24 +18,35 @@
  * dangling block simply never got its content_end (W3).
  *
  * Not yet ported (the switchover checklist in the design doc, each gated
- * by its pinned v1 translator tests): error-terminal rows
- * (reshapeErrorForWebview + api_req_failed), compaction dividers, and the
- * tool-specific renderings (completion, command, MCP, read_files /
- * apply_patch splits, ask_question suppression, spawn_agent aggregation,
- * approval-coordinator interactions). Until the switchover PR, v1 remains
- * the production ClineMessage source and this bridge runs shadow-only —
- * its output is drained and discarded by SdkFrameStream.
+ * by its pinned v1 translator tests): spawn_agent aggregation (renders
+ * generically until its dedicated port) and approval-coordinator
+ * interactions (approved-row upserts, denial suppression — annotation
+ * wiring at the flip). Until the switchover PR, v1 remains the production
+ * ClineMessage source and this bridge runs shadow-only — its output is
+ * drained and discarded by SdkFrameStream.
  */
 
 import type { SessionConsumer, StreamDiagnostic, TurnConsumer } from "@cline/core/frames"
 import type { CloseFinal, NoticeBody, Outcome, UsageBody } from "@cline/shared"
-import type { ClineApiReqInfo, ClineMessage } from "@shared/ExtensionMessage"
+import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
+import type { ClineApiReqInfo, ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import {
+	buildCompactionMessage,
+	buildMcpToolPayload,
+	extractCommandText,
+	extractFileReads,
+	extractToolOutputText,
+	getApplyPatchString,
+	getCompletionResultText,
 	isCompletionTool,
 	normalizeUsageEvent,
 	parseCompactionNoticeMetadata,
+	parseMcpToolName,
+	readLineRangeFields,
+	reshapeErrorForWebview,
 	sdkToolToClineSayTool,
+	splitApplyPatchByFile,
 	toDisplaySayTool,
 } from "./message-translator"
 
@@ -54,6 +67,9 @@ export interface FrameMessageBridgeDeps {
 	getUiMode?: () => "plan" | "act" | "yolo" | undefined
 	/** Working directory for tool-path relativization. */
 	getCwd?: () => string | undefined
+	/** Active provider/model ids for error reshaping (ErrorRow UI). */
+	getActiveProviderId?: () => string | undefined
+	getActiveModelId?: () => string | undefined
 }
 
 /**
@@ -119,10 +135,13 @@ export class FrameMessageBridge implements SessionConsumer {
 	}
 }
 
-/** Per-turn state: the completion-retag candidate, v1's turn-scoped rule. */
+/** Per-turn state: the completion-retag candidate and the open compaction
+ * divider — both turn-scoped by v1's emission rules (the divider is
+ * finalized at this turn's terminal, never carried across turns). */
 class BridgeTurnConsumer implements TurnConsumer {
 	private turnFinalText: { ts: number; text: string } | undefined
 	private attemptCompletionSeen = false
+	private openCompactionTs: number | undefined
 
 	constructor(private readonly bridge: FrameMessageBridge) {}
 
@@ -181,19 +200,135 @@ class BridgeTurnConsumer implements TurnConsumer {
 		// Tool activity after a text block means that text wasn't the
 		// turn-final response — drop the retag candidate (v1 rule).
 		this.turnFinalText = undefined
-		if (isCompletionTool(start.toolName)) {
-			this.attemptCompletionSeen = true
+		const toolName = start.toolName
+		const bridge = this.bridge
+		const cwd = bridge.deps.getCwd?.()
+
+		// ask_question (and ask_followup_question) is serviced by the
+		// interaction coordinator, which emits the proper ask:"followup"
+		// row; a generic tool row here would orphan (v1 suppresses it too).
+		// No mint, no row — at open or close.
+		if (toolName === "ask_question" || toolName === "ask_followup_question") {
+			return { onProgress() {}, onAnnotation() {}, onClose() {} }
 		}
-		const ts = this.bridge.deps.nextTs()
-		const cwd = this.bridge.deps.getCwd?.()
-		this.bridge.push({
+
+		if (isCompletionTool(toolName)) {
+			// The completion tool drives the green box: partial here, the
+			// non-partial finalize at close. attemptCompletionSeen makes the
+			// turn end in the "completed" phase rather than awaiting_followup.
+			this.attemptCompletionSeen = true
+			const ts = bridge.deps.nextTs()
+			bridge.push({
+				ts,
+				type: "say",
+				say: "completion_result",
+				text: getCompletionResultText(start.input),
+				partial: true,
+			})
+			return {
+				onProgress() {},
+				onAnnotation() {},
+				onClose(outcome: Outcome, final: CloseFinal): void {
+					if (outcome.kind === "interrupted" || final.type !== "tool") {
+						return
+					}
+					bridge.push({
+						ts,
+						type: "say",
+						say: "completion_result",
+						text: getCompletionResultText(final.input ?? start.input),
+						partial: false,
+					})
+				},
+			}
+		}
+
+		// Command tools render as say:"command" with the output marker while
+		// running (ChatRow shows "executing" until the marker resolves).
+		if (toolName === "run_commands" || toolName === "execute_command") {
+			const ts = bridge.deps.nextTs()
+			bridge.push({
+				ts,
+				type: "say",
+				say: "command",
+				text: `${extractCommandText(start.input)}\n${COMMAND_OUTPUT_STRING}`,
+				partial: true,
+			})
+			return {
+				onProgress() {},
+				onAnnotation() {},
+				onClose(outcome: Outcome, final: CloseFinal): void {
+					if (outcome.kind === "interrupted" || final.type !== "tool") {
+						return
+					}
+					const input = final.input ?? start.input
+					const commandText = extractCommandText(input)
+					const outputStr =
+						outcome.kind === "error" ? `Error: ${outcome.error.message}` : extractToolOutputText(final.output)
+					bridge.push({
+						ts,
+						type: "say",
+						say: "command",
+						text: outputStr ? `${commandText}\n${COMMAND_OUTPUT_STRING}\n${outputStr}` : commandText,
+						partial: false,
+						commandCompleted: true,
+					})
+				},
+			}
+		}
+
+		// MCP tools (serverName__toolName) render via use_mcp_server with
+		// ClineAskUseMcpServer JSON, plus a response row at close.
+		const mcpInfo = parseMcpToolName(toolName)
+		if (mcpInfo) {
+			const ts = bridge.deps.nextTs()
+			bridge.push({
+				ts,
+				type: "say",
+				say: "use_mcp_server",
+				text: buildMcpToolPayload(mcpInfo, start.input),
+				partial: true,
+			})
+			return {
+				onProgress() {},
+				onAnnotation() {},
+				onClose(outcome: Outcome, final: CloseFinal): void {
+					if (outcome.kind === "interrupted" || final.type !== "tool") {
+						return
+					}
+					const input = final.input ?? start.input
+					bridge.push({
+						ts,
+						type: "say",
+						say: "use_mcp_server",
+						text: buildMcpToolPayload(mcpInfo, input),
+						partial: false,
+					})
+					const outputStr =
+						outcome.kind === "error" ? `Error: ${outcome.error.message}` : extractToolOutputText(final.output)
+					if (outputStr) {
+						bridge.push({
+							ts: bridge.deps.nextTs(),
+							type: "say",
+							say: "mcp_server_response",
+							text: outputStr,
+							partial: false,
+						})
+					}
+				},
+			}
+		}
+
+		// Generic tool row (spawn_agent renders generically until its
+		// dedicated aggregation port — see the design doc checklist).
+		const ts = bridge.deps.nextTs()
+		bridge.push({
 			ts,
 			type: "say",
 			say: "tool",
-			text: JSON.stringify(toDisplaySayTool(sdkToolToClineSayTool(start.toolName, start.input), cwd)),
+			text: JSON.stringify(toDisplaySayTool(sdkToolToClineSayTool(toolName, start.input), cwd)),
 			partial: true,
 		})
-		const bridge = this.bridge
 		return {
 			onProgress(): void {
 				// v1 ignores content_update for generic tools; the partial
@@ -209,7 +344,52 @@ class BridgeTurnConsumer implements TurnConsumer {
 					return
 				}
 				const input = final.input ?? start.input
-				const sayTool = toDisplaySayTool(sdkToolToClineSayTool(start.toolName, input), cwd)
+
+				// read_files may read multiple files in one call: one tool
+				// row per file so the group summary reflects the reads.
+				if (toolName === "read_files" || toolName === "read_file") {
+					const fileReads = extractFileReads(input as Record<string, unknown> | undefined)
+					if (fileReads.length > 1) {
+						fileReads.forEach((fileRead, index) => {
+							const sayTool: ClineSayTool = {
+								tool: "readFile",
+								path: fileRead.path,
+								...readLineRangeFields(fileRead),
+							}
+							bridge.push({
+								ts: index === 0 ? ts : bridge.deps.nextTs(),
+								type: "say",
+								say: "tool",
+								text: JSON.stringify(toDisplaySayTool(sayTool, cwd)),
+								partial: false,
+							})
+						})
+						return
+					}
+				}
+
+				// apply_patch may edit multiple files in one call: one row
+				// per file so each diff row shows only that file's changes
+				// (cline#9904). Errored patches fall through to the generic
+				// error path below.
+				if (toolName === "apply_patch" && outcome.kind !== "error") {
+					const patch = getApplyPatchString(input)
+					const perFileTools = patch ? splitApplyPatchByFile(patch) : []
+					if (perFileTools.length > 1) {
+						perFileTools.forEach((sayTool, index) => {
+							bridge.push({
+								ts: index === 0 ? ts : bridge.deps.nextTs(),
+								type: "say",
+								say: "tool",
+								text: JSON.stringify(toDisplaySayTool(sayTool, cwd)),
+								partial: false,
+							})
+						})
+						return
+					}
+				}
+
+				const sayTool = toDisplaySayTool(sdkToolToClineSayTool(toolName, input), cwd)
 				bridge.push({ ts, type: "say", say: "tool", text: JSON.stringify(sayTool), partial: false })
 				if (outcome.kind === "error") {
 					bridge.push({
@@ -262,9 +442,18 @@ class BridgeTurnConsumer implements TurnConsumer {
 			case "status": {
 				const compaction = parseCompactionNoticeMetadata(notice.metadata)
 				if (compaction) {
-					// Compaction dividers are not yet ported (switchover
-					// checklist); log so the gap is visible in shadow runs.
-					Logger.warn(`[FrameMessageBridge] Compaction notice not yet ported (phase: ${compaction.status})`)
+					// Compaction dividers update in place: "started" mints the
+					// row's ts, the terminal notice reuses it. A divider still
+					// open at the turn's terminal is finalized there (see
+					// onClose) — v1's rule, kept turn-scoped here.
+					const ts =
+						compaction.status === "started"
+							? (this.openCompactionTs = this.bridge.deps.nextTs())
+							: (this.openCompactionTs ?? this.bridge.deps.nextTs())
+					if (compaction.status !== "started") {
+						this.openCompactionTs = undefined
+					}
+					this.bridge.push(buildCompactionMessage(compaction, ts))
 					return
 				}
 				if (INTERNAL_STATUS_NOTICES.has(notice.message ?? "")) {
@@ -305,6 +494,55 @@ class BridgeTurnConsumer implements TurnConsumer {
 	}
 
 	onClose(outcome: Outcome): void {
+		// A compaction divider still open here means the turn was aborted or
+		// errored mid-compaction: finalize it first so the divider row lands
+		// before the retag/error rows (v1 order). "failed" only for a
+		// terminal error event; done(reason:"error") and every other
+		// terminal finalizes as "cancelled" (v1's done branch does this
+		// unconditionally; its error branch is the only "failed").
+		const openCompactionTs = this.openCompactionTs
+		this.openCompactionTs = undefined
+		if (openCompactionTs !== undefined) {
+			const status = outcome.kind === "error" && outcome.via === "error" ? "failed" : "cancelled"
+			this.bridge.push(buildCompactionMessage({ status, mode: "auto" }, openCompactionTs))
+		}
+
+		if (outcome.kind === "error") {
+			// v1 retags neither errored turn: an errored turn didn't end on
+			// its text response.
+			this.turnFinalText = undefined
+			if (outcome.via === "error") {
+				// Serialize the error for the webview's ErrorRow (special
+				// types: insufficient credits, spend limit, auth, quota) and
+				// emit the recovery pair — the api_req_started replaces the
+				// spinner on the last request row, the ask renders Retry.
+				const errorPayload = reshapeErrorForWebview(
+					{ message: outcome.error.message },
+					this.bridge.deps.getActiveProviderId?.(),
+					this.bridge.deps.getActiveModelId?.(),
+					outcome.error.providerErrorClass,
+				)
+				this.bridge.push({
+					ts: this.bridge.deps.nextTs(),
+					type: "say",
+					say: "api_req_started",
+					text: JSON.stringify({ streamingFailedMessage: errorPayload } satisfies ClineApiReqInfo),
+					partial: false,
+				})
+				this.bridge.push({
+					ts: this.bridge.deps.nextTs(),
+					type: "ask",
+					ask: "api_req_failed",
+					text: errorPayload,
+					partial: false,
+				})
+			}
+			// via "done": done(reason:"error") records the error outcome
+			// (turn phase) but emits no rows — the coordinator reads the
+			// outcome at switchover.
+			return
+		}
+
 		// v1 retags only on done(reason:"completed") exactly —
 		// max_iterations/mistake_limit turns keep their plain text.
 		const completedExactly = outcome.kind === "completed" && (outcome.finishReason ?? "completed") === "completed"
@@ -323,11 +561,6 @@ class BridgeTurnConsumer implements TurnConsumer {
 				})
 			}
 			return
-		}
-		if (outcome.kind === "error") {
-			// Terminal error rows (api_req_failed pair) are not yet ported —
-			// the switchover checklist; logged so the gap is visible.
-			Logger.warn(`[FrameMessageBridge] Terminal error outcome rows not yet ported: ${outcome.error.message}`)
 		}
 		this.turnFinalText = undefined
 	}

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -865,7 +865,7 @@ export function isCompletionTool(toolName: string): boolean {
  * Extract the completion summary text from a completion-tool input. `attempt_completion` carries
  * it in `result`; `submit_and_exit` carries it in `summary`. Either renders the same completion UI.
  */
-function getCompletionResultText(input: unknown): string {
+export function getCompletionResultText(input: unknown): string {
 	const parsed = parseToolInput(input)
 	return getStringField(parsed, "summary") ?? getStringField(parsed, "result") ?? ""
 }
@@ -878,7 +878,7 @@ interface FileReadRequest {
 }
 
 /** Extract file read requests (path + optional one-based inclusive line range) from a read_files/read_file input */
-function extractFileReads(input: Record<string, unknown> | undefined): FileReadRequest[] {
+export function extractFileReads(input: Record<string, unknown> | undefined): FileReadRequest[] {
 	if (!input) return []
 	const files = input.files
 	if (Array.isArray(files) && files.length > 0) {
@@ -912,7 +912,7 @@ function extractFileReads(input: Record<string, unknown> | undefined): FileReadR
  * explicit end_line means the read began at line 1; an omitted end_line stays undefined
  * (open-ended read — the UI renders it as "start+").
  */
-function readLineRangeFields(read: FileReadRequest | undefined): Pick<ClineSayTool, "readLineStart" | "readLineEnd"> {
+export function readLineRangeFields(read: FileReadRequest | undefined): Pick<ClineSayTool, "readLineStart" | "readLineEnd"> {
 	if (!read || (read.startLine == null && read.endLine == null)) {
 		return {}
 	}
@@ -935,7 +935,7 @@ function getNumberField(input: Record<string, unknown> | undefined, field: strin
 	return undefined
 }
 
-function getApplyPatchString(input: unknown): string | undefined {
+export function getApplyPatchString(input: unknown): string | undefined {
 	const parsed = parseToolInput(input)
 	const fromFields = getStringField(parsed, "patch") ?? getStringField(parsed, "diff") ?? getStringField(parsed, "input")
 	if (fromFields !== undefined) {
@@ -951,7 +951,7 @@ function getApplyPatchString(input: unknown): string | undefined {
  * Returns [] for single-file (or unparseable) patches so callers keep the existing
  * single-message behavior — only genuinely multi-file patches are split.
  */
-function splitApplyPatchByFile(patch: string): ClineSayTool[] {
+export function splitApplyPatchByFile(patch: string): ClineSayTool[] {
 	const lines = patch.split("\n")
 	const blocks: { tool: ClineSayTool["tool"]; path: string; lines: string[] }[] = []
 	let current: { tool: ClineSayTool["tool"]; path: string; lines: string[] } | undefined
@@ -1080,7 +1080,7 @@ export function extractToolOutputText(output: unknown): string {
  *
  * Returns undefined if the tool name doesn't match the MCP naming convention.
  */
-function parseMcpToolName(toolName: string): { serverName: string; toolName: string } | undefined {
+export function parseMcpToolName(toolName: string): { serverName: string; toolName: string } | undefined {
 	const separatorIndex = toolName.indexOf("__")
 	if (separatorIndex <= 0) return undefined
 	const serverName = toolName.substring(0, separatorIndex)
@@ -1094,7 +1094,7 @@ function parseMcpToolName(toolName: string): { serverName: string; toolName: str
  * This is what the webview's ChatRow expects when rendering MCP tool calls
  * (message.ask === "use_mcp_server" or message.say === "use_mcp_server").
  */
-function buildMcpToolPayload(mcpInfo: { serverName: string; toolName: string }, input?: unknown): string {
+export function buildMcpToolPayload(mcpInfo: { serverName: string; toolName: string }, input?: unknown): string {
 	const parsedInput = parseToolInput(input)
 	// Format arguments as a JSON string (matching classic ClineAskUseMcpServer.arguments)
 	let argumentsStr: string | undefined
@@ -1112,7 +1112,7 @@ function buildMcpToolPayload(mcpInfo: { serverName: string; toolName: string }, 
 	} satisfies ClineAskUseMcpServer)
 }
 
-function extractCommandText(input: unknown): string {
+export function extractCommandText(input: unknown): string {
 	if (Array.isArray(input)) {
 		return input.map(formatStructuredCommand).join(" && ")
 	}

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -616,19 +616,34 @@ iteration_start reset() re-mints the streaming ts; the real adapter
 closes content within its iteration, so the shape is unmodeled in the
 tables — a framer note for the cleanup pass: force-close dangling
 text/reasoning at iteration notices, mirroring the reset, if the
-generator should model it). **Switchover checklist (each gated by its
-pinned v1 translator tests):** error-terminal rows
-(reshapeErrorForWebview + the api_req_failed pair); compaction
-dividers (parseCompactionNoticeMetadata/buildCompactionMessage are
-already exported for the bridge); tool-specific renderings —
-completion tools (say:"completion_result"), command tools
-(say:"command" + COMMAND_OUTPUT_STRING), MCP tools
-(use_mcp_server/mcp_server_response), read_files/apply_patch
-multi-file splits, ask_question suppression, spawn_agent aggregation
-(SubagentStatusRow consumer + onSubAgent), approval-coordinator
-interactions (approvedToolMessageTs upserts, denial suppression);
-then the flip — bridge output becomes the production ClineMessage
-source and the v1 switch deletes.
+generator should model it).
+
+**Phase 3c part 2b status: implemented (second tranche — tool
+renderings, compaction, error terminals).** The bridge now ports the
+remaining pure-translation surfaces: tool-specific renderings
+(completion tools, command tools with the COMMAND_OUTPUT_STRING
+marker, MCP use_mcp_server/mcp_server_response, read_files/apply_patch
+multi-file splits with per-file rows and line ranges, ask_question
+suppression), compaction dividers (in-place ts from the started
+notice, finalized at the turn terminal — "failed" only for a terminal
+error event, "cancelled" otherwise), and terminal error rows
+(reshapeErrorForWebview + the api_req_started/ask:api_req_failed pair).
+Two further contract amendments came out of it: (4) the error outcome
+carries `via: "error" | "done"` — v1 treats terminal error events and
+done(reason:"error") differently (divider failed/cancelled, error rows
+or none), and the framer stamps which; (5) the framer preserves the
+message of plain-object errors (`{ message }` is type-legal v1 input —
+the pinned translator tests use it), not `String(error)`'s
+"[object Object]". With those, the generated-trace exclusion for
+terminal errors was lifted — the differential now covers error
+terminals in the random traces too. **Remaining checklist:** spawn_agent
+aggregation (SubagentStatusRow consumer; the bridge renders it
+generically until then), approval-coordinator interactions
+(approvedToolMessageTs upserts, denial suppression — annotation wiring
+at the flip), StreamError carrying Error instances' `code`/`status`
+properties (real provider errors may set them; the reshape reads them —
+a `details` follow-up), then the flip — bridge output becomes the
+production ClineMessage source and the v1 switch deletes.
 
 **Phase 3d — history replay and reconnect.** Snapshot reconciliation
 in the assembler (diff against the live set), live-after-history dedup

--- a/sdk/packages/shared/src/agents/agent-event-framer.test.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.test.ts
@@ -310,6 +310,7 @@ describe("framer wart-fixes", () => {
 		expect(turnClose.outcome).toEqual({
 			kind: "error",
 			error: { code: "run_failed", message: "ok" },
+			via: "done",
 		});
 	});
 

--- a/sdk/packages/shared/src/agents/agent-event-framer.ts
+++ b/sdk/packages/shared/src/agents/agent-event-framer.ts
@@ -415,6 +415,7 @@ export class AgentEventFramer {
 				this.closeTurn(out, {
 					kind: "error",
 					error: toStreamError(event.error, event.errorClass),
+					via: "error",
 				});
 				break;
 			}
@@ -572,24 +573,36 @@ export class AgentEventFramer {
  */
 function toStreamError(
 	error: unknown,
-	providerErrorClass?: string,
+	providerErrorClass?: import("../agent").ProviderErrorClass,
 ): StreamError {
+	const message = toStreamErrorMessage(error);
 	if (error instanceof Error) {
 		return {
 			code: error.name || "Error",
-			message: error.message,
+			message,
 			...(providerErrorClass !== undefined ? { providerErrorClass } : {}),
 		};
 	}
 	return {
 		code: "Error",
-		message: String(error),
+		message,
 		...(providerErrorClass !== undefined ? { providerErrorClass } : {}),
 	};
 }
 
 function toStreamErrorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	if (error instanceof Error) {
+		return error.message;
+	}
+	// Plain-object errors ({ message }) are type-legal v1 input (the pinned
+	// translator tests use them); keep the message, not "[object Object]".
+	if (typeof error === "object" && error !== null && "message" in error) {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === "string") {
+			return message;
+		}
+	}
+	return String(error);
 }
 
 /**
@@ -617,6 +630,7 @@ function finishReasonToOutcome(
 					code: "run_failed",
 					message: event.text || "Run failed",
 				},
+				via: "done",
 			};
 		default: {
 			const _exhaustive: never = reason;

--- a/sdk/packages/shared/src/agents/stream-frames.ts
+++ b/sdk/packages/shared/src/agents/stream-frames.ts
@@ -14,6 +14,8 @@
  */
 export const FRAME_SCHEMA_VERSION = 2;
 
+import type { ProviderErrorClass } from "../agent";
+
 // =============================================================================
 // Scope address
 // =============================================================================
@@ -40,7 +42,7 @@ export interface StreamError {
 	code: string;
 	message: string;
 	/** Provider error classification when known (AgentErrorEvent.errorClass). */
-	providerErrorClass?: string;
+	providerErrorClass?: ProviderErrorClass;
 	/** Structured provider details when available (e.g. a JSON error body). */
 	details?: unknown;
 }
@@ -60,7 +62,12 @@ export type Outcome =
 	 * behavior on the exact reason (the completion retag) must see it.
 	 */
 	| { kind: "completed"; finishReason?: "completed" | "max_iterations" | "mistake_limit" }
-	| { kind: "error"; error: StreamError }
+	| { kind: "error"; error: StreamError; /** Distinguishes the terminal
+	 * `error` event (`"error"`) from `done(reason:"error")` (`"done"`):
+	 * v1 finalizes a dangling compaction divider as "failed" for the
+	 * former and "cancelled" for the latter, and only the former emits
+	 * the api_req_failed pair. Always set on turn closes; tool closes
+	 * carry no terminal distinction. */ via?: "error" | "done" }
 	| { kind: "interrupted" }
 	| { kind: "detached"; resource: ResourceRef };
 


### PR DESCRIPTION
## Summary

The agent-event stream design's VSCode translator port continues (stack #13794, on top of #13804). This tranche ports every remaining pure-translation surface of the v1 translator into FrameMessageBridge, still shadow-only — v1 remains the production ClineMessage source, zero webview behavior change.

Ported surfaces, each parity-locked by new handcrafted differential cases and the existing pinned translator tests:

- **Tool-specific renderings**: completion tools (partial + finalized say:completion_result), command tools (say:command with the COMMAND_OUTPUT_STRING running marker, commandCompleted final with output or error), MCP tools (use_mcp_server + mcp_server_response), read_files and apply_patch multi-file splits (one row per file, line ranges carried, first row reusing the tool ts), ask_question suppression (no mint, no row — the interaction coordinator owns it).
- **Compaction dividers**: in-place ts from the started notice, finalized at the turn terminal — "failed" only for a terminal error event, "cancelled" for every other terminal including done(reason:"error"), matching v1's branch semantics exactly.
- **Terminal error rows**: reshapeErrorForWebview + the api_req_started(streamingFailedMessage)/ask:api_req_failed pair, with provider/model/error-class context.

Two contract amendments the port forced:

- The frame Outcome error now carries `via: "error" | "done"` — v1 treats terminal error events and done(reason:"error") differently (compaction divider failed vs cancelled, error rows vs none), and the framer stamps which. The CLI is unaffected (it renders both as error by design).
- The framer preserves the message of plain-object errors (`{ message }` is de-facto v1 input — the pinned translator tests use it) instead of String(error)'s "[object Object]"; StreamError.providerErrorClass is typed as the real ProviderErrorClass union again.

With those, the generated-trace exclusion for terminal errors was lifted — the 100-seed differential now covers error terminals in the random traces too, and everything passes byte-identically (36 differential tests total).

Remaining before the production flip (design doc checklist): spawn_agent aggregation (renders generically until its dedicated port), approval-coordinator annotation wiring, and StreamError carrying code/status from real Error instances.

Stacked on #13804 (stack #13794).

## Test plan

- [x] `cd sdk/packages/shared && bunx vitest run --config vitest.config.ts src/agents` — 32/32
- [x] `cd sdk/packages/core && bunx vitest run --config vitest.config.ts src/runtime` — 357/357
- [x] `cd apps/cli && bunx vitest run --config vitest.config.ts src/utils/frame-renderer.differential.test.ts src/utils/events.test.ts src/acp` — 44/44
- [x] `cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk` — 1130/1130, including the 36-test differential parity suite
- [x] `cd apps/vscode && bunx tsc --noEmit` — 5 errors, all pre-existing, identical to the base branch
- [x] `bun run build:sdk` — all 6 packages build
