### PR TITLE
ui: keep section headers visible while searching in model picker

### DIFF
--- a/sdk/packages/ui/components/search-combobox.tsx
+++ b/sdk/packages/ui/components/search-combobox.tsx
@@ -43,8 +43,10 @@ export interface SearchComboboxProps {
 	placement?: "top" | "bottom";
 	searchPlaceholder?: string;
 	/**
-	 * Section headers, rendered while the search box is empty whenever a run of
-	 * consecutive options carries that section id. Searching flattens the list.
+	 * Section headers, rendered whenever a run of consecutive options carries
+	 * that section id. They stay visible while searching so same-named options
+	 * from different sections (e.g. a Subscribed and a Free row for one model)
+	 * remain distinguishable.
 	 */
 	sections?: SearchComboboxSection[];
 	value?: string;
@@ -284,9 +286,6 @@ export function SearchCombobox({
 	};
 
 	const renderOptions = () => {
-		if (query) {
-			return filtered.map((option, index) => renderOption(option, index));
-		}
 		const rows: ReactNode[] = [];
 		let previousSection: string | undefined;
 		filtered.forEach((option, index) => {

--- a/sdk/packages/ui/stories/search-combobox.stories.tsx
+++ b/sdk/packages/ui/stories/search-combobox.stories.tsx
@@ -141,7 +141,7 @@ export const ModelPicker: Story = {
 		docs: {
 			description: {
 				story:
-					"Sectioned model picker: recommended and free tiers first, the full catalog after. Searching flattens the sections into one ranked list.",
+					"Sectioned model picker: recommended and free tiers first, the full catalog after. Section headers stay visible while searching.",
 			},
 		},
 	},

--- a/sdk/packages/ui/tests/search-combobox.test.tsx
+++ b/sdk/packages/ui/tests/search-combobox.test.tsx
@@ -170,7 +170,7 @@ describe("SearchCombobox", () => {
 		expect(onValueChange).not.toHaveBeenCalled();
 	});
 
-	it("renders section headers and badges, and flattens while searching", async () => {
+	it("renders section headers and badges, and keeps matching sections while searching", async () => {
 		const sectionedOptions = [
 			{
 				badge: "NEW",
@@ -221,7 +221,9 @@ describe("SearchCombobox", () => {
 			search?.dispatchEvent(new Event("input", { bubbles: true }));
 		});
 		const searchedPanel = container.querySelector('[role="dialog"]');
+		// Sections without matches drop out; the matching one keeps its header.
 		expect(searchedPanel?.textContent).not.toContain("Recommended");
+		expect(searchedPanel?.textContent).toContain("Free");
 		expect(searchedPanel?.textContent).toContain("DeepSeek V4 Flash");
 		// Options remain searchable by id, and label matches are highlighted.
 		expect(


### PR DESCRIPTION
### Related Issue

N/A

### Description

In the desktop app model picker on the ClinePass provider, searching for "deepseek-v4-flash" or "glm-5.3-flash" showed two identical-looking rows. That is expected data: the recommended-models feed lists those models both under `clinePass` (`cline-pass/deepseek-v4-flash`, billed against the subscription) and under `free` (`deepseek/deepseek-v4-flash`, billed at $0), and `normalizeClineRecommendedProviderModels` intentionally adds the free rows to the ClinePass catalog too. Both resolve to the same OpenRouter display name.

The unfiltered dropdown separates them under Subscribed / Free headers, but `SearchCombobox` dropped the section headers as soon as a query was typed, so the two rows collapsed into what looked like a duplicate.

This change keeps section headers rendered while searching. Headers are emitted from runs of surviving options, so sections with no matches simply do not appear.

### Test Procedure

- `bun -F @cline/ui test` (148 tests pass), including the updated `search-combobox` test which now asserts the matching section header stays visible during search and non-matching sections drop out.
- `bun -F @cline/ui typecheck` and `biome check` on the touched files.
- Manually verified in the desktop app (`bun run dev:headless`, ClinePass provider): searching "flash" and "deepseek" now shows SUBSCRIBED and FREE headers above their rows.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Searching "flash" on ClinePass, section headers kept:

![Model search for flash with Subscribed and Free headers visible](https://cursor.com/artifacts/c/art-f6c313ff-14b0-40ec-8686-0c68c89bbdde)

Searching "deepseek":

![Model search for deepseek with Subscribed and Free headers visible](https://cursor.com/artifacts/c/art-ce7cd5be-5060-4164-b1a2-7e51739879f6)

### Additional Notes

Only `@cline/ui`'s `SearchCombobox` changes; the desktop app, CLI, and VS Code pickers built on it pick this up without further edits.