### PR TITLE
fix(core): make apply_patch Add File refuse to overwrite existing files

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.test.ts
@@ -233,6 +233,31 @@ describe("createApplyPatchExecutor", () => {
 		);
 	});
 
+	it("refuses to add a file that already exists", async () => {
+		const filePath = path.join(tempDir, "note.txt");
+		await fs.writeFile(filePath, "important data", "utf-8");
+		const execute = createApplyPatchExecutor();
+
+		await expect(
+			execute(
+				{
+					input: [
+						"*** Begin Patch",
+						"*** Add File: note.txt",
+						"+overwritten",
+						"*** End Patch",
+					].join("\n"),
+				},
+				tempDir,
+				{} as never,
+			),
+		).rejects.toThrow("Add File Error: File already exists: note.txt");
+
+		await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+			"important data",
+		);
+	});
+
 	it("rejects incomplete patch sentinels", async () => {
 		const execute = createApplyPatchExecutor();
 

--- a/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/apply-patch.ts
@@ -227,6 +227,20 @@ async function loadFiles(
 		eols[filePath] = detectLineEnding(fileContent);
 	}
 
+	// ADD targets are loaded only when they already exist, so the parser's
+	// "File already exists" guard reflects the real filesystem instead of
+	// silently overwriting the file.
+	for (const filePath of extractFilesForOperations(lines, [
+		PATCH_MARKERS.ADD,
+	])) {
+		const absolutePath = resolveFilePath(cwd, filePath, restrictToCwd);
+		try {
+			files[filePath] = await fs.readFile(absolutePath, encoding);
+		} catch {
+			// Missing file is the expected case for ADD.
+		}
+	}
+
 	return { files, eols };
 }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #13833

### Description

`PatchParser.parseAdd` is meant to throw `Add File Error: File already exists` when an `*** Add File:` target is already on disk, but it checks `currentFiles`, which `loadFiles()` only populates from `*** Update File:` / `*** Delete File:` headers. ADD targets never made it into that map, so the guard was dead code and `applyChanges()` went on to `fs.writeFile` over the existing file with no error.

`loadFiles()` now also reads ADD targets that already exist on disk into `files` (a missing file is the expected case and is ignored), so the parser's existing guard fires and the patch is rejected before anything is written. No parser or executor changes beyond that.

### Test Procedure

- Added `refuses to add a file that already exists` to `apply-patch.test.ts`: writes `note.txt`, applies an `Add File: note.txt` patch, asserts the `File already exists` rejection and that the original contents are untouched.
- Verified the new test fails on the unfixed source (`promise resolved "Successfully applied patch..." instead of rejecting`) and passes with the fix.
- `bun -F @cline/core test:unit -- apply-patch`: 11/11 pass.
- `bun tsc -p tsconfig.dev.json --noEmit` in `packages/core` is clean; `biome check` on both files is clean.
- Existing ADD tests (fresh temp dir, no pre-existing file) are unaffected since the new read only succeeds when the file exists.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend change)

### Additional Notes

The same `path in currentFiles` guard exists in OpenAI's reference `apply_patch.py` with the same `load_files` limitation, so this is inherited upstream behavior rather than a regression.