### PR TITLE
fix(core): return all ripgrep matches per file

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/search.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.test.ts
@@ -13,6 +13,29 @@ const ctx: AgentToolContext = {
 };
 
 describe("createSearchExecutor", () => {
+	it("returns multiple ripgrep matches from the same file", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-search-"));
+		await fs.writeFile(
+			path.join(dir, "matches.ts"),
+			[
+				"const needleOne = 1;",
+				"const needleTwo = 2;",
+				"const needleThree = 3;",
+			].join("\n"),
+			"utf-8",
+		);
+
+		try {
+			const search = createSearchExecutor({ contextLines: 0 });
+			const result = await search("needle", dir, ctx);
+
+			expect(result).toContain("Found 3 results for pattern: needle");
+			expect(result.match(/matches\.ts:/g)).toHaveLength(3);
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("middle-truncates oversized search output with recovery guidance", async () => {
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agents-search-"));
 		const filePath = path.join(dir, "large.ts");

--- a/sdk/packages/core/src/extensions/tools/executors/search.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/search.ts
@@ -177,7 +177,7 @@ function searchWithRipgrep(
 	return new Promise((resolve) => {
 		const child = spawn(
 			"rg",
-			["--json", `--context=${contextLines}`, "--max-count=1", "-i", query],
+			["--json", `--context=${contextLines}`, "-i", query],
 			{
 				cwd,
 				stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
### Related Issue

**Issue:** #13771

Fixes #13771

### Description

`search_files` prefers ripgrep when it is available, but its ripgrep invocation included `--max-count=1`. That flag stopped each file after its first matching line, so searches silently returned incomplete results while the manual fallback returned every match.

This change:

- removes the per-file `--max-count=1` restriction from the ripgrep command
- keeps the existing global `maxResults` limit and output-size cap unchanged
- adds a regression test with three matching lines in a single file

The ripgrep and fallback paths now both return multiple matches from the same file while remaining bounded by the executor-level limits.

### Test Procedure

All checks were run inside the repository development container with ripgrep available, ensuring the regression test exercised the ripgrep path:

- `bun run build:sdk`
- `bun biome check --diagnostic-level=error sdk/packages/core/src/extensions/tools/executors/search.ts sdk/packages/core/src/extensions/tools/executors/search.test.ts`
- `bun -F @cline/core typecheck`
- `bun -F @cline/core test:unit -- src/extensions/tools/executors/search.test.ts` — 3 passed
- `bun -F @cline/core test:unit` — 2,187 passed, 14 skipped, 0 failed

The regression test creates one file containing three matching lines and verifies that all three result entries are returned. Existing Core coverage verifies that output truncation and maximum-result limits continue to work.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and the changed code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is an SDK search executor fix with no UI changes.

### Additional Notes

The existing global `maxResults` check still stops result parsing at the configured limit, and `MAX_RG_STDOUT_CHARS` plus `capSearchOutput` continue to bound buffered and returned output.