### PR TITLE
chore(cerebras): replace Gemma 4 with Qwen 3.8

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -20593,39 +20593,6 @@ export const GENERATED_PROVIDER_MODELS: {
       "releaseDate": "2026-08-14",
       "family": "qwen"
     },
-    "gemma-4-31b": {
-      "id": "gemma-4-31b",
-      "name": "Gemma 4 31B IT",
-      "contextWindow": 131072,
-      "maxInputTokens": 131072,
-      "maxTokens": 40960,
-      "capabilities": [
-        "images",
-        "tools",
-        "reasoning",
-        "structured_output",
-        "temperature"
-      ],
-      "reasoningOptions": [
-        {
-          "type": "effort",
-          "values": [
-            "none",
-            "low",
-            "medium",
-            "high"
-          ]
-        }
-      ],
-      "pricing": {
-        "input": 0.99,
-        "output": 1.49,
-        "cacheRead": 0,
-        "cacheWrite": 0
-      },
-      "releaseDate": "2026-04-02",
-      "family": "gemma"
-    },
     "gpt-oss-120b": {
       "id": "gpt-oss-120b",
       "name": "GPT OSS 120B",

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -20560,6 +20560,39 @@ export const GENERATED_PROVIDER_MODELS: {
     }
   },
   "cerebras": {
+    "qwen-3.8-27b": {
+      "id": "qwen-3.8-27b",
+      "name": "Qwen3.8 27B",
+      "contextWindow": 65536,
+      "maxInputTokens": 65536,
+      "maxTokens": 32768,
+      "capabilities": [
+        "images",
+        "tools",
+        "reasoning",
+        "structured_output",
+        "temperature"
+      ],
+      "reasoningOptions": [
+        {
+          "type": "effort",
+          "values": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ]
+        }
+      ],
+      "pricing": {
+        "input": 0.99,
+        "output": 1.49,
+        "cacheRead": 0,
+        "cacheWrite": 0
+      },
+      "releaseDate": "2026-08-14",
+      "family": "qwen"
+    },
     "gemma-4-31b": {
       "id": "gemma-4-31b",
       "name": "Gemma 4 31B IT",

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -796,7 +796,7 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "Cerebras",
 		description: "Fast inference on Cerebras wafer-scale chips",
 		family: "openai-compatible",
-		defaultModelId: "zai-glm-4.7",
+		defaultModelId: "qwen-3.8-27b",
 		apiKeyEnv: ["CEREBRAS_API_KEY"],
 		defaults: { baseUrl: "https://api.cerebras.ai/v1" },
 	},

--- a/sdk/packages/llms/src/providers/providers.generated.ts
+++ b/sdk/packages/llms/src/providers/providers.generated.ts
@@ -445,7 +445,7 @@ export const GENERATED_PROVIDER_SPECS: readonly BuiltinSpec[] = [
 		family: "openai-compatible",
 		capabilities: ["tools", "reasoning"],
 		modelsProviderId: "cerebras",
-		defaultModelId: "gemma-4-31b",
+		defaultModelId: "qwen-3.8-27b",
 		apiKeyEnv: ["CEREBRAS_API_KEY"],
 		docsUrl: "https://inference-docs.cerebras.ai/models/overview",
 	},


### PR DESCRIPTION
### Related Issue

**Issue:** N/A - catalog maintenance for a newly available Cerebras model

### Description

Replaces Gemma 4 31B with qwen-3.8-27b in the checked-in Cerebras catalog used as the offline fallback. Qwen becomes the Cerebras default in both the generated provider spec and the built-in override. The normalized models.dev entry has a 65,536-token context, 32,768-token output, image/tool/structured-output support, $0.99/$1.49 pricing, and none/low/medium/high reasoning controls.

### Test Procedure

- built @cline/shared and @cline/llms sequentially
- ran @cline/llms typecheck
- ran catalog-live.test.ts and builtins.test.ts: 48 tests passed
- normalized the local models.dev API payload through catalog-live.ts and compared the resulting Qwen entry field by field

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (bun test) and code is formatted and linted (bun run format && bun run lint)
-   [ ] I have reviewed contributor guidelines

### Screenshots

Not applicable; catalog-only change.