### PR TITLE
feat(desktop): attribute lifecycle telemetry across the shared Hub

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -61,8 +61,9 @@ Emission ownership:
 
 - `user.extension_activated`: emitted **once per host process** by host-specific helpers
   (`captureCliExtensionActivated` for the CLI, `captureExtensionActivated` for VS Code).
-- `workspace.initialized` / `workspace.init_error`: emitted by a per-process de-duplicated
-  emitter in `prepareLocalRuntimeBootstrap`. Hosts must NOT re-emit these.
+- `workspace.initialized` / `workspace.init_error`: emitted by a de-duplicated emitter in
+  `prepareLocalRuntimeBootstrap`. A dedicated host emits once per workspace; a shared Hub emits
+  once per client surface and workspace. Hosts must NOT re-emit these.
 - `workspace.path_resolved`: emitted from default tool executors **only when**
   `WorkspaceManager` exposes more than one root.
 - `task.*`: emitted by core session lifecycle code in `sdk/packages/core/src/cline-core/` and
@@ -103,6 +104,19 @@ hub-backed session, so the daemon must own its own `ITelemetryService`. It build
 `createHubDaemonTelemetry()` (`sdk/packages/core/src/hub/daemon/telemetry.ts`), which
 identifies from the cached cline account (re-resolved periodically, since the daemon often
 starts before login) and flushes on every shutdown path, including startup failure.
+
+The Hub transport forwards the serializable `ExtensionContext.client` and
+`ExtensionContext.user` values with session create/restore requests. The daemon wraps its
+process-owned service with `createClientScopedTelemetryService()` so lifecycle events use the
+originating client's `cline_type`, platform/version, and current account/organization without
+mutating the singleton shared by concurrent clients. Keep canonical task fields named
+`provider` and `model`; do not reintroduce host-specific aliases such as `apiProvider` or
+`modelId` for `task.created`, `task.restarted`, or `task.completed`.
+
+`UserContext.distinctId` may be an anonymous machine ID. Set `UserContext.accountId` to the
+authenticated account ID (or `null` for an explicitly signed-out client) whenever a client
+forwards user context; this prevents machine IDs and stale daemon identity from becoming
+`user_id` / `organization_id` on task events.
 
 Flag changes that remove this wiring, construct runtime hosts inside the daemon without
 passing its telemetry handle, or add daemon exit paths that skip the flush — hub-backed

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -11,6 +11,8 @@ import {
 	getValidClineCredentials,
 	type ProviderSettings,
 	ProviderSettingsManager,
+	persistClineAccountTelemetryIdentity,
+	resolveClineAccountTelemetryIdentity,
 	saveLocalProviderOAuthCredentials,
 	type UserCurrentPlan,
 } from "@cline/core";
@@ -158,38 +160,6 @@ export async function createClineAccountService(input: {
 	});
 }
 
-/**
- * Persist the active organization so headless runs and the hub daemon can
- * attach it to telemetry identity. Personal account clears stale org fields.
- */
-function persistClineOrganizationContext(
-	activeOrganization: ClineAccountOrganization | null,
-	userId: string,
-): void {
-	try {
-		const manager = new ProviderSettingsManager();
-		const persisted = manager.getProviderSettings("cline");
-		if (!persisted) {
-			return;
-		}
-		manager.saveProviderSettings(
-			{
-				...persisted,
-				auth: {
-					...persisted.auth,
-					accountId: persisted.auth?.accountId ?? userId,
-					organizationId: activeOrganization?.organizationId,
-					organizationName: activeOrganization?.name,
-					memberId: activeOrganization?.memberId,
-				},
-			},
-			{ setLastUsed: false },
-		);
-	} catch {
-		// Best-effort only.
-	}
-}
-
 export async function loadClineAccountSnapshot(input: {
 	config: ClineAccountConfig;
 	clineApiBaseUrl?: string;
@@ -213,16 +183,12 @@ export async function loadClineAccountSnapshot(input: {
 	const displayedBalance = activeOrganization
 		? (organizationBalance?.balance ?? balance.balance)
 		: balance.balance;
-	const accountContext = {
-		id: user.id,
-		email: user.email,
-		provider: "cline",
-		organizationId: activeOrganization?.organizationId,
-		organizationName: activeOrganization?.name,
-		memberId: activeOrganization?.memberId,
-	};
+	const accountContext = resolveClineAccountTelemetryIdentity(user);
 	identifyTelemetryAccount(accountContext, input.config.logger);
-	persistClineOrganizationContext(activeOrganization, user.id);
+	persistClineAccountTelemetryIdentity(
+		new ProviderSettingsManager(),
+		accountContext,
+	);
 
 	return {
 		user,

--- a/apps/examples/desktop-app/sidecar/ARCHITECTURE.md
+++ b/apps/examples/desktop-app/sidecar/ARCHITECTURE.md
@@ -16,6 +16,7 @@ sidecar/
 ├── index.ts              # Entry point: starts HTTP+WS server
 ├── server.ts             # Bun HTTP server + WebSocket handlers
 ├── context.ts            # SidecarContext type and factory
+├── client-context.ts     # Desktop client/account identity for shared telemetry
 ├── commands.ts           # Command router
 ├── chat-session.ts       # Shared-Hub chat session adapter
 ├── session-data/         # Shared discovery, messages, artifacts, search helpers
@@ -80,6 +81,15 @@ sessionManager.subscribe((event) => {
 The compiled sidecar also recognizes Core's Hub-daemon launch mode. This lets
 the desktop start the same detached Hub when no CLI process has started it yet.
 Startup discovery and locking ensure concurrent clients converge on one Hub.
+
+Every create, restart, fork, and restore also attaches the serializable Desktop
+`ExtensionContext.client` and current `ExtensionContext.user`. Core forwards
+that context across the Hub transport and scopes the daemon-owned telemetry
+service to the originating surface. This keeps lifecycle events centralized in
+Core while reporting Desktop dimensions (`cline_type: "desktop"`, `platform:
+"Cline Desktop"`, and the Desktop app version) and the current account and
+organization. The shared Hub telemetry singleton is never mutated per session,
+so concurrent CLI and Desktop tasks retain their own attribution.
 
 ### 2. Tool Approval — Client-Owned Promise Resolution
 

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -195,25 +195,49 @@ describe("hasProviderChanged", () => {
 
 describe("pathless session starts", () => {
 	it("omits workspace paths and returns the SDK-resolved chat workspace", async () => {
-		const start = vi.fn(async (input: { config: Record<string, unknown> }) => {
-			expect(input.config).not.toHaveProperty("cwd");
-			expect(input.config).not.toHaveProperty("workspaceRoot");
-			expect(input.config).not.toHaveProperty("enableSpawnAgent");
-			expect(input.config).not.toHaveProperty("enableAgentTeams");
-			return {
-				sessionId: "session-pathless",
-				manifest: {
-					cwd: "/home/host/.cline/data/workspaces/chat",
-					workspace_root: "/home/host/.cline/data/workspaces/chat",
-				},
-				manifestPath: "/tmp/session-pathless.json",
-				messagesPath: "/tmp/session-pathless.messages.json",
-			};
-		});
+		const start = vi.fn(
+			async (input: {
+				config: Record<string, unknown>;
+				localRuntime?: {
+					extensionContext?: {
+						client?: Record<string, unknown>;
+						user?: Record<string, unknown>;
+					};
+				};
+			}) => {
+				expect(input.config).not.toHaveProperty("cwd");
+				expect(input.config).not.toHaveProperty("workspaceRoot");
+				expect(input.config).not.toHaveProperty("enableSpawnAgent");
+				expect(input.config).not.toHaveProperty("enableAgentTeams");
+				expect(input.localRuntime?.extensionContext?.client).toMatchObject({
+					name: "cline-desktop",
+					platform: "Cline Desktop",
+				});
+				expect(input.localRuntime?.extensionContext?.user).toEqual({
+					distinctId: "account-1",
+					accountId: "account-1",
+					organizationId: "org-1",
+				});
+				return {
+					sessionId: "session-pathless",
+					manifest: {
+						cwd: "/home/host/.cline/data/workspaces/chat",
+						workspace_root: "/home/host/.cline/data/workspaces/chat",
+					},
+					manifestPath: "/tmp/session-pathless.json",
+					messagesPath: "/tmp/session-pathless.messages.json",
+				};
+			},
+		);
 		const ctx = {
 			liveSessions: new Map(),
 			restoringWorkspacePaths: new Set(),
 			sessionManager: { start },
+			telemetryUser: {
+				distinctId: "account-1",
+				accountId: "account-1",
+				organizationId: "org-1",
+			},
 		} as unknown as SidecarContext;
 
 		const result = (await handleChatSessionCommand(ctx, {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -29,6 +29,7 @@ import {
 	materializeUserFiles,
 	trackQueuedAttachments,
 } from "./attachments";
+import { createDesktopExtensionContext } from "./client-context";
 import { emitChunk, nowMs, sendEvent } from "./context";
 import { readSessionManifest, sharedSessionDataDir } from "./paths";
 import { persistSessionMessages } from "./session-data/messages";
@@ -401,7 +402,10 @@ function readPositiveInteger(value: unknown): number | undefined {
 	return undefined;
 }
 
-function buildCoreSessionConfig(config: JsonRecord): JsonRecord {
+function buildCoreSessionConfig(
+	config: JsonRecord,
+	telemetryUser?: SidecarContext["telemetryUser"],
+): JsonRecord {
 	const rawWorkspaceRoot = config.workspaceRoot ?? config.workspace_root;
 	const workspaceRoot =
 		typeof rawWorkspaceRoot === "string" ? rawWorkspaceRoot.trim() : "";
@@ -444,6 +448,7 @@ function buildCoreSessionConfig(config: JsonRecord): JsonRecord {
 		checkpoint: { enabled: true },
 		sessions: config.sessions,
 		initialMessages: config.initialMessages,
+		extensionContext: createDesktopExtensionContext(telemetryUser),
 	};
 }
 
@@ -675,7 +680,7 @@ async function handleStart(
 				? (readPersistedChatMessages(requestedSessionId) ?? undefined)
 				: undefined;
 	const coreConfig: JsonRecord = {
-		...buildCoreSessionConfig(request.config),
+		...buildCoreSessionConfig(request.config, ctx.telemetryUser),
 		systemPrompt,
 		...(initialMessages ? { initialMessages } : {}),
 	};
@@ -794,6 +799,7 @@ async function handleAttach(
 
 async function startRebuiltSession(
 	manager: ClineCore,
+	telemetryUser: SidecarContext["telemetryUser"],
 	sessionId: string,
 	config: JsonRecord,
 	systemPrompt: string,
@@ -805,11 +811,14 @@ async function startRebuiltSession(
 		: undefined;
 	const restarted = await manager.start({
 		...splitCoreSessionConfig(
-			buildCoreSessionConfig({
-				...config,
-				sessionId,
-				systemPrompt,
-			}) as unknown as ClineCoreStartConfig,
+			buildCoreSessionConfig(
+				{
+					...config,
+					sessionId,
+					systemPrompt,
+				},
+				telemetryUser,
+			) as unknown as ClineCoreStartConfig,
 		),
 		source: SessionSource.DESKTOP,
 		interactive: true,
@@ -859,6 +868,7 @@ async function rebuildSessionForProviderChange(
 	try {
 		await startRebuiltSession(
 			manager,
+			ctx.telemetryUser,
 			sessionId,
 			nextConfig,
 			nextSystemPrompt,
@@ -880,6 +890,7 @@ async function rebuildSessionForProviderChange(
 			}
 			await startRebuiltSession(
 				manager,
+				ctx.telemetryUser,
 				sessionId,
 				previousConfig,
 				previousSystemPrompt,
@@ -1291,10 +1302,13 @@ async function handleForkUnlocked(
 	const systemPrompt = await resolveSystemPrompt(forkConfig);
 	const startInput = {
 		...splitCoreSessionConfig(
-			buildCoreSessionConfig({
-				...forkConfig,
-				systemPrompt,
-			}) as unknown as ClineCoreStartConfig,
+			buildCoreSessionConfig(
+				{
+					...forkConfig,
+					systemPrompt,
+				},
+				ctx.telemetryUser,
+			) as unknown as ClineCoreStartConfig,
 		),
 		source: SessionSource.DESKTOP,
 		interactive: true,
@@ -1423,10 +1437,13 @@ async function handleRestoreCheckpoint(
 			restore: { messages: true, workspace: true },
 			start: {
 				...splitCoreSessionConfig(
-					buildCoreSessionConfig({
-						...config,
-						systemPrompt: await resolveSystemPrompt(config),
-					}) as unknown as ClineCoreStartConfig,
+					buildCoreSessionConfig(
+						{
+							...config,
+							systemPrompt: await resolveSystemPrompt(config),
+						},
+						ctx.telemetryUser,
+					) as unknown as ClineCoreStartConfig,
 				),
 				source: SessionSource.DESKTOP,
 				interactive: true,

--- a/apps/examples/desktop-app/sidecar/client-context.ts
+++ b/apps/examples/desktop-app/sidecar/client-context.ts
@@ -1,0 +1,56 @@
+import * as os from "node:os";
+import { resolveCoreDistinctId } from "@cline/core";
+import type {
+	ClientContext,
+	ExtensionContext,
+	TelemetryMetadata,
+	UserContext,
+} from "@cline/shared";
+import { version } from "../package.json";
+
+/** Shared identity for request headers, Hub attribution, and telemetry. */
+export const DESKTOP_CLIENT_CONTEXT = {
+	name: "cline-desktop",
+	version,
+	platform: "Cline Desktop",
+	platformVersion: version,
+	isMultiRoot: false,
+} as const satisfies ClientContext;
+
+export const DESKTOP_TELEMETRY_METADATA = {
+	extension_version: version,
+	cline_type: "desktop",
+	platform: DESKTOP_CLIENT_CONTEXT.platform,
+	platform_version: DESKTOP_CLIENT_CONTEXT.platformVersion,
+	os_type: os.platform(),
+	os_version: os.version(),
+} satisfies TelemetryMetadata;
+
+export function resolveDesktopTelemetryUser(input?: {
+	accountId?: string;
+	email?: string;
+	organizationId?: string;
+}): UserContext {
+	const accountId = input?.accountId?.trim();
+	return accountId
+		? {
+				distinctId: accountId,
+				accountId,
+				email: input?.email,
+				organizationId: input?.organizationId,
+			}
+		: {
+				distinctId: resolveCoreDistinctId(),
+				accountId: null,
+			};
+}
+
+/** Serializable context attached to every Desktop session sent to the Hub. */
+export function createDesktopExtensionContext(
+	user?: UserContext,
+): ExtensionContext {
+	return {
+		client: DESKTOP_CLIENT_CONTEXT,
+		...(user ? { user: { ...user } } : {}),
+	};
+}

--- a/apps/examples/desktop-app/sidecar/commands-account.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-account.test.ts
@@ -6,6 +6,7 @@ const clineAccountServiceCtorMock = vi.hoisted(() => vi.fn());
 const executeClineAccountActionMock = vi.hoisted(() => vi.fn());
 const getProviderSettingsMock = vi.hoisted(() => vi.fn());
 const saveProviderSettingsMock = vi.hoisted(() => vi.fn());
+const persistProviderSettingsMock = vi.hoisted(() => vi.fn());
 const resolveProviderApiKeyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@cline/core", async () => {
@@ -21,6 +22,7 @@ vi.mock("@cline/core", async () => {
 		executeClineAccountAction: executeClineAccountActionMock,
 		ProviderSettingsManager: class {
 			getProviderSettings = getProviderSettingsMock;
+			saveProviderSettings = persistProviderSettingsMock;
 		},
 		saveLocalProviderSettings: saveProviderSettingsMock,
 		RuntimeOAuthTokenManager: class {
@@ -31,11 +33,13 @@ vi.mock("@cline/core", async () => {
 
 function createContext() {
 	const capture = vi.fn();
+	const setDistinctId = vi.fn();
+	const updateCommonProperties = vi.fn();
 	const ctx = {
-		telemetry: { capture },
+		telemetry: { capture, setDistinctId, updateCommonProperties },
 		logger: { debug: vi.fn(), log: vi.fn(), error: vi.fn() },
 	} as unknown as SidecarContext;
-	return { ctx, capture };
+	return { ctx, capture, setDistinctId, updateCommonProperties };
 }
 
 const FETCH_ME_ARGS = {
@@ -53,6 +57,7 @@ beforeEach(() => {
 	executeClineAccountActionMock.mockReset();
 	getProviderSettingsMock.mockReset();
 	saveProviderSettingsMock.mockReset();
+	persistProviderSettingsMock.mockReset();
 	resolveProviderApiKeyMock.mockReset();
 });
 
@@ -171,7 +176,7 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 	});
 
 	it("adopts the account identity on login", async () => {
-		const { ctx } = createContext();
+		const { ctx, setDistinctId, updateCommonProperties } = createContext();
 		resolveProviderApiKeyMock.mockResolvedValue({ apiKey: "token" });
 		getProviderSettingsMock.mockReturnValue({});
 		executeClineAccountActionMock.mockResolvedValue({
@@ -182,6 +187,62 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 		await runOperation(ctx, "fetchMe");
 
 		expect(await currentFlagsUserId()).toBe("acct-1");
+		expect(setDistinctId).toHaveBeenCalledWith("acct-1");
+		expect(updateCommonProperties).toHaveBeenCalledWith(
+			expect.objectContaining({ user_id: "acct-1", account_id: "acct-1" }),
+		);
+		expect(ctx.telemetryUser).toEqual({
+			distinctId: "acct-1",
+			accountId: "acct-1",
+			email: "dev@example.com",
+			organizationId: undefined,
+		});
+	});
+
+	it("applies and persists the active organization for task telemetry", async () => {
+		const { ctx, updateCommonProperties } = createContext();
+		resolveProviderApiKeyMock.mockResolvedValue({ apiKey: "token" });
+		getProviderSettingsMock.mockReturnValue({
+			provider: "cline",
+			auth: { accountId: "acct-1", accessToken: "token" },
+		});
+		executeClineAccountActionMock.mockResolvedValue({
+			id: "acct-1",
+			email: "dev@example.com",
+			organizations: [
+				{
+					active: true,
+					memberId: "member-1",
+					name: "Acme",
+					organizationId: "org-1",
+					roles: ["member"],
+				},
+			],
+		});
+
+		await runOperation(ctx, "fetchMe");
+
+		expect(updateCommonProperties).toHaveBeenCalledWith(
+			expect.objectContaining({
+				user_id: "acct-1",
+				organization_id: "org-1",
+			}),
+		);
+		expect(persistProviderSettingsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				auth: expect.objectContaining({
+					organizationId: "org-1",
+					memberId: "member-1",
+				}),
+			}),
+			{ setLastUsed: false },
+		);
+		expect(ctx.telemetryUser).toEqual({
+			distinctId: "acct-1",
+			accountId: "acct-1",
+			email: "dev@example.com",
+			organizationId: "org-1",
+		});
 	});
 
 	it("leaves the signed-in identity intact across an organization switch", async () => {
@@ -233,6 +294,12 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 		await runOperation(ctx, "fetchMe");
 
 		expect(await currentFlagsUserId()).toBeUndefined();
+		expect(ctx.telemetryUser).toEqual(
+			expect.objectContaining({
+				accountId: null,
+				distinctId: expect.any(String),
+			}),
+		);
 	});
 
 	it("clears the identity when sign-out blanks the cline auth settings", async () => {
@@ -259,6 +326,12 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 		});
 
 		expect(await currentFlagsUserId()).toBeUndefined();
+		expect(ctx.telemetryUser).toEqual(
+			expect.objectContaining({
+				accountId: null,
+				distinctId: expect.any(String),
+			}),
+		);
 	});
 
 	it("ignores settings writes for other providers", async () => {

--- a/apps/examples/desktop-app/sidecar/commands-account.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-account.test.ts
@@ -62,8 +62,9 @@ beforeEach(() => {
 });
 
 describe("cline_account command auth states", () => {
-	it("returns a typed not-authenticated result when signed out, without telemetry or a thrown error", async () => {
-		const { ctx, capture } = createContext();
+	it("returns a typed not-authenticated result and restores anonymous telemetry when signed out", async () => {
+		const { ctx, capture, setDistinctId, updateCommonProperties } =
+			createContext();
 		resolveProviderApiKeyMock.mockResolvedValue(null);
 		getProviderSettingsMock.mockReturnValue(undefined);
 
@@ -77,6 +78,14 @@ describe("cline_account command auth states", () => {
 		expect(executeClineAccountActionMock).not.toHaveBeenCalled();
 		expect(clineAccountServiceCtorMock).not.toHaveBeenCalled();
 		expect(capture).not.toHaveBeenCalled();
+		expect(setDistinctId).toHaveBeenCalledWith(expect.any(String));
+		expect(updateCommonProperties).toHaveBeenCalledWith(
+			expect.objectContaining({
+				user_id: undefined,
+				account_id: undefined,
+				organization_id: undefined,
+			}),
+		);
 	});
 
 	it("runs the account action unchanged when a fresh token resolves", async () => {
@@ -280,7 +289,7 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 	});
 
 	it("clears the account identity on logout", async () => {
-		const { ctx } = createContext();
+		const { ctx, setDistinctId, updateCommonProperties } = createContext();
 		resolveProviderApiKeyMock.mockResolvedValue({ apiKey: "token" });
 		getProviderSettingsMock.mockReturnValue({});
 		executeClineAccountActionMock.mockResolvedValue({ id: "acct-1" });
@@ -300,10 +309,22 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 				distinctId: expect.any(String),
 			}),
 		);
+		expect(setDistinctId).toHaveBeenLastCalledWith(
+			ctx.telemetryUser?.distinctId,
+		);
+		expect(ctx.telemetryUser?.distinctId).not.toBe("acct-1");
+		expect(updateCommonProperties).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				user_id: undefined,
+				account_id: undefined,
+				account_email: undefined,
+				organization_id: undefined,
+			}),
+		);
 	});
 
 	it("clears the identity when sign-out blanks the cline auth settings", async () => {
-		const { ctx } = createContext();
+		const { ctx, setDistinctId, updateCommonProperties } = createContext();
 		resolveProviderApiKeyMock.mockResolvedValue({ apiKey: "token" });
 		getProviderSettingsMock.mockReturnValue({});
 		executeClineAccountActionMock.mockResolvedValue({ id: "acct-1" });
@@ -330,6 +351,16 @@ describe("cline_account keeps feature-flag identity in sync", () => {
 			expect.objectContaining({
 				accountId: null,
 				distinctId: expect.any(String),
+			}),
+		);
+		expect(setDistinctId).toHaveBeenLastCalledWith(
+			ctx.telemetryUser?.distinctId,
+		);
+		expect(updateCommonProperties).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				user_id: undefined,
+				account_id: undefined,
+				organization_id: undefined,
 			}),
 		);
 	});

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -15,6 +15,7 @@ import type {
 import {
 	addLocalProvider,
 	ClineAccountService,
+	type ClineAccountUser,
 	captureAuthRefreshSoftFailure,
 	createConfiguredStreamingTranscriptionSession,
 	createUserInstructionConfigService,
@@ -23,14 +24,17 @@ import {
 	fetchClineRecommendedModels,
 	getCoreBuiltinToolCatalog,
 	getLocalProviderModels,
+	identifyAccount,
 	listHookConfigFiles,
 	listLocalProviders,
 	normalizeOAuthProvider,
 	ProviderSettingsManager,
 	parseMcpServerRegistration,
+	persistClineAccountTelemetryIdentity,
 	probeMcpServerConnection,
 	RuntimeOAuthTokenManager,
 	readGlobalSettings,
+	resolveClineAccountTelemetryIdentity,
 	resolveLocalClineAuthToken,
 	resolveMcpServerRegistration,
 	resolveSessionBackend,
@@ -66,6 +70,7 @@ import { readFileSyncStrippingUtf8Bom } from "@cline/shared/node";
 import packageJson from "../package.json";
 import { CLINE_ACCOUNT_NOT_AUTHENTICATED_RESULT } from "../webview/lib/cline-account-state";
 import { MAX_RECORDED_AUDIO_BYTES } from "../webview/lib/voice-input-limits";
+import { resolveDesktopTelemetryUser } from "./client-context";
 import {
 	listClineGitHubRepositories,
 	listClineIntegrations,
@@ -310,14 +315,23 @@ function removePathIfExists(
 // refreshes would invalidate each other.
 let clineOAuthTokenManager: RuntimeOAuthTokenManager | undefined;
 
-function syncFeatureFlagsAccountFromResult(
+function syncAccountContextFromResult(
 	ctx: SidecarContext,
+	manager: ProviderSettingsManager,
 	operation: string,
 	result: unknown,
 ): void {
 	if (operation === "fetchMe") {
-		const user = result as { id?: string; email?: string } | undefined;
+		const user = result as ClineAccountUser | undefined;
 		if (user?.id) {
+			const identity = resolveClineAccountTelemetryIdentity(user);
+			ctx.telemetryUser = resolveDesktopTelemetryUser({
+				accountId: identity.id,
+				email: identity.email,
+				organizationId: identity.organizationId,
+			});
+			identifyAccount(ctx.telemetry, identity);
+			persistClineAccountTelemetryIdentity(manager, identity);
 			void identifyDesktopFeatureFlagsAccount(
 				{ id: user.id, email: user.email },
 				{ logger: ctx.logger, telemetry: ctx.telemetry },
@@ -327,12 +341,26 @@ function syncFeatureFlagsAccountFromResult(
 	}
 }
 
-function syncFeatureFlagsAccountFromSettings(
+function syncAccountContextFromSettings(
 	ctx: SidecarContext,
 	manager: ProviderSettingsManager,
 ): void {
+	const auth = manager.getProviderSettings("cline")?.auth;
+	ctx.telemetryUser = resolveDesktopTelemetryUser({
+		accountId: auth?.accountId,
+		organizationId: auth?.organizationId,
+	});
+	if (auth?.accountId) {
+		identifyAccount(ctx.telemetry, {
+			id: auth.accountId,
+			provider: "cline",
+			organizationId: auth.organizationId,
+			organizationName: auth.organizationName,
+			memberId: auth.memberId,
+		});
+	}
 	void identifyDesktopFeatureFlagsAccount(
-		{ id: manager.getProviderSettings("cline")?.auth?.accountId },
+		{ id: auth?.accountId },
 		{ logger: ctx.logger, telemetry: ctx.telemetry },
 	);
 }
@@ -1835,6 +1863,7 @@ export async function handleCommand(
 				{},
 				{ logger: ctx.logger, telemetry: ctx.telemetry },
 			);
+			ctx.telemetryUser = resolveDesktopTelemetryUser();
 			return CLINE_ACCOUNT_NOT_AUTHENTICATED_RESULT;
 		}
 		const settings = manager.getProviderSettings("cline");
@@ -1847,7 +1876,7 @@ export async function handleCommand(
 			args as ClineAccountActionRequest,
 			accountService,
 		);
-		syncFeatureFlagsAccountFromResult(ctx, operation, result);
+		syncAccountContextFromResult(ctx, manager, operation, result);
 		return result;
 	}
 
@@ -2050,7 +2079,7 @@ export async function handleCommand(
 		// authoritative signal — it fires the moment credentials are cleared
 		// rather than waiting for the next account fetch.
 		if (saved.providerId === "cline" || saved.providerId === "cline-pass") {
-			syncFeatureFlagsAccountFromSettings(ctx, manager);
+			syncAccountContextFromSettings(ctx, manager);
 		}
 		return saved;
 	}

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -17,6 +17,7 @@ import {
 	ClineAccountService,
 	type ClineAccountUser,
 	captureAuthRefreshSoftFailure,
+	clearAccountTelemetryIdentity,
 	createConfiguredStreamingTranscriptionSession,
 	createUserInstructionConfigService,
 	ensureCustomProvidersLoaded,
@@ -346,21 +347,34 @@ function syncAccountContextFromSettings(
 	manager: ProviderSettingsManager,
 ): void {
 	const auth = manager.getProviderSettings("cline")?.auth;
-	ctx.telemetryUser = resolveDesktopTelemetryUser({
-		accountId: auth?.accountId,
-		organizationId: auth?.organizationId,
-	});
-	if (auth?.accountId) {
-		identifyAccount(ctx.telemetry, {
-			id: auth.accountId,
-			provider: "cline",
-			organizationId: auth.organizationId,
-			organizationName: auth.organizationName,
-			memberId: auth.memberId,
-		});
+	const accountId = auth?.accountId?.trim();
+	if (!auth || !accountId) {
+		syncSignedOutAccountContext(ctx);
+		return;
 	}
+	ctx.telemetryUser = resolveDesktopTelemetryUser({
+		accountId,
+		organizationId: auth.organizationId,
+	});
+	identifyAccount(ctx.telemetry, {
+		id: accountId,
+		provider: "cline",
+		organizationId: auth.organizationId,
+		organizationName: auth.organizationName,
+		memberId: auth.memberId,
+	});
 	void identifyDesktopFeatureFlagsAccount(
-		{ id: auth?.accountId },
+		{ id: accountId },
+		{ logger: ctx.logger, telemetry: ctx.telemetry },
+	);
+}
+
+function syncSignedOutAccountContext(ctx: SidecarContext): void {
+	const telemetryUser = resolveDesktopTelemetryUser();
+	ctx.telemetryUser = telemetryUser;
+	clearAccountTelemetryIdentity(ctx.telemetry, telemetryUser.distinctId);
+	void identifyDesktopFeatureFlagsAccount(
+		{},
 		{ logger: ctx.logger, telemetry: ctx.telemetry },
 	);
 }
@@ -1859,11 +1873,7 @@ export async function handleCommand(
 			// an expired or server-revoked token. Explicit sign-out is handled
 			// at its source in `save_provider_settings`; this catches the rest
 			// so a stale account never keeps serving its rollout cohort.
-			void identifyDesktopFeatureFlagsAccount(
-				{},
-				{ logger: ctx.logger, telemetry: ctx.telemetry },
-			);
-			ctx.telemetryUser = resolveDesktopTelemetryUser();
+			syncSignedOutAccountContext(ctx);
 			return CLINE_ACCOUNT_NOT_AUTHENTICATED_RESULT;
 		}
 		const settings = manager.getProviderSettings("cline");

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -570,6 +570,7 @@ export function createSidecarContext(
 	observability: {
 		logger?: BasicLogger;
 		telemetry?: ITelemetryService;
+		telemetryUser?: SidecarContext["telemetryUser"];
 	} = {},
 ): SidecarContext {
 	return {
@@ -584,6 +585,7 @@ export function createSidecarContext(
 		workspaceRoot,
 		logger: observability.logger,
 		telemetry: observability.telemetry,
+		telemetryUser: observability.telemetryUser,
 		unsubscribeSessionEvents: null,
 		hubBuildMismatch: null,
 	};

--- a/apps/examples/desktop-app/sidecar/observability.test.ts
+++ b/apps/examples/desktop-app/sidecar/observability.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { version } from "../package.json";
 
 const mocks = vi.hoisted(() => ({
 	captureExtensionActivated: vi.fn(),
@@ -28,7 +29,14 @@ vi.mock("@cline/core", async () => {
 		identifyAccount: mocks.identifyAccount,
 		ProviderSettingsManager: class {
 			getProviderSettings() {
-				return { auth: { accountId: "account-1" } };
+				return {
+					auth: {
+						accountId: "account-1",
+						organizationId: "org-1",
+						organizationName: "Acme",
+						memberId: "member-1",
+					},
+				};
 			}
 		},
 		setSdkLogger: mocks.setSdkLogger,
@@ -57,8 +65,10 @@ describe("desktop observability", () => {
 
 		expect(mocks.createClineTelemetryServiceConfig).toHaveBeenCalledWith({
 			metadata: expect.objectContaining({
+				extension_version: version,
 				cline_type: "desktop",
-				platform: "Cline",
+				platform: "Cline Desktop",
+				platform_version: version,
 			}),
 		});
 		expect(mocks.createConfiguredTelemetryHandle).toHaveBeenCalledWith(
@@ -67,9 +77,18 @@ describe("desktop observability", () => {
 		expect(mocks.identifyAccount).toHaveBeenCalledWith(telemetry, {
 			id: "account-1",
 			provider: "cline",
+			organizationId: "org-1",
+			organizationName: "Acme",
+			memberId: "member-1",
 		});
 		expect(mocks.captureExtensionActivated).toHaveBeenCalledWith(telemetry);
 		expect(mocks.setSdkLogger).toHaveBeenCalledWith(logger);
+		expect(observability.telemetryUser).toEqual({
+			distinctId: "account-1",
+			accountId: "account-1",
+			email: undefined,
+			organizationId: "org-1",
+		});
 
 		await observability.dispose();
 		await observability.dispose();

--- a/apps/examples/desktop-app/sidecar/observability.ts
+++ b/apps/examples/desktop-app/sidecar/observability.ts
@@ -1,4 +1,3 @@
-import * as os from "node:os";
 import {
 	captureExtensionActivated,
 	createClineTelemetryServiceConfig,
@@ -8,7 +7,11 @@ import {
 	ProviderSettingsManager,
 	setSdkLogger,
 } from "@cline/core";
-import { version } from "../package.json";
+import type { UserContext } from "@cline/shared";
+import {
+	DESKTOP_TELEMETRY_METADATA,
+	resolveDesktopTelemetryUser,
+} from "./client-context";
 import { setDesktopFeatureFlagsAccountContext } from "./feature-flags";
 import {
 	createDesktopLoggerAdapter,
@@ -18,6 +21,7 @@ import {
 export interface DesktopObservability {
 	readonly logger: DesktopLoggerAdapter["core"];
 	readonly telemetry: ITelemetryService;
+	readonly telemetryUser?: UserContext;
 	dispose(): Promise<void>;
 }
 
@@ -28,23 +32,23 @@ export function createDesktopObservability(): DesktopObservability {
 
 	const telemetryHandle = createConfiguredTelemetryHandle({
 		...createClineTelemetryServiceConfig({
-			metadata: {
-				extension_version: version,
-				cline_type: "desktop",
-				platform: "Cline",
-				platform_version: process.version,
-				os_type: os.platform(),
-				os_version: os.version(),
-			},
+			metadata: DESKTOP_TELEMETRY_METADATA,
 		}),
 		logger,
 	});
 	const telemetry = telemetryHandle.telemetry;
 	const auth = new ProviderSettingsManager().getProviderSettings("cline")?.auth;
+	const telemetryUser = resolveDesktopTelemetryUser({
+		accountId: auth?.accountId,
+		organizationId: auth?.organizationId,
+	});
 	if (auth?.accountId) {
 		identifyAccount(telemetry, {
 			id: auth.accountId,
 			provider: "cline",
+			organizationId: auth.organizationId,
+			organizationName: auth.organizationName,
+			memberId: auth.memberId,
 		});
 		setDesktopFeatureFlagsAccountContext({ id: auth.accountId });
 	}
@@ -54,6 +58,7 @@ export function createDesktopObservability(): DesktopObservability {
 	return {
 		logger,
 		telemetry,
+		telemetryUser,
 		async dispose() {
 			if (disposed) return;
 			disposed = true;

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -8,6 +8,7 @@ import type {
 	ToolApprovalResult,
 } from "@cline/core";
 import type { MessageWithMetadata } from "@cline/llms";
+import type { UserContext } from "@cline/shared";
 
 export type JsonRecord = Record<string, unknown>;
 
@@ -123,6 +124,8 @@ export type SidecarContext = {
 	workspaceRoot: string;
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
+	/** Analytics identity and explicit account state forwarded with each session. */
+	telemetryUser?: UserContext;
 	unsubscribeSessionEvents: (() => void) | null;
 	/**
 	 * Latest managed Hub build mismatch, broadcast as `hub_build_mismatch` and

--- a/sdk/packages/core/scripts/telemetry-smoke.ts
+++ b/sdk/packages/core/scripts/telemetry-smoke.ts
@@ -20,6 +20,7 @@ import {
 	captureTaskCompleted,
 	captureTaskCreated,
 	captureTaskRestarted,
+	captureTokenUsage,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
 	captureWorkspacePathResolved,
@@ -242,7 +243,8 @@ async function main() {
 		const t = new CapturingTelemetry();
 		captureTaskCreated(asITelemetryService(t), {
 			ulid: "ulid-smoke-task-1",
-			apiProvider: "anthropic",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
 		});
 		dumpEvents(t.events);
 		const created = t.events.filter((e) => e.name === "task.created");
@@ -257,7 +259,8 @@ async function main() {
 		const t = new CapturingTelemetry();
 		captureTaskRestarted(asITelemetryService(t), {
 			ulid: "ulid-smoke-task-1",
-			apiProvider: "anthropic",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
 		});
 		dumpEvents(t.events);
 		const restarted = t.events.filter((e) => e.name === "task.restarted");
@@ -314,6 +317,36 @@ async function main() {
 		);
 	}
 
+	header("task.tokens (per-request token and cost dimensions)");
+	{
+		const t = new CapturingTelemetry();
+		captureTokenUsage(asITelemetryService(t), {
+			ulid: "ulid-smoke-task-1",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			tokensIn: 125,
+			tokensOut: 50,
+			cacheReadTokens: 75,
+			cacheWriteTokens: 25,
+			totalCost: 0.0125,
+		});
+		dumpEvents(t.events);
+		const tokenEvents = t.events.filter(
+			(event) => event.name === "task.tokens",
+		);
+		assertSmoke("task.tokens count", tokenEvents.length, 1);
+		assertSmoke(
+			"task.tokens carries cacheReadTokens",
+			tokenEvents[0]?.properties?.cacheReadTokens === 75,
+			true,
+		);
+		assertSmoke(
+			"task.tokens carries totalCost",
+			tokenEvents[0]?.properties?.totalCost === 0.0125,
+			true,
+		);
+	}
+
 	header(
 		"task.completed source=submit_and_exit (assistant declared completion)",
 	);
@@ -322,7 +355,7 @@ async function main() {
 		captureTaskCompleted(asITelemetryService(t), {
 			ulid: "ulid-smoke-task-1",
 			provider: "anthropic",
-			modelId: "claude-sonnet-4-5",
+			model: "claude-sonnet-4-5",
 			mode: "act",
 			durationMs: 12_345,
 			source: "submit_and_exit",
@@ -351,7 +384,7 @@ async function main() {
 		captureTaskCompleted(asITelemetryService(t), {
 			ulid: "ulid-smoke-task-2",
 			provider: "anthropic",
-			modelId: "claude-sonnet-4-5",
+			model: "claude-sonnet-4-5",
 			mode: "act",
 			durationMs: 9_876,
 			source: "shutdown",
@@ -381,7 +414,8 @@ async function main() {
 		const ulid = "ulid-smoke-task-lifecycle";
 		captureTaskCreated(tSvc, {
 			ulid,
-			apiProvider: "anthropic",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
 		});
 		captureConversationTurnEvent(tSvc, {
 			ulid,
@@ -400,7 +434,7 @@ async function main() {
 		captureTaskCompleted(tSvc, {
 			ulid,
 			provider: "anthropic",
-			modelId: "claude-sonnet-4-5",
+			model: "claude-sonnet-4-5",
 			mode: "act",
 			durationMs: 4_242,
 			source: "submit_and_exit",

--- a/sdk/packages/core/src/account/index.ts
+++ b/sdk/packages/core/src/account/index.ts
@@ -9,6 +9,11 @@ export {
 	type ProviderActionExecutor,
 	RpcClineAccountService,
 } from "./rpc";
+export {
+	type ClineAccountTelemetryIdentity,
+	persistClineAccountTelemetryIdentity,
+	resolveClineAccountTelemetryIdentity,
+} from "./telemetry";
 export type {
 	ClineAccountBalance,
 	ClineAccountOrganization,

--- a/sdk/packages/core/src/account/telemetry.test.ts
+++ b/sdk/packages/core/src/account/telemetry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	persistClineAccountTelemetryIdentity,
+	resolveClineAccountTelemetryIdentity,
+} from "./telemetry";
+import type { ClineAccountUser } from "./types";
+
+function createUser(
+	overrides: Partial<ClineAccountUser> = {},
+): ClineAccountUser {
+	return {
+		id: "user-1",
+		email: "user@example.com",
+		displayName: "User",
+		photoUrl: "",
+		createdAt: "",
+		updatedAt: "",
+		organizations: [],
+		...overrides,
+	};
+}
+
+describe("Cline account telemetry identity", () => {
+	it("resolves the active organization", () => {
+		const identity = resolveClineAccountTelemetryIdentity(
+			createUser({
+				organizations: [
+					{
+						active: true,
+						memberId: "member-1",
+						name: "Acme",
+						organizationId: "org-1",
+						roles: ["member"],
+					},
+				],
+			}),
+		);
+
+		expect(identity).toEqual({
+			id: "user-1",
+			email: "user@example.com",
+			provider: "cline",
+			organizationId: "org-1",
+			organizationName: "Acme",
+			memberId: "member-1",
+		});
+	});
+
+	it("persists organization context for detached runtimes", () => {
+		const saveProviderSettings = vi.fn();
+		const manager = {
+			getProviderSettings: vi.fn(() => ({
+				provider: "cline" as const,
+				auth: { accountId: "user-1", accessToken: "secret" },
+			})),
+			saveProviderSettings,
+		};
+		const identity = resolveClineAccountTelemetryIdentity(
+			createUser({
+				organizations: [
+					{
+						active: true,
+						memberId: "member-1",
+						name: "Acme",
+						organizationId: "org-1",
+						roles: ["member"],
+					},
+				],
+			}),
+		);
+
+		expect(persistClineAccountTelemetryIdentity(manager, identity)).toBe(true);
+		expect(saveProviderSettings).toHaveBeenCalledWith(
+			{
+				provider: "cline",
+				auth: {
+					accountId: "user-1",
+					accessToken: "secret",
+					organizationId: "org-1",
+					organizationName: "Acme",
+					memberId: "member-1",
+				},
+			},
+			{ setLastUsed: false },
+		);
+	});
+
+	it("replaces stale persisted account identity after an account switch", () => {
+		const saveProviderSettings = vi.fn();
+		const manager = {
+			getProviderSettings: vi.fn(() => ({
+				provider: "cline" as const,
+				auth: { accountId: "old-user", accessToken: "secret" },
+			})),
+			saveProviderSettings,
+		};
+
+		persistClineAccountTelemetryIdentity(manager, {
+			id: "new-user",
+			provider: "cline",
+		});
+
+		expect(saveProviderSettings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				auth: expect.objectContaining({ accountId: "new-user" }),
+			}),
+			{ setLastUsed: false },
+		);
+	});
+});

--- a/sdk/packages/core/src/account/telemetry.ts
+++ b/sdk/packages/core/src/account/telemetry.ts
@@ -1,0 +1,67 @@
+import type { ProviderSettingsManager } from "../services/storage/provider-settings-manager";
+import type { ClineAccountUser } from "./types";
+
+/** Account identity shared by telemetry and feature-flag integrations. */
+export interface ClineAccountTelemetryIdentity {
+	id: string;
+	email?: string;
+	provider: "cline";
+	organizationId?: string;
+	organizationName?: string;
+	memberId?: string;
+}
+
+/**
+ * Resolve the authenticated user and active organization once so every client
+ * applies the same cross-surface account dimensions.
+ */
+export function resolveClineAccountTelemetryIdentity(
+	user: ClineAccountUser,
+): ClineAccountTelemetryIdentity {
+	const activeOrganization = user.organizations?.find(
+		(organization) => organization.active,
+	);
+	return {
+		id: user.id,
+		email: user.email,
+		provider: "cline",
+		organizationId: activeOrganization?.organizationId,
+		organizationName: activeOrganization?.name,
+		memberId: activeOrganization?.memberId,
+	};
+}
+
+/**
+ * Persist the latest active organization alongside OAuth settings. Detached
+ * runtime processes (notably the shared Hub) can then enrich task telemetry
+ * without making their own account API request.
+ */
+export function persistClineAccountTelemetryIdentity(
+	manager: Pick<
+		ProviderSettingsManager,
+		"getProviderSettings" | "saveProviderSettings"
+	>,
+	identity: ClineAccountTelemetryIdentity,
+): boolean {
+	try {
+		const persisted = manager.getProviderSettings("cline");
+		if (!persisted) return false;
+		manager.saveProviderSettings(
+			{
+				...persisted,
+				auth: {
+					...persisted.auth,
+					accountId: identity.id,
+					organizationId: identity.organizationId,
+					organizationName: identity.organizationName,
+					memberId: identity.memberId,
+				},
+			},
+			{ setLastUsed: false },
+		);
+		return true;
+	} catch {
+		// Account display and telemetry must continue if settings are read-only.
+		return false;
+	}
+}

--- a/sdk/packages/core/src/hub/daemon/telemetry.test.ts
+++ b/sdk/packages/core/src/hub/daemon/telemetry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+	mockClearAccountTelemetryIdentity,
 	mockIdentifyAccount,
 	mockGetProviderSettings,
 	mockFlush,
@@ -13,6 +14,7 @@ const {
 	const mockFlush = vi.fn(async () => undefined);
 	const mockDispose = vi.fn(async () => undefined);
 	return {
+		mockClearAccountTelemetryIdentity: vi.fn(),
 		mockIdentifyAccount: vi.fn(),
 		mockGetProviderSettings: vi.fn(),
 		mockFlush,
@@ -32,7 +34,12 @@ vi.mock("../../services/telemetry/OpenTelemetryProvider", () => ({
 }));
 
 vi.mock("../../services/telemetry/core-events", () => ({
+	clearAccountTelemetryIdentity: mockClearAccountTelemetryIdentity,
 	identifyAccount: mockIdentifyAccount,
+}));
+
+vi.mock("../../services/telemetry/distinct-id", () => ({
+	resolveCoreDistinctId: () => "machine-123",
 }));
 
 vi.mock("../../services/storage/provider-settings-manager", () => ({
@@ -53,6 +60,7 @@ describe("createHubDaemonTelemetry", () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		mockClearAccountTelemetryIdentity.mockClear();
 		mockIdentifyAccount.mockClear();
 		mockGetProviderSettings.mockClear();
 		mockFlush.mockClear();
@@ -145,6 +153,36 @@ describe("createHubDaemonTelemetry", () => {
 			mockTelemetryService,
 			expect.objectContaining({ id: "usr-123", organizationId: "org-2" }),
 		);
+	});
+
+	it("restores anonymous process identity when the cached account signs out", () => {
+		mockGetProviderSettings.mockReturnValue({
+			auth: { accountId: "usr-123", organizationId: "org-1" },
+		});
+		createHubDaemonTelemetry();
+		expect(mockIdentifyAccount).toHaveBeenCalledTimes(1);
+
+		mockGetProviderSettings.mockReturnValue(undefined);
+		vi.advanceTimersByTime(5 * 60 * 1000);
+
+		expect(mockClearAccountTelemetryIdentity).toHaveBeenCalledExactlyOnceWith(
+			mockTelemetryService,
+			"machine-123",
+		);
+		vi.advanceTimersByTime(5 * 60 * 1000);
+		expect(mockClearAccountTelemetryIdentity).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not clear a known identity for a transient settings read failure", () => {
+		mockGetProviderSettings.mockReturnValue({ auth: { accountId: "usr-123" } });
+		createHubDaemonTelemetry();
+
+		mockGetProviderSettings.mockImplementation(() => {
+			throw new Error("temporary settings failure");
+		});
+		vi.advanceTimersByTime(5 * 60 * 1000);
+
+		expect(mockClearAccountTelemetryIdentity).not.toHaveBeenCalled();
 	});
 
 	it("survives provider settings read failures", () => {

--- a/sdk/packages/core/src/hub/daemon/telemetry.ts
+++ b/sdk/packages/core/src/hub/daemon/telemetry.ts
@@ -5,7 +5,11 @@ import {
 } from "@cline/shared";
 import type { AuthSettings } from "../../services/llms/provider-settings";
 import { ProviderSettingsManager } from "../../services/storage/provider-settings-manager";
-import { identifyAccount } from "../../services/telemetry/core-events";
+import {
+	clearAccountTelemetryIdentity,
+	identifyAccount,
+} from "../../services/telemetry/core-events";
+import { resolveCoreDistinctId } from "../../services/telemetry/distinct-id";
 import { createConfiguredTelemetryHandle } from "../../services/telemetry/OpenTelemetryProvider";
 import { CORE_BUILD_VERSION } from "../../version";
 
@@ -50,21 +54,31 @@ export function createHubDaemonTelemetry(): HubDaemonTelemetry {
 	// migration and provider registration side effects, while
 	// getProviderSettings re-reads the file on every call anyway.
 	let settingsManager: ProviderSettingsManager | undefined;
-	const resolveCachedClineAuth = (): AuthSettings | undefined => {
+	const resolveCachedClineAuth = (): AuthSettings | null | undefined => {
 		try {
 			settingsManager ??= new ProviderSettingsManager();
 			return settingsManager.getProviderSettings("cline")?.auth;
 		} catch {
 			// Telemetry identity must never interfere with daemon operation.
-			return undefined;
+			return null;
 		}
 	};
 
 	let identifiedKey: string | undefined;
 	const refreshIdentity = (): void => {
 		const auth = resolveCachedClineAuth();
+		if (auth === null) {
+			return;
+		}
 		const accountId = auth?.accountId?.trim();
 		if (!auth || !accountId) {
+			if (identifiedKey !== undefined) {
+				identifiedKey = undefined;
+				clearAccountTelemetryIdentity(
+					handle.telemetry,
+					resolveCoreDistinctId(),
+				);
+			}
 			return;
 		}
 		// Re-identify on account OR active-organization change so a long-lived

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
@@ -106,7 +106,18 @@ describe("HubRuntimeHost", () => {
 			source: SessionSource.CLI,
 			localRuntime: {
 				extensionContext: {
-					client: { name: "cline-cli", version: "3.0.38" },
+					client: {
+						name: "cline-cli",
+						version: "3.0.38",
+						platform: "cli",
+						platformVersion: "3.0.38",
+						isMultiRoot: false,
+					},
+					user: {
+						distinctId: "account-1",
+						accountId: "account-1",
+						organizationId: "org-1",
+					},
 				},
 			},
 			prompt: "Hey",
@@ -155,7 +166,20 @@ describe("HubRuntimeHost", () => {
 					version: "3.0.38",
 				},
 			}),
-			runtimeOptions: {},
+			runtimeOptions: {
+				clientContext: {
+					name: "cline-cli",
+					version: "3.0.38",
+					platform: "cli",
+					platformVersion: "3.0.38",
+					isMultiRoot: false,
+				},
+				userContext: {
+					distinctId: "account-1",
+					accountId: "account-1",
+					organizationId: "org-1",
+				},
+			},
 			toolPolicies: undefined,
 			initialMessages: undefined,
 		});

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -868,6 +868,12 @@ export class HubRuntimeHost implements RuntimeHost {
 			input.localRuntime,
 			capabilities,
 		);
+		const clientContext = toJsonSerializable(
+			input.localRuntime?.extensionContext?.client,
+		);
+		const userContext = toJsonSerializable(
+			input.localRuntime?.extensionContext?.user,
+		);
 		const plannedSessionId =
 			input.config.sessionId?.trim() || createSessionId();
 		const sendCreateCommand = () =>
@@ -879,6 +885,8 @@ export class HubRuntimeHost implements RuntimeHost {
 				),
 				metadata: buildCommandSessionMetadata(input),
 				runtimeOptions: {
+					...(clientContext ? { clientContext } : {}),
+					...(userContext ? { userContext } : {}),
 					...(clientContributions.manifest.length > 0
 						? { clientContributions: clientContributions.manifest }
 						: {}),
@@ -978,6 +986,12 @@ export class HubRuntimeHost implements RuntimeHost {
 					manifest: [],
 					handlers: new Map<string, ClientContributionHandler>(),
 				};
+		const clientContext = startConfig
+			? toJsonSerializable(startConfig.localRuntime?.extensionContext?.client)
+			: undefined;
+		const userContext = startConfig
+			? toJsonSerializable(startConfig.localRuntime?.extensionContext?.user)
+			: undefined;
 		let plannedSessionId: string | undefined;
 		let startSessionConfig: Record<string, unknown> | undefined;
 		if (startConfig) {
@@ -1015,6 +1029,8 @@ export class HubRuntimeHost implements RuntimeHost {
 								sessionConfig: toJsonRecord(startSessionConfig),
 								metadata: buildCommandSessionMetadata(startConfig),
 								runtimeOptions: {
+									...(clientContext ? { clientContext } : {}),
+									...(userContext ? { userContext } : {}),
 									...(clientContributions.manifest.length > 0
 										? { clientContributions: clientContributions.manifest }
 										: {}),

--- a/sdk/packages/core/src/hub/server/boundary.test.ts
+++ b/sdk/packages/core/src/hub/server/boundary.test.ts
@@ -429,7 +429,20 @@ describe("HubServerTransport boundaries", () => {
 					modelId: "test-model",
 					systemPrompt: "system",
 				},
-				metadata: { source: "core", interactive: true },
+				metadata: { source: "desktop", interactive: true },
+				runtimeOptions: {
+					clientContext: {
+						name: "cline-desktop",
+						version: "0.0.23",
+						platform: "Cline Desktop",
+						platformVersion: "0.0.23",
+					},
+					userContext: {
+						distinctId: "account-1",
+						accountId: "account-1",
+						organizationId: "org-1",
+					},
+				},
 			},
 		});
 
@@ -438,6 +451,18 @@ describe("HubServerTransport boundaries", () => {
 		expect(capturedStartInput?.config.sessionId).toBe("session-boundary");
 		expect(capturedStartInput?.config.cwd).toBeUndefined();
 		expect(capturedStartInput?.config.workspaceRoot).toBeUndefined();
+		expect(capturedStartInput?.source).toBe("desktop");
+		expect(capturedStartInput?.localRuntime?.extensionContext?.client).toEqual({
+			name: "cline-desktop",
+			version: "0.0.23",
+			platform: "Cline Desktop",
+			platformVersion: "0.0.23",
+		});
+		expect(capturedStartInput?.localRuntime?.extensionContext?.user).toEqual({
+			distinctId: "account-1",
+			accountId: "account-1",
+			organizationId: "org-1",
+		});
 		expect(reply.payload?.session).toMatchObject({
 			cwd: resolvedWorkspace,
 			workspaceRoot: resolvedWorkspace,

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
@@ -1,11 +1,65 @@
 import { describe, expect, it } from "vitest";
 import {
+	readHubClientContext,
+	readHubUserContext,
 	readSessionConnectionUpdate,
 	resolveSessionAutoApproveTools,
 	selectSessionTools,
 } from "./session-handlers";
 
 const tool = (name: string) => ({ name });
+
+describe("readHubClientContext", () => {
+	it("accepts the serializable client identity used for telemetry", () => {
+		expect(
+			readHubClientContext({
+				name: " cline-desktop ",
+				version: " 0.0.23 ",
+				platform: " Cline Desktop ",
+				platformVersion: " 0.0.23 ",
+				isMultiRoot: false,
+			}),
+		).toEqual({
+			name: "cline-desktop",
+			version: "0.0.23",
+			platform: "Cline Desktop",
+			platformVersion: "0.0.23",
+			isMultiRoot: false,
+		});
+	});
+
+	it("rejects a client context without a name", () => {
+		expect(readHubClientContext({ version: "0.0.23" })).toBeUndefined();
+	});
+});
+
+describe("readHubUserContext", () => {
+	it("accepts the serializable authenticated identity used for telemetry", () => {
+		expect(
+			readHubUserContext({
+				distinctId: " account-1 ",
+				accountId: " account-1 ",
+				email: " dev@example.com ",
+				organizationId: " org-1 ",
+			}),
+		).toEqual({
+			distinctId: "account-1",
+			accountId: "account-1",
+			email: "dev@example.com",
+			organizationId: "org-1",
+		});
+	});
+
+	it("rejects an empty user context", () => {
+		expect(readHubUserContext({ distinctId: " " })).toBeUndefined();
+	});
+
+	it("preserves an explicit signed-out account state", () => {
+		expect(
+			readHubUserContext({ distinctId: "machine-1", accountId: null }),
+		).toEqual({ distinctId: "machine-1", accountId: null });
+	});
+});
 
 describe("selectSessionTools", () => {
 	it("excludes tasks in yolo mode and CLI/VS Code sessions", () => {

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -1,9 +1,11 @@
 import type {
+	ClientContext,
 	HubCommandEnvelope,
 	HubCommandInput,
 	HubReplyEnvelope,
 	JsonValue,
 	ToolApprovalRequest,
+	UserContext,
 } from "@cline/shared";
 import {
 	createSessionId,
@@ -45,6 +47,57 @@ import {
 } from "./context";
 
 const CAPABILITY_OWNER_METADATA_KEY = "hubCapabilityOwnerClientId";
+
+function readHubContextString(
+	record: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const candidate = record?.[key];
+	return typeof candidate === "string" && candidate.trim()
+		? candidate.trim()
+		: undefined;
+}
+
+/** Parse the serializable subset of ExtensionContext carried by Hub clients. */
+export function readHubClientContext(
+	value: unknown,
+): ClientContext | undefined {
+	const record = asPlainRecord(value);
+	const name = typeof record?.name === "string" ? record.name.trim() : "";
+	if (!name) return undefined;
+	const version = readHubContextString(record, "version");
+	const platform = readHubContextString(record, "platform");
+	const platformVersion = readHubContextString(record, "platformVersion");
+	return {
+		name,
+		...(version ? { version } : {}),
+		...(platform ? { platform } : {}),
+		...(platformVersion ? { platformVersion } : {}),
+		...(typeof record?.isMultiRoot === "boolean"
+			? { isMultiRoot: record.isMultiRoot }
+			: {}),
+	};
+}
+
+/** Parse authenticated identity separately from the transport-neutral config. */
+export function readHubUserContext(value: unknown): UserContext | undefined {
+	const record = asPlainRecord(value);
+	const distinctId = readHubContextString(record, "distinctId");
+	const rawAccountId = record?.accountId;
+	const accountId =
+		rawAccountId === null ? null : readHubContextString(record, "accountId");
+	const email = readHubContextString(record, "email");
+	const organizationId = readHubContextString(record, "organizationId");
+	if (!distinctId && accountId === undefined && !email && !organizationId) {
+		return undefined;
+	}
+	return {
+		...(distinctId ? { distinctId } : {}),
+		...(accountId !== undefined ? { accountId } : {}),
+		...(email ? { email } : {}),
+		...(organizationId ? { organizationId } : {}),
+	};
+}
 
 async function deleteSessionAndCleanDerivedState(
 	ctx: HubTransportContext,
@@ -237,6 +290,8 @@ export async function handleSessionCreate(
 		payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 			? (payload.runtimeOptions as Record<string, unknown>)
 			: {};
+	const clientContext = readHubClientContext(runtimeOptions.clientContext);
+	const userContext = readHubUserContext(runtimeOptions.userContext);
 	const initialCompactionState = parseSessionCompactionState(
 		payload.initialCompactionState,
 	);
@@ -341,6 +396,15 @@ export async function handleSessionCreate(
 			},
 			configExtensions,
 			...clientContributionRuntime.localRuntime,
+			...(clientContext || userContext
+				? {
+						extensionContext: {
+							...clientContributionRuntime.localRuntime.extensionContext,
+							...(clientContext ? { client: clientContext } : {}),
+							...(userContext ? { user: userContext } : {}),
+						},
+					}
+				: {}),
 			extensions: [
 				...(ctx.sessionExtensions ?? []),
 				...(clientContributionRuntime.localRuntime.extensions ?? []),
@@ -519,6 +583,8 @@ export async function handleSessionRestore(
 			payload.runtimeOptions && typeof payload.runtimeOptions === "object"
 				? (payload.runtimeOptions as Record<string, unknown>)
 				: {};
+		const clientContext = readHubClientContext(runtimeOptions.clientContext);
+		const userContext = readHubUserContext(runtimeOptions.userContext);
 		const initialCompactionState = parseSessionCompactionState(
 			payload.initialCompactionState,
 		);
@@ -623,6 +689,15 @@ export async function handleSessionRestore(
 						},
 						configExtensions,
 						...clientContributionRuntime.localRuntime,
+						...(clientContext || userContext
+							? {
+									extensionContext: {
+										...clientContributionRuntime.localRuntime.extensionContext,
+										...(clientContext ? { client: clientContext } : {}),
+										...(userContext ? { user: userContext } : {}),
+									},
+								}
+							: {}),
 						extensions: [
 							...(ctx.sessionExtensions ?? []),
 							...(clientContributionRuntime.localRuntime.extensions ?? []),

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -777,6 +777,7 @@ export {
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
 	captureWorkspacePathResolved,
+	clearAccountTelemetryIdentity,
 	identifyAccount,
 } from "./services/telemetry/core-events";
 export type { ITelemetryAdapter } from "./services/telemetry/ITelemetryAdapter";

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -129,6 +129,7 @@ export {
 	type ClineAccountPaymentTransaction,
 	ClineAccountService,
 	type ClineAccountServiceOptions,
+	type ClineAccountTelemetryIdentity,
 	type ClineAccountUsageTransaction,
 	type ClineAccountUser,
 	type ClineOrganization,
@@ -137,7 +138,9 @@ export {
 	type FeaturebaseTokenResponse,
 	isClineAccountActionRequest,
 	type ProviderActionExecutor,
+	persistClineAccountTelemetryIdentity,
 	RpcClineAccountService,
+	resolveClineAccountTelemetryIdentity,
 	type UserCurrentPlan,
 	type UserRemoteConfigOrganization,
 	type UserRemoteConfigResponse,
@@ -786,6 +789,12 @@ export {
 	OpenTelemetryProvider,
 	type OpenTelemetryProviderOptions,
 } from "./services/telemetry/OpenTelemetryProvider";
+export {
+	type ClientTelemetryContext,
+	createClientScopedTelemetryService,
+	createScopedTelemetryService,
+	resolveClientTelemetryProperties,
+} from "./services/telemetry/scoped-telemetry";
 export {
 	TelemetryLoggerSink,
 	type TelemetryLoggerSinkOptions,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -217,6 +217,19 @@ describe("LocalRuntimeHost", () => {
 		}
 	});
 
+	it("preserves a caller-owned telemetry identity when no distinct id is supplied", async () => {
+		const setDistinctId = vi.fn();
+		const manager = new RuntimeHostUnderTest({
+			sessionService: new FileSessionService(
+				join(isolatedHomeDir, "sessions-identity"),
+			),
+			telemetry: { setDistinctId } as never,
+		});
+
+		expect(setDistinctId).not.toHaveBeenCalled();
+		await manager.dispose();
+	});
+
 	it.each([
 		{ source: "generated", requestedSessionId: undefined },
 		{ source: "requested", requestedSessionId: "session-explicit" },
@@ -7053,7 +7066,7 @@ describe("LocalRuntimeHost", () => {
 				ulid: sessionId,
 				source: "submit_and_exit",
 				provider: "mock-provider",
-				modelId: "mock-model",
+				model: "mock-model",
 			});
 		});
 
@@ -7338,7 +7351,7 @@ describe("LocalRuntimeHost", () => {
 				ulid: sessionId,
 				source: "shutdown",
 				provider: "mock-provider",
-				modelId: "mock-model",
+				model: "mock-model",
 			});
 		});
 

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -307,7 +307,13 @@ export class LocalRuntimeHost implements RuntimeHost {
 			});
 		this.defaultTelemetry = options.telemetry;
 		this.defaultLogger = options.logger;
-		this.defaultTelemetry?.setDistinctId(distinctId);
+		// A caller-owned telemetry service may already be identified to an
+		// authenticated account (the long-lived Hub daemon is one example).
+		// Only replace that identity when the caller explicitly supplied the
+		// runtime distinct id. ClineCore always does so through host.ts.
+		if (options.distinctId !== undefined) {
+			this.defaultTelemetry?.setDistinctId(distinctId);
+		}
 		this.defaultFetch = options.fetch;
 		recoverDetachedCommandLogsOnce(this.defaultLogger, this.defaultTelemetry);
 
@@ -2000,7 +2006,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		captureTaskCompleted(session.config.telemetry, {
 			ulid: session.sessionId,
 			provider: session.config.providerId,
-			modelId: session.config.modelId,
+			model: session.config.modelId,
 			mode: session.config.mode,
 			durationMs: Date.now() - Date.parse(session.startedAt),
 			source: "submit_and_exit",
@@ -2048,7 +2054,7 @@ export class LocalRuntimeHost implements RuntimeHost {
 		captureTaskCompleted(session.config.telemetry, {
 			ulid: session.sessionId,
 			provider: session.config.providerId,
-			modelId: session.config.modelId,
+			model: session.config.modelId,
 			mode: session.config.mode,
 			durationMs: Date.now() - Date.parse(session.startedAt),
 			source: "shutdown",

--- a/sdk/packages/core/src/services/local-runtime-bootstrap.ts
+++ b/sdk/packages/core/src/services/local-runtime-bootstrap.ts
@@ -59,6 +59,7 @@ import {
 } from "./global-settings";
 import { hasRuntimeHooks, mergeAgentExtensions } from "./session-data";
 import type { ProviderSettingsManager } from "./storage/provider-settings-manager";
+import { createClientScopedTelemetryService } from "./telemetry/scoped-telemetry";
 import { InMemoryWorkspaceManager } from "./workspace/workspace-manager";
 import type { GitWorkspaceState } from "./workspace/workspace-manifest";
 import { buildWorkspaceMetadataWithInfo } from "./workspace/workspace-manifest";
@@ -116,11 +117,9 @@ function logAgentPluginDiagnostics(
 
 /**
  * Recover client identity from the Cline request headers baked into the
- * session config. Hub-backed sessions do not transport `extensionContext`
- * (it is local-only), but the hub client resolves `X-CLIENT-TYPE` /
- * `X-CLIENT-VERSION` headers before `session.create`, so the daemon can
- * rebuild `extensionContext.client` from them and keep trace metadata
- * (Langfuse `clientName` / `clientVersion`) consistent with local runtimes.
+ * session config. Current Hub clients transport the serializable identity
+ * explicitly; these headers preserve attribution for older clients and other
+ * transport implementations that only forward the neutral session config.
  */
 function resolveClientContextFromHeaders(
 	headers: Record<string, string> | undefined,
@@ -330,6 +329,23 @@ export async function prepareLocalRuntimeBootstrap(
 	const headerClientContext = configuredExtensionContext?.client
 		? undefined
 		: resolveClientContextFromHeaders(input.config.headers);
+	const clientContext =
+		configuredExtensionContext?.client ?? headerClientContext;
+	const configuredTelemetry =
+		configuredExtensionContext?.telemetry ?? localConfig?.telemetry;
+	// Hub-backed sessions execute inside a shared daemon and therefore inherit
+	// its process telemetry service. Scope that singleton to the serialized
+	// client identity without mutating it; local clients already carry their
+	// own telemetry instance and keep using it directly.
+	const telemetry =
+		configuredTelemetry ??
+		(defaultTelemetry && clientContext
+			? createClientScopedTelemetryService(defaultTelemetry, {
+					client: clientContext,
+					source: input.source,
+					user: configuredExtensionContext?.user,
+				})
+			: defaultTelemetry);
 	const extensionContext: ExtensionContext = {
 		...(configuredExtensionContext ?? {}),
 		...(headerClientContext ? { client: headerClientContext } : {}),
@@ -345,14 +361,12 @@ export async function prepareLocalRuntimeBootstrap(
 			configuredExtensionContext?.logger ??
 			localConfig?.logger ??
 			defaultLogger,
-		telemetry:
-			configuredExtensionContext?.telemetry ??
-			localConfig?.telemetry ??
-			defaultTelemetry,
+		telemetry,
 	};
 	emitWorkspaceLifecycleTelemetry({
 		telemetry: extensionContext.telemetry,
 		rootPath: workspaceInfo.rootPath,
+		dedupeScope: extensionContext.client?.name ?? input.source,
 		workspaceInfo,
 		rootCount: 1,
 		vcsType,

--- a/sdk/packages/core/src/services/session-telemetry.ts
+++ b/sdk/packages/core/src/services/session-telemetry.ts
@@ -29,13 +29,15 @@ export function emitSessionCreationTelemetry(
 	if (isRestart) {
 		captureTaskRestarted(config.telemetry, {
 			ulid: sessionId,
-			apiProvider: config.providerId,
+			provider: config.providerId,
+			model: config.modelId,
 			...agentIdentity,
 		});
 	} else {
 		captureTaskCreated(config.telemetry, {
 			ulid: sessionId,
-			apiProvider: config.providerId,
+			provider: config.providerId,
+			model: config.modelId,
 			...agentIdentity,
 		});
 	}

--- a/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
+++ b/sdk/packages/core/src/services/telemetry/OpenTelemetryProvider.ts
@@ -101,12 +101,20 @@ class OptedOutTelemetryService implements ITelemetryService {
 	private resolveProperties(
 		properties?: TelemetryProperties,
 	): TelemetryProperties {
-		return {
+		const scopedDistinctId =
+			typeof properties?.distinct_id === "string" &&
+			properties.distinct_id.trim()
+				? properties.distinct_id.trim()
+				: this.distinctId;
+		const resolved = {
 			...this.commonProperties,
-			...properties,
 			...this.metadata,
-			...(this.distinctId ? { distinct_id: this.distinctId } : {}),
+			...properties,
+			...(scopedDistinctId ? { distinct_id: scopedDistinctId } : {}),
 		};
+		return Object.fromEntries(
+			Object.entries(resolved).filter(([, value]) => value !== undefined),
+		);
 	}
 }
 

--- a/sdk/packages/core/src/services/telemetry/TelemetryService.test.ts
+++ b/sdk/packages/core/src/services/telemetry/TelemetryService.test.ts
@@ -73,6 +73,36 @@ describe("TelemetryService", () => {
 		);
 	});
 
+	it("treats metadata as host defaults that event context may override", () => {
+		const { adapter, emit } = createAdapter();
+		const service = new TelemetryService({
+			adapters: [adapter],
+			metadata: {
+				extension_version: "0.0.82",
+				cline_type: "hub",
+				platform: "cline-hub-daemon",
+			},
+		});
+
+		service.capture({
+			event: "task.created",
+			properties: {
+				extension_version: "0.0.23",
+				cline_type: "desktop",
+				platform: "Cline Desktop",
+			},
+		});
+
+		expect(emit).toHaveBeenCalledWith(
+			"task.created",
+			expect.objectContaining({
+				extension_version: "0.0.23",
+				cline_type: "desktop",
+				platform: "Cline Desktop",
+			}),
+		);
+	});
+
 	it("mirrors telemetry events into the logger when provided", () => {
 		const logger: BasicLogger = {
 			debug: vi.fn(),

--- a/sdk/packages/core/src/services/telemetry/TelemetryService.ts
+++ b/sdk/packages/core/src/services/telemetry/TelemetryService.ts
@@ -137,12 +137,22 @@ export class TelemetryService implements ITelemetryService {
 	private buildAttributes(
 		properties?: TelemetryProperties,
 	): TelemetryProperties {
-		return {
+		const scopedDistinctId =
+			typeof properties?.distinct_id === "string" &&
+			properties.distinct_id.trim()
+				? properties.distinct_id.trim()
+				: this.distinctId;
+		const attributes = {
 			...this.commonProperties,
-			...properties,
 			...this.metadata,
-			...(this.distinctId ? { distinct_id: this.distinctId } : {}),
+			// Metadata is the host default. A scoped session may override client
+			// dimensions when execution happens in a shared Hub process.
+			...properties,
+			...(scopedDistinctId ? { distinct_id: scopedDistinctId } : {}),
 			device_id: this.deviceId,
 		};
+		return Object.fromEntries(
+			Object.entries(attributes).filter(([, value]) => value !== undefined),
+		);
 	}
 }

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -26,6 +26,7 @@ import {
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
 	captureWorkspacePathResolved,
+	clearAccountTelemetryIdentity,
 	identifyAccount,
 } from "./core-events";
 import type { ITelemetryAdapter } from "./ITelemetryAdapter";
@@ -953,6 +954,31 @@ describe("identifyAccount", () => {
 	test("no-ops when telemetry is undefined", () => {
 		expect(() =>
 			identifyAccount(undefined, { id: "usr-123", provider: "cline" }),
+		).not.toThrow();
+	});
+});
+
+describe("clearAccountTelemetryIdentity", () => {
+	test("restores anonymous identity and clears account properties", () => {
+		const stub = createTelemetryStub();
+
+		clearAccountTelemetryIdentity(stub.telemetry, "  machine-123  ");
+
+		expect(stub.telemetry.setDistinctId).toHaveBeenCalledWith("machine-123");
+		expect(stub.telemetry.updateCommonProperties).toHaveBeenCalledWith({
+			user_id: undefined,
+			account_id: undefined,
+			account_email: undefined,
+			provider: undefined,
+			organization_id: undefined,
+			organization_name: undefined,
+			member_id: undefined,
+		});
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() =>
+			clearAccountTelemetryIdentity(undefined, "machine-123"),
 		).not.toThrow();
 	});
 });

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -1,12 +1,12 @@
 import {
 	AGENT_UNEXPECTED_REASONING_TOKENS_EVENT,
+	captureTaskLifecycleEvent as captureSharedTaskLifecycleEvent,
 	type ITelemetryService,
 	TASK_CANCELLED_EVENT,
 	TASK_FIRST_CHUNK_RECEIVED_EVENT,
 	TASK_PROVIDER_REQUEST_STARTED_EVENT,
 	TASK_PROVIDER_STREAM_FAILED_EVENT,
 	TASK_PROVIDER_STREAM_STARTED_EVENT,
-	captureTaskLifecycleEvent as captureSharedTaskLifecycleEvent,
 } from "@cline/shared";
 import { describe, expect, test, vi } from "vitest";
 import {
@@ -18,8 +18,11 @@ import {
 	captureMistakeLimitReached,
 	captureProviderConfigured,
 	captureRunCommandsTimeout,
-	captureTelemetryOptOut,
+	captureTaskCompleted,
+	captureTaskCreated,
 	captureTaskLifecycleEvent,
+	captureTaskRestarted,
+	captureTelemetryOptOut,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
 	captureWorkspacePathResolved,
@@ -86,6 +89,49 @@ describe("captureTelemetryOptOut", () => {
 			"user.opt_out",
 			undefined,
 		);
+	});
+});
+
+describe("task lifecycle contract", () => {
+	test.each([
+		["task.created", captureTaskCreated],
+		["task.restarted", captureTaskRestarted],
+	] as const)("emits %s with canonical provider and model fields", (event, emit) => {
+		const stub = createTelemetryStub();
+		emit(stub.telemetry, {
+			ulid: "session-1",
+			provider: "anthropic",
+			model: "claude-sonnet-4.6",
+		});
+
+		expect(captureCallAt(stub, 0)).toEqual({
+			event,
+			properties: {
+				ulid: "session-1",
+				provider: "anthropic",
+				model: "claude-sonnet-4.6",
+			},
+		});
+	});
+
+	test("emits task.completed with canonical provider and model fields", () => {
+		const stub = createTelemetryStub();
+		captureTaskCompleted(stub.telemetry, {
+			ulid: "session-1",
+			provider: "anthropic",
+			model: "claude-sonnet-4.6",
+			source: "submit_and_exit",
+		});
+
+		expect(captureCallAt(stub, 0)).toEqual({
+			event: "task.completed",
+			properties: {
+				ulid: "session-1",
+				provider: "anthropic",
+				model: "claude-sonnet-4.6",
+				source: "submit_and_exit",
+			},
+		});
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -395,8 +395,8 @@ export function captureTaskCreated(
 	telemetry: ITelemetryService | undefined,
 	properties: {
 		ulid: string;
-		apiProvider?: string;
-		openAiCompatibleDomain?: string;
+		provider?: string;
+		model?: string;
 	} & Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.CREATED, properties);
@@ -406,8 +406,8 @@ export function captureTaskRestarted(
 	telemetry: ITelemetryService | undefined,
 	properties: {
 		ulid: string;
-		apiProvider?: string;
-		openAiCompatibleDomain?: string;
+		provider?: string;
+		model?: string;
 	} & Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.RESTARTED, properties);
@@ -431,7 +431,7 @@ export function captureTaskCompleted(
 	properties: {
 		ulid: string;
 		provider?: string;
-		modelId?: string;
+		model?: string;
 		mode?: string;
 		durationMs?: number;
 		source?: TaskCompletedSource;

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -391,6 +391,29 @@ export function identifyAccount(
 	});
 }
 
+/**
+ * Restore anonymous process identity after an account signs out.
+ *
+ * Account properties are explicitly set to undefined so they replace values
+ * previously merged into a long-lived telemetry service. Implementations
+ * remove undefined attributes before export.
+ */
+export function clearAccountTelemetryIdentity(
+	telemetry: ITelemetryService | undefined,
+	anonymousDistinctId?: string,
+): void {
+	telemetry?.setDistinctId(anonymousDistinctId?.trim() || undefined);
+	telemetry?.updateCommonProperties({
+		user_id: undefined,
+		account_id: undefined,
+		account_email: undefined,
+		provider: undefined,
+		organization_id: undefined,
+		organization_name: undefined,
+		member_id: undefined,
+	});
+}
+
 export function captureTaskCreated(
 	telemetry: ITelemetryService | undefined,
 	properties: {

--- a/sdk/packages/core/src/services/telemetry/index.ts
+++ b/sdk/packages/core/src/services/telemetry/index.ts
@@ -21,3 +21,9 @@ export {
 	OpenTelemetryProvider,
 	type OpenTelemetryProviderOptions,
 } from "./OpenTelemetryProvider";
+export {
+	type ClientTelemetryContext,
+	createClientScopedTelemetryService,
+	createScopedTelemetryService,
+	resolveClientTelemetryProperties,
+} from "./scoped-telemetry";

--- a/sdk/packages/core/src/services/telemetry/scoped-telemetry.test.ts
+++ b/sdk/packages/core/src/services/telemetry/scoped-telemetry.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ITelemetryAdapter } from "./ITelemetryAdapter";
+import {
+	createClientScopedTelemetryService,
+	resolveClientTelemetryProperties,
+} from "./scoped-telemetry";
+import { TelemetryService } from "./TelemetryService";
+
+function createAdapter() {
+	const emit = vi.fn();
+	const dispose = vi.fn(async () => {});
+	const adapter: ITelemetryAdapter = {
+		name: "test",
+		emit,
+		emitRequired: vi.fn(),
+		recordCounter: vi.fn(),
+		recordHistogram: vi.fn(),
+		recordGauge: vi.fn(),
+		isEnabled: () => true,
+		flush: async () => {},
+		dispose,
+	};
+	return { adapter, emit, dispose };
+}
+
+describe("client-scoped telemetry", () => {
+	it("maps shared client identity to cross-surface dimensions", () => {
+		expect(
+			resolveClientTelemetryProperties({
+				source: "desktop",
+				client: {
+					name: "cline-desktop",
+					version: "0.0.23",
+					platform: "Cline Desktop",
+					platformVersion: "0.0.23",
+				},
+			}),
+		).toEqual({
+			cline_type: "desktop",
+			extension_version: "0.0.23",
+			platform: "Cline Desktop",
+			platform_version: "0.0.23",
+		});
+	});
+
+	it("overrides Hub host defaults with current client and account context", () => {
+		const { adapter, emit } = createAdapter();
+		const parent = new TelemetryService({
+			adapters: [adapter],
+			distinctId: "stale-account",
+			deviceId: "device-1",
+			commonProperties: {
+				user_id: "stale-account",
+				account_id: "stale-account",
+				organization_id: "stale-org",
+			},
+			metadata: {
+				extension_version: "0.0.82",
+				cline_type: "hub",
+				platform: "cline-hub-daemon",
+				platform_version: "v24.0.0",
+				os_type: "darwin",
+				os_version: "test-os",
+			},
+		});
+		const telemetry = createClientScopedTelemetryService(parent, {
+			source: "desktop",
+			client: {
+				name: "cline-desktop",
+				version: "0.0.23",
+				platform: "Cline Desktop",
+				platformVersion: "0.0.23",
+			},
+			user: {
+				distinctId: "account-1",
+				accountId: "account-1",
+				email: "dev@example.com",
+				organizationId: "org-1",
+			},
+		});
+
+		telemetry.capture({
+			event: "task.created",
+			properties: {
+				ulid: "session-1",
+				provider: "anthropic",
+				model: "claude-sonnet-4.6",
+			},
+		});
+
+		expect(emit).toHaveBeenCalledWith("task.created", {
+			user_id: "account-1",
+			account_id: "account-1",
+			account_email: "dev@example.com",
+			organization_id: "org-1",
+			extension_version: "0.0.23",
+			cline_type: "desktop",
+			platform: "Cline Desktop",
+			platform_version: "0.0.23",
+			os_type: "darwin",
+			os_version: "test-os",
+			ulid: "session-1",
+			provider: "anthropic",
+			model: "claude-sonnet-4.6",
+			distinct_id: "account-1",
+			device_id: "device-1",
+		});
+	});
+
+	it("keeps anonymous identity while clearing stale Hub account fields", () => {
+		const { adapter, emit } = createAdapter();
+		const parent = new TelemetryService({
+			adapters: [adapter],
+			distinctId: "stale-account",
+			commonProperties: {
+				user_id: "stale-account",
+				account_id: "stale-account",
+				account_email: "stale@example.com",
+				organization_id: "stale-org",
+			},
+			metadata: {
+				extension_version: "0.0.82",
+				cline_type: "hub",
+				platform: "cline-hub-daemon",
+				platform_version: "v24.0.0",
+			},
+		});
+		const telemetry = createClientScopedTelemetryService(parent, {
+			client: { name: "cline-desktop" },
+			user: { distinctId: "machine-1", accountId: null },
+		});
+
+		telemetry.capture({ event: "task.created" });
+
+		expect(emit).toHaveBeenCalledWith("task.created", {
+			cline_type: "desktop",
+			platform: "cline-desktop",
+			distinct_id: "machine-1",
+			device_id: expect.any(String),
+		});
+	});
+
+	it("does not dispose the process-owned parent from a session view", async () => {
+		const { adapter, dispose } = createAdapter();
+		const parent = new TelemetryService({ adapters: [adapter] });
+		const telemetry = createClientScopedTelemetryService(parent, {
+			client: { name: "cline-desktop" },
+		});
+
+		await telemetry.dispose();
+
+		expect(dispose).not.toHaveBeenCalled();
+	});
+});

--- a/sdk/packages/core/src/services/telemetry/scoped-telemetry.test.ts
+++ b/sdk/packages/core/src/services/telemetry/scoped-telemetry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { CORE_TELEMETRY_EVENTS } from "./core-events";
 import type { ITelemetryAdapter } from "./ITelemetryAdapter";
 import {
 	createClientScopedTelemetryService,
@@ -80,7 +81,7 @@ describe("client-scoped telemetry", () => {
 		});
 
 		telemetry.capture({
-			event: "task.created",
+			event: CORE_TELEMETRY_EVENTS.TASK.CREATED,
 			properties: {
 				ulid: "session-1",
 				provider: "anthropic",
@@ -88,7 +89,7 @@ describe("client-scoped telemetry", () => {
 			},
 		});
 
-		expect(emit).toHaveBeenCalledWith("task.created", {
+		expect(emit).toHaveBeenCalledWith(CORE_TELEMETRY_EVENTS.TASK.CREATED, {
 			user_id: "account-1",
 			account_id: "account-1",
 			account_email: "dev@example.com",
@@ -130,9 +131,9 @@ describe("client-scoped telemetry", () => {
 			user: { distinctId: "machine-1", accountId: null },
 		});
 
-		telemetry.capture({ event: "task.created" });
+		telemetry.capture({ event: CORE_TELEMETRY_EVENTS.TASK.CREATED });
 
-		expect(emit).toHaveBeenCalledWith("task.created", {
+		expect(emit).toHaveBeenCalledWith(CORE_TELEMETRY_EVENTS.TASK.CREATED, {
 			cline_type: "desktop",
 			platform: "cline-desktop",
 			distinct_id: "machine-1",

--- a/sdk/packages/core/src/services/telemetry/scoped-telemetry.ts
+++ b/sdk/packages/core/src/services/telemetry/scoped-telemetry.ts
@@ -1,0 +1,152 @@
+import type {
+	ClientContext,
+	ITelemetryService,
+	TelemetryMetadata,
+	TelemetryProperties,
+	UserContext,
+} from "@cline/shared";
+import { resolveClientSessionSource } from "../../session/history-origin";
+
+/**
+ * Client identity that can safely cross a runtime boundary and be attached to
+ * telemetry emitted by the process that actually executes a session.
+ */
+export interface ClientTelemetryContext {
+	client: ClientContext;
+	source?: string;
+	user?: UserContext;
+}
+
+function trimNonEmpty(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Converts the shared client context into the established cross-surface
+ * analytics dimensions. Event-specific fields still take precedence.
+ */
+export function resolveClientTelemetryProperties(
+	context: ClientTelemetryContext,
+): TelemetryProperties {
+	const client = context.client;
+	const clineType =
+		resolveClientSessionSource(client) ?? trimNonEmpty(context.source);
+	const version = trimNonEmpty(client.version);
+	const platform = trimNonEmpty(client.platform) ?? trimNonEmpty(client.name);
+	const platformVersion = trimNonEmpty(client.platformVersion) ?? version;
+	const clientProperties: TelemetryProperties = {
+		cline_type: clineType,
+		extension_version: version,
+		platform,
+		platform_version: platformVersion,
+	};
+	if (context.user?.accountId === undefined) {
+		return clientProperties;
+	}
+	const accountId =
+		typeof context.user.accountId === "string"
+			? trimNonEmpty(context.user.accountId)
+			: undefined;
+	return {
+		...clientProperties,
+		// `undefined` deliberately masks stale process-level account fields.
+		// TelemetryService removes it after merging all attribute layers.
+		distinct_id: accountId ?? trimNonEmpty(context.user.distinctId),
+		user_id: accountId,
+		account_id: accountId,
+		account_email: accountId ? trimNonEmpty(context.user.email) : undefined,
+		organization_id: accountId
+			? trimNonEmpty(context.user.organizationId)
+			: undefined,
+	};
+}
+
+/**
+ * A non-owning view over a host telemetry service. It adds immutable
+ * per-session properties without mutating the host singleton, which is
+ * essential for a Hub process that can execute sessions from several clients
+ * concurrently.
+ *
+ * The returned view never disposes the parent. The process that created the
+ * parent telemetry service remains responsible for its lifecycle.
+ */
+export function createScopedTelemetryService(
+	parent: ITelemetryService,
+	properties: TelemetryProperties,
+): ITelemetryService {
+	let metadata: Partial<TelemetryMetadata> = {};
+	let commonProperties: TelemetryProperties = {};
+	let distinctId: string | undefined;
+
+	const merge = (
+		eventProperties?: TelemetryProperties,
+	): TelemetryProperties => ({
+		...properties,
+		...commonProperties,
+		...metadata,
+		...eventProperties,
+		...(distinctId ? { distinct_id: distinctId } : {}),
+	});
+
+	return {
+		setDistinctId(value) {
+			distinctId = trimNonEmpty(value);
+		},
+		setMetadata(value) {
+			metadata = { ...value };
+		},
+		updateMetadata(value) {
+			metadata = { ...metadata, ...value };
+		},
+		setCommonProperties(value) {
+			commonProperties = { ...value };
+		},
+		updateCommonProperties(value) {
+			commonProperties = { ...commonProperties, ...value };
+		},
+		isEnabled: () => parent.isEnabled(),
+		capture: (input) =>
+			parent.capture({
+				event: input.event,
+				properties: merge(input.properties),
+			}),
+		captureRequired: (event, eventProperties) =>
+			parent.captureRequired(event, merge(eventProperties)),
+		recordCounter: (name, value, attributes, description, required) =>
+			parent.recordCounter(
+				name,
+				value,
+				merge(attributes),
+				description,
+				required,
+			),
+		recordHistogram: (name, value, attributes, description, required) =>
+			parent.recordHistogram(
+				name,
+				value,
+				merge(attributes),
+				description,
+				required,
+			),
+		recordGauge: (name, value, attributes, description, required) =>
+			parent.recordGauge(name, value, merge(attributes), description, required),
+		flush: () => parent.flush(),
+		dispose: async () => {},
+	};
+}
+
+/**
+ * Scopes a host telemetry singleton to one runtime client. This is the
+ * reusable bridge used by Hub-hosted sessions; local clients that already
+ * provide their own telemetry service do not need it.
+ */
+export function createClientScopedTelemetryService(
+	parent: ITelemetryService,
+	context: ClientTelemetryContext,
+): ITelemetryService {
+	return createScopedTelemetryService(
+		parent,
+		resolveClientTelemetryProperties(context),
+	);
+}

--- a/sdk/packages/core/src/services/workspace/workspace-telemetry.test.ts
+++ b/sdk/packages/core/src/services/workspace/workspace-telemetry.test.ts
@@ -44,7 +44,7 @@ describe("emitWorkspaceLifecycleTelemetry", () => {
 		resetWorkspaceTelemetryForTests();
 	});
 
-	test("emits workspace.initialized once per process per workspace path", () => {
+	test("emits workspace.initialized once per process, client, and workspace path", () => {
 		const stub = createTelemetryStub();
 		emitWorkspaceLifecycleTelemetry({
 			telemetry: stub.telemetry,
@@ -62,6 +62,20 @@ describe("emitWorkspaceLifecycleTelemetry", () => {
 		});
 		const initialized = findCalls(stub, "workspace.initialized");
 		expect(initialized).toHaveLength(1);
+	});
+
+	test("emits once for each client sharing the same runtime and workspace", () => {
+		const stub = createTelemetryStub();
+		for (const dedupeScope of ["cline-cli", "cline-desktop"]) {
+			emitWorkspaceLifecycleTelemetry({
+				telemetry: stub.telemetry,
+				rootPath: "/tmp/repo",
+				dedupeScope,
+				vcsType: "git",
+			});
+		}
+
+		expect(findCalls(stub, "workspace.initialized")).toHaveLength(2);
 	});
 
 	test("emits separate workspace.initialized events for distinct paths", () => {

--- a/sdk/packages/core/src/services/workspace/workspace-telemetry.ts
+++ b/sdk/packages/core/src/services/workspace/workspace-telemetry.ts
@@ -8,6 +8,11 @@ import {
 export interface WorkspaceLifecycleTelemetryInput {
 	telemetry?: ITelemetryService;
 	rootPath: string;
+	/**
+	 * Optional client identity used for de-duplication in a shared runtime
+	 * process. The same workspace still emits once per client surface.
+	 */
+	dedupeScope?: string;
 	workspaceInfo?: WorkspaceInfo;
 	rootCount?: number;
 	vcsType?: "git" | "none";
@@ -21,8 +26,12 @@ export interface WorkspaceLifecycleTelemetryInput {
 const initializedWorkspaceHashes = new Set<string>();
 const initErrorWorkspaceHashes = new Set<string>();
 
-function hashWorkspacePath(rootPath: string): string {
-	return createHash("sha256").update(rootPath).digest("hex");
+function hashWorkspacePath(rootPath: string, scope?: string): string {
+	return createHash("sha256")
+		.update(rootPath)
+		.update("\0")
+		.update(scope?.trim() ?? "")
+		.digest("hex");
 }
 
 function normalizeVcsTypes(
@@ -40,7 +49,7 @@ export function emitWorkspaceLifecycleTelemetry(
 	if (!input.telemetry) {
 		return;
 	}
-	const workspaceHash = hashWorkspacePath(input.rootPath);
+	const workspaceHash = hashWorkspacePath(input.rootPath, input.dedupeScope);
 	const rootCount = input.rootCount ?? 1;
 	if (!initializedWorkspaceHashes.has(workspaceHash)) {
 		initializedWorkspaceHashes.add(workspaceHash);

--- a/sdk/packages/shared/src/extensions/context.ts
+++ b/sdk/packages/shared/src/extensions/context.ts
@@ -39,8 +39,10 @@ export interface ClientContext {
  * Identity of the authenticated user.
  */
 export interface UserContext {
-	/** PostHog / analytics distinct ID */
+	/** PostHog / analytics distinct ID (an account or anonymous machine ID). */
 	distinctId?: string;
+	/** Authenticated Cline account ID, or null when explicitly signed out. */
+	accountId?: string | null;
 	email?: string;
 	organizationId?: string;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Desktop sessions execute inside the same detached Hub used by other clients, but telemetry emitted by that process previously inherited daemon identity. This change carries the initiating client's serializable identity and account context through session creation and restore, then applies it through a non-owning telemetry scope inside Core.

The per-session scope is intentional: a long-lived Hub can run CLI and Desktop sessions concurrently, so updating its singleton metadata would allow one client to overwrite another client's attribution. Keeping the wrapper in Core also preserves a single lifecycle-emission path instead of creating a parallel Desktop event implementation.

The change also:

- defines one Desktop identity using `cline_type=desktop`, `platform=Cline Desktop`, and the application version;
- forwards current authenticated or explicitly signed-out account context and persists active organization details for detached runtimes;
- emits workspace initialization once per client surface in a shared process;
- standardizes task lifecycle dimensions on `provider` and `model`, while retaining the shared token event and its request-level usage and cost fields;
- extracts the account telemetry resolver/persistence used by the CLI so other clients can share the same behavior.

### Test Procedure

- Built all SDK packages with `bun run build:sdk`.
- Ran the full Core unit suite: 2,203 passed and 15 skipped.
- Ran focused tests after the final Desktop platform-label update: 58 Core tests and 50 Desktop tests passed.
- Ran the broader Desktop sidecar integration set (94 tests) and CLI account tests (9 tests).
- Passed Core, CLI, and Desktop typechecks, the telemetry smoke script, Biome checks, and `git diff --check`.

The highest-risk boundaries were Hub serialization, concurrent telemetry identity, login/logout transitions, workspace deduplication, and canonical event properties; each has direct coverage.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes telemetry, Hub transport, and account plumbing without altering the UI.

### Additional Notes

The source-level lifecycle helper contract now uses `provider` and `model` consistently. All in-repository call sites were updated directly, with no compatibility adapter. Process-owned activation telemetry remains in Desktop, while workspace and task lifecycle telemetry remain owned by shared Core.
