### PR TITLE
Port spawn_agent aggregation into the frame bridge

### DIFF
--- a/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.differential.test.ts
@@ -563,3 +563,111 @@ describe("FrameMessageBridge differential parity (compaction and errors)", () =>
 		])
 	})
 })
+
+describe("FrameMessageBridge differential parity (spawn_agent aggregation)", () => {
+	const spawnStart = (toolCallId: string, task: string): AgentEvent => ({
+		type: "content_start",
+		contentType: "tool",
+		toolCallId,
+		toolName: "spawn_agent",
+		input: { task },
+	})
+	const spawnProgress = (toolCallId: string, update: unknown): AgentEvent => ({
+		type: "content_update",
+		contentType: "tool",
+		toolCallId,
+		toolName: "spawn_agent",
+		update,
+	})
+	const spawnEnd = (toolCallId: string, extra: { output?: unknown; error?: string } = {}): AgentEvent => ({
+		type: "content_end",
+		contentType: "tool",
+		toolCallId,
+		toolName: "spawn_agent",
+		...extra,
+	})
+	const spawnOutput = (text: string, inputTokens: number, outputTokens: number) => ({
+		text,
+		iterations: 2,
+		finishReason: "completed",
+		usage: { inputTokens, outputTokens },
+	})
+
+	it("a single spawn renders prompts, running status, completed status, and usage", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "research the API"),
+			spawnProgress("s1", { toolCalls: 2, inputTokens: 100, outputTokens: 20, latestToolCall: "read_file" }),
+			spawnEnd("s1", { output: spawnOutput("found it", 300, 40) }),
+			{ type: "iteration_end", iteration: 1, hadToolCalls: true, toolCallCount: 1 },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("parallel spawns aggregate into one prompts row and one status row", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "task one"),
+			spawnStart("s2", "task two"),
+			spawnProgress("s2", { toolCalls: 1, contextTokens: 5000, contextWindow: 200000, contextUsagePercentage: 2.5 }),
+			spawnProgress("s1", { toolCalls: 3, totalCost: 0.02 }),
+			spawnEnd("s2", { output: spawnOutput("two done", 10, 5) }),
+			spawnProgress("s1", { toolCalls: 4 }),
+			spawnEnd("s1", { output: spawnOutput("one done", 20, 8) }),
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("a failed spawn marks the group failed once every spawn has closed", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "will fail"),
+			spawnStart("s2", "will pass"),
+			spawnEnd("s1", { error: "sub-agent crashed" }),
+			spawnEnd("s2", { output: spawnOutput("ok", 1, 1) }),
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("a spawn closing after the iteration boundary reports to the reset group", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "long task"),
+			{ type: "iteration_end", iteration: 1, hadToolCalls: true, toolCallCount: 1 },
+			{ type: "iteration_start", iteration: 2 },
+			spawnProgress("s1", { toolCalls: 9 }),
+			spawnEnd("s1", { output: spawnOutput("late", 1, 1) }),
+			{ type: "done", text: "", reason: "completed", iterations: 2 },
+		])
+	})
+
+	it("non-object progress and output payloads leave the entry unchanged", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "task"),
+			spawnProgress("s1", "plain string"),
+			spawnEnd("s1", { output: "not an object" }),
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+
+	it("an aborted turn leaves dangling spawns silent (W3)", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			spawnStart("s1", "task"),
+			spawnProgress("s1", { toolCalls: 1 }),
+			{ type: "done", text: "", reason: "aborted", iterations: 1 },
+		])
+	})
+
+	it("spawn_agent after text drops the completion retag like any tool", () => {
+		expectParity([
+			{ type: "iteration_start", iteration: 1 },
+			{ type: "content_end", contentType: "text", text: "delegating" },
+			spawnStart("s1", "task"),
+			spawnEnd("s1", { output: spawnOutput("done", 1, 1) }),
+			{ type: "content_end", contentType: "text", text: "summary" },
+			{ type: "done", text: "", reason: "completed", iterations: 1 },
+		])
+	})
+})

--- a/apps/vscode/src/sdk/frame-message-bridge.ts
+++ b/apps/vscode/src/sdk/frame-message-bridge.ts
@@ -6,9 +6,10 @@
  * same ClineMessages as the v1 translator (`message-translator.ts`):
  * streaming text/reasoning rows, tool rows (generic, completion, command,
  * MCP, read_files/apply_patch multi-file splits, ask_question
- * suppression), usage, iteration markers, notices including compaction
- * dividers, and turn terminals (completion retag, terminal error rows
- * with ErrorRow reshaping). Parity with v1 is differential-test locked
+ * suppression, spawn_agent aggregation into the SubagentStatusRow rows),
+ * usage, iteration markers, notices including compaction dividers, and
+ * turn terminals (completion retag, terminal error rows with ErrorRow
+ * reshaping). Parity with v1 is differential-test locked
  * (frame-message-bridge.differential.test.ts): both paths mint message
  * ids at identical points, so the produced rows must be equal.
  *
@@ -17,19 +18,26 @@
  * turn, and a force-close (interrupted) is silent — matching v1, where a
  * dangling block simply never got its content_end (W3).
  *
- * Not yet ported (the switchover checklist in the design doc, each gated
- * by its pinned v1 translator tests): spawn_agent aggregation (renders
- * generically until its dedicated port) and approval-coordinator
- * interactions (approved-row upserts, denial suppression — annotation
- * wiring at the flip). Until the switchover PR, v1 remains the production
- * ClineMessage source and this bridge runs shadow-only — its output is
- * drained and discarded by SdkFrameStream.
+ * Not yet ported (the switchover checklist in the design doc, gated by
+ * the pinned v1 translator tests): approval-coordinator interactions
+ * (approved-row upserts, denial suppression — annotation wiring at the
+ * flip). Until the switchover PR, v1 remains the production ClineMessage
+ * source and this bridge runs shadow-only — its output is drained and
+ * discarded by SdkFrameStream.
  */
 
-import type { SessionConsumer, StreamDiagnostic, TurnConsumer } from "@cline/core/frames"
-import type { CloseFinal, NoticeBody, Outcome, UsageBody } from "@cline/shared"
+import type { SessionConsumer, StreamDiagnostic, ToolSink, TurnConsumer } from "@cline/core/frames"
+import type { CloseFinal, NoticeBody, Outcome, ToolStart, UsageBody } from "@cline/shared"
 import { COMMAND_OUTPUT_STRING } from "@shared/combineCommandSequences"
-import type { ClineApiReqInfo, ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
+import type {
+	ClineApiReqInfo,
+	ClineAskUseSubagents,
+	ClineMessage,
+	ClineSaySubagentStatus,
+	ClineSayTool,
+	ClineSubagentUsageInfo,
+	SubagentStatusItem,
+} from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import {
 	buildCompactionMessage,
@@ -39,6 +47,7 @@ import {
 	extractToolOutputText,
 	getApplyPatchString,
 	getCompletionResultText,
+	getSpawnAgentTaskPrompt,
 	isCompletionTool,
 	normalizeUsageEvent,
 	parseCompactionNoticeMetadata,
@@ -135,13 +144,165 @@ export class FrameMessageBridge implements SessionConsumer {
 	}
 }
 
-/** Per-turn state: the completion-retag candidate and the open compaction
- * divider — both turn-scoped by v1's emission rules (the divider is
- * finalized at this turn's terminal, never carried across turns). */
+/**
+ * Aggregates the spawn_agent tool blocks of one iteration into the
+ * SubagentStatusRow UI: one say:"use_subagents" prompts row and one
+ * say:"subagent" status row, each replaced in place as spawns open,
+ * progress, and close, plus a say:"subagent_usage" row once every spawn
+ * has closed. The group is the sole owner of the item list — the status
+ * and usage payloads are derived from it — and of the two row identities,
+ * minted lazily in v1's order (prompts at the first open, status at the
+ * first progress or close).
+ *
+ * Iteration-scoped, as in v1: the turn consumer replaces its group at
+ * each iteration_started, so a spawn block that closes after the boundary
+ * finds no entry and only re-emits the (then empty) group's status.
+ */
+class SpawnAgentGroup {
+	private readonly entries = new Map<string, SubagentStatusItem>()
+	private promptsTs: number | undefined
+	private statusTs: number | undefined
+
+	constructor(private readonly bridge: FrameMessageBridge) {}
+
+	register(blockId: string, prompt: string): void {
+		this.entries.set(blockId, {
+			index: this.entries.size + 1,
+			prompt,
+			status: "running",
+			toolCalls: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			contextTokens: 0,
+			contextWindow: 0,
+			contextUsagePercentage: 0,
+		})
+		const payload: ClineAskUseSubagents = { prompts: this.items().map((entry) => entry.prompt) }
+		if (this.promptsTs === undefined) {
+			this.promptsTs = this.bridge.deps.nextTs()
+		}
+		this.bridge.push({
+			ts: this.promptsTs,
+			type: "say",
+			say: "use_subagents",
+			text: JSON.stringify(payload),
+			partial: true,
+		})
+	}
+
+	progress(blockId: string, update: unknown): void {
+		if (this.entries.size === 0) {
+			// v1 renders progress only while the group has members; a
+			// stray update after the iteration reset emits nothing.
+			return
+		}
+		const entry = this.entries.get(blockId)
+		const data = isRecord(update) ? update : undefined
+		if (entry && data) {
+			if (typeof data.toolCalls === "number") entry.toolCalls = data.toolCalls
+			if (typeof data.inputTokens === "number") entry.inputTokens = data.inputTokens
+			if (typeof data.outputTokens === "number") entry.outputTokens = data.outputTokens
+			if (typeof data.totalCost === "number") entry.totalCost = data.totalCost
+			if (typeof data.contextTokens === "number") entry.contextTokens = data.contextTokens
+			if (typeof data.contextWindow === "number") entry.contextWindow = data.contextWindow
+			if (typeof data.contextUsagePercentage === "number") entry.contextUsagePercentage = data.contextUsagePercentage
+			if (typeof data.latestToolCall === "string") entry.latestToolCall = data.latestToolCall
+		}
+		this.pushStatus("running", true)
+	}
+
+	close(blockId: string, outcome: Outcome, final: CloseFinal): void {
+		const entry = this.entries.get(blockId)
+		if (entry) {
+			// SpawnAgentOutput: { text, usage: { inputTokens, outputTokens } }.
+			const output = final.type === "tool" && isRecord(final.output) ? final.output : undefined
+			if (output) {
+				entry.result = typeof output.text === "string" ? output.text : undefined
+				const usage = isRecord(output.usage) ? output.usage : undefined
+				if (usage) {
+					if (typeof usage.inputTokens === "number") entry.inputTokens = usage.inputTokens
+					if (typeof usage.outputTokens === "number") entry.outputTokens = usage.outputTokens
+				}
+			}
+			if (outcome.kind === "error") {
+				entry.status = "failed"
+				entry.error = outcome.error.message
+			} else {
+				entry.status = "completed"
+			}
+		}
+
+		const items = this.items()
+		const allDone = items.every((item) => item.status === "completed" || item.status === "failed")
+		const hasFailed = items.some((item) => item.status === "failed")
+		this.pushStatus(allDone ? (hasFailed ? "failed" : "completed") : "running", !allDone)
+
+		if (allDone) {
+			const usage: ClineSubagentUsageInfo = {
+				source: "subagents",
+				tokensIn: items.reduce((acc, item) => acc + (item.inputTokens || 0), 0),
+				tokensOut: items.reduce((acc, item) => acc + (item.outputTokens || 0), 0),
+				cacheWrites: 0,
+				cacheReads: 0,
+				cost: items.reduce((acc, item) => acc + (item.totalCost || 0), 0),
+			}
+			this.bridge.push({
+				ts: this.bridge.deps.nextTs(),
+				type: "say",
+				say: "subagent_usage",
+				text: JSON.stringify(usage),
+				partial: false,
+			})
+		}
+	}
+
+	private items(): SubagentStatusItem[] {
+		return Array.from(this.entries.values()).sort((a, b) => a.index - b.index)
+	}
+
+	private pushStatus(status: ClineSaySubagentStatus["status"], partial: boolean): void {
+		const items = this.items()
+		const payload: ClineSaySubagentStatus = {
+			status,
+			total: items.length,
+			completed: items.filter((item) => item.status === "completed" || item.status === "failed").length,
+			successes: items.filter((item) => item.status === "completed").length,
+			failures: items.filter((item) => item.status === "failed").length,
+			toolCalls: items.reduce((acc, item) => acc + (item.toolCalls || 0), 0),
+			inputTokens: items.reduce((acc, item) => acc + (item.inputTokens || 0), 0),
+			outputTokens: items.reduce((acc, item) => acc + (item.outputTokens || 0), 0),
+			contextWindow: items.reduce((acc, item) => Math.max(acc, item.contextWindow || 0), 0),
+			maxContextTokens: items.reduce((acc, item) => Math.max(acc, item.contextTokens || 0), 0),
+			maxContextUsagePercentage: items.reduce((acc, item) => Math.max(acc, item.contextUsagePercentage || 0), 0),
+			items,
+		}
+		if (this.statusTs === undefined) {
+			this.statusTs = this.bridge.deps.nextTs()
+		}
+		this.bridge.push({
+			ts: this.statusTs,
+			type: "say",
+			say: "subagent",
+			text: JSON.stringify(payload),
+			partial,
+		})
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Per-turn state: the completion-retag candidate, the open compaction
+ * divider, and the current iteration's spawn_agent group — all turn-scoped
+ * by v1's emission rules (the divider is finalized at this turn's terminal,
+ * never carried across turns; the group is replaced per iteration). */
 class BridgeTurnConsumer implements TurnConsumer {
 	private turnFinalText: { ts: number; text: string } | undefined
 	private attemptCompletionSeen = false
 	private openCompactionTs: number | undefined
+	private spawnAgents: SpawnAgentGroup | undefined
 
 	constructor(private readonly bridge: FrameMessageBridge) {}
 
@@ -196,7 +357,7 @@ class BridgeTurnConsumer implements TurnConsumer {
 		}
 	}
 
-	onTool(start: { toolName: string; input?: unknown }): ReturnType<TurnConsumer["onTool"]> {
+	onTool(start: ToolStart): ToolSink {
 		// Tool activity after a text block means that text wasn't the
 		// turn-final response — drop the retag candidate (v1 rule).
 		this.turnFinalText = undefined
@@ -210,6 +371,28 @@ class BridgeTurnConsumer implements TurnConsumer {
 		// No mint, no row — at open or close.
 		if (toolName === "ask_question" || toolName === "ask_followup_question") {
 			return { onProgress() {}, onAnnotation() {}, onClose() {} }
+		}
+
+		// spawn_agent blocks aggregate into the iteration's group rather than
+		// rendering a row each. The sink resolves the group at each call, not
+		// at open: a block that outlives the iteration reports to the group
+		// current at that moment, as v1's per-callId lookup does.
+		if (toolName === "spawn_agent") {
+			const blockId = start.blockId
+			const turn = this
+			turn.spawnAgentGroup().register(blockId, getSpawnAgentTaskPrompt(start.input))
+			return {
+				onProgress(update: unknown): void {
+					turn.spawnAgentGroup().progress(blockId, update)
+				},
+				onAnnotation(): void {},
+				onClose(outcome: Outcome, final: CloseFinal): void {
+					if (outcome.kind === "interrupted") {
+						return
+					}
+					turn.spawnAgentGroup().close(blockId, outcome, final)
+				},
+			}
 		}
 
 		if (isCompletionTool(toolName)) {
@@ -417,8 +600,10 @@ class BridgeTurnConsumer implements TurnConsumer {
 	onNotice(notice: NoticeBody): void {
 		switch (notice.noticeType) {
 			case "iteration_started": {
-				// v1's iteration_start: an api_req_started row per API
-				// request (spinner + cost display placeholder).
+				// v1's iteration_start: the spawn_agent aggregation resets
+				// (its reset() clears the group) and an api_req_started row
+				// per API request (spinner + cost display placeholder).
+				this.spawnAgents = undefined
 				this.bridge.push({
 					ts: this.bridge.deps.nextTs(),
 					type: "say",
@@ -567,5 +752,13 @@ class BridgeTurnConsumer implements TurnConsumer {
 
 	private recordTurnFinalText(ts: number, text: string): void {
 		this.turnFinalText = { ts, text }
+	}
+
+	/** The current iteration's spawn_agent group, created on first use. */
+	private spawnAgentGroup(): SpawnAgentGroup {
+		if (this.spawnAgents === undefined) {
+			this.spawnAgents = new SpawnAgentGroup(this.bridge)
+		}
+		return this.spawnAgents
 	}
 }

--- a/apps/vscode/src/sdk/message-translator.ts
+++ b/apps/vscode/src/sdk/message-translator.ts
@@ -322,13 +322,18 @@ export class MessageTranslatorState {
 		return this.streamingToolName
 	}
 
-	/** Clear streaming tool */
+	/** Clear streaming tool, returning its row ts (minted now if the tool never rendered a row). */
 	clearStreamingTool(): number {
 		const ts = this.streamingToolTs ?? this.nextTs()
+		this.discardStreamingTool()
+		return ts
+	}
+
+	/** Forget the active tool stream without minting — for tools that render through other rows (spawn_agent). */
+	discardStreamingTool(): void {
 		this.streamingToolTs = undefined
 		this.streamingToolInput = undefined
 		this.streamingToolName = undefined
-		return ts
 	}
 
 	/** Whether attempt_completion tool was called in this turn */
@@ -870,6 +875,11 @@ export function getCompletionResultText(input: unknown): string {
 	return getStringField(parsed, "summary") ?? getStringField(parsed, "result") ?? ""
 }
 
+/** The task prompt of a spawn_agent input, shown in the use_subagents prompts row. */
+export function getSpawnAgentTaskPrompt(input: unknown): string {
+	return getStringField(parseToolInput(input), "task") ?? ""
+}
+
 /** A single file read request parsed from a read_files/read_file input */
 interface FileReadRequest {
 	path: string
@@ -1159,14 +1169,12 @@ export function buildToolApprovalAskMessage(toolName: string, input: unknown, ts
 	}
 
 	if (toolName === "spawn_agent") {
-		const parsedInput = parseToolInput(input)
-		const taskPrompt = getStringField(parsedInput, "task") ?? ""
 		return {
 			ts,
 			type: "ask",
 			ask: "use_subagents",
 			text: JSON.stringify({
-				prompts: [taskPrompt],
+				prompts: [getSpawnAgentTaskPrompt(input)],
 			} satisfies ClineAskUseSubagents),
 			partial: false,
 		}
@@ -1372,10 +1380,8 @@ export function translateAgentEvent(event: AgentEvent, state: MessageTranslatorS
 					// with running status. Multiple parallel spawn_agent calls in the
 					// same iteration are aggregated into a single status message.
 					if (toolName === "spawn_agent") {
-						const parsedInput = parseToolInput(input)
-						const taskPrompt = getStringField(parsedInput, "task") ?? ""
 						const callId = event.toolCallId ?? `spawn-${state.nextTs()}`
-						state.addSpawnAgent(callId, taskPrompt)
+						state.addSpawnAgent(callId, getSpawnAgentTaskPrompt(input))
 						if (approvedToolMessageTs !== undefined) {
 							state.setSpawnAgentPromptsTs(approvedToolMessageTs)
 						}
@@ -1393,8 +1399,8 @@ export function translateAgentEvent(event: AgentEvent, state: MessageTranslatorS
 							partial: true,
 						})
 
-						// Clear the generic streaming tool so it doesn't also emit say:"tool"
-						state.clearStreamingTool()
+						// Forget the generic streaming tool so it doesn't also emit say:"tool"
+						state.discardStreamingTool()
 						break
 					}
 

--- a/sdk/packages/core/docs/agent-event-stream-design.md
+++ b/sdk/packages/core/docs/agent-event-stream-design.md
@@ -636,14 +636,35 @@ message of plain-object errors (`{ message }` is type-legal v1 input —
 the pinned translator tests use it), not `String(error)`'s
 "[object Object]". With those, the generated-trace exclusion for
 terminal errors was lifted — the differential now covers error
-terminals in the random traces too. **Remaining checklist:** spawn_agent
-aggregation (SubagentStatusRow consumer; the bridge renders it
-generically until then), approval-coordinator interactions
-(approvedToolMessageTs upserts, denial suppression — annotation wiring
-at the flip), StreamError carrying Error instances' `code`/`status`
-properties (real provider errors may set them; the reshape reads them —
-a `details` follow-up), then the flip — bridge output becomes the
-production ClineMessage source and the v1 switch deletes.
+terminals in the random traces too.
+
+**Phase 3c part 2c status: implemented (third tranche — spawn_agent
+aggregation).** The one translation surface whose state spans several
+tool blocks: parallel spawn_agent calls render as a single
+say:"use_subagents" prompts row and a single say:"subagent" status row
+(each replaced in place), plus say:"subagent_usage" once every spawn
+has closed. In the bridge this is `SpawnAgentGroup`, owned by the turn
+consumer and replaced at each `iteration_started` (v1's `reset()`
+clears its spawn registry); the group is the sole owner of the item
+list and of the two row identities, so the status and usage payloads
+cannot disagree with each other. Spawn sinks resolve the group at each
+callback rather than capturing it at open, so a block closing after
+the iteration boundary reports to the reset group exactly as v1's
+per-callId lookup does. Differential coverage is handcrafted (the
+generator emits only read_file): single and parallel spawns with
+progress, failure, the post-boundary close, non-object payloads, abort
+(W3 silence), and the retag-drop rule. One v1 fix fell out: v1's
+spawn_agent content_start discarded the generic tool stream via
+`clearStreamingTool()`, which mints a ts for a row it never emits; it
+now calls `discardStreamingTool()`, which does not mint. v1's
+suppression heuristic (`hasRunningSpawnAgents()`) is not ported — P5's
+`onSubAgent → null` is its structural replacement. **Remaining
+checklist:** approval-coordinator interactions (approvedToolMessageTs
+upserts, denial suppression — annotation wiring at the flip),
+StreamError carrying Error instances' `code`/`status` properties (real
+provider errors may set them; the reshape reads them — a `details`
+follow-up), then the flip — bridge output becomes the production
+ClineMessage source and the v1 switch deletes.
 
 **Phase 3d — history replay and reconnect.** Snapshot reconciliation
 in the assembler (diff against the live set), live-after-history dedup


### PR DESCRIPTION
## Summary

The agent-event stream design's VSCode translator port continues (stack #13794, on top of #13806). This tranche ports spawn_agent aggregation — the last pure-translation surface of the v1 translator — into FrameMessageBridge, still shadow-only: v1 remains the production ClineMessage source, zero webview behavior change.

spawn_agent is the one place where rendering state spans several tool blocks: parallel spawns render as a single `say:use_subagents` prompts row and a single `say:subagent` status row, each replaced in place, plus a `say:subagent_usage` row once every spawn has closed. The bridge models this as `SpawnAgentGroup`, owned by the turn consumer and replaced at each `iteration_started` (v1's `reset()` clears its registry). The group is the sole owner of the item list and both row identities, so the status and usage payloads derive from one source. Spawn sinks resolve the group at each callback rather than capturing it at open, so a block that closes after the iteration boundary reports to the reset group exactly as v1's per-callId lookup does.

Parity is differential-locked with handcrafted traces (the generator emits only read_file): single and parallel spawns with progress, failure, the post-boundary close, non-object payloads, abort (W3 silence), and the retag-drop rule.

One v1 fix fell out of matching it: v1's spawn_agent `content_start` discarded the generic tool stream with `clearStreamingTool()`, which mints a message id for a row it never emits. It now calls `discardStreamingTool()`, which does not mint. Message ids are opaque identities, so this has no user-visible effect; it removes a gap in the id sequence.

v1's `hasRunningSpawnAgents()` suppression heuristic is not ported — `onSubAgent → null` (P5) is its structural replacement.

Remaining before the production flip (design doc checklist): approval-coordinator annotation wiring, and StreamError carrying code/status from real Error instances.

Stacked on #13806 (stack #13794).

## Test plan

- [x] `cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk/frame-message-bridge.differential.test.ts` — 43/43 (7 new spawn_agent cases)
- [x] `cd apps/vscode && bunx vitest run --config vitest.config.ts src/sdk` — 1137/1137
- [x] `cd apps/vscode && bunx biome check --config-path ./biome.jsonc src/sdk/frame-message-bridge.ts src/sdk/frame-message-bridge.differential.test.ts src/sdk/message-translator.ts` — clean at error level
- [x] `cd apps/vscode && bunx tsc --noEmit` — 2 errors, both pre-existing stale generated protos (`bun run protos` regenerates), none in src/sdk
