### PR TITLE
fix(core): carry LiteLLM per-model pricing instead of reporting every model free

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -656,6 +656,131 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["gpt-5.4"]).toBeUndefined();
 	});
 
+	it("carries LiteLLM per-token pricing through as dollars per million tokens", async () => {
+		// #13812: LiteLLM returns real per-token costs on /model/info and Cline showed every model as
+		// "free", so cost tracking read $0 for paid models. The two scales are the whole bug: LiteLLM
+		// reports dollars PER TOKEN, ModelInfo.pricing is dollars per MILLION tokens, and the numbers
+		// below are the ones from the report ($0.40 / $1.60 per 1M).
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							model_name: "gpt-4.1-mini",
+							litellm_params: { model: "openai/gpt-4.1-mini" },
+							model_info: {
+								max_input_tokens: 1_000_000,
+								input_cost_per_token: 4e-7,
+								output_cost_per_token: 1.6e-6,
+								cache_read_input_token_cost: 1e-7,
+								cache_creation_input_token_cost: 5e-7,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"litellm",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "litellm",
+				modelId: "",
+				apiKey: "litellm-key",
+				baseUrl: "http://localhost:4000/v1/",
+			},
+		);
+
+		expect(resolved?.knownModels?.["openai/gpt-4.1-mini"]?.pricing).toEqual({
+			input: 0.4,
+			output: 1.6,
+			cacheRead: 0.1,
+			cacheWrite: 0.5,
+		});
+		// The display-name alias is the entry the model picker shows, and it is a separate object.
+		expect(resolved?.knownModels?.["gpt-4.1-mini"]?.pricing).toEqual({
+			input: 0.4,
+			output: 1.6,
+			cacheRead: 0.1,
+			cacheWrite: 0.5,
+		});
+	});
+
+	it("omits LiteLLM pricing entirely when the proxy reports no costs", async () => {
+		// A genuinely free proxy, and the shape every older LiteLLM returns. `pricing` must stay
+		// absent rather than becoming a block of zeros: zero is a price, and claiming one the proxy
+		// never sent is the same class of wrong answer as the bug above, pointing the other way.
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							model_name: "local-model",
+							litellm_params: { model: "ollama/local-model" },
+							model_info: { max_input_tokens: 8_000 },
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"litellm",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "litellm",
+				modelId: "",
+				apiKey: "litellm-key",
+				baseUrl: "http://localhost:4000/v1/",
+			},
+		);
+
+		expect(resolved?.knownModels?.["ollama/local-model"]).toBeDefined();
+		expect(
+			resolved?.knownModels?.["ollama/local-model"]?.pricing,
+		).toBeUndefined();
+	});
+
+	it("keeps a partial LiteLLM price list partial", async () => {
+		// Input priced, output not. Defaulting the missing half to 0 would under-report every
+		// completion; leaving it undefined keeps "unknown" distinguishable from "free".
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							model_name: "half-priced",
+							litellm_params: { model: "openai/half-priced" },
+							model_info: { input_cost_per_token: 2e-6 },
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"litellm",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "litellm",
+				modelId: "",
+				apiKey: "litellm-key",
+				baseUrl: "http://localhost:4000/v1/",
+			},
+		);
+
+		expect(resolved?.knownModels?.["openai/half-priced"]?.pricing).toEqual({
+			input: 2,
+		});
+	});
+
 	it("returns an empty authoritative LiteLLM model list without auth", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -306,6 +306,7 @@ function buildModelFromPrivateSource(
 		supportsPromptCache?: boolean;
 		supportsReasoning?: boolean;
 		releaseDate?: string;
+		pricing?: ModelPricing;
 	},
 ): ModelInfo {
 	const capabilities: NonNullable<ModelInfo["capabilities"]> = [
@@ -332,6 +333,7 @@ function buildModelFromPrivateSource(
 		capabilities,
 		releaseDate: input.releaseDate,
 		status: "active",
+		...(input.pricing === undefined ? {} : { pricing: input.pricing }),
 	};
 }
 
@@ -544,7 +546,71 @@ interface LiteLlmModelInfoResponse {
 		supports_vision?: boolean;
 		supports_prompt_caching?: boolean;
 		supports_reasoning?: boolean;
+		input_cost_per_token?: number | string;
+		output_cost_per_token?: number | string;
+		cache_read_input_token_cost?: number | string;
+		cache_creation_input_token_cost?: number | string;
 	};
+}
+
+/**
+ * The pricing block on a model, derived from ModelInfo rather than imported: this module already
+ * takes its ModelInfo from `./provider-settings`, and deriving keeps the two from drifting apart.
+ */
+type ModelPricing = NonNullable<ModelInfo["pricing"]>;
+
+/** LiteLLM quotes costs per token; ModelInfo.pricing is per million tokens. */
+const TOKENS_PER_PRICED_UNIT = 1_000_000;
+
+/**
+ * Significant digits kept when rescaling a per-token cost.
+ *
+ * The multiply is not exact in binary: 4e-7 * 1e6 is 0.39999999999999997, which is the price the
+ * cost readout would then show. Twelve significant digits is far more than any real quote carries
+ * (the cheapest models are around 1e-8 per token) and removes the artifact.
+ */
+const PRICE_PRECISION = 12;
+
+function perMillionTokens(
+	value: number | string | undefined,
+): number | undefined {
+	const perToken = parseOptionalNumber(value);
+	if (perToken === undefined) {
+		return undefined;
+	}
+	return Number(
+		(perToken * TOKENS_PER_PRICED_UNIT).toPrecision(PRICE_PRECISION),
+	);
+}
+
+/**
+ * The prices a LiteLLM proxy reported, or undefined when it reported none.
+ *
+ * Undefined rather than a block of zeros on purpose: zero is a price, and a proxy that says nothing
+ * about cost has not said the model is free. Each field is carried independently for the same
+ * reason, so a half-priced quote stays half a quote instead of gaining a fabricated zero.
+ */
+function litellmPricing(
+	info: LiteLlmModelInfoResponse["model_info"],
+): ModelPricing | undefined {
+	const pricing: ModelPricing = {};
+	const input = perMillionTokens(info?.input_cost_per_token);
+	const output = perMillionTokens(info?.output_cost_per_token);
+	const cacheRead = perMillionTokens(info?.cache_read_input_token_cost);
+	const cacheWrite = perMillionTokens(info?.cache_creation_input_token_cost);
+	if (input !== undefined) {
+		pricing.input = input;
+	}
+	if (output !== undefined) {
+		pricing.output = output;
+	}
+	if (cacheRead !== undefined) {
+		pricing.cacheRead = cacheRead;
+	}
+	if (cacheWrite !== undefined) {
+		pricing.cacheWrite = cacheWrite;
+	}
+	return Object.keys(pricing).length > 0 ? pricing : undefined;
 }
 
 function normalizeLiteLlmBaseUrl(baseUrl: string | undefined): string {
@@ -613,6 +679,7 @@ async function fetchLiteLlmPrivateModels(
 							supportsImages: info?.supports_vision,
 							supportsPromptCache: info?.supports_prompt_caching,
 							supportsReasoning: info?.supports_reasoning,
+							pricing: litellmPricing(info),
 						});
 						models[modelId] = converted;
 						if (displayName) {


### PR DESCRIPTION
Fixes #13812.

## The bug

A LiteLLM proxy returns real costs on `/model/info`, and Cline showed every model on it as **free**, so cost tracking read $0 for paid models.

`LiteLlmModelInfoResponse.model_info` declared only token limits and capability flags:

```ts
model_info?: {
    max_output_tokens?: number;
    max_tokens?: number;
    max_input_tokens?: number;
    supports_vision?: boolean;
    supports_prompt_caching?: boolean;
    supports_reasoning?: boolean;
};
```

No cost fields, so `input_cost_per_token` and `output_cost_per_token` were never read, `pricing` was never set on the resolved `ModelInfo`, and `adaptSdkModelInfo` defaults a missing `pricing.input` to `0`. Every layer behaved exactly as written. The price was dropped at the first one, and the zero further down is what the UI renders as "free".

## The two scales, which are the substance of the fix

LiteLLM quotes dollars **per token**; `ModelInfo.pricing` is dollars **per million** (the catalog has Opus at `{ input: 5, output: 25 }`). So the values are rescaled by `1e6`, and the report's `4e-7` becomes `0.4`, which is the $0.40 / 1M it stands for.

That multiply is not exact in binary:

```
4e-7 * 1e6  ===  0.39999999999999997
1.6e-6 * 1e6 === 1.5999999999999999
```

Left alone, `$0.39999999999999997` is the number the cost readout would show. The result is taken to 12 significant digits, which is far more than any real quote carries (the cheapest models sit around `1e-8` per token, and `1.234e-9` still round-trips to `0.001234`) and enough to remove the artifact. There is a test that fails on exactly this, so it cannot quietly regress.

## What it deliberately does not do

**Pricing stays `undefined` when the proxy reports no costs**, and each field is carried independently.

Zero is a price. A proxy that says nothing about cost has not said the model is free, and filling in a zero would be the same wrong answer as the bug, pointing the other way. A quote with only an input price stays half a quote rather than gaining a fabricated free output. Both cases are pinned.

Cache costs (`cache_read_input_token_cost`, `cache_creation_input_token_cost`) ride the same path, since the adapter already maps `cacheRead`/`cacheWrite`.

## Tests

Three cases in `provider-defaults.test.ts`, beside the existing LiteLLM `/model/info` test, using the exact numbers from the report:

- per-token costs arrive as `{ input: 0.4, output: 1.6, cacheRead: 0.1, cacheWrite: 0.5 }`, on both the model id and the display-name alias, which are separate objects
- a proxy reporting no costs leaves `pricing` absent rather than a block of zeros
- an input-only quote stays input-only

Written RED first. Mutation-checked in both directions:

- dropping the `pricing:` mapping (the original bug) reddens 2 of the 3, and correctly leaves the "no costs reported" case green, since that one asserts the same `undefined` the buggy code produced
- replacing `toPrecision` with a plain multiply reddens exactly 1, with `expected { input: 0.39999999999999997 } to deeply equal { input: 0.4 }`

## Checks

`biome check` clean on both files, `@cline/core typecheck` clean, and the core unit suite at **2188 passing**. Three failures in `compact-session-script.test.ts` and `task-spec-parser.test.ts` reproduce identically on a clean `main` on this Windows box and are unrelated to this change.
