### PR TITLE
fix(desktop): embed hub identity in packaged sidecars

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -425,6 +425,10 @@ jobs:
             exit 1
           fi
 
+      - name: Verify packaged sidecar cold start
+        working-directory: apps/examples/desktop-app
+        run: bun run scripts/verify-sidecar-startup.ts ./src-tauri/bin/code-sidecar-universal-apple-darwin
+
       - name: Collect artifacts
         working-directory: apps/examples/desktop-app
         env:
@@ -677,6 +681,10 @@ jobs:
             echo "Check the OTEL_EXPORTER_OTLP_ENDPOINT secret."
             exit 1
           fi
+
+      - name: Verify packaged sidecar cold start
+        working-directory: apps/examples/desktop-app
+        run: bun run scripts/verify-sidecar-startup.ts ./src-tauri/bin/code-sidecar-x86_64-pc-windows-msvc.exe
 
       - name: Collect artifacts
         shell: bash

--- a/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
@@ -1,6 +1,18 @@
+import { fileURLToPath } from "node:url";
 import { $ } from "bun";
+import { resolveSdkRuntimeBuildId } from "../../../../sdk/packages/core/scripts/runtime-build-id";
 import { prepareWindowsCrossCompileRuntime } from "./bun-cross-compile-runtime";
 import { telemetryDefineArgs } from "./telemetry-define-args";
+
+// Desktop tsconfig aliases resolve SDK imports to source, so the SDK dist
+// build's defines never reach this bundle. Embed one identity for every local
+// sidecar and remote helper; packaged processes cannot fingerprint a checkout.
+const runtimeDefineArgs = [
+	"--define",
+	`__CLINE_CORE_RUNTIME_BUILD_ID__=${JSON.stringify(resolveSdkRuntimeBuildId(fileURLToPath(new URL("../../../../", import.meta.url))))}`,
+	"--define",
+	`__CLINE_CORE_RUNTIME_BUILD_EPOCH_MS__=${Date.now()}`,
+];
 
 const resolveTargetTriple = async (): Promise<string> => {
 	const fromEnv = process.env.TAURI_ENV_TARGET_TRIPLE ?? process.env.TARGET;
@@ -50,7 +62,7 @@ const buildSidecar = async (
 	// app launched from Finder/the Dock has no OTEL_* env at runtime, so
 	// without this the sidecar silently ships with telemetry disabled.
 	// Verify with `<binary> --telemetry-selfcheck` after building.
-	const defines = telemetryDefineArgs();
+	const defines = [...telemetryDefineArgs(), ...runtimeDefineArgs];
 	const optimizationArgs = minify ? ["--minify"] : [];
 	// A compiled Bun executable otherwise reads .env and bunfig.toml from its
 	// launch directory before our entrypoint runs. Remote helpers are launched

--- a/apps/examples/desktop-app/scripts/verify-sidecar-startup.ts
+++ b/apps/examples/desktop-app/scripts/verify-sidecar-startup.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { CLINE_HUB_DEV_PORT } from "@cline/shared";
+import { resolveSdkRuntimeBuildId } from "../../../../sdk/packages/core/scripts/runtime-build-id";
+
+// Exercise the actual compiled binary from outside the checkout, without an
+// existing Hub or runtime identity overrides. Source tests cannot catch missing
+// build-time defines in the sidecar or its embedded daemon entrypoint.
+const binary = process.argv[2];
+assert(binary, "usage: bun run scripts/verify-sidecar-startup.ts <binary>");
+const expectedBuildId = resolveSdkRuntimeBuildId(
+	fileURLToPath(new URL("../../../../", import.meta.url)),
+);
+
+async function availablePort(port = 0): Promise<number> {
+	const server = createServer();
+	server.listen(port, "127.0.0.1");
+	await once(server, "listening");
+	const address = server.address();
+	assert(address && typeof address !== "string");
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+	return address.port;
+}
+
+async function main(): Promise<void> {
+	// Refuse to touch a developer's running Hub. Keep the normal managed-port
+	// path: CLINE_HUB_PORT is an explicit endpoint with different auth semantics.
+	await availablePort(CLINE_HUB_DEV_PORT);
+	const sidecarPort = await availablePort();
+	const directory = await mkdtemp(join(tmpdir(), "cline-sidecar-startup-"));
+	const discoveryPath = join(directory, "hub.json");
+	const env = Object.fromEntries(
+		Object.entries(process.env).filter(([key]) =>
+			[
+				"PATH",
+				"SHELL",
+				"SystemRoot",
+				"SYSTEMROOT",
+				"WINDIR",
+				"COMSPEC",
+				"PATHEXT",
+				"TMP",
+				"TEMP",
+				"TMPDIR",
+			].includes(key),
+		),
+	);
+	Object.assign(env, {
+		CLINE_BUILD_ENV: "development",
+		CLINE_DIR: directory,
+		CLINE_DATA_DIR: join(directory, "data"),
+		CLINE_HUB_DISCOVERY_PATH: discoveryPath,
+		CLINE_SIDECAR_PORT: String(sidecarPort),
+	});
+
+	const child = spawn(resolve(binary), [], {
+		cwd: directory,
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+		windowsHide: true,
+	});
+	const exited = once(child, "exit");
+	let stderr = "";
+	child.stderr.setEncoding("utf8").on("data", (chunk: string) => {
+		stderr += chunk;
+	});
+	const lines = createInterface({ input: child.stdout });
+	let deadline: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const ready = await Promise.race([
+			(async () => {
+				for await (const line of lines) {
+					let message: { type?: string; endpoint?: string };
+					try {
+						message = JSON.parse(line);
+					} catch {
+						continue;
+					}
+					if (message.type === "ready" && message.endpoint) {
+						return message.endpoint;
+					}
+				}
+				throw new Error(
+					`Sidecar exited before publishing its endpoint: ${stderr}`,
+				);
+			})(),
+			new Promise<never>((_, reject) => {
+				deadline = setTimeout(
+					() => reject(new Error("Sidecar startup timed out")),
+					30_000,
+				);
+			}),
+		]);
+		const health = await fetch(`${ready}/health`, {
+			signal: AbortSignal.timeout(5_000),
+		});
+		assert(health.ok, "sidecar health request failed");
+		assert.equal((await health.json()).ok, true);
+		const discovery = JSON.parse(await readFile(discoveryPath, "utf8"));
+		assert.equal(
+			discovery.buildId,
+			expectedBuildId,
+			"packaged Hub identity must match SDK sources",
+		);
+		assert(
+			discovery.buildEpochMs > 0,
+			"packaged Hub must carry its build epoch",
+		);
+		assert(
+			discovery.pid > 0 && discovery.pid !== child.pid,
+			"sidecar must start a detached Hub",
+		);
+		console.log(
+			"Packaged sidecar cold start passed: detached Hub, embedded identity, ready endpoint, and health.",
+		);
+	} catch (error) {
+		console.error(
+			await readFile(join(directory, "data/logs/hub-daemon.log"), "utf8").catch(
+				() => "",
+			),
+		);
+		throw error;
+	} finally {
+		clearTimeout(deadline);
+		lines.close();
+		// The Hub outlives its client. Clean up both processes even on a failed test.
+		if (child.exitCode === null && child.signalCode === null) child.kill();
+		const killTimeout = setTimeout(() => child.kill("SIGKILL"), 7_000);
+		await exited;
+		clearTimeout(killTimeout);
+		const discovery = await readFile(discoveryPath, "utf8")
+			.then(JSON.parse)
+			.catch(() => undefined);
+		if (discovery) {
+			const url = new URL(discovery.url);
+			url.protocol = "http:";
+			url.pathname = "/shutdown";
+			const response = await fetch(url, {
+				method: "POST",
+				headers: { authorization: `Bearer ${discovery.authToken}` },
+				signal: AbortSignal.timeout(5_000),
+			});
+			assert(response.ok, "test Hub shutdown failed");
+			// Wait for the daemon to release its database files before cleanup (Windows).
+			for (let attempt = 0; attempt < 100; attempt++) {
+				try {
+					process.kill(discovery.pid, 0);
+				} catch {
+					break;
+				}
+				await Bun.sleep(100);
+			}
+		}
+		await rm(directory, {
+			recursive: true,
+			force: true,
+			maxRetries: 5,
+			retryDelay: 200,
+		});
+	}
+}
+
+main().catch((error: unknown) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -350,6 +350,13 @@ user to update and restart. Hubs that are older, unordered, or missing build
 metadata are retired and replaced as before, so two concurrently running
 installations converge on the newest build instead of repeatedly replacing
 each other's daemons.
+Desktop sidecar compilation resolves SDK imports through source aliases, so it
+must embed the same runtime fingerprint itself, plus one build epoch shared by
+all local sidecar and remote-helper targets. A packaged process must never scan
+for an SDK checkout to determine its identity. Release validation starts the
+compiled sidecar from an empty temporary directory and verifies that it launches
+a detached Hub, publishes its endpoint, and serves a healthy backend.
+
 Explicit endpoints, including loopback URLs such as
 `ws://127.0.0.1:<port>/hub`, are sticky exact targets and remain protocol-only:
 reconnects may retry the same socket URL, but command recovery and


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — follow-up to #13850 for the beta desktop startup regression.

### Description

Desktop sidecar compilation follows TypeScript aliases into SDK source, bypassing the SDK dist build that embeds the Hub runtime identity. The released beta therefore tried to fingerprint a nonexistent source checkout and exited before publishing its backend endpoint. #13850 removed that failing fallback, but packaged sidecars still lacked the SDK fingerprint and build epoch.

Compute the fingerprint with Core's existing build-time helper and embed it, with one build epoch, into every desktop sidecar and remote-helper target. Runtime code no longer needs the checkout to identify the packaged build, and managed Hub comparisons receive the actual SDK fingerprint instead of the source package-version fallback.

Add a compiled-binary cold-start check to the macOS and Windows release jobs. It runs outside the checkout with fresh storage and a sanitized environment, verifies the detached Hub's identity and epoch, and requires the desktop ready endpoint and healthy HTTP response.

### Test Procedure

- Reproduced the original installed beta failure and confirmed the Hub log points to source-checkout fingerprinting.
- Confirmed the regression check rejects a pre-fix binary.
- Rebuilt SDK packages after rebasing onto the merged #13850.
- Built macOS arm64 sidecar and Linux x64/arm64 remote helpers.
- Before rebase: the full macOS compiled-binary cold-start check passed with no existing Hub, fresh storage, and no runtime identity overrides.
- After rebase: bootstrapped a fresh embedded Hub on a random port and started the final macOS sidecar against that isolated discovery record; endpoint and health checks passed. The default-port smoke check refused to run because a developer Hub had since occupied its port.
- Desktop typecheck; 24 focused Core discovery, runtime identity, and build-order tests; Biome checks; workflow YAML parsing.
- Windows execution and Linux helper runtime execution are not locally verified.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [x] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. Successful regression output: `Packaged sidecar cold start passed: detached Hub, embedded identity, ready endpoint, and health.`

### Additional Notes

Targets `desktop-experimental` and includes the already merged #13850. Focused validation is listed above; the full monorepo test/lint suite was not run. The installed application is unchanged; the fix takes effect in a rebuilt release. The startup check refuses to run when the development Hub port is already occupied.
