### PR TITLE
Unify Tools, Skills, and Rules tab styling in desktop Customize view

### DIFF
--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -920,7 +920,7 @@ async function listHubSettings(
 async function toggleHubSetting(
 	ctx: SidecarContext,
 	input: {
-		type: "plugins" | "tools";
+		type: "plugins" | "tools" | "skills";
 		path?: string;
 		name?: string;
 		enabled?: boolean;
@@ -959,13 +959,18 @@ async function listUserInstructionConfigs(
 		const items: unknown[] = [];
 		for (const record of userInstructionService.listRecords(type)) {
 			const item = record.item as unknown as JsonRecord;
-			if (item.disabled === true) continue;
+			const disabled = item.disabled === true;
+			// Rules and workflows have no toggle UI, so keep hiding disabled
+			// ones; skills need to stay visible (disabled) so they can be
+			// re-enabled from the Skills tab.
+			if (disabled && type !== "skill") continue;
 			items.push({
 				id: record.id,
 				name: item.name ?? record.id,
 				description: item.description,
 				instructions: item.instructions,
 				path: record.filePath,
+				...(type === "skill" ? { enabled: !disabled } : {}),
 			});
 		}
 		return items;
@@ -2503,6 +2508,18 @@ export async function handleCommand(
 		const snapshot = await toggleHubSetting(ctx, {
 			type: "plugins",
 			path: pluginPath,
+			enabled: args?.disabled !== true,
+		});
+		return await listUserInstructionConfigs(ctx, snapshot);
+	}
+	if (command === "set_skill_disabled") {
+		const skillPath = String(args?.path ?? "").trim();
+		if (!skillPath) {
+			throw new Error("skill path is required");
+		}
+		const snapshot = await toggleHubSetting(ctx, {
+			type: "skills",
+			path: skillPath,
 			enabled: args?.disabled !== true,
 		});
 		return await listUserInstructionConfigs(ctx, snapshot);

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -914,12 +914,12 @@ export function AgentSidebar({
 								newTaskActive && "bg-surface-hover text-sidebar-foreground",
 							)}
 							onClick={openHome}
-							title="Start a new task"
+							title="Start a new session"
 							type="button"
 							variant="sidebarItem"
 						>
 							<Plus className="size-4 shrink-0" />
-							<span className="truncate">New</span>
+							<span className="truncate">Session</span>
 						</Button>
 						<Button
 							aria-label="Schedule"

--- a/apps/examples/desktop-app/webview/components/ui/badge.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/badge.tsx
@@ -17,6 +17,8 @@ const badgeVariants = cva(
 					"border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
 					"text-foreground [a&]:hover:bg-surface-hover [a&]:hover:text-foreground",
+				muted:
+					"text-muted-foreground [a&]:hover:bg-surface-hover [a&]:hover:text-foreground",
 			},
 		},
 		defaultVariants: {

--- a/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
@@ -22,12 +22,12 @@ import { McpServersContent } from "./mcp-view";
 type CustomizeTab = "skills" | "mcp" | "plugins" | "rules" | "hooks" | "tools";
 
 const CUSTOMIZE_TABS: { id: CustomizeTab; label: string }[] = [
-	{ id: "skills", label: "Skills" },
-	{ id: "mcp", label: "MCP" },
-	{ id: "plugins", label: "Plugins" },
-	{ id: "rules", label: "Rules" },
-	{ id: "hooks", label: "Hooks" },
 	{ id: "tools", label: "Tools" },
+	{ id: "plugins", label: "Plugins" },
+	{ id: "skills", label: "Skills" },
+	{ id: "rules", label: "Rules" },
+	{ id: "mcp", label: "MCP" },
+	{ id: "hooks", label: "Hooks" },
 ];
 
 type TabCounts = Partial<Record<CustomizeTab, number>>;
@@ -51,7 +51,7 @@ export function CustomizeView({
 }: {
 	onOpenMarketplace?: () => void;
 }) {
-	const [tab, setTab] = useState<CustomizeTab>("skills");
+	const [tab, setTab] = useState<CustomizeTab>("tools");
 	const [counts, setCounts] = useState<TabCounts>({});
 
 	const refreshCounts = useCallback(async () => {
@@ -107,7 +107,7 @@ export function CustomizeView({
 						</Button>
 					) : undefined
 				}
-				description="Extend what Cline can do and change how it works. Manage what's installed, or browse the marketplace for more options."
+				description="Extend what Cline can do and how it works. Explore the marketplace for more options."
 				title="Customize"
 			/>
 

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
@@ -137,3 +137,52 @@ describe("CustomizationSectionView Agent Plugin inventory", () => {
 		});
 	});
 });
+
+describe("tool state controls", () => {
+	it.each([
+		true,
+		false,
+	])("sets duplicate built-in names explicitly (enabled=%s)", async (initialEnabled) => {
+		let enabled = initialEnabled;
+		const inventory = () => ({
+			workspaceRoot: "/workspace",
+			tools: [
+				{
+					id: "web_search",
+					name: "web_search",
+					headlessToolNames: ["web_search"],
+					source: "builtin",
+					enabled,
+				},
+			],
+		});
+		invoke.mockImplementation(async (command, args) => {
+			if (command === "list_marketplace_installed_entries")
+				return { installedKeys: [] };
+			if (command === "list_user_instruction_configs") return inventory();
+			if (command === "set_tool_disabled") {
+				enabled = !args.disabled;
+				return inventory();
+			}
+			throw new Error(`Unexpected command: ${command}`);
+		});
+		await act(async () => {
+			root.render(<CustomizationSectionView section="Tools" />);
+		});
+		await act(async () => {
+			container
+				.querySelector<HTMLButtonElement>('[aria-label="Toggle web_search"]')
+				?.click();
+		});
+		expect(enabled).toBe(!initialEnabled);
+		expect(invoke).toHaveBeenCalledWith("set_tool_disabled", {
+			names: ["web_search", "web_search"],
+			disabled: initialEnabled,
+		});
+		expect(
+			container
+				.querySelector('[aria-label="Toggle web_search"]')
+				?.getAttribute("aria-checked"),
+		).toBe(String(!initialEnabled));
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -634,6 +634,18 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
+					// toggle_disabled_plugin_tool flips one name with no
+					// explicit target state, which only reliably lands on the
+					// desired state when the tool maps to a single
+					// underlying name. A tool with several headless names in
+					// a mixed disabled state can't be forced to the opposite
+					// state by blindly flipping every name — some flips
+					// would move it further from the goal instead of closer.
+					if (names.length > 1) {
+						throw new Error(
+							`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
+						);
+					}
 					for (const name of names) {
 						response = await desktopClient.invoke<UserInstructionListsResponse>(
 							"toggle_disabled_plugin_tool",
@@ -684,6 +696,7 @@ export function CustomizationSectionView({
 					throw new Error("tool name is required");
 				}
 				let response: UserInstructionListsResponse | undefined;
+				const unreachableTools: ToolItem[] = [];
 				try {
 					response = await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
@@ -696,11 +709,24 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
+					// toggle_disabled_plugin_tool flips one name with no
+					// explicit target state, which only reliably lands on
+					// the desired state when the tool maps to a single
+					// underlying name. A tool with several headless names in
+					// a mixed disabled state can't be forced to the target
+					// state by blindly flipping every name — some flips
+					// would move it further from the goal instead of
+					// closer — so skip those instead of silently leaving
+					// them wrong, and apply whatever did succeed.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
+						if (toolNames.length > 1) {
+							unreachableTools.push(tool);
+							continue;
+						}
 						for (const name of toolNames) {
 							response =
 								await desktopClient.invoke<UserInstructionListsResponse>(
@@ -710,12 +736,20 @@ export function CustomizationSectionView({
 						}
 					}
 				}
+				if (response) {
+					applyResponse(response);
+				}
+				if (unreachableTools.length > 0) {
+					const names = unreachableTools.map((tool) => tool.name).join(", ");
+					throw new Error(
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in bulk.`,
+					);
+				}
 				if (!response) {
 					throw new Error(
 						"tool toggle did not return an updated extension list",
 					);
 				}
-				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -380,6 +380,77 @@ function isUnsupportedDesktopCommand(error: unknown, command: string): boolean {
 	return message.includes(`unsupported desktop command: ${command}`);
 }
 
+/**
+ * Legacy fallback for sidecars that predate `set_tool_disabled`:
+ * `toggle_disabled_plugin_tool` flips one name with no explicit target
+ * state, so a tool with several headless names needs care to land on an
+ * exact target rather than some other combination.
+ *
+ * A grouped tool's `enabled` flag is true only when *none* of its names are
+ * disabled, so flipping every name once turns the aggregate true if and
+ * only if every name was disabled right before that flip — the exact
+ * "enable all" success condition. That makes the aggregate a reliable
+ * one-shot check for the enable direction, but not for disable: `false`
+ * there just means "at least one name disabled," which is equally true for
+ * "still mixed" and "now fully disabled." So for disable, a second
+ * (probe) flip is used — it turns the aggregate true only if every name was
+ * disabled right after the *first* flip, which is exactly what "disable"
+ * needs to confirm — and a third flip redoes the first if that holds.
+ * Either way, an unconfirmed attempt is flipped back to its exact starting
+ * state rather than left in some other unintended combination.
+ */
+async function toggleLegacyToolGroup(
+	toolNames: string[],
+	toolId: string,
+	desiredEnabled: boolean,
+): Promise<{ response: UserInstructionListsResponse; reached: boolean }> {
+	let response: UserInstructionListsResponse | undefined;
+	const flipAll = async () => {
+		for (const name of toolNames) {
+			response = await desktopClient.invoke<UserInstructionListsResponse>(
+				"toggle_disabled_plugin_tool",
+				{ name },
+			);
+		}
+	};
+	const readEnabled = () =>
+		response?.tools.find((candidate) => candidate.id === toolId)?.enabled;
+
+	await flipAll();
+	if (toolNames.length <= 1) {
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: true,
+		};
+	}
+
+	if (desiredEnabled) {
+		if (readEnabled() === true) {
+			return {
+				response: response as UserInstructionListsResponse,
+				reached: true,
+			};
+		}
+		await flipAll(); // Undo: restores the exact original state.
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: false,
+		};
+	}
+
+	await flipAll(); // Probe.
+	if (readEnabled() === true) {
+		await flipAll(); // Redo: the probe flipped everyone back on.
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: true,
+		};
+	}
+	// The first flip left the group mixed; the probe already restored the
+	// original state.
+	return { response: response as UserInstructionListsResponse, reached: false };
+}
+
 export function CustomizationSectionView({
 	catalogPrimitive,
 	chrome = "page",
@@ -636,42 +707,20 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
-					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state. Flipping every name once
-					// reaches the target correctly when the tool's
-					// underlying names shared the same prior state; if they
-					// didn't (a mixed disabled state), flip everyone back to
-					// restore the original state instead of leaving some
-					// other unintended combination, and report that the
-					// tool needs an update.
-					for (const name of names) {
-						response = await desktopClient.invoke<UserInstructionListsResponse>(
-							"toggle_disabled_plugin_tool",
-							{ name },
-						);
-					}
-					if (names.length > 1) {
-						const reachedTarget =
-							response?.tools?.find((candidate) => candidate.id === tool.id)
-								?.enabled === desiredEnabled;
-						if (!reachedTarget) {
-							for (const name of names) {
-								response =
-									await desktopClient.invoke<UserInstructionListsResponse>(
-										"toggle_disabled_plugin_tool",
-										{ name },
-									);
-							}
-							unreachable = true;
-						}
-					}
+					const result = await toggleLegacyToolGroup(
+						names,
+						tool.id,
+						desiredEnabled,
+					);
+					response = result.response;
+					unreachable = !result.reached;
 				}
 				if (response) {
 					applyResponse(response);
 				}
 				if (unreachable) {
 					throw new Error(
-						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
 					);
 				}
 				if (!response) {
@@ -729,40 +778,21 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
-					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state. Flipping every name of a tool
-					// once reaches the target correctly when its underlying
-					// names shared the same prior state; if they didn't (a
-					// mixed disabled state), flip everyone back to restore
-					// the original state instead of leaving some other
-					// unintended combination, and report that tool as
-					// needing an update.
+					// See toggleLegacyToolGroup for why grouped tools need
+					// verify-and-revert instead of a blind flip.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
-						for (const name of toolNames) {
-							response =
-								await desktopClient.invoke<UserInstructionListsResponse>(
-									"toggle_disabled_plugin_tool",
-									{ name },
-								);
-						}
-						if (toolNames.length > 1) {
-							const reachedTarget =
-								response?.tools?.find((candidate) => candidate.id === tool.id)
-									?.enabled === enabled;
-							if (!reachedTarget) {
-								for (const name of toolNames) {
-									response =
-										await desktopClient.invoke<UserInstructionListsResponse>(
-											"toggle_disabled_plugin_tool",
-											{ name },
-										);
-								}
-								unreachableTools.push(tool);
-							}
+						const result = await toggleLegacyToolGroup(
+							toolNames,
+							tool.id,
+							enabled,
+						);
+						response = result.response;
+						if (!result.reached) {
+							unreachableTools.push(tool);
 						}
 					}
 				}
@@ -772,7 +802,7 @@ export function CustomizationSectionView({
 				if (unreachableTools.length > 0) {
 					const names = unreachableTools.map((tool) => tool.name).join(", ");
 					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions.`,
 					);
 				}
 				if (!response) {

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -621,7 +621,9 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
+				const desiredEnabled = !tool.enabled;
 				let response: UserInstructionListsResponse | undefined;
+				let unreachable = false;
 				try {
 					response = await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
@@ -635,30 +637,48 @@ export function CustomizationSectionView({
 						throw error;
 					}
 					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state, which only reliably lands on the
-					// desired state when the tool maps to a single
-					// underlying name. A tool with several headless names in
-					// a mixed disabled state can't be forced to the opposite
-					// state by blindly flipping every name — some flips
-					// would move it further from the goal instead of closer.
-					if (names.length > 1) {
-						throw new Error(
-							`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
-						);
-					}
+					// explicit target state. Flipping every name once
+					// reaches the target correctly when the tool's
+					// underlying names shared the same prior state; if they
+					// didn't (a mixed disabled state), flip everyone back to
+					// restore the original state instead of leaving some
+					// other unintended combination, and report that the
+					// tool needs an update.
 					for (const name of names) {
 						response = await desktopClient.invoke<UserInstructionListsResponse>(
 							"toggle_disabled_plugin_tool",
 							{ name },
 						);
 					}
+					if (names.length > 1) {
+						const reachedTarget =
+							response?.tools?.find((candidate) => candidate.id === tool.id)
+								?.enabled === desiredEnabled;
+						if (!reachedTarget) {
+							for (const name of names) {
+								response =
+									await desktopClient.invoke<UserInstructionListsResponse>(
+										"toggle_disabled_plugin_tool",
+										{ name },
+									);
+							}
+							unreachable = true;
+						}
+					}
+				}
+				if (response) {
+					applyResponse(response);
+				}
+				if (unreachable) {
+					throw new Error(
+						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+					);
 				}
 				if (!response) {
 					throw new Error(
 						"tool toggle did not return an updated extension list",
 					);
 				}
-				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
@@ -710,29 +730,39 @@ export function CustomizationSectionView({
 						throw error;
 					}
 					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state, which only reliably lands on
-					// the desired state when the tool maps to a single
-					// underlying name. A tool with several headless names in
-					// a mixed disabled state can't be forced to the target
-					// state by blindly flipping every name — some flips
-					// would move it further from the goal instead of
-					// closer — so skip those instead of silently leaving
-					// them wrong, and apply whatever did succeed.
+					// explicit target state. Flipping every name of a tool
+					// once reaches the target correctly when its underlying
+					// names shared the same prior state; if they didn't (a
+					// mixed disabled state), flip everyone back to restore
+					// the original state instead of leaving some other
+					// unintended combination, and report that tool as
+					// needing an update.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
-						if (toolNames.length > 1) {
-							unreachableTools.push(tool);
-							continue;
-						}
 						for (const name of toolNames) {
 							response =
 								await desktopClient.invoke<UserInstructionListsResponse>(
 									"toggle_disabled_plugin_tool",
 									{ name },
 								);
+						}
+						if (toolNames.length > 1) {
+							const reachedTarget =
+								response?.tools?.find((candidate) => candidate.id === tool.id)
+									?.enabled === enabled;
+							if (!reachedTarget) {
+								for (const name of toolNames) {
+									response =
+										await desktopClient.invoke<UserInstructionListsResponse>(
+											"toggle_disabled_plugin_tool",
+											{ name },
+										);
+								}
+								unreachableTools.push(tool);
+							}
 						}
 					}
 				}
@@ -742,7 +772,7 @@ export function CustomizationSectionView({
 				if (unreachableTools.length > 0) {
 					const names = unreachableTools.map((tool) => tool.name).join(", ");
 					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in bulk.`,
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
 					);
 				}
 				if (!response) {

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -9,6 +9,7 @@ import {
 	Play,
 	Puzzle,
 	RefreshCw,
+	Search,
 	Server,
 	Trash2,
 	TriangleAlert,
@@ -18,12 +19,14 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { desktopClient } from "@/lib/desktop-client";
@@ -84,6 +87,7 @@ type SkillItem = {
 	description?: string;
 	instructions: string;
 	path: string;
+	enabled?: boolean;
 	agentPlugin?: boolean;
 	pluginName?: string;
 };
@@ -94,6 +98,7 @@ type CommandItem = {
 	name: string;
 	description?: string;
 	instructions: string;
+	enabled?: boolean;
 	path: string;
 	scope: ItemScope;
 	agentPlugin?: boolean;
@@ -143,6 +148,22 @@ type ToolItem = {
 	headlessToolNames?: string[];
 };
 
+function toolMatchesQuery(tool: ToolItem, normalizedQuery: string): boolean {
+	if (!normalizedQuery) {
+		return true;
+	}
+	const haystacks = [
+		tool.name,
+		tool.description,
+		tool.pluginName,
+		tool.path,
+		...(tool.headlessToolNames ?? []),
+	];
+	return haystacks.some((value) =>
+		value?.toLowerCase().includes(normalizedQuery),
+	);
+}
+
 type HookItem = {
 	fileName: string;
 	hookEventName?: string;
@@ -183,7 +204,7 @@ type McpServersResponse = {
 	servers: McpServer[];
 };
 
-type LocalUninstallType = "mcp" | "skill" | "workflow" | "plugin";
+type LocalUninstallType = "mcp" | "skill" | "workflow" | "plugin" | "rule";
 
 type LocalUninstallTarget = {
 	key: string;
@@ -422,7 +443,11 @@ export function CustomizationSectionView({
 	const [togglingToolIds, setTogglingToolIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	const [toolsSearchQuery, setToolsSearchQuery] = useState("");
 	const [togglingPluginPaths, setTogglingPluginPaths] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [togglingSkillPaths, setTogglingSkillPaths] = useState<Set<string>>(
 		() => new Set(),
 	);
 	const [localUninstallingKeys, setLocalUninstallingKeys] = useState<
@@ -636,6 +661,77 @@ export function CustomizationSectionView({
 		[applyResponse],
 	);
 
+	const setAllToolsEnabled = useCallback(
+		async (toolsList: ToolItem[], enabled: boolean) => {
+			const targets = toolsList.filter((tool) => tool.enabled !== enabled);
+			if (targets.length === 0) {
+				return;
+			}
+			const targetIds = targets.map((tool) => tool.id);
+			setTogglingToolIds((current) => {
+				const next = new Set(current);
+				for (const id of targetIds) {
+					next.add(id);
+				}
+				return next;
+			});
+			setErrorMessage(null);
+			try {
+				const names = targets.flatMap((tool) =>
+					[tool.name, ...(tool.headlessToolNames ?? [])].filter(Boolean),
+				);
+				if (names.length === 0) {
+					throw new Error("tool name is required");
+				}
+				let response: UserInstructionListsResponse | undefined;
+				try {
+					response = await desktopClient.invoke<UserInstructionListsResponse>(
+						"set_tool_disabled",
+						{
+							names,
+							disabled: !enabled,
+						},
+					);
+				} catch (error) {
+					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
+						throw error;
+					}
+					for (const tool of targets) {
+						const toolNames = [
+							tool.name,
+							...(tool.headlessToolNames ?? []),
+						].filter(Boolean);
+						for (const name of toolNames) {
+							response =
+								await desktopClient.invoke<UserInstructionListsResponse>(
+									"toggle_disabled_plugin_tool",
+									{ name },
+								);
+						}
+					}
+				}
+				if (!response) {
+					throw new Error(
+						"tool toggle did not return an updated extension list",
+					);
+				}
+				applyResponse(response);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				setErrorMessage(message);
+			} finally {
+				setTogglingToolIds((current) => {
+					const next = new Set(current);
+					for (const id of targetIds) {
+						next.delete(id);
+					}
+					return next;
+				});
+			}
+		},
+		[applyResponse],
+	);
+
 	const setPluginEnabled = useCallback(
 		async (plugin: PluginItem) => {
 			setTogglingPluginPaths((current) => new Set(current).add(plugin.path));
@@ -657,6 +753,34 @@ export function CustomizationSectionView({
 				setTogglingPluginPaths((current) => {
 					const next = new Set(current);
 					next.delete(plugin.path);
+					return next;
+				});
+			}
+		},
+		[applyResponse],
+	);
+
+	const setSkillEnabled = useCallback(
+		async (skill: CommandItem) => {
+			setTogglingSkillPaths((current) => new Set(current).add(skill.path));
+			setErrorMessage(null);
+			try {
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
+						"set_skill_disabled",
+						{
+							path: skill.path,
+							disabled: skill.enabled !== false,
+						},
+					);
+				applyResponse(response);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				setErrorMessage(message);
+			} finally {
+				setTogglingSkillPaths((current) => {
+					const next = new Set(current);
+					next.delete(skill.path);
 					return next;
 				});
 			}
@@ -782,6 +906,7 @@ export function CustomizationSectionView({
 			name: skill.name,
 			description: skill.description,
 			instructions: skill.instructions,
+			enabled: skill.enabled,
 			path: skill.path,
 			scope: getPathScope(skill.path, workspaceRoot),
 			agentPlugin: skill.agentPlugin,
@@ -852,11 +977,17 @@ export function CustomizationSectionView({
 	}, [plugins, workspaceRoot]);
 
 	const builtinTools = useMemo(
-		() => tools.filter((tool) => tool.source === "builtin"),
+		() =>
+			tools
+				.filter((tool) => tool.source === "builtin")
+				.sort((a, b) => a.name.localeCompare(b.name)),
 		[tools],
 	);
 	const pluginTools = useMemo(
-		() => tools.filter((tool) => tool.source !== "builtin"),
+		() =>
+			tools
+				.filter((tool) => tool.source !== "builtin")
+				.sort((a, b) => a.name.localeCompare(b.name)),
 		[tools],
 	);
 	const pluginToolsByPluginKey = useMemo(() => {
@@ -872,6 +1003,33 @@ export function CustomizationSectionView({
 		}
 		return grouped;
 	}, [pluginTools]);
+	const normalizedToolsSearchQuery = toolsSearchQuery.trim().toLowerCase();
+	const filteredBuiltinTools = useMemo(
+		() =>
+			builtinTools.filter((tool) =>
+				toolMatchesQuery(tool, normalizedToolsSearchQuery),
+			),
+		[builtinTools, normalizedToolsSearchQuery],
+	);
+	const filteredPluginTools = useMemo(
+		() =>
+			pluginTools.filter((tool) =>
+				toolMatchesQuery(tool, normalizedToolsSearchQuery),
+			),
+		[pluginTools, normalizedToolsSearchQuery],
+	);
+	const allBuiltinToolsEnabled = useMemo(
+		() =>
+			filteredBuiltinTools.length > 0 &&
+			filteredBuiltinTools.every((tool) => tool.enabled),
+		[filteredBuiltinTools],
+	);
+	const allPluginToolsEnabled = useMemo(
+		() =>
+			filteredPluginTools.length > 0 &&
+			filteredPluginTools.every((tool) => tool.enabled),
+		[filteredPluginTools],
+	);
 
 	const scopedPlugins = useMemo(
 		() => [
@@ -950,7 +1108,11 @@ export function CustomizationSectionView({
 		);
 	};
 
-	const renderPluginMenu = (target: LocalUninstallTarget) => {
+	const renderLocalItemMenu = (
+		target: LocalUninstallTarget,
+		options: { showDelete?: boolean } = {},
+	) => {
+		const { showDelete = true } = options;
 		const uninstalling = localUninstallingKeys.has(target.key);
 		return (
 			<DropdownMenu>
@@ -975,14 +1137,16 @@ export function CustomizationSectionView({
 						<Copy className="size-4" />
 						Copy path
 					</DropdownMenuItem>
-					<DropdownMenuItem
-						className="text-destructive focus:text-destructive"
-						disabled={uninstalling}
-						onClick={() => void uninstallLocalPrimitive(target)}
-					>
-						{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
-						{uninstalling ? "Uninstalling..." : "Uninstall"}
-					</DropdownMenuItem>
+					{showDelete ? (
+						<DropdownMenuItem
+							className="text-destructive focus:text-destructive"
+							disabled={uninstalling}
+							onClick={() => void uninstallLocalPrimitive(target)}
+						>
+							{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
+							{uninstalling ? "Uninstalling..." : "Uninstall"}
+						</DropdownMenuItem>
+					) : null}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		);
@@ -996,26 +1160,15 @@ export function CustomizationSectionView({
 		return (
 			<div
 				key={key}
-				className="relative grid min-w-0 gap-2 rounded-lg border bg-card p-4"
+				className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 			>
-				{item.agentPlugin !== true ? (
-					<div className="absolute top-4 right-4">
-						{renderLocalActionButton({
-							key,
-							type: item.type,
-							id: item.id,
-							name: item.name,
-							path: item.path,
-						})}
-					</div>
-				) : null}
-				<div className="flex min-w-0 items-center gap-2 pr-28">
+				<div className="flex min-w-0 items-center gap-2">
 					{item.type === "workflow" ? (
 						<Play className="h-4 w-4 shrink-0 text-primary" />
 					) : (
 						<Zap className="h-4 w-4 shrink-0 text-primary" />
 					)}
-					<h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
+					<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 						{item.name}
 					</h3>
 					<ScopeBadge scope={item.scope} />
@@ -1032,6 +1185,32 @@ export function CustomizationSectionView({
 							Marketplace
 						</Badge>
 					) : null}
+					<Switch
+						checked={item.enabled !== false}
+						onCheckedChange={() => {
+							void setSkillEnabled(item);
+						}}
+						disabled={
+							item.type === "workflow" ||
+							item.agentPlugin === true ||
+							togglingSkillPaths.has(item.path)
+						}
+						title={
+							item.type === "workflow"
+								? "Toggling workflows isn't supported yet"
+								: undefined
+						}
+						aria-label={`Toggle ${item.name}`}
+					/>
+					{item.agentPlugin !== true
+						? renderLocalItemMenu({
+								key,
+								type: item.type,
+								id: item.id,
+								name: item.name,
+								path: item.path,
+							})
+						: null}
 				</div>
 				<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 					{item.description?.trim() || previewText(item.instructions)}
@@ -1094,9 +1273,6 @@ export function CustomizationSectionView({
 							Marketplace
 						</Badge>
 					) : null}
-					<span className="text-xs text-muted-foreground">
-						{plugin.enabled ? "Enabled" : "Disabled"}
-					</span>
 					<Switch
 						checked={plugin.enabled}
 						onCheckedChange={() => {
@@ -1110,7 +1286,7 @@ export function CustomizationSectionView({
 						aria-label={`Toggle ${plugin.name}`}
 					/>
 					{plugin.agentPlugin !== true
-						? renderPluginMenu({
+						? renderLocalItemMenu({
 								key,
 								type: "plugin",
 								id: plugin.name,
@@ -1377,16 +1553,30 @@ export function CustomizationSectionView({
 								>
 									<div className="flex min-w-0 items-center gap-2">
 										<FileText className="h-4 w-4 shrink-0 text-primary" />
-										<span className="min-w-0 truncate text-sm font-semibold text-foreground">
+										<span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 											{rule.name}
 										</span>
 										<ScopeBadge scope={scope} />
+										<Switch
+											checked
+											onCheckedChange={() => {}}
+											disabled
+											title="Toggling rules isn't supported yet"
+											aria-label={`Toggle ${rule.name}`}
+										/>
+										{renderLocalItemMenu(
+											{
+												key: rule.path,
+												type: "rule",
+												id: rule.path,
+												name: rule.name,
+												path: rule.path,
+											},
+											{ showDelete: false },
+										)}
 									</div>
 									<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 										{previewText(rule.instructions)}
-									</p>
-									<p className="truncate text-xs font-mono text-muted-foreground">
-										{rule.path}
 									</p>
 								</div>
 							))}
@@ -1603,17 +1793,57 @@ export function CustomizationSectionView({
 
 			{activeTab === "Tools" && (
 				<div>
+					<div className="relative mb-6 block">
+						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+						<Input
+							aria-label="Search tools"
+							className="h-10 pl-8"
+							onChange={(event) => setToolsSearchQuery(event.target.value)}
+							placeholder="Search tools"
+							value={toolsSearchQuery}
+						/>
+					</div>
+
 					<div className="mb-6 grid gap-3">
 						<div className="flex items-center justify-between gap-3">
 							<h3 className="text-base font-semibold text-foreground">
-								Builtin Tools
+								BuiltIn Tools{" "}
+								<span className="text-muted-foreground">
+									{filteredBuiltinTools.length}
+								</span>
 							</h3>
-							<span className="text-sm text-muted-foreground">
-								{builtinTools.length}
-							</span>
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Checkbox
+									checked={allBuiltinToolsEnabled}
+									onCheckedChange={() => {
+										void setAllToolsEnabled(
+											filteredBuiltinTools,
+											!allBuiltinToolsEnabled,
+										);
+									}}
+									disabled={
+										filteredBuiltinTools.length === 0 ||
+										filteredBuiltinTools.some((tool) =>
+											togglingToolIds.has(tool.id),
+										)
+									}
+									id="builtin-tools-toggle-all"
+									aria-label={
+										allBuiltinToolsEnabled
+											? "Disable all builtin tools"
+											: "Enable all builtin tools"
+									}
+								/>
+								<label
+									className="cursor-pointer"
+									htmlFor="builtin-tools-toggle-all"
+								>
+									{allBuiltinToolsEnabled ? "Disable all" : "Enable all"}
+								</label>
+							</div>
 						</div>
 						<div className="flex flex-col gap-2">
-							{builtinTools.map((tool) =>
+							{filteredBuiltinTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
@@ -1626,9 +1856,6 @@ export function CustomizationSectionView({
 												<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 													{tool.name}
 												</h3>
-												<span className="text-xs text-muted-foreground">
-													{tool.enabled ? "Enabled" : "Disabled"}
-												</span>
 												<Switch
 													checked={tool.enabled}
 													onCheckedChange={() => {
@@ -1642,18 +1869,21 @@ export function CustomizationSectionView({
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
-											{!!tool.headlessToolNames?.length && (
-												<p className="truncate text-xs font-mono text-muted-foreground">
-													{tool.headlessToolNames.join(", ")}
-												</p>
-											)}
+											{!!tool.headlessToolNames?.length &&
+												tool.headlessToolNames?.length > 1 && (
+													<p className="truncate text-xs font-mono text-muted-foreground">
+														{tool.headlessToolNames.join(", ")}
+													</p>
+												)}
 										</div>
 									);
 								})(),
 							)}
-							{builtinTools.length === 0 && (
+							{filteredBuiltinTools.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No builtin tools found.
+									{builtinTools.length === 0
+										? "No builtin tools found."
+										: "No tools match your search."}
 								</p>
 							)}
 						</div>
@@ -1662,14 +1892,43 @@ export function CustomizationSectionView({
 					<div className="grid gap-3">
 						<div className="flex items-center justify-between gap-3">
 							<h3 className="text-base font-semibold text-foreground">
-								Plugin Tools
+								Plugin Tools{" "}
+								<span className="text-muted-foreground">
+									{filteredPluginTools.length}
+								</span>
 							</h3>
-							<span className="text-sm text-muted-foreground">
-								{pluginTools.length}
-							</span>
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Checkbox
+									checked={allPluginToolsEnabled}
+									onCheckedChange={() => {
+										void setAllToolsEnabled(
+											filteredPluginTools,
+											!allPluginToolsEnabled,
+										);
+									}}
+									disabled={
+										filteredPluginTools.length === 0 ||
+										filteredPluginTools.some((tool) =>
+											togglingToolIds.has(tool.id),
+										)
+									}
+									id="plugin-tools-toggle-all"
+									aria-label={
+										allPluginToolsEnabled
+											? "Disable all plugin tools"
+											: "Enable all plugin tools"
+									}
+								/>
+								<label
+									className="cursor-pointer"
+									htmlFor="plugin-tools-toggle-all"
+								>
+									{allPluginToolsEnabled ? "Disable all" : "Enable all"}
+								</label>
+							</div>
 						</div>
 						<div className="flex flex-col gap-2">
-							{pluginTools.map((tool) =>
+							{filteredPluginTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
@@ -1684,15 +1943,13 @@ export function CustomizationSectionView({
 												</h3>
 												{tool.pluginName && (
 													<Badge
-														variant="outline"
-														className="shrink-0 text-muted-foreground"
+														variant="muted"
+														className="shrink-0"
+														title={tool.path || tool.pluginName}
 													>
 														{tool.pluginName}
 													</Badge>
 												)}
-												<span className="text-xs text-muted-foreground">
-													{tool.enabled ? "Enabled" : "Disabled"}
-												</span>
 												<Switch
 													checked={tool.enabled}
 													onCheckedChange={() => {
@@ -1706,18 +1963,15 @@ export function CustomizationSectionView({
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
-											{tool.path && (
-												<p className="truncate text-xs font-mono text-muted-foreground">
-													{tool.path}
-												</p>
-											)}
 										</div>
 									);
 								})(),
 							)}
-							{pluginTools.length === 0 && (
+							{filteredPluginTools.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No plugin tools found.
+									{pluginTools.length === 0
+										? "No plugin tools found."
+										: "No tools match your search."}
 								</p>
 							)}
 						</div>

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -375,82 +375,6 @@ async function fetchUserInstructionLists(): Promise<UserInstructionListsResponse
 	return normalizeInstructionListsResponse(response);
 }
 
-function isUnsupportedDesktopCommand(error: unknown, command: string): boolean {
-	const message = error instanceof Error ? error.message : String(error);
-	return message.includes(`unsupported desktop command: ${command}`);
-}
-
-/**
- * Legacy fallback for sidecars that predate `set_tool_disabled`:
- * `toggle_disabled_plugin_tool` flips one name with no explicit target
- * state, so a tool with several headless names needs care to land on an
- * exact target rather than some other combination.
- *
- * A grouped tool's `enabled` flag is true only when *none* of its names are
- * disabled, so flipping every name once turns the aggregate true if and
- * only if every name was disabled right before that flip — the exact
- * "enable all" success condition. That makes the aggregate a reliable
- * one-shot check for the enable direction, but not for disable: `false`
- * there just means "at least one name disabled," which is equally true for
- * "still mixed" and "now fully disabled." So for disable, a second
- * (probe) flip is used — it turns the aggregate true only if every name was
- * disabled right after the *first* flip, which is exactly what "disable"
- * needs to confirm — and a third flip redoes the first if that holds.
- * Either way, an unconfirmed attempt is flipped back to its exact starting
- * state rather than left in some other unintended combination.
- */
-async function toggleLegacyToolGroup(
-	toolNames: string[],
-	toolId: string,
-	desiredEnabled: boolean,
-): Promise<{ response: UserInstructionListsResponse; reached: boolean }> {
-	let response: UserInstructionListsResponse | undefined;
-	const flipAll = async () => {
-		for (const name of toolNames) {
-			response = await desktopClient.invoke<UserInstructionListsResponse>(
-				"toggle_disabled_plugin_tool",
-				{ name },
-			);
-		}
-	};
-	const readEnabled = () =>
-		response?.tools.find((candidate) => candidate.id === toolId)?.enabled;
-
-	await flipAll();
-	if (toolNames.length <= 1) {
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: true,
-		};
-	}
-
-	if (desiredEnabled) {
-		if (readEnabled() === true) {
-			return {
-				response: response as UserInstructionListsResponse,
-				reached: true,
-			};
-		}
-		await flipAll(); // Undo: restores the exact original state.
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: false,
-		};
-	}
-
-	await flipAll(); // Probe.
-	if (readEnabled() === true) {
-		await flipAll(); // Redo: the probe flipped everyone back on.
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: true,
-		};
-	}
-	// The first flip left the group mixed; the probe already restored the
-	// original state.
-	return { response: response as UserInstructionListsResponse, reached: false };
-}
-
 export function CustomizationSectionView({
 	catalogPrimitive,
 	chrome = "page",
@@ -692,42 +616,12 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
-				const desiredEnabled = !tool.enabled;
-				let response: UserInstructionListsResponse | undefined;
-				let unreachable = false;
-				try {
-					response = await desktopClient.invoke<UserInstructionListsResponse>(
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
-						{
-							names,
-							disabled: tool.enabled,
-						},
+						{ names, disabled: tool.enabled },
 					);
-				} catch (error) {
-					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
-						throw error;
-					}
-					const result = await toggleLegacyToolGroup(
-						names,
-						tool.id,
-						desiredEnabled,
-					);
-					response = result.response;
-					unreachable = !result.reached;
-				}
-				if (response) {
-					applyResponse(response);
-				}
-				if (unreachable) {
-					throw new Error(
-						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
-					);
-				}
-				if (!response) {
-					throw new Error(
-						"tool toggle did not return an updated extension list",
-					);
-				}
+				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
@@ -744,7 +638,7 @@ export function CustomizationSectionView({
 
 	const setAllToolsEnabled = useCallback(
 		async (toolsList: ToolItem[], enabled: boolean) => {
-			const targets = toolsList.filter((tool) => tool.enabled !== enabled);
+			const targets = toolsList.filter((tool) => !enabled || !tool.enabled);
 			if (targets.length === 0) {
 				return;
 			}
@@ -764,52 +658,12 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
-				let response: UserInstructionListsResponse | undefined;
-				const unreachableTools: ToolItem[] = [];
-				try {
-					response = await desktopClient.invoke<UserInstructionListsResponse>(
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
-						{
-							names,
-							disabled: !enabled,
-						},
+						{ names, disabled: !enabled },
 					);
-				} catch (error) {
-					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
-						throw error;
-					}
-					// See toggleLegacyToolGroup for why grouped tools need
-					// verify-and-revert instead of a blind flip.
-					for (const tool of targets) {
-						const toolNames = [
-							tool.name,
-							...(tool.headlessToolNames ?? []),
-						].filter(Boolean);
-						const result = await toggleLegacyToolGroup(
-							toolNames,
-							tool.id,
-							enabled,
-						);
-						response = result.response;
-						if (!result.reached) {
-							unreachableTools.push(tool);
-						}
-					}
-				}
-				if (response) {
-					applyResponse(response);
-				}
-				if (unreachableTools.length > 0) {
-					const names = unreachableTools.map((tool) => tool.name).join(", ");
-					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions.`,
-					);
-				}
-				if (!response) {
-					throw new Error(
-						"tool toggle did not return an updated extension list",
-					);
-				}
+				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);


### PR DESCRIPTION
### Related Issue

N/A — internal UI consistency pass, no linked issue.

### Description

The Tools, Skills, and Rules tabs in the desktop app's Customize view each had their own bespoke card layout, while Plugins already had a more complete pattern (dots menu for actions, inline enable/disable toggle, muted count in the header). This PR brings the other tabs in line so every tab reads as one consistent list style:

**Tools**
- Section titles now read "BuiltIn Tools `<count>`" / "Plugin Tools `<count>`", with the count in muted text.
- Added a search bar that filters both the Builtin and Plugin Tools sections by name, description, plugin name, path, and headless tool names.
- Added an "Enable all" / "Disable all" checkbox per section (flips to "Disable all" once everything currently visible is enabled), scoped to whatever the search currently has filtered into view.

**Skills**
- Replaced the standalone destructive "Uninstall" button with the same dots menu (Copy path / Uninstall) Plugins use.
- Added a toggle switch to enable/disable a skill in place, matching what's already possible from the CLI's TUI config panel.
- This needed backend wiring, since skills had no enabled/disabled concept in the desktop app before: a new `set_skill_disabled` sidecar command calls the existing hub `settings.toggle({type: "skills"})` path, and disabled skills are no longer filtered out of the listing entirely (they now show up disabled, findable, and re-enable-able) — rules/workflows listings are unaffected and keep filtering disabled items since they have no toggle UI.

**Workflows**
- Show the same toggle switch as skills for visual consistency, but disabled with a tooltip, since core's settings-toggle service doesn't have a `"workflows"` branch yet (it isn't wired end to end for any consumer, not just the desktop app).

**Rules**
- Added the same dots menu (Copy path only — rule deletion isn't supported by `uninstallLocalPrimitive` yet, so no Uninstall item is shown) and a disabled toggle switch for the same reason as workflows.
- Dropped the raw path text from the card now that it's reachable via Copy path, matching how Skills/Plugins cards are laid out.

**Also included in this branch**
- Reordered the Customize tabs to Tools, Plugins, Skills, Rules, MCP, Hooks, and changed the default tab to Tools.
- Added a `muted` badge variant, used by the Plugin Tools badge.
- Renamed the sidebar "New Task" button to "New Session".

### Test Procedure

- `bun run typecheck` (desktop app) passes.
- `bun biome lint` / `bun biome format` on all changed files pass with no issues.
- Manually walked the Tools tab (search filtering, per-section enable/disable-all, individual tool toggles), Skills tab (dots menu copy path/uninstall, individual enable/disable, including that agent-plugin-contributed skills correctly keep the switch disabled since they can only be toggled via their owning plugin), and Rules tab (dots menu with copy path only, disabled toggle with tooltip).

### Type of Change

- [x] 💅 Cosmetic Changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing (typecheck/lint/format) and code is formatted and linted
- [x] I have reviewed contributor guidelines

### Additional Notes

The Skills/Rules/Workflows toggle switches that are disabled-with-tooltip are intentional placeholders: the write path for those (`CoreSettingsService.toggle()` in `sdk/packages/core`) doesn't support `"workflows"` or `"rules"` yet. Wiring that up is a follow-up that touches the shared core package (and would give the CLI's TUI the same capability), so it's out of scope here.

#### Skills

Before
<img width="1197" height="817" alt="image" src="https://github.com/user-attachments/assets/df3fd03a-6eb8-41b3-a331-e4b067400c8c" />

After
<img width="1176" height="913" alt="image" src="https://github.com/user-attachments/assets/083b1692-6a27-4f57-a984-f4604756d253" />


#### Tools

Before
<img width="1145" height="917" alt="image" src="https://github.com/user-attachments/assets/e953db3b-0e3e-42e3-b0f1-f8c0526debbb" />

After
<img width="1444" height="937" alt="image" src="https://github.com/user-attachments/assets/8970cdff-32e6-4342-9604-8d8e7daca485" />

#### Rules

Before
<img width="1203" height="931" alt="image" src="https://github.com/user-attachments/assets/c0c87af0-0852-45de-bc5c-8d5d30bbbf22" />


After
<img width="1161" height="914" alt="image" src="https://github.com/user-attachments/assets/de8960bf-f9b1-489a-aba0-f5467a6a01aa" />

#### Plugins

Before
<img width="1194" height="904" alt="image" src="https://github.com/user-attachments/assets/e4e8b2e1-b9c7-42f2-89b1-ed73abbe0217" />

After
<img width="1155" height="886" alt="image" src="https://github.com/user-attachments/assets/91772a11-b68f-48b9-919a-d5afbe602bd3" />
