### PR TITLE
feat(desktop): add cloud chat state

### DIFF
--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -27,7 +27,7 @@
 		"typecheck": "tsc -p tsconfig.dev.json --noEmit",
 		"pretest:chat-ui": "bun run build:ui",
 		"test:chat-ui": "vitest run webview/components/views/chat/chat-messages.test.tsx webview/components/views/chat/messages --config vitest.config.ts",
-		"test:sidecar": "vitest run sidecar scripts/telemetry-define-args.test.ts webview/lib/cloud-repositories.test.ts --config vitest.config.ts",
+		"test:sidecar": "vitest run sidecar scripts/telemetry-define-args.test.ts webview/hooks/chat-session/helpers.test.ts webview/hooks/use-chat-session.test.tsx webview/hooks/use-provisioning-outcome.test.tsx webview/hooks/use-session-history.test.tsx webview/lib/cloud-repositories.test.ts webview/lib/cloud-session-error.test.ts webview/lib/session-status.test.ts webview/lib/workspace-paths.test.ts --config vitest.config.ts",
 		"clean": "rm -rf webview/.next webview/out node_modules dist && (cd src-tauri && rm -rf target node_modules dist)"
 	},
 	"dependencies": {

--- a/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/constants.ts
@@ -15,6 +15,8 @@ export { OAUTH_PROVIDER_IDS as OAUTH_MANAGED_PROVIDERS } from "@/lib/provider-co
 
 export const DEFAULT_CHAT_CONFIG: ChatSessionConfig = {
 	sessionId: undefined,
+	executionTarget: "local",
+	repoUrl: undefined,
 	workspaceRoot: "",
 	cwd: "",
 	provider: "cline",

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -8,6 +8,7 @@ import type {
 	ChatSessionConfig,
 	ChatSessionStatus,
 } from "@/lib/chat-schema";
+import { isGitHubRepositoryUrl } from "@/lib/cloud-repositories";
 import type { SessionHistoryStatus } from "@/lib/session-history";
 import { OAUTH_MANAGED_PROVIDERS } from "./constants";
 
@@ -151,9 +152,15 @@ export function normalizeRuntimeConfig(
 ): ChatSessionConfig {
 	const normalizedWorkspaceRoot = config.workspaceRoot.trim();
 	const normalizedCwd = (config.cwd?.trim() || normalizedWorkspaceRoot).trim();
+	const executionTarget = config.executionTarget ?? "local";
+	const repoUrl = config.repoUrl?.trim();
+	const branch = config.branch?.trim();
 	const thinking = config.reasoningEffort ? true : config.thinking;
 	return {
 		...config,
+		executionTarget,
+		repoUrl: executionTarget === "cloud" ? repoUrl : undefined,
+		branch: executionTarget === "cloud" ? branch || undefined : undefined,
 		workspaceRoot: normalizedWorkspaceRoot,
 		cwd: normalizedCwd || normalizedWorkspaceRoot,
 		thinking,
@@ -161,9 +168,60 @@ export function normalizeRuntimeConfig(
 	};
 }
 
+/**
+ * Maps a cloud runtime status (hub vocabulary plus the sidecar-side
+ * "expired"/"error" values) to the chat UI status. Returns null for unknown
+ * values so callers leave the current status alone — a malformed snapshot
+ * must never flip a running turn to "done".
+ */
+export function mapCloudRuntimeStatus(
+	status: string | undefined,
+): ChatSessionStatus | null {
+	switch (status) {
+		case "failed":
+		case "error":
+			return "failed";
+		case "aborted":
+		case "cancelled":
+			return "cancelled";
+		case "running":
+		case "pending":
+			return "running";
+		case "idle":
+		case "ready":
+			return "idle";
+		case "completed":
+		case "expired":
+			return "completed";
+		default:
+			return null;
+	}
+}
+
 export function resolveCredentialError(
 	config: ChatSessionConfig,
+	options?: { hasActiveSession?: boolean },
 ): string | null {
+	if (config.executionTarget === "cloud") {
+		if (config.provider.trim().toLowerCase() !== "cline") {
+			return "Cloud sessions require the Cline provider.";
+		}
+		// Sends into an existing cloud session need no repo URL — the sandbox
+		// was already provisioned with one.
+		if (options?.hasActiveSession) {
+			return null;
+		}
+		const repoUrl = config.repoUrl?.trim() ?? "";
+		if (!repoUrl) {
+			return "Select a GitHub repository before starting a cloud session.";
+		}
+		// The picker validates as-you-type, but config accepts any keystroke —
+		// re-validate here so a half-typed URL can't reach the create call.
+		if (!isGitHubRepositoryUrl(repoUrl)) {
+			return "Enter a valid HTTPS GitHub repository URL (https://github.com/owner/repo).";
+		}
+		return null;
+	}
 	const providerId = config.provider.trim().toLowerCase();
 	if (!providerId) {
 		return "Provider is required before starting a chat session.";

--- a/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
@@ -112,6 +112,8 @@ export type ChatSessionCommandResponse = {
 	result?: ChatApiResult;
 	ok?: boolean;
 	queued?: boolean;
+	recoveredAfterDisconnect?: boolean;
+	status?: string;
 	promptsInQueue?: PromptInQueue[];
 	prompt?: PromptInQueue;
 	updated?: boolean;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDisplayUserInput } from "@cline/shared/browser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	serializeAttachments,
@@ -11,6 +12,7 @@ import {
 	extractAssistantTurnDataFromRpcMessages,
 	inferHydratedChatStatus,
 	makeId,
+	mapCloudRuntimeStatus,
 	mapSessionRecordStatus,
 	normalizeRuntimeConfig,
 	resolveCredentialError,
@@ -40,6 +42,7 @@ import {
 	ChatSessionConfigSchema,
 	type ChatSessionStatus,
 } from "@/lib/chat-schema";
+import { humanizeCloudSessionError } from "@/lib/cloud-session-error";
 import { appendCappedCommandOutput } from "@/lib/command-output";
 import { desktopClient } from "@/lib/desktop-client";
 import {
@@ -49,9 +52,10 @@ import {
 	type SessionFileDiff,
 	type SessionHookEvent,
 } from "@/lib/session-diff";
-import type {
-	SessionHistoryItem,
-	SessionHistoryStatus,
+import {
+	getSessionMetadataGitBranch,
+	type SessionHistoryItem,
+	type SessionHistoryStatus,
 } from "@/lib/session-history";
 import {
 	normalizeWorkspacePath,
@@ -120,13 +124,16 @@ function makeErrorChatMessage(
 		id: makeId("error"),
 		sessionId: sid,
 		role: "error",
-		content,
+		// Sidecar cloud errors arrive wrapped in a machine-readable envelope;
+		// only the human message belongs in the transcript.
+		content: humanizeCloudSessionError(content),
 		createdAt: Date.now(),
 	};
 }
 
 function validateConfig(
 	config: ChatSessionConfig,
+	options?: { hasActiveSession?: boolean },
 ):
 	| { parsed: ChatSessionConfig; error: null }
 	| { parsed: null; error: string } {
@@ -138,7 +145,7 @@ function validateConfig(
 			error: result.error.issues.map((i) => i.message).join(", "),
 		};
 	}
-	const credentialError = resolveCredentialError(result.data);
+	const credentialError = resolveCredentialError(result.data, options);
 	if (credentialError) {
 		return { parsed: null, error: credentialError };
 	}
@@ -196,6 +203,183 @@ function mergeHydratedMessagesWithLive(options: {
 		return true;
 	});
 	return sortMessagesChronologically([...hydrated, ...nonDuplicateLive]);
+}
+
+type CloudOptimisticState = {
+	sessionId: string;
+	state: "pending" | "failed";
+};
+
+function comparableUserContent(content: string): string {
+	return formatDisplayUserInput(content.trim());
+}
+
+function userMessageCounts(messages: ChatMessage[]): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const message of messages) {
+		if (message.role !== "user") continue;
+		const content = comparableUserContent(message.content);
+		counts.set(content, (counts.get(content) ?? 0) + 1);
+	}
+	return counts;
+}
+
+export function mergeCloudSnapshotWithLive(
+	hydrated: ChatMessage[],
+	current: ChatMessage[],
+	options: {
+		sessionId: string;
+		transcriptKnown: boolean;
+		previousUserCounts: Map<string, number>;
+		optimisticStates: Map<string, CloudOptimisticState>;
+		preserveUnmatchedLive?: boolean;
+		preserveLiveMessageIds?: Set<string>;
+	},
+): ChatMessage[] {
+	const reconciledHydrated = [...hydrated];
+	const mergeImagesIntoHydrated = (
+		index: number | undefined,
+		source: ChatMessage,
+	) => {
+		if (index === undefined) return;
+		const target = reconciledHydrated[index];
+		if (!target) return;
+		const existing = target.images ?? [];
+		const additions = (source.images ?? []).filter(
+			(image) =>
+				!existing.some(
+					(candidate) =>
+						candidate.data === image.data &&
+						candidate.mediaType === image.mediaType,
+				),
+		);
+		const preserveId = options.preserveLiveMessageIds?.has(source.id) === true;
+		if (additions.length > 0 || preserveId) {
+			reconciledHydrated[index] = {
+				...target,
+				...(preserveId ? { id: source.id } : {}),
+				images: [...existing, ...additions],
+			};
+		}
+	};
+	const messageKey = (message: ChatMessage) => {
+		if (message.role === "tool" && message.meta?.toolCallId) {
+			return `tool\u0000${message.meta.toolCallId}`;
+		}
+		const content =
+			message.role === "user"
+				? comparableUserContent(message.content)
+				: message.content;
+		return `${message.role}\u0000${content}\u0000${message.reasoning ?? ""}`;
+	};
+	const hydratedIndexesByKey = new Map<string, number[]>();
+	for (const [index, message] of hydrated.entries()) {
+		const key = messageKey(message);
+		const indexes = hydratedIndexesByKey.get(key) ?? [];
+		indexes.push(index);
+		hydratedIndexesByKey.set(key, indexes);
+	}
+	const unmatchedHydratedAssistants = hydrated.flatMap((message, index) =>
+		message.role === "assistant" && message.content
+			? [{ index, text: message.content }]
+			: [],
+	);
+	const liveOnly: ChatMessage[] = [];
+	const optimistic: ChatMessage[] = [];
+	for (const message of current) {
+		// Never let another session's live messages bleed into this merge.
+		if (message.sessionId && message.sessionId !== options.sessionId) {
+			continue;
+		}
+		const optimisticState = options.optimisticStates.get(message.id);
+		if (
+			message.role === "user" &&
+			optimisticState?.sessionId === options.sessionId
+		) {
+			optimistic.push(message);
+			continue;
+		}
+		const key = messageKey(message);
+		const matchingHydratedIndexes = hydratedIndexesByKey.get(key);
+		if (matchingHydratedIndexes?.length) {
+			const matchingIndex = matchingHydratedIndexes.shift();
+			mergeImagesIntoHydrated(matchingIndex, message);
+			if (matchingHydratedIndexes.length === 0) {
+				hydratedIndexesByKey.delete(key);
+			}
+			if (message.role === "assistant" && message.content) {
+				const index = unmatchedHydratedAssistants.findIndex(
+					(candidate) => candidate.text === message.content,
+				);
+				if (index >= 0) unmatchedHydratedAssistants.splice(index, 1);
+			}
+			continue;
+		}
+		if (message.role === "assistant" && message.content) {
+			const index = unmatchedHydratedAssistants.findIndex((candidate) =>
+				candidate.text.includes(message.content),
+			);
+			if (index >= 0) {
+				const [match] = unmatchedHydratedAssistants.splice(index, 1);
+				mergeImagesIntoHydrated(match?.index, message);
+				continue;
+			}
+		}
+		// UI-only error bubbles never appear in canonical snapshots; dropping
+		// them here would erase the explanation for the most recent failure
+		// (mirrors applyCanonicalHistory for local sessions).
+		if (options.preserveUnmatchedLive === false && message.role !== "error") {
+			continue;
+		}
+		liveOnly.push(message);
+	}
+
+	const currentUserCounts = userMessageCounts(hydrated);
+	const reflectedPromptBudget = new Map<string, number>();
+	const reflectedUserIndexes = new Map<string, number[]>();
+	for (const [index, message] of hydrated.entries()) {
+		if (message.role !== "user") continue;
+		const content = comparableUserContent(message.content);
+		const indexes = reflectedUserIndexes.get(content) ?? [];
+		indexes.push(index);
+		reflectedUserIndexes.set(content, indexes);
+	}
+	for (const [content, count] of currentUserCounts) {
+		const previousCount = options.previousUserCounts.get(content) ?? 0;
+		reflectedPromptBudget.set(
+			content,
+			options.transcriptKnown ? Math.max(0, count - previousCount) : count,
+		);
+		if (options.transcriptKnown && previousCount > 0) {
+			reflectedUserIndexes.set(
+				content,
+				(reflectedUserIndexes.get(content) ?? []).slice(previousCount),
+			);
+		}
+	}
+	// Reconcile pending prompts by count delta; always retain failed bubbles.
+	for (const message of optimistic) {
+		const optimisticState = options.optimisticStates.get(message.id);
+		const content = comparableUserContent(message.content);
+		const budget = reflectedPromptBudget.get(content) ?? 0;
+		if (
+			options.transcriptKnown &&
+			optimisticState?.state === "pending" &&
+			budget > 0
+		) {
+			reflectedPromptBudget.set(content, budget - 1);
+			mergeImagesIntoHydrated(
+				reflectedUserIndexes.get(content)?.shift(),
+				message,
+			);
+			options.optimisticStates.delete(message.id);
+			continue;
+		}
+		liveOnly.push(message);
+	}
+	return sliceMessages(
+		sortMessagesChronologically([...reconciledHydrated, ...liveOnly]),
+	);
 }
 
 function deriveLiveToolState(messages: ChatMessage[]): {
@@ -399,6 +583,13 @@ export function useChatSession() {
 	// A chat_queued_prompt_start event may only re-key one of these — never a
 	// same-content message left over from an earlier turn (see the handler).
 	const outstandingOptimisticUserIdsRef = useRef<Set<string>>(new Set());
+	const cloudOptimisticStatesRef = useRef<Map<string, CloudOptimisticState>>(
+		new Map(),
+	);
+	const cloudTranscriptKnownRef = useRef<Record<string, boolean>>({});
+	const cloudTranscriptUserCountsRef = useRef<
+		Record<string, Map<string, number>>
+	>({});
 	// Which optimistic bubble each queued user-message id re-keyed. The re-key
 	// updater consumes the outstanding set on its first run, so StrictMode's
 	// double-invoked updater needs this memo to reach the same result on its
@@ -417,6 +608,7 @@ export function useChatSession() {
 	const sessionStartPromiseRef = useRef<Promise<string> | null>(null);
 	const promptDispatchTailRef = useRef<Promise<void>>(Promise.resolve());
 	const activePromptSubmissionsRef = useRef(0);
+	const pendingDirectSendSessionIdsRef = useRef<Set<string>>(new Set());
 	const activeTurnCostTrackerRef = useRef<TurnCostTracker | null>(null);
 	const unpersistedCostUsdRef = useRef(0);
 	const lastPersistedCostUsdRef = useRef(0);
@@ -514,6 +706,50 @@ export function useChatSession() {
 		liveToolInputsRef.current = {};
 		pendingToolOutputRef.current = new Map();
 	}, []);
+
+	const applyCloudSnapshotMessages = useCallback(
+		(options: {
+			sessionId: string;
+			messages: ChatMessage[];
+			preserveUnmatchedLive?: boolean;
+			transcriptKnown?: boolean;
+			preserveLiveRouting?: boolean;
+		}) => {
+			const previousUserCounts =
+				cloudTranscriptUserCountsRef.current[options.sessionId] ?? new Map();
+			const transcriptKnown =
+				cloudTranscriptKnownRef.current[options.sessionId] === true;
+			const preservedMessageIds = options.preserveLiveRouting
+				? new Set([
+						...(activeAssistantMessageIdRef.current
+							? [activeAssistantMessageIdRef.current]
+							: []),
+						...Object.values(liveToolMessageIdsRef.current),
+					])
+				: undefined;
+			setMessages((current) => {
+				const merged = mergeCloudSnapshotWithLive(options.messages, current, {
+					sessionId: options.sessionId,
+					transcriptKnown,
+					previousUserCounts,
+					optimisticStates: cloudOptimisticStatesRef.current,
+					preserveUnmatchedLive: options.preserveUnmatchedLive,
+					preserveLiveMessageIds: preservedMessageIds,
+				});
+				if (options.preserveLiveRouting) {
+					const liveToolState = deriveLiveToolState(merged);
+					liveToolMessageIdsRef.current = liveToolState.messageIds;
+					liveToolInputsRef.current = liveToolState.inputs;
+				}
+				return merged;
+			});
+			cloudTranscriptUserCountsRef.current[options.sessionId] =
+				userMessageCounts(options.messages);
+			cloudTranscriptKnownRef.current[options.sessionId] =
+				options.transcriptKnown !== false;
+		},
+		[],
+	);
 
 	const resetStreamDedupe = useCallback((targetSessionId?: string | null) => {
 		if (targetSessionId) {
@@ -703,7 +939,14 @@ export function useChatSession() {
 
 	const postSession = useCallback(async (body: Record<string, unknown>) => {
 		const request = { request: body };
-		if (body.action === "send") {
+		const config =
+			body.config && typeof body.config === "object"
+				? (body.config as Record<string, unknown>)
+				: undefined;
+		const isLongRunningCommand =
+			body.action === "send" ||
+			(body.action === "start" && config?.executionTarget === "cloud");
+		if (isLongRunningCommand) {
 			return await desktopClient.invoke<ChatSessionCommandResponse>(
 				"chat_session_command",
 				request,
@@ -1242,8 +1485,13 @@ export function useChatSession() {
 				return;
 			}
 			lastLiveChunkAtRef.current = Date.now();
-			if (abortedRef.current && payload.stream !== "chat_done") {
-				return;
+			if (abortedRef.current) {
+				if (payload.stream === "chat_queued_prompt_start") {
+					abortedRef.current = false;
+					clearAbortFallbackTimeout();
+				} else if (payload.stream !== "chat_done") {
+					return;
+				}
 			}
 
 			// --- Text stream (buffered) ---
@@ -1497,6 +1745,19 @@ export function useChatSession() {
 								outstandingOptimisticUserIdsRef.current.delete(candidate.id);
 								rekeyedOptimisticIdByMessageIdRef.current[userMessageId] =
 									candidate.id;
+								// Keep the cloud optimistic bookkeeping attached to the
+								// bubble across the re-key, or its failed-send retention
+								// semantics silently stop applying.
+								const cloudState = cloudOptimisticStatesRef.current.get(
+									candidate.id,
+								);
+								if (cloudState) {
+									cloudOptimisticStatesRef.current.delete(candidate.id);
+									cloudOptimisticStatesRef.current.set(
+										userMessageId,
+										cloudState,
+									);
+								}
 								const next = [...prev];
 								next[i] = {
 									...candidate,
@@ -1719,6 +1980,7 @@ export function useChatSession() {
 		[
 			addMessage,
 			appendTurnFailureMessage,
+			clearAbortFallbackTimeout,
 			clearLiveToolRefs,
 			finalizeSettledTurn,
 			flushPendingStream,
@@ -1787,7 +2049,11 @@ export function useChatSession() {
 					return;
 				}
 				authoritativeStatusRevisionRef.current += 1;
-				setStatus(nextStatus as ChatSessionStatus);
+				setStatus(
+					(nextStatus === "aborted"
+						? "cancelled"
+						: nextStatus) as ChatSessionStatus,
+				);
 			},
 		);
 		const unsubscribeEnded = desktopClient.subscribe(
@@ -1807,20 +2073,119 @@ export function useChatSession() {
 				) {
 					return;
 				}
-				activeAssistantMessageIdRef.current = null;
-				setActiveAssistantMessageId(null);
+				// The Hub publishes the terminal event before the blocking send RPC
+				// returns. Keep the streamed message id until that reply can reconcile
+				// its full text into the same bubble; the send's finally block clears it.
+				if (!pendingDirectSendSessionIdsRef.current.has(targetSessionId)) {
+					activeAssistantMessageIdRef.current = null;
+					setActiveAssistantMessageId(null);
+				}
 				clearLiveToolRefs();
 				turnSettledEpochRef.current = turnEpochRef.current;
+				const endReason = record.reason?.trim() || "idle";
+				if (endReason === "error" || endReason === "failed") {
+					appendTurnFailureMessage(targetSessionId, "");
+				}
 				authoritativeStatusRevisionRef.current += 1;
-				setStatus((record.reason?.trim() || "idle") as ChatSessionStatus);
+				setStatus(
+					(endReason === "aborted"
+						? "cancelled"
+						: endReason) as ChatSessionStatus,
+				);
 				finalizeSettledTurn(targetSessionId);
+			},
+		);
+		const unsubscribeRehydrated = desktopClient.subscribe(
+			"cloud_session_rehydrated",
+			(payload) => {
+				if (!payload || typeof payload !== "object") return;
+				const record = payload as {
+					sessionId?: string;
+					status?: string;
+					messages?: ChatMessage[];
+					transcriptKnown?: boolean;
+				};
+				const targetSessionId = record.sessionId?.trim();
+				if (
+					!targetSessionId ||
+					targetSessionId !== activeSessionIdRef.current
+				) {
+					return;
+				}
+				const rehydrationEpoch = turnEpochRef.current;
+				const applySnapshot = (rehydratedMessages: ChatMessage[]) => {
+					if (activeSessionIdRef.current !== targetSessionId) return;
+					if (turnEpochRef.current !== rehydrationEpoch) return;
+					const nextStatus = record.status?.trim();
+					// A locally submitted turn owns status and live routing until its RPC
+					// settles. A reconnect snapshot may describe the preceding turn.
+					const localSubmissionActive = activePromptSubmissionsRef.current > 0;
+					const snapshotBusy =
+						nextStatus === "running" || nextStatus === "pending";
+					applyCloudSnapshotMessages({
+						sessionId: targetSessionId,
+						messages: rehydratedMessages,
+						transcriptKnown: record.transcriptKnown,
+						preserveUnmatchedLive: snapshotBusy || localSubmissionActive,
+						preserveLiveRouting: snapshotBusy || localSubmissionActive,
+					});
+					if (!snapshotBusy && localSubmissionActive) return;
+					if (!snapshotBusy) {
+						clearLiveToolRefs();
+					}
+					const mappedStatus = mapCloudRuntimeStatus(nextStatus);
+					if (
+						mappedStatus === "running" &&
+						turnEpochRef.current === turnSettledEpochRef.current
+					) {
+						return;
+					}
+					if (mappedStatus) {
+						setStatus(mappedStatus);
+					}
+				};
+				if (Array.isArray(record.messages)) {
+					applySnapshot(record.messages);
+					return;
+				}
+				void desktopClient
+					.invoke<ChatMessage[]>("read_session_messages", {
+						sessionId: targetSessionId,
+						maxMessages: MAX_MESSAGES,
+					})
+					.then(applySnapshot)
+					.catch((error) => {
+						if (activeSessionIdRef.current !== targetSessionId) return;
+						setError(humanizeCloudSessionError(errorMessage(error)));
+					});
+			},
+		);
+		const unsubscribeSyncFailed = desktopClient.subscribe(
+			"cloud_session_sync_failed",
+			(payload) => {
+				if (!payload || typeof payload !== "object") return;
+				const record = payload as { sessionId?: string; message?: string };
+				if (record.sessionId?.trim() !== activeSessionIdRef.current) return;
+				// Sync failures carry sidecar CloudSessionError messages (e.g.
+				// signed-out reconnects); show the human text, not the envelope.
+				setError(
+					humanizeCloudSessionError(record.message?.trim() || "") ||
+						"Cloud session history could not be refreshed. Live updates are still connected.",
+				);
 			},
 		);
 		return () => {
 			unsubscribeStatus();
 			unsubscribeEnded();
+			unsubscribeRehydrated();
+			unsubscribeSyncFailed();
 		};
-	}, [clearLiveToolRefs, finalizeSettledTurn]);
+	}, [
+		appendTurnFailureMessage,
+		applyCloudSnapshotMessages,
+		clearLiveToolRefs,
+		finalizeSettledTurn,
+	]);
 
 	// ---- Stale-stream fallback for attached sessions ----
 	// Scheduled/automation runs execute on a session host whose events are
@@ -1947,14 +2312,24 @@ export function useChatSession() {
 	const startSession = useCallback(
 		async (
 			validatedConfig: ChatSessionConfig,
-			options: { preserveStatus?: boolean } = {},
+			options: { preserveStatus?: boolean; initialPrompt?: string } = {},
 		): Promise<string> => {
 			const payload = await postSession({
 				action: "start",
 				config: validatedConfig,
+				...(options.initialPrompt?.trim()
+					? { prompt: options.initialPrompt.trim() }
+					: {}),
 			});
 			const id = payload.sessionId;
 			if (!id) throw new Error("Missing session id from server");
+			if (
+				validatedConfig.executionTarget === "cloud" &&
+				id !== validatedConfig.sessionId
+			) {
+				cloudTranscriptKnownRef.current[id] = true;
+				cloudTranscriptUserCountsRef.current[id] = new Map();
+			}
 			const workspaceRoot =
 				payload.workspaceRoot?.trim() || validatedConfig.workspaceRoot.trim();
 			const cwd =
@@ -1985,7 +2360,9 @@ export function useChatSession() {
 
 	const start = useCallback(
 		async (nextConfig: ChatSessionConfig) => {
-			const validation = validateConfig(nextConfig);
+			const validation = validateConfig(nextConfig, {
+				hasActiveSession: Boolean(nextConfig.sessionId),
+			});
 			if (!validation.parsed) {
 				setErrorState(validation.error);
 				return;
@@ -2040,7 +2417,9 @@ export function useChatSession() {
 			const pendingSessionStart = sessionStartPromiseRef.current;
 			let activeSessionId = sessionId ?? activeSessionIdRef.current;
 
-			const validation = validateConfig(config);
+			const validation = validateConfig(config, {
+				hasActiveSession: Boolean(activeSessionId),
+			});
 			if (!validation.parsed) {
 				setErrorState(validation.error, activeSessionId);
 				return;
@@ -2104,9 +2483,22 @@ export function useChatSession() {
 				: null;
 			const optimisticUserMessageId = shouldQueue ? null : makeId("user");
 			const plannedSessionId = activeSessionId ?? makeId("session");
+			const markCloudOptimisticFailed = () => {
+				if (!optimisticUserMessageId) return;
+				const cloudOptimistic = cloudOptimisticStatesRef.current.get(
+					optimisticUserMessageId,
+				);
+				if (cloudOptimistic) cloudOptimistic.state = "failed";
+			};
 
 			if (optimisticUserMessageId) {
 				outstandingOptimisticUserIdsRef.current.add(optimisticUserMessageId);
+				if (parsed.executionTarget === "cloud") {
+					cloudOptimisticStatesRef.current.set(optimisticUserMessageId, {
+						sessionId: plannedSessionId,
+						state: "pending",
+					});
+				}
 				addMessage({
 					id: optimisticUserMessageId,
 					sessionId: plannedSessionId,
@@ -2155,6 +2547,7 @@ export function useChatSession() {
 								prev.filter((item) => item.id !== optimisticQueuedPromptId),
 							);
 						}
+						markCloudOptimisticFailed();
 						setErrorState(errorMessage(err), activeSessionId);
 						finishPromptSubmission();
 						return;
@@ -2174,6 +2567,7 @@ export function useChatSession() {
 					try {
 						activeSessionId = await startPromise;
 					} catch (err) {
+						markCloudOptimisticFailed();
 						setErrorState(errorMessage(err), activeSessionId);
 						finishPromptSubmission();
 						return;
@@ -2190,7 +2584,11 @@ export function useChatSession() {
 							...parsed,
 							sessionId: plannedSessionId,
 						},
-						{ preserveStatus: true },
+						{
+							preserveStatus: true,
+							initialPrompt:
+								parsed.executionTarget === "cloud" ? userLabel : undefined,
+						},
 					);
 					sessionStartPromiseRef.current = startPromise;
 					try {
@@ -2199,6 +2597,7 @@ export function useChatSession() {
 						if (activeSessionIdRef.current === plannedSessionId) {
 							activeSessionIdRef.current = null;
 						}
+						markCloudOptimisticFailed();
 						setErrorState(errorMessage(err));
 						finishPromptSubmission();
 						return;
@@ -2208,8 +2607,32 @@ export function useChatSession() {
 						}
 					}
 				}
+				if (optimisticUserMessageId) {
+					const cloudOptimistic = cloudOptimisticStatesRef.current.get(
+						optimisticUserMessageId,
+					);
+					if (cloudOptimistic) {
+						cloudOptimistic.sessionId = activeSessionId;
+						// Re-key the bubble itself too: a cloud create returns a
+						// server-assigned id, and the snapshot merge drops
+						// other-session messages before consulting the optimistic
+						// map. Without this, the first prompt's bubble loses its
+						// retention semantics (a failed first send would vanish
+						// from the next rehydration).
+						if (activeSessionId && activeSessionId !== plannedSessionId) {
+							const rekeyedSessionId = activeSessionId;
+							setMessages((prev) =>
+								updateMessageById(prev, optimisticUserMessageId, (message) => ({
+									...message,
+									sessionId: rekeyedSessionId,
+								})),
+							);
+						}
+					}
+				}
 				const serializedAttachmentsResult = await serializedAttachmentsTask;
 				if (!serializedAttachmentsResult.ok) {
+					markCloudOptimisticFailed();
 					setErrorState(
 						errorMessage(serializedAttachmentsResult.error),
 						activeSessionId,
@@ -2245,6 +2668,9 @@ export function useChatSession() {
 				}
 				await precedingPromptDispatch;
 				turnEpochAtDispatch = turnEpochRef.current;
+				if (!shouldQueue) {
+					pendingDirectSendSessionIdsRef.current.add(activeSessionId);
+				}
 				sendTask = postSession({
 					action: "send",
 					sessionId: activeSessionId,
@@ -2452,8 +2878,9 @@ export function useChatSession() {
 					fallbackAssistantTurn.reasoningRedacted ||
 					fallbackImages.length > 0 ||
 					fallbackMedia.length > 0;
-				if (!hasFallbackAssistantTurn) {
+				if (!hasFallbackAssistantTurn && config.executionTarget !== "cloud") {
 					// Recovery: load canonical messages if transport missed result text.
+					// Cloud sessions hydrate through the snapshot path below instead.
 					try {
 						const historyMessages = await desktopClient.invoke<ChatMessage[]>(
 							"read_session_messages",
@@ -2479,48 +2906,55 @@ export function useChatSession() {
 						"read_session_messages",
 						{ sessionId: activeSessionId, maxMessages: MAX_MESSAGES },
 					);
-					const hasCanonicalAssistantTurn = historyMessages.some(
-						(message) => message.role === "assistant",
-					);
-					if (
-						historyMessages.length > 0 &&
-						(!hasFallbackAssistantTurn || hasCanonicalAssistantTurn)
-					) {
-						const assistantIndex = historyMessages.findLastIndex(
-							(message) => message.role === "assistant",
-						);
-						const canonicalMessages =
-							assistantIndex >= 0 && hasFallbackAssistantTurn
-								? historyMessages.map((message, index) => {
-										if (index !== assistantIndex) return message;
-										const existingImages = message.images ?? [];
-										const missingImages = fallbackImages.filter(
-											(image) =>
-												!existingImages.some(
-													(candidate) =>
-														candidate.data === image.data &&
-														candidate.mediaType === image.mediaType,
-												),
-										);
-										return {
-											...message,
-											content: message.content || resolvedAssistantText,
-											reasoning:
-												message.reasoning ||
-												fallbackAssistantTurn.reasoning ||
-												undefined,
-											reasoningRedacted:
-												message.reasoningRedacted ||
-												fallbackAssistantTurn.reasoningRedacted ||
-												undefined,
-											images:
-												missingImages.length > 0
-													? [...existingImages, ...missingImages]
-													: message.images,
-										};
-									})
-								: historyMessages;
-						applyCanonicalHistory(activeSessionId, canonicalMessages);
+					if (historyMessages.length > 0) {
+						if (config.executionTarget === "cloud") {
+							applyCloudSnapshotMessages({
+								sessionId: activeSessionId,
+								messages: historyMessages,
+								preserveUnmatchedLive: true,
+							});
+						} else {
+							const hasCanonicalAssistantTurn = historyMessages.some(
+								(message) => message.role === "assistant",
+							);
+							if (!hasFallbackAssistantTurn || hasCanonicalAssistantTurn) {
+								const assistantIndex = historyMessages.findLastIndex(
+									(message) => message.role === "assistant",
+								);
+								const canonicalMessages =
+									assistantIndex >= 0 && hasFallbackAssistantTurn
+										? historyMessages.map((message, index) => {
+												if (index !== assistantIndex) return message;
+												const existingImages = message.images ?? [];
+												const missingImages = fallbackImages.filter(
+													(image) =>
+														!existingImages.some(
+															(candidate) =>
+																candidate.data === image.data &&
+																candidate.mediaType === image.mediaType,
+														),
+												);
+												return {
+													...message,
+													content: message.content || resolvedAssistantText,
+													reasoning:
+														message.reasoning ||
+														fallbackAssistantTurn.reasoning ||
+														undefined,
+													reasoningRedacted:
+														message.reasoningRedacted ||
+														fallbackAssistantTurn.reasoningRedacted ||
+														undefined,
+													images:
+														missingImages.length > 0
+															? [...existingImages, ...missingImages]
+															: message.images,
+												};
+											})
+										: historyMessages;
+								applyCanonicalHistory(activeSessionId, canonicalMessages);
+							}
+						}
 					}
 				} catch {
 					// Keep optimistic state if canonical hydration fails.
@@ -2594,7 +3028,18 @@ export function useChatSession() {
 					Array.isArray(payload.promptsInQueue) &&
 					payload.promptsInQueue.length > 0;
 				if (settleAbortedSend()) return;
-				if (result?.finishReason === "error") {
+				if (payload.recoveredAfterDisconnect) {
+					const recoveredStatus = mapCloudRuntimeStatus(payload.status);
+					if (
+						recoveredStatus &&
+						!(
+							recoveredStatus === "running" &&
+							turnEpochRef.current === turnSettledEpochRef.current
+						)
+					) {
+						setStatus(recoveredStatus);
+					}
+				} else if (result?.finishReason === "error") {
 					// On a failed run result.text is the runtime's error string
 					// (never assistant content — see isErrorResult above), so it
 					// is the best failure detail available. The reporter dedupes
@@ -2626,10 +3071,12 @@ export function useChatSession() {
 						prev.filter((item) => item.id !== optimisticQueuedPromptId),
 					);
 				}
+				markCloudOptimisticFailed();
 				setErrorState(errorMessage(err), activeSessionId);
 			} finally {
 				clearAbortFallbackTimeout();
 				if (!shouldQueue) {
+					pendingDirectSendSessionIdsRef.current.delete(activeSessionId);
 					activeAssistantMessageIdRef.current = null;
 					setActiveAssistantMessageId(null);
 					clearLiveToolRefs();
@@ -2648,6 +3095,7 @@ export function useChatSession() {
 			addMessage,
 			appendTurnFailureMessage,
 			applyCanonicalHistory,
+			applyCloudSnapshotMessages,
 			applyPromptsInQueue,
 			clearAbortFallbackTimeout,
 			clearLiveToolRefs,
@@ -2668,17 +3116,23 @@ export function useChatSession() {
 		async (requestId: string, approved: boolean) => {
 			const activeSessionId = activeSessionIdRef.current;
 			if (!activeSessionId) return;
-			await desktopClient.invoke("respond_tool_approval", {
-				sessionId: activeSessionId,
-				requestId,
-				approved,
-				reason: approved
-					? undefined
-					: "Tool call rejected from desktop approval prompt",
-			});
-			setPendingToolApprovals((prev) =>
-				prev.filter((item) => item.requestId !== requestId),
-			);
+			try {
+				await desktopClient.invoke("respond_tool_approval", {
+					sessionId: activeSessionId,
+					requestId,
+					approved,
+					reason: approved
+						? undefined
+						: "Tool call rejected from desktop approval prompt",
+				});
+				setPendingToolApprovals((prev) =>
+					prev.filter((item) => item.requestId !== requestId),
+				);
+			} catch (error) {
+				// Keep the approval card actionable and surface the failed remote ack
+				// without marking the still-running agent session as failed.
+				setError(errorMessage(error));
+			}
 		},
 		[],
 	);
@@ -2860,6 +3314,9 @@ export function useChatSession() {
 		outstandingOptimisticUserIdsRef.current.clear();
 		rekeyedOptimisticIdByMessageIdRef.current = {};
 		lastCoreErrorBySessionRef.current = {};
+		cloudOptimisticStatesRef.current.clear();
+		cloudTranscriptKnownRef.current = {};
+		cloudTranscriptUserCountsRef.current = {};
 		activeAssistantMessageIdRef.current = null;
 		setActiveAssistantMessageId(null);
 		setHydratedHistorySessionId(null);
@@ -2898,6 +3355,12 @@ export function useChatSession() {
 			setConfig((prev) => ({
 				...prev,
 				sessionId: session.sessionId,
+				executionTarget: session.origin === "cloud" ? "cloud" : "local",
+				repoUrl: session.origin === "cloud" ? session.repoUrl : undefined,
+				branch:
+					session.origin === "cloud"
+						? getSessionMetadataGitBranch(session.metadata)
+						: undefined,
 				provider: session.provider || prev.provider,
 				model: session.model || prev.model,
 				workspaceRoot: session.workspaceRoot || prev.workspaceRoot,
@@ -2924,22 +3387,36 @@ export function useChatSession() {
 				outstandingOptimisticUserIdsRef.current.clear();
 				rekeyedOptimisticIdByMessageIdRef.current = {};
 				lastCoreErrorBySessionRef.current = {};
-				const mergedMessages = mergeHydratedMessagesWithLive({
-					hydrated: msgs,
-					current: messagesRef.current,
-					sessionId: session.sessionId,
-					hydrationStartedAt,
-				});
-				// Hub attachment starts forwarding future events but does not replay the
-				// tool.started event for a command already in flight. Rebuild its routing
-				// key from canonical history before those future updates can arrive.
-				const liveToolState = deriveLiveToolState(mergedMessages);
-				liveToolMessageIdsRef.current = liveToolState.messageIds;
-				liveToolInputsRef.current = liveToolState.inputs;
-				setMessages(mergedMessages);
+				if (session.origin === "cloud") {
+					applyCloudSnapshotMessages({
+						sessionId: session.sessionId,
+						messages: msgs,
+						preserveUnmatchedLive: true,
+						preserveLiveRouting: sessionStatus === "running",
+					});
+				} else {
+					const mergedMessages = mergeHydratedMessagesWithLive({
+						hydrated: msgs,
+						current: messagesRef.current,
+						sessionId: session.sessionId,
+						hydrationStartedAt,
+					});
+					// Hub attachment starts forwarding future events but does not replay the
+					// tool.started event for a command already in flight. Rebuild its routing
+					// key from canonical history before those future updates can arrive.
+					const liveToolState = deriveLiveToolState(mergedMessages);
+					liveToolMessageIdsRef.current = liveToolState.messageIds;
+					liveToolInputsRef.current = liveToolState.inputs;
+					setMessages(mergedMessages);
+				}
 				setRawTranscript("");
 				resetCounters();
-				setStatus(inferHydratedChatStatus(sessionStatus, msgs));
+				setStatus(
+					session.origin === "cloud"
+						? (mapCloudRuntimeStatus(sessionStatus) ??
+								inferHydratedChatStatus(sessionStatus, msgs))
+						: inferHydratedChatStatus(sessionStatus, msgs),
+				);
 				void refreshSessionDiffSummary(session.sessionId);
 			};
 
@@ -2963,12 +3440,15 @@ export function useChatSession() {
 						model?: string;
 						cwd?: string;
 						workspaceRoot?: string;
+						branch?: string;
 						prompt?: string;
 					}>("chat_session_command", {
 						request: {
 							action: "attach",
 							sessionId: session.sessionId,
 							config: {
+								executionTarget: session.origin === "cloud" ? "cloud" : "local",
+								repoUrl: session.repoUrl,
 								provider: session.provider,
 								model: session.model,
 								cwd: session.cwd,
@@ -2987,6 +3467,13 @@ export function useChatSession() {
 				setConfig((prev) => ({
 					...prev,
 					sessionId: session.sessionId,
+					executionTarget: session.origin === "cloud" ? "cloud" : "local",
+					repoUrl: session.origin === "cloud" ? session.repoUrl : undefined,
+					branch:
+						attached?.branch ||
+						(session.origin === "cloud"
+							? getSessionMetadataGitBranch(session.metadata)
+							: undefined),
 					provider: attached?.provider || session.provider || prev.provider,
 					model: attached?.model || session.model || prev.model,
 					workspaceRoot:
@@ -3003,21 +3490,30 @@ export function useChatSession() {
 
 				if (historyMessages.length > 0) {
 					setStatus(
-						inferHydratedChatStatus(
-							(attached?.status || session.status) as SessionHistoryStatus,
-							historyMessages,
-						),
+						session.origin === "cloud"
+							? (mapCloudRuntimeStatus(attached?.status || session.status) ??
+									inferHydratedChatStatus(
+										(attached?.status ||
+											session.status) as SessionHistoryStatus,
+										historyMessages,
+									))
+							: inferHydratedChatStatus(
+									(attached?.status || session.status) as SessionHistoryStatus,
+									historyMessages,
+								),
 					);
 					return;
 				}
 
 				const synthesized: ChatMessage[] = [];
-				if (session.prompt?.trim()) {
+				const initialPrompt =
+					attached?.prompt?.trim() || session.prompt?.trim();
+				if (initialPrompt) {
 					synthesized.push({
 						id: makeId("history_user"),
 						sessionId: session.sessionId,
 						role: "user",
-						content: session.prompt.trim(),
+						content: initialPrompt,
 						createdAt: Date.now(),
 					});
 				}
@@ -3039,6 +3535,7 @@ export function useChatSession() {
 			}
 		},
 		[
+			applyCloudSnapshotMessages,
 			clearAbortFallbackTimeout,
 			clearLiveToolRefs,
 			discardPendingStream,

--- a/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-provisioning-outcome.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from "react";
+import { humanizeCloudSessionError } from "@/lib/cloud-session-error";
+import { desktopClient } from "@/lib/desktop-client";
+
+export type CloudProvisioningOutcome =
+	| { status: "provisioning" }
+	| { status: "ready"; sessionId: string }
+	| { status: "failed"; message: string };
+
+export const PROVISIONING_OUTCOME_POLL_MS = 1_500;
+export const PROVISIONING_UNKNOWN_GIVE_UP_POLLS = 8;
+export const PROVISIONING_OPEN_GIVE_UP_ATTEMPTS = 5;
+
+export function useProvisioningOutcome(options: {
+	placeholderId: string | undefined;
+	onOpenReady: (sessionId: string) => Promise<boolean>;
+	onResolved: () => void;
+	onError: (message: string) => void;
+}): void {
+	const callbacksRef = useRef(options);
+	callbacksRef.current = options;
+
+	useEffect(() => {
+		if (!options.placeholderId) return;
+		const placeholderId = options.placeholderId;
+		let cancelled = false;
+		let retryTimer: number | undefined;
+		let unknownPolls = 0;
+		let failedOpens = 0;
+
+		async function checkOutcome() {
+			try {
+				const outcome =
+					await desktopClient.invoke<CloudProvisioningOutcome | null>(
+						"get_cloud_provisioning_outcome",
+						{ placeholderId },
+					);
+				if (cancelled) return;
+				if (outcome?.status === "ready") {
+					const opened = await callbacksRef.current.onOpenReady(
+						outcome.sessionId,
+					);
+					if (cancelled) return;
+					if (opened) {
+						callbacksRef.current.onResolved();
+						return;
+					}
+					failedOpens += 1;
+					if (failedOpens >= PROVISIONING_OPEN_GIVE_UP_ATTEMPTS) {
+						callbacksRef.current.onError(
+							"The cloud session was created but could not be opened automatically. Open it from the sidebar.",
+						);
+						return;
+					}
+				} else if (outcome?.status === "failed") {
+					callbacksRef.current.onError(
+						humanizeCloudSessionError(outcome.message) ||
+							"The cloud session could not be started.",
+					);
+					return;
+				} else if (outcome === null) {
+					unknownPolls += 1;
+					if (unknownPolls >= PROVISIONING_UNKNOWN_GIVE_UP_POLLS) {
+						callbacksRef.current.onError(
+							"This session's provisioning state was lost. Check the sidebar for the session, or start a new one.",
+						);
+						return;
+					}
+				} else {
+					unknownPolls = 0;
+				}
+			} catch {
+				// Keep polling through a temporary sidecar interruption.
+			}
+			if (!cancelled) {
+				retryTimer = window.setTimeout(
+					checkOutcome,
+					PROVISIONING_OUTCOME_POLL_MS,
+				);
+			}
+		}
+
+		void checkOutcome();
+		return () => {
+			cancelled = true;
+			if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+		};
+	}, [options.placeholderId]);
+}

--- a/apps/examples/desktop-app/webview/hooks/use-session-history.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-session-history.ts
@@ -4,6 +4,7 @@ import { isChatWorkspacePath } from "@cline/shared/browser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { normalizeTitle } from "@/components/utils";
 import { toast } from "@/hooks/use-toast";
+import { humanizeCloudSessionError } from "@/lib/cloud-session-error";
 import { desktopClient } from "@/lib/desktop-client";
 import type {
 	SessionHistoryItem,
@@ -25,6 +26,8 @@ type CliDiscoveredSession = Omit<SessionHistoryItem, "status"> & {
 
 export interface SessionThread {
 	id: string;
+	origin?: "local" | "cloud";
+	repoUrl?: string;
 	title: string;
 	source?: string;
 	codebase: string;
@@ -157,6 +160,9 @@ export function normalizeDiscoveredStatus(
 	) {
 		return "cancelled";
 	}
+	if (normalized.includes("provision")) {
+		return "provisioning";
+	}
 	if (normalized.includes("fail") || normalized.includes("error")) {
 		return "failed";
 	}
@@ -240,7 +246,13 @@ function inferStatusFromMessages(
 		return content.trim().length > 0;
 	});
 	if (meaningfulMessages.length === 0) {
-		return status === "running" ? "running" : "idle";
+		// Provisioning placeholders legitimately have no messages — inferring
+		// "idle" here would kill the sidebar's provisioning state within one
+		// hydration cycle and flap it on every refresh after.
+		if (status === "running" || status === "provisioning") {
+			return status;
+		}
+		return "idle";
 	}
 	const lastMeaningful = meaningfulMessages[meaningfulMessages.length - 1];
 	if (status === "failed" && lastMeaningful.role === "assistant") {
@@ -250,9 +262,14 @@ function inferStatusFromMessages(
 }
 
 function toThread(session: SessionHistoryItem): SessionThread {
-	const workspacePath = (session.workspaceRoot || session.cwd).trim();
+	const workspacePath =
+		session.origin === "cloud" && session.repoUrl?.trim()
+			? session.repoUrl.trim()
+			: (session.workspaceRoot || session.cwd).trim();
 	return {
 		id: session.sessionId,
+		origin: session.origin,
+		repoUrl: session.repoUrl,
 		title: toTitle(session),
 		source: getSessionSource(session) || undefined,
 		codebase: basenamePath(workspacePath),
@@ -356,6 +373,8 @@ function areSessionsEquivalent(
 		const b = next[i];
 		if (
 			a.sessionId !== b.sessionId ||
+			a.origin !== b.origin ||
+			a.repoUrl !== b.repoUrl ||
 			getSessionSource(a) !== getSessionSource(b) ||
 			a.status !== b.status ||
 			a.startedAt !== b.startedAt ||
@@ -392,6 +411,8 @@ function areThreadsEquivalent(
 		const b = next[i];
 		if (
 			a.id !== b.id ||
+			a.origin !== b.origin ||
+			a.repoUrl !== b.repoUrl ||
 			a.title !== b.title ||
 			a.source !== b.source ||
 			a.codebase !== b.codebase ||
@@ -806,7 +827,10 @@ export function useSessionHistory({
 
 	useEffect(() => {
 		const recent = sessions
-			.filter((session) => session.sessionId !== activeSessionId)
+			.filter(
+				(session) =>
+					session.sessionId !== activeSessionId && session.origin !== "cloud",
+			)
 			.slice(0, 4);
 		let cancelled = false;
 		const timer = window.setTimeout(() => {
@@ -1002,7 +1026,20 @@ export function useSessionHistory({
 				const known = sessionsRef.current.some(
 					(session) => session.sessionId === sessionId,
 				);
-				const status = normalizeDiscoveredStatus(record.status);
+				const status = normalizeDiscoveredStatus(
+					record.status,
+					"active session",
+				);
+				setThreads((current) =>
+					updateThreadById(current, sessionId, (thread) =>
+						thread.status === status ? thread : { ...thread, status },
+					),
+				);
+				setSessions((current) =>
+					updateSessionById(current, sessionId, (session) =>
+						session.status === status ? session : { ...session, status },
+					),
+				);
 				if (!known) {
 					scheduleRefresh(HISTORY_EVENT_REFRESH_DELAY_MS);
 				} else if (isTerminalHistoryStatus(status)) {
@@ -1017,6 +1054,14 @@ export function useSessionHistory({
 						return next;
 					});
 				}
+			},
+		);
+		// Account/organization switches re-scope the cloud session list; the
+		// sidebar must reflect the new scope immediately, not on the next poll.
+		const unsubscribeCloudScope = desktopClient.subscribe(
+			"cloud_sessions_changed",
+			() => {
+				scheduleRefresh(HISTORY_FAST_REFRESH_DELAY_MS, { force: true });
 			},
 		);
 		const unsubscribeTransportEnded = desktopClient.subscribe(
@@ -1078,6 +1123,7 @@ export function useSessionHistory({
 			);
 			unsubscribeTransportDelete();
 			unsubscribeTransportStatus();
+			unsubscribeCloudScope();
 			unsubscribeTransportEnded();
 			unsubscribeTransportChatEvent();
 		};
@@ -1085,7 +1131,10 @@ export function useSessionHistory({
 
 	useEffect(() => {
 		const recent = sessions
-			.filter((session) => session.sessionId !== activeSessionId)
+			.filter(
+				(session) =>
+					session.sessionId !== activeSessionId && session.origin !== "cloud",
+			)
 			.slice(0, 4);
 		let cancelled = false;
 		const timer = window.setTimeout(() => {
@@ -1231,10 +1280,12 @@ export function useSessionHistory({
 				toast({
 					variant: "destructive",
 					title: "Rename failed",
-					description:
+					// Cloud failures arrive as a machine envelope; never show it raw.
+					description: humanizeCloudSessionError(
 						error instanceof Error
 							? error.message
 							: "The session title could not be updated.",
+					),
 				});
 				return false;
 			} finally {
@@ -1390,10 +1441,11 @@ export function useSessionHistory({
 				toast({
 					variant: "destructive",
 					title: "Delete failed",
-					description:
+					description: humanizeCloudSessionError(
 						error instanceof Error
 							? error.message
 							: "The session could not be removed from local history.",
+					),
 				});
 				return false;
 			} finally {

--- a/apps/examples/desktop-app/webview/lib/chat-schema.ts
+++ b/apps/examples/desktop-app/webview/lib/chat-schema.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 
 export const ChatSessionConfigSchema = z.object({
 	sessionId: z.string().min(1).optional(),
+	executionTarget: z.enum(["local", "cloud"]).default("local"),
+	repoUrl: z.string().optional(),
+	branch: z.string().optional(),
 	workspaceRoot: z.string(),
 	cwd: z.string().optional(),
 	provider: z.string().min(1),

--- a/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
+++ b/apps/examples/desktop-app/webview/lib/cloud-session-error.ts
@@ -1,0 +1,75 @@
+import { CLINE_ENVIRONMENTS } from "@cline/shared/browser";
+
+const CLOUD_SESSION_ERROR_PREFIX = "CLOUD_SESSION_ERROR:";
+
+export type CloudSessionError = {
+	code:
+		| "github_not_connected"
+		| "authentication_required"
+		| "session_not_found"
+		| "session_expired"
+		| "session_failed"
+		| "request_failed";
+	message: string;
+	connectUrl?: string;
+};
+
+/**
+ * The error envelope travels in Error.message and is authenticated by string
+ * prefix only, so error strings a session pod controls can smuggle a spoofed
+ * envelope through the sidecar. Legitimate connectUrls are always built from
+ * the Cline app base URL; only honor those origins, or the "Connect GitHub"
+ * action would open an attacker-chosen page in the user's browser.
+ */
+function trustedConnectUrl(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value.trim()) {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	try {
+		const origin = new URL(trimmed).origin;
+		return Object.values(CLINE_ENVIRONMENTS).some(
+			(environment) => new URL(environment.appBaseUrl).origin === origin,
+		)
+			? trimmed
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function parseCloudSessionError(
+	value: string | null | undefined,
+): CloudSessionError | null {
+	if (!value?.startsWith(CLOUD_SESSION_ERROR_PREFIX)) return null;
+	try {
+		const parsed = JSON.parse(
+			value.slice(CLOUD_SESSION_ERROR_PREFIX.length),
+		) as Partial<CloudSessionError>;
+		if (typeof parsed.code !== "string" || typeof parsed.message !== "string") {
+			return null;
+		}
+		if (
+			parsed.code !== "github_not_connected" &&
+			parsed.code !== "authentication_required" &&
+			parsed.code !== "session_not_found" &&
+			parsed.code !== "session_expired" &&
+			parsed.code !== "session_failed" &&
+			parsed.code !== "request_failed"
+		) {
+			return null;
+		}
+		return {
+			code: parsed.code,
+			message: parsed.message,
+			connectUrl: trustedConnectUrl(parsed.connectUrl),
+		};
+	} catch {
+		return null;
+	}
+}
+
+/** Strips the machine-readable cloud error envelope for display. */
+export function humanizeCloudSessionError(value: string): string {
+	return parseCloudSessionError(value)?.message ?? value;
+}

--- a/apps/examples/desktop-app/webview/lib/session-history.ts
+++ b/apps/examples/desktop-app/webview/lib/session-history.ts
@@ -3,6 +3,7 @@ export type SessionHistoryStatus =
 	| "completed"
 	| "failed"
 	| "cancelled"
+	| "provisioning"
 	| "idle";
 
 export type SessionMetadata = {
@@ -28,6 +29,8 @@ export const PINNED_METADATA_KEY = "pinned";
 
 export interface SessionHistoryItem {
 	sessionId: string;
+	origin?: "local" | "cloud";
+	repoUrl?: string;
 	source?: string;
 	status: SessionHistoryStatus;
 	provider: string;

--- a/apps/examples/desktop-app/webview/lib/session-status.ts
+++ b/apps/examples/desktop-app/webview/lib/session-status.ts
@@ -1,4 +1,19 @@
 import type { SessionStatusTone } from "@cline/ui";
+import type { ChatSessionStatus } from "@/lib/chat-schema";
+import type { SessionHistoryStatus } from "@/lib/session-history";
+
+export function resolveSessionHeaderStatus({
+	chatStatus,
+	isCloudSession,
+	liveHistoryStatus,
+}: {
+	chatStatus: ChatSessionStatus;
+	isCloudSession: boolean;
+	liveHistoryStatus?: SessionHistoryStatus;
+}): ChatSessionStatus {
+	if (!isCloudSession || !liveHistoryStatus) return chatStatus;
+	return liveHistoryStatus === "provisioning" ? "starting" : liveHistoryStatus;
+}
 
 /**
  * Session status presentation shared by every surface that renders a status

--- a/apps/examples/desktop-app/webview/lib/workspace-paths.ts
+++ b/apps/examples/desktop-app/webview/lib/workspace-paths.ts
@@ -13,7 +13,14 @@ export type WorkspacePathSource = {
 	workspaceRoot?: string;
 	startedAt?: string;
 	endedAt?: string;
+	origin?: string;
 };
+
+// Cloud sessions run in the sandbox's synthetic /workspace root — offering it
+// in the local workspace picker (or persisting it) would be meaningless.
+function isLocalWorkspaceSource(session: WorkspacePathSource): boolean {
+	return session.origin !== "cloud";
+}
 
 /** Typed/pasted folder paths in search boxes double as manual path entry. */
 export function looksLikeFolderPath(value: string): boolean {
@@ -143,8 +150,9 @@ export function filterWorkspacePaths(paths: readonly string[]): string[] {
  * the end.
  */
 export function workspacePathsFromSessions(
-	sessions: readonly WorkspacePathSource[],
+	allSessions: readonly WorkspacePathSource[],
 ): string[] {
+	const sessions = allSessions.filter(isLocalWorkspaceSource);
 	const lastActivityByPath = new Map<string, number>();
 	for (const session of sessions) {
 		const normalized = normalizeWorkspacePath(


### PR DESCRIPTION
## Summary

Adds the cloud webview state utilities and chat-session integration as a focused slice of #13556.

## Validation

- focused tests for this layer
- desktop typecheck
- diff check

Part of the Cloud Sessions stacked PR split.