### PR TITLE
Enable instruction toggles and global creation in Customize

### DIFF
--- a/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -1187,25 +1187,41 @@ Review with the bundled skill.`,
 		expect(docs?.loadError).toBeUndefined();
 	});
 
-	it("does not toggle workflow items", async () => {
+	it.each([
+		"rule",
+		"workflow",
+	] as const)("toggles %s items through shared settings", async (kind) => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);
-		const workflowPath = join(tempRoot, "workflow.md");
-		await writeFile(workflowPath, "Run this workflow.");
+		const directory = join(
+			tempRoot,
+			".cline",
+			kind === "rule" ? "rules" : "workflows",
+		);
+		await mkdir(directory, { recursive: true });
+		const path = join(directory, "review.md");
+		await writeFile(path, "Review carefully.");
 		const loader = createInteractiveConfigDataLoader({
 			config: createConfig(tempRoot),
 		});
-		const item: InteractiveConfigItem = {
-			id: "workflow-one",
-			name: "workflow-one",
-			path: workflowPath,
+		await loader.onToggleConfigItem({
+			id: path,
+			name: "review",
+			path,
 			enabled: true,
 			source: "workspace",
-			kind: "workflow",
-		};
-
-		await expect(loader.onToggleConfigItem(item)).resolves.toBeUndefined();
-		expect(await readFile(workflowPath, "utf8")).toBe("Run this workflow.");
+			kind,
+		});
+		expect(await readFile(path, "utf8")).toContain("disabled: true");
+		await loader.onToggleConfigItem({
+			id: path,
+			name: "review",
+			path,
+			enabled: false,
+			source: "workspace",
+			kind,
+		});
+		expect(await readFile(path, "utf8")).toBe("Review carefully.");
 	});
 
 	it("returns undefined for non-toggleable items", async () => {

--- a/apps/cli/src/runtime/interactive/config-data.ts
+++ b/apps/cli/src/runtime/interactive/config-data.ts
@@ -90,9 +90,19 @@ export function createInteractiveConfigDataLoader(input: {
 			return undefined;
 		}
 		const settings = createCoreSettingsService();
-		if (item.kind === "skill" && typeof item.enabled === "boolean") {
+		if (
+			(item.kind === "skill" ||
+				item.kind === "rule" ||
+				item.kind === "workflow") &&
+			typeof item.enabled === "boolean"
+		) {
 			await settings.toggle({
-				type: "skills",
+				type:
+					item.kind === "skill"
+						? "skills"
+						: item.kind === "rule"
+							? "rules"
+							: "workflows",
 				id: item.id,
 				path: item.path,
 				name: item.name,

--- a/apps/cli/src/tui/components/dialogs/config-dialogs.test.ts
+++ b/apps/cli/src/tui/components/dialogs/config-dialogs.test.ts
@@ -37,7 +37,7 @@ describe("config detail dialog helpers", () => {
 		expect(shouldToggleExtDetailForKey("space", skill)).toBe(true);
 		expect(shouldToggleExtDetailForKey("space", mcp)).toBe(true);
 		expect(shouldToggleExtDetailForKey("return", skill)).toBe(false);
-		expect(shouldToggleExtDetailForKey("space", workflow)).toBe(false);
+		expect(shouldToggleExtDetailForKey("space", workflow)).toBe(true);
 	});
 
 	it("builds useful detail rows with status for toggleable items", () => {
@@ -62,7 +62,7 @@ describe("config detail dialog helpers", () => {
 
 	it("omits status and toggle hint for non-toggleable items", () => {
 		const workflow = createItem({
-			kind: "workflow",
+			kind: "agent",
 			name: "release",
 			description: "Run release workflow",
 		});

--- a/apps/cli/src/tui/interactive-config.ts
+++ b/apps/cli/src/tui/interactive-config.ts
@@ -121,6 +121,8 @@ export function isToggleableInteractiveConfigItem(
 	}
 	return (
 		item.kind === "skill" ||
+		item.kind === "rule" ||
+		item.kind === "workflow" ||
 		item.kind === "plugin" ||
 		item.source === "builtin" ||
 		item.source === "workspace-plugin" ||

--- a/apps/cli/src/tui/views/config-view.test.ts
+++ b/apps/cli/src/tui/views/config-view.test.ts
@@ -36,14 +36,12 @@ describe("config view helpers", () => {
 		expect(isToggleableConfigItem(createItem({ kind: "skill" }))).toBe(true);
 	});
 
-	it("does not treat workflow rows as toggleable", () => {
-		expect(isToggleableConfigItem(createItem({ kind: "workflow" }))).toBe(
-			false,
-		);
+	it("treats workflow rows as toggleable", () => {
+		expect(isToggleableConfigItem(createItem({ kind: "workflow" }))).toBe(true);
 	});
 
-	it("does not treat rule, agent, or hook rows as toggleable", () => {
-		expect(isToggleableConfigItem(createItem({ kind: "rule" }))).toBe(false);
+	it("supports rules while leaving agents and hooks non-toggleable", () => {
+		expect(isToggleableConfigItem(createItem({ kind: "rule" }))).toBe(true);
 		expect(isToggleableConfigItem(createItem({ kind: "agent" }))).toBe(false);
 		expect(isToggleableConfigItem(createItem({ kind: "hook" }))).toBe(false);
 	});

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -23,6 +23,8 @@ import {
 	fetchClineRecommendedModels,
 	getCoreBuiltinToolCatalog,
 	getLocalProviderModels,
+	HOOK_CONFIG_FILE_EVENT_MAP,
+	HookConfigFileName,
 	listHookConfigFiles,
 	listLocalProviders,
 	normalizeOAuthProvider,
@@ -920,7 +922,7 @@ async function listHubSettings(
 async function toggleHubSetting(
 	ctx: SidecarContext,
 	input: {
-		type: "plugins" | "tools" | "skills";
+		type: "plugins" | "tools" | "skills" | "rules" | "workflows";
 		path?: string;
 		name?: string;
 		enabled?: boolean;
@@ -960,17 +962,13 @@ async function listUserInstructionConfigs(
 		for (const record of userInstructionService.listRecords(type)) {
 			const item = record.item as unknown as JsonRecord;
 			const disabled = item.disabled === true;
-			// Rules and workflows have no toggle UI, so keep hiding disabled
-			// ones; skills need to stay visible (disabled) so they can be
-			// re-enabled from the Skills tab.
-			if (disabled && type !== "skill") continue;
 			items.push({
 				id: record.id,
 				name: item.name ?? record.id,
 				description: item.description,
 				instructions: item.instructions,
 				path: record.filePath,
-				...(type === "skill" ? { enabled: !disabled } : {}),
+				enabled: !disabled,
 			});
 		}
 		return items;
@@ -2512,14 +2510,31 @@ export async function handleCommand(
 		});
 		return await listUserInstructionConfigs(ctx, snapshot);
 	}
-	if (command === "set_skill_disabled") {
-		const skillPath = String(args?.path ?? "").trim();
-		if (!skillPath) {
-			throw new Error("skill path is required");
+	if (command === "list_creatable_hook_events") {
+		return {
+			events: Object.values(HookConfigFileName).filter(
+				(event) => HOOK_CONFIG_FILE_EVENT_MAP[event] !== undefined,
+			),
+		};
+	}
+	if (command === "create_global_customization") {
+		const hubClient = await ensureSharedHubClient(ctx);
+		const reply = await hubClient.command("settings.createGlobal", args ?? {});
+		if (!reply.ok)
+			throw new Error(reply.error?.message ?? "Unable to create customization");
+		return reply.payload;
+	}
+	if (command === "set_instruction_disabled") {
+		const type = args?.type;
+		if (type !== "skills" && type !== "rules" && type !== "workflows")
+			throw new Error("Invalid instruction type");
+		const instructionPath = String(args?.path ?? "").trim();
+		if (!instructionPath) {
+			throw new Error("instruction path is required");
 		}
 		const snapshot = await toggleHubSetting(ctx, {
-			type: "skills",
-			path: skillPath,
+			type,
+			path: instructionPath,
 			enabled: args?.disabled !== true,
 		});
 		return await listUserInstructionConfigs(ctx, snapshot);

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -920,7 +920,7 @@ async function listHubSettings(
 async function toggleHubSetting(
 	ctx: SidecarContext,
 	input: {
-		type: "plugins" | "tools";
+		type: "plugins" | "tools" | "skills";
 		path?: string;
 		name?: string;
 		enabled?: boolean;
@@ -959,13 +959,18 @@ async function listUserInstructionConfigs(
 		const items: unknown[] = [];
 		for (const record of userInstructionService.listRecords(type)) {
 			const item = record.item as unknown as JsonRecord;
-			if (item.disabled === true) continue;
+			const disabled = item.disabled === true;
+			// Rules and workflows have no toggle UI, so keep hiding disabled
+			// ones; skills need to stay visible (disabled) so they can be
+			// re-enabled from the Skills tab.
+			if (disabled && type !== "skill") continue;
 			items.push({
 				id: record.id,
 				name: item.name ?? record.id,
 				description: item.description,
 				instructions: item.instructions,
 				path: record.filePath,
+				...(type === "skill" ? { enabled: !disabled } : {}),
 			});
 		}
 		return items;
@@ -2503,6 +2508,18 @@ export async function handleCommand(
 		const snapshot = await toggleHubSetting(ctx, {
 			type: "plugins",
 			path: pluginPath,
+			enabled: args?.disabled !== true,
+		});
+		return await listUserInstructionConfigs(ctx, snapshot);
+	}
+	if (command === "set_skill_disabled") {
+		const skillPath = String(args?.path ?? "").trim();
+		if (!skillPath) {
+			throw new Error("skill path is required");
+		}
+		const snapshot = await toggleHubSetting(ctx, {
+			type: "skills",
+			path: skillPath,
 			enabled: args?.disabled !== true,
 		});
 		return await listUserInstructionConfigs(ctx, snapshot);

--- a/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
+++ b/apps/examples/desktop-app/webview/components/agent-sidebar.tsx
@@ -914,12 +914,12 @@ export function AgentSidebar({
 								newTaskActive && "bg-surface-hover text-sidebar-foreground",
 							)}
 							onClick={openHome}
-							title="Start a new task"
+							title="Start a new session"
 							type="button"
 							variant="sidebarItem"
 						>
 							<Plus className="size-4 shrink-0" />
-							<span className="truncate">New</span>
+							<span className="truncate">Session</span>
 						</Button>
 						<Button
 							aria-label="Schedule"

--- a/apps/examples/desktop-app/webview/components/ui/badge.tsx
+++ b/apps/examples/desktop-app/webview/components/ui/badge.tsx
@@ -17,6 +17,8 @@ const badgeVariants = cva(
 					"border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline:
 					"text-foreground [a&]:hover:bg-surface-hover [a&]:hover:text-foreground",
+				muted:
+					"text-muted-foreground [a&]:hover:bg-surface-hover [a&]:hover:text-foreground",
 			},
 		},
 		defaultVariants: {

--- a/apps/examples/desktop-app/webview/components/views/settings/create-customization-dialog.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/create-customization-dialog.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CreateCustomizationDialog } from "./create-customization-dialog";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@/lib/desktop-client", () => ({ desktopClient: { invoke } }));
+let root: Root;
+let container: HTMLDivElement;
+beforeEach(() => {
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+	invoke.mockReset();
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+afterEach(async () => {
+	await act(async () => root.unmount());
+	container.remove();
+});
+async function fill(id: string, value: string) {
+	const element = document.getElementById(id);
+	if (
+		!(
+			element instanceof HTMLInputElement ||
+			element instanceof HTMLTextAreaElement
+		)
+	)
+		throw new Error("Missing field");
+	const prototype =
+		element instanceof HTMLInputElement
+			? HTMLInputElement.prototype
+			: HTMLTextAreaElement.prototype;
+	await act(async () => {
+		Object.getOwnPropertyDescriptor(prototype, "value")?.set?.call(
+			element,
+			value,
+		);
+		element.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+}
+it.each([
+	"rule",
+	"skill",
+] as const)("creates a global %s and refreshes the inventory", async (type) => {
+	const onCreated = vi.fn().mockResolvedValue(undefined);
+	invoke.mockResolvedValue({ path: "/global/review.md" });
+	await act(async () =>
+		root.render(
+			<CreateCustomizationDialog type={type} onCreated={onCreated} />,
+		),
+	);
+	await act(async () => container.querySelector("button")?.click());
+	await fill("customization-name", "review");
+	if (type === "skill") await fill("customization-description", "Review code");
+	await fill("customization-content", "Review carefully.");
+	await act(async () =>
+		document
+			.querySelector("form")
+			?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+	);
+	expect(invoke).toHaveBeenCalledWith("create_global_customization", {
+		type,
+		name: "review",
+		content: "Review carefully.",
+		description: type === "skill" ? "Review code" : "",
+	});
+	expect(onCreated).toHaveBeenCalledOnce();
+	expect(document.querySelector('[role="dialog"]')).toBeNull();
+});
+it("loads supported hook events and preserves the draft when creation fails", async () => {
+	invoke.mockImplementation(async (command) => {
+		if (command === "list_creatable_hook_events")
+			return { events: ["TaskStart", "PostToolUse"] };
+		throw new Error("A hook already exists.");
+	});
+	const onCreated = vi.fn();
+	await act(async () =>
+		root.render(
+			<CreateCustomizationDialog type="hook" onCreated={onCreated} />,
+		),
+	);
+	await act(async () => container.querySelector("button")?.click());
+	expect(document.querySelectorAll("option")).toHaveLength(2);
+	await act(async () =>
+		document
+			.querySelector("form")
+			?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+	);
+	expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+		"already exists",
+	);
+	expect(document.querySelector("textarea")?.value).toContain("process.stdin");
+	expect(onCreated).not.toHaveBeenCalled();
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/create-customization-dialog.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/create-customization-dialog.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { desktopClient } from "@/lib/desktop-client";
+
+const DEFAULT_HOOK = `// Read the event payload from standard input.
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+const event = JSON.parse(input);
+
+// Add your hook logic here.
+process.stdout.write(JSON.stringify({}));
+`;
+
+export function CreateCustomizationDialog({
+	type,
+	onCreated,
+}: {
+	type: "rule" | "skill" | "hook";
+	onCreated: () => Promise<void>;
+}) {
+	const [open, setOpen] = useState(false);
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [content, setContent] = useState(type === "hook" ? DEFAULT_HOOK : "");
+	const [events, setEvents] = useState<string[]>([]);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!open || type !== "hook") return;
+		let cancelled = false;
+		void desktopClient
+			.invoke<{ events: string[] }>("list_creatable_hook_events")
+			.then((result) => {
+				if (cancelled) return;
+				setEvents(result.events);
+				setName((current) => current || result.events[0] || "");
+			})
+			.catch((error) => {
+				if (!cancelled) setError(String(error));
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, type]);
+
+	const submit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		if (saving) return;
+		setSaving(true);
+		setError(null);
+		try {
+			await desktopClient.invoke("create_global_customization", {
+				type,
+				name,
+				description,
+				content,
+			});
+			setOpen(false);
+			setName("");
+			setDescription("");
+			setContent(type === "hook" ? DEFAULT_HOOK : "");
+			await onCreated();
+		} catch (error) {
+			setError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<>
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={() => {
+					setError(null);
+					setOpen(true);
+				}}
+			>
+				<Plus className="size-4" />
+				New {type}
+			</Button>
+			<Dialog
+				open={open}
+				onOpenChange={(next) => {
+					if (!saving) setOpen(next);
+				}}
+			>
+				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+					<DialogHeader>
+						<DialogTitle>Create global {type}</DialogTitle>
+						<DialogDescription>
+							{type === "hook"
+								? "Runs for the selected event across all projects. Write a JavaScript script that reads JSON from stdin and writes its result to stdout."
+								: "Available across all projects. Write the instructions in Markdown."}
+						</DialogDescription>
+					</DialogHeader>
+					<form onSubmit={submit} className="grid gap-4">
+						<div className="grid gap-2">
+							<Label htmlFor="customization-name">
+								{type === "hook" ? "Event" : "Name"}
+							</Label>
+							{type === "hook" ? (
+								<select
+									id="customization-name"
+									value={name}
+									onChange={(event) => setName(event.target.value)}
+									disabled={saving || !events.length}
+									className="h-9 rounded-md border bg-background px-3 text-sm"
+								>
+									{events.map((event) => (
+										<option key={event} value={event}>
+											{event}
+										</option>
+									))}
+								</select>
+							) : (
+								<Input
+									id="customization-name"
+									placeholder="code-review"
+									value={name}
+									onChange={(event) => setName(event.target.value)}
+									pattern="[a-z0-9]+(-[a-z0-9]+)*"
+									maxLength={64}
+									required
+									disabled={saving}
+								/>
+							)}
+						</div>
+						{type === "skill" && (
+							<div className="grid gap-2">
+								<Label htmlFor="customization-description">Description</Label>
+								<Input
+									id="customization-description"
+									placeholder="When should Cline use this skill?"
+									value={description}
+									onChange={(event) => setDescription(event.target.value)}
+									required
+									disabled={saving}
+								/>
+							</div>
+						)}
+						<div className="grid gap-2">
+							<Label htmlFor="customization-content">
+								{type === "hook" ? "JavaScript" : "Instructions"}
+							</Label>
+							<Textarea
+								id="customization-content"
+								value={content}
+								onChange={(event) => setContent(event.target.value)}
+								className="min-h-64 max-h-[45vh] font-mono text-sm"
+								required
+								disabled={saving}
+							/>
+						</div>
+						{error && (
+							<p role="alert" className="text-sm text-destructive">
+								{error}
+							</p>
+						)}
+						<div className="flex justify-end gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => setOpen(false)}
+								disabled={saving}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								disabled={
+									saving ||
+									!name.trim() ||
+									!content.trim() ||
+									(type === "skill" && !description.trim())
+								}
+							>
+								{saving ? "Creating..." : `Create ${type}`}
+							</Button>
+						</div>
+					</form>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/customize-view.tsx
@@ -22,12 +22,12 @@ import { McpServersContent } from "./mcp-view";
 type CustomizeTab = "skills" | "mcp" | "plugins" | "rules" | "hooks" | "tools";
 
 const CUSTOMIZE_TABS: { id: CustomizeTab; label: string }[] = [
-	{ id: "skills", label: "Skills" },
-	{ id: "mcp", label: "MCP" },
-	{ id: "plugins", label: "Plugins" },
-	{ id: "rules", label: "Rules" },
-	{ id: "hooks", label: "Hooks" },
 	{ id: "tools", label: "Tools" },
+	{ id: "plugins", label: "Plugins" },
+	{ id: "skills", label: "Skills" },
+	{ id: "rules", label: "Rules" },
+	{ id: "mcp", label: "MCP" },
+	{ id: "hooks", label: "Hooks" },
 ];
 
 type TabCounts = Partial<Record<CustomizeTab, number>>;
@@ -51,7 +51,7 @@ export function CustomizeView({
 }: {
 	onOpenMarketplace?: () => void;
 }) {
-	const [tab, setTab] = useState<CustomizeTab>("skills");
+	const [tab, setTab] = useState<CustomizeTab>("tools");
 	const [counts, setCounts] = useState<TabCounts>({});
 
 	const refreshCounts = useCallback(async () => {
@@ -107,7 +107,7 @@ export function CustomizeView({
 						</Button>
 					) : undefined
 				}
-				description="Extend what Cline can do and change how it works. Manage what's installed, or browse the marketplace for more options."
+				description="Extend what Cline can do and how it works. Explore the marketplace for more options."
 				title="Customize"
 			/>
 

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
@@ -186,3 +186,74 @@ describe("tool state controls", () => {
 		).toBe(String(!initialEnabled));
 	});
 });
+
+describe("instruction controls", () => {
+	it.each([
+		"rule",
+		"workflow",
+		"skill",
+	] as const)("disables and re-enables a %s in place", async (type) => {
+		let enabled = true;
+		const inventory = () => ({
+			workspaceRoot: "/workspace",
+			[type === "rule"
+				? "rules"
+				: type === "workflow"
+					? "workflows"
+					: "skills"]: [
+				{
+					id: "review",
+					name: "review",
+					path: "/workspace/review.md",
+					instructions: "Review carefully.",
+					enabled,
+				},
+			],
+		});
+		invoke.mockImplementation(async (command, args) => {
+			if (command === "list_marketplace_installed_entries")
+				return { installedKeys: [] };
+			if (command === "list_user_instruction_configs") return inventory();
+			if (command === "set_instruction_disabled") {
+				enabled = !args.disabled;
+				return inventory();
+			}
+			throw new Error(`Unexpected command: ${command}`);
+		});
+		await act(async () => {
+			root.render(
+				<CustomizationSectionView
+					section={type === "rule" ? "Rules" : "Skills"}
+				/>,
+			);
+		});
+		await vi.waitFor(() =>
+			expect(
+				container.querySelector('[aria-label="Toggle review"]'),
+			).not.toBeNull(),
+		);
+		for (const desired of [false, true]) {
+			await act(async () => {
+				container
+					.querySelector<HTMLButtonElement>('[aria-label="Toggle review"]')
+					?.click();
+			});
+			expect(enabled).toBe(desired);
+			expect(
+				container
+					.querySelector('[aria-label="Toggle review"]')
+					?.getAttribute("aria-checked"),
+			).toBe(String(desired));
+			expect(invoke).toHaveBeenLastCalledWith("set_instruction_disabled", {
+				type:
+					type === "rule"
+						? "rules"
+						: type === "workflow"
+							? "workflows"
+							: "skills",
+				path: "/workspace/review.md",
+				disabled: !desired,
+			});
+		}
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.test.tsx
@@ -137,3 +137,52 @@ describe("CustomizationSectionView Agent Plugin inventory", () => {
 		});
 	});
 });
+
+describe("tool state controls", () => {
+	it.each([
+		true,
+		false,
+	])("sets duplicate built-in names explicitly (enabled=%s)", async (initialEnabled) => {
+		let enabled = initialEnabled;
+		const inventory = () => ({
+			workspaceRoot: "/workspace",
+			tools: [
+				{
+					id: "web_search",
+					name: "web_search",
+					headlessToolNames: ["web_search"],
+					source: "builtin",
+					enabled,
+				},
+			],
+		});
+		invoke.mockImplementation(async (command, args) => {
+			if (command === "list_marketplace_installed_entries")
+				return { installedKeys: [] };
+			if (command === "list_user_instruction_configs") return inventory();
+			if (command === "set_tool_disabled") {
+				enabled = !args.disabled;
+				return inventory();
+			}
+			throw new Error(`Unexpected command: ${command}`);
+		});
+		await act(async () => {
+			root.render(<CustomizationSectionView section="Tools" />);
+		});
+		await act(async () => {
+			container
+				.querySelector<HTMLButtonElement>('[aria-label="Toggle web_search"]')
+				?.click();
+		});
+		expect(enabled).toBe(!initialEnabled);
+		expect(invoke).toHaveBeenCalledWith("set_tool_disabled", {
+			names: ["web_search", "web_search"],
+			disabled: initialEnabled,
+		});
+		expect(
+			container
+				.querySelector('[aria-label="Toggle web_search"]')
+				?.getAttribute("aria-checked"),
+		).toBe(String(!initialEnabled));
+	});
+});

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -634,6 +634,18 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
+					// toggle_disabled_plugin_tool flips one name with no
+					// explicit target state, which only reliably lands on the
+					// desired state when the tool maps to a single
+					// underlying name. A tool with several headless names in
+					// a mixed disabled state can't be forced to the opposite
+					// state by blindly flipping every name — some flips
+					// would move it further from the goal instead of closer.
+					if (names.length > 1) {
+						throw new Error(
+							`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
+						);
+					}
 					for (const name of names) {
 						response = await desktopClient.invoke<UserInstructionListsResponse>(
 							"toggle_disabled_plugin_tool",
@@ -684,6 +696,7 @@ export function CustomizationSectionView({
 					throw new Error("tool name is required");
 				}
 				let response: UserInstructionListsResponse | undefined;
+				const unreachableTools: ToolItem[] = [];
 				try {
 					response = await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
@@ -696,11 +709,24 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
+					// toggle_disabled_plugin_tool flips one name with no
+					// explicit target state, which only reliably lands on
+					// the desired state when the tool maps to a single
+					// underlying name. A tool with several headless names in
+					// a mixed disabled state can't be forced to the target
+					// state by blindly flipping every name — some flips
+					// would move it further from the goal instead of
+					// closer — so skip those instead of silently leaving
+					// them wrong, and apply whatever did succeed.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
+						if (toolNames.length > 1) {
+							unreachableTools.push(tool);
+							continue;
+						}
 						for (const name of toolNames) {
 							response =
 								await desktopClient.invoke<UserInstructionListsResponse>(
@@ -710,12 +736,20 @@ export function CustomizationSectionView({
 						}
 					}
 				}
+				if (response) {
+					applyResponse(response);
+				}
+				if (unreachableTools.length > 0) {
+					const names = unreachableTools.map((tool) => tool.name).join(", ");
+					throw new Error(
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in bulk.`,
+					);
+				}
 				if (!response) {
 					throw new Error(
 						"tool toggle did not return an updated extension list",
 					);
 				}
-				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -380,6 +380,77 @@ function isUnsupportedDesktopCommand(error: unknown, command: string): boolean {
 	return message.includes(`unsupported desktop command: ${command}`);
 }
 
+/**
+ * Legacy fallback for sidecars that predate `set_tool_disabled`:
+ * `toggle_disabled_plugin_tool` flips one name with no explicit target
+ * state, so a tool with several headless names needs care to land on an
+ * exact target rather than some other combination.
+ *
+ * A grouped tool's `enabled` flag is true only when *none* of its names are
+ * disabled, so flipping every name once turns the aggregate true if and
+ * only if every name was disabled right before that flip — the exact
+ * "enable all" success condition. That makes the aggregate a reliable
+ * one-shot check for the enable direction, but not for disable: `false`
+ * there just means "at least one name disabled," which is equally true for
+ * "still mixed" and "now fully disabled." So for disable, a second
+ * (probe) flip is used — it turns the aggregate true only if every name was
+ * disabled right after the *first* flip, which is exactly what "disable"
+ * needs to confirm — and a third flip redoes the first if that holds.
+ * Either way, an unconfirmed attempt is flipped back to its exact starting
+ * state rather than left in some other unintended combination.
+ */
+async function toggleLegacyToolGroup(
+	toolNames: string[],
+	toolId: string,
+	desiredEnabled: boolean,
+): Promise<{ response: UserInstructionListsResponse; reached: boolean }> {
+	let response: UserInstructionListsResponse | undefined;
+	const flipAll = async () => {
+		for (const name of toolNames) {
+			response = await desktopClient.invoke<UserInstructionListsResponse>(
+				"toggle_disabled_plugin_tool",
+				{ name },
+			);
+		}
+	};
+	const readEnabled = () =>
+		response?.tools.find((candidate) => candidate.id === toolId)?.enabled;
+
+	await flipAll();
+	if (toolNames.length <= 1) {
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: true,
+		};
+	}
+
+	if (desiredEnabled) {
+		if (readEnabled() === true) {
+			return {
+				response: response as UserInstructionListsResponse,
+				reached: true,
+			};
+		}
+		await flipAll(); // Undo: restores the exact original state.
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: false,
+		};
+	}
+
+	await flipAll(); // Probe.
+	if (readEnabled() === true) {
+		await flipAll(); // Redo: the probe flipped everyone back on.
+		return {
+			response: response as UserInstructionListsResponse,
+			reached: true,
+		};
+	}
+	// The first flip left the group mixed; the probe already restored the
+	// original state.
+	return { response: response as UserInstructionListsResponse, reached: false };
+}
+
 export function CustomizationSectionView({
 	catalogPrimitive,
 	chrome = "page",
@@ -636,42 +707,20 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
-					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state. Flipping every name once
-					// reaches the target correctly when the tool's
-					// underlying names shared the same prior state; if they
-					// didn't (a mixed disabled state), flip everyone back to
-					// restore the original state instead of leaving some
-					// other unintended combination, and report that the
-					// tool needs an update.
-					for (const name of names) {
-						response = await desktopClient.invoke<UserInstructionListsResponse>(
-							"toggle_disabled_plugin_tool",
-							{ name },
-						);
-					}
-					if (names.length > 1) {
-						const reachedTarget =
-							response?.tools?.find((candidate) => candidate.id === tool.id)
-								?.enabled === desiredEnabled;
-						if (!reachedTarget) {
-							for (const name of names) {
-								response =
-									await desktopClient.invoke<UserInstructionListsResponse>(
-										"toggle_disabled_plugin_tool",
-										{ name },
-									);
-							}
-							unreachable = true;
-						}
-					}
+					const result = await toggleLegacyToolGroup(
+						names,
+						tool.id,
+						desiredEnabled,
+					);
+					response = result.response;
+					unreachable = !result.reached;
 				}
 				if (response) {
 					applyResponse(response);
 				}
 				if (unreachable) {
 					throw new Error(
-						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
 					);
 				}
 				if (!response) {
@@ -729,40 +778,21 @@ export function CustomizationSectionView({
 					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
 						throw error;
 					}
-					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state. Flipping every name of a tool
-					// once reaches the target correctly when its underlying
-					// names shared the same prior state; if they didn't (a
-					// mixed disabled state), flip everyone back to restore
-					// the original state instead of leaving some other
-					// unintended combination, and report that tool as
-					// needing an update.
+					// See toggleLegacyToolGroup for why grouped tools need
+					// verify-and-revert instead of a blind flip.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
-						for (const name of toolNames) {
-							response =
-								await desktopClient.invoke<UserInstructionListsResponse>(
-									"toggle_disabled_plugin_tool",
-									{ name },
-								);
-						}
-						if (toolNames.length > 1) {
-							const reachedTarget =
-								response?.tools?.find((candidate) => candidate.id === tool.id)
-									?.enabled === enabled;
-							if (!reachedTarget) {
-								for (const name of toolNames) {
-									response =
-										await desktopClient.invoke<UserInstructionListsResponse>(
-											"toggle_disabled_plugin_tool",
-											{ name },
-										);
-								}
-								unreachableTools.push(tool);
-							}
+						const result = await toggleLegacyToolGroup(
+							toolNames,
+							tool.id,
+							enabled,
+						);
+						response = result.response;
+						if (!result.reached) {
+							unreachableTools.push(tool);
 						}
 					}
 				}
@@ -772,7 +802,7 @@ export function CustomizationSectionView({
 				if (unreachableTools.length > 0) {
 					const names = unreachableTools.map((tool) => tool.name).join(", ");
 					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions.`,
 					);
 				}
 				if (!response) {

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -621,7 +621,9 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
+				const desiredEnabled = !tool.enabled;
 				let response: UserInstructionListsResponse | undefined;
+				let unreachable = false;
 				try {
 					response = await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
@@ -635,30 +637,48 @@ export function CustomizationSectionView({
 						throw error;
 					}
 					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state, which only reliably lands on the
-					// desired state when the tool maps to a single
-					// underlying name. A tool with several headless names in
-					// a mixed disabled state can't be forced to the opposite
-					// state by blindly flipping every name — some flips
-					// would move it further from the goal instead of closer.
-					if (names.length > 1) {
-						throw new Error(
-							`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
-						);
-					}
+					// explicit target state. Flipping every name once
+					// reaches the target correctly when the tool's
+					// underlying names shared the same prior state; if they
+					// didn't (a mixed disabled state), flip everyone back to
+					// restore the original state instead of leaving some
+					// other unintended combination, and report that the
+					// tool needs an update.
 					for (const name of names) {
 						response = await desktopClient.invoke<UserInstructionListsResponse>(
 							"toggle_disabled_plugin_tool",
 							{ name },
 						);
 					}
+					if (names.length > 1) {
+						const reachedTarget =
+							response?.tools?.find((candidate) => candidate.id === tool.id)
+								?.enabled === desiredEnabled;
+						if (!reachedTarget) {
+							for (const name of names) {
+								response =
+									await desktopClient.invoke<UserInstructionListsResponse>(
+										"toggle_disabled_plugin_tool",
+										{ name },
+									);
+							}
+							unreachable = true;
+						}
+					}
+				}
+				if (response) {
+					applyResponse(response);
+				}
+				if (unreachable) {
+					throw new Error(
+						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
+					);
 				}
 				if (!response) {
 					throw new Error(
 						"tool toggle did not return an updated extension list",
 					);
 				}
-				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
@@ -710,29 +730,39 @@ export function CustomizationSectionView({
 						throw error;
 					}
 					// toggle_disabled_plugin_tool flips one name with no
-					// explicit target state, which only reliably lands on
-					// the desired state when the tool maps to a single
-					// underlying name. A tool with several headless names in
-					// a mixed disabled state can't be forced to the target
-					// state by blindly flipping every name — some flips
-					// would move it further from the goal instead of
-					// closer — so skip those instead of silently leaving
-					// them wrong, and apply whatever did succeed.
+					// explicit target state. Flipping every name of a tool
+					// once reaches the target correctly when its underlying
+					// names shared the same prior state; if they didn't (a
+					// mixed disabled state), flip everyone back to restore
+					// the original state instead of leaving some other
+					// unintended combination, and report that tool as
+					// needing an update.
 					for (const tool of targets) {
 						const toolNames = [
 							tool.name,
 							...(tool.headlessToolNames ?? []),
 						].filter(Boolean);
-						if (toolNames.length > 1) {
-							unreachableTools.push(tool);
-							continue;
-						}
 						for (const name of toolNames) {
 							response =
 								await desktopClient.invoke<UserInstructionListsResponse>(
 									"toggle_disabled_plugin_tool",
 									{ name },
 								);
+						}
+						if (toolNames.length > 1) {
+							const reachedTarget =
+								response?.tools?.find((candidate) => candidate.id === tool.id)
+									?.enabled === enabled;
+							if (!reachedTarget) {
+								for (const name of toolNames) {
+									response =
+										await desktopClient.invoke<UserInstructionListsResponse>(
+											"toggle_disabled_plugin_tool",
+											{ name },
+										);
+								}
+								unreachableTools.push(tool);
+							}
 						}
 					}
 				}
@@ -742,7 +772,7 @@ export function CustomizationSectionView({
 				if (unreachableTools.length > 0) {
 					const names = unreachableTools.map((tool) => tool.name).join(", ");
 					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in bulk.`,
+						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions in a mixed state.`,
 					);
 				}
 				if (!response) {

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -9,6 +9,7 @@ import {
 	Play,
 	Puzzle,
 	RefreshCw,
+	Search,
 	Server,
 	Trash2,
 	TriangleAlert,
@@ -18,12 +19,14 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { desktopClient } from "@/lib/desktop-client";
@@ -84,6 +87,7 @@ type SkillItem = {
 	description?: string;
 	instructions: string;
 	path: string;
+	enabled?: boolean;
 	agentPlugin?: boolean;
 	pluginName?: string;
 };
@@ -94,6 +98,7 @@ type CommandItem = {
 	name: string;
 	description?: string;
 	instructions: string;
+	enabled?: boolean;
 	path: string;
 	scope: ItemScope;
 	agentPlugin?: boolean;
@@ -143,6 +148,22 @@ type ToolItem = {
 	headlessToolNames?: string[];
 };
 
+function toolMatchesQuery(tool: ToolItem, normalizedQuery: string): boolean {
+	if (!normalizedQuery) {
+		return true;
+	}
+	const haystacks = [
+		tool.name,
+		tool.description,
+		tool.pluginName,
+		tool.path,
+		...(tool.headlessToolNames ?? []),
+	];
+	return haystacks.some((value) =>
+		value?.toLowerCase().includes(normalizedQuery),
+	);
+}
+
 type HookItem = {
 	fileName: string;
 	hookEventName?: string;
@@ -183,7 +204,7 @@ type McpServersResponse = {
 	servers: McpServer[];
 };
 
-type LocalUninstallType = "mcp" | "skill" | "workflow" | "plugin";
+type LocalUninstallType = "mcp" | "skill" | "workflow" | "plugin" | "rule";
 
 type LocalUninstallTarget = {
 	key: string;
@@ -422,7 +443,11 @@ export function CustomizationSectionView({
 	const [togglingToolIds, setTogglingToolIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	const [toolsSearchQuery, setToolsSearchQuery] = useState("");
 	const [togglingPluginPaths, setTogglingPluginPaths] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [togglingSkillPaths, setTogglingSkillPaths] = useState<Set<string>>(
 		() => new Set(),
 	);
 	const [localUninstallingKeys, setLocalUninstallingKeys] = useState<
@@ -636,6 +661,77 @@ export function CustomizationSectionView({
 		[applyResponse],
 	);
 
+	const setAllToolsEnabled = useCallback(
+		async (toolsList: ToolItem[], enabled: boolean) => {
+			const targets = toolsList.filter((tool) => tool.enabled !== enabled);
+			if (targets.length === 0) {
+				return;
+			}
+			const targetIds = targets.map((tool) => tool.id);
+			setTogglingToolIds((current) => {
+				const next = new Set(current);
+				for (const id of targetIds) {
+					next.add(id);
+				}
+				return next;
+			});
+			setErrorMessage(null);
+			try {
+				const names = targets.flatMap((tool) =>
+					[tool.name, ...(tool.headlessToolNames ?? [])].filter(Boolean),
+				);
+				if (names.length === 0) {
+					throw new Error("tool name is required");
+				}
+				let response: UserInstructionListsResponse | undefined;
+				try {
+					response = await desktopClient.invoke<UserInstructionListsResponse>(
+						"set_tool_disabled",
+						{
+							names,
+							disabled: !enabled,
+						},
+					);
+				} catch (error) {
+					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
+						throw error;
+					}
+					for (const tool of targets) {
+						const toolNames = [
+							tool.name,
+							...(tool.headlessToolNames ?? []),
+						].filter(Boolean);
+						for (const name of toolNames) {
+							response =
+								await desktopClient.invoke<UserInstructionListsResponse>(
+									"toggle_disabled_plugin_tool",
+									{ name },
+								);
+						}
+					}
+				}
+				if (!response) {
+					throw new Error(
+						"tool toggle did not return an updated extension list",
+					);
+				}
+				applyResponse(response);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				setErrorMessage(message);
+			} finally {
+				setTogglingToolIds((current) => {
+					const next = new Set(current);
+					for (const id of targetIds) {
+						next.delete(id);
+					}
+					return next;
+				});
+			}
+		},
+		[applyResponse],
+	);
+
 	const setPluginEnabled = useCallback(
 		async (plugin: PluginItem) => {
 			setTogglingPluginPaths((current) => new Set(current).add(plugin.path));
@@ -657,6 +753,34 @@ export function CustomizationSectionView({
 				setTogglingPluginPaths((current) => {
 					const next = new Set(current);
 					next.delete(plugin.path);
+					return next;
+				});
+			}
+		},
+		[applyResponse],
+	);
+
+	const setSkillEnabled = useCallback(
+		async (skill: CommandItem) => {
+			setTogglingSkillPaths((current) => new Set(current).add(skill.path));
+			setErrorMessage(null);
+			try {
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
+						"set_skill_disabled",
+						{
+							path: skill.path,
+							disabled: skill.enabled !== false,
+						},
+					);
+				applyResponse(response);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				setErrorMessage(message);
+			} finally {
+				setTogglingSkillPaths((current) => {
+					const next = new Set(current);
+					next.delete(skill.path);
 					return next;
 				});
 			}
@@ -782,6 +906,7 @@ export function CustomizationSectionView({
 			name: skill.name,
 			description: skill.description,
 			instructions: skill.instructions,
+			enabled: skill.enabled,
 			path: skill.path,
 			scope: getPathScope(skill.path, workspaceRoot),
 			agentPlugin: skill.agentPlugin,
@@ -852,11 +977,17 @@ export function CustomizationSectionView({
 	}, [plugins, workspaceRoot]);
 
 	const builtinTools = useMemo(
-		() => tools.filter((tool) => tool.source === "builtin"),
+		() =>
+			tools
+				.filter((tool) => tool.source === "builtin")
+				.sort((a, b) => a.name.localeCompare(b.name)),
 		[tools],
 	);
 	const pluginTools = useMemo(
-		() => tools.filter((tool) => tool.source !== "builtin"),
+		() =>
+			tools
+				.filter((tool) => tool.source !== "builtin")
+				.sort((a, b) => a.name.localeCompare(b.name)),
 		[tools],
 	);
 	const pluginToolsByPluginKey = useMemo(() => {
@@ -872,6 +1003,33 @@ export function CustomizationSectionView({
 		}
 		return grouped;
 	}, [pluginTools]);
+	const normalizedToolsSearchQuery = toolsSearchQuery.trim().toLowerCase();
+	const filteredBuiltinTools = useMemo(
+		() =>
+			builtinTools.filter((tool) =>
+				toolMatchesQuery(tool, normalizedToolsSearchQuery),
+			),
+		[builtinTools, normalizedToolsSearchQuery],
+	);
+	const filteredPluginTools = useMemo(
+		() =>
+			pluginTools.filter((tool) =>
+				toolMatchesQuery(tool, normalizedToolsSearchQuery),
+			),
+		[pluginTools, normalizedToolsSearchQuery],
+	);
+	const allBuiltinToolsEnabled = useMemo(
+		() =>
+			filteredBuiltinTools.length > 0 &&
+			filteredBuiltinTools.every((tool) => tool.enabled),
+		[filteredBuiltinTools],
+	);
+	const allPluginToolsEnabled = useMemo(
+		() =>
+			filteredPluginTools.length > 0 &&
+			filteredPluginTools.every((tool) => tool.enabled),
+		[filteredPluginTools],
+	);
 
 	const scopedPlugins = useMemo(
 		() => [
@@ -950,7 +1108,11 @@ export function CustomizationSectionView({
 		);
 	};
 
-	const renderPluginMenu = (target: LocalUninstallTarget) => {
+	const renderLocalItemMenu = (
+		target: LocalUninstallTarget,
+		options: { showDelete?: boolean } = {},
+	) => {
+		const { showDelete = true } = options;
 		const uninstalling = localUninstallingKeys.has(target.key);
 		return (
 			<DropdownMenu>
@@ -975,14 +1137,16 @@ export function CustomizationSectionView({
 						<Copy className="size-4" />
 						Copy path
 					</DropdownMenuItem>
-					<DropdownMenuItem
-						className="text-destructive focus:text-destructive"
-						disabled={uninstalling}
-						onClick={() => void uninstallLocalPrimitive(target)}
-					>
-						{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
-						{uninstalling ? "Uninstalling..." : "Uninstall"}
-					</DropdownMenuItem>
+					{showDelete ? (
+						<DropdownMenuItem
+							className="text-destructive focus:text-destructive"
+							disabled={uninstalling}
+							onClick={() => void uninstallLocalPrimitive(target)}
+						>
+							{uninstalling ? <Spinner /> : <Trash2 className="size-4" />}
+							{uninstalling ? "Uninstalling..." : "Uninstall"}
+						</DropdownMenuItem>
+					) : null}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		);
@@ -996,26 +1160,15 @@ export function CustomizationSectionView({
 		return (
 			<div
 				key={key}
-				className="relative grid min-w-0 gap-2 rounded-lg border bg-card p-4"
+				className="grid min-w-0 gap-2 rounded-lg border bg-card p-4"
 			>
-				{item.agentPlugin !== true ? (
-					<div className="absolute top-4 right-4">
-						{renderLocalActionButton({
-							key,
-							type: item.type,
-							id: item.id,
-							name: item.name,
-							path: item.path,
-						})}
-					</div>
-				) : null}
-				<div className="flex min-w-0 items-center gap-2 pr-28">
+				<div className="flex min-w-0 items-center gap-2">
 					{item.type === "workflow" ? (
 						<Play className="h-4 w-4 shrink-0 text-primary" />
 					) : (
 						<Zap className="h-4 w-4 shrink-0 text-primary" />
 					)}
-					<h3 className="min-w-0 truncate text-sm font-semibold text-foreground">
+					<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 						{item.name}
 					</h3>
 					<ScopeBadge scope={item.scope} />
@@ -1032,6 +1185,32 @@ export function CustomizationSectionView({
 							Marketplace
 						</Badge>
 					) : null}
+					<Switch
+						checked={item.enabled !== false}
+						onCheckedChange={() => {
+							void setSkillEnabled(item);
+						}}
+						disabled={
+							item.type === "workflow" ||
+							item.agentPlugin === true ||
+							togglingSkillPaths.has(item.path)
+						}
+						title={
+							item.type === "workflow"
+								? "Toggling workflows isn't supported yet"
+								: undefined
+						}
+						aria-label={`Toggle ${item.name}`}
+					/>
+					{item.agentPlugin !== true
+						? renderLocalItemMenu({
+								key,
+								type: item.type,
+								id: item.id,
+								name: item.name,
+								path: item.path,
+							})
+						: null}
 				</div>
 				<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 					{item.description?.trim() || previewText(item.instructions)}
@@ -1094,9 +1273,6 @@ export function CustomizationSectionView({
 							Marketplace
 						</Badge>
 					) : null}
-					<span className="text-xs text-muted-foreground">
-						{plugin.enabled ? "Enabled" : "Disabled"}
-					</span>
 					<Switch
 						checked={plugin.enabled}
 						onCheckedChange={() => {
@@ -1110,7 +1286,7 @@ export function CustomizationSectionView({
 						aria-label={`Toggle ${plugin.name}`}
 					/>
 					{plugin.agentPlugin !== true
-						? renderPluginMenu({
+						? renderLocalItemMenu({
 								key,
 								type: "plugin",
 								id: plugin.name,
@@ -1377,16 +1553,30 @@ export function CustomizationSectionView({
 								>
 									<div className="flex min-w-0 items-center gap-2">
 										<FileText className="h-4 w-4 shrink-0 text-primary" />
-										<span className="min-w-0 truncate text-sm font-semibold text-foreground">
+										<span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 											{rule.name}
 										</span>
 										<ScopeBadge scope={scope} />
+										<Switch
+											checked
+											onCheckedChange={() => {}}
+											disabled
+											title="Toggling rules isn't supported yet"
+											aria-label={`Toggle ${rule.name}`}
+										/>
+										{renderLocalItemMenu(
+											{
+												key: rule.path,
+												type: "rule",
+												id: rule.path,
+												name: rule.name,
+												path: rule.path,
+											},
+											{ showDelete: false },
+										)}
 									</div>
 									<p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
 										{previewText(rule.instructions)}
-									</p>
-									<p className="truncate text-xs font-mono text-muted-foreground">
-										{rule.path}
 									</p>
 								</div>
 							))}
@@ -1603,17 +1793,57 @@ export function CustomizationSectionView({
 
 			{activeTab === "Tools" && (
 				<div>
+					<div className="relative mb-6 block">
+						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+						<Input
+							aria-label="Search tools"
+							className="h-10 pl-8"
+							onChange={(event) => setToolsSearchQuery(event.target.value)}
+							placeholder="Search tools"
+							value={toolsSearchQuery}
+						/>
+					</div>
+
 					<div className="mb-6 grid gap-3">
 						<div className="flex items-center justify-between gap-3">
 							<h3 className="text-base font-semibold text-foreground">
-								Builtin Tools
+								BuiltIn Tools{" "}
+								<span className="text-muted-foreground">
+									{filteredBuiltinTools.length}
+								</span>
 							</h3>
-							<span className="text-sm text-muted-foreground">
-								{builtinTools.length}
-							</span>
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Checkbox
+									checked={allBuiltinToolsEnabled}
+									onCheckedChange={() => {
+										void setAllToolsEnabled(
+											filteredBuiltinTools,
+											!allBuiltinToolsEnabled,
+										);
+									}}
+									disabled={
+										filteredBuiltinTools.length === 0 ||
+										filteredBuiltinTools.some((tool) =>
+											togglingToolIds.has(tool.id),
+										)
+									}
+									id="builtin-tools-toggle-all"
+									aria-label={
+										allBuiltinToolsEnabled
+											? "Disable all builtin tools"
+											: "Enable all builtin tools"
+									}
+								/>
+								<label
+									className="cursor-pointer"
+									htmlFor="builtin-tools-toggle-all"
+								>
+									{allBuiltinToolsEnabled ? "Disable all" : "Enable all"}
+								</label>
+							</div>
 						</div>
 						<div className="flex flex-col gap-2">
-							{builtinTools.map((tool) =>
+							{filteredBuiltinTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
@@ -1626,9 +1856,6 @@ export function CustomizationSectionView({
 												<h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
 													{tool.name}
 												</h3>
-												<span className="text-xs text-muted-foreground">
-													{tool.enabled ? "Enabled" : "Disabled"}
-												</span>
 												<Switch
 													checked={tool.enabled}
 													onCheckedChange={() => {
@@ -1642,18 +1869,21 @@ export function CustomizationSectionView({
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
-											{!!tool.headlessToolNames?.length && (
-												<p className="truncate text-xs font-mono text-muted-foreground">
-													{tool.headlessToolNames.join(", ")}
-												</p>
-											)}
+											{!!tool.headlessToolNames?.length &&
+												tool.headlessToolNames?.length > 1 && (
+													<p className="truncate text-xs font-mono text-muted-foreground">
+														{tool.headlessToolNames.join(", ")}
+													</p>
+												)}
 										</div>
 									);
 								})(),
 							)}
-							{builtinTools.length === 0 && (
+							{filteredBuiltinTools.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No builtin tools found.
+									{builtinTools.length === 0
+										? "No builtin tools found."
+										: "No tools match your search."}
 								</p>
 							)}
 						</div>
@@ -1662,14 +1892,43 @@ export function CustomizationSectionView({
 					<div className="grid gap-3">
 						<div className="flex items-center justify-between gap-3">
 							<h3 className="text-base font-semibold text-foreground">
-								Plugin Tools
+								Plugin Tools{" "}
+								<span className="text-muted-foreground">
+									{filteredPluginTools.length}
+								</span>
 							</h3>
-							<span className="text-sm text-muted-foreground">
-								{pluginTools.length}
-							</span>
+							<div className="flex items-center gap-2 text-sm text-muted-foreground">
+								<Checkbox
+									checked={allPluginToolsEnabled}
+									onCheckedChange={() => {
+										void setAllToolsEnabled(
+											filteredPluginTools,
+											!allPluginToolsEnabled,
+										);
+									}}
+									disabled={
+										filteredPluginTools.length === 0 ||
+										filteredPluginTools.some((tool) =>
+											togglingToolIds.has(tool.id),
+										)
+									}
+									id="plugin-tools-toggle-all"
+									aria-label={
+										allPluginToolsEnabled
+											? "Disable all plugin tools"
+											: "Enable all plugin tools"
+									}
+								/>
+								<label
+									className="cursor-pointer"
+									htmlFor="plugin-tools-toggle-all"
+								>
+									{allPluginToolsEnabled ? "Disable all" : "Enable all"}
+								</label>
+							</div>
 						</div>
 						<div className="flex flex-col gap-2">
-							{pluginTools.map((tool) =>
+							{filteredPluginTools.map((tool) =>
 								(() => {
 									const isToggling = togglingToolIds.has(tool.id);
 									return (
@@ -1684,15 +1943,13 @@ export function CustomizationSectionView({
 												</h3>
 												{tool.pluginName && (
 													<Badge
-														variant="outline"
-														className="shrink-0 text-muted-foreground"
+														variant="muted"
+														className="shrink-0"
+														title={tool.path || tool.pluginName}
 													>
 														{tool.pluginName}
 													</Badge>
 												)}
-												<span className="text-xs text-muted-foreground">
-													{tool.enabled ? "Enabled" : "Disabled"}
-												</span>
 												<Switch
 													checked={tool.enabled}
 													onCheckedChange={() => {
@@ -1706,18 +1963,15 @@ export function CustomizationSectionView({
 												{tool.description?.trim() ||
 													"No description available."}
 											</p>
-											{tool.path && (
-												<p className="truncate text-xs font-mono text-muted-foreground">
-													{tool.path}
-												</p>
-											)}
 										</div>
 									);
 								})(),
 							)}
-							{pluginTools.length === 0 && (
+							{filteredPluginTools.length === 0 && (
 								<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-									No plugin tools found.
+									{pluginTools.length === 0
+										? "No plugin tools found."
+										: "No tools match your search."}
 								</p>
 							)}
 						</div>

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -40,6 +40,8 @@ import {
 } from "../marketplace-view";
 import { CommandBadge, PageFrame, PageHeader } from "../page-layout";
 
+import { CreateCustomizationDialog } from "./create-customization-dialog";
+
 export type CustomizationSection =
 	| "Rules"
 	| "Hooks"
@@ -70,12 +72,14 @@ const sectionCommands: Record<CustomizationSection, string> = {
 };
 
 type RuleItem = {
+	enabled: boolean;
 	name: string;
 	instructions: string;
 	path: string;
 };
 
 type WorkflowItem = {
+	enabled: boolean;
 	id: string;
 	name: string;
 	instructions: string;
@@ -442,9 +446,9 @@ export function CustomizationSectionView({
 	const [togglingPluginPaths, setTogglingPluginPaths] = useState<Set<string>>(
 		() => new Set(),
 	);
-	const [togglingSkillPaths, setTogglingSkillPaths] = useState<Set<string>>(
-		() => new Set(),
-	);
+	const [togglingInstructionPaths, setTogglingInstructionPaths] = useState<
+		Set<string>
+	>(() => new Set());
 	const [localUninstallingKeys, setLocalUninstallingKeys] = useState<
 		Set<string>
 	>(() => new Set());
@@ -708,15 +712,27 @@ export function CustomizationSectionView({
 		[applyResponse],
 	);
 
-	const setSkillEnabled = useCallback(
-		async (skill: CommandItem) => {
-			setTogglingSkillPaths((current) => new Set(current).add(skill.path));
+	const setInstructionEnabled = useCallback(
+		async (skill: {
+			path: string;
+			enabled?: boolean;
+			type: "skill" | "rule" | "workflow";
+		}) => {
+			setTogglingInstructionPaths((current) =>
+				new Set(current).add(skill.path),
+			);
 			setErrorMessage(null);
 			try {
 				const response =
 					await desktopClient.invoke<UserInstructionListsResponse>(
-						"set_skill_disabled",
+						"set_instruction_disabled",
 						{
+							type:
+								skill.type === "skill"
+									? "skills"
+									: skill.type === "rule"
+										? "rules"
+										: "workflows",
 							path: skill.path,
 							disabled: skill.enabled !== false,
 						},
@@ -726,7 +742,7 @@ export function CustomizationSectionView({
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
 			} finally {
-				setTogglingSkillPaths((current) => {
+				setTogglingInstructionPaths((current) => {
 					const next = new Set(current);
 					next.delete(skill.path);
 					return next;
@@ -845,6 +861,7 @@ export function CustomizationSectionView({
 			type: "workflow",
 			name: workflow.name,
 			instructions: workflow.instructions,
+			enabled: workflow.enabled,
 			path: workflow.path,
 			scope: getPathScope(workflow.path, workspaceRoot),
 		}));
@@ -1136,17 +1153,11 @@ export function CustomizationSectionView({
 					<Switch
 						checked={item.enabled !== false}
 						onCheckedChange={() => {
-							void setSkillEnabled(item);
+							void setInstructionEnabled(item);
 						}}
 						disabled={
-							item.type === "workflow" ||
 							item.agentPlugin === true ||
-							togglingSkillPaths.has(item.path)
-						}
-						title={
-							item.type === "workflow"
-								? "Toggling workflows isn't supported yet"
-								: undefined
+							togglingInstructionPaths.has(item.path)
 						}
 						aria-label={`Toggle ${item.name}`}
 					/>
@@ -1411,6 +1422,27 @@ export function CustomizationSectionView({
 		</Button>
 	);
 
+	const sectionActions = (
+		<div className="flex shrink-0 items-center gap-2">
+			{(activeTab === "Rules" ||
+				activeTab === "Skills" ||
+				activeTab === "Hooks") && (
+				<CreateCustomizationDialog
+					key={activeTab}
+					type={
+						activeTab === "Rules"
+							? "rule"
+							: activeTab === "Skills"
+								? "skill"
+								: "hook"
+					}
+					onCreated={() => refresh(true)}
+				/>
+			)}
+			{refreshButton}
+		</div>
+	);
+
 	const content = (
 		<>
 			{chrome === "page" ? (
@@ -1418,14 +1450,14 @@ export function CustomizationSectionView({
 					description={sectionDescriptions[activeTab]}
 					title={activeTab}
 					meta={<CommandBadge>{sectionCommands[activeTab]}</CommandBadge>}
-					actions={refreshButton}
+					actions={sectionActions}
 				/>
 			) : (
 				<div className="mb-4 flex items-center justify-between gap-3">
 					<p className="text-sm text-muted-foreground">
 						{sectionDescriptions[activeTab]}
 					</p>
-					{refreshButton}
+					{sectionActions}
 				</div>
 			)}
 
@@ -1506,10 +1538,11 @@ export function CustomizationSectionView({
 										</span>
 										<ScopeBadge scope={scope} />
 										<Switch
-											checked
-											onCheckedChange={() => {}}
-											disabled
-											title="Toggling rules isn't supported yet"
+											checked={rule.enabled !== false}
+											onCheckedChange={() =>
+												void setInstructionEnabled({ ...rule, type: "rule" })
+											}
+											disabled={togglingInstructionPaths.has(rule.path)}
 											aria-label={`Toggle ${rule.name}`}
 										/>
 										{renderLocalItemMenu(
@@ -1634,35 +1667,10 @@ export function CustomizationSectionView({
 					</p>
 
 					<div className="flex flex-col gap-3">
-						{commandItems.map((item) => (
-							<div
-								key={`${item.type}:${item.path}`}
-								className="rounded-lg border border-border px-5 py-4"
-							>
-								<div className="flex items-center gap-3">
-									{item.type === "workflow" ? (
-										<Play className="h-4 w-4 shrink-0 text-primary" />
-									) : (
-										<Zap className="h-4 w-4 shrink-0 text-primary" />
-									)}
-									<h3 className="text-sm font-semibold text-foreground">
-										{item.name}
-									</h3>
-									<span className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground">
-										{item.type}
-									</span>
-								</div>
-								<p className="mt-2 ml-7 text-xs text-muted-foreground">
-									{item.description?.trim() || previewText(item.instructions)}
-								</p>
-								<p className="mt-1 ml-7 text-xs font-mono text-muted-foreground">
-									{item.path}
-								</p>
-							</div>
-						))}
+						{commandItems.map((item) => renderSkillCard(item))}
 						{commandItems.length === 0 && (
 							<p className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
-								No enabled skills or workflows found.
+								No skills or workflows found.
 							</p>
 						)}
 					</div>

--- a/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/extensions-view.tsx
@@ -375,82 +375,6 @@ async function fetchUserInstructionLists(): Promise<UserInstructionListsResponse
 	return normalizeInstructionListsResponse(response);
 }
 
-function isUnsupportedDesktopCommand(error: unknown, command: string): boolean {
-	const message = error instanceof Error ? error.message : String(error);
-	return message.includes(`unsupported desktop command: ${command}`);
-}
-
-/**
- * Legacy fallback for sidecars that predate `set_tool_disabled`:
- * `toggle_disabled_plugin_tool` flips one name with no explicit target
- * state, so a tool with several headless names needs care to land on an
- * exact target rather than some other combination.
- *
- * A grouped tool's `enabled` flag is true only when *none* of its names are
- * disabled, so flipping every name once turns the aggregate true if and
- * only if every name was disabled right before that flip — the exact
- * "enable all" success condition. That makes the aggregate a reliable
- * one-shot check for the enable direction, but not for disable: `false`
- * there just means "at least one name disabled," which is equally true for
- * "still mixed" and "now fully disabled." So for disable, a second
- * (probe) flip is used — it turns the aggregate true only if every name was
- * disabled right after the *first* flip, which is exactly what "disable"
- * needs to confirm — and a third flip redoes the first if that holds.
- * Either way, an unconfirmed attempt is flipped back to its exact starting
- * state rather than left in some other unintended combination.
- */
-async function toggleLegacyToolGroup(
-	toolNames: string[],
-	toolId: string,
-	desiredEnabled: boolean,
-): Promise<{ response: UserInstructionListsResponse; reached: boolean }> {
-	let response: UserInstructionListsResponse | undefined;
-	const flipAll = async () => {
-		for (const name of toolNames) {
-			response = await desktopClient.invoke<UserInstructionListsResponse>(
-				"toggle_disabled_plugin_tool",
-				{ name },
-			);
-		}
-	};
-	const readEnabled = () =>
-		response?.tools.find((candidate) => candidate.id === toolId)?.enabled;
-
-	await flipAll();
-	if (toolNames.length <= 1) {
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: true,
-		};
-	}
-
-	if (desiredEnabled) {
-		if (readEnabled() === true) {
-			return {
-				response: response as UserInstructionListsResponse,
-				reached: true,
-			};
-		}
-		await flipAll(); // Undo: restores the exact original state.
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: false,
-		};
-	}
-
-	await flipAll(); // Probe.
-	if (readEnabled() === true) {
-		await flipAll(); // Redo: the probe flipped everyone back on.
-		return {
-			response: response as UserInstructionListsResponse,
-			reached: true,
-		};
-	}
-	// The first flip left the group mixed; the probe already restored the
-	// original state.
-	return { response: response as UserInstructionListsResponse, reached: false };
-}
-
 export function CustomizationSectionView({
 	catalogPrimitive,
 	chrome = "page",
@@ -692,42 +616,12 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
-				const desiredEnabled = !tool.enabled;
-				let response: UserInstructionListsResponse | undefined;
-				let unreachable = false;
-				try {
-					response = await desktopClient.invoke<UserInstructionListsResponse>(
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
-						{
-							names,
-							disabled: tool.enabled,
-						},
+						{ names, disabled: tool.enabled },
 					);
-				} catch (error) {
-					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
-						throw error;
-					}
-					const result = await toggleLegacyToolGroup(
-						names,
-						tool.id,
-						desiredEnabled,
-					);
-					response = result.response;
-					unreachable = !result.reached;
-				}
-				if (response) {
-					applyResponse(response);
-				}
-				if (unreachable) {
-					throw new Error(
-						`Couldn't toggle ${tool.name}: this desktop build needs an update to change tools with multiple underlying actions.`,
-					);
-				}
-				if (!response) {
-					throw new Error(
-						"tool toggle did not return an updated extension list",
-					);
-				}
+				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);
@@ -744,7 +638,7 @@ export function CustomizationSectionView({
 
 	const setAllToolsEnabled = useCallback(
 		async (toolsList: ToolItem[], enabled: boolean) => {
-			const targets = toolsList.filter((tool) => tool.enabled !== enabled);
+			const targets = toolsList.filter((tool) => !enabled || !tool.enabled);
 			if (targets.length === 0) {
 				return;
 			}
@@ -764,52 +658,12 @@ export function CustomizationSectionView({
 				if (names.length === 0) {
 					throw new Error("tool name is required");
 				}
-				let response: UserInstructionListsResponse | undefined;
-				const unreachableTools: ToolItem[] = [];
-				try {
-					response = await desktopClient.invoke<UserInstructionListsResponse>(
+				const response =
+					await desktopClient.invoke<UserInstructionListsResponse>(
 						"set_tool_disabled",
-						{
-							names,
-							disabled: !enabled,
-						},
+						{ names, disabled: !enabled },
 					);
-				} catch (error) {
-					if (!isUnsupportedDesktopCommand(error, "set_tool_disabled")) {
-						throw error;
-					}
-					// See toggleLegacyToolGroup for why grouped tools need
-					// verify-and-revert instead of a blind flip.
-					for (const tool of targets) {
-						const toolNames = [
-							tool.name,
-							...(tool.headlessToolNames ?? []),
-						].filter(Boolean);
-						const result = await toggleLegacyToolGroup(
-							toolNames,
-							tool.id,
-							enabled,
-						);
-						response = result.response;
-						if (!result.reached) {
-							unreachableTools.push(tool);
-						}
-					}
-				}
-				if (response) {
-					applyResponse(response);
-				}
-				if (unreachableTools.length > 0) {
-					const names = unreachableTools.map((tool) => tool.name).join(", ");
-					throw new Error(
-						`Couldn't ${enabled ? "enable" : "disable"} ${names}: this desktop build needs an update to change tools with multiple underlying actions.`,
-					);
-				}
-				if (!response) {
-					throw new Error(
-						"tool toggle did not return an updated extension list",
-					);
-				}
+				applyResponse(response);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				setErrorMessage(message);

--- a/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/mcp-view.tsx
@@ -747,6 +747,10 @@ export function McpServersContent({
 
 	const headerActions = (
 		<>
+			<Button variant="outline" size="sm" onClick={openCreateDialog}>
+				<Plus className="size-4" />
+				New MCP
+			</Button>
 			<Button
 				variant="outline"
 				size="sm"
@@ -754,10 +758,6 @@ export function McpServersContent({
 				disabled={isLoading}
 			>
 				<RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
-			</Button>
-			<Button size="sm" onClick={openCreateDialog}>
-				<Plus className="h-4 w-4" />
-				Add MCP Server
 			</Button>
 		</>
 	);

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -422,7 +422,8 @@ Design implication:
 ### 4. Settings Mutation Boundary
 
 Core owns settings snapshots and mutations through `packages/core/src/settings`.
-The hub exposes the same path through `settings.list` and `settings.toggle`.
+The hub exposes the same path through `settings.list`, `settings.toggle`, and `settings.createGlobal`.
+Rule, workflow, and skill toggles persist the Markdown disabled field and refresh discovery; disabled entries remain in settings inventories but are excluded from runtime instructions and commands. Global creation writes validated rules, skills, and JavaScript event hooks into the canonical global configuration directories without overwriting existing files, then publishes `settings.changed`.
 
 Design implication:
 

--- a/sdk/packages/core/README.md
+++ b/sdk/packages/core/README.md
@@ -106,6 +106,7 @@ The package also exports storage and settings helpers such as:
 
 - `ProviderSettingsManager`
 - `CoreSettingsService` and `createCoreSettingsService`
+- Rule, workflow, and skill enablement through `CoreSettingsService.toggle()`; global rule, skill, and hook creation through `CoreSettingsService.createGlobal()` (also exposed as the `settings.createGlobal` hub command)
 - MCP settings helpers such as `setMcpServerDisabled`
 - `SqliteTeamStore`
 - SQLite-backed local session stores and artifacts through `@cline/core`

--- a/sdk/packages/core/src/extensions/config/instruction-frontmatter-toggle.test.ts
+++ b/sdk/packages/core/src/extensions/config/instruction-frontmatter-toggle.test.ts
@@ -3,9 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	toggleSkillFrontmatter,
-	updateSkillMarkdownEnabledState,
-} from "./skill-frontmatter-toggle";
+	toggleInstructionFrontmatter,
+	updateInstructionMarkdownEnabledState,
+} from "./instruction-frontmatter-toggle";
 import { parseSkillConfigFromMarkdown } from "./user-instruction-config-loader";
 
 describe("skill frontmatter toggle", () => {
@@ -27,7 +27,7 @@ First line.
 
 Second line.`;
 
-		const updated = updateSkillMarkdownEnabledState(content, false);
+		const updated = updateInstructionMarkdownEnabledState(content, false);
 		const parsed = parseSkillConfigFromMarkdown(updated, "fallback");
 
 		expect(parsed.disabled).toBe(true);
@@ -43,7 +43,7 @@ disabled: true
 ---
 Use the review checklist.`;
 
-		const updated = updateSkillMarkdownEnabledState(content, true);
+		const updated = updateInstructionMarkdownEnabledState(content, true);
 		const parsed = parseSkillConfigFromMarkdown(updated, "fallback");
 
 		expect(parsed.disabled).toBeUndefined();
@@ -58,7 +58,7 @@ enabled: false
 ---
 Use legacy instructions.`;
 
-		const updated = updateSkillMarkdownEnabledState(content, true);
+		const updated = updateInstructionMarkdownEnabledState(content, true);
 		const parsed = parseSkillConfigFromMarkdown(updated, "fallback");
 
 		expect(parsed.disabled).toBeUndefined();
@@ -69,7 +69,7 @@ Use legacy instructions.`;
 	it("prepends frontmatter when disabling a skill without frontmatter", () => {
 		const content = "Follow the incident response runbook.";
 
-		const updated = updateSkillMarkdownEnabledState(content, false);
+		const updated = updateInstructionMarkdownEnabledState(content, false);
 		const parsed = parseSkillConfigFromMarkdown(updated, "incident-response");
 
 		expect(parsed.disabled).toBe(true);
@@ -83,7 +83,7 @@ ${content}`);
 	it("leaves a skill without frontmatter unchanged when enabling", () => {
 		const content = "Follow the incident response runbook.";
 
-		expect(updateSkillMarkdownEnabledState(content, true)).toBe(content);
+		expect(updateInstructionMarkdownEnabledState(content, true)).toBe(content);
 	});
 
 	// Regression test for https://github.com/cline/cline/issues/12151: a leading UTF-8 BOM
@@ -96,7 +96,7 @@ description: Review code carefully
 ---
 First line.`;
 
-		const updated = updateSkillMarkdownEnabledState(content, false);
+		const updated = updateInstructionMarkdownEnabledState(content, false);
 		const parsed = parseSkillConfigFromMarkdown(updated, "fallback");
 
 		expect(parsed.disabled).toBe(true);
@@ -116,7 +116,10 @@ name: file-skill
 Use file-backed instructions.`,
 		);
 
-		const result = await toggleSkillFrontmatter({ filePath, enabled: false });
+		const result = await toggleInstructionFrontmatter({
+			filePath,
+			enabled: false,
+		});
 		const written = await readFile(filePath, "utf8");
 		const parsed = parseSkillConfigFromMarkdown(written, "fallback");
 

--- a/sdk/packages/core/src/extensions/config/instruction-frontmatter-toggle.ts
+++ b/sdk/packages/core/src/extensions/config/instruction-frontmatter-toggle.ts
@@ -2,12 +2,12 @@ import { readFile, writeFile } from "node:fs/promises";
 import { stripUtf8Bom } from "@cline/shared";
 import YAML from "yaml";
 
-export interface ToggleSkillFrontmatterOptions {
+export interface ToggleInstructionFrontmatterOptions {
 	filePath: string;
 	enabled: boolean;
 }
 
-export interface ToggleSkillFrontmatterResult {
+export interface ToggleInstructionFrontmatterResult {
 	filePath: string;
 	enabled: boolean;
 	disabled: boolean;
@@ -48,7 +48,7 @@ function serializeMarkdownFrontmatter(
 	return `---\n${yaml}\n---\n${body}`;
 }
 
-export function updateSkillMarkdownEnabledState(
+export function updateInstructionMarkdownEnabledState(
 	content: string,
 	enabled: boolean,
 ): string {
@@ -73,12 +73,12 @@ export function updateSkillMarkdownEnabledState(
 	return serializeMarkdownFrontmatter(data, body);
 }
 
-export async function toggleSkillFrontmatter({
+export async function toggleInstructionFrontmatter({
 	filePath,
 	enabled,
-}: ToggleSkillFrontmatterOptions): Promise<ToggleSkillFrontmatterResult> {
+}: ToggleInstructionFrontmatterOptions): Promise<ToggleInstructionFrontmatterResult> {
 	const content = await readFile(filePath, "utf8");
-	const updated = updateSkillMarkdownEnabledState(content, enabled);
+	const updated = updateInstructionMarkdownEnabledState(content, enabled);
 	await writeFile(filePath, updated);
 
 	return {

--- a/sdk/packages/core/src/extensions/config/runtime-commands.test.ts
+++ b/sdk/packages/core/src/extensions/config/runtime-commands.test.ts
@@ -2,11 +2,11 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { toggleInstructionFrontmatter } from "./instruction-frontmatter-toggle";
 import {
 	listAvailableRuntimeCommandsFromWatcher,
 	resolveRuntimeSlashCommandFromWatcher,
 } from "./runtime-commands";
-import { toggleSkillFrontmatter } from "./skill-frontmatter-toggle";
 import { createUserInstructionConfigWatcher } from "./user-instruction-config-loader";
 
 describe("runtime command registry", () => {
@@ -439,7 +439,10 @@ Review the current branch and summarize findings.
 				"Use the review skill.",
 			);
 
-			await toggleSkillFrontmatter({ filePath: skillPath, enabled: false });
+			await toggleInstructionFrontmatter({
+				filePath: skillPath,
+				enabled: false,
+			});
 			await watcher.refreshType("skill");
 
 			expect(resolveRuntimeSlashCommandFromWatcher("/review", watcher)).toBe(

--- a/sdk/packages/core/src/hub/server/hub-server-transport.ts
+++ b/sdk/packages/core/src/hub/server/hub-server-transport.ts
@@ -905,6 +905,8 @@ export class HubServerTransport implements NativeHubTransport {
 				return okReply(envelope);
 			case "settings.list":
 				return await this.handleSettingsList(envelope);
+			case "settings.createGlobal":
+				return await this.handleSettingsCreateGlobal(envelope);
 			case "settings.toggle":
 				return await this.handleSettingsToggle(envelope);
 			case "connector.channels":
@@ -997,6 +999,62 @@ export class HubServerTransport implements NativeHubTransport {
 				ok: false,
 				error: {
 					code: "settings_list_failed",
+					message: error instanceof Error ? error.message : String(error),
+				},
+			};
+		}
+	}
+
+	private async handleSettingsCreateGlobal(
+		envelope: HubCommandEnvelope,
+	): Promise<HubReplyEnvelope> {
+		try {
+			const input = envelope.payload;
+			if (!input || typeof input !== "object" || Array.isArray(input))
+				throw new Error("settings.createGlobal payload must be an object.");
+			if (
+				input.type !== "rule" &&
+				input.type !== "skill" &&
+				input.type !== "hook"
+			)
+				throw new Error("Choose a rule, skill, or hook.");
+			if (typeof input.name !== "string" || typeof input.content !== "string")
+				throw new Error("Name and content are required.");
+			if (
+				input.description !== undefined &&
+				typeof input.description !== "string"
+			)
+				throw new Error("Description must be a string.");
+			const result = await this.settings.createGlobal({
+				type: input.type,
+				name: input.name,
+				content: input.content,
+				description: input.description,
+			});
+			this.publish(
+				buildHubEvent("settings.changed", {
+					types: [
+						input.type === "rule"
+							? "rules"
+							: input.type === "skill"
+								? "skills"
+								: "hooks",
+					],
+				}),
+			);
+			return {
+				version: envelope.version,
+				requestId: envelope.requestId,
+				ok: true,
+				payload: result,
+			};
+		} catch (error) {
+			return {
+				version: envelope.version,
+				requestId: envelope.requestId,
+				ok: false,
+				error: {
+					code: "settings_create_failed",
 					message: error instanceof Error ? error.message : String(error),
 				},
 			};

--- a/sdk/packages/core/src/hub/settings.test.ts
+++ b/sdk/packages/core/src/hub/settings.test.ts
@@ -63,6 +63,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService: new CoreSettingsService({ pluginSource }),
 		});
 
@@ -128,6 +129,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService: new CoreSettingsService({ pluginSource }),
 		});
 		const settingsEvents: unknown[] = [];
@@ -210,6 +212,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService,
 		});
 		const events: string[] = [];
@@ -270,6 +273,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService,
 		});
 
@@ -307,6 +311,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService,
 		});
 
@@ -341,6 +346,7 @@ describe("hub settings commands", () => {
 		const transport = new HubServerTransport({
 			runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
 			scheduleOptions: { dbPath: ":memory:" },
+			taskOptions: { dbPath: ":memory:", watchFiles: false },
 			settingsService,
 		});
 
@@ -367,4 +373,57 @@ describe("hub settings commands", () => {
 			await transport.stop();
 		}
 	});
+});
+
+it("routes global creation through settings and publishes inventory invalidation", async () => {
+	const settingsService = new CoreSettingsService();
+	const create = vi
+		.spyOn(settingsService, "createGlobal")
+		.mockResolvedValue({ path: "/global/rules/review.md" });
+	const transport = new HubServerTransport({
+		runtimeHandlers: createLocalHubScheduleRuntimeHandlers(),
+		scheduleOptions: { dbPath: ":memory:" },
+		taskOptions: { dbPath: ":memory:", watchFiles: false },
+		settingsService,
+	});
+	const events: unknown[] = [];
+	const unsubscribe = transport.subscribe("creator", (event) => {
+		if (event.event === "settings.changed") events.push(event.payload);
+	});
+	try {
+		const payload = {
+			type: "rule",
+			name: "review",
+			content: "Review carefully.",
+		};
+		const reply = await transport.handleCommand({
+			version: "v1",
+			command: "settings.createGlobal",
+			requestId: "create",
+			clientId: "creator",
+			payload,
+		});
+		expect(create).toHaveBeenCalledWith({ ...payload, description: undefined });
+		expect(reply).toMatchObject({
+			ok: true,
+			payload: { path: "/global/rules/review.md" },
+		});
+		expect(events).toEqual([{ types: ["rules"] }]);
+		create.mockRejectedValueOnce(new Error("already exists"));
+		const failure = await transport.handleCommand({
+			version: "v1",
+			command: "settings.createGlobal",
+			requestId: "duplicate",
+			clientId: "creator",
+			payload,
+		});
+		expect(failure).toMatchObject({
+			ok: false,
+			error: { code: "settings_create_failed", message: "already exists" },
+		});
+		expect(events).toHaveLength(1);
+	} finally {
+		unsubscribe();
+		await transport.stop();
+	}
 });

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -879,6 +879,7 @@ export type {
 	CorePluginContributions,
 	CorePluginSettingsSnapshot,
 	CorePluginSettingsSource,
+	CoreSettingsCreateGlobalInput,
 	CoreSettingsItem,
 	CoreSettingsItemKind,
 	CoreSettingsItemSource,

--- a/sdk/packages/core/src/settings/create-global-customization.test.ts
+++ b/sdk/packages/core/src/settings/create-global-customization.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { setHomeDir } from "@cline/shared/storage";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import {
+	createUserInstructionConfigService,
+	listHookConfigFiles,
+} from "../index";
+import { createGlobalCustomization } from "./create-global-customization";
+
+const originalHome = homedir();
+let root: string;
+beforeEach(async () => {
+	root = await mkdtemp(join(tmpdir(), "desktop-customization-"));
+	setHomeDir(root);
+});
+afterEach(async () => {
+	setHomeDir(originalHome);
+	await rm(root, { recursive: true, force: true });
+});
+
+it("creates globally discoverable rules, skills, and runnable hook files", async () => {
+	const rule = await createGlobalCustomization({
+		type: "rule",
+		name: "review",
+		content: "Check the diff.",
+	});
+	const skill = await createGlobalCustomization({
+		type: "skill",
+		name: "review",
+		description: 'Review "code": carefully',
+		content: "Read the changes.",
+	});
+	const hook = await createGlobalCustomization({
+		type: "hook",
+		name: "TaskStart",
+		content: 'process.stdout.write("{}");',
+	});
+	const service = createUserInstructionConfigService();
+	try {
+		await service.start();
+		expect(
+			service.listRecords("rule").some((item) => item.filePath === rule.path),
+		).toBe(true);
+		expect(
+			service.listRecords("skill").some((item) => item.filePath === skill.path),
+		).toBe(true);
+		expect(
+			listHookConfigFiles().some(
+				(item) =>
+					item.path === hook.path && item.hookEventName === "agent_start",
+			),
+		).toBe(true);
+	} finally {
+		service.stop();
+	}
+});
+
+it("refuses overwrites and invalid paths or events", async () => {
+	const input = { type: "rule" as const, name: "review", content: "Original." };
+	const { path } = await createGlobalCustomization(input);
+	await expect(
+		createGlobalCustomization({ ...input, content: "Replacement." }),
+	).rejects.toThrow("already exists");
+	expect(await readFile(path, "utf8")).toContain("Original.");
+	for (const name of ["../escape", "/tmp/escape", "a/b", "a\\b"]) {
+		await expect(createGlobalCustomization({ ...input, name })).rejects.toThrow(
+			"lowercase",
+		);
+	}
+	await expect(
+		createGlobalCustomization({
+			type: "hook",
+			name: "PreCompact",
+			content: "x",
+		}),
+	).rejects.toThrow("supported");
+	await expect(
+		createGlobalCustomization({ type: "skill", name: "review", content: "x" }),
+	).rejects.toThrow("description");
+	await expect(
+		createGlobalCustomization({ ...input, content: " " }),
+	).rejects.toThrow("Content");
+});

--- a/sdk/packages/core/src/settings/create-global-customization.ts
+++ b/sdk/packages/core/src/settings/create-global-customization.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { resolveClineDir } from "@cline/shared/storage";
+import {
+	parseRuleConfigFromMarkdown,
+	parseSkillConfigFromMarkdown,
+} from "../extensions/config";
+import {
+	HOOK_CONFIG_FILE_EVENT_MAP,
+	HookConfigFileName,
+} from "../hooks/hook-file-config";
+
+import type { CoreSettingsCreateGlobalInput } from "./types";
+
+const creatableHookEvents = Object.values(HookConfigFileName).filter(
+	(event) => HOOK_CONFIG_FILE_EVENT_MAP[event] !== undefined,
+);
+
+/** Create only in the canonical global directories; never replace an existing file. */
+export async function createGlobalCustomization(
+	input: CoreSettingsCreateGlobalInput,
+): Promise<{ path: string }> {
+	const { type } = input;
+	if (type !== "rule" && type !== "skill" && type !== "hook") {
+		throw new Error("Choose a rule, skill, or hook.");
+	}
+	const name = typeof input.name === "string" ? input.name.trim() : "";
+	const content = typeof input.content === "string" ? input.content : "";
+	if (!content.trim()) throw new Error("Content is required.");
+	let path: string;
+	let markdown = content;
+	if (type === "hook") {
+		if (!creatableHookEvents.some((event) => event === name)) {
+			throw new Error("Choose a supported hook event.");
+		}
+		path = join(resolveClineDir(), "hooks", `${name}.mjs`);
+	} else {
+		if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) || name.length > 64) {
+			throw new Error(
+				"Use up to 64 lowercase letters, numbers, and single hyphens for the name.",
+			);
+		}
+		const description =
+			typeof input.description === "string" ? input.description.trim() : "";
+		if (type === "skill" && !description)
+			throw new Error("A skill description is required.");
+		markdown = `---\nname: ${JSON.stringify(name)}\n${type === "skill" ? `description: ${JSON.stringify(description)}\n` : ""}---\n\n${content.trim()}\n`;
+		(type === "skill"
+			? parseSkillConfigFromMarkdown
+			: parseRuleConfigFromMarkdown)(markdown, name);
+		path =
+			type === "skill"
+				? join(resolveClineDir(), "skills", name, "SKILL.md")
+				: join(resolveClineDir(), "rules", `${name}.md`);
+	}
+	await mkdir(dirname(path), { recursive: true });
+	try {
+		await writeFile(path, markdown, { flag: "wx" });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+			throw new Error(
+				`A ${type} named "${name}" already exists. Choose another name or edit the existing file.`,
+			);
+		}
+		throw error;
+	}
+	return { path };
+}

--- a/sdk/packages/core/src/settings/index.ts
+++ b/sdk/packages/core/src/settings/index.ts
@@ -7,6 +7,7 @@ export type {
 	CorePluginContributions,
 	CorePluginSettingsSnapshot,
 	CorePluginSettingsSource,
+	CoreSettingsCreateGlobalInput,
 	CoreSettingsItem,
 	CoreSettingsItemKind,
 	CoreSettingsItemSource,

--- a/sdk/packages/core/src/settings/settings-service.test.ts
+++ b/sdk/packages/core/src/settings/settings-service.test.ts
@@ -46,6 +46,40 @@ describe("CoreSettingsService", () => {
 		tempRoots.length = 0;
 	});
 
+	it.each([
+		"rule",
+		"workflow",
+	] as const)("persists %s toggles and keeps disabled items discoverable", async (kind) => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "instruction-settings-"));
+		tempRoots.push(tempRoot);
+		const directory = join(
+			tempRoot,
+			".cline",
+			kind === "rule" ? "rules" : "workflows",
+		);
+		await mkdir(directory, { recursive: true });
+		const path = join(directory, "review.md");
+		await writeFile(
+			path,
+			"---\nname: review\ncustom: preserve\n---\nReview carefully.\n",
+		);
+		const settings = new CoreSettingsService();
+		const type = kind === "rule" ? "rules" : "workflows";
+		const input = { type, path, cwd: tempRoot } as const;
+		const disabled = await settings.toggle({ ...input, enabled: false });
+		expect(disabled.changedTypes).toEqual([type]);
+		expect(
+			disabled.snapshot[type].find((item) => item.path === path),
+		).toMatchObject({ enabled: false, toggleable: true });
+		expect(await readFile(path, "utf8")).toContain("disabled: true");
+		const enabled = await settings.toggle(input);
+		expect(
+			enabled.snapshot[type].find((item) => item.path === path)?.enabled,
+		).toBe(true);
+		expect(await readFile(path, "utf8")).toContain("custom: preserve");
+		expect(await readFile(path, "utf8")).not.toContain("disabled:");
+	});
+
 	it("toggles skill frontmatter and refreshes the skill service before returning a snapshot", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "core-settings-"));
 		tempRoots.push(tempRoot);

--- a/sdk/packages/core/src/settings/settings-service.ts
+++ b/sdk/packages/core/src/settings/settings-service.ts
@@ -19,7 +19,7 @@ import {
 	type UserInstructionConfigService,
 	type WorkflowConfig,
 } from "../extensions/config";
-import { toggleSkillFrontmatter } from "../extensions/config/skill-frontmatter-toggle";
+import { toggleInstructionFrontmatter } from "../extensions/config/instruction-frontmatter-toggle";
 import {
 	hasMcpSettingsFile,
 	resolveDefaultMcpSettingsPath,
@@ -41,8 +41,10 @@ import {
 	toggleDisabledTool,
 } from "../services/global-settings";
 import { listPluginToolsWithDiagnostics } from "../services/plugin-tools";
+import { createGlobalCustomization } from "./create-global-customization";
 import type {
 	CorePluginSettingsSource,
+	CoreSettingsCreateGlobalInput,
 	CoreSettingsItem,
 	CoreSettingsListInput,
 	CoreSettingsMutationResult,
@@ -432,14 +434,17 @@ async function withUserInstructionService<T>(
 	}
 }
 
-function findSkillRecord(
+function findInstructionRecord(
 	service: UserInstructionConfigService | undefined,
 	input: CoreSettingsToggleInput,
+	type: "skill" | "rule" | "workflow",
 ) {
 	if (!service) {
 		return undefined;
 	}
-	const records = service.listRecords<SkillConfig>("skill");
+	const records = service.listRecords<
+		SkillConfig | RuleConfig | WorkflowConfig
+	>(type);
 	if (input.id) {
 		const match = records.find((record) => record.id === input.id);
 		if (match) {
@@ -522,7 +527,7 @@ export class CoreSettingsService {
 						kind: "workflow",
 						source: detectSource(record.filePath, workspaceRoot),
 						description: workflow.instructions,
-						toggleable: false,
+						toggleable: true,
 					});
 				}
 				for (const record of service.listRecords<RuleConfig>("rule")) {
@@ -535,7 +540,7 @@ export class CoreSettingsService {
 						kind: "rule",
 						source: detectSource(record.filePath, workspaceRoot),
 						description: rule.instructions,
-						toggleable: false,
+						toggleable: true,
 					});
 				}
 				for (const record of service.listRecords<SkillConfig>("skill")) {
@@ -660,13 +665,33 @@ export class CoreSettingsService {
 		});
 	}
 
+	async createGlobal(
+		input: CoreSettingsCreateGlobalInput,
+	): Promise<{ path: string }> {
+		return await createGlobalCustomization(input);
+	}
+
 	async toggle(
 		input: CoreSettingsToggleInput,
 	): Promise<CoreSettingsMutationResult> {
-		if (input.type === "skills") {
+		if (
+			input.type === "skills" ||
+			input.type === "rules" ||
+			input.type === "workflows"
+		) {
+			const type =
+				input.type === "skills"
+					? "skill"
+					: input.type === "rules"
+						? "rule"
+						: "workflow";
 			return await withUserInstructionService(input, async (service) => {
-				const record = findSkillRecord(service, input);
-				if (record?.item.source?.type === "agent-plugin") {
+				const record = findInstructionRecord(service, input, type);
+				if (
+					record &&
+					"source" in record.item &&
+					record.item.source?.type === "agent-plugin"
+				) {
 					// Agent Plugin skills are only toggleable as part of their
 					// plugin (`type: "plugins"`). Writing `disabled` into the
 					// skill's frontmatter would corrupt it: the strict Agent
@@ -679,7 +704,7 @@ export class CoreSettingsService {
 				const filePath = record?.filePath;
 				if (!filePath) {
 					throw new Error(
-						`Unable to resolve skill setting '${input.id ?? input.name ?? basename(input.path ?? "")}'.`,
+						`Unable to resolve ${type} setting '${input.id ?? input.name ?? basename(input.path ?? "")}'.`,
 					);
 				}
 				const currentEnabled =
@@ -691,17 +716,17 @@ export class CoreSettingsService {
 					(currentEnabled !== undefined ? !currentEnabled : undefined);
 				if (enabled === undefined) {
 					throw new Error(
-						`Cannot determine toggle state for skill '${input.id ?? input.name ?? basename(input.path ?? "")}'; provide an explicit enabled value or a resolvable workspace context.`,
+						`Cannot determine toggle state for ${type} '${input.id ?? input.name ?? basename(input.path ?? "")}'; provide an explicit enabled value or a resolvable workspace context.`,
 					);
 				}
-				await toggleSkillFrontmatter({ filePath, enabled });
-				await service?.refreshType("skill");
+				await toggleInstructionFrontmatter({ filePath, enabled });
+				await service?.refreshType(type);
 				return {
 					snapshot: await this.list({
 						...input,
 						userInstructionService: service,
 					}),
-					changedTypes: ["skills"],
+					changedTypes: [input.type],
 				};
 			});
 		}

--- a/sdk/packages/core/src/settings/types.ts
+++ b/sdk/packages/core/src/settings/types.ts
@@ -94,6 +94,13 @@ export interface CoreSettingsListInput {
 	availabilityContext?: BuiltinToolAvailabilityContext;
 }
 
+export interface CoreSettingsCreateGlobalInput {
+	type: "rule" | "skill" | "hook";
+	name: string;
+	content: string;
+	description?: string;
+}
+
 export interface CoreSettingsToggleInput extends CoreSettingsListInput {
 	type: CoreSettingsType;
 	id?: string;

--- a/sdk/packages/shared/src/hub.ts
+++ b/sdk/packages/shared/src/hub.ts
@@ -590,6 +590,7 @@ export type HubCommandName =
 	| "settings.get"
 	| "settings.patch"
 	| "settings.toggle"
+	| "settings.createGlobal"
 	| "connector.channels"
 	| "connector.configure"
 	| "connector.delete_config"


### PR DESCRIPTION
### Related Issue

Follow-up to #13837, based on `bee/unify-ui`.

### Description

Rules and workflows can now be enabled and disabled from desktop Customize and the CLI config view. Core persists their Markdown disabled state using the same implementation as skills, refreshes discovery, and keeps disabled items visible for re-enabling. Plugin-owned Agent Skills remain controlled by their owning plugin.

Customize also gains New rule, New skill, and New hook dialogs. Rules and skills accept Markdown instructions; skills include a description. Hooks offer supported lifecycle events and a JavaScript editor with a starter script. Creation goes through the new `settings.createGlobal` hub command and core settings service, writes to the canonical global `.cline` directories, refuses overwrites, and publishes an inventory invalidation. Hook files use `.mjs` so the starter script's top-level await works explicitly.

### Test Procedure

- SDK build passes.
- Focused core settings, creation, hub routing, Markdown persistence, and runtime-command tests pass.
- 49 CLI config tests pass.
- 10 desktop component tests pass, covering instruction toggles, creation submission, and draft preservation on errors.
- Desktop sidecar typecheck and CLI typecheck pass.
- Biome checks and `git diff --check` pass for changed files.
- The broader webview TypeScript check reports errors in unchanged generated Next routes, chat/speech tests, transcription code, and shared environment typing. No errors were reported in the changed UI files.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not captured. Dialog interaction and inventory behavior are covered by component tests.

### Additional Notes

Stacked on #13837; merge that PR first and retarget this one to main afterward. The full monorepo suite was not run; scoped validation is listed above.

New hooks are global JavaScript event scripts, one canonical file per event. Existing files are never overwritten, and the currently unimplemented PreCompact event is omitted from the creation selector. Creating workflows and independently toggling plugin-owned Agent Skills are outside this follow-up.
