### PR TITLE
fix(core): remove unintended source runtime fingerprinting

### DIFF
--- a/sdk/packages/core/bun.mts
+++ b/sdk/packages/core/bun.mts
@@ -1,5 +1,10 @@
 /// <reference types="@types/bun" />
-import { resolveSdkRuntimeBuildIdFromCoreSource } from "./src/hub/discovery/runtime-build-id";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	resolveRepoRootFromCorePackage,
+	resolveSdkRuntimeBuildId,
+} from "./scripts/runtime-build-id";
 
 type PackageManifest = {
 	dependencies?: Record<string, string>;
@@ -9,7 +14,10 @@ type PackageManifest = {
 const packageJson = (await Bun.file(
 	new URL("./package.json", import.meta.url),
 ).json()) as PackageManifest;
-const runtimeBuildId = resolveSdkRuntimeBuildIdFromCoreSource();
+const corePackageRoot = dirname(fileURLToPath(import.meta.url));
+const runtimeBuildId = resolveSdkRuntimeBuildId(
+	resolveRepoRootFromCorePackage(corePackageRoot),
+);
 
 // Keep declared runtime packages external so they are not duplicated inside each
 // bundled entrypoint and installed again from package.json.

--- a/sdk/packages/core/scripts/runtime-build-id.ts
+++ b/sdk/packages/core/scripts/runtime-build-id.ts
@@ -1,15 +1,9 @@
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join, relative } from "node:path";
 
 const RUNTIME_PACKAGE_NAMES = ["shared", "llms", "agents", "core"] as const;
 const TEST_DIRECTORY_NAMES = new Set(["__tests__", "fixtures", "tests"]);
-
-export interface SdkRuntimeSourceIdentity {
-	buildId: string;
-	buildEpochMs: number;
-}
 
 function collectRuntimeSourceFiles(directory: string): string[] {
 	const files: string[] = [];
@@ -38,9 +32,7 @@ function collectRuntimeSourceFiles(directory: string): string[] {
  * same identity, while runtime changes are detected even when package versions
  * have not been bumped yet.
  */
-export function resolveSdkRuntimeSourceIdentity(
-	repoRoot: string,
-): SdkRuntimeSourceIdentity {
+export function resolveSdkRuntimeBuildId(repoRoot: string): string {
 	const packagesRoot = join(repoRoot, "sdk", "packages");
 	const inputs = [join(repoRoot, "bun.lock")];
 
@@ -55,26 +47,14 @@ export function resolveSdkRuntimeSourceIdentity(
 	}
 
 	const hash = createHash("sha256");
-	let buildEpochMs = 0;
 	for (const path of inputs.sort()) {
 		const inputName = relative(repoRoot, path).replaceAll("\\", "/");
 		hash.update(inputName);
 		hash.update("\0");
 		hash.update(readFileSync(path));
 		hash.update("\0");
-		buildEpochMs = Math.max(buildEpochMs, Math.floor(statSync(path).mtimeMs));
 	}
-	return {
-		// Keep timestamped source-graph builds ordered after both the legacy
-		// `source-<package-version>` identity and the short-lived hash-only v2
-		// identity, allowing the first v3 client to replace either daemon.
-		buildId: `source-v3-${hash.digest("hex")}`,
-		buildEpochMs,
-	};
-}
-
-export function resolveSdkRuntimeBuildId(repoRoot: string): string {
-	return resolveSdkRuntimeSourceIdentity(repoRoot).buildId;
+	return `sdk-v1-${hash.digest("hex")}`;
 }
 
 export function resolveRepoRootFromCorePackage(
@@ -87,21 +67,4 @@ export function resolveRepoRootFromCorePackage(
 		);
 	}
 	return join(packagesRoot, "..", "..");
-}
-
-/** Resolve the SDK fingerprint while executing Core directly from source. */
-export function resolveSdkRuntimeBuildIdFromCoreSource(): string {
-	return resolveSdkRuntimeSourceIdentityFromCoreSource().buildId;
-}
-
-export function resolveSdkRuntimeSourceIdentityFromCoreSource(): SdkRuntimeSourceIdentity {
-	const corePackageRoot = join(
-		dirname(fileURLToPath(import.meta.url)),
-		"..",
-		"..",
-		"..",
-	);
-	return resolveSdkRuntimeSourceIdentity(
-		resolveRepoRootFromCorePackage(corePackageRoot),
-	);
 }

--- a/sdk/packages/core/scripts/verify-runtime-build-id.ts
+++ b/sdk/packages/core/scripts/verify-runtime-build-id.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveSdkRuntimeBuildIdFromCoreSource } from "../src/hub/discovery/runtime-build-id";
+import {
+	resolveRepoRootFromCorePackage,
+	resolveSdkRuntimeBuildId,
+} from "./runtime-build-id";
 
 const corePackageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const buildId = resolveSdkRuntimeBuildIdFromCoreSource();
+const buildId = resolveSdkRuntimeBuildId(
+	resolveRepoRootFromCorePackage(corePackageRoot),
+);
 const entrypoints = [
 	join(corePackageRoot, "dist", "index.js"),
 	join(corePackageRoot, "dist", "hub", "index.js"),

--- a/sdk/packages/core/src/hub/discovery/build-order.test.ts
+++ b/sdk/packages/core/src/hub/discovery/build-order.test.ts
@@ -141,35 +141,6 @@ describe("isManagedHubReusable", () => {
 		).toBe(true);
 	});
 
-	it("retires the legacy static source daemon after runtime fingerprinting", () => {
-		const legacy = {
-			buildId: "source-0.0.75",
-			coreVersion: "0.0.75",
-		};
-		const fingerprinted = {
-			buildId: `source-v3-${"a".repeat(64)}`,
-			coreVersion: "0.0.75",
-		};
-
-		expect(retires(fingerprinted, legacy)).toBe(true);
-		expect(retires(legacy, fingerprinted)).toBe(false);
-	});
-
-	it("retires the hash-only source daemon after adding source epochs", () => {
-		const hashOnly = {
-			buildId: `source-v2-${"f".repeat(64)}`,
-			coreVersion: "0.0.75",
-		};
-		const timestamped = {
-			buildId: `source-v3-${"0".repeat(64)}`,
-			buildEpochMs: 2_000,
-			coreVersion: "0.0.75",
-		};
-
-		expect(retires(timestamped, hashOnly)).toBe(true);
-		expect(retires(hashOnly, timestamped)).toBe(false);
-	});
-
 	it("attaches to a strictly newer Hub instead of downgrading it", () => {
 		expect(
 			retires(

--- a/sdk/packages/core/src/hub/discovery/index.test.ts
+++ b/sdk/packages/core/src/hub/discovery/index.test.ts
@@ -13,7 +13,6 @@ import {
 	resolveHubOwnerContext,
 	writeHubDiscovery,
 } from ".";
-import { resolveSdkRuntimeBuildIdFromCoreSource } from "./runtime-build-id";
 
 type EnvSnapshot = {
 	CLINE_DATA_DIR: string | undefined;
@@ -70,11 +69,10 @@ describe("hub discovery", () => {
 		);
 	});
 
-	it("fingerprints unbundled source builds and allows an explicit override", () => {
+	it("allows tests to override the unbundled source build identity", () => {
 		snapshot = captureEnv();
 		delete process.env.CLINE_HUB_BUILD_ID;
-		expect(resolveHubBuildId()).toBe(resolveSdkRuntimeBuildIdFromCoreSource());
-		expect(resolveHubBuildId()).toMatch(/^source-v3-[a-f0-9]{64}$/);
+		expect(resolveHubBuildId()).toMatch(/^source-/);
 
 		process.env.CLINE_HUB_BUILD_ID = "e2e-build";
 		expect(resolveHubBuildId()).toBe("e2e-build");
@@ -104,10 +102,10 @@ describe("hub discovery", () => {
 		).toEqual({ compatible: false, reason: "unsupported_protocol" });
 	});
 
-	it("orders source builds by runtime input time and allows an explicit override", () => {
+	it("allows tests to override the build epoch and treats sources as unordered", () => {
 		snapshot = captureEnv();
 		delete process.env.CLINE_HUB_BUILD_EPOCH_MS;
-		expect(resolveHubBuildEpochMs()).toBeGreaterThan(0);
+		expect(resolveHubBuildEpochMs()).toBeUndefined();
 
 		process.env.CLINE_HUB_BUILD_EPOCH_MS = "12345";
 		expect(resolveHubBuildEpochMs()).toBe(12345);

--- a/sdk/packages/core/src/hub/discovery/index.ts
+++ b/sdk/packages/core/src/hub/discovery/index.ts
@@ -9,10 +9,6 @@ import {
 } from "@cline/shared";
 import { resolveClineDataDir, resolveClineDir } from "@cline/shared/storage";
 import corePackage from "../../../package.json";
-import {
-	resolveSdkRuntimeSourceIdentityFromCoreSource,
-	type SdkRuntimeSourceIdentity,
-} from "./runtime-build-id";
 
 declare const __CLINE_CORE_RUNTIME_BUILD_ID__: string | undefined;
 declare const __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__: number | undefined;
@@ -23,14 +19,6 @@ const HUB_BUILD_EPOCH_ENV = "CLINE_HUB_BUILD_EPOCH_MS";
 const HUB_STARTUP_LOCK_MAX_AGE_MS = 30_000;
 const HUB_STARTUP_LOCK_WAIT_MS = 15_000;
 const HUB_STARTUP_LOCK_POLL_MS = 100;
-
-let sourceRuntimeBuildIdentity: SdkRuntimeSourceIdentity | undefined;
-
-function resolveSourceRuntimeBuildIdentity(): SdkRuntimeSourceIdentity {
-	sourceRuntimeBuildIdentity ??=
-		resolveSdkRuntimeSourceIdentityFromCoreSource();
-	return sourceRuntimeBuildIdentity;
-}
 
 export interface HubServerDiscoveryRecord {
 	hubId: string;
@@ -139,34 +127,24 @@ export function resolveHubBuildId(): string {
 		typeof __CLINE_CORE_RUNTIME_BUILD_ID__ === "string"
 			? __CLINE_CORE_RUNTIME_BUILD_ID__.trim()
 			: "";
-	if (embedded) {
-		return embedded;
-	}
-	// Source processes are long-lived too. Fingerprint the runtime graph so a
-	// restarted client cannot mistake a daemon loaded before an edit for its own
-	// build merely because neither process bumped the package version.
-	return resolveSourceRuntimeBuildIdentity().buildId;
+	return embedded || `source-${String(corePackage.version)}`;
 }
 
 /**
  * When this SDK build was produced, embedded at bundle time. Orders builds so
  * managed-Hub handling can distinguish a newer daemon (attach and prompt the
- * user to update) from a stale one (retire and replace). Unbundled source uses
- * the newest runtime-input modification time, which is stable across the
- * client and daemon for one checkout but advances after an edit.
+ * user to update) from a stale one (retire and replace). Undefined when
+ * running from unbundled sources, where no meaningful ordering exists.
  */
 export function resolveHubBuildEpochMs(): number | undefined {
 	const configured = Number(process.env[HUB_BUILD_EPOCH_ENV]);
 	if (Number.isFinite(configured) && configured > 0) {
 		return configured;
 	}
-	if (
-		typeof __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__ === "number" &&
+	return typeof __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__ === "number" &&
 		Number.isFinite(__CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__)
-	) {
-		return __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__;
-	}
-	return resolveSourceRuntimeBuildIdentity().buildEpochMs;
+		? __CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__
+		: undefined;
 }
 
 export type ManagedHubCompatibilityResult =

--- a/sdk/packages/core/src/hub/discovery/runtime-build-id.test.ts
+++ b/sdk/packages/core/src/hub/discovery/runtime-build-id.test.ts
@@ -1,18 +1,8 @@
-import {
-	mkdirSync,
-	mkdtempSync,
-	rmSync,
-	statSync,
-	utimesSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-	resolveSdkRuntimeBuildId,
-	resolveSdkRuntimeSourceIdentity,
-} from "./runtime-build-id";
+import { resolveSdkRuntimeBuildId } from "../../../scripts/runtime-build-id";
 
 describe("SDK runtime build identity", () => {
 	const tempDirs: string[] = [];
@@ -63,26 +53,5 @@ describe("SDK runtime build identity", () => {
 		);
 
 		expect(resolveSdkRuntimeBuildId(root)).toBe(first);
-	});
-
-	it("advances the source epoch when a runtime input changes", () => {
-		const root = createRuntimeFixture();
-		const first = resolveSdkRuntimeSourceIdentity(root);
-		const changedPath = join(
-			root,
-			"sdk",
-			"packages",
-			"core",
-			"src",
-			"index.ts",
-		);
-		const later = new Date(first.buildEpochMs + 10_000);
-		utimesSync(changedPath, later, later);
-
-		const updated = resolveSdkRuntimeSourceIdentity(root);
-		expect(updated.buildEpochMs).toBe(
-			Math.floor(statSync(changedPath).mtimeMs),
-		);
-		expect(updated.buildEpochMs).toBeGreaterThan(first.buildEpochMs);
 	});
 });


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — Beta `0.0.23-beta.1` desktop startup regression

### Description

PR #13778 ported configurable media generation to `desktop-experimental`, but also carried seven unrelated Core/Hub runtime-identity changes that are not present on `main`. The changed source fallback tries to locate and hash a real `sdk/packages` checkout at runtime. In a packaged Bun sidecar, that source tree does not exist, so the backend exits before publishing its endpoint.

This PR removes only those unrelated runtime-identity changes and restores the seven affected files to their known-good `desktop-v0.0.22-beta.1` state. It preserves the media-generation work and every later `desktop-experimental` commit. No files under `apps/examples/desktop-app/` are changed.

The runtime-breaking call was introduced in `sdk/packages/core/src/hub/discovery/index.ts`, where the missing-define fallback began calling `resolveSdkRuntimeSourceIdentityFromCoreSource()`.

### Test Procedure

- Confirmed all seven affected files exactly match `desktop-v0.0.22-beta.1` after the cleanup
- `bun run build:sdk`
- Core discovery tests: 3 files passed, 24 tests passed
- Biome check on all affected files
- Built the unchanged desktop sidecar for macOS arm64 and Linux x64/arm64
- Ran the compiled sidecar with runtime build overrides removed; the original `expected Core package under sdk/packages` crash is gone

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single bugfix
- [x] Focused tests, SDK build, and formatting checks are passing
- [x] I have reviewed the contributor guidelines

### Screenshots

Not applicable; this fixes backend startup before the webview connects.

### Additional Notes

The isolated no-existing-Hub smoke test proceeds beyond the reported source-checkout crash and then reaches the separate existing `No compatible hub runtime is available` cold-start path. That behavior is intentionally outside this cleanup.