### PR TITLE
fix(desktop): align cloud sessions with reviewed stack

### DIFF
--- a/apps/examples/desktop-app/scripts/telemetry-define-args.test.ts
+++ b/apps/examples/desktop-app/scripts/telemetry-define-args.test.ts
@@ -65,16 +65,23 @@ describe("telemetryDefineArgs", () => {
 		expect(withKeys["process.env.ERROR_SERVICE_API_KEY"]).toBe('"ek"');
 	});
 
-	it("inlines the cloud-agents toggle only when set at build time", () => {
+	it("inlines cloud feature overrides only when set at build time", () => {
 		const withoutToggle = defineMap(telemetryDefineArgs({}));
 		expect(withoutToggle).not.toHaveProperty(
 			"process.env.CLINE_CODE_CLOUD_AGENTS",
 		);
+		expect(withoutToggle).not.toHaveProperty(
+			"process.env.CLINE_CODE_CLOUD_HANDOFF",
+		);
 
 		const withToggle = defineMap(
-			telemetryDefineArgs({ CLINE_CODE_CLOUD_AGENTS: "1" }),
+			telemetryDefineArgs({
+				CLINE_CODE_CLOUD_AGENTS: "1",
+				CLINE_CODE_CLOUD_HANDOFF: "1",
+			}),
 		);
 		expect(withToggle["process.env.CLINE_CODE_CLOUD_AGENTS"]).toBe('"1"');
+		expect(withToggle["process.env.CLINE_CODE_CLOUD_HANDOFF"]).toBe('"1"');
 	});
 
 	it("JSON-escapes values so headers with quotes survive the define", () => {

--- a/apps/examples/desktop-app/scripts/telemetry-define-args.ts
+++ b/apps/examples/desktop-app/scripts/telemetry-define-args.ts
@@ -16,7 +16,10 @@ const OPTIONAL_SECRET_ENV_VARS = [
 ] as const;
 
 /** Optional build-time overrides for packaged dogfood builds. */
-const OPTIONAL_FEATURE_ENV_VARS = ["CLINE_CODE_CLOUD_AGENTS"] as const;
+const OPTIONAL_FEATURE_ENV_VARS = [
+	"CLINE_CODE_CLOUD_AGENTS",
+	"CLINE_CODE_CLOUD_HANDOFF",
+] as const;
 
 /**
  * Every env var `getTelemetryBuildTimeConfig` reads

--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { materializeUserFiles } from "./attachments";
 import {
 	assertSessionDeleteAllowedDuringHandoff,
+	beginSessionMetadataUpdate,
 	buildSessionConnectionUpdate,
 	cloudHandoffGitStateMatchesFingerprint,
 	combineCloudHandoffModels,
@@ -884,9 +885,28 @@ describe("session forks", () => {
 			...localRuntimeContext(manager, { sessionIds: [sessionId] }),
 		} as unknown as SidecarContext;
 
+		const releaseDelete = await assertSessionDeleteAllowedDuringHandoff(
+			ctx,
+			sessionId,
+		);
+		expect(releaseDelete).toBeTypeOf("function");
+		releaseDelete();
+	});
+
+	it("blocks handoff while a metadata update is active", async () => {
+		const ctx = {
+			liveSessions: new Map(),
+			...localRuntimeContext({}, { sessionIds: ["metadata-source"] }),
+		} as unknown as SidecarContext;
+		const releaseUpdate = beginSessionMetadataUpdate(ctx, "metadata-source");
+
 		await expect(
-			assertSessionDeleteAllowedDuringHandoff(ctx, sessionId),
-		).resolves.toBeUndefined();
+			handleChatSessionCommand(ctx, {
+				action: "handoff",
+				sessionId: "metadata-source",
+			}),
+		).rejects.toThrow("metadata update to finish");
+		releaseUpdate();
 	});
 
 	it("keeps a persisted pending handoff read-only after restart", async () => {
@@ -2467,7 +2487,7 @@ describe("cloud handoff gates", () => {
 				action: "prepare_handoff",
 				sessionId,
 			}),
-		).rejects.toThrow("requires Cloud sessions");
+		).rejects.toThrow("Enable Cloud sessions");
 	});
 
 	it("explains how to recover a mismatched resumed handoff", () => {
@@ -2595,7 +2615,7 @@ describe("cloud handoff gates", () => {
 		expect(update).not.toHaveBeenCalled();
 	});
 
-	it("clears a mismatched pending handoff only after the target is gone", async () => {
+	it("preserves a mismatched pending handoff when the target is not visible", async () => {
 		const update = vi.fn(async () => ({ updated: true }));
 		await expect(
 			reconcilePendingCloudHandoff(
@@ -2609,10 +2629,8 @@ describe("cloud handoff gates", () => {
 					appBaseUrl: "https://app.cline.bot",
 				},
 			),
-		).resolves.toEqual({ metadata: { workspace: "preserved" } });
-		expect(update).toHaveBeenCalledWith("local-1", {
-			metadata: { workspace: "preserved" },
-		});
+		).rejects.toThrow("not visible from the current account");
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it("preserves pending lineage when target lookup is uncertain", async () => {
@@ -2637,10 +2655,11 @@ describe("cloud handoff gates", () => {
 		expect(update).not.toHaveBeenCalled();
 	});
 
-	it("keeps the source locked when clearing gone lineage is not persisted", async () => {
+	it("does not clear invisible lineage when metadata updates are unavailable", async () => {
+		const update = vi.fn(async () => ({ updated: false }));
 		await expect(
 			reconcilePendingCloudHandoff(
-				{ update: vi.fn(async () => ({ updated: false })) } as never,
+				{ update } as never,
 				{ handoffTargetExists: vi.fn(async () => false) },
 				{
 					sourceSessionId: "local-1",
@@ -2650,7 +2669,8 @@ describe("cloud handoff gates", () => {
 					appBaseUrl: "https://app.cline.bot",
 				},
 			),
-		).rejects.toThrow("local pending handoff record could not be cleared");
+		).rejects.toThrow("not visible from the current account");
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it("fails when a required handoff metadata update is not persisted", async () => {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -55,6 +55,7 @@ import {
 } from "./attachments";
 import {
 	CloudHandoffSeedUnsupportedError,
+	CloudQueueUnconfirmedError,
 	CloudSessionError,
 	type CloudSessionManager,
 	getCloudSessionManager,
@@ -66,7 +67,7 @@ import {
 	nowMs,
 	sendEvent,
 } from "./context";
-import { isCloudAgentsEnabled } from "./feature-flags";
+import { isCloudAgentsEnabled, isCloudHandoffEnabled } from "./feature-flags";
 import { readSessionManifest, sharedSessionDataDir } from "./paths";
 import { persistSessionMessages } from "./session-data/messages";
 import type {
@@ -138,7 +139,14 @@ function workspacePathKey(
  * token: the slash menu hides same-named user commands, so expansion must
  * not hijack them either.
  */
-const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "handoff", "team"]);
+const BUILTIN_SLASH_COMMAND_NAMES = new Set(["fork", "team"]);
+
+function isBuiltinSlashCommand(name: string): boolean {
+	return (
+		BUILTIN_SLASH_COMMAND_NAMES.has(name) ||
+		(name === "handoff" && isCloudHandoffEffectivelyEnabled())
+	);
+}
 
 /**
  * Expand a leading `/skill` or `/workflow` token into its configured
@@ -162,7 +170,7 @@ async function expandRuntimeSlashCommand(
 		return prompt;
 	}
 	const name = prompt.match(/^\/(\S+)/)?.[1]?.toLowerCase();
-	if (!name || BUILTIN_SLASH_COMMAND_NAMES.has(name)) {
+	if (!name || isBuiltinSlashCommand(name)) {
 		return prompt;
 	}
 	const service = createUserInstructionConfigService({
@@ -1182,6 +1190,25 @@ async function handleSend(
 ): Promise<unknown> {
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error(
+			"Cloud handoff is in progress. Wait for it to finish before sending another prompt.",
+		);
+	}
+	const finishActiveSend = beginActiveSessionSend(ctx, sessionId);
+	try {
+		return await handleSendOnce(ctx, request);
+	} finally {
+		finishActiveSend();
+	}
+}
+
+async function handleSendOnce(
+	ctx: SidecarContext,
+	request: ChatSessionCommandRequest,
+): Promise<unknown> {
+	const sessionId = request.sessionId?.trim();
+	if (!sessionId) throw new Error("sessionId is required");
 	const prompt = request.prompt?.trim() ?? "";
 	const hasAttachments =
 		(request.attachments?.userImages?.length ?? 0) > 0 ||
@@ -2098,6 +2125,9 @@ async function assertHandoffIdle(
 	manager: ClineCore,
 	sessionId: string,
 ): Promise<void> {
+	if ((activeSendRequests.get(ctx)?.get(sessionId) ?? 0) > 0) {
+		throw new Error("Wait for the current send to finish before handing off.");
+	}
 	const live = ctx.liveSessions.get(sessionId);
 	const persisted = await manager.get(sessionId);
 	if (!live && !persisted) {
@@ -2138,7 +2168,7 @@ export async function updateHandoffMetadataOrThrow(
 }
 
 export async function reconcilePendingCloudHandoff(
-	manager: Pick<ClineCore, "update">,
+	_manager: Pick<ClineCore, "update">,
 	cloud: Pick<CloudSessionManager, "handoffTargetExists">,
 	input: {
 		sourceSessionId: string;
@@ -2165,14 +2195,9 @@ export async function reconcilePendingCloudHandoff(
 			`A previous cloud handoff is still pending for a different repository, branch, commit, or model. Continue or delete it before retrying: ${dashboardUrl}`,
 		);
 	}
-	const metadata = clearCloudHandoffMetadata(input.metadata);
-	await updateHandoffMetadataOrThrow(
-		manager,
-		input.sourceSessionId,
-		metadata,
-		"The previous cloud workspace is gone, but its local pending handoff record could not be cleared.",
+	throw new Error(
+		"The previous cloud handoff is not visible from the current account. Sign back into the account that created it before retrying.",
 	);
-	return { metadata };
 }
 
 export function shouldCleanupFailedHandoffVerification(
@@ -2193,12 +2218,31 @@ export function formatPendingHandoffVerificationError(
 	return `${error.message} Open the pending cloud workspace to inspect it, or delete it before retrying /handoff: ${dashboardUrl}`;
 }
 
-function assertCloudHandoffAvailable(): void {
-	if (!isCloudAgentsEnabled()) {
-		throw new Error(
-			"Cloud handoff requires Cloud sessions to be enabled in Settings.",
+function isCloudHandoffEffectivelyEnabled(): boolean {
+	return isCloudHandoffEnabled() && isCloudAgentsEnabled();
+}
+
+async function assertCloudHandoffAvailable(
+	ctx: SidecarContext,
+	sourceSessionId?: string,
+): Promise<void> {
+	const flagEnabled = isCloudHandoffEnabled();
+	if (isCloudHandoffEffectivelyEnabled()) return;
+	if (sourceSessionId) {
+		const binding = await findSessionRuntimeBinding(ctx, sourceSessionId);
+		const manager =
+			binding?.sessionManager ?? getSessionManager(ctx, sourceSessionId);
+		const persisted = await manager.get(sourceSessionId).catch(() => undefined);
+		const pending = readCloudHandoffMetadata(
+			persisted?.metadata ?? readSessionMetadata(sourceSessionId),
 		);
+		if (pending?.status === "pending") return;
 	}
+	throw new Error(
+		flagEnabled
+			? "Enable Cloud sessions in Settings before using cloud handoff."
+			: "Cloud handoff is not enabled for this account.",
+	);
 }
 
 async function prepareCloudHandoff(
@@ -2312,7 +2356,7 @@ async function handlePrepareHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
 ): Promise<PreparedCloudHandoff> {
-	assertCloudHandoffAvailable();
+	await assertCloudHandoffAvailable(ctx, request.sessionId?.trim());
 	return await prepareCloudHandoff(ctx, request);
 }
 
@@ -2321,11 +2365,13 @@ async function handleHandoffOnce(
 	request: ChatSessionCommandRequest,
 ): Promise<unknown> {
 	const sourceSessionId = request.sessionId?.trim();
+	await assertCloudHandoffAvailable(ctx, sourceSessionId);
 	if (!sourceSessionId) throw new Error("sessionId is required");
 	if (request.attachments?.userFiles?.length) {
 		throw new Error("Only image attachments can be sent with a cloud handoff.");
 	}
 	const nextCommand = request.nextCommand?.trim() ?? "";
+	const handoffAttemptId = request.handoffAttemptId?.trim();
 	if (!nextCommand && request.attachments?.userImages?.length) {
 		throw new Error("Add a command to send the attached images after handoff.");
 	}
@@ -2356,6 +2402,7 @@ async function handleHandoffOnce(
 	) => {
 		sendEvent(ctx, "cloud_handoff_progress", {
 			sourceSessionId,
+			...(handoffAttemptId ? { handoffAttemptId } : {}),
 			phase,
 			message,
 			...(outerSessionId
@@ -2374,6 +2421,20 @@ async function handleHandoffOnce(
 	const sourceConfig = {
 		...(ctx.liveSessions.get(sourceSessionId)?.config ?? {}),
 		...(request.config ?? {}),
+	};
+	const sourceReasoningEffort = readReasoningEffort(
+		sourceConfig.reasoningEffort,
+	);
+	const handoffConfig = {
+		...(typeof sourceConfig.autoApproveTools === "boolean"
+			? { autoApproveTools: sourceConfig.autoApproveTools }
+			: {}),
+		...(typeof sourceConfig.thinking === "boolean"
+			? { thinking: sourceConfig.thinking }
+			: {}),
+		...(sourceReasoningEffort
+			? { reasoningEffort: sourceReasoningEffort }
+			: {}),
 	};
 	const sourceCwd =
 		readWorkspacePath(sourceConfig) ?? readWorkspacePath(persistedBefore);
@@ -2490,6 +2551,7 @@ async function handleHandoffOnce(
 				messages: seed,
 				workspaceRelativePath: prepared.fingerprint.workspaceRelativePath,
 				mode: prepared.fingerprint.mode ?? "act",
+				config: handoffConfig,
 				onSeeding: () =>
 					emitProgress(
 						"seeding",
@@ -2534,25 +2596,14 @@ async function handleHandoffOnce(
 	if (!outerSessionId) {
 		emitProgress("creating", "Creating the cloud workspace…");
 		const created = await cloud.create({
+			requestId: `handoff:${sourceSessionId}:${prepared.headSha.toLowerCase()}`,
 			repoUrl: prepared.repoUrl,
 			branch: prepared.branch,
 			modelId: prepared.modelId,
 			mode: prepared.fingerprint.mode ?? "act",
 			workspaceRelativePath: prepared.fingerprint.workspaceRelativePath,
 			organizationId: prepared.fingerprint.organizationId ?? null,
-			...(typeof request.config?.autoApproveTools === "boolean"
-				? { autoApproveTools: request.config.autoApproveTools }
-				: {}),
-			...(typeof request.config?.thinking === "boolean"
-				? { thinking: request.config.thinking }
-				: {}),
-			...(readReasoningEffort(request.config?.reasoningEffort)
-				? {
-						reasoningEffort: readReasoningEffort(
-							request.config?.reasoningEffort,
-						),
-					}
-				: {}),
+			...handoffConfig,
 			handoff: {
 				sourceSessionId,
 				resolveMessages: readSeedMessages,
@@ -2693,6 +2744,7 @@ async function handleHandoffOnce(
 	);
 
 	let warning: string | undefined;
+	let warningKind: "unqueued" | "unconfirmed" | undefined;
 	if (nextCommand) {
 		try {
 			await cloud.send(
@@ -2703,17 +2755,30 @@ async function handleHandoffOnce(
 				request.attachments?.userImages,
 			);
 		} catch (error) {
-			warning = `The handoff completed, but the follow-up command was not queued: ${error instanceof Error ? error.message : String(error)}`;
+			if (error instanceof CloudQueueUnconfirmedError) {
+				warningKind = "unconfirmed";
+				warning =
+					"The handoff completed, but Cline could not confirm whether the follow-up command was queued. Check the cloud session before resending it.";
+			} else {
+				warningKind = "unqueued";
+				warning = `The handoff completed, but the follow-up command was not queued: ${error instanceof Error ? error.message : String(error)}`;
+			}
 		}
 	}
-	const destination = "in_app" as const;
+	const destination = isCloudAgentsEnabled() ? "in_app" : "external";
 	sendEvent(ctx, "cloud_handoff_progress", {
 		sourceSessionId,
+		...(handoffAttemptId ? { handoffAttemptId } : {}),
 		phase: "complete",
 		message: "Ready in Cline Cloud.",
 		sessionId: outerSessionId,
 		dashboardUrl,
 		destination,
+		...(warning ? { warning } : {}),
+		...(warningKind ? { warningKind } : {}),
+		...(warningKind === "unqueued" && nextCommand
+			? { undeliveredCommand: nextCommand }
+			: {}),
 	});
 	return {
 		sessionId: outerSessionId,
@@ -2722,11 +2787,14 @@ async function handleHandoffOnce(
 		dashboardUrl,
 		destination,
 		...(warning ? { warning } : {}),
+		...(warningKind ? { warningKind } : {}),
 	};
 }
 
 type HandoffRequestIdentity = {
+	handoffAttemptId: string;
 	fingerprint: JsonRecord | null;
+	config: JsonRecord | null;
 	nextCommand: string;
 	userImages: string[];
 	userFiles: Array<{ name: string; content: string }>;
@@ -2737,6 +2805,64 @@ const handoffRequests = new WeakMap<
 	Map<string, { identity: HandoffRequestIdentity; promise: Promise<unknown> }>
 >();
 
+const activeSendRequests = new WeakMap<SidecarContext, Map<string, number>>();
+const activeDeleteRequests = new WeakMap<SidecarContext, Map<string, number>>();
+const activeMetadataUpdateRequests = new WeakMap<
+	SidecarContext,
+	Map<string, number>
+>();
+
+function beginTrackedRequest(
+	requestsByContext: WeakMap<SidecarContext, Map<string, number>>,
+	ctx: SidecarContext,
+	sessionId: string,
+): () => void {
+	let requests = requestsByContext.get(ctx);
+	if (!requests) {
+		requests = new Map();
+		requestsByContext.set(ctx, requests);
+	}
+	requests.set(sessionId, (requests.get(sessionId) ?? 0) + 1);
+	let finished = false;
+	return () => {
+		if (finished) return;
+		finished = true;
+		const remaining = (requests?.get(sessionId) ?? 1) - 1;
+		if (remaining > 0) requests?.set(sessionId, remaining);
+		else requests?.delete(sessionId);
+		if (requests?.size === 0) requestsByContext.delete(ctx);
+	};
+}
+
+function beginActiveSessionSend(
+	ctx: SidecarContext,
+	sessionId: string,
+): () => void {
+	return beginTrackedRequest(activeSendRequests, ctx, sessionId);
+}
+
+function beginActiveSessionDelete(
+	ctx: SidecarContext,
+	sessionId: string,
+): () => void {
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error("Wait for the cloud handoff to finish before deleting.");
+	}
+	return beginTrackedRequest(activeDeleteRequests, ctx, sessionId);
+}
+
+export function beginSessionMetadataUpdate(
+	ctx: SidecarContext,
+	sessionId: string,
+): () => void {
+	if (handoffRequests.get(ctx)?.has(sessionId)) {
+		throw new Error(
+			"Wait for the cloud handoff to finish before updating session metadata.",
+		);
+	}
+	return beginTrackedRequest(activeMetadataUpdateRequests, ctx, sessionId);
+}
+
 /**
  * Deleting a source session while its cloud handoff is in flight can remove
  * the only durable recovery record for an already-created sandbox. Keep this
@@ -2745,23 +2871,28 @@ const handoffRequests = new WeakMap<
 export async function assertSessionDeleteAllowedDuringHandoff(
 	ctx: SidecarContext,
 	sessionId: string,
-	sessionManager?: ClineCore,
-): Promise<void> {
-	if (handoffRequests.get(ctx)?.has(sessionId)) {
-		throw new Error("Wait for the cloud handoff to finish before deleting.");
-	}
-	const manager =
-		sessionManager ??
-		(await findSessionRuntimeBinding(ctx, sessionId))?.sessionManager ??
-		getSessionManager(ctx, sessionId);
-	const persisted = await manager.get(sessionId);
-	const handoff = readCloudHandoffMetadata(
-		persisted?.metadata ?? readSessionMetadata(sessionId),
-	);
-	if (handoff?.status === "pending") {
-		throw new Error(
-			`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+	environmentId?: string,
+): Promise<() => void> {
+	const release = beginActiveSessionDelete(ctx, sessionId);
+	try {
+		const manager = getSessionManager(
+			ctx,
+			sessionId,
+			environmentId ? { environmentId } : undefined,
 		);
+		const persisted = await manager.get(sessionId);
+		const handoff = readCloudHandoffMetadata(
+			persisted?.metadata ?? readSessionMetadata(sessionId),
+		);
+		if (handoff?.status === "pending") {
+			throw new Error(
+				`Cloud handoff is still pending. Retry /handoff or continue here: ${handoff.dashboardUrl ?? buildCloudHandoffDashboardUrl(getClineEnvironmentConfig().appBaseUrl, handoff.toCloudSessionId)}`,
+			);
+		}
+		return release;
+	} catch (error) {
+		release();
+		throw error;
 	}
 }
 
@@ -2769,16 +2900,25 @@ async function handleHandoff(
 	ctx: SidecarContext,
 	request: ChatSessionCommandRequest,
 ): Promise<unknown> {
-	assertCloudHandoffAvailable();
 	const sourceSessionId = request.sessionId?.trim();
 	if (!sourceSessionId) throw new Error("sessionId is required");
+	if (activeDeleteRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error("Wait for session deletion to finish before handing off.");
+	}
+	if (activeMetadataUpdateRequests.get(ctx)?.has(sourceSessionId)) {
+		throw new Error(
+			"Wait for the session metadata update to finish before handing off.",
+		);
+	}
 	let requests = handoffRequests.get(ctx);
 	if (!requests) {
 		requests = new Map();
 		handoffRequests.set(ctx, requests);
 	}
 	const identity: HandoffRequestIdentity = {
+		handoffAttemptId: request.handoffAttemptId?.trim() ?? "",
 		fingerprint: request.fingerprint ?? null,
+		config: request.config ?? null,
 		nextCommand: request.nextCommand?.trim() ?? "",
 		userImages: [...(request.attachments?.userImages ?? [])],
 		userFiles: (request.attachments?.userFiles ?? []).map((file) => ({

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -2875,6 +2875,7 @@ export async function handleChatSessionCommand(
 					request.config?.reasoningEffort,
 				);
 				return await cloud.create({
+					...(requestedSessionId ? { requestId: requestedSessionId } : {}),
 					repoUrl,
 					modelId,
 					...(initialPrompt ? { initialPrompt } : {}),
@@ -2893,12 +2894,14 @@ export async function handleChatSessionCommand(
 				return await cloud.attach(sessionId);
 			case "send": {
 				if (!sessionId) throw new Error("sessionId is required");
-				const prompt = request.prompt?.trim();
-				if (!prompt) throw new Error("prompt is required");
 				if (request.attachments?.userFiles?.length) {
 					throw new Error(
 						"File attachments are not supported in cloud sessions",
 					);
+				}
+				const prompt = request.prompt?.trim() ?? "";
+				if (!prompt && !request.attachments?.userImages?.length) {
+					throw new Error("prompt or image is required");
 				}
 				const modelId = String(
 					request.config?.model ?? request.config?.modelId ?? "",

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { handleChatSessionCommand } from "./chat-session";
 import {
 	CloudHandoffSeedUnsupportedError,
+	type CloudProvisioningPhase,
 	CloudSessionApi,
 	CloudSessionError,
 	CloudSessionManager,
@@ -147,8 +148,11 @@ class FakeHubClient {
 	invalidMessagesSnapshot = false;
 	malformedQueueReply = false;
 	listedModel?: string;
+	attachedModel?: string;
 	sessionStatus?: string;
 	sessionRows?: Array<Record<string, unknown>>;
+	subscriptionSessionId?: string;
+	readonly subscriptionSessionIds: Array<string | undefined> = [];
 	messages: unknown[] = [{ role: "user", content: "hi" }];
 	prompts: Array<Record<string, unknown>> = [
 		{
@@ -174,8 +178,13 @@ class FakeHubClient {
 		return "code-cloud-ses-outer";
 	}
 
-	subscribe(listener: (event: HubEventEnvelope) => void): () => void {
+	subscribe(
+		listener: (event: HubEventEnvelope) => void,
+		options?: { sessionId?: string },
+	): () => void {
 		this.events = listener;
+		this.subscriptionSessionId = options?.sessionId;
+		this.subscriptionSessionIds.push(options?.sessionId);
 		return () => {
 			this.events = undefined;
 		};
@@ -223,6 +232,17 @@ class FakeHubClient {
 				payload: { session: { sessionId: "inner-created" } },
 			};
 		}
+		if (command === "session.attach" && this.attachedModel) {
+			return {
+				ok: true,
+				payload: {
+					session: {
+						sessionId,
+						metadata: { model: this.attachedModel },
+					},
+				},
+			};
+		}
 		if (command === "approval.list_pending") {
 			return {
 				ok: true,
@@ -260,10 +280,20 @@ class FakeHubClient {
 					: { messages: this.messages },
 			};
 		}
-		if (command === "session.get" && this.sessionStatus) {
+		if (
+			command === "session.get" &&
+			(this.sessionStatus || this.attachedModel)
+		) {
 			return {
 				ok: true,
-				payload: { session: { status: this.sessionStatus } },
+				payload: {
+					session: {
+						status: this.sessionStatus,
+						...(this.attachedModel
+							? { metadata: { model: this.attachedModel } }
+							: {}),
+					},
+				},
 			};
 		}
 		return { ok: true, payload: {} };
@@ -523,16 +553,20 @@ describe("CloudSessionApi", () => {
 			repoUrl: "https://github.com/cline/test",
 		});
 
-		expect(body).toEqual({
+		expect(body).toMatchObject({
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 		});
+		expect(body?.title).toEqual(
+			expect.stringMatching(/^__cline_create_request__:/),
+		);
 		expect(body).not.toHaveProperty("branch");
 	});
 
 	it("waits for the current asynchronous provisioning contract", async () => {
 		vi.useFakeTimers();
 		let statusCalls = 0;
+		const phases: Array<string | undefined> = [];
 		try {
 			const api = new CloudSessionApi({
 				apiBaseUrl: "https://api.example",
@@ -556,15 +590,19 @@ describe("CloudSessionApi", () => {
 						data: {
 							sessionId: "ses-1",
 							status: statusCalls === 1 ? "provisioning" : "ready",
+							phase: statusCalls === 1 ? "cloning_repo" : "ready",
 						},
 					});
 				},
 			});
 
-			const creating = api.create({
-				modelId: "anthropic/claude-sonnet-5",
-				repoUrl: "https://github.com/cline/test",
-			});
+			const creating = api.create(
+				{
+					modelId: "anthropic/claude-sonnet-5",
+					repoUrl: "https://github.com/cline/test",
+				},
+				({ phase }) => phases.push(phase),
+			);
 			await vi.waitFor(() => expect(statusCalls).toBe(1));
 			await vi.advanceTimersByTimeAsync(3_000);
 
@@ -573,6 +611,7 @@ describe("CloudSessionApi", () => {
 				sandboxUrl: "",
 			});
 			expect(statusCalls).toBe(2);
+			expect(phases).toEqual(["cloning_repo", "ready"]);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -691,6 +730,7 @@ describe("CloudSessionApi", () => {
 	it("waits for a recovered provisioning session before returning it", async () => {
 		vi.useFakeTimers();
 		let statusCalls = 0;
+		let recoveryTitle = "";
 		try {
 			const now = new Date().toISOString();
 			const api = new CloudSessionApi({
@@ -700,6 +740,7 @@ describe("CloudSessionApi", () => {
 				fetch: async (input, init) => {
 					const path = new URL(String(input)).pathname;
 					if (init?.method === "POST") {
+						recoveryTitle = String(JSON.parse(String(init.body)).title);
 						return jsonResponse({ success: false, error: "gateway" }, 500);
 					}
 					if (path.endsWith("/status")) {
@@ -717,6 +758,7 @@ describe("CloudSessionApi", () => {
 						data: [
 							{
 								id: "ses-recovered",
+								title: recoveryTitle,
 								status: "provisioning",
 								sandboxUrl: "",
 								repoContext: { repoUrl: "https://github.com/cline/test" },
@@ -748,6 +790,7 @@ describe("CloudSessionApi", () => {
 	it("uses a fresh timeout while recovering after the create request times out", async () => {
 		vi.useFakeTimers();
 		let statusCalls = 0;
+		let recoveryTitle = "";
 		try {
 			const now = new Date().toISOString();
 			const api = new CloudSessionApi({
@@ -758,6 +801,7 @@ describe("CloudSessionApi", () => {
 				fetch: async (input, init) => {
 					const path = new URL(String(input)).pathname;
 					if (init?.method === "POST") {
+						recoveryTitle = String(JSON.parse(String(init.body)).title);
 						return await new Promise<Response>((_resolve, reject) => {
 							init.signal?.addEventListener(
 								"abort",
@@ -778,6 +822,7 @@ describe("CloudSessionApi", () => {
 						data: [
 							{
 								id: "ses-recovered",
+								title: recoveryTitle,
 								status: "provisioning",
 								sandboxUrl: "",
 								repoContext: { repoUrl: "https://github.com/cline/test" },
@@ -1039,6 +1084,7 @@ describe("CloudSessionApi", () => {
 		const now = new Date().toISOString();
 		const record = (id: string, createdAt: string) => ({
 			id,
+			title: "__cline_create_request__:same-request",
 			status: "running",
 			sandboxUrl: `pod-${id}`,
 			repoContext: { repoUrl: "https://github.com/cline/test" },
@@ -1062,6 +1108,7 @@ describe("CloudSessionApi", () => {
 						}),
 		});
 		const input = {
+			requestId: "same-request",
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 		};
@@ -1133,6 +1180,7 @@ describe("CloudSessionApi", () => {
 			},
 		});
 		const input = {
+			requestId: "client-start-1",
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 		};
@@ -1188,6 +1236,7 @@ describe("CloudSessionApi", () => {
 			},
 		});
 		const input = {
+			requestId: "client-start-1",
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 		};
@@ -1654,6 +1703,7 @@ describe("CloudSessionManager", () => {
 		expect(
 			cloudSessionToDiscoveryRecord({
 				...REMOTE_SESSION,
+				lastActivityAt: "2026-08-05T10:02:00.000Z",
 				repoContext: {
 					...REMOTE_SESSION.repoContext,
 					branch: "feature/cloud",
@@ -1665,6 +1715,7 @@ describe("CloudSessionManager", () => {
 			executionTarget: "cloud",
 			repoUrl: "https://github.com/cline/test",
 			workspaceRoot: "/workspace",
+			lastActivityAt: "2026-08-05T10:02:00.000Z",
 			branch: "feature/cloud",
 			metadata: {
 				git: {
@@ -1755,6 +1806,128 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
+	it("ignores newer child sessions when reconnecting to the cloud root", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.sessionRows = [
+			{ sessionId: "inner-root", updatedAt: 20 },
+			{
+				sessionId: "inner-child",
+				updatedAt: 30,
+				metadata: { parentSessionId: "inner-root" },
+			},
+		];
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		await manager.list();
+		await manager.attach("ses-outer");
+
+		expect(hub.commands).toContainEqual(
+			expect.objectContaining({
+				command: "session.attach",
+				sessionId: "inner-root",
+			}),
+		);
+	});
+
+	it("uses unique Hub client ids and keeps subscriptions session-scoped", async () => {
+		const clientIds: string[] = [];
+		const hubs = [new FakeHubClient(), new FakeHubClient()];
+		for (const hub of hubs) {
+			const { ctx } = createContext();
+			const manager = new CloudSessionManager(ctx, {
+				api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+				apiBaseUrl: "https://api.example",
+				getAuthToken: async () => "workos:fresh",
+				createHubClient: (options) => {
+					clientIds.push(String(options.clientId));
+					return hub as never;
+				},
+			});
+			await manager.list();
+			await manager.attach("ses-outer");
+		}
+
+		expect(new Set(clientIds).size).toBe(2);
+		expect(clientIds).toEqual([
+			expect.stringMatching(/^code-cloud-ses-outer-/),
+			expect.stringMatching(/^code-cloud-ses-outer-/),
+		]);
+		expect(hubs.map((hub) => hub.subscriptionSessionId)).toEqual([
+			"inner-1",
+			"inner-1",
+		]);
+		expect(hubs.map((hub) => hub.subscriptionSessionIds)).toEqual([
+			["ses-outer", "inner-1"],
+			["ses-outer", "inner-1"],
+		]);
+	});
+
+	it("resolves the Hub session by the server task id", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		const originalCommand = hub.command.bind(hub);
+		hub.command = async (command, payload, sessionId, options) => {
+			if (command === "session.get") {
+				hub.commands.push({ command, payload, sessionId, options });
+				return { ok: true, payload: { session: { sessionId: "task-1" } } };
+			}
+			return await originalCommand(command, payload, sessionId, options);
+		};
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => [
+					{
+						...REMOTE_SESSION,
+						metadata: { ...REMOTE_SESSION.metadata, taskId: "task-1" },
+					},
+				],
+			} as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		await manager.list();
+		await manager.attach("ses-outer");
+
+		expect(hub.commands[0]).toMatchObject({
+			command: "session.get",
+			payload: { sessionId: "task-1" },
+			sessionId: "task-1",
+		});
+		expect(hub.commands.some(({ command }) => command === "session.list")).toBe(
+			false,
+		);
+	});
+
+	it("keeps a scoped client alive after the initial WebSocket fails", async () => {
+		const { ctx } = createContext();
+		const hub = new (class extends FakeHubClient {
+			override async connect(): Promise<void> {
+				throw new HubTransportError("hub_connect_failed", "pod starting");
+			}
+		})();
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+
+		await manager.list();
+		await expect(manager.attach("ses-outer")).resolves.toMatchObject({
+			sessionId: "ses-outer",
+		});
+		expect(hub.disposed).toBe(false);
+		expect(hub.subscriptionSessionId).toBe("ses-outer");
+		await manager.dispose();
+	});
 	it("treats a Hub pending session as an active desktop run", async () => {
 		const { ctx, events } = createContext();
 		const hub = new FakeHubClient();
@@ -1901,6 +2074,54 @@ describe("CloudSessionManager", () => {
 		expect(
 			events.some((event) => event.name === "cloud_session_sync_failed"),
 		).toBe(true);
+	});
+
+	it("stops reconnecting when the sandbox is reconciled to failed", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		let reconciled = false;
+		let resolveHeaders:
+			| (() =>
+					| Readonly<Record<string, string>>
+					| Promise<Readonly<Record<string, string>>>)
+			| undefined;
+		hub.commandHook = (command) => {
+			if (reconciled && command === "session.get") {
+				throw new Error("rehydration failed");
+			}
+		};
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => [
+					{
+						...REMOTE_SESSION,
+						status: reconciled ? "failed" : "ready",
+					},
+				],
+			} as unknown as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: (options) => {
+				resolveHeaders = options.resolveConnectionHeaders;
+				return hub as never;
+			},
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+
+		const live = ctx.liveSessions.get("ses-outer");
+		expect(live).toBeDefined();
+		if (!live) throw new Error("missing live cloud session");
+		live.busy = true;
+		live.status = "running";
+		await resolveHeaders?.();
+		reconciled = true;
+		await resolveHeaders?.();
+
+		await vi.waitFor(() => expect(hub.disposed).toBe(true));
+		expect(live.busy).toBe(false);
+		expect(live.status).toBe("failed");
+		expect(live.endedAt).toBeDefined();
 	});
 
 	it("keeps buffered queue state when the queue snapshot reply is malformed", async () => {
@@ -2154,11 +2375,63 @@ describe("CloudSessionManager", () => {
 		});
 	});
 
+	it("does not restore pending approvals after the manager is disposed", async () => {
+		const { ctx, events } = createContext();
+		const hub = new FakeHubClient();
+		hub.pendingApprovals = [
+			{
+				approvalId: "approval-old-account",
+				toolCallId: "tool-old-account",
+				toolName: "write_to_file",
+				inputJson: '{"path":"secret.txt"}',
+			},
+		];
+		let enterList!: () => void;
+		let releaseList!: () => void;
+		const listEntered = new Promise<void>((resolve) => {
+			enterList = resolve;
+		});
+		const listReleased = new Promise<void>((resolve) => {
+			releaseList = resolve;
+		});
+		hub.commandHook = async (command) => {
+			if (command !== "approval.list_pending") return;
+			enterList();
+			await listReleased;
+		};
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+
+		const attaching = manager.attach("ses-outer");
+		await listEntered;
+		await manager.dispose();
+		releaseList();
+		await attaching;
+
+		expect(ctx.pendingApprovals.size).toBe(0);
+		expect(
+			events.some((event) =>
+				JSON.stringify(event.payload).includes("approval-old-account"),
+			),
+		).toBe(false);
+	});
+
 	it("creates and sends to an inner session while preserving the outer id", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient(false);
 		const manager = new CloudSessionManager(ctx, {
 			api: {
+				list: async () => [
+					{
+						...REMOTE_SESSION,
+						metadata: { ...REMOTE_SESSION.metadata, taskId: "task-created" },
+					},
+				],
 				create: async () => ({
 					sessionId: "ses-outer",
 					sandboxUrl: "",
@@ -2187,6 +2460,7 @@ describe("CloudSessionManager", () => {
 				command: "session.create",
 				payload: expect.objectContaining({
 					workspaceRoot: "/workspace",
+					requestedSessionId: "task-created",
 					sessionConfig: expect.objectContaining({
 						thinking: true,
 						reasoningEffort: "high",
@@ -2235,7 +2509,7 @@ describe("CloudSessionManager", () => {
 			.mockResolvedValue({ sessionId: "ses-retried", sandboxUrl: "pod" });
 		const sleep = vi.fn(async () => undefined);
 		const manager = new CloudSessionManager(ctx, {
-			api: { create } as unknown as CloudSessionApi,
+			api: { create, list: async () => [] } as unknown as CloudSessionApi,
 			apiBaseUrl: "https://api.example",
 			getAuthToken: async () => "workos:fresh",
 			createHubClient: () => hub as never,
@@ -2299,6 +2573,7 @@ describe("CloudSessionManager", () => {
 		];
 		const manager = new CloudSessionManager(ctx, {
 			api: {
+				list: async () => [],
 				create: async (input: {
 					handoff?: {
 						onOuterSessionCreated(id: string): Promise<void>;
@@ -2372,6 +2647,7 @@ describe("CloudSessionManager", () => {
 		const history = vi.fn(async () => expected);
 		const manager = new CloudSessionManager(ctx, {
 			api: {
+				list: async () => [],
 				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
 				history,
 			} as unknown as CloudSessionApi,
@@ -2405,6 +2681,7 @@ describe("CloudSessionManager", () => {
 		const expected = [{ role: "user" as const, content: "continue" }];
 		const manager = new CloudSessionManager(ctx, {
 			api: {
+				list: async () => [],
 				create: async () => ({ sessionId: "ses-handoff", sandboxUrl: "pod" }),
 			} as unknown as CloudSessionApi,
 			apiBaseUrl: "https://api.example",
@@ -2622,7 +2899,116 @@ describe("CloudSessionManager", () => {
 		);
 	});
 
-	it("forwards cloud images and continues rejecting file attachments", async () => {
+	it("preserves the live Hub model across REST discovery refreshes", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		hub.listedModel = "anthropic/claude-opus-4-1";
+		const manager = new CloudSessionManager(ctx, {
+			api: {
+				list: async () => [
+					{
+						...REMOTE_SESSION,
+						metadata: {
+							...REMOTE_SESSION.metadata,
+							modelId: "anthropic/claude-sonnet-5",
+						},
+					},
+				],
+			} as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+
+		await expect(manager.listForDiscovery()).resolves.toEqual([
+			expect.objectContaining({ model: "anthropic/claude-opus-4-1" }),
+		]);
+		await manager.send(
+			"ses-outer",
+			"Continue with the live model",
+			undefined,
+			"anthropic/claude-opus-4-1",
+		);
+
+		expect(
+			hub.commands.filter(
+				(command) => command.command === "session.update_connection",
+			),
+		).toHaveLength(0);
+	});
+
+	it("reconciles another client's model change before the next prompt", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		const originalModel = REMOTE_SESSION.metadata.modelId ?? "";
+		const externalModel = "anthropic/claude-opus-4-1";
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+
+		hub.events?.({
+			version: "v1",
+			event: "session.updated",
+			eventId: "evt-model-change",
+			timestamp: Date.now(),
+			sessionId: "inner-1",
+			payload: { session: { metadata: { model: externalModel } } },
+		});
+		expect(ctx.liveSessions.get("ses-outer")?.config.model).toBe(externalModel);
+
+		await manager.send(
+			"ses-outer",
+			"Use the selected model",
+			undefined,
+			originalModel,
+		);
+		expect(
+			hub.commands.filter(
+				(command) => command.command === "session.update_connection",
+			),
+		).toEqual([
+			expect.objectContaining({
+				payload: {
+					sessionId: "inner-1",
+					updates: { modelId: originalModel },
+				},
+			}),
+		]);
+	});
+
+	it("uses the attach reply as the final model authority before sending", async () => {
+		const { ctx } = createContext();
+		const hub = new FakeHubClient();
+		const selectedModel = REMOTE_SESSION.metadata.modelId ?? "";
+		const externalModel = "anthropic/claude-opus-4-1";
+		const manager = new CloudSessionManager(ctx, {
+			api: { list: async () => [REMOTE_SESSION] } as CloudSessionApi,
+			apiBaseUrl: "https://api.example",
+			getAuthToken: async () => "workos:fresh",
+			createHubClient: () => hub as never,
+		});
+		await manager.list();
+		await manager.attach("ses-outer");
+		hub.attachedModel = externalModel;
+
+		await manager.send("ses-outer", "Continue", undefined, selectedModel);
+
+		expect(
+			hub.commands.filter(
+				(command) => command.command === "session.update_connection",
+			),
+		).toHaveLength(1);
+		expect(ctx.liveSessions.get("ses-outer")?.config.model).toBe(selectedModel);
+	});
+
+	it("forwards image-only cloud messages and rejects file attachments", async () => {
 		const { ctx } = createContext();
 		const hub = new FakeHubClient();
 		const manager = new CloudSessionManager(ctx, {
@@ -2639,7 +3025,7 @@ describe("CloudSessionManager", () => {
 		await handleChatSessionCommand(ctx, {
 			action: "send",
 			sessionId: "ses-outer",
-			prompt: "Inspect this image",
+			prompt: "",
 			attachments: { userImages: [image] },
 			config: {
 				executionTarget: "cloud",
@@ -2650,7 +3036,7 @@ describe("CloudSessionManager", () => {
 		expect(hub.commands.at(-1)).toMatchObject({
 			command: "session.send_input",
 			payload: {
-				prompt: "Inspect this image",
+				prompt: "",
 				delivery: undefined,
 				attachments: { userImages: [image] },
 			},
@@ -3411,8 +3797,12 @@ describe("CloudSessionManager", () => {
 					},
 					{ ...REMOTE_SESSION, id: "ses-failed", status: "failed" },
 				],
-				create: () =>
+				create: (
+					_input: unknown,
+					onStatus?: (status: { phase?: CloudProvisioningPhase }) => void,
+				) =>
 					new Promise((resolve) => {
+						onStatus?.({ phase: "cloning_repo" });
 						finishCreate = resolve;
 					}),
 			} as unknown as CloudSessionApi,
@@ -3453,7 +3843,7 @@ describe("CloudSessionManager", () => {
 		const placeholderId = String(placeholder?.sessionId);
 		await expect(
 			handleCommand(ctx, "get_cloud_provisioning_outcome", { placeholderId }),
-		).resolves.toEqual({ status: "provisioning" });
+		).resolves.toEqual({ status: "provisioning", phase: "cloning_repo" });
 		await expect(manager.attach(placeholderId)).resolves.toMatchObject({
 			sessionId: placeholderId,
 			status: "provisioning",
@@ -3576,6 +3966,7 @@ describe("CloudSessionManager", () => {
 			createHubClient: () => hub as never,
 		});
 		const input = {
+			requestId: "client-start-1",
 			modelId: "anthropic/claude-sonnet-5",
 			repoUrl: "https://github.com/cline/test",
 		};
@@ -3818,6 +4209,7 @@ describe("CloudSessionManager", () => {
 		const scopeLookup = vi.fn(async () => "org-cline-bot");
 		const manager = new CloudSessionManager(ctx, {
 			api: {
+				list: async () => [],
 				create: async (input: Record<string, unknown>) => {
 					createInput = input;
 					return { sessionId: "ses-personal", sandboxUrl: "pod" };

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -124,6 +124,11 @@ type CloudHandoffSeed = {
 	messages: MessageWithMetadata[];
 	mode?: AgentMode;
 	workspaceRelativePath?: string;
+	config?: {
+		autoApproveTools?: boolean;
+		thinking?: boolean;
+		reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+	};
 	onSeeding?: () => void;
 };
 
@@ -171,6 +176,17 @@ export class CloudSessionError extends Error {
 			`${CLOUD_ERROR_PREFIX}${JSON.stringify({ code, message: detail, connectUrl })}`,
 		);
 		this.name = "CloudSessionError";
+	}
+}
+
+/** A queued prompt whose delivery outcome could not be confirmed. */
+export class CloudQueueUnconfirmedError extends CloudSessionError {
+	constructor() {
+		super(
+			"request_failed",
+			"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
+		);
+		this.name = "CloudQueueUnconfirmedError";
 	}
 }
 
@@ -2314,13 +2330,13 @@ export class CloudSessionManager {
 						live.busy = false;
 						live.status = "error";
 					}
+					if (delivery === "queue") {
+						throw new CloudQueueUnconfirmedError();
+					}
 					throw recoveryError;
 				}
 				if (delivery === "queue" && snapshot.prompts === undefined) {
-					throw new CloudSessionError(
-						"request_failed",
-						"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
-					);
+					throw new CloudQueueUnconfirmedError();
 				}
 				const promptOccurrencesAfterRecovery = countPromptOccurrences(
 					snapshot.messages,

--- a/apps/examples/desktop-app/sidecar/cloud-sessions.ts
+++ b/apps/examples/desktop-app/sidecar/cloud-sessions.ts
@@ -9,11 +9,13 @@ import {
 	cloudHandoffTranscriptsEqual,
 	isHubCommandTimeoutError,
 	isHubReconnectableTransportError,
+	isSessionNotFoundError,
 	NodeHubClient,
 	ProviderSettingsManager,
 } from "@cline/core";
 import {
 	type AgentMode,
+	decodeJwtPayload,
 	getClineEnvironmentConfig,
 	type HubEventEnvelope,
 	type MessageWithMetadata,
@@ -50,6 +52,7 @@ const REQUEST_TIMEOUT_MS = 15_000;
 const CLOUD_ERROR_PREFIX = "CLOUD_SESSION_ERROR:";
 const MAX_BUFFERED_SYNC_EVENTS = 2_000;
 const MAX_SEEN_EVENT_IDS = 2_000;
+const CREATE_REQUEST_TITLE_PREFIX = "__cline_create_request__:";
 type FetchLike = (
 	input: string | URL | Request,
 	init?: RequestInit,
@@ -61,14 +64,28 @@ export type CloudSessionRecord = {
 	title?: string;
 	sandboxUrl: string;
 	repoContext: { repoUrl?: string; branch?: string };
-	metadata: { modelId?: string; statusReason?: string };
+	metadata: {
+		modelId?: string;
+		taskId?: string;
+		statusReason?: string;
+		provisioningPhase?: CloudProvisioningPhase;
+		createRequestTitle?: string;
+	};
 	expiredAt?: string | null;
+	lastActivityAt?: string;
 	createdAt: string;
 	updatedAt: string;
 };
 
+export type CloudProvisioningPhase =
+	| "provisioning"
+	| "cloning_repo"
+	| "agent_starting"
+	| "ready"
+	| "failed";
+
 export type CloudProvisioningOutcome =
-	| { status: "provisioning" }
+	| { status: "provisioning"; phase?: CloudProvisioningPhase }
 	| { status: "ready"; sessionId: string }
 	| { status: "failed"; message: string };
 
@@ -77,6 +94,8 @@ export function deriveCloudSessionTitle(prompt: string): string {
 }
 
 export type CreateCloudSessionInput = {
+	/** Stable client-planned id for single-flighting one chat's start request. */
+	requestId?: string;
 	modelId: string;
 	repoUrl: string;
 	initialPrompt?: string;
@@ -184,6 +203,42 @@ function trimTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, "");
 }
 
+function createRequestTitle(requestId: string): string {
+	return `${CREATE_REQUEST_TITLE_PREFIX}${requestId}`.slice(0, 255);
+}
+
+function isCreateRequestTitle(title: string | undefined): boolean {
+	return title?.startsWith(CREATE_REQUEST_TITLE_PREFIX) === true;
+}
+
+function parseCloudProvisioningPhase(
+	value: unknown,
+): CloudProvisioningPhase | undefined {
+	switch (value) {
+		case "provisioning":
+		case "cloning_repo":
+		case "agent_starting":
+		case "ready":
+		case "failed":
+			return value;
+		default:
+			return undefined;
+	}
+}
+
+type CreationAuth = {
+	token: string;
+	subject?: string;
+};
+
+type RequestAuth = string | CreationAuth;
+
+function authSubject(token: string): string | undefined {
+	const payload = decodeJwtPayload(token.replace(/^workos:/, ""));
+	return typeof payload?.sub === "string" && payload.sub.trim()
+		? payload.sub.trim()
+		: undefined;
+}
 function waitForProvisioningPoll(signal: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
 		if (signal.aborted) {
@@ -286,38 +341,67 @@ export class CloudSessionApi {
 		path: string,
 		init: RequestInit = {},
 		githubConnectUrl?: string,
-		authToken?: string,
+		auth?: RequestAuth,
 	): Promise<T> {
-		const token = authToken ?? (await this.options.getAuthToken());
-		if (!token?.trim()) {
-			throw new CloudSessionError(
-				"authentication_required",
-				"Sign in to Cline before starting a cloud session.",
-			);
+		let refreshed = false;
+		while (true) {
+			const token =
+				typeof auth === "string"
+					? auth
+					: (auth?.token ?? (await this.options.getAuthToken()));
+			if (!token?.trim()) {
+				throw new CloudSessionError(
+					"authentication_required",
+					"Sign in to Cline before starting a cloud session.",
+				);
+			}
+			const response = await this.fetchImpl(`${this.apiBaseUrl}${path}`, {
+				...init,
+				signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+				headers: {
+					Accept: "application/json",
+					Authorization: `Bearer ${token.trim()}`,
+					...(init.body ? { "Content-Type": "application/json" } : {}),
+					...init.headers,
+				},
+			});
+			const payload =
+				response.status === 204
+					? undefined
+					: await response.json().catch(() => undefined);
+			if (!response.ok) {
+				if (
+					response.status === 401 &&
+					typeof auth === "object" &&
+					!refreshed &&
+					(await this.refreshCreationAuth(auth))
+				) {
+					refreshed = true;
+					continue;
+				}
+				throw cloudErrorForResponse(
+					response.status,
+					payload,
+					this.appBaseUrl,
+					githubConnectUrl,
+				);
+			}
+			return (payload as ApiResponse<T> | undefined)?.data as T;
 		}
-		const response = await this.fetchImpl(`${this.apiBaseUrl}${path}`, {
-			...init,
-			signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-			headers: {
-				Accept: "application/json",
-				Authorization: `Bearer ${token.trim()}`,
-				...(init.body ? { "Content-Type": "application/json" } : {}),
-				...init.headers,
-			},
-		});
-		const payload =
-			response.status === 204
-				? undefined
-				: await response.json().catch(() => undefined);
-		if (!response.ok) {
-			throw cloudErrorForResponse(
-				response.status,
-				payload,
-				this.appBaseUrl,
-				githubConnectUrl,
-			);
+	}
+
+	private async refreshCreationAuth(auth: CreationAuth): Promise<boolean> {
+		if (!auth.subject) return false;
+		const freshToken = (await this.options.getAuthToken())?.trim();
+		if (
+			!freshToken ||
+			freshToken === auth.token ||
+			authSubject(freshToken) !== auth.subject
+		) {
+			return false;
 		}
-		return (payload as ApiResponse<T> | undefined)?.data as T;
+		auth.token = freshToken;
+		return true;
 	}
 
 	async list(organizationId?: string): Promise<CloudSessionRecord[]> {
@@ -326,7 +410,8 @@ export class CloudSessionApi {
 
 	private async listWithToken(
 		organizationId?: string,
-		authToken?: string,
+		auth?: RequestAuth,
+		preserveCreateRequestTitle = false,
 	): Promise<CloudSessionRecord[]> {
 		const query = organizationId?.trim()
 			? `?organizationId=${encodeURIComponent(organizationId.trim())}`
@@ -336,7 +421,7 @@ export class CloudSessionApi {
 				`/api/v1/session${query}`,
 				{},
 				undefined,
-				authToken,
+				auth,
 			)) ?? [];
 		// Normalize before anything touches the rows: one malformed record
 		// (missing repoContext/metadata) must not crash discovery or turn a
@@ -348,14 +433,22 @@ export class CloudSessionApi {
 			return [
 				{
 					...row,
+					title:
+						!preserveCreateRequestTitle && isCreateRequestTitle(row.title)
+							? undefined
+							: row.title,
 					repoContext:
 						row.repoContext && typeof row.repoContext === "object"
 							? row.repoContext
 							: {},
-					metadata:
-						row.metadata && typeof row.metadata === "object"
+					metadata: {
+						...(row.metadata && typeof row.metadata === "object"
 							? row.metadata
-							: {},
+							: {}),
+						...(!preserveCreateRequestTitle && isCreateRequestTitle(row.title)
+							? { createRequestTitle: row.title }
+							: {}),
+					},
 				},
 			];
 		});
@@ -478,8 +571,13 @@ export class CloudSessionApi {
 
 	async status(
 		sessionId: string,
-		options: { authToken?: string; signal?: AbortSignal } = {},
-	): Promise<{ sessionId?: string; status?: string; statusReason?: string }> {
+		options: { authToken?: RequestAuth; signal?: AbortSignal } = {},
+	): Promise<{
+		sessionId?: string;
+		status?: string;
+		phase?: CloudProvisioningPhase;
+		statusReason?: string;
+	}> {
 		return await this.request(
 			`/api/v1/session/${encodeURIComponent(sessionId)}/status`,
 			{ signal: options.signal },
@@ -488,18 +586,28 @@ export class CloudSessionApi {
 		);
 	}
 
-	async create(input: CreateCloudSessionInput): Promise<{
+	async create(
+		input: CreateCloudSessionInput,
+		onProvisioningStatus?: (status: { phase?: CloudProvisioningPhase }) => void,
+	): Promise<{
 		sessionId: string;
 		sandboxUrl: string;
 		cleanupAuthToken: string;
 	}> {
-		const creationAuthToken = (await this.options.getAuthToken())?.trim();
-		if (!creationAuthToken) {
+		const initialAuthToken = (await this.options.getAuthToken())?.trim();
+		if (!initialAuthToken) {
 			throw new CloudSessionError(
 				"authentication_required",
 				"Sign in to Cline before starting a cloud session.",
 			);
 		}
+		const creationAuth: CreationAuth = {
+			token: initialAuthToken,
+			subject: authSubject(initialAuthToken),
+		};
+		const recoveryTitle = input.handoff
+			? undefined
+			: createRequestTitle(input.requestId?.trim() || randomUUID());
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), this.createTimeoutMs);
 		const requestedAt = Date.now();
@@ -530,6 +638,7 @@ export class CloudSessionApi {
 					body: JSON.stringify({
 						modelId: input.modelId,
 						repoUrl: input.repoUrl,
+						...(recoveryTitle ? { title: recoveryTitle } : {}),
 						...(input.branch?.trim() ? { branch: input.branch.trim() } : {}),
 						...(input.organizationId?.trim()
 							? { organizationId: input.organizationId.trim() }
@@ -540,7 +649,7 @@ export class CloudSessionApi {
 				input.organizationId?.trim()
 					? `${this.appBaseUrl}/dashboard/organization/integrations`
 					: undefined,
-				creationAuthToken,
+				creationAuth,
 			);
 			const sessionId = created?.sessionId?.trim();
 			if (!sessionId) {
@@ -555,19 +664,20 @@ export class CloudSessionApi {
 			await this.persistHandoffOuterSession(
 				input,
 				sessionId,
-				creationAuthToken,
+				creationAuth.token,
 			);
 			if (created.status === "provisioning" || !created.sandboxUrl?.trim()) {
 				await this.waitUntilReady(
 					sessionId,
 					controller.signal,
-					creationAuthToken,
+					creationAuth,
+					onProvisioningStatus,
 				);
 			}
 			return {
 				sessionId,
 				sandboxUrl: created.sandboxUrl?.trim() ?? "",
-				cleanupAuthToken: creationAuthToken,
+				cleanupAuthToken: creationAuth.token,
 			};
 		} catch (error) {
 			if (createdSessionId) {
@@ -576,7 +686,7 @@ export class CloudSessionApi {
 					error.code === "session_failed"
 				) {
 					try {
-						await this.delete(createdSessionId, creationAuthToken);
+						await this.deleteWithAuth(createdSessionId, creationAuth);
 					} catch (cleanupError) {
 						if (
 							!(
@@ -604,6 +714,7 @@ export class CloudSessionApi {
 			// on the same account.
 			const mayStillBeProvisioning =
 				controller.signal.aborted ||
+				!(error instanceof CloudSessionError) ||
 				(error instanceof CloudSessionError &&
 					error.code === "request_failed" &&
 					(error.status === undefined || error.status >= 500));
@@ -627,21 +738,30 @@ export class CloudSessionApi {
 				const candidates = (
 					await this.listWithToken(
 						input.organizationId ?? undefined,
-						creationAuthToken,
+						creationAuth,
+						Boolean(recoveryTitle),
 					).catch(() => [])
 				)
 					.filter(
 						(session) =>
+							(!recoveryTitle || session.title === recoveryTitle) &&
 							session.repoContext.repoUrl === input.repoUrl &&
 							session.metadata.modelId === input.modelId &&
 							(!requestedBranch ||
 								session.repoContext.branch === requestedBranch) &&
-							Date.parse(session.createdAt) >= requestedAt - 60_000,
+							(Boolean(recoveryTitle) ||
+								Date.parse(session.createdAt) >= requestedAt - 60_000),
 					)
 					.sort(
 						(left, right) =>
 							Date.parse(right.createdAt) - Date.parse(left.createdAt),
 					);
+				if (recoveryTitle && candidates.length > 1) {
+					throw new CloudSessionError(
+						"request_failed",
+						"Cloud session creation had an ambiguous result. Check your cloud session list before trying again.",
+					);
+				}
 				// A peer can register while auth or the list request is awaiting.
 				// If so, let it claim any row already present in this snapshot.
 				const latePeers = [...peers.entries()].filter(
@@ -663,7 +783,7 @@ export class CloudSessionApi {
 					await this.persistHandoffOuterSession(
 						input,
 						recovered.id,
-						creationAuthToken,
+						creationAuth.token,
 					);
 					if (
 						recovered.status === "provisioning" ||
@@ -678,8 +798,31 @@ export class CloudSessionApi {
 							await this.waitUntilReady(
 								recovered.id,
 								recoveryController.signal,
-								creationAuthToken,
+								creationAuth,
+								onProvisioningStatus,
 							);
+						} catch (recoveryError) {
+							if (
+								recoveryError instanceof CloudSessionError &&
+								recoveryError.code === "session_failed"
+							) {
+								await this.deleteWithAuth(recovered.id, creationAuth).catch(
+									(cleanupError) => {
+										if (
+											!(
+												cleanupError instanceof CloudSessionError &&
+												(cleanupError.code === "session_not_found" ||
+													cleanupError.code === "session_expired")
+											)
+										) {
+											throw cleanupError;
+										}
+									},
+								);
+								this.claimedSessionIds.delete(recovered.id);
+								await input.handoff?.onOuterSessionRemoved?.(recovered.id);
+							}
+							throw recoveryError;
 						} finally {
 							clearTimeout(recoveryTimeout);
 						}
@@ -687,7 +830,7 @@ export class CloudSessionApi {
 					return {
 						sessionId: recovered.id,
 						sandboxUrl: recovered.sandboxUrl,
-						cleanupAuthToken: creationAuthToken,
+						cleanupAuthToken: creationAuth.token,
 					};
 				}
 			}
@@ -705,11 +848,17 @@ export class CloudSessionApi {
 	async waitUntilReady(
 		sessionId: string,
 		signal: AbortSignal = AbortSignal.timeout(CREATE_TIMEOUT_MS),
-		authToken?: string,
+		authToken?: RequestAuth,
+		onStatus?: (status: { phase?: CloudProvisioningPhase }) => void,
 	): Promise<void> {
 		while (!signal.aborted) {
 			let result:
-				| { sessionId?: string; status?: string; statusReason?: string }
+				| {
+						sessionId?: string;
+						status?: string;
+						phase?: CloudProvisioningPhase;
+						statusReason?: string;
+				  }
 				| undefined;
 			try {
 				result = await this.status(sessionId, {
@@ -731,6 +880,7 @@ export class CloudSessionApi {
 				continue;
 			}
 			const status = result?.status?.trim().toLowerCase();
+			onStatus?.({ phase: parseCloudProvisioningPhase(result?.phase) });
 			if (status === "ready" || status === "active") return;
 			if (status === "failed") {
 				throw new CloudSessionError(
@@ -809,11 +959,18 @@ export class CloudSessionApi {
 	}
 
 	async delete(sessionId: string, authToken?: string): Promise<void> {
+		await this.deleteWithAuth(sessionId, authToken);
+	}
+
+	private async deleteWithAuth(
+		sessionId: string,
+		auth?: RequestAuth,
+	): Promise<void> {
 		await this.request(
 			`/api/v1/session/${encodeURIComponent(sessionId)}`,
 			{ method: "DELETE" },
 			undefined,
-			authToken,
+			auth,
 		);
 	}
 
@@ -877,6 +1034,7 @@ type CloudRehydrationSnapshot = {
 	status: string;
 	messages: unknown[];
 	prompts?: PromptInQueue[];
+	submittedPrompts: PromptInQueue[];
 };
 
 type CloudConnection = {
@@ -1016,6 +1174,7 @@ export function cloudSessionToDiscoveryRecord(
 		branch: record.repoContext.branch ?? "",
 		// updatedAt changes on every reconnect, so it is not a stable start time.
 		startedAt: record.createdAt,
+		...(record.lastActivityAt ? { lastActivityAt: record.lastActivityAt } : {}),
 		endedAt: isExpiredRecord(record)
 			? (record.expiredAt ?? undefined)
 			: undefined,
@@ -1024,6 +1183,9 @@ export function cloudSessionToDiscoveryRecord(
 		metadata: {
 			...(record.title?.trim() ? { title: record.title.trim() } : {}),
 			origin: "cloud",
+			...(record.metadata.provisioningPhase
+				? { provisioningPhase: record.metadata.provisioningPhase }
+				: {}),
 			repoUrl: record.repoContext.repoUrl ?? "",
 			git: {
 				url: record.repoContext.repoUrl ?? "",
@@ -1057,6 +1219,16 @@ function sessionRowModelId(record: JsonRecord | undefined): string {
 			? (record.metadata as JsonRecord)
 			: undefined;
 	return String(metadata?.model ?? record?.model ?? "").trim();
+}
+
+function isRootSessionRow(record: JsonRecord): boolean {
+	const metadata =
+		record.metadata && typeof record.metadata === "object"
+			? (record.metadata as JsonRecord)
+			: undefined;
+	return !String(
+		metadata?.parentSessionId ?? record.parentSessionId ?? "",
+	).trim();
 }
 
 function sessionRowHandoffSourceSessionId(
@@ -1130,6 +1302,50 @@ function countPromptOccurrences(
 		prompts.filter((item) => normalizeUserPrompt(item.prompt) === expected)
 			.length
 	);
+}
+
+function submittedPromptsFromEvents(
+	events: HubEventEnvelope[],
+): PromptInQueue[] {
+	return events.flatMap((event) => {
+		if (event.event !== "session.pending_prompt_submitted") return [];
+		const prompt =
+			event.payload?.prompt &&
+			typeof event.payload.prompt === "object" &&
+			!Array.isArray(event.payload.prompt)
+				? (event.payload.prompt as JsonRecord)
+				: undefined;
+		const id = String(prompt?.id ?? "").trim();
+		if (!id) return [];
+		return [
+			{
+				id,
+				prompt: String(prompt?.prompt ?? ""),
+				steer: prompt?.delivery === "steer",
+				attachmentCount:
+					typeof prompt?.attachmentCount === "number"
+						? prompt.attachmentCount
+						: 0,
+				userImages: Array.isArray(prompt?.userImages)
+					? prompt.userImages.filter(
+							(image): image is string => typeof image === "string",
+						)
+					: undefined,
+			},
+		];
+	});
+}
+
+function mergePromptEvidence(
+	prompts: PromptInQueue[] | undefined,
+	submittedPrompts: PromptInQueue[],
+): PromptInQueue[] {
+	const merged = [...(prompts ?? [])];
+	const knownIds = new Set(merged.map((prompt) => prompt.id));
+	for (const prompt of submittedPrompts) {
+		if (!knownIds.has(prompt.id)) merged.push(prompt);
+	}
+	return merged;
 }
 
 const TERMINAL_RUN_EVENTS = new Set([
@@ -1231,6 +1447,7 @@ export function reconcileBufferedCloudEvents(
 		 * silently losing queued/steered prompts.
 		 */
 		queueSnapshotApplied?: boolean;
+		queueSnapshotEventCutoff?: number;
 		baselineMessages?: unknown[];
 	} = {},
 ): HubEventEnvelope[] {
@@ -1241,9 +1458,12 @@ export function reconcileBufferedCloudEvents(
 	);
 	const snapshotToolCallIds = collectToolCallIds(snapshotMessages);
 	// Queue events are full snapshots, so only the newest one matters.
-	const lastQueueEvent = queueSnapshotApplied
-		? undefined
-		: events.findLast((event) => event.event === "session.pending_prompts");
+	const queueEvents = queueSnapshotApplied
+		? events.slice(options.queueSnapshotEventCutoff ?? events.length)
+		: events;
+	const lastQueueEvent = queueEvents.findLast(
+		(event) => event.event === "session.pending_prompts",
+	);
 	const reconciled: HubEventEnvelope[] = [];
 	let segment: HubEventEnvelope[] = [];
 
@@ -1299,6 +1519,8 @@ export class CloudSessionManager {
 	private readonly createRequests = new Map<string, Promise<JsonRecord>>();
 	// Keep locally-created sessions visible while their sandbox is provisioning.
 	private readonly pendingCreates = new Map<string, JsonRecord>();
+	// Reconcile ordinary creates only with the server row stamped for that request.
+	private readonly pendingCreateRecoveryTitles = new Map<string, string>();
 	private readonly provisioningOutcomes = new Map<
 		string,
 		Exclude<CloudProvisioningOutcome, { status: "provisioning" }>
@@ -1364,15 +1586,21 @@ export class CloudSessionManager {
 	getProvisioningOutcome(
 		placeholderId: string,
 	): CloudProvisioningOutcome | null {
-		if (this.pendingCreates.has(placeholderId)) {
-			return { status: "provisioning" };
+		const pending = this.pendingCreates.get(placeholderId);
+		if (pending) {
+			return {
+				status: "provisioning",
+				phase: parseCloudProvisioningPhase(pending.provisioningPhase),
+			};
 		}
 		return this.provisioningOutcomes.get(placeholderId) ?? null;
 	}
 
 	async list(): Promise<CloudSessionRecord[]> {
 		const organizationId = await this.resolveActiveOrganizationId();
-		const listed = await this.options.api.list(organizationId);
+		const listed = (await this.options.api.list(organizationId)).map(
+			(session) => this.preserveConnectedRuntimeModel(session),
+		);
 		// Keep canonical rows available while their status checks run.
 		this.lastListedSessions = listed;
 		for (const session of listed) {
@@ -1396,6 +1624,9 @@ export class CloudSessionManager {
 					status,
 					metadata: {
 						...session.metadata,
+						...(parseCloudProvisioningPhase(result?.phase)
+							? { provisioningPhase: result?.phase }
+							: {}),
 						...(result?.statusReason?.trim()
 							? { statusReason: result.statusReason.trim() }
 							: {}),
@@ -1412,6 +1643,16 @@ export class CloudSessionManager {
 				// other devices), and reap connections whose sandbox expired so
 				// they stop reconnect-looping against a dead proxy.
 				connection.remote = session;
+				if (session.status === "failed") {
+					const live = this.ctx.liveSessions.get(session.id);
+					if (live) {
+						live.busy = false;
+						live.status = "failed";
+						live.endedAt = Date.parse(session.updatedAt) || Date.now();
+					}
+					void this.disposeConnection(session.id).catch(() => undefined);
+					continue;
+				}
 				if (isExpiredRecord(session)) {
 					void this.disposeConnection(session.id).catch(() => undefined);
 				}
@@ -1419,6 +1660,21 @@ export class CloudSessionManager {
 		}
 		this.lastListedSessions = scoped;
 		return scoped;
+	}
+
+	private preserveConnectedRuntimeModel(
+		session: CloudSessionRecord,
+	): CloudSessionRecord {
+		const runtimeModel = this.connections
+			.get(session.id)
+			?.remote.metadata.modelId?.trim();
+		if (!runtimeModel || runtimeModel === session.metadata.modelId) {
+			return session;
+		}
+		return {
+			...session,
+			metadata: { ...session.metadata, modelId: runtimeModel },
+		};
 	}
 
 	/**
@@ -1532,9 +1788,19 @@ export class CloudSessionManager {
 		}
 
 		const placeholders = Array.from(this.pendingCreates.values());
-		const unmatchedPlaceholders = [...placeholders];
+		const unmatchedRecoveryTitles = new Set(
+			this.pendingCreateRecoveryTitles.values(),
+		);
+		const unmatchedLegacyPlaceholders = placeholders.filter(
+			(placeholder) =>
+				typeof placeholder.sessionId !== "string" ||
+				!this.pendingCreateRecoveryTitles.has(placeholder.sessionId),
+		);
 		const listedRecords = records.filter((record) => {
-			const placeholderIndex = unmatchedPlaceholders.findIndex(
+			const title =
+				record.metadata.createRequestTitle?.trim() ?? record.title?.trim();
+			if (title && unmatchedRecoveryTitles.delete(title)) return false;
+			const placeholderIndex = unmatchedLegacyPlaceholders.findIndex(
 				(placeholder) =>
 					placeholder.repoUrl === record.repoContext.repoUrl &&
 					placeholder.model === record.metadata.modelId &&
@@ -1542,7 +1808,7 @@ export class CloudSessionManager {
 						String(record.repoContext.branch ?? ""),
 			);
 			if (placeholderIndex < 0) return true;
-			unmatchedPlaceholders.splice(placeholderIndex, 1);
+			unmatchedLegacyPlaceholders.splice(placeholderIndex, 1);
 			return false;
 		});
 		const listed = listedRecords.map((record) => {
@@ -1575,20 +1841,22 @@ export class CloudSessionManager {
 	}
 
 	async create(input: CreateCloudSessionInput): Promise<JsonRecord> {
-		const key = [
-			input.organizationId === null
-				? "personal"
-				: (input.organizationId?.trim() ?? "active"),
-			input.repoUrl,
-			input.branch?.trim() ?? "",
-			input.modelId,
-			String(input.thinking ?? ""),
-			input.reasoningEffort ?? "",
-			String(input.autoApproveTools ?? ""),
-			input.mode ?? "act",
-			input.workspaceRelativePath ?? "",
-			input.handoff?.sourceSessionId ?? "",
-		].join("\u0000");
+		const key =
+			input.requestId?.trim() ||
+			(input.handoff
+				? [
+						input.organizationId === null
+							? "personal"
+							: (input.organizationId?.trim() ?? "active"),
+						input.repoUrl,
+						input.branch?.trim() ?? "",
+						input.modelId,
+						input.mode ?? "act",
+						input.workspaceRelativePath ?? "",
+						input.handoff.sourceSessionId,
+					].join("\u0000")
+				: "");
+		if (!key) return await this.createOnce(input);
 		const existing = this.createRequests.get(key);
 		if (existing) return await existing;
 		const creating = this.createOnce(input).finally(() => {
@@ -1664,6 +1932,13 @@ export class CloudSessionManager {
 		}
 		// Keep the session visible while the blocking create request provisions it.
 		const placeholderId = `${CLOUD_PROVISIONING_SESSION_ID_PREFIX}${randomUUID()}`;
+		const requestId = input.requestId?.trim();
+		if (requestId) {
+			this.pendingCreateRecoveryTitles.set(
+				placeholderId,
+				createRequestTitle(requestId),
+			);
+		}
 		const startedAt = new Date().toISOString();
 		this.pendingCreates.set(placeholderId, {
 			sessionId: placeholderId,
@@ -1694,7 +1969,22 @@ export class CloudSessionManager {
 			status: "provisioning",
 		});
 		try {
-			const created = await this.createProvisionedSession(input);
+			const created = await this.createProvisionedSession(
+				input,
+				({ phase }) => {
+					const pending = this.pendingCreates.get(placeholderId);
+					if (!pending) return;
+					pending.provisioningPhase = phase;
+					const metadata = pending.metadata;
+					if (
+						metadata &&
+						typeof metadata === "object" &&
+						!Array.isArray(metadata)
+					) {
+						(metadata as JsonRecord).provisioningPhase = phase;
+					}
+				},
+			);
 			const sessionId = String(created.sessionId ?? "");
 			this.provisioningOutcomes.set(placeholderId, {
 				status: "ready",
@@ -1721,6 +2011,7 @@ export class CloudSessionManager {
 			throw error;
 		} finally {
 			this.pendingCreates.delete(placeholderId);
+			this.pendingCreateRecoveryTitles.delete(placeholderId);
 			sendEvent(this.ctx, "chat_session_status", {
 				sessionId: placeholderId,
 				status: "ended",
@@ -1730,6 +2021,7 @@ export class CloudSessionManager {
 
 	private async createProvisionedSession(
 		input: CreateCloudSessionInput,
+		onProvisioningStatus?: (status: { phase?: CloudProvisioningPhase }) => void,
 	): Promise<JsonRecord> {
 		const organizationId =
 			input.organizationId === undefined
@@ -1738,10 +2030,13 @@ export class CloudSessionManager {
 		let created: Awaited<ReturnType<CloudSessionApi["create"]>> | undefined;
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			try {
-				created = await this.options.api.create({
-					...input,
-					organizationId,
-				});
+				created = await this.options.api.create(
+					{
+						...input,
+						organizationId,
+					},
+					onProvisioningStatus,
+				);
 				break;
 			} catch (error) {
 				if (!isTransientGitHubTokenVendFailure(error) || attempt === 2) {
@@ -1769,18 +2064,27 @@ export class CloudSessionManager {
 				"Cline account changed while the cloud session was starting",
 			);
 		}
-		const record: CloudSessionRecord = {
-			id: created.sessionId,
-			status: "ready",
-			sandboxUrl: created.sandboxUrl,
-			repoContext: {
-				repoUrl: input.repoUrl,
-				...(input.branch?.trim() ? { branch: input.branch.trim() } : {}),
-			},
-			metadata: { modelId: input.modelId },
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-		};
+		const canonical = (
+			await this.options.api.list(organizationId).catch(() => [])
+		).find((session) => session.id === created.sessionId);
+		const record: CloudSessionRecord = canonical
+			? {
+					...canonical,
+					status:
+						canonical.status === "provisioning" ? "ready" : canonical.status,
+				}
+			: {
+					id: created.sessionId,
+					status: "ready",
+					sandboxUrl: created.sandboxUrl,
+					repoContext: {
+						repoUrl: input.repoUrl,
+						...(input.branch?.trim() ? { branch: input.branch.trim() } : {}),
+					},
+					metadata: { modelId: input.modelId },
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				};
 		this.knownSessions.set(record.id, record);
 		const live = recordToLiveSession(record);
 		live.prompt = input.initialPrompt?.trim() || undefined;
@@ -1927,10 +2231,12 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub session was not initialized");
 		}
 		await this.ensureAttached(connection);
-		await this.updateModel(connection, modelId);
 		if (!connection.transcriptKnown) {
 			await this.rehydrateAfterTransportDrop(outerSessionId, connection);
 		}
+		// Rehydration may reveal a model change made by another client. Enforce
+		// this send's selection only after the final authoritative snapshot.
+		await this.updateModel(connection, modelId);
 		const live = this.ctx.liveSessions.get(outerSessionId);
 		const delivery = requestedDelivery ?? (live?.busy ? "queue" : undefined);
 		const promptOccurrencesBeforeSend = countPromptOccurrences(
@@ -1939,6 +2245,20 @@ export class CloudSessionManager {
 			prompt,
 		);
 		const ownsBusyState = delivery !== "queue" && delivery !== "steer";
+		const pendingMessage: MessageWithMetadata | undefined =
+			live && delivery !== "queue"
+				? { role: "user", content: [{ type: "text", text: prompt }] }
+				: undefined;
+		if (live && pendingMessage) {
+			live.messages = [...live.messages, pendingMessage];
+		}
+		const removePendingMessage = () => {
+			if (live && pendingMessage) {
+				live.messages = live.messages.filter(
+					(message) => message !== pendingMessage,
+				);
+			}
+		};
 		if (live && ownsBusyState) {
 			live.busy = true;
 			live.status = "running";
@@ -1971,13 +2291,6 @@ export class CloudSessionManager {
 					? { timeoutMs: QUEUE_COMMAND_TIMEOUT_MS }
 					: { timeoutMs: null },
 			);
-			// Advance the baseline so an older identical prompt cannot confirm this send.
-			if (live && delivery !== "queue") {
-				live.messages = [
-					...live.messages,
-					{ role: "user", content: [{ type: "text", text: prompt }] },
-				];
-			}
 			return {
 				sessionId: outerSessionId,
 				ok: true,
@@ -1996,24 +2309,25 @@ export class CloudSessionManager {
 						connection,
 					);
 				} catch (recoveryError) {
+					removePendingMessage();
 					if (live && ownsBusyState) {
 						live.busy = false;
 						live.status = "error";
 					}
 					throw recoveryError;
 				}
+				if (delivery === "queue" && snapshot.prompts === undefined) {
+					throw new CloudSessionError(
+						"request_failed",
+						"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
+					);
+				}
 				const promptOccurrencesAfterRecovery = countPromptOccurrences(
 					snapshot.messages,
-					snapshot.prompts ?? [],
+					mergePromptEvidence(snapshot.prompts, snapshot.submittedPrompts),
 					prompt,
 				);
 				if (promptOccurrencesAfterRecovery <= promptOccurrencesBeforeSend) {
-					if (delivery === "queue" && snapshot.prompts === undefined) {
-						throw new CloudSessionError(
-							"request_failed",
-							"The connection was interrupted and Cline could not confirm whether this message was queued. Check the cloud session before resending it.",
-						);
-					}
 					throw new CloudSessionError(
 						"request_failed",
 						"The connection was interrupted before this message could be confirmed. It was not found in the cloud session, so please send it again.",
@@ -2027,6 +2341,7 @@ export class CloudSessionManager {
 					status: snapshot.status,
 				};
 			}
+			removePendingMessage();
 			if (live && ownsBusyState) {
 				live.busy = false;
 				live.status = "error";
@@ -2119,6 +2434,7 @@ export class CloudSessionManager {
 				!Array.isArray(sessionReply.payload.session)
 					? (sessionReply.payload.session as JsonRecord)
 					: undefined;
+			this.applySessionModel(connection, session);
 			const live = this.ctx.liveSessions.get(outerSessionId);
 			const baselineMessages = live?.messages ?? [];
 			const runtimeStatus = String(
@@ -2142,6 +2458,7 @@ export class CloudSessionManager {
 					innerSessionId,
 				)
 				.catch(() => undefined);
+			const queueSnapshotEventCutoff = connection.bufferedEvents.length;
 
 			if (live) {
 				const statusChanged = live.status !== status;
@@ -2154,7 +2471,7 @@ export class CloudSessionManager {
 						status === "failed" ||
 						status === "aborted"
 					) {
-						live.endedAt ??= Date.now();
+						live.endedAt = Date.now();
 						sendEvent(this.ctx, "chat_session_ended", {
 							sessionId: outerSessionId,
 							// The live run.failed path reports "error"; keep the
@@ -2196,18 +2513,20 @@ export class CloudSessionManager {
 					messages,
 				),
 			});
-			const buffered = reconcileBufferedCloudEvents(
-				connection.bufferedEvents,
-				messages,
-				{ queueSnapshotApplied: queueSnapshotValid, baselineMessages },
-			);
+			const bufferedEvents = connection.bufferedEvents;
+			const submittedPrompts = submittedPromptsFromEvents(bufferedEvents);
+			const buffered = reconcileBufferedCloudEvents(bufferedEvents, messages, {
+				queueSnapshotApplied: queueSnapshotValid,
+				queueSnapshotEventCutoff,
+				baselineMessages,
+			});
 			connection.bufferedEvents = [];
 			connection.bufferingEvents = false;
 			connection.syncFailureNotified = false;
 			for (const event of buffered) {
 				this.forwardEvent(outerSessionId, connection, event);
 			}
-			return { status, messages, prompts };
+			return { status, messages, prompts, submittedPrompts };
 		} catch (error) {
 			// Preserve the current view and release the full tail on snapshot failure.
 			const buffered = connection.bufferedEvents;
@@ -2595,7 +2914,7 @@ export class CloudSessionManager {
 			let socketAttempt = 0;
 			const client = this.createHubClient({
 				url: toWebSocketUrl(this.options.apiBaseUrl, outerSessionId),
-				clientId: `code-cloud-${outerSessionId}`,
+				clientId: `code-cloud-${outerSessionId}-${randomUUID()}`,
 				clientType: "code-cloud-sidecar",
 				displayName: "Cline cloud session",
 				workspaceRoot: CLOUD_WORKSPACE_ROOT,
@@ -2610,10 +2929,15 @@ export class CloudSessionManager {
 							// A dropped transport invalidates the duplicate-prompt
 							// baseline send() computes from live.messages.
 							reconnected.transcriptKnown = false;
-							void this.rehydrateAfterTransportDrop(
-								outerSessionId,
-								reconnected,
-							).catch(() =>
+							void (async () => {
+								await this.resolveInnerSession(outerSessionId, reconnected);
+								if (reconnected.innerSessionId) {
+									await this.rehydrateAfterTransportDrop(
+										outerSessionId,
+										reconnected,
+									);
+								}
+							})().catch(() =>
 								this.disposeConnectionIfSessionGone(
 									outerSessionId,
 									reconnected,
@@ -2641,51 +2965,37 @@ export class CloudSessionManager {
 				seenEventIdOrder: [],
 				unsubscribe: () => {},
 			};
-			connection.unsubscribe = client.subscribe((event) => {
-				this.handleEvent(outerSessionId, connection, event);
+			// A scoped placeholder subscription keeps the client's built-in retry
+			// loop alive if the first WebSocket upgrade races pod startup.
+			connection.unsubscribe = client.subscribe(() => {}, {
+				sessionId: remote.metadata.taskId?.trim() || outerSessionId,
 			});
+			this.connections.set(outerSessionId, connection);
 			try {
 				await client.connect();
 				if (this.disposed) {
 					throw new Error("Cloud session manager was disposed");
 				}
-				const listed = await client.command("session.list", { limit: 100 });
-				const rows = readSessionRows(listed.payload);
-				let newest: JsonRecord | undefined;
-				if (options.handoffSeed && rows.length > 0) {
-					const [only] = rows;
-					if (
-						rows.length !== 1 ||
-						sessionRowHandoffSourceSessionId(only) !==
-							options.handoffSeed.sourceSessionId
-					) {
-						throw new CloudSessionError(
-							"request_failed",
-							"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
-						);
-					}
-					newest = only;
-				} else {
-					newest = rows.sort(
-						(left, right) => updatedAt(right) - updatedAt(left),
-					)[0];
-				}
-				const innerSessionId = String(newest?.sessionId ?? "").trim();
-				if (innerSessionId) {
-					connection.innerSessionId = innerSessionId;
-					const modelId = sessionRowModelId(newest);
-					if (modelId) this.applyModel(connection, modelId);
-					await this.ensureAttached(connection);
-				}
+				await this.resolveInnerSession(
+					outerSessionId,
+					connection,
+					options.handoffSeed,
+				);
 				if (this.disposed) {
 					throw new Error("Cloud session manager was disposed");
 				}
-				this.connections.set(outerSessionId, connection);
 				if (options.createInner && !connection.innerSessionId) {
 					await this.createInnerSession(connection, options.handoffSeed);
 				}
 				return connection;
 			} catch (error) {
+				if (
+					isHubReconnectableTransportError(error) &&
+					!this.disposed &&
+					!connection.disposed
+				) {
+					return connection;
+				}
 				// Never retain a client whose registration or inner creation failed.
 				this.connections.delete(outerSessionId);
 				connection.disposed = true;
@@ -2727,6 +3037,67 @@ export class CloudSessionManager {
 				"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
 			);
 		}
+	}
+
+	private async resolveInnerSession(
+		outerSessionId: string,
+		connection: CloudConnection,
+		handoffSeed?: CloudHandoffSeed,
+	): Promise<void> {
+		if (connection.innerSessionId) return;
+		let session: JsonRecord | undefined;
+		if (handoffSeed) {
+			const listed = await connection.client.command("session.list", {
+				limit: 100,
+			});
+			const rows = readSessionRows(listed.payload);
+			if (rows.length > 0) {
+				const [only] = rows;
+				if (
+					rows.length !== 1 ||
+					sessionRowHandoffSourceSessionId(only) !== handoffSeed.sourceSessionId
+				) {
+					throw new CloudSessionError(
+						"request_failed",
+						"This cloud workspace already contains another conversation. Open it in Cline Cloud or delete it before retrying the handoff.",
+					);
+				}
+				session = only;
+			}
+		} else {
+			const taskId = connection.remote.metadata.taskId?.trim();
+			if (taskId) {
+				try {
+					const reply = await connection.client.command(
+						"session.get",
+						{ sessionId: taskId },
+						taskId,
+					);
+					session =
+						reply.payload?.session &&
+						typeof reply.payload.session === "object" &&
+						!Array.isArray(reply.payload.session)
+							? (reply.payload.session as JsonRecord)
+							: undefined;
+				} catch (error) {
+					if (!isSessionNotFoundError(error)) throw error;
+				}
+			} else {
+				const listed = await connection.client.command("session.list", {
+					limit: 100,
+				});
+				session = readSessionRows(listed.payload)
+					.filter(isRootSessionRow)
+					.sort((left, right) => updatedAt(right) - updatedAt(left))[0];
+			}
+		}
+		const innerSessionId = String(session?.sessionId ?? "").trim();
+		if (!innerSessionId) return;
+		connection.innerSessionId = innerSessionId;
+		this.subscribeToInnerSession(outerSessionId, connection);
+		const modelId = sessionRowModelId(session);
+		if (modelId) this.applyModel(connection, modelId);
+		await this.ensureAttached(connection);
 	}
 
 	private async createInnerSession(
@@ -2803,6 +3174,9 @@ export class CloudSessionManager {
 						}
 					: {}),
 			},
+			...(connection.remote.metadata.taskId?.trim()
+				? { requestedSessionId: connection.remote.metadata.taskId.trim() }
+				: {}),
 			runtimeOptions: { mode },
 			modelSelection: { provider: "cline", model: modelId },
 			toolPolicies: {
@@ -2820,6 +3194,9 @@ export class CloudSessionManager {
 			throw new Error("Cloud Hub did not return an inner session id");
 		}
 		connection.innerSessionId = innerSessionId;
+		this.subscribeToInnerSession(connection.remote.id, connection);
+		const createdModelId = sessionRowModelId(session);
+		if (createdModelId) this.applyModel(connection, createdModelId);
 		// Seeded content is authoritative only after a strict session.messages
 		// read-back verifies that the pod persisted initialMessages.
 		connection.transcriptKnown = !handoffSeed;
@@ -2866,6 +3243,13 @@ export class CloudSessionManager {
 		connection: CloudConnection,
 		event: HubEventEnvelope,
 	): void {
+		if (
+			event.event === "session.attached" ||
+			event.event === "session.updated" ||
+			event.event === "session.created"
+		) {
+			this.applySessionModel(connection, event.payload?.session);
+		}
 		if (event.event === "approval.requested") {
 			this.handleApprovalRequested(outerSessionId, connection, event);
 			return;
@@ -2962,6 +3346,13 @@ export class CloudSessionManager {
 		if (!reply?.ok || !Array.isArray(reply.payload?.approvals)) {
 			return;
 		}
+		if (
+			this.disposed ||
+			connection.disposed ||
+			this.connections.get(outerSessionId) !== connection
+		) {
+			return;
+		}
 		for (const [requestId, pending] of this.ctx.pendingApprovals) {
 			if (pending.item.sessionId === outerSessionId) {
 				this.ctx.pendingApprovals.delete(requestId);
@@ -2998,15 +3389,40 @@ export class CloudSessionManager {
 		});
 	}
 
+	private subscribeToInnerSession(
+		outerSessionId: string,
+		connection: CloudConnection,
+	): void {
+		const innerSessionId = connection.innerSessionId;
+		if (!innerSessionId) return;
+		connection.unsubscribe();
+		connection.unsubscribe = connection.client.subscribe(
+			(event) => this.handleEvent(outerSessionId, connection, event),
+			{ sessionId: innerSessionId },
+		);
+	}
+
 	private async ensureAttached(connection: CloudConnection): Promise<void> {
 		if (!connection.innerSessionId) {
 			return;
 		}
-		await connection.client.command(
+		const reply = await connection.client.command(
 			"session.attach",
 			{ sessionId: connection.innerSessionId },
 			connection.innerSessionId,
 		);
+		this.applySessionModel(connection, reply.payload?.session);
+	}
+
+	private applySessionModel(
+		connection: CloudConnection,
+		session: unknown,
+	): void {
+		if (!session || typeof session !== "object" || Array.isArray(session)) {
+			return;
+		}
+		const modelId = sessionRowModelId(session as JsonRecord);
+		if (modelId) this.applyModel(connection, modelId);
 	}
 
 	private async disposeConnection(outerSessionId: string): Promise<void> {
@@ -3053,6 +3469,16 @@ export class CloudSessionManager {
 		}
 		this.knownSessions.set(outerSessionId, listed);
 		connection.remote = listed;
+		if (listed.status === "failed") {
+			const live = this.ctx.liveSessions.get(outerSessionId);
+			if (live) {
+				live.busy = false;
+				live.status = "failed";
+				live.endedAt = Date.parse(listed.updatedAt) || Date.now();
+			}
+			await this.disposeConnection(outerSessionId).catch(() => undefined);
+			return;
+		}
 		if (isExpiredRecord(listed)) {
 			await this.attachExpired(listed).catch(() => undefined);
 			await this.disposeConnection(outerSessionId).catch(() => undefined);

--- a/apps/examples/desktop-app/sidecar/commands-settings.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-settings.test.ts
@@ -44,26 +44,24 @@ beforeEach(() => {
 
 afterEach(() => {
 	delete process.env.CLINE_CODE_CLOUD_AGENTS;
+	delete process.env.CLINE_CODE_CLOUD_HANDOFF;
 	delete process.env.CLINE_DATA_DIR;
 	rmSync(dataDir, { recursive: true, force: true });
 });
 
 describe("desktop settings commands", () => {
-	it("reads default desktop settings and an off feature gate", async () => {
+	it("reads default desktop settings with beta cloud availability", async () => {
 		const { ctx } = createContext();
 
 		await expect(
 			handleCommand(ctx, "get_desktop_settings", {}),
 		).resolves.toEqual({ cloudSessionsEnabled: false });
-		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
+		await expect(
+			handleCommand(ctx, "get_feature_flags", {}),
+		).resolves.toMatchObject({
 			cloudAgents: false,
-			cloudAgentsAvailable: false,
-			flags: {
-				"code-cloud-agents": false,
-				"code-onboarding-github": false,
-				"ext-cline-pass": false,
-				"internal-composio-connectors": false,
-			},
+			cloudAgentsAvailable: true,
+			cloudHandoff: true,
 		});
 	});
 
@@ -78,7 +76,7 @@ describe("desktop settings commands", () => {
 		expect(events).toEqual([]);
 	});
 
-	it("persists the toggle and broadcasts the rollout-gated state", async () => {
+	it("persists the toggle and broadcasts the new gate immediately", async () => {
 		const { ctx, events } = createContext();
 
 		await expect(
@@ -87,30 +85,35 @@ describe("desktop settings commands", () => {
 			}),
 		).resolves.toEqual({ cloudSessionsEnabled: true });
 		// Open webviews re-evaluate without waiting for a restart or account
-		// change.
+		// change. Beta makes cloud capabilities available without PostHog; the
+		// existing desktop opt-in remains the effective user-facing gate.
 		expect(events).toEqual([
 			{
 				name: "feature_flags_changed",
-				payload: { cloudAgents: false, cloudAgentsAvailable: false },
+				payload: {
+					cloudAgents: true,
+					cloudAgentsAvailable: true,
+					cloudHandoff: true,
+				},
 			},
 		]);
-		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
-			cloudAgents: false,
-			cloudAgentsAvailable: false,
-			flags: {
-				"code-cloud-agents": false,
-				"code-onboarding-github": false,
-				"ext-cline-pass": false,
-				"internal-composio-connectors": false,
-			},
-		});
+		await expect(
+			handleCommand(ctx, "get_feature_flags", {}),
+		).resolves.toMatchObject({ cloudAgents: true });
+		await expect(
+			handleCommand(ctx, "get_desktop_settings", {}),
+		).resolves.toEqual({ cloudSessionsEnabled: true });
 
 		await handleCommand(ctx, "set_cloud_sessions_enabled", {
 			cloud_sessions_enabled: false,
 		});
 		expect(events.at(-1)).toEqual({
 			name: "feature_flags_changed",
-			payload: { cloudAgents: false, cloudAgentsAvailable: false },
+			payload: {
+				cloudAgents: false,
+				cloudAgentsAvailable: true,
+				cloudHandoff: true,
+			},
 		});
 	});
 
@@ -118,15 +121,11 @@ describe("desktop settings commands", () => {
 		const { ctx } = createContext();
 		process.env.CLINE_CODE_CLOUD_AGENTS = "1";
 
-		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
+		await expect(
+			handleCommand(ctx, "get_feature_flags", {}),
+		).resolves.toMatchObject({
 			cloudAgents: true,
 			cloudAgentsAvailable: true,
-			flags: {
-				"code-cloud-agents": false,
-				"code-onboarding-github": false,
-				"ext-cline-pass": false,
-				"internal-composio-connectors": false,
-			},
 		});
 		// The toggle's stored value is reported as-is; the override only
 		// affects the effective gate.

--- a/apps/examples/desktop-app/sidecar/commands-settings.test.ts
+++ b/apps/examples/desktop-app/sidecar/commands-settings.test.ts
@@ -57,7 +57,9 @@ describe("desktop settings commands", () => {
 		).resolves.toEqual({ cloudSessionsEnabled: false });
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
 			cloudAgents: false,
+			cloudAgentsAvailable: false,
 			flags: {
+				"code-cloud-agents": false,
 				"code-onboarding-github": false,
 				"ext-cline-pass": false,
 				"internal-composio-connectors": false,
@@ -76,7 +78,7 @@ describe("desktop settings commands", () => {
 		expect(events).toEqual([]);
 	});
 
-	it("persists the toggle and broadcasts the new gate immediately", async () => {
+	it("persists the toggle and broadcasts the rollout-gated state", async () => {
 		const { ctx, events } = createContext();
 
 		await expect(
@@ -89,12 +91,14 @@ describe("desktop settings commands", () => {
 		expect(events).toEqual([
 			{
 				name: "feature_flags_changed",
-				payload: { cloudAgents: true },
+				payload: { cloudAgents: false, cloudAgentsAvailable: false },
 			},
 		]);
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
-			cloudAgents: true,
+			cloudAgents: false,
+			cloudAgentsAvailable: false,
 			flags: {
+				"code-cloud-agents": false,
 				"code-onboarding-github": false,
 				"ext-cline-pass": false,
 				"internal-composio-connectors": false,
@@ -106,7 +110,7 @@ describe("desktop settings commands", () => {
 		});
 		expect(events.at(-1)).toEqual({
 			name: "feature_flags_changed",
-			payload: { cloudAgents: false },
+			payload: { cloudAgents: false, cloudAgentsAvailable: false },
 		});
 	});
 
@@ -116,7 +120,9 @@ describe("desktop settings commands", () => {
 
 		await expect(handleCommand(ctx, "get_feature_flags", {})).resolves.toEqual({
 			cloudAgents: true,
+			cloudAgentsAvailable: true,
 			flags: {
+				"code-cloud-agents": false,
 				"code-onboarding-github": false,
 				"ext-cline-pass": false,
 				"internal-composio-connectors": false,

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -121,6 +121,7 @@ import {
 	identifyDesktopFeatureFlagsAccount,
 	isCloudAgentsAvailable,
 	isCloudAgentsEnabled,
+	isCloudHandoffEnabled,
 	isDesktopInternalFeatureEnabled,
 	refreshDesktopFeatureFlags,
 } from "./feature-flags";
@@ -2352,44 +2353,50 @@ export async function handleCommand(
 		if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
 			throw new Error("metadata patch is required");
 		}
-		// updateSession replaces metadata wholesale in both the session row and
-		// the manifest, so merge over what each already holds. A null value
-		// removes the key, which is how callers clear a flag.
-		const binding = await getCommandSessionBinding(ctx, sessionId, args);
-		if (!binding) throw new Error(`Session ${sessionId} not found`);
-		const store = new SqliteSessionStore();
-		const asRecord = (value: unknown): JsonRecord =>
-			value && typeof value === "object" && !Array.isArray(value)
-				? (value as JsonRecord)
-				: {};
-		const existingSession = await binding.sessionManager.get(sessionId);
-		const existing =
-			binding.kind === "local" ? store.get(sessionId) : undefined;
-		const merged: JsonRecord = {
-			...(binding.kind === "local"
-				? asRecord(readSessionManifest(sessionId)?.metadata)
-				: {}),
-			...asRecord(existingSession?.metadata),
-			...asRecord(existing?.metadata),
-		};
-		for (const [key, value] of Object.entries(patch as JsonRecord)) {
-			if (value === null) delete merged[key];
-			else merged[key] = value;
+		const { beginSessionMetadataUpdate } = await import("./chat-session");
+		const releaseMetadataUpdate = beginSessionMetadataUpdate(ctx, sessionId);
+		try {
+			// updateSession replaces metadata wholesale in both the session row and
+			// the manifest, so merge over what each already holds. A null value
+			// removes the key, which is how callers clear a flag.
+			const binding = await getCommandSessionBinding(ctx, sessionId, args);
+			if (!binding) throw new Error(`Session ${sessionId} not found`);
+			const store = new SqliteSessionStore();
+			const asRecord = (value: unknown): JsonRecord =>
+				value && typeof value === "object" && !Array.isArray(value)
+					? (value as JsonRecord)
+					: {};
+			const existingSession = await binding.sessionManager.get(sessionId);
+			const existing =
+				binding.kind === "local" ? store.get(sessionId) : undefined;
+			const merged: JsonRecord = {
+				...(binding.kind === "local"
+					? asRecord(readSessionManifest(sessionId)?.metadata)
+					: {}),
+				...asRecord(existingSession?.metadata),
+				...asRecord(existing?.metadata),
+			};
+			for (const [key, value] of Object.entries(patch as JsonRecord)) {
+				if (value === null) delete merged[key];
+				else merged[key] = value;
+			}
+			const result = await binding.sessionManager.update(sessionId, {
+				metadata: merged,
+			});
+			if (!result.updated) throw new Error(`Session ${sessionId} not found`);
+			// Annotating a session is not session activity. updateSession stamps
+			// updated_at, which clients sort and label rows by, so a pin would
+			// otherwise make an old session look like it just ran.
+			if (binding.kind === "local" && existing?.updatedAt) {
+				store.run("UPDATE sessions SET updated_at = ? WHERE session_id = ?", [
+					existing.updatedAt,
+					sessionId,
+				]);
+			}
+			return merged;
+		} finally {
+			releaseMetadataUpdate();
 		}
-		const result = await binding.sessionManager.update(sessionId, {
-			metadata: merged,
-		});
-		if (!result.updated) throw new Error(`Session ${sessionId} not found`);
-		// Annotating a session is not session activity. updateSession stamps
-		// updated_at, which clients sort and label rows by, so a pin would
-		// otherwise make an old session look like it just ran.
-		if (binding.kind === "local" && existing?.updatedAt) {
-			store.run("UPDATE sessions SET updated_at = ? WHERE session_id = ?", [
-				existing.updatedAt,
-				sessionId,
-			]);
-		}
-		return merged;
 	}
 	if (command === "delete_chat_session" || command === "delete_cli_session") {
 		const sessionId = String(args?.sessionId ?? args?.session_id ?? "").trim();
@@ -2402,47 +2409,113 @@ export async function handleCommand(
 		const { assertSessionDeleteAllowedDuringHandoff } = await import(
 			"./chat-session"
 		);
-		const binding = await getCommandSessionBinding(ctx, sessionId, args);
-		await assertSessionDeleteAllowedDuringHandoff(
+		const releaseDelete = await assertSessionDeleteAllowedDuringHandoff(
 			ctx,
 			sessionId,
-			binding?.sessionManager,
+			requestedEnvironmentId(args),
 		);
-		ctx.logger?.log("Deleting desktop chat session", { command, sessionId });
-		const store = new SqliteSessionStore();
-		const row = store.get(sessionId);
-		const manifest = readSessionManifest(sessionId);
-		let deleted = false;
-		let deleteError: Error | null = null;
+		const binding = await getCommandSessionBinding(ctx, sessionId, args);
 		try {
-			if (binding) {
-				deleted = await binding.sessionManager.delete(sessionId);
-			} else {
-				const backend = await resolveSessionBackend({ backendMode: "local" });
-				const deleteSession = (
-					backend as {
-						deleteSession: (
-							sessionId: string,
-							cascade?: boolean,
-						) => Promise<boolean | { deleted: boolean }>;
-					}
-				).deleteSession.bind(backend);
-				const deleteResult = await deleteSession(sessionId, true);
-				deleted =
-					typeof deleteResult === "boolean"
-						? deleteResult
-						: deleteResult.deleted;
+			ctx.logger?.log("Deleting desktop chat session", { command, sessionId });
+			const store = new SqliteSessionStore();
+			const row = store.get(sessionId);
+			const manifest = readSessionManifest(sessionId);
+			let deleted = false;
+			let deleteError: Error | null = null;
+			try {
+				if (binding) {
+					deleted = await binding.sessionManager.delete(sessionId);
+				} else {
+					const backend = await resolveSessionBackend({ backendMode: "local" });
+					const deleteSession = (
+						backend as {
+							deleteSession: (
+								sessionId: string,
+								cascade?: boolean,
+							) => Promise<boolean | { deleted: boolean }>;
+						}
+					).deleteSession.bind(backend);
+					const deleteResult = await deleteSession(sessionId, true);
+					deleted =
+						typeof deleteResult === "boolean"
+							? deleteResult
+							: deleteResult.deleted;
+				}
+			} catch (error) {
+				deleteError = error instanceof Error ? error : new Error(String(error));
 			}
-		} catch (error) {
-			deleteError = error instanceof Error ? error : new Error(String(error));
-		}
-		if (binding?.kind !== "ssh" && store.delete(sessionId, true)) {
-			deleted = true;
-		}
-		ctx.liveSessions.delete(sessionId);
-		ctx.sessionEnvironmentIds.delete(sessionId);
-		if (binding?.kind === "ssh") {
-			if (!deleted && deleteError) throw deleteError;
+			if (binding?.kind !== "ssh" && store.delete(sessionId, true)) {
+				deleted = true;
+			}
+			ctx.liveSessions.delete(sessionId);
+			ctx.sessionEnvironmentIds.delete(sessionId);
+			if (binding?.kind === "ssh") {
+				if (!deleted && deleteError) throw deleteError;
+				if (deleted) {
+					broadcastEvent(ctx, "session_deleted", {
+						sessionId,
+						command,
+						deleted: true,
+					});
+				}
+				return deleted;
+			}
+			const directoryCandidates = new Set<string>([
+				join(sharedSessionDataDir(), sessionId),
+			]);
+			for (const path of [
+				row?.messagesPath,
+				typeof manifest?.messages_path === "string"
+					? manifest.messages_path
+					: null,
+			]) {
+				if (typeof path === "string" && path.trim().length > 0) {
+					directoryCandidates.add(dirname(path));
+				}
+			}
+			for (const path of [sessionLogPath(sessionId)]) {
+				if (removePathIfExists(path, { recursive: true })) {
+					deleted = true;
+				}
+			}
+			for (const dir of directoryCandidates) {
+				if (removePathIfExists(dir, { recursive: true })) {
+					deleted = true;
+				}
+			}
+			for (const path of [
+				row?.messagesPath,
+				typeof manifest?.messages_path === "string"
+					? manifest.messages_path
+					: null,
+				join(sharedSessionDataDir(), sessionId, `${sessionId}.json`),
+			].filter((v): v is string => typeof v === "string" && v.length > 0)) {
+				if (removePathIfExists(path)) {
+					deleted = true;
+				}
+			}
+			for (const suffix of ["messages.json"]) {
+				const fileName = `${sessionId}.${suffix}`;
+				const found = findArtifactUnderDir(
+					join(sharedSessionDataDir(), rootSessionIdFrom(sessionId)),
+					fileName,
+					4,
+				);
+				if (found && removePathIfExists(found)) {
+					deleted = true;
+				}
+			}
+			if (!deleted && deleteError) {
+				ctx.logger?.error?.("Failed to delete desktop chat session", {
+					sessionId,
+					error: deleteError,
+				});
+				throw deleteError;
+			}
+			ctx.logger?.log("Desktop chat session delete completed", {
+				sessionId,
+				deleted,
+			});
 			if (deleted) {
 				broadcastEvent(ctx, "session_deleted", {
 					sessionId,
@@ -2451,71 +2524,9 @@ export async function handleCommand(
 				});
 			}
 			return deleted;
+		} finally {
+			releaseDelete();
 		}
-		const directoryCandidates = new Set<string>([
-			join(sharedSessionDataDir(), sessionId),
-		]);
-		for (const path of [
-			row?.messagesPath,
-			typeof manifest?.messages_path === "string"
-				? manifest.messages_path
-				: null,
-		]) {
-			if (typeof path === "string" && path.trim().length > 0) {
-				directoryCandidates.add(dirname(path));
-			}
-		}
-		for (const path of [sessionLogPath(sessionId)]) {
-			if (removePathIfExists(path, { recursive: true })) {
-				deleted = true;
-			}
-		}
-		for (const dir of directoryCandidates) {
-			if (removePathIfExists(dir, { recursive: true })) {
-				deleted = true;
-			}
-		}
-		for (const path of [
-			row?.messagesPath,
-			typeof manifest?.messages_path === "string"
-				? manifest.messages_path
-				: null,
-			join(sharedSessionDataDir(), sessionId, `${sessionId}.json`),
-		].filter((v): v is string => typeof v === "string" && v.length > 0)) {
-			if (removePathIfExists(path)) {
-				deleted = true;
-			}
-		}
-		for (const suffix of ["messages.json"]) {
-			const fileName = `${sessionId}.${suffix}`;
-			const found = findArtifactUnderDir(
-				join(sharedSessionDataDir(), rootSessionIdFrom(sessionId)),
-				fileName,
-				4,
-			);
-			if (found && removePathIfExists(found)) {
-				deleted = true;
-			}
-		}
-		if (!deleted && deleteError) {
-			ctx.logger?.error?.("Failed to delete desktop chat session", {
-				sessionId,
-				error: deleteError,
-			});
-			throw deleteError;
-		}
-		ctx.logger?.log("Desktop chat session delete completed", {
-			sessionId,
-			deleted,
-		});
-		if (deleted) {
-			broadcastEvent(ctx, "session_deleted", {
-				sessionId,
-				command,
-				deleted: true,
-			});
-		}
-		return deleted;
 	}
 
 	// ── Workspace file search ─────────────────────────────────────────
@@ -3086,6 +3097,7 @@ export async function handleCommand(
 		broadcastEvent(ctx, "feature_flags_changed", {
 			cloudAgents: isCloudAgentsEnabled(),
 			cloudAgentsAvailable: isCloudAgentsAvailable(),
+			cloudHandoff: isCloudHandoffEnabled(),
 		});
 		return settings;
 	}
@@ -3107,6 +3119,10 @@ export async function handleCommand(
 				telemetry: ctx.telemetry,
 			}),
 			cloudAgentsAvailable: isCloudAgentsAvailable({
+				logger: ctx.logger,
+				telemetry: ctx.telemetry,
+			}),
+			cloudHandoff: isCloudHandoffEnabled({
 				logger: ctx.logger,
 				telemetry: ctx.telemetry,
 			}),

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -119,6 +119,7 @@ import {
 } from "./desktop-settings";
 import {
 	identifyDesktopFeatureFlagsAccount,
+	isCloudAgentsAvailable,
 	isCloudAgentsEnabled,
 	isDesktopInternalFeatureEnabled,
 	refreshDesktopFeatureFlags,
@@ -2907,7 +2908,11 @@ export async function handleCommand(
 	}
 	if (command === "save_media_generation_settings") {
 		const mediaType = String(args?.media_type ?? "").trim();
-		if (mediaType !== "image" && mediaType !== "audio" && mediaType !== "video") {
+		if (
+			mediaType !== "image" &&
+			mediaType !== "audio" &&
+			mediaType !== "video"
+		) {
 			throw new Error('media_type must be "image", "audio", or "video"');
 		}
 		const providerId = String(args?.provider ?? "").trim();
@@ -3080,6 +3085,7 @@ export async function handleCommand(
 		// gate immediately instead of waiting for the next sign-in refresh.
 		broadcastEvent(ctx, "feature_flags_changed", {
 			cloudAgents: isCloudAgentsEnabled(),
+			cloudAgentsAvailable: isCloudAgentsAvailable(),
 		});
 		return settings;
 	}
@@ -3094,7 +3100,17 @@ export async function handleCommand(
 			logger: ctx.logger,
 			telemetry: ctx.telemetry,
 		});
-		return { ...snapshot, cloudAgents: isCloudAgentsEnabled() };
+		return {
+			...snapshot,
+			cloudAgents: isCloudAgentsEnabled({
+				logger: ctx.logger,
+				telemetry: ctx.telemetry,
+			}),
+			cloudAgentsAvailable: isCloudAgentsAvailable({
+				logger: ctx.logger,
+				telemetry: ctx.telemetry,
+			}),
+		};
 	}
 
 	// ── Connector channels ─────────────────────────────────────────────

--- a/apps/examples/desktop-app/sidecar/feature-flags.test.ts
+++ b/apps/examples/desktop-app/sidecar/feature-flags.test.ts
@@ -63,6 +63,7 @@ import {
 	getDesktopFeatureFlagsService,
 	isCloudAgentsAvailable,
 	isCloudAgentsEnabled,
+	isCloudHandoffEnabled,
 	isDesktopInternalFeatureEnabled,
 	refreshDesktopFeatureFlags,
 	resetDesktopFeatureFlagsForTesting,
@@ -88,6 +89,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	delete process.env.CLINE_CODE_CLOUD_AGENTS;
+	delete process.env.CLINE_CODE_CLOUD_HANDOFF;
 	delete process.env.CLINE_DATA_DIR;
 	rmSync(dataDir, { recursive: true, force: true });
 	if (originalApiKey === undefined) {
@@ -381,21 +383,12 @@ describe("disposeDesktopFeatureFlagsService", () => {
 });
 
 describe("cloud agents gate", () => {
-	it("defaults to unavailable and disabled", () => {
-		expect(isCloudAgentsAvailable()).toBe(false);
-		expect(isCloudAgentsEnabled()).toBe(false);
-	});
-
-	it("requires the rollout flag and the user's opt-in", () => {
-		setCloudSessionsEnabled(true);
-		expect(isCloudAgentsEnabled()).toBe(false);
-		mocks.getBooleanFlagEnabled.mockImplementation(
-			(flag: unknown) => flag === "code-cloud-agents",
-		);
+	it("is available in beta and follows the existing Settings toggle", () => {
 		expect(isCloudAgentsAvailable()).toBe(true);
-		expect(isCloudAgentsEnabled()).toBe(true);
 		setCloudSessionsEnabled(false);
 		expect(isCloudAgentsEnabled()).toBe(false);
+		setCloudSessionsEnabled(true);
+		expect(isCloudAgentsEnabled()).toBe(true);
 	});
 
 	it("honors the env override in both directions", () => {
@@ -410,5 +403,18 @@ describe("cloud agents gate", () => {
 		expect(isCloudAgentsEnabled()).toBe(false);
 		process.env.CLINE_CODE_CLOUD_AGENTS = "false";
 		expect(isCloudAgentsEnabled()).toBe(false);
+	});
+});
+
+describe("cloud handoff gate", () => {
+	it("is enabled by default in beta", () => {
+		expect(isCloudHandoffEnabled()).toBe(true);
+	});
+
+	it("honors the diagnostic env override", () => {
+		process.env.CLINE_CODE_CLOUD_HANDOFF = "0";
+		expect(isCloudHandoffEnabled()).toBe(false);
+		process.env.CLINE_CODE_CLOUD_HANDOFF = "1";
+		expect(isCloudHandoffEnabled()).toBe(true);
 	});
 });

--- a/apps/examples/desktop-app/sidecar/feature-flags.test.ts
+++ b/apps/examples/desktop-app/sidecar/feature-flags.test.ts
@@ -61,6 +61,7 @@ import {
 	disposeDesktopFeatureFlagsService,
 	getDesktopFeatureFlagsContext,
 	getDesktopFeatureFlagsService,
+	isCloudAgentsAvailable,
 	isCloudAgentsEnabled,
 	isDesktopInternalFeatureEnabled,
 	refreshDesktopFeatureFlags,
@@ -379,13 +380,19 @@ describe("disposeDesktopFeatureFlagsService", () => {
 	});
 });
 
-describe("isCloudAgentsEnabled", () => {
-	it("defaults to off with no setting and no override", () => {
+describe("cloud agents gate", () => {
+	it("defaults to unavailable and disabled", () => {
+		expect(isCloudAgentsAvailable()).toBe(false);
 		expect(isCloudAgentsEnabled()).toBe(false);
 	});
 
-	it("follows the user's settings opt-in toggle", () => {
+	it("requires the rollout flag and the user's opt-in", () => {
 		setCloudSessionsEnabled(true);
+		expect(isCloudAgentsEnabled()).toBe(false);
+		mocks.getBooleanFlagEnabled.mockImplementation(
+			(flag: unknown) => flag === "code-cloud-agents",
+		);
+		expect(isCloudAgentsAvailable()).toBe(true);
 		expect(isCloudAgentsEnabled()).toBe(true);
 		setCloudSessionsEnabled(false);
 		expect(isCloudAgentsEnabled()).toBe(false);
@@ -393,11 +400,13 @@ describe("isCloudAgentsEnabled", () => {
 
 	it("honors the env override in both directions", () => {
 		process.env.CLINE_CODE_CLOUD_AGENTS = "1";
+		expect(isCloudAgentsAvailable()).toBe(true);
 		expect(isCloudAgentsEnabled()).toBe(true);
 		process.env.CLINE_CODE_CLOUD_AGENTS = "true";
 		expect(isCloudAgentsEnabled()).toBe(true);
 		setCloudSessionsEnabled(true);
 		process.env.CLINE_CODE_CLOUD_AGENTS = "0";
+		expect(isCloudAgentsAvailable()).toBe(false);
 		expect(isCloudAgentsEnabled()).toBe(false);
 		process.env.CLINE_CODE_CLOUD_AGENTS = "false";
 		expect(isCloudAgentsEnabled()).toBe(false);

--- a/apps/examples/desktop-app/sidecar/feature-flags.ts
+++ b/apps/examples/desktop-app/sidecar/feature-flags.ts
@@ -22,13 +22,11 @@ import {
 	buildClinePostHogClient,
 	PostHogFeatureFlagsProvider,
 } from "@cline/core/services/feature-flags/posthog";
-import { FeatureFlag as SharedFeatureFlag } from "@cline/shared";
 import { resolveClineDataDir } from "@cline/shared/storage";
 import { readDesktopSettings } from "./desktop-settings";
 
 const DESKTOP_FEATURE_FLAGS_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const DESKTOP_ACCOUNT_CONTEXT_FILE_VERSION = 1;
-const FEATURE_FLAG_CODE_CLOUD_AGENTS = SharedFeatureFlag.CODE_CLOUD_AGENTS;
 
 let desktopFeatureFlagsContext: FeatureFlagsContext = {
 	clientName: "cline-code",
@@ -298,27 +296,39 @@ export function readCloudAgentsEnvOverride(): boolean | undefined {
 	return undefined;
 }
 
-/** The rollout flag controls whether this install can expose Cloud sessions. */
-export function isCloudAgentsAvailable(options?: {
+/** The beta always exposes the existing Cloud sessions opt-in. */
+export function isCloudAgentsAvailable(_options?: {
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
 }): boolean {
 	const override = readCloudAgentsEnvOverride();
 	if (override !== undefined) return override;
-	return getDesktopFeatureFlagsService(options).getBooleanFlagEnabled(
-		FEATURE_FLAG_CODE_CLOUD_AGENTS,
-	);
+	return true;
 }
 
-/** The rollout gate and the user's Settings opt-in must both be enabled. */
-export function isCloudAgentsEnabled(options?: {
+/** The existing Settings toggle remains the beta opt-in. */
+export function isCloudAgentsEnabled(_options?: {
 	logger?: BasicLogger;
 	telemetry?: ITelemetryService;
 }): boolean {
 	const override = readCloudAgentsEnvOverride();
 	if (override !== undefined) return override;
-	if (!isCloudAgentsAvailable(options)) return false;
 	return readDesktopSettings().cloudSessionsEnabled;
+}
+
+export function readCloudHandoffEnvOverride(): boolean | undefined {
+	const override = process.env.CLINE_CODE_CLOUD_HANDOFF?.trim().toLowerCase();
+	if (override === "1" || override === "true") return true;
+	if (override === "0" || override === "false") return false;
+	return undefined;
+}
+
+/** Handoff ships with the beta and remains gated by Cloud sessions in the UI. */
+export function isCloudHandoffEnabled(_options?: {
+	logger?: BasicLogger;
+	telemetry?: ITelemetryService;
+}): boolean {
+	return readCloudHandoffEnvOverride() ?? true;
 }
 
 export function resetDesktopFeatureFlagsForTesting(): void {

--- a/apps/examples/desktop-app/sidecar/feature-flags.ts
+++ b/apps/examples/desktop-app/sidecar/feature-flags.ts
@@ -22,11 +22,13 @@ import {
 	buildClinePostHogClient,
 	PostHogFeatureFlagsProvider,
 } from "@cline/core/services/feature-flags/posthog";
+import { FeatureFlag as SharedFeatureFlag } from "@cline/shared";
 import { resolveClineDataDir } from "@cline/shared/storage";
 import { readDesktopSettings } from "./desktop-settings";
 
 const DESKTOP_FEATURE_FLAGS_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const DESKTOP_ACCOUNT_CONTEXT_FILE_VERSION = 1;
+const FEATURE_FLAG_CODE_CLOUD_AGENTS = SharedFeatureFlag.CODE_CLOUD_AGENTS;
 
 let desktopFeatureFlagsContext: FeatureFlagsContext = {
 	clientName: "cline-code",
@@ -289,20 +291,33 @@ export async function identifyDesktopFeatureFlagsAccount(
 	}
 }
 
-/**
- * Env override first; otherwise the user's explicit opt-in from Settings.
- *
- * Cloud sessions are in preview, so the gate is a toggle the user flips in
- * Settings → General (default off) rather than a remote rollout flag.
- */
-export function isCloudAgentsEnabled(): boolean {
+export function readCloudAgentsEnvOverride(): boolean | undefined {
 	const override = process.env.CLINE_CODE_CLOUD_AGENTS?.trim().toLowerCase();
-	if (override === "1" || override === "true") {
-		return true;
-	}
-	if (override === "0" || override === "false") {
-		return false;
-	}
+	if (override === "1" || override === "true") return true;
+	if (override === "0" || override === "false") return false;
+	return undefined;
+}
+
+/** The rollout flag controls whether this install can expose Cloud sessions. */
+export function isCloudAgentsAvailable(options?: {
+	logger?: BasicLogger;
+	telemetry?: ITelemetryService;
+}): boolean {
+	const override = readCloudAgentsEnvOverride();
+	if (override !== undefined) return override;
+	return getDesktopFeatureFlagsService(options).getBooleanFlagEnabled(
+		FEATURE_FLAG_CODE_CLOUD_AGENTS,
+	);
+}
+
+/** The rollout gate and the user's Settings opt-in must both be enabled. */
+export function isCloudAgentsEnabled(options?: {
+	logger?: BasicLogger;
+	telemetry?: ITelemetryService;
+}): boolean {
+	const override = readCloudAgentsEnvOverride();
+	if (override !== undefined) return override;
+	if (!isCloudAgentsAvailable(options)) return false;
 	return readDesktopSettings().cloudSessionsEnabled;
 }
 

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -49,6 +49,8 @@ export type ChatSessionCommandRequest = {
 	attachments?: ChatTurnAttachments;
 	/** Opaque preflight result returned by prepare_handoff and revalidated by handoff. */
 	fingerprint?: JsonRecord;
+	/** Opaque webview correlation token echoed on handoff progress events. */
+	handoffAttemptId?: string;
 	/** Optional first prompt to queue after ownership moves to the cloud session. */
 	nextCommand?: string;
 };

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -71,7 +71,10 @@ import {
 	useProvisioningOutcome,
 } from "@/hooks/use-provisioning-outcome";
 import { useSessionAgents } from "@/hooks/use-session-agents";
-import { useSessionHistory } from "@/hooks/use-session-history";
+import {
+	resolveLiveHistorySession,
+	useSessionHistory,
+} from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
 import { applyAppZoomAction, syncAppFontSize } from "@/lib/app-font-size";
 import { syncAppIcon } from "@/lib/app-icon";
@@ -86,24 +89,28 @@ import {
 	parseHandoffCommand,
 	readHandoffReceipt,
 	readPendingHandoffRecovery,
-	shouldOpenHandoffInApp,
 	validateHandoffAttachments,
 } from "@/lib/cloud-handoff";
+import {
+	createHandoffLifecycle,
+	type HandoffLifecycle,
+} from "@/lib/cloud-handoff-lifecycle";
 import {
 	appendPendingHandoffPrompt,
 	type CloudHandoffUiAction,
 	type CloudHandoffUiState,
 	cloudHandoffUiReducer,
+	hasLivePendingHandoff,
 	matchingUserPromptCount,
 	type PendingHandoffPrompt,
 	pendingHandoffPromptCaughtUp,
+	resolveHandoffReceipt,
 } from "@/lib/cloud-handoff-ui-state";
 import {
 	cloudRepositoryLabel,
 	isCloudProvisioningSessionId,
 } from "@/lib/cloud-repositories";
 import {
-	humanizeCloudHandoffError,
 	humanizeCloudSessionError,
 	parseCloudSessionError,
 } from "@/lib/cloud-session-error";
@@ -320,37 +327,6 @@ export default function Home() {
 	const [handoffUiState, dispatchHandoffUi] = useReducer(
 		cloudHandoffUiReducer,
 		{},
-	);
-	useEffect(
-		() =>
-			desktopClient.subscribe("cloud_handoff_progress", (payload) => {
-				if (!payload || typeof payload !== "object") return;
-				const progress = payload as {
-					sourceSessionId?: string;
-					phase?: HandoffProgressPhase;
-					message?: string;
-					dashboardUrl?: string;
-					sessionId?: string;
-					destination?: "in_app" | "external";
-				};
-				if (
-					!progress.sourceSessionId?.trim() ||
-					!progress.phase ||
-					!(progress.phase in HANDOFF_PROGRESS_LABELS)
-				) {
-					return;
-				}
-				dispatchHandoffUi({
-					type: "progress",
-					sourceSessionId: progress.sourceSessionId,
-					phase: progress.phase,
-					message: progress.message,
-					dashboardUrl: progress.dashboardUrl,
-					sessionId: progress.sessionId,
-					destination: progress.destination,
-				});
-			}),
-		[],
 	);
 	// Starts false on both server and first client render (hydration-safe);
 	// the effect below reads the persisted state right after mount.
@@ -727,7 +703,11 @@ export default function Home() {
 	}, []);
 
 	const handleOpenSession = useCallback(
-		(session: SessionHistoryItem, initialPromptDraft?: string) => {
+		(
+			session: SessionHistoryItem,
+			initialPromptDraft?: string,
+			initialAttachments?: File[],
+		) => {
 			const environmentId =
 				session.environmentId?.trim() || LOCAL_WORKSPACE_ENVIRONMENT_ID;
 			navigationRef.current = {
@@ -740,6 +720,7 @@ export default function Home() {
 				session: { ...session, environmentId },
 				environmentId,
 				initialPromptDraft,
+				initialAttachments,
 			});
 		},
 		[],
@@ -866,6 +847,10 @@ export default function Home() {
 		onOpenSession: handleOpenSession,
 		onUpdateSessionMetadata: handleUpdateSessionMetadata,
 	});
+	const activeHistorySession = resolveLiveHistorySession(
+		activeThread?.historySession,
+		sessionHistory.sessions,
+	);
 	const sessionHistoryRef = useRef(sessionHistory.sessions);
 	useEffect(() => {
 		sessionHistoryRef.current = sessionHistory.sessions;
@@ -874,7 +859,12 @@ export default function Home() {
 		async (
 			sessionId: string,
 			environmentId?: string,
-			options: { silent?: boolean; expectedActiveThreadId?: string } = {},
+			options: {
+				silent?: boolean;
+				initialPromptDraft?: string;
+				initialAttachments?: File[];
+				expectedActiveThreadId?: string;
+			} = {},
 		): Promise<boolean> => {
 			const stillExpectedThread = () =>
 				!options.expectedActiveThreadId ||
@@ -889,7 +879,11 @@ export default function Home() {
 			);
 			if (cachedSession) {
 				if (!stillExpectedThread()) return false;
-				handleOpenSession(cachedSession);
+				handleOpenSession(
+					cachedSession,
+					options.initialPromptDraft,
+					options.initialAttachments,
+				);
 				return true;
 			}
 			try {
@@ -912,7 +906,11 @@ export default function Home() {
 					);
 				}
 				if (!stillExpectedThread()) return false;
-				handleOpenSession(session);
+				handleOpenSession(
+					session,
+					options.initialPromptDraft,
+					options.initialAttachments,
+				);
 				return true;
 			} catch (error) {
 				if (!options.silent) {
@@ -928,6 +926,67 @@ export default function Home() {
 			}
 		},
 		[handleOpenSession],
+	);
+	const openHandoffSessionRef = useRef(handleOpenSessionById);
+	openHandoffSessionRef.current = handleOpenSessionById;
+	const handoffLifecycleRef = useRef<HandoffLifecycle | null>(null);
+	if (handoffLifecycleRef.current === null) {
+		handoffLifecycleRef.current = createHandoffLifecycle({
+			dispatch: dispatchHandoffUi,
+			toast: ({ connectUrl, ...toastFields }) =>
+				toast({
+					...toastFields,
+					action: connectUrl ? (
+						<ToastAction
+							altText="Connect GitHub"
+							onClick={() => void openExternalUrl(connectUrl)}
+						>
+							Connect GitHub
+						</ToastAction>
+					) : undefined,
+				}),
+			openSession: (sessionId, options) =>
+				openHandoffSessionRef.current(sessionId, undefined, options),
+			openExternal: openExternalUrl,
+		});
+	}
+	const handoffLifecycle = handoffLifecycleRef.current;
+	useEffect(
+		() =>
+			desktopClient.subscribe("cloud_handoff_progress", (payload) => {
+				if (!payload || typeof payload !== "object") return;
+				const progress = payload as {
+					sourceSessionId?: string;
+					handoffAttemptId?: string;
+					phase?: HandoffProgressPhase;
+					message?: string;
+					dashboardUrl?: string;
+					sessionId?: string;
+					destination?: "in_app" | "external";
+					warning?: string;
+					warningKind?: "unqueued" | "unconfirmed";
+					undeliveredCommand?: string;
+				};
+				if (
+					!progress.sourceSessionId?.trim() ||
+					!progress.phase ||
+					!(progress.phase in HANDOFF_PROGRESS_LABELS)
+				)
+					return;
+				void handoffLifecycle.onEvent({
+					sourceSessionId: progress.sourceSessionId,
+					handoffAttemptId: progress.handoffAttemptId,
+					phase: progress.phase,
+					message: progress.message,
+					dashboardUrl: progress.dashboardUrl,
+					sessionId: progress.sessionId,
+					destination: progress.destination,
+					warning: progress.warning,
+					warningKind: progress.warningKind,
+					undeliveredCommand: progress.undeliveredCommand,
+				});
+			}),
+		[handoffLifecycle],
 	);
 	useEffect(
 		() =>
@@ -1089,16 +1148,18 @@ export default function Home() {
 											environmentProfilesLoading={
 												remoteEnvironmentProfilesLoading
 											}
-											historySession={activeThread.historySession}
+											historySession={activeHistorySession}
 											handoffUiState={handoffUiState}
 											onHandoffUiAction={dispatchHandoffUi}
+											handoffLifecycle={handoffLifecycle}
 											liveHistoryStatus={
 												sessionHistory.sessions.find(
 													(session) =>
 														session.sessionId ===
 														activeThread.historySession?.sessionId,
-												)?.status ?? activeThread.historySession?.status
+												)?.status ?? activeHistorySession?.status
 											}
+											initialAttachments={activeThread.initialAttachments}
 											initialPromptDraft={activeThread.initialPromptDraft}
 											knownWorkspacePaths={historyWorkspacePaths}
 											onInitialPromptDraftConsumed={
@@ -1207,7 +1268,9 @@ function ChatThreadPane({
 	environmentProfilesLoading,
 	historySession,
 	liveHistoryStatus,
+	initialAttachments,
 	initialPromptDraft,
+	handoffLifecycle,
 	knownWorkspacePaths,
 	onInitialPromptDraftConsumed,
 	onUpdateSessionMetadata,
@@ -1238,7 +1301,12 @@ function ChatThreadPane({
 	historySession?: SessionHistoryItem;
 	/** Current status from the live list; the history snapshot may be stale. */
 	liveHistoryStatus?: SessionHistoryItem["status"];
+	initialAttachments?: File[];
 	initialPromptDraft?: string;
+	handoffLifecycle: Pick<
+		HandoffLifecycle,
+		"onRpcStarted" | "onRpcResolved" | "onRpcRejected"
+	>;
 	knownWorkspacePaths: string[];
 	onInitialPromptDraftConsumed?: (threadId: string) => void;
 	onUpdateSessionMetadata?: (
@@ -1251,11 +1319,17 @@ function ChatThreadPane({
 	onOpenSession?: (
 		session: SessionHistoryItem,
 		initialPromptDraft?: string,
+		initialAttachments?: File[],
 	) => void;
 	onOpenSessionById?: (
 		sessionId: string,
 		environmentId?: string,
-		options?: { silent?: boolean; expectedActiveThreadId?: string },
+		options?: {
+			silent?: boolean;
+			initialPromptDraft?: string;
+			initialAttachments?: File[];
+			expectedActiveThreadId?: string;
+		},
 	) => boolean | Promise<boolean>;
 	onPickRemoteWorkspaceDirectory: (
 		environment: RemoteWorkspaceEnvironment,
@@ -1330,6 +1404,8 @@ function ChatThreadPane({
 	const [gitBranch, setGitBranch] = useState<string | null>(null);
 	// Re-evaluate the account-targeted flag after sign-in changes.
 	const [cloudAgentsEnabled, setCloudAgentsEnabled] = useState(false);
+	const [cloudHandoffEnabled, setCloudHandoffEnabled] = useState(false);
+	const cloudHandoffAvailable = cloudAgentsEnabled && cloudHandoffEnabled;
 	const handoffStartingRef = useRef(false);
 	const sourceSessionId = sessionId ?? historySession?.sessionId;
 	const handoffUi = sourceSessionId
@@ -1339,6 +1415,14 @@ function ChatThreadPane({
 	const pendingHandoffRecovery = readPendingHandoffRecovery(
 		historySession?.metadata,
 	);
+	const handoffRetryEligible =
+		Boolean(pendingHandoffRecovery) ||
+		handoffUi?.status === "recovery" ||
+		handoffUi?.status === "recovery_dismissed" ||
+		handoffUi?.status === "failed" ||
+		handoffUi?.status === "retry_restored";
+	const handoffOwnershipPending =
+		Boolean(pendingHandoffRecovery) || hasLivePendingHandoff(handoffUi);
 	const dismissedHandoffRecoveryUrl =
 		handoffUi?.status === "recovery_dismissed" ? handoffUi.dashboardUrl : null;
 	const handoffRecoveryUrl =
@@ -1348,16 +1432,20 @@ function ChatThreadPane({
 			: null) ??
 		null;
 	const handoffRetry =
-		(handoffUi?.status === "recovery" || handoffUi?.status === "failed") &&
+		(handoffUi?.status === "recovery" ||
+			handoffUi?.status === "recovery_dismissed" ||
+			handoffUi?.status === "failed" ||
+			handoffUi?.status === "retry_restored") &&
 		(handoffUi.retryDraft || handoffUi.retryAttachments?.length)
 			? {
 					draft: handoffUi.retryDraft,
 					attachments: handoffUi.retryAttachments,
 				}
 			: null;
-	const handoffReceipt =
-		(handoffUi?.status === "complete" ? handoffUi.receipt : null) ??
-		readHandoffReceipt(historySession?.metadata);
+	const handoffReceipt = resolveHandoffReceipt(
+		handoffUi,
+		readHandoffReceipt(historySession?.metadata),
+	);
 	const handoffExternalPresentation =
 		handoffUi?.status === "complete" && handoffUi.externalPresentation;
 	const { user: accountUser, activeOrganization } = useAccount();
@@ -1382,8 +1470,12 @@ function ChatThreadPane({
 				.invoke("get_feature_flags", {})
 				.then((flags) => {
 					if (!cancelled) {
-						const featureFlags = flags as { cloudAgents?: boolean };
+						const featureFlags = flags as {
+							cloudAgents?: boolean;
+							cloudHandoff?: boolean;
+						};
 						setCloudAgentsEnabled(Boolean(featureFlags.cloudAgents));
+						setCloudHandoffEnabled(Boolean(featureFlags.cloudHandoff));
 					}
 				})
 				.catch(() => {
@@ -1400,8 +1492,12 @@ function ChatThreadPane({
 			"feature_flags_changed",
 			(payload) => {
 				if (!cancelled) {
-					const featureFlags = payload as { cloudAgents?: boolean };
+					const featureFlags = payload as {
+						cloudAgents?: boolean;
+						cloudHandoff?: boolean;
+					};
 					setCloudAgentsEnabled(Boolean(featureFlags.cloudAgents));
+					setCloudHandoffEnabled(Boolean(featureFlags.cloudHandoff));
 				}
 			},
 		);
@@ -1928,20 +2024,27 @@ function ChatThreadPane({
 		if (!historySession) {
 			return;
 		}
+		const hasInitialComposerState =
+			initialPromptDraft !== undefined || initialAttachments !== undefined;
+		if (hasInitialComposerState) {
+			setPromptInput(initialPromptDraft ?? "");
+			setPendingAttachments(initialAttachments ? [...initialAttachments] : []);
+			onInitialPromptDraftConsumed?.(threadId);
+		}
 		if (hydratedSessionRef.current === historySession.sessionId) {
 			return;
 		}
 		hydratedSessionRef.current = historySession.sessionId;
-		setPromptInput(initialPromptDraft ?? "");
-		if (initialPromptDraft !== undefined) {
-			onInitialPromptDraftConsumed?.(threadId);
+		if (!hasInitialComposerState) {
+			setPromptInput("");
+			setPendingAttachments([]);
 		}
-		setPendingAttachments([]);
 		setManualTitle(getSessionMetadataTitle(historySession.metadata));
 		void hydrateSession(historySession);
 	}, [
 		historySession,
 		hydrateSession,
+		initialAttachments,
 		initialPromptDraft,
 		onInitialPromptDraftConsumed,
 		setPromptInput,
@@ -1951,17 +2054,47 @@ function ChatThreadPane({
 	// Hydrate first, then restore a failed handoff's draft and attachments. If
 	// this ran above the hydration effect, hydration would immediately wipe the
 	// only retained retry payload after navigation back to the source session.
+	const restoredHandoffRetryRef = useRef<{
+		sourceSessionId: string;
+		draft?: string;
+		attachments?: File[];
+	} | null>(null);
 	useEffect(() => {
-		if (!sourceSessionId || !handoffRetry) return;
+		if (!sourceSessionId || !handoffRetry) {
+			restoredHandoffRetryRef.current = null;
+			return;
+		}
+		const restored = restoredHandoffRetryRef.current;
+		if (
+			restored?.sourceSessionId === sourceSessionId &&
+			restored.draft === handoffRetry.draft &&
+			restored.attachments === handoffRetry.attachments
+		)
+			return;
+		restoredHandoffRetryRef.current = {
+			sourceSessionId,
+			draft: handoffRetry.draft,
+			attachments: handoffRetry.attachments,
+		};
 		if (handoffRetry.draft) setPromptInput(handoffRetry.draft);
 		if (handoffRetry.attachments?.length) {
 			setPendingAttachments([...handoffRetry.attachments]);
 		}
-		onHandoffUiAction({
-			type: "retry_restored",
-			sourceSessionId,
-		});
-	}, [handoffRetry, onHandoffUiAction, setPromptInput, sourceSessionId]);
+		if (handoffUi?.status !== "retry_restored") {
+			onHandoffUiAction({ type: "retry_restored", sourceSessionId });
+		}
+	}, [
+		handoffRetry,
+		handoffUi?.status,
+		onHandoffUiAction,
+		setPromptInput,
+		sourceSessionId,
+	]);
+
+	const handoffUiRef = useRef(handoffUi);
+	useEffect(() => {
+		handoffUiRef.current = handoffUi;
+	}, [handoffUi]);
 
 	const runHandoff = useCallback(
 		async (
@@ -1970,6 +2103,7 @@ function ChatThreadPane({
 			sourceAttachments: File[],
 			attachments: SerializedAttachments,
 			sourceSessionId: string,
+			handoffAttemptId: string,
 			pendingPrompt?: PendingHandoffPrompt,
 		) => {
 			onHandoffUiAction({
@@ -1986,6 +2120,7 @@ function ChatThreadPane({
 							sessionId: sourceSessionId,
 							config,
 							fingerprint: preflight.fingerprint,
+							handoffAttemptId,
 							nextCommand: nextCommand || undefined,
 							attachments:
 								attachments.userImages.length > 0 ? attachments : undefined,
@@ -1993,102 +2128,29 @@ function ChatThreadPane({
 					},
 					{ timeoutMs: HANDOFF_INVOKE_TIMEOUT_MS },
 				);
-				const targetSessionId = (
-					result.outerSessionId ||
-					result.sessionId ||
-					""
-				).trim();
-				const dashboardUrl = result.dashboardUrl?.trim();
-				if (!targetSessionId || !dashboardUrl) {
-					throw new Error("Cloud handoff did not return a cloud session.");
-				}
-				const receipt = { targetSessionId, dashboardUrl };
-				const destination = result.destination ?? "in_app";
-				onHandoffUiAction({
-					type: "complete",
-					sourceSessionId,
-					receipt,
-					externalPresentation: destination === "external",
+				await handoffLifecycle.onRpcResolved(sourceSessionId, {
+					handoffAttemptId,
+					result,
+					nextCommand,
+					sourceAttachments,
 					pendingPrompt,
+					isThreadActive,
 				});
-				if (result.warning) {
-					onHandoffUiAction({
-						type: "prompt_reconciled",
-						sourceSessionId: targetSessionId,
-					});
-				}
-				if (shouldOpenHandoffInApp(destination, isThreadActive?.() ?? true)) {
-					const opened = await Promise.resolve(
-						onOpenSessionById?.(targetSessionId, undefined, { silent: true }),
-					).catch(() => false);
-					if (!opened) {
-						onHandoffUiAction({ type: "external", sourceSessionId });
-						try {
-							await openExternalUrl(dashboardUrl);
-							toast({
-								title: "Opened handoff in your browser",
-								description:
-									"The cloud session could not be attached inside Cline.",
-							});
-						} catch {
-							toast({
-								title: "Unable to open the browser",
-								description:
-									"Use the recovery link to open the cloud session manually.",
-								variant: "destructive",
-							});
-						}
-					}
-				} else if (destination === "external") {
-					await openExternalUrl(dashboardUrl).catch(() =>
-						toast({
-							title: "Cloud handoff complete",
-							description: "Use the recovery link to open the cloud session.",
-						}),
-					);
-				} else {
-					toast({
-						title: "Cloud handoff complete",
-						description: "The cloud session is ready in your session list.",
-					});
-				}
-				if (result.warning) {
-					toast({
-						title: "Handoff completed with a warning",
-						description: result.warning,
-					});
-				}
 			} catch (error) {
-				onHandoffUiAction({
-					type: "failed",
-					sourceSessionId,
-					exposeRecovery: true,
-					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
-					retryAttachments: sourceAttachments,
-				});
-				const rawError = error instanceof Error ? error.message : String(error);
-				const cloudError = parseCloudSessionError(rawError);
-				const connectUrl = cloudError?.connectUrl;
-				toast({
-					title: "Handoff failed",
-					description: humanizeCloudHandoffError(
-						cloudError?.message ?? rawError,
-					),
-					variant: "destructive",
-					action: connectUrl ? (
-						<ToastAction
-							altText="Connect GitHub"
-							onClick={() => void openExternalUrl(connectUrl)}
-						>
-							Connect GitHub
-						</ToastAction>
-					) : undefined,
+				const reducerEntry = handoffUiRef.current;
+				await handoffLifecycle.onRpcRejected(sourceSessionId, {
+					handoffAttemptId,
+					error,
+					nextCommand,
+					sourceAttachments,
+					reducerEntryIsComplete:
+						reducerEntry?.status === "complete" ? reducerEntry : undefined,
+					isThreadActive,
 				});
 			}
 		},
-		[config, isThreadActive, onOpenSessionById, onHandoffUiAction],
+		[config, handoffLifecycle, isThreadActive, onHandoffUiAction],
 	);
-
 	const prepareHandoff = useCallback(
 		async (nextCommand: string) => {
 			const sourceSessionId = sessionId ?? historySession?.sessionId;
@@ -2100,12 +2162,13 @@ function ChatThreadPane({
 				});
 				return;
 			}
-			if (!cloudAgentsEnabled) {
+			if (!cloudHandoffAvailable && !handoffRetryEligible) {
 				setPromptInput(nextCommand ? `/handoff ${nextCommand}` : "/handoff");
 				toast({
 					title: "Cloud handoff is not available",
-					description:
-						"Enable Cloud sessions in Settings before using /handoff.",
+					description: cloudAgentsEnabled
+						? "Cloud handoff is not enabled for this account yet."
+						: "Enable Cloud sessions in Settings before using /handoff.",
 				});
 				return;
 			}
@@ -2154,6 +2217,7 @@ function ChatThreadPane({
 			}
 			handoffStartingRef.current = true;
 			const sourceAttachments = [...pendingAttachments];
+			const handoffAttemptId = handoffLifecycle.onRpcStarted(sourceSessionId);
 			const submittedAt = Date.now();
 			setPendingAttachments([]);
 			try {
@@ -2205,33 +2269,19 @@ function ChatThreadPane({
 					sourceAttachments,
 					attachments,
 					sourceSessionId,
+					handoffAttemptId,
 					pendingPrompt,
 				);
 			} catch (error) {
-				onHandoffUiAction({
-					type: "failed",
-					sourceSessionId,
-					exposeRecovery: true,
-					retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
-					retryAttachments: sourceAttachments,
-				});
-				const rawError = error instanceof Error ? error.message : String(error);
-				const cloudError = parseCloudSessionError(rawError);
-				const connectUrl = cloudError?.connectUrl;
-				toast({
-					title: "Handoff is not ready",
-					description: humanizeCloudHandoffError(
-						cloudError?.message ?? rawError,
-					),
-					variant: "destructive",
-					action: connectUrl ? (
-						<ToastAction
-							altText="Connect GitHub"
-							onClick={() => void openExternalUrl(connectUrl)}
-						>
-							Connect GitHub
-						</ToastAction>
-					) : undefined,
+				const reducerEntry = handoffUiRef.current;
+				await handoffLifecycle.onRpcRejected(sourceSessionId, {
+					handoffAttemptId,
+					error,
+					nextCommand,
+					sourceAttachments,
+					reducerEntryIsComplete:
+						reducerEntry?.status === "complete" ? reducerEntry : undefined,
+					isThreadActive,
 				});
 			} finally {
 				handoffStartingRef.current = false;
@@ -2239,7 +2289,10 @@ function ChatThreadPane({
 		},
 		[
 			cloudAgentsEnabled,
+			cloudHandoffAvailable,
 			config,
+			handoffLifecycle,
+			handoffRetryEligible,
 			historySession?.sessionId,
 			isCloudSession,
 			messages,
@@ -2247,6 +2300,7 @@ function ChatThreadPane({
 			pendingHandoffRecovery,
 			promptsInQueue.length,
 			runHandoff,
+			isThreadActive,
 			sessionId,
 			setPromptInput,
 			status,
@@ -2258,8 +2312,17 @@ function ChatThreadPane({
 		async (prompt: string) => {
 			const trimmed = prompt.trim();
 			const handoff = parseHandoffCommand(trimmed);
-			if (handoff) {
+			if (handoff && (cloudHandoffAvailable || handoffRetryEligible)) {
 				await prepareHandoff(handoff.nextCommand);
+				return;
+			}
+			if (!handoff && handoffOwnershipPending) {
+				setPromptInput(prompt);
+				toast({
+					title: "Cloud handoff is still pending",
+					description:
+						"Retry /handoff or use the recovery link before sending another prompt.",
+				});
 				return;
 			}
 			if (!trimmed && pendingAttachments.length === 0) {
@@ -2287,6 +2350,9 @@ function ChatThreadPane({
 			sessionId,
 			setPromptInput,
 			threadId,
+			cloudHandoffAvailable,
+			handoffRetryEligible,
+			handoffOwnershipPending,
 		],
 	);
 	const handleRealtimeSend = useCallback(
@@ -2432,7 +2498,7 @@ function ChatThreadPane({
 		? null
 		: (sessionId ?? visibleHistorySession?.sessionId ?? null);
 	const handoffDeleteLocked = Boolean(
-		handoffProgress || pendingHandoffRecovery,
+		handoffProgress || handoffOwnershipPending,
 	);
 
 	const requestDeleteSession = useCallback(() => {
@@ -2659,12 +2725,23 @@ function ChatThreadPane({
 			return;
 		}
 		if (cloudAgentsEnabled) {
+			const retryDraft =
+				handoffUi?.status === "complete" ? handoffUi.retryDraft : undefined;
+			const retryAttachments =
+				handoffUi?.status === "complete"
+					? handoffUi.retryAttachments
+					: undefined;
 			const opened = await Promise.resolve(
 				onOpenSessionById?.(receipt.targetSessionId, undefined, {
 					silent: true,
+					initialPromptDraft: retryDraft,
+					initialAttachments: retryAttachments,
 				}),
 			).catch(() => false);
 			if (opened) {
+				if (sourceSessionId && (retryDraft || retryAttachments?.length)) {
+					onHandoffUiAction({ type: "retry_delivered", sourceSessionId });
+				}
 				return;
 			}
 			if (sourceSessionId) {
@@ -2681,6 +2758,7 @@ function ChatThreadPane({
 	}, [
 		cloudAgentsEnabled,
 		handoffReceipt,
+		handoffUi,
 		onHandoffUiAction,
 		onOpenSessionById,
 		sourceSessionId,
@@ -2902,7 +2980,7 @@ function ChatThreadPane({
 	const chatComposer = (
 		<ChatInputBar
 			attachments={attachmentList}
-			cloudHandoffAvailable={cloudAgentsEnabled}
+			cloudHandoffAvailable={cloudHandoffAvailable || handoffRetryEligible}
 			hasRunningAgents={agentActivity.running > 0}
 			onAbort={handleAbort}
 			onAttachFiles={handleAttachFiles}

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -2217,7 +2217,10 @@ function ChatThreadPane({
 			}
 			handoffStartingRef.current = true;
 			const sourceAttachments = [...pendingAttachments];
-			const handoffAttemptId = handoffLifecycle.onRpcStarted(sourceSessionId);
+			const handoffAttemptId = handoffLifecycle.onRpcStarted(
+				sourceSessionId,
+				threadId,
+			);
 			const submittedAt = Date.now();
 			setPendingAttachments([]);
 			try {
@@ -2305,6 +2308,7 @@ function ChatThreadPane({
 			setPromptInput,
 			status,
 			onHandoffUiAction,
+			threadId,
 		],
 	);
 

--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -66,7 +66,10 @@ import type {
 } from "@/hooks/chat-session/types";
 import { useAppUpdate } from "@/hooks/use-app-update";
 import { useChatSession } from "@/hooks/use-chat-session";
-import { useProvisioningOutcome } from "@/hooks/use-provisioning-outcome";
+import {
+	type CloudProvisioningPhase,
+	useProvisioningOutcome,
+} from "@/hooks/use-provisioning-outcome";
 import { useSessionAgents } from "@/hooks/use-session-agents";
 import { useSessionHistory } from "@/hooks/use-session-history";
 import { toast } from "@/hooks/use-toast";
@@ -217,37 +220,64 @@ const GIT_BRANCH_REFRESH_INTERVAL_MS = 5_000;
 
 type AppLocation = DesktopAppLocation<SettingsSection>;
 
-const PROVISIONING_PHASE_INTERVAL_MS = 4_500;
 // create() can spend one 610s window on the original POST and another on
 // timeout recovery. Leave room for auth, Hub attach, seeding, and verification
 // without waiting forever for a lost transport response.
 const HANDOFF_INVOKE_TIMEOUT_MS = 25 * 60_000;
+const LONG_PROVISIONING_THRESHOLD_MS = 60_000;
+
+function readCloudProvisioningPhase(
+	value: unknown,
+): CloudProvisioningPhase | undefined {
+	return value === "provisioning" ||
+		value === "cloning_repo" ||
+		value === "agent_starting" ||
+		value === "ready" ||
+		value === "failed"
+		? value
+		: undefined;
+}
 
 /** Shared provisioning status for the originating thread and placeholder. */
-function useCloudProvisioningPhase(repoUrl?: string): string {
+function useCloudProvisioningPhase(
+	repoUrl: string | undefined,
+	active: boolean,
+	phase: CloudProvisioningPhase | undefined,
+	startedAt: string | undefined,
+): string {
 	const repoLabel = cloudRepositoryLabel(repoUrl ?? "");
-	const phases = useMemo(
-		() => [
-			"Spinning up a fresh sandbox",
-			repoLabel ? `Cloning ${repoLabel}` : "Cloning your repository",
-			"Waking up the agent",
-			"Getting everything ready",
-		],
-		[repoLabel],
-	);
-	const [phaseIndex, setPhaseIndex] = useState(0);
-	// Hold the final phase so provisioning does not appear to restart. The
-	// interval stops via this guard instead of inside the state updater,
-	// which must stay pure (StrictMode double-invokes it).
-	const lastPhase = phaseIndex >= phases.length - 1;
+	const [longRunning, setLongRunning] = useState(false);
 	useEffect(() => {
-		if (lastPhase) return;
-		const interval = window.setInterval(() => {
-			setPhaseIndex((current) => Math.min(current + 1, phases.length - 1));
-		}, PROVISIONING_PHASE_INTERVAL_MS);
-		return () => window.clearInterval(interval);
-	}, [lastPhase, phases.length]);
-	return `${phases[phaseIndex]}...`;
+		if (!active) {
+			setLongRunning(false);
+			return;
+		}
+		const parsedStartedAt = Date.parse(startedAt ?? "");
+		const elapsed = Number.isFinite(parsedStartedAt)
+			? Math.max(0, Date.now() - parsedStartedAt)
+			: 0;
+		if (elapsed >= LONG_PROVISIONING_THRESHOLD_MS) {
+			setLongRunning(true);
+			return;
+		}
+		setLongRunning(false);
+		const timeout = window.setTimeout(
+			() => setLongRunning(true),
+			LONG_PROVISIONING_THRESHOLD_MS - elapsed,
+		);
+		return () => window.clearTimeout(timeout);
+	}, [active, startedAt]);
+	const label =
+		phase === "cloning_repo"
+			? repoLabel
+				? `Cloning ${repoLabel}`
+				: "Cloning your repository"
+			: phase === "agent_starting"
+				? "Starting the agent"
+				: "Starting your workspace";
+	return longRunning
+		? `${label}... This may take several minutes.`
+		: `${label}...`;
 }
 
 /** Matches the compact loading row shown inside a starting chat. */
@@ -359,6 +389,10 @@ export default function Home() {
 	const activeRealtimeBridgeRef = useRef<RealtimeChatBridge | null>(null);
 	const { navigation, threads } = appState;
 	const { activeThreadId, settingsSection, view } = navigation.current;
+	const navigationRef = useRef(navigation.current);
+	navigationRef.current = navigation.current;
+	const threadsRef = useRef(threads);
+	threadsRef.current = threads;
 	const activeEnvironmentId =
 		activeRemoteEnvironment?.id ?? LOCAL_WORKSPACE_ENVIRONMENT_ID;
 
@@ -419,6 +453,7 @@ export default function Home() {
 	}, []);
 
 	const navigate = useCallback((destination: AppLocation) => {
+		navigationRef.current = destination;
 		dispatchApp({ type: "navigate", destination });
 	}, []);
 	const navigateWith = useCallback(
@@ -428,11 +463,15 @@ export default function Home() {
 		[navigate, navigation.current],
 	);
 	const handleNavigateBack = useCallback(() => {
+		const destination = navigation.back.at(-1);
+		if (destination) navigationRef.current = destination;
 		dispatchApp({ type: "back" });
-	}, []);
+	}, [navigation.back]);
 	const handleNavigateForward = useCallback(() => {
+		const destination = navigation.forward[0];
+		if (destination) navigationRef.current = destination;
 		dispatchApp({ type: "forward" });
-	}, []);
+	}, [navigation.forward]);
 
 	useAppUpdate();
 
@@ -519,9 +558,15 @@ export default function Home() {
 	useEffect(() => watchDesktopNotifications(), []);
 
 	const createThreadForEnvironment = useCallback((environmentId: string) => {
+		const threadId = makeThreadId();
+		navigationRef.current = {
+			...navigationRef.current,
+			activeThreadId: threadId,
+			view: "chat",
+		};
 		dispatchApp({
 			type: "new-thread",
-			threadId: makeThreadId(),
+			threadId,
 			environmentId,
 		});
 		requestPromptInputFocus();
@@ -530,10 +575,16 @@ export default function Home() {
 		createThreadForEnvironment(activeEnvironmentId);
 	}, [activeEnvironmentId, createThreadForEnvironment]);
 	const selectEnvironmentDraft = useCallback((environmentId: string) => {
+		const threadId = makeThreadId();
+		navigationRef.current = {
+			...navigationRef.current,
+			activeThreadId: threadId,
+			view: "chat",
+		};
 		dispatchApp({
 			type: "select-environment-draft",
 			environmentId,
-			threadId: makeThreadId(),
+			threadId,
 		});
 	}, []);
 	const handleSelectEnvironment = useCallback(
@@ -679,6 +730,11 @@ export default function Home() {
 		(session: SessionHistoryItem, initialPromptDraft?: string) => {
 			const environmentId =
 				session.environmentId?.trim() || LOCAL_WORKSPACE_ENVIRONMENT_ID;
+			navigationRef.current = {
+				...navigationRef.current,
+				activeThreadId: `session_${session.sessionId}`,
+				view: "chat",
+			};
 			dispatchApp({
 				type: "open-session",
 				session: { ...session, environmentId },
@@ -691,11 +747,22 @@ export default function Home() {
 
 	const handleDeleteSession = useCallback(
 		(deletedSessionId: string, deletedThreadId?: string) => {
+			const fallbackThreadId = makeThreadId();
+			if (
+				navigationRef.current.activeThreadId === deletedThreadId ||
+				navigationRef.current.activeThreadId === `session_${deletedSessionId}`
+			) {
+				navigationRef.current = {
+					...navigationRef.current,
+					activeThreadId: fallbackThreadId,
+					view: "chat",
+				};
+			}
 			dispatchApp({
 				type: "delete-session",
 				deletedSessionId,
 				deletedThreadId,
-				fallbackThreadId: makeThreadId(),
+				fallbackThreadId,
 				fallbackEnvironmentId: activeEnvironmentId,
 			});
 		},
@@ -807,8 +874,13 @@ export default function Home() {
 		async (
 			sessionId: string,
 			environmentId?: string,
-			options: { silent?: boolean } = {},
+			options: { silent?: boolean; expectedActiveThreadId?: string } = {},
 		): Promise<boolean> => {
+			const stillExpectedThread = () =>
+				!options.expectedActiveThreadId ||
+				(navigationRef.current.view === "chat" &&
+					navigationRef.current.activeThreadId ===
+						options.expectedActiveThreadId);
 			const cachedSession = sessionHistoryRef.current.find(
 				(session) =>
 					session.sessionId === sessionId &&
@@ -816,6 +888,7 @@ export default function Home() {
 						session.environmentId === environmentId),
 			);
 			if (cachedSession) {
+				if (!stillExpectedThread()) return false;
 				handleOpenSession(cachedSession);
 				return true;
 			}
@@ -838,6 +911,7 @@ export default function Home() {
 						`The session belongs to environment ${session.environmentId}, not ${environmentId}.`,
 					);
 				}
+				if (!stillExpectedThread()) return false;
 				handleOpenSession(session);
 				return true;
 			} catch (error) {
@@ -891,19 +965,33 @@ export default function Home() {
 			if (!placeholderId?.trim() || !sessionId?.trim()) {
 				return;
 			}
-			const placeholderThread = threads.find(
+			const placeholderThread = threadsRef.current.find(
 				(thread) => thread.historySession?.sessionId === placeholderId,
 			);
 			if (!placeholderThread) {
 				return;
 			}
-			// The mounted chat pane owns active-placeholder recovery, including
-			// retries. Background placeholders need only be removed.
-			if (placeholderThread.id !== activeThreadId) {
-				handleDeleteSession(placeholderId, placeholderThread.id);
+			if (
+				navigationRef.current.view === "chat" &&
+				placeholderThread.id === navigationRef.current.activeThreadId
+			) {
+				void handleOpenSessionById(sessionId, undefined, {
+					silent: true,
+					expectedActiveThreadId: placeholderThread.id,
+				}).then((opened) => {
+					if (
+						opened ||
+						navigationRef.current.view !== "chat" ||
+						navigationRef.current.activeThreadId !== placeholderThread.id
+					) {
+						handleDeleteSession(placeholderId, placeholderThread.id);
+					}
+				});
+				return;
 			}
+			handleDeleteSession(placeholderId, placeholderThread.id);
 		});
-	}, [threads, activeThreadId, handleDeleteSession]);
+	}, [handleDeleteSession, handleOpenSessionById]);
 
 	const historyWorkspacePaths = useMemo(
 		() =>
@@ -1167,7 +1255,7 @@ function ChatThreadPane({
 	onOpenSessionById?: (
 		sessionId: string,
 		environmentId?: string,
-		options?: { silent?: boolean },
+		options?: { silent?: boolean; expectedActiveThreadId?: string },
 	) => boolean | Promise<boolean>;
 	onPickRemoteWorkspaceDirectory: (
 		environment: RemoteWorkspaceEnvironment,
@@ -1373,6 +1461,8 @@ function ChatThreadPane({
 	const [provisioningError, setProvisioningError] = useState<string | null>(
 		null,
 	);
+	const [liveProvisioningPhase, setLiveProvisioningPhase] =
+		useState<CloudProvisioningPhase>();
 	const provisioningPlaceholderId =
 		historySession?.sessionId &&
 		isCloudProvisioningSessionId(historySession.sessionId)
@@ -1381,13 +1471,17 @@ function ChatThreadPane({
 	useEffect(() => {
 		void provisioningPlaceholderId;
 		setProvisioningError(null);
+		setLiveProvisioningPhase(undefined);
 	}, [provisioningPlaceholderId]);
 	const handleProvisioningReady = useCallback(
 		async (sessionId: string) =>
 			Boolean(
-				await onOpenSessionById?.(sessionId, undefined, { silent: true }),
+				await onOpenSessionById?.(sessionId, undefined, {
+					silent: true,
+					expectedActiveThreadId: threadId,
+				}),
 			),
-		[onOpenSessionById],
+		[onOpenSessionById, threadId],
 	);
 	const handleProvisioningResolved = useCallback(() => {
 		if (provisioningPlaceholderId) {
@@ -1399,6 +1493,7 @@ function ChatThreadPane({
 		onOpenReady: handleProvisioningReady,
 		onResolved: handleProvisioningResolved,
 		onError: setProvisioningError,
+		onPhase: setLiveProvisioningPhase,
 	});
 	// The placeholder id covers list-refresh lag before live status arrives.
 	const isProvisioningCloudSession =
@@ -1410,6 +1505,10 @@ function ChatThreadPane({
 			));
 	const provisioningPhase = useCloudProvisioningPhase(
 		config.repoUrl || historySession?.repoUrl,
+		isProvisioningCloudSession || (isCloudSession && status === "starting"),
+		liveProvisioningPhase ??
+			readCloudProvisioningPhase(historySession?.metadata?.provisioningPhase),
+		historySession?.startedAt,
 	);
 	const activeWorkspaceCwd = isCloudSession
 		? ""

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -406,7 +406,11 @@ describe("ChatInputBar", () => {
 
 	it("blocks a new cloud message until a GitHub repository is selected", async () => {
 		const onSend = vi.fn();
-		const render = async (repoUrl?: string) => {
+		const render = async (
+			repoUrl?: string,
+			prompt = "Continue in cloud",
+			attachments: Array<{ id: string; name: string; isImage: boolean }> = [],
+		) => {
 			await act(async () => {
 				root.render(
 					<WorkspaceProvider
@@ -421,7 +425,7 @@ describe("ChatInputBar", () => {
 						}}
 					>
 						<ChatInputBar
-							attachments={[]}
+							attachments={attachments}
 							executionTarget="cloud"
 							gitBranch="no-git"
 							hasActiveSession={false}
@@ -444,7 +448,7 @@ describe("ChatInputBar", () => {
 							onSend={onSend}
 							onSteerPromptInQueue={vi.fn()}
 							onSwitchGitBranch={vi.fn(async () => false)}
-							promptDraft={{ version: 0, value: "Continue in cloud" }}
+							promptDraft={{ version: 0, value: prompt }}
 							promptsInQueue={[]}
 							provider="cline"
 							reasoningEffort="low"
@@ -481,6 +485,17 @@ describe("ChatInputBar", () => {
 		expect(sendButton?.disabled).toBe(false);
 		await act(async () => sendButton?.click());
 		expect(onSend).toHaveBeenCalledWith("Continue in cloud");
+
+		onSend.mockClear();
+		await render("https://github.com/cline/cline", "", [
+			{ id: "image-1", name: "image.png", isImage: true },
+		]);
+		const imageOnlySendButton = container.querySelector<HTMLButtonElement>(
+			'[aria-label="Send message"]',
+		);
+		expect(imageOnlySendButton?.disabled).toBe(false);
+		await act(async () => imageOnlySendButton?.click());
+		expect(onSend).toHaveBeenCalledWith("");
 	});
 
 	it("top-aligns the textarea in the taller welcome composer", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -534,11 +534,7 @@ function ChatInputBarImpl({
 	const needsCloudRepository =
 		executionTarget === "cloud" && !hasActiveSession && !repoUrl?.trim();
 	const cloudSettingsLocked = executionTarget === "cloud" && hasActiveSession;
-	const canSend =
-		hasDraft &&
-		!speechInputActive &&
-		!needsCloudRepository &&
-		(executionTarget !== "cloud" || promptInput.trim().length > 0);
+	const canSend = hasDraft && !speechInputActive && !needsCloudRepository;
 	const cloudContextLabel = useMemo(
 		() =>
 			[cloudRepositoryLabel(repoUrl ?? "", "Cloud"), cloudBranch?.trim()]

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.test.tsx
@@ -9,11 +9,16 @@ import {
 	CloudHandoffRecoveryNotice,
 } from "./cloud-handoff";
 
+const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
+
+vi.mock("@/hooks/use-toast", () => ({ toast: toastMock }));
+
 let container: HTMLDivElement | null = null;
 
 afterEach(() => {
 	container?.remove();
 	container = null;
+	toastMock.mockReset();
 });
 
 function render(node: React.ReactNode) {
@@ -88,6 +93,42 @@ describe("CloudHandoffReceipt", () => {
 		);
 		expect(view.textContent).not.toContain("sessionId=cloud-1");
 		expect(view.textContent).not.toContain("Copy recovery link");
+	});
+
+	it.each([
+		"unavailable",
+		"rejected",
+	] as const)("explains when clipboard copying is %s", async (failure) => {
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value:
+				failure === "rejected"
+					? { writeText: vi.fn().mockRejectedValue(new Error("denied")) }
+					: undefined,
+		});
+		const view = render(
+			<CloudHandoffReceipt
+				onForkLocally={() => undefined}
+				onOpenCloud={() => undefined}
+				receipt={{
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				}}
+				showRecoveryUrl
+			/>,
+		);
+		await act(async () => {
+			Array.from(view.querySelectorAll("button"))
+				.find((item) => item.textContent?.includes("Copy recovery link"))
+				?.click();
+			await Promise.resolve();
+		});
+
+		expect(toastMock).toHaveBeenCalledExactlyOnceWith({
+			title: "Copy failed",
+			description: "Use Open Cloud or select the recovery link above.",
+			variant: "destructive",
+		});
 	});
 });
 

--- a/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/cloud-handoff.tsx
@@ -3,6 +3,7 @@
 import { Cloud, Copy, ExternalLink, GitFork, Loader2, X } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
 import type {
 	HandoffProgressPhase,
 	HandoffReceipt as HandoffReceiptValue,
@@ -110,6 +111,20 @@ export function CloudHandoffReceipt({
 	onForkLocally: () => void;
 	showRecoveryUrl?: boolean;
 }) {
+	const copyRecoveryLink = async () => {
+		try {
+			if (!navigator.clipboard?.writeText)
+				throw new Error("Clipboard unavailable");
+			await navigator.clipboard.writeText(receipt.dashboardUrl);
+		} catch {
+			toast({
+				title: "Copy failed",
+				description: "Use Open Cloud or select the recovery link above.",
+				variant: "destructive",
+			});
+		}
+	};
+
 	return (
 		<div className="mx-auto flex w-full max-w-xl flex-col items-center gap-4 px-6 py-10 text-center">
 			<div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
@@ -148,9 +163,7 @@ export function CloudHandoffReceipt({
 			{showRecoveryUrl ? (
 				<button
 					className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
-					onClick={() =>
-						void navigator.clipboard?.writeText(receipt.dashboardUrl)
-					}
+					onClick={() => void copyRecoveryLink()}
 					type="button"
 				>
 					<Copy className="size-3" />

--- a/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/sessions/sessions-view.tsx
@@ -544,7 +544,9 @@ export function SessionsView({ activeSessionId, history }: SessionsViewProps) {
 								: null;
 							const workspace = session?.workspaceRoot || session?.cwd || "";
 							const updated = formatRelativeTime(
-								session?.endedAt || session?.startedAt,
+								session?.lastActivityAt ||
+									session?.endedAt ||
+									session?.startedAt,
 							);
 							return (
 								<div

--- a/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/settings-view.tsx
@@ -939,12 +939,8 @@ function GeneralSettingsContent({
 	const [cloudSessionsEffective, setCloudSessionsEffective] = useState<
 		boolean | null
 	>(null);
-	// Hard-wired on for the preview. If rollout control is ever needed,
-	// gate this on a PostHog flag exposed through the sidecar's
-	// get_feature_flags command (the sidecar's remote-flag evaluation
-	// plumbing was removed with the old rollout gate; see the git history
-	// of sidecar/feature-flags.ts for the hardened version).
-	const cloudSessionsSettingVisible = true;
+	const [cloudSessionsAvailable, setCloudSessionsAvailable] = useState(true);
+	const cloudSessionsSettingVisible = cloudSessionsAvailable;
 	// Connected providers that offer native web search; null until the
 	// catalog loads. The toggle silently does nothing with other providers,
 	// so the row spells out whether it will actually take effect.
@@ -955,10 +951,12 @@ function GeneralSettingsContent({
 
 	const refreshCloudSessionsEffective = useCallback(async () => {
 		try {
-			const flags = await desktopClient.invoke<{ cloudAgents?: boolean }>(
-				"get_feature_flags",
-			);
+			const flags = await desktopClient.invoke<{
+				cloudAgents?: boolean;
+				cloudAgentsAvailable?: boolean;
+			}>("get_feature_flags");
 			setCloudSessionsEffective(Boolean(flags.cloudAgents));
+			setCloudSessionsAvailable(flags.cloudAgentsAvailable !== false);
 		} catch {
 			setCloudSessionsEffective(null);
 		}

--- a/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.test.tsx
@@ -22,6 +22,7 @@ type HarnessProps = {
 	onOpenReady: (sessionId: string) => Promise<boolean>;
 	onResolved: () => void;
 	onError: (message: string) => void;
+	onPhase?: (phase: string | undefined) => void;
 };
 
 let container: HTMLDivElement;
@@ -64,6 +65,24 @@ afterEach(async () => {
 });
 
 describe("useProvisioningOutcome", () => {
+	it("reports the current provisioning phase", async () => {
+		invokeMock.mockResolvedValue({
+			status: "provisioning",
+			phase: "cloning_repo",
+		} satisfies CloudProvisioningOutcome);
+		const onPhase = vi.fn();
+
+		await renderHarness({
+			placeholderId: "cloud-provisioning-1",
+			onOpenReady: vi.fn(async () => true),
+			onResolved: vi.fn(),
+			onError: vi.fn(),
+			onPhase,
+		});
+
+		expect(onPhase).toHaveBeenCalledWith("cloning_repo");
+	});
+
 	it("opens the ready session and resolves its placeholder", async () => {
 		invokeMock.mockResolvedValue({
 			status: "ready",

--- a/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
@@ -2,8 +2,18 @@ import { useEffect, useRef } from "react";
 import { humanizeCloudSessionError } from "@/lib/cloud-session-error";
 import { desktopClient } from "@/lib/desktop-client";
 
+export type CloudProvisioningPhase =
+	| "provisioning"
+	| "cloning_repo"
+	| "agent_starting"
+	| "ready"
+	| "failed";
+
 export type CloudProvisioningOutcome =
-	| { status: "provisioning" }
+	| {
+			status: "provisioning";
+			phase?: CloudProvisioningPhase;
+	  }
 	| { status: "ready"; sessionId: string }
 	| { status: "failed"; message: string };
 
@@ -16,6 +26,7 @@ export function useProvisioningOutcome(options: {
 	onOpenReady: (sessionId: string) => Promise<boolean>;
 	onResolved: () => void;
 	onError: (message: string) => void;
+	onPhase?: (phase: CloudProvisioningPhase | undefined) => void;
 }): void {
 	const callbacksRef = useRef(options);
 	callbacksRef.current = options;
@@ -68,6 +79,7 @@ export function useProvisioningOutcome(options: {
 					}
 				} else {
 					unknownPolls = 0;
+					callbacksRef.current.onPhase?.(outcome?.phase);
 				}
 			} catch {
 				// Keep polling through a temporary sidecar interruption.

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	resolveLiveHistorySession,
 	sessionActivityTimestamp,
 	useSessionHistory,
 } from "./use-session-history";
@@ -39,6 +40,19 @@ function sessionRow(sessionId: string) {
 		endedAt: "2026-07-20T11:00:00.000Z",
 	};
 }
+
+it("uses refreshed metadata for an already-open session", () => {
+	const snapshot = sessionRow("handoff-source");
+	const refreshed = {
+		...snapshot,
+		metadata: {
+			handoff: { status: "complete", toCloudSessionId: "cloud-1" },
+		},
+	};
+
+	expect(resolveLiveHistorySession(snapshot, [refreshed])).toBe(refreshed);
+	expect(resolveLiveHistorySession(snapshot, [])).toBe(snapshot);
+});
 
 it("uses server activity when it is newer than local timestamps", () => {
 	expect(

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.test.tsx
@@ -3,7 +3,10 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useSessionHistory } from "./use-session-history";
+import {
+	sessionActivityTimestamp,
+	useSessionHistory,
+} from "./use-session-history";
 
 const { invokeMock, subscribeMock } = vi.hoisted(() => ({
 	invokeMock: vi.fn(),
@@ -36,6 +39,15 @@ function sessionRow(sessionId: string) {
 		endedAt: "2026-07-20T11:00:00.000Z",
 	};
 }
+
+it("uses server activity when it is newer than local timestamps", () => {
+	expect(
+		sessionActivityTimestamp({
+			...sessionRow("ses-cloud"),
+			lastActivityAt: "2026-07-20T12:00:00.000Z",
+		}),
+	).toBe(Date.parse("2026-07-20T12:00:00.000Z"));
+});
 
 let container: HTMLDivElement;
 let root: Root;

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -427,6 +427,8 @@ function areSessionsEquivalent(
 			getSessionMetadataPinned(a.metadata) !==
 				getSessionMetadataPinned(b.metadata) ||
 			a.environmentId !== b.environmentId ||
+			JSON.stringify(a.metadata?.handoff) !==
+				JSON.stringify(b.metadata?.handoff) ||
 			!areScheduleInfosEqual(
 				getSessionMetadataSchedule(a.metadata),
 				getSessionMetadataSchedule(b.metadata),
@@ -551,6 +553,17 @@ function mergeDiscoveredSessions(
 			},
 		};
 	});
+}
+
+export function resolveLiveHistorySession(
+	snapshot: SessionHistoryItem | undefined,
+	sessions: readonly SessionHistoryItem[],
+): SessionHistoryItem | undefined {
+	if (!snapshot) return undefined;
+	return (
+		sessions.find((session) => session.sessionId === snapshot.sessionId) ??
+		snapshot
+	);
 }
 
 export function useSessionHistory({

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -141,9 +141,10 @@ export function parseTimestamp(value?: string): number {
 }
 
 export function sessionActivityTimestamp(session: SessionHistoryItem): number {
+	const lastActivityAt = parseTimestamp(session.lastActivityAt);
 	const endedAt = parseTimestamp(session.endedAt);
 	const startedAt = parseTimestamp(session.startedAt);
-	return Math.max(endedAt, startedAt);
+	return Math.max(lastActivityAt, endedAt, startedAt);
 }
 
 // Order by last activity, not by start time: a long-running session that was
@@ -295,7 +296,9 @@ function toThread(session: SessionHistoryItem): SessionThread {
 		source: getSessionSource(session) || undefined,
 		codebase: basenamePath(workspacePath),
 		workspacePath,
-		time: formatRelativeTime(session.endedAt || session.startedAt),
+		time: formatRelativeTime(
+			session.lastActivityAt || session.endedAt || session.startedAt,
+		),
 		provider: session.provider || "",
 		model: session.model || "",
 		gitBranch: getSessionMetadataGitBranch(session.metadata) || undefined,
@@ -413,6 +416,7 @@ function areSessionsEquivalent(
 			a.status !== b.status ||
 			a.startedAt !== b.startedAt ||
 			a.endedAt !== b.endedAt ||
+			a.lastActivityAt !== b.lastActivityAt ||
 			a.prompt !== b.prompt ||
 			getSessionMetadataIsScheduled(a.metadata) !==
 				getSessionMetadataIsScheduled(b.metadata) ||

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.test.ts
@@ -1,0 +1,1272 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HandoffResult } from "./cloud-handoff";
+import {
+	createHandoffLifecycle,
+	type HandoffLifecycleToast,
+	type HandoffProgressEventPayload,
+} from "./cloud-handoff-lifecycle";
+import {
+	type CloudHandoffUiAction,
+	type CloudHandoffUiState,
+	cloudHandoffUiReducer,
+} from "./cloud-handoff-ui-state";
+
+const SOURCE = "local-1";
+const TARGET = "cloud-1";
+const DASHBOARD_URL = "https://app.cline.bot/agents/cloud-1";
+
+function makeAttachment(name = "shot.png"): File {
+	return new File(["img"], name, { type: "image/png" });
+}
+
+function makeResult(overrides: Partial<HandoffResult> = {}): HandoffResult {
+	return {
+		outerSessionId: TARGET,
+		innerSessionId: "inner-1",
+		dashboardUrl: DASHBOARD_URL,
+		destination: "in_app",
+		...overrides,
+	};
+}
+
+function completeEvent(
+	overrides: Partial<HandoffProgressEventPayload> = {},
+): HandoffProgressEventPayload {
+	return {
+		sourceSessionId: SOURCE,
+		phase: "complete",
+		sessionId: TARGET,
+		dashboardUrl: DASHBOARD_URL,
+		destination: "in_app",
+		...overrides,
+	};
+}
+
+/** Mock effects; dispatch feeds the REAL reducer so tests can assert the
+ * final UI entries each ordering produces. */
+function makeHarness(options: { openSessionResult?: boolean } = {}) {
+	let state: CloudHandoffUiState = {};
+	const dispatched: CloudHandoffUiAction[] = [];
+	const dispatch = vi.fn((action: CloudHandoffUiAction) => {
+		dispatched.push(action);
+		state = cloudHandoffUiReducer(state, action);
+	});
+	const toast = vi.fn((_t: HandoffLifecycleToast) => {});
+	const openSession = vi.fn(
+		(
+			_sessionId: string,
+			_opts: {
+				silent: true;
+				initialPromptDraft?: string;
+				initialAttachments?: File[];
+			},
+		) => Promise.resolve(options.openSessionResult ?? true),
+	);
+	const openExternal = vi.fn((_url: string) => Promise.resolve());
+	const lifecycle = createHandoffLifecycle({
+		dispatch,
+		toast,
+		openSession,
+		openExternal,
+	});
+	return {
+		lifecycle,
+		dispatch,
+		dispatched,
+		toast,
+		openSession,
+		openExternal,
+		getState: () => state,
+	};
+}
+
+function warningToastCount(toastMock: {
+	mock: { calls: [HandoffLifecycleToast][] };
+}): number {
+	return toastMock.mock.calls.filter(
+		([t]) => t.title === "Handoff completed with a warning",
+	).length;
+}
+
+describe("cloud handoff lifecycle: RPC resolved", () => {
+	it("(a) no warning: complete dispatch, in-app open, no toast at all", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult(),
+			nextCommand: "",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "complete",
+				sourceSessionId: SOURCE,
+				receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+				externalPresentation: false,
+				pendingPrompt: undefined,
+			},
+		]);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+		});
+		expect(h.toast).not.toHaveBeenCalled();
+		expect(h.openExternal).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({ status: "complete" });
+	});
+
+	it("accepts the legacy sessionId alias when outerSessionId is empty", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({ outerSessionId: "", sessionId: TARGET }),
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+		});
+	});
+
+	it("throws when the result carries no cloud session, so the caller's catch routes it to onRpcRejected", async () => {
+		const h = makeHarness();
+		await expect(
+			h.lifecycle.onRpcResolved(SOURCE, {
+				result: makeResult({ outerSessionId: "", dashboardUrl: "" }),
+				nextCommand: "",
+				sourceAttachments: [],
+			}),
+		).rejects.toThrow("Cloud handoff did not return a cloud session.");
+		expect(h.dispatch).not.toHaveBeenCalled();
+		expect(h.toast).not.toHaveBeenCalled();
+	});
+
+	it("(b) unqueued warning: prompt_reconciled + open with draft and attachments + single warning toast quoting the command", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		const pendingPrompt = {
+			content: "fix the tests",
+			submittedAt: 1,
+			baselineOccurrences: 0,
+		};
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+			nextCommand: "fix the tests",
+			sourceAttachments: [attachment],
+			pendingPrompt,
+			isThreadActive: () => true,
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "complete",
+				sourceSessionId: SOURCE,
+				receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+				externalPresentation: false,
+				pendingPrompt,
+				warningKind: "unqueued",
+				retryDraft: "fix the tests",
+				retryAttachments: [attachment],
+			},
+			{ type: "prompt_reconciled", sourceSessionId: TARGET },
+			{ type: "retry_delivered", sourceSessionId: SOURCE },
+		]);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "fix the tests",
+			initialAttachments: [attachment],
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed with a warning",
+			description:
+				'The follow-up command could not be queued. Your command was kept: "fix the tests" — send it from the cloud session.',
+		});
+		// The optimistic bubble is cleared: the target_prompt entry seeded by
+		// the complete dispatch is removed by prompt_reconciled.
+		expect(h.getState()[TARGET]).toBeUndefined();
+	});
+
+	it("(c) unconfirmed warning: destructive toast, NO prefill", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({
+				warning: "Cline could not confirm the follow-up was queued.",
+				warningKind: "unconfirmed",
+			}),
+			nextCommand: "deploy it",
+			sourceAttachments: [makeAttachment()],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed with a warning",
+			description: "Cline could not confirm the follow-up was queued.",
+			variant: "destructive",
+		});
+	});
+
+	it("falls back to the browser when the in-app open fails", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult(),
+			nextCommand: "",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(h.dispatched).toEqual([
+			expect.objectContaining({ type: "complete" }),
+			{ type: "external", sourceSessionId: SOURCE },
+		]);
+		expect(h.openExternal).toHaveBeenCalledExactlyOnceWith(DASHBOARD_URL);
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Opened handoff in your browser",
+			description: "The cloud session could not be attached inside Cline.",
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			externalPresentation: true,
+		});
+	});
+
+	it("shows the destructive fallback toast when the browser cannot open either", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		h.openExternal.mockRejectedValueOnce(new Error("no browser"));
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult(),
+			nextCommand: "",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Unable to open the browser",
+			description: "Use the recovery link to open the cloud session manually.",
+			variant: "destructive",
+		});
+	});
+
+	it("external destination: opens the browser, no in-app open, no toast on success", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({ destination: "external" }),
+			nextCommand: "",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.openExternal).toHaveBeenCalledExactlyOnceWith(DASHBOARD_URL);
+		expect(h.toast).not.toHaveBeenCalled();
+	});
+
+	it("external destination: browser failure downgrades to the recovery-link toast", async () => {
+		const h = makeHarness();
+		h.openExternal.mockRejectedValueOnce(new Error("no browser"));
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({ destination: "external" }),
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Cloud handoff complete",
+			description: "Use the recovery link to open the cloud session.",
+		});
+	});
+
+	it("inactive source thread: no in-app open, session-list toast instead", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult(),
+			nextCommand: "",
+			sourceAttachments: [],
+			isThreadActive: () => false,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Cloud handoff complete",
+			description: "The cloud session is ready in your session list.",
+		});
+	});
+
+	it("assumes the thread is active when the caller provides no probe", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult(),
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+		});
+	});
+});
+
+describe("cloud handoff lifecycle: event/RPC ordering races", () => {
+	it("event before a successful RPC leaves the full in-app open to the attachment-bearing RPC result", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+				undeliveredCommand: "run the suite",
+			}),
+		);
+		expect(h.openSession).not.toHaveBeenCalled();
+
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "run the suite",
+			initialAttachments: [attachment],
+		});
+	});
+
+	it("RPC before its completion event keeps recovery payload after the target cannot open", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		const attachment = makeAttachment();
+		const handoffAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			handoffAttemptId,
+			result: makeResult({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId,
+				warningKind: "unqueued",
+				undeliveredCommand: "run the suite",
+			}),
+		);
+
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+		expect(h.getState()[SOURCE]).toEqual({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+			externalPresentation: true,
+			warningKind: "unqueued",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+	});
+
+	it("duplicate completion events do not open or reopen the target", async () => {
+		const h = makeHarness();
+		const event = completeEvent({
+			warningKind: "unqueued",
+			undeliveredCommand: "run the suite",
+		});
+		await h.lifecycle.onEvent(event);
+		await h.lifecycle.onEvent(event);
+		expect(h.openSession).not.toHaveBeenCalled();
+	});
+
+	it("ignores mismatched and uncorrelated completions after a newer attempt is accepted", async () => {
+		const h = makeHarness();
+		const currentAttachment = makeAttachment("current.png");
+		const staleAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		const currentAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onEvent({
+			sourceSessionId: SOURCE,
+			handoffAttemptId: currentAttemptId,
+			phase: "creating",
+		});
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: currentAttemptId,
+			error: new Error("current attempt failed"),
+			nextCommand: "current command",
+			sourceAttachments: [currentAttachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId: staleAttemptId,
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+				undeliveredCommand: "stale command",
+			}),
+		);
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warningKind: "unqueued",
+				undeliveredCommand: "untagged stale command",
+			}),
+		);
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "failed",
+			retryDraft: "/handoff current command",
+			retryAttachments: [currentAttachment],
+		});
+	});
+
+	it("keeps the edited retry payload after consecutive preflight failures", async () => {
+		const h = makeHarness();
+		const originalAttachment = makeAttachment("original.png");
+		const retryAttachment = makeAttachment("retry.png");
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("first preflight failed"),
+			nextCommand: "original command",
+			sourceAttachments: [originalAttachment],
+		});
+
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: retryAttemptId,
+			error: new Error("retry preflight failed"),
+			nextCommand: "edited retry command",
+			sourceAttachments: [retryAttachment],
+		});
+
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "failed",
+			retryDraft: "/handoff edited retry command",
+			retryAttachments: [retryAttachment],
+		});
+	});
+
+	it("restores only the matching payload when an older timed-out attempt completes", async () => {
+		const h = makeHarness();
+		const originalAttachment = makeAttachment("original.png");
+		const retryAttachment = makeAttachment("retry.png");
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("request timed out"),
+			nextCommand: "original command",
+			sourceAttachments: [originalAttachment],
+		});
+
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: retryAttemptId,
+			error: new Error(
+				"A different cloud handoff is already in progress for this session.",
+			),
+			nextCommand: "retry command",
+			sourceAttachments: [retryAttachment],
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "failed",
+			retryDraft: "/handoff retry command",
+			retryAttachments: [retryAttachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId: originalAttemptId,
+				warningKind: "unqueued",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "original command",
+			initialAttachments: [originalAttachment],
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "retry command",
+			retryAttachments: [retryAttachment],
+		});
+	});
+
+	it("does not carry a bare newer handoff command into an older target", async () => {
+		const h = makeHarness();
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("request timed out"),
+			nextCommand: "original command",
+			sourceAttachments: [],
+		});
+
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: retryAttemptId,
+			error: new Error("retry preflight failed"),
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({ handoffAttemptId: originalAttemptId }),
+		);
+		expect(h.getState()[SOURCE]).toMatchObject({ status: "complete" });
+		expect(h.getState()[SOURCE]).not.toHaveProperty("retryDraft");
+	});
+
+	it("retains attachment-only newer retries without a handoff command", async () => {
+		const h = makeHarness();
+		const retryAttachment = makeAttachment("retry.png");
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("request timed out"),
+			nextCommand: "original command",
+			sourceAttachments: [],
+		});
+
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: retryAttemptId,
+			error: new Error("retry preflight failed"),
+			nextCommand: "",
+			sourceAttachments: [retryAttachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({ handoffAttemptId: originalAttemptId }),
+		);
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryAttachments: [retryAttachment],
+		});
+		expect(h.getState()[SOURCE]).not.toHaveProperty("retryDraft");
+	});
+
+	it("clears a rejected attempt's payload when its clean completion arrives", async () => {
+		const h = makeHarness();
+		const attemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: attemptId,
+			error: new Error("response lost"),
+			nextCommand: "already queued",
+			sourceAttachments: [makeAttachment()],
+		});
+
+		await h.lifecycle.onEvent(completeEvent({ handoffAttemptId: attemptId }));
+
+		expect(h.getState()[SOURCE]).toEqual({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+			externalPresentation: false,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+	});
+
+	it("accepts a matching retry completion even when all of its progress was lost", async () => {
+		const h = makeHarness();
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onEvent({
+			sourceSessionId: SOURCE,
+			handoffAttemptId: originalAttemptId,
+			phase: "creating",
+		});
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("original request timed out"),
+			nextCommand: "original command",
+			sourceAttachments: [makeAttachment("original.png")],
+		});
+
+		const retryAttachment = makeAttachment("retry.png");
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: retryAttemptId,
+			error: new Error("retry transport failed"),
+			nextCommand: "retry command",
+			sourceAttachments: [retryAttachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId: retryAttemptId,
+				warningKind: "unqueued",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "retry command",
+			initialAttachments: [retryAttachment],
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({ status: "complete" });
+	});
+
+	it("does not let an older completion overwrite a retry accepted while its target open awaited", async () => {
+		const h = makeHarness();
+		let resolveOpen: ((opened: boolean) => void) | undefined;
+		h.openSession.mockImplementationOnce(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolveOpen = resolve;
+				}),
+		);
+		const originalAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId: originalAttemptId,
+			error: new Error("request timed out"),
+			nextCommand: "original command",
+			sourceAttachments: [],
+		});
+
+		const originalCompletion = h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId: originalAttemptId,
+				warningKind: "unqueued",
+			}),
+		);
+		await vi.waitFor(() => expect(h.openSession).toHaveBeenCalledTimes(1));
+
+		const retryAttemptId = h.lifecycle.onRpcStarted(SOURCE);
+		await h.lifecycle.onEvent({
+			sourceSessionId: SOURCE,
+			handoffAttemptId: retryAttemptId,
+			phase: "creating",
+			message: "Creating the retry",
+		});
+		resolveOpen?.(true);
+		await originalCompletion;
+
+		expect(
+			h.dispatched.filter(
+				(action) => action.type === "progress" && action.phase === "complete",
+			),
+		).toHaveLength(0);
+		expect(h.dispatched.at(-1)).toMatchObject({
+			type: "progress",
+			sourceSessionId: SOURCE,
+			phase: "creating",
+			message: "Creating the retry",
+		});
+	});
+
+	it("(d) event then reject in the same tick: restoration via the completions registry, benign toast, NO failed dispatch", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		// The completion event lands first (no warning string, so it toasts
+		// nothing itself) and records the authoritative completion...
+		h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		// ...then the RPC rejection arrives before any re-render could update
+		// a reducer-fed ref: the caller passes no reducer entry.
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "run the suite",
+			initialAttachments: [attachment],
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed",
+			description:
+				"The connection dropped while reporting the result, but the cloud session is ready.",
+		});
+		expect(h.dispatched.filter((action) => action.type === "failed")).toEqual(
+			[],
+		);
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+		});
+	});
+
+	it("event then reject without an unqueued warning: benign toast only, no restoration", async () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent(completeEvent());
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [makeAttachment()],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ title: "Handoff completed" }),
+		);
+		expect(h.dispatched.filter((action) => action.type === "failed")).toEqual(
+			[],
+		);
+	});
+
+	it("event then reject: a false target-open result exposes the draft and attachments for recovery", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		const attachment = makeAttachment();
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "run the suite",
+			initialAttachments: [attachment],
+		});
+		expect(h.dispatched.at(-1)).toEqual({
+			type: "target_open_failed",
+			sourceSessionId: SOURCE,
+			dashboardUrl: DASHBOARD_URL,
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+		expect(h.getState()[SOURCE]).toEqual({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+			externalPresentation: false,
+			warningKind: "unqueued",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+	});
+
+	it("event then reject: a rejected target open exposes the draft and attachments for recovery", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		h.openSession.mockRejectedValueOnce(new Error("discovery failed"));
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+		expect(h.getState()[SOURCE]).toEqual({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+			externalPresentation: false,
+			warningKind: "unqueued",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+	});
+
+	it("ref-lag fallback: a reducer-fed complete entry drives restoration when the registry is empty", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [],
+			reducerEntryIsComplete: {
+				receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+				externalPresentation: false,
+				warningKind: "unqueued",
+			},
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "run the suite",
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ title: "Handoff completed" }),
+		);
+		expect(h.dispatched).toEqual([
+			expect.objectContaining({
+				type: "complete",
+				retryDraft: "run the suite",
+			}),
+			{ type: "retry_delivered", sourceSessionId: SOURCE },
+		]);
+	});
+
+	it("registry completion wins over a conflicting reducer entry", async () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [],
+			// A stale reducer entry pointing elsewhere must lose to the
+			// synchronously recorded completion.
+			reducerEntryIsComplete: {
+				receipt: {
+					targetSessionId: "stale-target",
+					dashboardUrl: "https://app.cline.bot/agents/stale",
+				},
+				externalPresentation: false,
+				warningKind: "unqueued",
+			},
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(
+			TARGET,
+			expect.objectContaining({ initialPromptDraft: "run the suite" }),
+		);
+	});
+
+	it("completed externally: no restoration open, benign toast still shown", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		h.lifecycle.onEvent(
+			completeEvent({ destination: "external", warningKind: "unqueued" }),
+		);
+		h.openSession.mockClear();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+		expect(h.toast).toHaveBeenCalledWith(
+			expect.objectContaining({ title: "Handoff completed" }),
+		);
+	});
+
+	it("completed but the source thread went inactive: no restoration open", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("socket closed"),
+			nextCommand: "run the suite",
+			sourceAttachments: [attachment],
+			isThreadActive: () => false,
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "run the suite",
+			retryAttachments: [attachment],
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ title: "Handoff completed" }),
+		);
+	});
+
+	it("(e) reject then event: recovery stays available until the target opens with the saved draft and attachments", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		let resolveOpen: ((opened: boolean) => void) | undefined;
+		h.openSession.mockImplementationOnce(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolveOpen = resolve;
+				}),
+		);
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "fix flaky test",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "failed",
+				sourceSessionId: SOURCE,
+				exposeRecovery: true,
+				retryDraft: "/handoff fix flaky test",
+				retryAttachments: [attachment],
+			},
+		]);
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff failed",
+			description:
+				"Couldn’t reach Cline Cloud. Your local conversation is still available.",
+			variant: "destructive",
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+
+		const completion = h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+		);
+		await vi.waitFor(() => expect(h.openSession).toHaveBeenCalledTimes(1));
+		// Do not replace the recoverable failure while the open outcome is
+		// unknown: these File objects otherwise have no durable owner.
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "failed",
+			retryDraft: "/handoff fix flaky test",
+			retryAttachments: [attachment],
+		});
+		resolveOpen?.(true);
+		await completion;
+		// The retry registry (written synchronously at rejection) is the only
+		// carrier of the unsent command and attachments once the reducer's
+		// failed entry has been replaced by the receipt.
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "fix flaky test",
+			initialAttachments: [attachment],
+		});
+		expect(warningToastCount(h.toast)).toBe(1);
+		expect(h.toast).toHaveBeenCalledTimes(2);
+		// The receipt wins in the reducer: the failed entry is replaced.
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
+			warningKind: "unqueued",
+		});
+	});
+
+	it("reject then event: a false target-open result preserves the recovery payload", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		const attachment = makeAttachment();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "fix flaky test",
+			sourceAttachments: [attachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "fix flaky test",
+			initialAttachments: [attachment],
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "fix flaky test",
+			retryAttachments: [attachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warningKind: "unqueued",
+				undeliveredCommand: "fix flaky test",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("reject then event: a rejected target open preserves the recovery payload", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		h.openSession.mockRejectedValueOnce(new Error("discovery failed"));
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "fix flaky test",
+			sourceAttachments: [attachment],
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "fix flaky test",
+			retryAttachments: [attachment],
+		});
+	});
+
+	it("reject then event: the event's undeliveredCommand overrides the recorded retry command", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "recorded command",
+			sourceAttachments: [],
+		});
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warningKind: "unqueued",
+				undeliveredCommand: "authoritative command",
+			}),
+		);
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "authoritative command",
+		});
+	});
+
+	it("reject with an empty command and no attachments: a later unqueued event restores nothing", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "failed",
+				sourceSessionId: SOURCE,
+				exposeRecovery: true,
+				retryDraft: "/handoff",
+				retryAttachments: [],
+			},
+		]);
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		expect(h.openSession).not.toHaveBeenCalled();
+	});
+
+	it("the retry registry is consumed by the first unqueued completion", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("fetch failed"),
+			nextCommand: "fix it",
+			sourceAttachments: [],
+		});
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+		// A duplicate event finds the registry empty and restores nothing.
+		await h.lifecycle.onEvent(completeEvent({ warningKind: "unqueued" }));
+		expect(h.openSession).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("cloud handoff lifecycle: warning toast claim", () => {
+	it("(f) duplicate completion events surface exactly one warning toast", () => {
+		const h = makeHarness();
+		const event = completeEvent({
+			warning: "The follow-up command could not be queued.",
+			warningKind: "unqueued",
+			undeliveredCommand: "do it",
+		});
+		h.lifecycle.onEvent(event);
+		h.lifecycle.onEvent(event);
+		expect(warningToastCount(h.toast)).toBe(1);
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed with a warning",
+			description:
+				'The follow-up command could not be queued. Your command was kept: "do it" — send it from the cloud session.',
+		});
+	});
+
+	it("(f) event completion then RPC result with the same warning: one warning toast total", async () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+				undeliveredCommand: "do it",
+			}),
+		);
+		expect(warningToastCount(h.toast)).toBe(1);
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+			nextCommand: "do it",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(warningToastCount(h.toast)).toBe(1);
+	});
+
+	it("the RPC path claims the toast when it lands before any event", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcResolved(SOURCE, {
+			result: makeResult({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+			}),
+			nextCommand: "do it",
+			sourceAttachments: [],
+			isThreadActive: () => true,
+		});
+		expect(warningToastCount(h.toast)).toBe(1);
+		h.lifecycle.onEvent(
+			completeEvent({
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+				undeliveredCommand: "do it",
+			}),
+		);
+		expect(warningToastCount(h.toast)).toBe(1);
+	});
+
+	it("claims are per source session", () => {
+		const h = makeHarness();
+		const warning = "The follow-up command could not be queued.";
+		h.lifecycle.onEvent(completeEvent({ warning, warningKind: "unqueued" }));
+		h.lifecycle.onEvent(
+			completeEvent({
+				sourceSessionId: "local-2",
+				sessionId: "cloud-2",
+				dashboardUrl: "https://app.cline.bot/agents/cloud-2",
+				warning,
+				warningKind: "unqueued",
+			}),
+		);
+		expect(warningToastCount(h.toast)).toBe(2);
+	});
+});
+
+describe("cloud handoff lifecycle: event handling", () => {
+	it("(g) external destination: no openSession restoration, toast quotes the command", () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent(
+			completeEvent({
+				destination: "external",
+				warning: "The follow-up command could not be queued.",
+				warningKind: "unqueued",
+				undeliveredCommand: "ship it",
+			}),
+		);
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed with a warning",
+			description:
+				'The follow-up command could not be queued. Your command was kept: "ship it" — send it from the cloud session.',
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			externalPresentation: true,
+			warningKind: "unqueued",
+		});
+	});
+
+	it("does not open from an unqueued completion event without an RPC rejection", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onEvent(
+			completeEvent({
+				warningKind: "unqueued",
+				undeliveredCommand: "ship it",
+			}),
+		);
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({ status: "complete" });
+	});
+
+	it("forwards non-complete progress phases to the reducer verbatim", () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent({
+			sourceSessionId: SOURCE,
+			phase: "seeding",
+			message: "Transferring the conversation...",
+			dashboardUrl: DASHBOARD_URL,
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "progress",
+				sourceSessionId: SOURCE,
+				phase: "seeding",
+				message: "Transferring the conversation...",
+				dashboardUrl: DASHBOARD_URL,
+				sessionId: undefined,
+				destination: undefined,
+				warningKind: undefined,
+			},
+		]);
+		expect(h.toast).not.toHaveBeenCalled();
+		expect(h.openSession).not.toHaveBeenCalled();
+	});
+
+	it("an unconfirmed completion event never restores and toasts destructively", () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent(
+			completeEvent({
+				warning: "Cline could not confirm the follow-up was queued.",
+				warningKind: "unconfirmed",
+				undeliveredCommand: "must not resend",
+			}),
+		);
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff completed with a warning",
+			description: "Cline could not confirm the follow-up was queued.",
+			variant: "destructive",
+		});
+	});
+});
+
+describe("cloud handoff lifecycle: RPC rejected with no completion", () => {
+	it("(h) failed dispatch + failure toast with connectUrl passthrough", async () => {
+		const h = makeHarness();
+		const attachment = makeAttachment();
+		const envelope = `CLOUD_SESSION_ERROR:${JSON.stringify({
+			code: "github_not_connected",
+			message: "Connect GitHub to hand off this repository.",
+			connectUrl: "https://app.cline.bot/dashboard/integrations",
+		})}`;
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error(envelope),
+			nextCommand: "open a PR",
+			sourceAttachments: [attachment],
+			isThreadActive: () => true,
+		});
+		expect(h.dispatched).toEqual([
+			{
+				type: "failed",
+				sourceSessionId: SOURCE,
+				exposeRecovery: true,
+				retryDraft: "/handoff open a PR",
+				retryAttachments: [attachment],
+			},
+		]);
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff failed",
+			description: "Connect GitHub to hand off this repository.",
+			variant: "destructive",
+			connectUrl: "https://app.cline.bot/dashboard/integrations",
+		});
+		expect(h.openSession).not.toHaveBeenCalled();
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "failed",
+			retryDraft: "/handoff open a PR",
+		});
+	});
+
+	it("omits connectUrl for a plain error and stringifies non-Error rejections", async () => {
+		const h = makeHarness();
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: "plain failure",
+			nextCommand: "",
+			sourceAttachments: [],
+		});
+		expect(h.toast).toHaveBeenCalledExactlyOnceWith({
+			title: "Handoff failed",
+			description: "plain failure",
+			variant: "destructive",
+		});
+	});
+
+	it("preserves the recovery URL when the reducer already saw progress", async () => {
+		const h = makeHarness();
+		h.lifecycle.onEvent({
+			sourceSessionId: SOURCE,
+			phase: "seeding",
+			dashboardUrl: DASHBOARD_URL,
+		});
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			error: new Error("boom"),
+			nextCommand: "retry me",
+			sourceAttachments: [],
+		});
+		// Reducer interplay: exposeRecovery + a known dashboardUrl produces a
+		// recovery entry carrying the retry draft.
+		expect(h.getState()[SOURCE]).toEqual({
+			status: "recovery",
+			dashboardUrl: DASHBOARD_URL,
+			retryDraft: "/handoff retry me",
+			retryAttachments: [],
+		});
+	});
+});

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.test.ts
@@ -59,6 +59,7 @@ function makeHarness(options: { openSessionResult?: boolean } = {}) {
 				silent: true;
 				initialPromptDraft?: string;
 				initialAttachments?: File[];
+				expectedActiveThreadId?: string;
 			},
 		) => Promise.resolve(options.openSessionResult ?? true),
 	);
@@ -924,6 +925,38 @@ describe("cloud handoff lifecycle: event/RPC ordering races", () => {
 			status: "complete",
 			receipt: { targetSessionId: TARGET, dashboardUrl: DASHBOARD_URL },
 			warningKind: "unqueued",
+		});
+	});
+
+	it("reject then delayed event keeps recovery when the source thread is no longer active", async () => {
+		const h = makeHarness({ openSessionResult: false });
+		const attachment = makeAttachment();
+		const handoffAttemptId = h.lifecycle.onRpcStarted(SOURCE, "thread-a");
+		await h.lifecycle.onRpcRejected(SOURCE, {
+			handoffAttemptId,
+			error: new Error("fetch failed"),
+			nextCommand: "fix flaky test",
+			sourceAttachments: [attachment],
+			isThreadActive: () => false,
+		});
+
+		await h.lifecycle.onEvent(
+			completeEvent({
+				handoffAttemptId,
+				warningKind: "unqueued",
+			}),
+		);
+
+		expect(h.openSession).toHaveBeenCalledExactlyOnceWith(TARGET, {
+			silent: true,
+			initialPromptDraft: "fix flaky test",
+			initialAttachments: [attachment],
+			expectedActiveThreadId: "thread-a",
+		});
+		expect(h.getState()[SOURCE]).toMatchObject({
+			status: "complete",
+			retryDraft: "fix flaky test",
+			retryAttachments: [attachment],
 		});
 	});
 

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.ts
@@ -1,0 +1,536 @@
+import {
+	buildHandoffWarningToast,
+	claimHandoffWarningSurface,
+	type HandoffProgressPhase,
+	type HandoffReceipt,
+	type HandoffResult,
+	shouldOpenHandoffInApp,
+} from "./cloud-handoff";
+import type {
+	CloudHandoffUiAction,
+	PendingHandoffPrompt,
+} from "./cloud-handoff-ui-state";
+import {
+	humanizeCloudHandoffError,
+	parseCloudSessionError,
+} from "./cloud-session-error";
+
+/**
+ * Pure coordinator for handoff completion, failure, and follow-up restoration.
+ *
+ * The `cloud_handoff_progress` completion event and the handoff RPC result
+ * race each other in every direction (event-before-rejection,
+ * rejection-before-event, same tick, either first), and the React reducer
+ * state lags a render behind both. This module owns the synchronous
+ * registries that resolve those races — the authoritative completions map,
+ * the retry-state map, and the warning-toast claim set — so every ordering is
+ * decided by plain function calls that unit tests can drive directly.
+ */
+export type HandoffLifecycleToast = {
+	title: string;
+	description?: string;
+	variant?: "destructive";
+	/**
+	 * When set, the caller should attach a "Connect GitHub" action that opens
+	 * this URL. The action itself is JSX, so the coordinator stays pure and
+	 * hands the URL back through the toast effect instead.
+	 */
+	connectUrl?: string;
+};
+
+export type HandoffLifecycleEffects = {
+	dispatch: (action: CloudHandoffUiAction) => void;
+	toast: (t: HandoffLifecycleToast) => void;
+	openSession: (
+		sessionId: string,
+		opts: {
+			silent: true;
+			initialPromptDraft?: string;
+			initialAttachments?: File[];
+		},
+	) => Promise<boolean> | boolean | undefined;
+	openExternal: (url: string) => Promise<void>;
+};
+
+/** The validated `cloud_handoff_progress` payload (caller checks the shape). */
+export type HandoffProgressEventPayload = {
+	sourceSessionId: string;
+	handoffAttemptId?: string;
+	phase: HandoffProgressPhase;
+	message?: string;
+	dashboardUrl?: string;
+	sessionId?: string;
+	destination?: "in_app" | "external";
+	warning?: string;
+	warningKind?: "unqueued" | "unconfirmed";
+	undeliveredCommand?: string;
+};
+
+export type HandoffCompletionRecord = {
+	targetSessionId: string;
+	dashboardUrl: string;
+	externalPresentation: boolean;
+	warningKind?: "unqueued" | "unconfirmed";
+};
+
+export type HandoffRpcResolvedContext = {
+	handoffAttemptId?: string;
+	result: HandoffResult;
+	nextCommand: string;
+	sourceAttachments: File[];
+	pendingPrompt?: PendingHandoffPrompt;
+	/**
+	 * Whether the source thread is still the active chat view. Scoped to the
+	 * pane that ran the RPC, so it travels per-call instead of living in the
+	 * effects; the event path never consults it (mirroring the pre-extraction
+	 * behavior). Absent means "assume active".
+	 */
+	isThreadActive?: () => boolean;
+};
+
+export type HandoffRpcRejectedContext = {
+	handoffAttemptId?: string;
+	error: unknown;
+	nextCommand: string;
+	sourceAttachments: File[];
+	/**
+	 * The reducer entry for the source session IF it already shows a completed
+	 * handoff, read by the caller at rejection time. The coordinator's own
+	 * registry wins the same-tick race; this reducer-fed fallback covers
+	 * completions that landed a render earlier.
+	 */
+	reducerEntryIsComplete?: {
+		receipt: HandoffReceipt;
+		externalPresentation: boolean;
+		warningKind?: "unqueued" | "unconfirmed";
+	};
+	isThreadActive?: () => boolean;
+};
+
+export function createHandoffLifecycle(effects: HandoffLifecycleEffects) {
+	// Source sessions whose completion warning has already been toasted. The
+	// completion event and the RPC result both carry the warning; whichever
+	// lands first claims it here so the user never sees it twice.
+	const surfacedWarnings = new Set<string>();
+	// Completions recorded SYNCHRONOUSLY by attempt. Besides bridging reducer
+	// lag for event-before-rejection, this makes a trailing/duplicate event a
+	// no-op after either completion path has already updated the UI.
+	const completions = new Map<string, HandoffCompletionRecord>();
+	// Retry payloads belong to the attempt that submitted them. This prevents a
+	// delayed completion for A from ever restoring B's edited command or files.
+	const retryStates = new Map<
+		string,
+		{ command?: string; attachments?: File[] }
+	>();
+	// A duplicate completion event must not retry an in-app recovery open. If
+	// the first attempt fails, the reducer and retry registry remain the user's
+	// recovery surface instead of an event replay repeatedly stealing focus.
+	const targetOpenAttempts = new Set<string>();
+	const latestAttempts = new Map<string, string>();
+	const acceptedAttempts = new Map<string, string>();
+	const attemptOrders = new Map<string, number>();
+	let nextAttemptOrder = 0;
+
+	const attemptKey = (sourceSessionId: string, attemptId?: string) =>
+		attemptId ?? sourceSessionId;
+
+	// Correlated progress or a successful RPC positively establishes an
+	// attempt. Missing progress does not: a later completion can still prove
+	// that a newer retry was accepted. The local order lets a positively
+	// established newer attempt reject genuinely stale older events.
+	const acceptAttempt = (
+		sourceSessionId: string,
+		attemptId?: string,
+	): boolean => {
+		if (!attemptId) {
+			return !latestAttempts.has(sourceSessionId);
+		}
+		const order = attemptOrders.get(attemptId) ?? 0;
+		const accepted = acceptedAttempts.get(sourceSessionId);
+		if (
+			accepted &&
+			accepted !== attemptId &&
+			order < (attemptOrders.get(accepted) ?? 0)
+		) {
+			return false;
+		}
+		acceptedAttempts.set(sourceSessionId, attemptId);
+		return true;
+	};
+
+	const claimWarningToast = (sourceSessionId: string) =>
+		claimHandoffWarningSurface(surfacedWarnings, sourceSessionId);
+	const toastFailure = (error: unknown) => {
+		const rawError = error instanceof Error ? error.message : String(error);
+		const cloudError = parseCloudSessionError(rawError);
+		effects.toast({
+			title: "Handoff failed",
+			description: humanizeCloudHandoffError(cloudError?.message ?? rawError),
+			variant: "destructive",
+			...(cloudError?.connectUrl ? { connectUrl: cloudError.connectUrl } : {}),
+		});
+	};
+
+	return {
+		/** Starts a distinct RPC attempt for this source session. */
+		onRpcStarted(sourceSessionId: string): string {
+			const attemptId = crypto.randomUUID();
+			attemptOrders.set(attemptId, ++nextAttemptOrder);
+			latestAttempts.set(sourceSessionId, attemptId);
+			surfacedWarnings.delete(sourceSessionId);
+			return attemptId;
+		},
+
+		/** Handles a validated `cloud_handoff_progress` event. */
+		async onEvent(progress: HandoffProgressEventPayload): Promise<void> {
+			const { sourceSessionId, handoffAttemptId } = progress;
+			if (!acceptAttempt(sourceSessionId, handoffAttemptId)) return;
+			const acceptedAttempt = handoffAttemptId;
+			const key = attemptKey(sourceSessionId, handoffAttemptId);
+			if (progress.phase === "complete" && completions.has(key)) return;
+			let retryDraft: string | undefined;
+			let retryAttachments: File[] | undefined;
+			let retryDelivered = false;
+			const latestAttempt = latestAttempts.get(sourceSessionId);
+			const newerRetry =
+				handoffAttemptId && latestAttempt && latestAttempt !== handoffAttemptId
+					? retryStates.get(attemptKey(sourceSessionId, latestAttempt))
+					: undefined;
+			const retainNewerRetry = Boolean(
+				newerRetry?.command || newerRetry?.attachments?.length,
+			);
+			if (
+				progress.phase === "complete" &&
+				progress.sessionId?.trim() &&
+				progress.dashboardUrl?.trim()
+			) {
+				const targetSessionId = progress.sessionId.trim();
+				completions.set(key, {
+					targetSessionId,
+					dashboardUrl: progress.dashboardUrl,
+					externalPresentation: progress.destination === "external",
+					warningKind: progress.warningKind,
+				});
+				// Completion after an RPC rejection: restore the definitely
+				// unqueued command and attachments from here because the RPC path
+				// already took its failure branch. Only then may the receipt
+				// replace the saved recovery state.
+				const saved = retryStates.get(key);
+				if (progress.warningKind === "unqueued" && saved) {
+					retryDraft = progress.undeliveredCommand ?? saved.command;
+					retryAttachments = saved.attachments;
+				} else if (saved) {
+					retryStates.delete(key);
+				}
+				if (retryDraft || retryAttachments?.length) {
+					if (progress.destination !== "external") {
+						if (!targetOpenAttempts.has(key)) {
+							targetOpenAttempts.add(key);
+							const opened = await Promise.resolve()
+								.then(() =>
+									effects.openSession(targetSessionId, {
+										silent: true,
+										...(retryDraft ? { initialPromptDraft: retryDraft } : {}),
+										...(retryAttachments?.length
+											? { initialAttachments: retryAttachments }
+											: {}),
+									}),
+								)
+								.catch(() => false);
+							if (
+								acceptedAttempt &&
+								acceptedAttempts.get(sourceSessionId) !== acceptedAttempt
+							) {
+								return;
+							}
+							if (opened) {
+								retryStates.delete(key);
+								retryDelivered = true;
+							}
+						}
+					}
+				}
+				if (
+					acceptedAttempt &&
+					acceptedAttempts.get(sourceSessionId) !== acceptedAttempt
+				) {
+					return;
+				}
+			}
+			effects.dispatch({
+				type: "progress",
+				sourceSessionId: progress.sourceSessionId,
+				phase: progress.phase,
+				message: progress.message,
+				dashboardUrl: progress.dashboardUrl,
+				sessionId: progress.sessionId,
+				destination: progress.destination,
+				warningKind: progress.warningKind,
+				...(retainNewerRetry
+					? { retryDraft: newerRetry?.command ?? "" }
+					: retryDraft
+						? { retryDraft }
+						: {}),
+				...(retainNewerRetry
+					? { retryAttachments: newerRetry?.attachments }
+					: retryAttachments?.length
+						? { retryAttachments }
+						: {}),
+				...(retainNewerRetry ? { retainRetry: true } : {}),
+			});
+			if (retryDelivered && !retainNewerRetry) {
+				effects.dispatch({ type: "retry_delivered", sourceSessionId });
+			}
+			// If the RPC dies mid-flight this event is the only carrier of a
+			// follow-up queue failure; surface it exactly like the RPC path.
+			if (progress.phase === "complete") {
+				const warningToast = buildHandoffWarningToast(progress);
+				if (warningToast && claimWarningToast(progress.sourceSessionId)) {
+					effects.toast(warningToast);
+				}
+			}
+		},
+
+		/** The success tail of the handoff RPC. Throws when the result carries
+		 * no cloud session, so the caller's catch routes into onRpcRejected. */
+		async onRpcResolved(
+			sourceSessionId: string,
+			ctx: HandoffRpcResolvedContext,
+		): Promise<void> {
+			const { result, nextCommand, sourceAttachments, pendingPrompt } = ctx;
+			const targetSessionId = (
+				result.outerSessionId ||
+				result.sessionId ||
+				""
+			).trim();
+			const dashboardUrl = result.dashboardUrl?.trim();
+			if (!targetSessionId || !dashboardUrl) {
+				throw new Error("Cloud handoff did not return a cloud session.");
+			}
+			if (!acceptAttempt(sourceSessionId, ctx.handoffAttemptId)) return;
+			const receipt = { targetSessionId, dashboardUrl };
+			const destination = result.destination ?? "in_app";
+			const key = attemptKey(sourceSessionId, ctx.handoffAttemptId);
+			completions.set(key, {
+				targetSessionId,
+				dashboardUrl,
+				externalPresentation: destination === "external",
+				warningKind: result.warningKind,
+			});
+			// A warning means the follow-up command was NOT queued. Clear the
+			// optimistic bubble (it would read as sent), but preserve the
+			// user's command by pre-filling the target session's composer —
+			// the completed source is read-only, so this is the only copy.
+			const undeliveredCommand =
+				result.warning && result.warningKind !== "unconfirmed"
+					? nextCommand.trim() || undefined
+					: undefined;
+			// The images travel with the command: a definite queue failure
+			// dropped them too, so restore them into the target composer.
+			const undeliveredAttachments =
+				result.warning &&
+				result.warningKind !== "unconfirmed" &&
+				sourceAttachments.length > 0
+					? sourceAttachments
+					: undefined;
+			effects.dispatch({
+				type: "complete",
+				sourceSessionId,
+				receipt,
+				externalPresentation: destination === "external",
+				pendingPrompt,
+				...(result.warningKind ? { warningKind: result.warningKind } : {}),
+				...(undeliveredCommand ? { retryDraft: undeliveredCommand } : {}),
+				...(undeliveredAttachments
+					? { retryAttachments: undeliveredAttachments }
+					: {}),
+			});
+			if (result.warning) {
+				effects.dispatch({
+					type: "prompt_reconciled",
+					sourceSessionId: targetSessionId,
+				});
+			}
+			if (shouldOpenHandoffInApp(destination, ctx.isThreadActive?.() ?? true)) {
+				if (!targetOpenAttempts.has(key)) {
+					targetOpenAttempts.add(key);
+					const opened = await Promise.resolve(
+						effects.openSession(targetSessionId, {
+							silent: true,
+							...(undeliveredCommand
+								? { initialPromptDraft: undeliveredCommand }
+								: {}),
+							...(undeliveredAttachments
+								? { initialAttachments: undeliveredAttachments }
+								: {}),
+						}),
+					).catch(() => false);
+					if (opened && (undeliveredCommand || undeliveredAttachments)) {
+						effects.dispatch({ type: "retry_delivered", sourceSessionId });
+					}
+					if (!opened) {
+						effects.dispatch({ type: "external", sourceSessionId });
+						try {
+							await effects.openExternal(dashboardUrl);
+							effects.toast({
+								title: "Opened handoff in your browser",
+								description:
+									"The cloud session could not be attached inside Cline.",
+							});
+						} catch {
+							effects.toast({
+								title: "Unable to open the browser",
+								description:
+									"Use the recovery link to open the cloud session manually.",
+								variant: "destructive",
+							});
+						}
+					}
+				}
+			} else if (destination === "external") {
+				await effects.openExternal(dashboardUrl).catch(() =>
+					effects.toast({
+						title: "Cloud handoff complete",
+						description: "Use the recovery link to open the cloud session.",
+					}),
+				);
+			} else {
+				effects.toast({
+					title: "Cloud handoff complete",
+					description: "The cloud session is ready in your session list.",
+				});
+			}
+			if (result.warning) {
+				const warningToast = buildHandoffWarningToast({
+					warning: result.warning,
+					warningKind: result.warningKind,
+					undeliveredCommand,
+				});
+				// The completion event usually lands first and claims the
+				// toast; only surface it here when the event path did not.
+				if (warningToast && claimWarningToast(sourceSessionId)) {
+					effects.toast(warningToast);
+				}
+			}
+		},
+
+		/** The failure tail of the handoff RPC (its catch block). */
+		async onRpcRejected(
+			sourceSessionId: string,
+			ctx: HandoffRpcRejectedContext,
+		): Promise<void> {
+			const { error, nextCommand, sourceAttachments } = ctx;
+			const key = attemptKey(sourceSessionId, ctx.handoffAttemptId);
+			// The authoritative completion event may have landed while the
+			// RPC transport failed; the handoff succeeded, so a destructive
+			// "failed" toast would contradict the visible receipt.
+			// The reducer-fed entry lags a render; this registry is written
+			// synchronously at event arrival and wins the same-tick race.
+			const syncCompletion = completions.get(key);
+			const completedEntry = syncCompletion
+				? {
+						receipt: {
+							targetSessionId: syncCompletion.targetSessionId,
+							dashboardUrl: syncCompletion.dashboardUrl,
+						},
+						externalPresentation: syncCompletion.externalPresentation,
+						warningKind: syncCompletion.warningKind,
+					}
+				: ctx.handoffAttemptId
+					? undefined
+					: ctx.reducerEntryIsComplete;
+			if (completedEntry) {
+				// The event told the user their command was kept; honor that
+				// even though the RPC (the usual restoration driver) is gone.
+				const restoreCommand =
+					completedEntry.warningKind === "unqueued"
+						? nextCommand.trim() || undefined
+						: undefined;
+				const restoreAttachments =
+					completedEntry.warningKind === "unqueued" &&
+					sourceAttachments.length > 0
+						? sourceAttachments
+						: undefined;
+				effects.dispatch({
+					type: "complete",
+					sourceSessionId,
+					receipt: completedEntry.receipt,
+					externalPresentation: completedEntry.externalPresentation,
+					...(completedEntry.warningKind
+						? { warningKind: completedEntry.warningKind }
+						: {}),
+					...(restoreCommand ? { retryDraft: restoreCommand } : {}),
+					...(restoreAttachments
+						? { retryAttachments: restoreAttachments }
+						: {}),
+				});
+				if (
+					(restoreCommand || restoreAttachments) &&
+					shouldOpenHandoffInApp(
+						completedEntry.externalPresentation ? "external" : "in_app",
+						ctx.isThreadActive?.() ?? true,
+					) &&
+					!targetOpenAttempts.has(key)
+				) {
+					targetOpenAttempts.add(key);
+					const opened = await Promise.resolve()
+						.then(() =>
+							effects.openSession(completedEntry.receipt.targetSessionId, {
+								silent: true,
+								...(restoreCommand
+									? { initialPromptDraft: restoreCommand }
+									: {}),
+								...(restoreAttachments
+									? { initialAttachments: restoreAttachments }
+									: {}),
+							}),
+						)
+						.catch(() => false);
+					if (!opened) {
+						effects.dispatch({
+							type: "target_open_failed",
+							sourceSessionId,
+							dashboardUrl: completedEntry.receipt.dashboardUrl,
+							retryDraft: restoreCommand,
+							retryAttachments: sourceAttachments,
+						});
+					} else {
+						effects.dispatch({ type: "retry_delivered", sourceSessionId });
+					}
+				}
+				effects.toast({
+					title: "Handoff completed",
+					description:
+						"The connection dropped while reporting the result, but the cloud session is ready.",
+				});
+				return;
+			}
+			// Record the retry payload synchronously: if the authoritative
+			// completion lands after this rejection, the reducer replaces the
+			// failed entry, and the event path restores the command and
+			// attachments from this registry.
+			retryStates.set(key, {
+				...(nextCommand.trim() ? { command: nextCommand.trim() } : {}),
+				...(sourceAttachments.length > 0
+					? { attachments: sourceAttachments }
+					: {}),
+			});
+			if (
+				ctx.handoffAttemptId &&
+				latestAttempts.get(sourceSessionId) !== ctx.handoffAttemptId
+			) {
+				return;
+			}
+			effects.dispatch({
+				type: "failed",
+				sourceSessionId,
+				exposeRecovery: true,
+				retryDraft: nextCommand ? `/handoff ${nextCommand}` : "/handoff",
+				retryAttachments: sourceAttachments,
+			});
+			toastFailure(error);
+		},
+	};
+}
+
+export type HandoffLifecycle = ReturnType<typeof createHandoffLifecycle>;

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-lifecycle.ts
@@ -47,6 +47,7 @@ export type HandoffLifecycleEffects = {
 			silent: true;
 			initialPromptDraft?: string;
 			initialAttachments?: File[];
+			expectedActiveThreadId?: string;
 		},
 	) => Promise<boolean> | boolean | undefined;
 	openExternal: (url: string) => Promise<void>;
@@ -129,6 +130,7 @@ export function createHandoffLifecycle(effects: HandoffLifecycleEffects) {
 	const latestAttempts = new Map<string, string>();
 	const acceptedAttempts = new Map<string, string>();
 	const attemptOrders = new Map<string, number>();
+	const sourceThreadIds = new Map<string, string>();
 	let nextAttemptOrder = 0;
 
 	const attemptKey = (sourceSessionId: string, attemptId?: string) =>
@@ -173,10 +175,16 @@ export function createHandoffLifecycle(effects: HandoffLifecycleEffects) {
 
 	return {
 		/** Starts a distinct RPC attempt for this source session. */
-		onRpcStarted(sourceSessionId: string): string {
+		onRpcStarted(sourceSessionId: string, sourceThreadId?: string): string {
 			const attemptId = crypto.randomUUID();
 			attemptOrders.set(attemptId, ++nextAttemptOrder);
 			latestAttempts.set(sourceSessionId, attemptId);
+			if (sourceThreadId) {
+				sourceThreadIds.set(
+					attemptKey(sourceSessionId, attemptId),
+					sourceThreadId,
+				);
+			}
 			surfacedWarnings.delete(sourceSessionId);
 			return attemptId;
 		},
@@ -187,6 +195,7 @@ export function createHandoffLifecycle(effects: HandoffLifecycleEffects) {
 			if (!acceptAttempt(sourceSessionId, handoffAttemptId)) return;
 			const acceptedAttempt = handoffAttemptId;
 			const key = attemptKey(sourceSessionId, handoffAttemptId);
+			const sourceThreadId = sourceThreadIds.get(key);
 			if (progress.phase === "complete" && completions.has(key)) return;
 			let retryDraft: string | undefined;
 			let retryAttachments: File[] | undefined;
@@ -233,6 +242,11 @@ export function createHandoffLifecycle(effects: HandoffLifecycleEffects) {
 										...(retryDraft ? { initialPromptDraft: retryDraft } : {}),
 										...(retryAttachments?.length
 											? { initialAttachments: retryAttachments }
+											: {}),
+										...(sourceThreadId
+											? {
+													expectedActiveThreadId: sourceThreadId,
+												}
 											: {}),
 									}),
 								)

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.test.ts
@@ -2,9 +2,65 @@ import { describe, expect, it } from "vitest";
 import {
 	appendPendingHandoffPrompt,
 	cloudHandoffUiReducer,
+	hasLivePendingHandoff,
+	resolveHandoffReceipt,
 } from "./cloud-handoff-ui-state";
 
 describe("cloudHandoffUiReducer", () => {
+	it("recognizes live recovery ownership before history refreshes", () => {
+		expect(
+			hasLivePendingHandoff({
+				status: "recovery",
+				dashboardUrl: "https://app.cline.bot/agents/cloud-1",
+			}),
+		).toBe(true);
+		expect(
+			hasLivePendingHandoff({
+				status: "retry_restored",
+				dashboardUrl: "https://app.cline.bot/agents/cloud-1",
+			}),
+		).toBe(true);
+		expect(hasLivePendingHandoff({ status: "retry_restored" })).toBe(false);
+		expect(hasLivePendingHandoff({ status: "failed" })).toBe(false);
+	});
+
+	it("keeps a persisted completion receipt alongside live recovery state", () => {
+		const persisted = {
+			targetSessionId: "cloud-1",
+			dashboardUrl: "https://app.cline.bot/agents/cloud-1",
+		};
+		expect(
+			resolveHandoffReceipt(
+				{
+					status: "recovery",
+					dashboardUrl: persisted.dashboardUrl,
+					retryDraft: "/handoff continue",
+				},
+				persisted,
+			),
+		).toBe(persisted);
+		expect(resolveHandoffReceipt(undefined, persisted)).toBe(persisted);
+	});
+
+	it("carries the event's warningKind into the completed entry", () => {
+		const next = cloudHandoffUiReducer(
+			{},
+			{
+				type: "progress",
+				sourceSessionId: "local-1",
+				phase: "complete",
+				sessionId: "cloud-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				destination: "in_app",
+				warningKind: "unqueued",
+			},
+		);
+		expect(next["local-1"]).toMatchObject({
+			status: "complete",
+			warningKind: "unqueued",
+		});
+	});
+
 	it("keeps a source locked across pane remounts and preserves its latest phase", () => {
 		const creating = cloudHandoffUiReducer(
 			{},
@@ -54,8 +110,10 @@ describe("cloudHandoffUiReducer", () => {
 				sourceSessionId: "local-1",
 			})["local-1"],
 		).toEqual({
-			status: "recovery",
+			status: "retry_restored",
 			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			retryDraft: "/handoff continue",
+			retryAttachments: undefined,
 		});
 		expect(
 			cloudHandoffUiReducer(progress, {
@@ -91,7 +149,11 @@ describe("cloudHandoffUiReducer", () => {
 			type: "retry_restored",
 			sourceSessionId: "local-1",
 		});
-		expect(restored["local-1"]).toEqual({ status: "retry_restored" });
+		expect(restored["local-1"]).toEqual({
+			status: "retry_restored",
+			retryDraft: undefined,
+			retryAttachments: undefined,
+		});
 		expect(
 			cloudHandoffUiReducer(restored, {
 				type: "progress",
@@ -123,10 +185,13 @@ describe("cloudHandoffUiReducer", () => {
 		expect(retry["local-1"]).toEqual({
 			status: "progress",
 			phase: "checking",
+			// A retry keeps the recovery URL so an early failure cannot drop
+			// the only dashboard link held in live state.
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
 		});
 	});
 
-	it("reconciles an authoritative late completion after a webview failure", () => {
+	it("clears same-attempt recovery after a clean authoritative completion", () => {
 		const failed = {
 			"local-1": {
 				status: "failed" as const,
@@ -149,6 +214,89 @@ describe("cloudHandoffUiReducer", () => {
 				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
 			},
 			externalPresentation: false,
+		});
+	});
+
+	it("keeps the completion receipt when a late failure lands after complete", () => {
+		const completed = cloudHandoffUiReducer(
+			{},
+			{
+				type: "complete",
+				sourceSessionId: "local-1",
+				receipt: {
+					targetSessionId: "cloud-1",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				},
+				externalPresentation: false,
+			},
+		);
+
+		// The RPC transport can fail after the authoritative completion event
+		// already landed; the receipt and its cloud URL must survive.
+		const withRecovery = cloudHandoffUiReducer(completed, {
+			type: "failed",
+			sourceSessionId: "local-1",
+			exposeRecovery: true,
+			retryDraft: "/handoff continue",
+		});
+		expect(withRecovery["local-1"]).toMatchObject({
+			status: "complete",
+			receipt: {
+				targetSessionId: "cloud-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+			retryDraft: "/handoff continue",
+		});
+		expect(
+			cloudHandoffUiReducer(completed, {
+				type: "failed",
+				sourceSessionId: "local-1",
+				exposeRecovery: false,
+			}),
+		).toBe(completed);
+		expect(completed["local-1"]).toEqual({
+			status: "complete",
+			receipt: {
+				targetSessionId: "cloud-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+			externalPresentation: false,
+		});
+	});
+
+	it("keeps a completed receipt with recovery payload when its target cannot open", () => {
+		const attachment = new File(["img"], "shot.png", {
+			type: "image/png",
+		});
+		const recovered = cloudHandoffUiReducer(
+			{
+				"local-1": {
+					status: "complete",
+					receipt: {
+						targetSessionId: "cloud-1",
+						dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+					},
+					externalPresentation: false,
+				},
+			},
+			{
+				type: "target_open_failed",
+				sourceSessionId: "local-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+				retryDraft: "/handoff continue",
+				retryAttachments: [attachment],
+			},
+		);
+
+		expect(recovered["local-1"]).toEqual({
+			status: "complete",
+			receipt: {
+				targetSessionId: "cloud-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+			externalPresentation: false,
+			retryDraft: "/handoff continue",
+			retryAttachments: [attachment],
 		});
 	});
 
@@ -180,7 +328,39 @@ describe("cloudHandoffUiReducer", () => {
 				type: "start",
 				sourceSessionId: "local-1",
 			})["local-1"],
-		).toEqual({ status: "progress", phase: "checking" });
+		).toEqual({
+			status: "progress",
+			phase: "checking",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+		});
+	});
+
+	it("retains a restored retry payload when recovery is dismissed", () => {
+		const attachment = new File(["image"], "diagram.png", {
+			type: "image/png",
+		});
+		const dismissed = cloudHandoffUiReducer(
+			{
+				"local-1": {
+					status: "retry_restored",
+					dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+					retryDraft: "/handoff continue",
+					retryAttachments: [attachment],
+				},
+			},
+			{
+				type: "dismiss_recovery",
+				sourceSessionId: "local-1",
+				dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			},
+		);
+
+		expect(dismissed["local-1"]).toEqual({
+			status: "recovery_dismissed",
+			dashboardUrl: "https://app.cline.bot/agents?sessionId=cloud-1",
+			retryDraft: "/handoff continue",
+			retryAttachments: [attachment],
+		});
 	});
 
 	it("keeps the temporary handoff prompt ahead of a live response", () => {
@@ -192,7 +372,7 @@ describe("cloudHandoffUiReducer", () => {
 			images: [
 				{
 					id: "handoff-image",
-					mediaType: "image/png",
+					mediaType: "image/png" as const,
 					data: "aGVsbG8=",
 				},
 			],

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff-ui-state.ts
@@ -24,17 +24,51 @@ export type CloudHandoffUiEntry =
 			retryDraft?: string;
 			retryAttachments?: File[];
 	  }
-	| { status: "recovery_dismissed"; dashboardUrl: string }
+	| {
+			status: "recovery_dismissed";
+			dashboardUrl: string;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
 	| { status: "failed"; retryDraft?: string; retryAttachments?: File[] }
-	| { status: "retry_restored" }
+	| {
+			status: "retry_restored";
+			dashboardUrl?: string;
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
 	| { status: "target_prompt"; pendingPrompt: PendingHandoffPrompt }
 	| {
 			status: "complete";
 			receipt: HandoffReceipt;
 			externalPresentation: boolean;
+			/** Follow-up queue outcome, carried so a lost RPC response can
+			 * still drive the definite-failure restoration. */
+			warningKind?: "unqueued" | "unconfirmed";
+			retryDraft?: string;
+			retryAttachments?: File[];
+			retainRetry?: boolean;
 	  };
 
 export type CloudHandoffUiState = Record<string, CloudHandoffUiEntry>;
+
+export function hasLivePendingHandoff(
+	entry: CloudHandoffUiEntry | undefined,
+): boolean {
+	return (
+		entry?.status === "recovery" ||
+		entry?.status === "recovery_dismissed" ||
+		(entry?.status === "retry_restored" && Boolean(entry.dashboardUrl))
+	);
+}
+
+export function resolveHandoffReceipt(
+	live: CloudHandoffUiEntry | undefined,
+	persisted: HandoffReceipt | null,
+): HandoffReceipt | null {
+	if (!live) return persisted;
+	return live.status === "complete" ? live.receipt : persisted;
+}
 
 export type CloudHandoffUiAction =
 	| {
@@ -50,6 +84,10 @@ export type CloudHandoffUiAction =
 			dashboardUrl?: string;
 			sessionId?: string;
 			destination?: "in_app" | "external";
+			warningKind?: "unqueued" | "unconfirmed";
+			retryDraft?: string;
+			retryAttachments?: File[];
+			retainRetry?: boolean;
 	  }
 	| {
 			type: "failed";
@@ -64,6 +102,16 @@ export type CloudHandoffUiAction =
 			receipt: HandoffReceipt;
 			externalPresentation: boolean;
 			pendingPrompt?: PendingHandoffPrompt;
+			warningKind?: "unqueued" | "unconfirmed";
+			retryDraft?: string;
+			retryAttachments?: File[];
+	  }
+	| {
+			type: "target_open_failed";
+			sourceSessionId: string;
+			dashboardUrl: string;
+			retryDraft?: string;
+			retryAttachments?: File[];
 	  }
 	| { type: "external"; sourceSessionId: string }
 	| { type: "prompt_reconciled"; sourceSessionId: string }
@@ -72,7 +120,8 @@ export type CloudHandoffUiAction =
 			sourceSessionId: string;
 			dashboardUrl: string;
 	  }
-	| { type: "retry_restored"; sourceSessionId: string };
+	| { type: "retry_restored"; sourceSessionId: string }
+	| { type: "retry_delivered"; sourceSessionId: string };
 
 function completeHandoff(
 	state: CloudHandoffUiState,
@@ -80,13 +129,41 @@ function completeHandoff(
 	receipt: HandoffReceipt,
 	externalPresentation: boolean,
 	pendingPrompt?: PendingHandoffPrompt,
+	warningKind?: "unqueued" | "unconfirmed",
+	retryDraft?: string,
+	retryAttachments?: File[],
+	retainRetry = false,
 ): CloudHandoffUiState {
+	const current = state[sourceSessionId];
+	const carriedRetryDraft =
+		retryDraft ??
+		(retainRetry &&
+		(current?.status === "failed" ||
+			current?.status === "recovery" ||
+			current?.status === "retry_restored" ||
+			current?.status === "complete")
+			? current.retryDraft
+			: undefined);
+	const carriedRetryAttachments =
+		retryAttachments ??
+		(retainRetry &&
+		(current?.status === "failed" ||
+			current?.status === "recovery" ||
+			current?.status === "retry_restored" ||
+			current?.status === "complete")
+			? current.retryAttachments
+			: undefined);
 	return {
 		...state,
 		[sourceSessionId]: {
 			status: "complete",
 			receipt,
 			externalPresentation,
+			...(warningKind ? { warningKind } : {}),
+			...(carriedRetryDraft ? { retryDraft: carriedRetryDraft } : {}),
+			...(carriedRetryAttachments?.length
+				? { retryAttachments: carriedRetryAttachments }
+				: {}),
 		},
 		...(!externalPresentation && pendingPrompt
 			? {
@@ -106,11 +183,21 @@ export function cloudHandoffUiReducer(
 	const current = state[action.sourceSessionId];
 	switch (action.type) {
 		case "start": {
+			// A retry of a pending handoff must not discard the recovery URL:
+			// if the retry fails before any progress event re-supplies it, the
+			// dashboard link would be gone from live state entirely.
+			const carriedDashboardUrl =
+				current?.status === "recovery" ||
+				current?.status === "recovery_dismissed" ||
+				current?.status === "progress"
+					? current.dashboardUrl
+					: undefined;
 			return {
 				...state,
 				[action.sourceSessionId]: {
 					status: "progress",
 					phase: "checking",
+					...(carriedDashboardUrl ? { dashboardUrl: carriedDashboardUrl } : {}),
 					...(action.pendingPrompt
 						? { pendingPrompt: action.pendingPrompt }
 						: {}),
@@ -131,6 +218,11 @@ export function cloudHandoffUiReducer(
 						dashboardUrl: action.dashboardUrl,
 					},
 					action.destination === "external",
+					undefined,
+					action.warningKind,
+					action.retryDraft,
+					action.retryAttachments,
+					action.retainRetry,
 				);
 			}
 			if (
@@ -156,6 +248,21 @@ export function cloudHandoffUiReducer(
 				},
 			};
 		case "failed": {
+			// An authoritative completion event may have already landed while
+			// the RPC transport failed; the receipt (and its cloud URL) must
+			// survive, since the source session is locked either way.
+			if (current?.status === "complete") {
+				if (!action.retryDraft && !action.retryAttachments?.length)
+					return state;
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						...current,
+						retryDraft: action.retryDraft,
+						retryAttachments: action.retryAttachments,
+					},
+				};
+			}
 			const dashboardUrl =
 				current?.status === "progress" ? current.dashboardUrl : undefined;
 			if (action.exposeRecovery && dashboardUrl) {
@@ -185,7 +292,30 @@ export function cloudHandoffUiReducer(
 				action.receipt,
 				action.externalPresentation,
 				action.pendingPrompt,
+				action.warningKind,
+				action.retryDraft,
+				action.retryAttachments,
 			);
+		case "target_open_failed":
+			if (current?.status === "complete") {
+				return {
+					...state,
+					[action.sourceSessionId]: {
+						...current,
+						retryDraft: action.retryDraft,
+						retryAttachments: action.retryAttachments,
+					},
+				};
+			}
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "recovery",
+					dashboardUrl: action.dashboardUrl,
+					retryDraft: action.retryDraft,
+					retryAttachments: action.retryAttachments,
+				},
+			};
 		case "external": {
 			if (current?.status !== "complete") return state;
 			const next = {
@@ -212,25 +342,49 @@ export function cloudHandoffUiReducer(
 				[action.sourceSessionId]: {
 					status: "recovery_dismissed",
 					dashboardUrl: action.dashboardUrl,
+					...(current && "retryDraft" in current
+						? { retryDraft: current.retryDraft }
+						: {}),
+					...(current && "retryAttachments" in current
+						? { retryAttachments: current.retryAttachments }
+						: {}),
 				},
 			};
 		case "retry_restored":
 			if (current?.status === "failed") {
 				return {
 					...state,
-					[action.sourceSessionId]: { status: "retry_restored" },
+					[action.sourceSessionId]: {
+						status: "retry_restored",
+						retryDraft: current.retryDraft,
+						retryAttachments: current.retryAttachments,
+					},
 				};
 			}
 			if (current?.status === "recovery") {
 				return {
 					...state,
 					[action.sourceSessionId]: {
-						status: "recovery",
+						status: "retry_restored",
 						dashboardUrl: current.dashboardUrl,
+						retryDraft: current.retryDraft,
+						retryAttachments: current.retryAttachments,
 					},
 				};
 			}
 			return state;
+		case "retry_delivered": {
+			if (current?.status !== "complete") return state;
+			return {
+				...state,
+				[action.sourceSessionId]: {
+					status: "complete",
+					receipt: current.receipt,
+					externalPresentation: current.externalPresentation,
+					...(current.warningKind ? { warningKind: current.warningKind } : {}),
+				},
+			};
+		}
 	}
 }
 

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildHandoffWarningToast,
+	claimHandoffWarningSurface,
 	formatHandoffModelFallback,
 	parseHandoffCommand,
 	readHandoffReceipt,
@@ -84,5 +86,48 @@ describe("cloud handoff helpers", () => {
 		expect(shouldOpenHandoffInApp("in_app", true)).toBe(true);
 		expect(shouldOpenHandoffInApp("in_app", false)).toBe(false);
 		expect(shouldOpenHandoffInApp("external", true)).toBe(false);
+	});
+});
+
+describe("handoff completion warnings", () => {
+	it("surfaces an unqueued warning once across the event and RPC paths", () => {
+		const surfaced = new Set<string>();
+		// The sidecar's completion event lands first with the full payload.
+		const eventToast = buildHandoffWarningToast({
+			warning:
+				"The handoff completed, but the follow-up command was not queued.",
+			warningKind: "unqueued",
+			undeliveredCommand: "fix the failing tests",
+		});
+		expect(eventToast).toEqual({
+			title: "Handoff completed with a warning",
+			description:
+				'The handoff completed, but the follow-up command was not queued. Your command was kept: "fix the failing tests" — send it from the cloud session.',
+		});
+		expect(claimHandoffWarningSurface(surfaced, "source-1")).toBe(true);
+
+		// The RPC result then reports the same warning: no second toast.
+		expect(claimHandoffWarningSurface(surfaced, "source-1")).toBe(false);
+		// A different source session is unaffected by the claim.
+		expect(claimHandoffWarningSurface(surfaced, "source-2")).toBe(true);
+	});
+
+	it("marks unconfirmed warnings destructive and never quotes the command", () => {
+		expect(
+			buildHandoffWarningToast({
+				warning: "Cline could not confirm whether the command was queued.",
+				warningKind: "unconfirmed",
+				undeliveredCommand: "fix the failing tests",
+			}),
+		).toEqual({
+			title: "Handoff completed with a warning",
+			description: "Cline could not confirm whether the command was queued.",
+			variant: "destructive",
+		});
+	});
+
+	it("returns no toast for a clean completion payload", () => {
+		expect(buildHandoffWarningToast({})).toBeNull();
+		expect(buildHandoffWarningToast({ warning: "   " })).toBeNull();
 	});
 });

--- a/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-handoff.ts
@@ -124,3 +124,56 @@ export function shouldOpenHandoffInApp(
 ): boolean {
 	return destination === "in_app" && isSourceStillActive;
 }
+
+export type HandoffWarningToast = {
+	title: string;
+	description: string;
+	variant?: "destructive";
+};
+
+/**
+ * The single source of truth for how a handoff completion warning is shown,
+ * shared by the RPC result path and the `cloud_handoff_progress` complete
+ * event path so both surface the identical toast. Returns null when the
+ * payload carries no warning. An unconfirmed follow-up must never quote the
+ * command for resending — it may already be durably queued.
+ */
+export function buildHandoffWarningToast(fields: {
+	warning?: unknown;
+	warningKind?: unknown;
+	undeliveredCommand?: unknown;
+}): HandoffWarningToast | null {
+	const warning =
+		typeof fields.warning === "string" ? fields.warning.trim() : "";
+	if (!warning) {
+		return null;
+	}
+	const unconfirmed = fields.warningKind === "unconfirmed";
+	const undeliveredCommand =
+		!unconfirmed && typeof fields.undeliveredCommand === "string"
+			? fields.undeliveredCommand.trim()
+			: "";
+	return {
+		title: "Handoff completed with a warning",
+		description: undeliveredCommand
+			? `${warning} Your command was kept: "${undeliveredCommand}" — send it from the cloud session.`
+			: warning,
+		...(unconfirmed ? { variant: "destructive" as const } : {}),
+	};
+}
+
+/**
+ * Both the completion event and the RPC result can report the same warning;
+ * whichever lands first claims the toast and the other stays silent. Returns
+ * true when this caller should surface the warning for the source session.
+ */
+export function claimHandoffWarningSurface(
+	surfaced: Set<string>,
+	sourceSessionId: string,
+): boolean {
+	if (surfaced.has(sourceSessionId)) {
+		return false;
+	}
+	surfaced.add(sourceSessionId);
+	return true;
+}

--- a/apps/examples/desktop-app/webview/lib/desktop-app-state.test.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-app-state.test.ts
@@ -43,6 +43,35 @@ describe("desktopAppReducer", () => {
 		).toBeUndefined();
 	});
 
+	it("hands attachment-only recovery to the target thread exactly once", () => {
+		const attachment = new File(["png-bytes"], "screenshot.png", {
+			type: "image/png",
+		});
+		let state = createDesktopAppState("welcome", settingsSection);
+		state = desktopAppReducer(state, {
+			type: "open-session",
+			session: createSession("handoff-target"),
+			initialAttachments: [attachment],
+		});
+
+		const thread = state.threads.find(
+			(item) => item.id === "session_handoff-target",
+		);
+		expect(thread?.initialPromptDraft).toBeUndefined();
+		expect(thread?.initialAttachments).toEqual([attachment]);
+
+		state = desktopAppReducer(state, {
+			type: "consume-initial-prompt-draft",
+			threadId: "session_handoff-target",
+		});
+
+		const consumed = state.threads.find(
+			(item) => item.id === "session_handoff-target",
+		);
+		expect(consumed?.initialPromptDraft).toBeUndefined();
+		expect(consumed?.initialAttachments).toBeUndefined();
+	});
+
 	it("keeps both sessions deleted when deletion actions are queued together", () => {
 		let state = createDesktopAppState("welcome", settingsSection, "local");
 		state = desktopAppReducer(state, {

--- a/apps/examples/desktop-app/webview/lib/desktop-app-state.ts
+++ b/apps/examples/desktop-app/webview/lib/desktop-app-state.ts
@@ -13,6 +13,8 @@ export type DesktopThread = {
 	historySession?: SessionHistoryItem;
 	hasStarted?: boolean;
 	initialPromptDraft?: string;
+	/** Attachments restored into the composer alongside initialPromptDraft. */
+	initialAttachments?: File[];
 };
 
 export type DesktopAppLocation<SettingsSection extends string> = {
@@ -42,6 +44,7 @@ export type DesktopAppAction<SettingsSection extends string> =
 			session: SessionHistoryItem;
 			environmentId: string;
 			initialPromptDraft?: string;
+			initialAttachments?: File[];
 	  }
 	| { type: "consume-initial-prompt-draft"; threadId: string }
 	| {
@@ -185,6 +188,7 @@ export function desktopAppReducer<SettingsSection extends string>(
 											environmentId: action.environmentId,
 										},
 										initialPromptDraft: action.initialPromptDraft,
+										initialAttachments: action.initialAttachments,
 									}
 								: thread,
 						)
@@ -199,6 +203,7 @@ export function desktopAppReducer<SettingsSection extends string>(
 									environmentId: action.environmentId,
 								},
 								initialPromptDraft: action.initialPromptDraft,
+								initialAttachments: action.initialAttachments,
 							},
 						];
 			return {
@@ -218,8 +223,13 @@ export function desktopAppReducer<SettingsSection extends string>(
 				...state,
 				threads: state.threads.map((thread) =>
 					thread.id === action.threadId &&
-					thread.initialPromptDraft !== undefined
-						? { ...thread, initialPromptDraft: undefined }
+					(thread.initialPromptDraft !== undefined ||
+						thread.initialAttachments !== undefined)
+						? {
+								...thread,
+								initialPromptDraft: undefined,
+								initialAttachments: undefined,
+							}
 						: thread,
 				),
 			};

--- a/apps/examples/desktop-app/webview/lib/session-history.ts
+++ b/apps/examples/desktop-app/webview/lib/session-history.ts
@@ -68,6 +68,7 @@ export interface SessionHistoryItem {
 	prompt?: string;
 	startedAt: string;
 	endedAt?: string;
+	lastActivityAt?: string;
 	metadata?: SessionMetadata;
 }
 

--- a/sdk/packages/core/src/hub/client/index.test.ts
+++ b/sdk/packages/core/src/hub/client/index.test.ts
@@ -16,6 +16,7 @@ class MockWebSocket {
 	static readonly CLOSED = 3;
 	static instances: MockWebSocket[] = [];
 	static commandPayloads = new Map<string, unknown>();
+	static failNextOpen = false;
 
 	readyState = MockWebSocket.CONNECTING;
 	readonly sentFrames: unknown[] = [];
@@ -24,6 +25,11 @@ class MockWebSocket {
 	constructor(public readonly url: string) {
 		MockWebSocket.instances.push(this);
 		queueMicrotask(() => {
+			if (MockWebSocket.failNextOpen) {
+				MockWebSocket.failNextOpen = false;
+				this.emit("error", new Error("connection refused"));
+				return;
+			}
 			this.readyState = MockWebSocket.OPEN;
 			this.emit("open");
 		});
@@ -32,6 +38,7 @@ class MockWebSocket {
 	static reset(): void {
 		MockWebSocket.instances = [];
 		MockWebSocket.commandPayloads.clear();
+		MockWebSocket.failNextOpen = false;
 	}
 
 	send(data: string): void {
@@ -216,6 +223,30 @@ describe("NodeHubClient", () => {
 					clientId: client.getClientId(),
 				});
 
+				await client.dispose();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("retries an initial connection failure with an active subscription", async () => {
+			vi.useFakeTimers();
+			vi.stubGlobal("WebSocket", MockWebSocket);
+			MockWebSocket.failNextOpen = true;
+
+			try {
+				const client = new NodeHubClient({ url: "ws://127.0.0.1:25463/hub" });
+				client.subscribe(() => {}, { sessionId: "session-1" });
+				await expect(client.connect()).rejects.toMatchObject({
+					code: "hub_connect_failed",
+				});
+
+				await vi.advanceTimersByTimeAsync(251);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				expect(MockWebSocket.instances).toHaveLength(2);
+				expect(client.isConnected()).toBe(true);
 				await client.dispose();
 			} finally {
 				vi.useRealTimers();

--- a/sdk/packages/core/src/hub/client/index.ts
+++ b/sdk/packages/core/src/hub/client/index.ts
@@ -473,6 +473,9 @@ export class NodeHubClient {
 					// best-effort close
 				}
 			}
+			if (!this.closedByClient && this.hasActiveSubscriptions()) {
+				this.scheduleReconnect();
+			}
 			throw error;
 		}
 	}

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.test.ts
@@ -72,6 +72,32 @@ describe("run handlers", () => {
 		);
 	});
 
+	it("accepts an image-only session input", async () => {
+		const runTurn = vi.fn().mockResolvedValue(undefined);
+		const ctx = createContext({ runTurn });
+		const image = "data:image/png;base64,aGVsbG8=";
+
+		await expect(
+			handleSessionInput(ctx, {
+				version: "v1",
+				command: "session.send_input",
+				requestId: "req-image",
+				sessionId: "session-1",
+				payload: {
+					prompt: "",
+					attachments: { userImages: [image] },
+				},
+			}),
+		).resolves.toMatchObject({ ok: true });
+
+		expect(runTurn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prompt: "",
+				userImages: [image],
+			}),
+		);
+	});
+
 	it("does not publish run start for an unknown session", async () => {
 		const runTurn = vi.fn();
 		const ctx = createContext({

--- a/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/run-handlers.ts
@@ -216,11 +216,23 @@ export async function handleSessionInput(
 			: typeof payload.input === "string"
 				? payload.input
 				: "";
-	if (!prompt.trim()) {
+	const attachments =
+		payload.attachments &&
+		typeof payload.attachments === "object" &&
+		!Array.isArray(payload.attachments)
+			? (payload.attachments as Record<string, unknown>)
+			: undefined;
+	const userImages = Array.isArray(attachments?.userImages)
+		? attachments.userImages.filter((image) => typeof image === "string")
+		: undefined;
+	const userFiles = Array.isArray(attachments?.userFiles)
+		? attachments.userFiles.filter((filePath) => typeof filePath === "string")
+		: undefined;
+	if (!prompt.trim() && !userImages?.length && !userFiles?.length) {
 		return errorReply(
 			envelope,
 			"invalid_session_input",
-			"session input requires a prompt string",
+			"session input requires a prompt or attachment",
 		);
 	}
 	const session = await ctx.sessionHost.getSession(sessionId);
@@ -237,15 +249,6 @@ export async function handleSessionInput(
 			sessionId,
 		),
 	);
-	const attachments =
-		payload.attachments &&
-		typeof payload.attachments === "object" &&
-		!Array.isArray(payload.attachments)
-			? (payload.attachments as Record<string, unknown>)
-			: undefined;
-	const userFiles = Array.isArray(attachments?.userFiles)
-		? attachments.userFiles.filter((filePath) => typeof filePath === "string")
-		: undefined;
 	const timeoutMs = parseRunTimeoutMs(payload);
 	ctx.suppressNextTerminalEventBySession.set(sessionId, "run.start.reply");
 	const releaseActiveRpcTurn = trackActiveRpcTurn(ctx, sessionId);
@@ -263,9 +266,7 @@ export async function handleSessionInput(
 						payload.delivery === "queue" || payload.delivery === "steer"
 							? payload.delivery
 							: undefined,
-					userImages: Array.isArray(attachments?.userImages)
-						? (attachments.userImages as string[])
-						: undefined,
+					userImages,
 					userFiles,
 					timeoutMs,
 				},

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -3699,6 +3699,63 @@ describe("LocalRuntimeHost", () => {
 		});
 	});
 
+	it("reflects persisted metadata updates for an active session", async () => {
+		const sessionId = "sess-active-metadata-update";
+		const updateSession = vi.fn().mockResolvedValue({ updated: true });
+		const manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: {
+				ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+				createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+					manifestPath: "/tmp/manifest.json",
+					messagesPath: "/tmp/messages.json",
+					manifest: createManifest(sessionId),
+				}),
+				persistSessionMessages: vi.fn(),
+				updateSessionStatus: vi.fn().mockResolvedValue({ updated: true }),
+				updateSession,
+				writeSessionManifest: vi.fn(),
+				listSessions: vi.fn().mockResolvedValue([]),
+				deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+			} as never,
+			runtimeBuilder: {
+				build: vi.fn().mockReturnValue({ tools: [], shutdown: vi.fn() }),
+			} as never,
+			createAgent: () =>
+				({
+					run: vi.fn().mockResolvedValue(createResult()),
+					continue: vi.fn().mockResolvedValue(createResult()),
+					getMessages: vi.fn().mockReturnValue([]),
+					getAgentId: vi.fn().mockReturnValue("agent-active-metadata"),
+					getConversationId: vi.fn().mockReturnValue("conv-active-metadata"),
+					abort: vi.fn(),
+					subscribeEvents: vi.fn().mockReturnValue(() => {}),
+					canStartRun: vi.fn().mockReturnValue(true),
+					shutdown: vi.fn().mockResolvedValue(undefined),
+				}) as never,
+		});
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				interactive: true,
+				sessionMetadata: { before: true },
+			}),
+		);
+
+		const metadata = {
+			handoff: { status: "complete", toCloudSessionId: "cloud-1" },
+		};
+		await expect(
+			manager.updateSession(sessionId, { metadata }),
+		).resolves.toEqual({
+			updated: true,
+		});
+		expect(updateSession).toHaveBeenCalledWith({ sessionId, metadata });
+		await expect(manager.getSession(sessionId)).resolves.toMatchObject({
+			metadata,
+		});
+	});
+
 	it("keeps the same live interactive session usable after aborting before the first response", async () => {
 		const sessionId = "sess-abort-then-next-turn";
 		const manifest = createManifest(sessionId);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -1345,7 +1345,12 @@ export class LocalRuntimeHost implements RuntimeHost {
 				title: updates.title,
 			},
 		);
-		return { updated: result?.updated === true };
+		const updated = result?.updated === true;
+		if (updated && updates.metadata !== undefined) {
+			const active = this.sessions.get(sessionId.trim());
+			if (active) active.sessionMetadata = updates.metadata ?? undefined;
+		}
+		return { updated };
 	}
 
 	async updateSessionCompactionState(

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.test.ts
@@ -12,7 +12,7 @@ function fakeGit(overrides: Record<string, string | Error> = {}): GitCommand {
 	const outputs: Record<string, string | Error> = {
 		"rev-parse --is-inside-work-tree": "true\n",
 		"rev-parse --show-prefix": "",
-		"status --porcelain=v1 --untracked-files=all": "",
+		"status --porcelain=v1 --untracked-files=all --ignore-submodules=none": "",
 		"symbolic-ref --quiet --short HEAD": "feature/handoff\n",
 		"config --get branch.feature/handoff.remote": "origin\n",
 		"config --get branch.feature/handoff.merge": "refs/heads/feature/handoff\n",
@@ -49,14 +49,24 @@ describe("normalizeGitHubRemoteUrl", () => {
 
 describe("preflightCloudHandoffGit", () => {
 	it("returns the exact pushed upstream context", async () => {
+		const git = fakeGit();
 		await expect(
-			preflightCloudHandoffGit({ cwd: "/repo", git: fakeGit() }),
+			preflightCloudHandoffGit({ cwd: "/repo", git }),
 		).resolves.toEqual({
 			repoUrl: "https://github.com/cline/cline",
 			branch: "feature/handoff",
 			remoteName: "origin",
 			headSha: HEAD,
 		});
+		expect(git).toHaveBeenCalledWith(
+			[
+				"status",
+				"--porcelain=v1",
+				"--untracked-files=all",
+				"--ignore-submodules=none",
+			],
+			expect.objectContaining({ cwd: "/repo" }),
+		);
 	});
 
 	it("preserves a workspace path relative to the repository root", async () => {
@@ -70,6 +80,17 @@ describe("preflightCloudHandoffGit", () => {
 		);
 	});
 
+	it("preserves significant whitespace in repository-relative workspace paths", async () => {
+		await expect(
+			preflightCloudHandoffGit({
+				cwd: "/repo/ leading ",
+				git: fakeGit({ "rev-parse --show-prefix": " leading /\n" }),
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({ workspaceRelativePath: " leading " }),
+		);
+	});
+
 	it("refuses tracked or untracked worktree changes with a compact summary", async () => {
 		const dirty = Array.from(
 			{ length: 8 },
@@ -78,7 +99,8 @@ describe("preflightCloudHandoffGit", () => {
 		const error = await preflightCloudHandoffGit({
 			cwd: "/repo",
 			git: fakeGit({
-				"status --porcelain=v1 --untracked-files=all": dirty,
+				"status --porcelain=v1 --untracked-files=all --ignore-submodules=none":
+					dirty,
 			}),
 		}).catch((caught) => caught);
 
@@ -180,5 +202,24 @@ describe("preflightCloudHandoffGit", () => {
 		expect(error.code).toBe("missing_upstream");
 		expect(error.message).toBe("Could not resolve the upstream remote.");
 		expect(error.message).not.toContain(secret);
+		expect(error.cause).toBeUndefined();
+	});
+
+	it("supports a GitHub URL configured directly as the branch remote", async () => {
+		const remote = "https://github_pat_secret@github.com/cline/cline.git";
+		await expect(
+			preflightCloudHandoffGit({
+				cwd: "/repo",
+				git: fakeGit({
+					"config --get branch.feature/handoff.remote": remote,
+					[`ls-remote --exit-code ${remote} refs/heads/feature/handoff`]: `${HEAD}\trefs/heads/feature/handoff\n`,
+				}),
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({
+				repoUrl: "https://github.com/cline/cline",
+				remoteName: "https://github.com/cline/cline",
+			}),
+		);
 	});
 });

--- a/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/git-preflight.ts
@@ -57,10 +57,14 @@ function defaultGitCommand(
 }
 
 function trimGitSuffix(pathname: string): string {
-	return pathname
-		.replace(/^\/+/, "")
-		.replace(/\/+$/, "")
-		.replace(/\.git$/i, "");
+	let start = 0;
+	let end = pathname.length;
+	while (start < end && pathname[start] === "/") start += 1;
+	while (end > start && pathname[end - 1] === "/") end -= 1;
+	const trimmed = pathname.slice(start, end);
+	return trimmed.toLowerCase().endsWith(".git")
+		? trimmed.slice(0, -4)
+		: trimmed;
 }
 
 /** Converts supported GitHub clone URLs to the URL expected by cloud sessions. */
@@ -106,9 +110,10 @@ async function runRequired(
 	code: CloudHandoffGitPreflightErrorCode,
 	message: string,
 	signal?: AbortSignal,
+	normalizeOutput: (stdout: string) => string = (stdout) => stdout.trim(),
 ): Promise<string> {
 	try {
-		return (await git(args, { cwd, signal })).stdout.trim();
+		return normalizeOutput((await git(args, { cwd, signal })).stdout);
 	} catch (error) {
 		const detail = commandErrorMessage(error);
 		throw new CloudHandoffGitPreflightError(
@@ -131,7 +136,7 @@ function parseRemoteHead(stdout: string, branch: string): string | null {
 }
 
 function normalizeWorkspaceRelativePath(value: string): string | undefined {
-	const normalized = value.trim().replace(/\/+$/, "");
+	const normalized = value.replace(/[\r\n]+$/, "").replace(/\/+$/, "");
 	if (!normalized) return undefined;
 	const parts = normalized.split("/");
 	if (
@@ -180,13 +185,19 @@ export async function preflightCloudHandoffGit(input: {
 			"git_command_failed",
 			"Could not resolve the workspace path relative to the Git repository.",
 			input.signal,
+			(stdout) => stdout.replace(/[\r\n]+$/, ""),
 		),
 	);
 
 	const dirty = await runRequired(
 		git,
 		cwd,
-		["status", "--porcelain=v1", "--untracked-files=all"],
+		[
+			"status",
+			"--porcelain=v1",
+			"--untracked-files=all",
+			"--ignore-submodules=none",
+		],
 		"git_command_failed",
 		"Could not inspect the Git worktree.",
 		input.signal,
@@ -267,22 +278,23 @@ export async function preflightCloudHandoffGit(input: {
 	}
 
 	const upstreamBranch = mergeRef.slice("refs/heads/".length);
-	let rawRemoteUrl: string;
-	try {
-		rawRemoteUrl = (
-			await git(["remote", "get-url", remoteName], {
-				cwd,
-				signal: input.signal,
-			})
-		).stdout.trim();
-	} catch (error) {
-		// A branch remote may legally be a URL. Git can echo that argument in
-		// stderr, including embedded credentials, so do not append stderr here.
-		throw new CloudHandoffGitPreflightError(
-			"missing_upstream",
-			"Could not resolve the upstream remote.",
-			{ cause: error },
-		);
+	let rawRemoteUrl = remoteName;
+	if (!normalizeGitHubRemoteUrl(remoteName)) {
+		try {
+			rawRemoteUrl = (
+				await git(["remote", "get-url", remoteName], {
+					cwd,
+					signal: input.signal,
+				})
+			).stdout.trim();
+		} catch {
+			// Git may echo credential-bearing remote URLs in stderr. Do not retain
+			// the raw command error in either the message or the cause chain.
+			throw new CloudHandoffGitPreflightError(
+				"missing_upstream",
+				"Could not resolve the upstream remote.",
+			);
+		}
 	}
 	const repoUrl = normalizeGitHubRemoteUrl(rawRemoteUrl);
 	if (!repoUrl) {
@@ -308,7 +320,6 @@ export async function preflightCloudHandoffGit(input: {
 		throw new CloudHandoffGitPreflightError(
 			missing ? "remote_branch_missing" : "git_command_failed",
 			message,
-			{ cause: error },
 		);
 	}
 	const remoteSha = parseRemoteHead(remoteOutput, upstreamBranch);
@@ -328,7 +339,7 @@ export async function preflightCloudHandoffGit(input: {
 	return {
 		repoUrl,
 		branch: upstreamBranch,
-		remoteName,
+		remoteName: normalizeGitHubRemoteUrl(remoteName) ? repoUrl : remoteName,
 		headSha,
 		...(workspaceRelativePath ? { workspaceRelativePath } : {}),
 	};

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.test.ts
@@ -14,7 +14,7 @@ describe("cloud handoff metadata", () => {
 		branch: " main ",
 		headSha: "A".repeat(40),
 		modelId: " cloud/model ",
-		workspaceRelativePath: " apps/desktop ",
+		workspaceRelativePath: "apps/desktop",
 		mode: "plan",
 	});
 
@@ -91,6 +91,18 @@ describe("cloud handoff metadata", () => {
 			}),
 		).toBe(false);
 		expect(cloudHandoffFingerprintsEqual(undefined, undefined)).toBe(false);
+	});
+
+	it("preserves significant whitespace in workspace paths", () => {
+		expect(
+			createCloudHandoffFingerprint({
+				repoUrl: "https://github.com/cline/cline",
+				branch: "main",
+				headSha: "a".repeat(40),
+				modelId: "cloud/model",
+				workspaceRelativePath: " leading/trailing ",
+			}).workspaceRelativePath,
+		).toBe(" leading/trailing ");
 	});
 
 	it("builds an environment-specific dashboard URL", () => {

--- a/sdk/packages/core/src/services/cloud-handoff/metadata.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/metadata.ts
@@ -12,6 +12,10 @@ function readRequiredString(value: unknown): string | undefined {
 	return trimmed || undefined;
 }
 
+function readWorkspaceRelativePath(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 export function createCloudHandoffFingerprint(input: {
 	repoUrl: string;
 	branch: string;
@@ -29,7 +33,9 @@ export function createCloudHandoffFingerprint(input: {
 		throw new Error("Cloud handoff fingerprint fields cannot be empty.");
 	}
 	const organizationId = readRequiredString(input.organizationId);
-	const workspaceRelativePath = readRequiredString(input.workspaceRelativePath);
+	const workspaceRelativePath = readWorkspaceRelativePath(
+		input.workspaceRelativePath,
+	);
 	const mode = input.mode;
 	return {
 		repoUrl,

--- a/sdk/packages/core/src/services/cloud-handoff/types.ts
+++ b/sdk/packages/core/src/services/cloud-handoff/types.ts
@@ -44,4 +44,7 @@ export type CloudHandoffResult = {
 	dashboardUrl: string;
 	destination: CloudHandoffDestination;
 	warning?: string;
+	/** How the follow-up command failed: definitely unqueued, or unconfirmed
+	 * either way (an unconfirmed prompt must not be resubmitted blindly). */
+	warningKind?: "unqueued" | "unconfirmed";
 };

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -5,6 +5,8 @@ export const FeatureFlag = {
 	CLINE_PASS: "ext-cline-pass",
 	/** Makes the Cloud sessions opt-in visible in the Cline Code desktop app. */
 	CODE_CLOUD_AGENTS: "code-cloud-agents",
+	/** Enables /handoff (local-to-cloud session handoff) in the Cline Code desktop app. */
+	CODE_CLOUD_HANDOFF: "code-cloud-handoff",
 	/** Shows the GitHub integration step in the desktop app. */
 	CODE_ONBOARDING_GITHUB: "code-onboarding-github",
 	/** Widens access to the internal-only Composio connectors beyond

--- a/sdk/packages/shared/src/feature-flags.ts
+++ b/sdk/packages/shared/src/feature-flags.ts
@@ -3,6 +3,8 @@ import { InternalFeature } from "./internal-features";
 export const FeatureFlag = {
 	/** Enables ClinePass provider/model list exposure in supported clients. */
 	CLINE_PASS: "ext-cline-pass",
+	/** Makes the Cloud sessions opt-in visible in the Cline Code desktop app. */
+	CODE_CLOUD_AGENTS: "code-cloud-agents",
 	/** Shows the GitHub integration step in the desktop app. */
 	CODE_ONBOARDING_GITHUB: "code-onboarding-github",
 	/** Widens access to the internal-only Composio connectors beyond
@@ -75,6 +77,7 @@ export const FeatureFlagDefaultValue: Partial<
 	Record<FeatureFlag, FeatureFlagPayload | undefined>
 > = {
 	[FeatureFlag.CLINE_PASS]: false,
+	[FeatureFlag.CODE_CLOUD_AGENTS]: false,
 	[FeatureFlag.CODE_ONBOARDING_GITHUB]: false,
 	[FeatureFlag.INTERNAL_COMPOSIO_CONNECTORS]: false,
 };

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -102,7 +102,7 @@ export {
 export { PLUGIN_FILE_EXTENSIONS } from "./extensions/plugin";
 export {
 	FEATURE_FLAGS,
-	type FeatureFlag,
+	FeatureFlag,
 	FeatureFlagDefaultValue,
 	type FeatureFlagPayload,
 	type FeatureFlagsAndPayloads,
@@ -169,6 +169,7 @@ export {
 	DEFAULT_MAX_IMAGE_DECODED_BYTES,
 	DEFAULT_MAX_IMAGE_ENCODED_BYTES,
 	DEFAULT_MAX_TOTAL_MEDIA_BYTES,
+	GENERATED_MEDIA_OMITTED_PLACEHOLDER,
 	type GeneratedMedia,
 	type GeneratedMediaModality,
 	GeneratedMediaModalitySchema,
@@ -176,7 +177,6 @@ export {
 	type GeneratedMediaSource,
 	GeneratedMediaSourceSchema,
 	generatedMediaModalityFromMediaType,
-	GENERATED_MEDIA_OMITTED_PLACEHOLDER,
 	IMAGE_OMITTED_PLACEHOLDER,
 	IMAGE_UNSUPPORTED_PLACEHOLDER,
 	type ImageMediaLimits,


### PR DESCRIPTION
## Summary

- port the reviewed Cloud Sessions fixes from the stacked PRs into `desktop-experimental`
- align provisioning, reconnect/model reconciliation, create recovery, activity status, and image-only prompt behavior
- sync the reviewed Cloud Handoff transaction and lifecycle race fixes while preserving SSH, media, realtime, and multi-environment behavior
- keep Cloud Sessions behind the existing desktop Settings opt-in; handoff is available whenever that beta opt-in is enabled

## Scope

This is a parity sync into `desktop-experimental`. It does not add another visible setting, require a PostHog flag for beta use, or update changelog/release metadata.

## Validation

- desktop app typecheck
- 279 focused handoff tests
- 149 additional affected desktop tests
- 115 focused SDK tests
- SDK build
- desktop production build
- Biome check on every changed TypeScript file
- `git diff --check`

A broad local Vitest sweep also reproduced three unchanged failures on the prior PR head (onboarding storage fallback, Streamdown `scrollTo` in jsdom, and a Settings media-generation timing assertion); the focused changed-feature lanes above pass.