### PR TITLE
fix(llms): limit Langfuse telemetry to Cline backend providers

### DIFF
--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -118,8 +118,8 @@ describe("langfuse telemetry", () => {
 		expect(registerTelemetrySpy).not.toHaveBeenCalled();
 	});
 
-	it("keeps non-cline telemetry disabled after cline initialization", async () => {
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
+	it("enables Cline backend providers and keeps other providers disabled", async () => {
+		await expect(ensureLangfuseTelemetry("cline-pass")).resolves.toBe(true);
 		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
 		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
 

--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -110,9 +110,18 @@ describe("langfuse telemetry", () => {
 		resetLangfuseTelemetryForTests();
 	});
 
-	it("enables telemetry for non-cline providers when langfuse config is available", async () => {
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+	it("does not initialize telemetry for non-cline providers", async () => {
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
+
+		expect(registerDisposableSpy).not.toHaveBeenCalled();
+		expect(addSpanProcessorSpy).not.toHaveBeenCalled();
+		expect(registerTelemetrySpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps non-cline telemetry disabled after cline initialization", async () => {
 		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
 
 		expect(registerDisposableSpy).toHaveBeenCalledTimes(1);
 		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
@@ -135,7 +144,7 @@ describe("langfuse telemetry", () => {
 			addSpanProcessor: addSpanProcessorSpy,
 		});
 
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
 		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
 		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
 	});
@@ -151,7 +160,7 @@ describe("langfuse telemetry", () => {
 				registeredGlobalProvider.current ?? { constructor: { name: "Qn" } },
 		});
 
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
 		expect(registeredGlobalProvider.current).toBeInstanceOf(
 			MockNodeTracerProvider,
 		);
@@ -163,7 +172,7 @@ describe("langfuse telemetry", () => {
 			getDelegate: () => ({ addSpanProcessor: addSpanProcessorSpy }),
 		});
 
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
 		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
 		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
 	});
@@ -176,7 +185,7 @@ describe("langfuse telemetry", () => {
 			}),
 		});
 
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
 		expect(registerTelemetrySpy).not.toHaveBeenCalled();
 	});
 
@@ -187,12 +196,12 @@ describe("langfuse telemetry", () => {
 			getDelegate: () => ({ constructor: { name: "SomethingInert" } }),
 		});
 
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
 		expect(registerTelemetrySpy).not.toHaveBeenCalled();
 	});
 
 	it("connects an AI SDK 7 call to the registered telemetry integration", async () => {
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(true);
+		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
 
 		await generateText({
 			model: new MockLanguageModelV4({

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -64,7 +64,7 @@ export function hasLangfuseTelemetryConfig(): boolean {
 export async function ensureLangfuseTelemetry(
 	providerId: string,
 ): Promise<boolean> {
-	if (providerId !== "cline") {
+	if (providerId !== "cline" && providerId !== "cline-pass") {
 		return false;
 	}
 

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -62,8 +62,12 @@ export function hasLangfuseTelemetryConfig(): boolean {
 }
 
 export async function ensureLangfuseTelemetry(
-	_providerId: string,
+	providerId: string,
 ): Promise<boolean> {
+	if (providerId !== "cline") {
+		return false;
+	}
+
 	if (!hasLangfuseTelemetryConfig()) {
 		return false;
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2505](https://linear.app/cline-bot/issue/ENG-2505/limit-langfuse-telemetry-to-the-cline-provider)

### Description

Limits Langfuse telemetry to requests using the `cline` or `cline-pass` providers.

`ensureLangfuseTelemetry(providerId)` previously ignored the provider ID, so configured Langfuse credentials enabled AI SDK tracing for every provider using this stream path. The function now returns `false` for non-Cline providers before consulting or populating the process-wide readiness cache.

This keeps unrelated provider requests disabled both before and after Langfuse has been initialized by a Cline backend request. The existing tracer-provider tests initialize through the `cline` provider, and new coverage verifies that `cline-pass` can initialize the shared integration, `cline` reuses it, and unrelated providers remain disabled.

No OpenTelemetry Collector changes are needed because the SDK's `LangfuseSpanProcessor` exports directly from the process.

### Test Procedure

Validated from a clean worktree based on the latest `origin/main`:

```text
bun run build:sdk
bun -F @cline/llms test -- src/services/langfuse-telemetry.test.ts
bun -F @cline/llms typecheck
bun biome check sdk/packages/llms/src/services/langfuse-telemetry.ts sdk/packages/llms/src/services/langfuse-telemetry.test.ts
```

Results:

- Full SDK build passed.
- Targeted Langfuse suite passed: 9/9 tests.
- `@cline/llms` typecheck passed.
- Biome passed for both changed files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Relevant tests are passing and changed code is formatted and linted
-   [x] I have reviewed the contributor guidelines relevant to this small bug fix

### Screenshots

Not applicable — SDK behavior only.

### Additional Notes

The provider guard intentionally runs before cached readiness is checked. Otherwise, an unrelated provider request made after Cline backend initialization could incorrectly inherit a cached `true` result. Both `cline` and `cline-pass` are included because they are distinct canonical provider IDs that share the Cline API backend.
