### PR TITLE
fix(cli): make TUI toasts wrap instead of clipping after the first line

### DIFF
--- a/apps/cli/src/tui/components/toast.tsx
+++ b/apps/cli/src/tui/components/toast.tsx
@@ -23,6 +23,9 @@ export function Toast(props: { toast: ToastState | null }) {
 	};
 	const availableWidth = Math.max(1, width - 4);
 	const maxWidth = Math.min(44, availableWidth);
+	// Border and horizontal padding take four columns. An explicit width (not
+	// maxWidth) is what makes the text wrap instead of clipping at the edge.
+	const boxWidth = Math.min(maxWidth, props.toast.message.length + 4);
 	const right = width < 32 ? 0 : 2;
 	const color = variantColor[props.toast.variant];
 
@@ -32,7 +35,7 @@ export function Toast(props: { toast: ToastState | null }) {
 			zIndex={100}
 			top={1}
 			right={right}
-			maxWidth={maxWidth}
+			width={boxWidth}
 			border
 			borderStyle="rounded"
 			borderColor={color}


### PR DESCRIPTION
### Related Issue

Follow-up to #13727 (outdated-hub drain and replace flow) and #13754 (keep-Hub reminder toast on Esc). Same rendering limitation that #13249 ran into.

### Description

The `Toast` box only set `maxWidth`, so any message longer than the 44-column cap was clipped to its first line instead of wrapping. Every toast in the Hub update flow is longer than that. In particular, the keep-Hub reminder that #13754 made appear after Esc rendered as `The running Cline Hub stays on the` and never reached the `Run 'cline hub upgrade'` instruction it exists to deliver. The build-mismatch advisory, the still-busy retry hint, and the `upgradeManagedHub` error messages have the same problem.

Give the box an explicit `width` (message length plus border and padding, capped at the existing 44 / terminal-width limit) so the text has a real edge to wrap at. Short toasts keep their compact size; the cap and right-anchored position are unchanged.

### Test Procedure

Reproduced the real flow end to end against an actual older release rather than a synthetic mismatch:

1. Installed `cline@3.0.60` (core 0.0.81) into a temp dir and ran its TUI in an isolated `CLINE_DATA_DIR`, sent one message so its Hub had a session with a live participant.
2. Launched the CLI from this branch (core 0.0.82) in the same data dir with `CLINE_HUB_BUILD_WATCH_INTERVAL_MS=3000`. The `Cline Hub update required` dialog appeared with `1 active session from 1 connected Cline client`.
3. Esc: before this change the toast was cut off after `stays on the`; after, it wraps onto three lines.
4. Enter on a fresh launch: `Updating the Cline Hub…` then `Cline Hub updated.`, the 0.0.81 daemon pid was gone, discovery record showed the 0.0.82 Hub, and the 3.0.60 TUI got its own "Cline Hub was updated" prompt.

Also ran `bunx biome check` and `tsc --noEmit` for `apps/cli`, and the existing `managed-hub-build-watcher`, `hub/daemon`, and `hub-update-required` unit suites (all green).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (Esc on the outdated-hub dialog):

![Truncated keep-Hub toast before the fix](https://cursor.com/artifacts/c/art-bfb93571-f64b-424b-8070-50d949070669)

After:

![Wrapped keep-Hub toast after the fix](https://cursor.com/artifacts/c/art-f4b370a4-d0cc-44f3-84f1-c1d182fe663c)

Short toasts stay compact (Enter path):

![Cline Hub updated toast](https://cursor.com/artifacts/c/art-7adaf995-8ed6-446e-b597-7e1c656af99f)

### Additional Notes

The dialog itself from #13727 works as designed; this only fixes the toasts around it.