### PR TITLE
fix(vscode): settle a pending approval when a mode switch rebuilds the session

### DIFF
--- a/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.test.ts
@@ -677,6 +677,29 @@ describe("SdkModeCoordinator", () => {
 		expect(options.sessions.fireAndForgetSend).not.toHaveBeenCalled()
 	})
 
+	it("settles an approval that was pending while the session sat idle, which is the real shape of one", async () => {
+		// A turn awaiting approval is NOT running: the session is parked on the user. The settle
+		// path was reached only through `wasRunning`, so the case its own comment named, "dead
+		// approval buttons (aborted while awaiting approval)", was the one case it could not reach.
+		// The rebuild then replaced the session underneath a still-pending ask, and the footer fell
+		// back to a generic Approve that answered nothing (#13814).
+		//
+		// The existing test above pairs `awaiting_approval` with `isRunning: true`, a combination
+		// the product does not produce, which is how the gap survived having a test.
+		const activeSession = makeActiveSession({ isRunning: false })
+		const task = makeTask("old-session")
+		const { coordinator, options } = makeCoordinator({ activeSession, task, turnPhase: "awaiting_approval" })
+
+		await coordinator.rebuildSessionForMode("plan")
+
+		expect(options.interactions.clearPending).toHaveBeenCalledWith("Mode changed")
+		const resumeAppend = (options.messages.appendAndEmit as ReturnType<typeof vi.fn>).mock.calls.find(
+			([messages]) => messages[0]?.ask === "resume_task",
+		)
+		expect(resumeAppend).toBeDefined()
+		expect(options.setTurnPhase).toHaveBeenCalledWith("resumable", resumeAppend?.[0][0].ts)
+	})
+
 	it("does not touch the turn phase when rebuilding an idle session", async () => {
 		const activeSession = makeActiveSession({ isRunning: false })
 		const task = makeTask("old-session")

--- a/apps/vscode/src/sdk/sdk-mode-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-mode-coordinator.ts
@@ -238,7 +238,14 @@ export class SdkModeCoordinator {
 			Logger.warn("[SdkController] Failed to post mode state before session rebuild:", error)
 		}
 
-		if (wasRunning) {
+		// A turn AWAITING APPROVAL is parked on the user, so `isRunning` is false and this gate used
+		// to skip it. That left the ask pending and the phase stuck on `awaiting_approval` while the
+		// session underneath was replaced, so the footer fell back to a generic Approve that answered
+		// nothing (#13814). It is exactly the case the settle path's own comment names, "dead approval
+		// buttons (aborted while awaiting approval)", and `wasRunning` was the one condition under
+		// which that case could never arrive.
+		const awaitingApproval = this.options.getTurnPhase() === "awaiting_approval"
+		if (wasRunning || awaitingApproval) {
 			await this.cancelRunningTurnForModeChange(oldManager, oldSessionId)
 		}
 


### PR DESCRIPTION
Fixes #13814.

## The fix already existed and could not reach this case

`cancelRunningTurnForModeChange` appends a resume ask and marks the turn resumable. Its comment names both cases it is for:

> instead of an eternal Thinking spinner (aborted while streaming) **or dead approval buttons (aborted while awaiting approval)**

It was reached only through one gate:

```ts
if (wasRunning) {
    await this.cancelRunningTurnForModeChange(oldManager, oldSessionId)
}
```

**A turn awaiting approval is not running.** The session is parked on the user, so `isRunning` is false, and the second case in that comment was the one case the gate could never admit.

So the rebuild replaced the session underneath a still-pending ask: `interactions.clearPending("Mode changed")` never ran, no resume row was appended, and the phase stayed `awaiting_approval` with an `anchorTs` pointing into the turn that no longer exists. `buttonsForPhase` resolves that anchor with `messages.find(m => m.ts === turnState.anchorTs)` and falls back to `BUTTON_CONFIGS.tool_approve` when it misses — which is where the bare **"Approve"** in the report comes from, rather than "Run Command" or "Resume Task".

The gate now also admits a turn whose phase is `awaiting_approval`. Everything behind it is unchanged and already tested: same abort, same finalize, same resume ask, same phase transition. An idle session is still left alone, which its own test pins.

## Why this survived having a test

The existing test for the settle path is `"settles the aborted turn as resumable so the footer never keeps a stale streaming/approval state"`, and it sets up:

```ts
const activeSession = makeActiveSession({ isRunning: true })
const { coordinator, options } = makeCoordinator({ activeSession, task, turnPhase: "awaiting_approval" })
```

`awaiting_approval` **with** `isRunning: true` — a combination the product does not produce, since awaiting approval is precisely when the session has stopped running. The test named the approval case and then arranged for the gate to pass anyway, so the real shape was never exercised.

The new test uses the real shape: `awaiting_approval` on a session that is **not** running.

## Verification

- Mutation-checked: reverting the gate to `if (wasRunning)` reddens **exactly one** test, the new one, and leaves the other 34 in the file green — including `"does not touch the turn phase when rebuilding an idle session"`, which is the guard that this must not over-reach.
- `sdk-mode-coordinator.test.ts`: 35/35.
- The whole `apps/vscode/src/sdk` suite: **1091 tests across 69 files, all passing.**
- `biome check` clean on both files with `apps/vscode/biome.jsonc`.

## One small thing I left alone

`cancelRunningTurnForModeChange` is now called for a turn that was not running, so its name is a little narrower than its job. I left it, to keep the diff to the gate that was wrong rather than mixing in a rename. Happy to rename it if you would prefer.
