### PR TITLE
fix(tools): reject apply_patch Add File when target already exists

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
@@ -272,4 +272,29 @@ describe("createApplyPatchExecutor", () => {
 
 		await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(original);
 	});
+
+	it("rejects an add patch when the file already exists", async () => {
+		const filePath = path.join(tempDir, "note.txt");
+		await fs.writeFile(filePath, "do not overwrite", "utf-8");
+		const execute = createApplyPatchExecutor();
+
+		await expect(
+			execute(
+				{
+					input: [
+						"*** Begin Patch",
+						"*** Add File: note.txt",
+						"+hello",
+						"*** End Patch",
+					].join("\n"),
+				},
+				tempDir,
+				{} as never,
+			),
+		).rejects.toThrow(/Add File Error: File already exists: note\.txt/);
+
+		await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+			"do not overwrite",
+		);
+	});
 });

--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
@@ -208,14 +208,15 @@ async function loadFiles(
 	encoding: BufferEncoding,
 	restrictToCwd: boolean,
 ): Promise<LoadedFiles> {
-	const filesToLoad = extractFilesForOperations(lines, [
+	const requiredFiles = extractFilesForOperations(lines, [
 		PATCH_MARKERS.UPDATE,
 		PATCH_MARKERS.DELETE,
 	]);
+	const optionalFiles = extractFilesForOperations(lines, [PATCH_MARKERS.ADD]);
 	const files: Record<string, string> = {};
 	const eols: Record<string, LineEnding> = {};
 
-	for (const filePath of filesToLoad) {
+	for (const filePath of requiredFiles) {
 		const absolutePath = resolveFilePath(cwd, filePath, restrictToCwd);
 		let fileContent: string;
 		try {
@@ -225,6 +226,23 @@ async function loadFiles(
 		}
 		files[filePath] = fileContent.replace(/\r\n/g, "\n");
 		eols[filePath] = detectLineEnding(fileContent);
+	}
+
+	for (const filePath of optionalFiles) {
+		if (filePath in files) {
+			continue;
+		}
+		const absolutePath = resolveFilePath(cwd, filePath, restrictToCwd);
+		try {
+			const fileContent = await fs.readFile(absolutePath, encoding);
+			files[filePath] = fileContent.replace(/\r\n/g, "\n");
+			eols[filePath] = detectLineEnding(fileContent);
+		} catch (err) {
+			if ((err as { code?: string }).code === "ENOENT") {
+				continue;
+			}
+			throw err;
+		}
 	}
 
 	return { files, eols };


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!
-->

### Related Issue

**Issue:** #13833

### Description

#### Problem
`apply_patch` **Add File** silently overwrites files that already exist on disk. The intended behavior is to throw `Add File Error: File already exists`, but that guard was never reached for Add-only patches.

#### Root cause
`loadFiles()` preloaded only the paths behind `*** Update File:` and `*** Delete File:` headers, so an `*** Add File:` target was never present in the `currentFiles` map that `parseAdd()` checks. When the add path was already on disk, `fs.writeFile` simply replaced it.

#### Fix
`loadFiles()` now also attempts to read `*** Add File:` targets. If the file exists, its content is loaded into `currentFiles`, which lets the existing `parseAdd()` guard reject the patch with `Add File Error: File already exists`. If the file does not exist (`ENOENT`), the optional load is skipped, preserving the normal "create new file" path.

#### Verification
- Added a regression test in `apply-patch.test.ts`: an existing `note.txt` plus an Add File patch throws and the file content is unchanged.
- Focused unit test run: `bunx vitest run src/extensions/tools/executors/apply-patch.test.ts --config vitest.config.ts` — 11/11 passing.
- `bun -F @cline/core typecheck` passes.
- `bun run biome check --diagnostic-level=error` on the two changed files passes.

#### Risks
- Update/Delete behavior is unchanged: those paths are still loaded in the required-file loop and still throw `File not found` when missing.
- The add-path load is best-effort and only treats `ENOENT` as expected; any other read error is still rethrown so permission or I/O problems do not go unnoticed.

## Assistance

AI-assisted. I wrote and verified this change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Small, focused bug fix as permitted by the contributing guidelines without a prior feature discussion.
