### PR TITLE
fix(hooks): deliver VS Code run-start context to the SDK

### DIFF
--- a/apps/cli/src/utils/hooks.test.ts
+++ b/apps/cli/src/utils/hooks.test.ts
@@ -33,6 +33,7 @@ import { createRuntimeHooks } from "./hooks";
 
 async function emitRunStartAndPrompt(
 	hooks: NonNullable<ReturnType<typeof createRuntimeHooks>["hooks"]>,
+	displayRole?: "system",
 ): Promise<void> {
 	const snapshot = {
 		agentId: "agent-1",
@@ -59,6 +60,7 @@ async function emitRunStartAndPrompt(
 			role: "user",
 			content: [{ type: "text", text: "hello" }],
 			createdAt: 0,
+			metadata: displayRole ? { displayRole } : undefined,
 		},
 	});
 }
@@ -153,6 +155,16 @@ describe("createRuntimeHooks", () => {
 				taskId: "conversation-1",
 				workspaceRoots: ["/workspace"],
 			}),
+		);
+	});
+
+	it("does not dispatch prompt_submit for synthetic context", async () => {
+		const dispatchHookEvent = vi.fn().mockResolvedValue(undefined);
+		const runtimeHooks = createRuntimeHooks({ yolo: false, dispatchHookEvent });
+		await emitRunStartAndPrompt(runtimeHooks.hooks!, "system");
+		expect(dispatchHookEvent).toHaveBeenCalledTimes(1);
+		expect(dispatchHookEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ hookName: "agent_start" }),
 		);
 	});
 

--- a/apps/cli/src/utils/hooks.ts
+++ b/apps/cli/src/utils/hooks.ts
@@ -328,7 +328,11 @@ export function createRuntimeHooks(options: {
 				);
 			},
 			onEvent: async (event) => {
-				if (event.type !== "message-added" || event.message.role !== "user") {
+				if (
+					event.type !== "message-added" ||
+					event.message.role !== "user" ||
+					event.message.metadata?.displayRole === "system"
+				) {
 					return;
 				}
 				await dispatchHookPayload(

--- a/apps/vscode/src/sdk/hooks-adapter.test.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.test.ts
@@ -70,6 +70,42 @@ describe("hooks-adapter task id threading", () => {
 		expect(mocks.create).toHaveBeenCalledWith("UserPromptSubmit", "conv-1")
 	})
 
+	it("combines TaskStart and UserPromptSubmit context", async () => {
+		runner.run
+			.mockResolvedValueOnce({ cancel: false, contextModification: "task context", errorMessage: "" })
+			.mockResolvedValueOnce({ cancel: false, contextModification: "prompt context", errorMessage: "" })
+		expect(await buildAgentHooks(stateManager).beforeRun?.({ snapshot })).toEqual({
+			appendContext: "task context\n\nprompt context",
+		})
+	})
+
+	it.each(["TaskStart", "UserPromptSubmit"])("honors %s cancellation without injecting context", async (hookName) => {
+		if (hookName === "UserPromptSubmit") {
+			runner.run.mockResolvedValueOnce({ cancel: false, contextModification: "discard me", errorMessage: "" })
+		}
+		runner.run.mockResolvedValueOnce({ cancel: true, contextModification: "cancel explanation", errorMessage: "" })
+		expect(await buildAgentHooks(stateManager).beforeRun?.({ snapshot })).toEqual({
+			stop: true,
+			reason: "cancel explanation",
+		})
+		expect(mocks.create).toHaveBeenCalledTimes(hookName === "TaskStart" ? 1 : 2)
+	})
+
+	it("skips synthetic context when finding the user prompt", async () => {
+		await buildAgentHooks(stateManager).beforeRun?.({
+			snapshot: {
+				...(snapshot as object),
+				messages: [
+					{ role: "user", content: [{ type: "text", text: "real prompt" }] },
+					{ role: "user", content: [{ type: "text", text: "hook context" }], metadata: { displayRole: "system" } },
+				],
+			},
+		} as never)
+		expect(runner.run).toHaveBeenLastCalledWith(
+			expect.objectContaining({ userPromptSubmit: { prompt: "real prompt", attachments: [] } }),
+		)
+	})
+
 	it("passes the task id when creating the TaskComplete runner", async () => {
 		const hooks = buildAgentHooks(stateManager)
 		await hooks.afterRun?.({ snapshot, result: { status: "completed", outputText: "done" } } as never)

--- a/apps/vscode/src/sdk/hooks-adapter.ts
+++ b/apps/vscode/src/sdk/hooks-adapter.ts
@@ -13,10 +13,10 @@
 
 import type {
 	AgentAfterToolContext,
+	AgentBeforeRunResult,
 	AgentBeforeToolContext,
 	AgentHooks,
 	AgentRunLifecycleContext,
-	AgentStopControl,
 } from "@cline/shared"
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
@@ -37,13 +37,14 @@ function toStringRecord(input: unknown): Record<string, string> {
 	return result
 }
 
-function mapStopControl(hookOutput: {
+function mapHookResult(hookOutput: {
 	cancel?: boolean
 	errorMessage?: string
 	contextModification?: string
-}): AgentStopControl | undefined {
+}): AgentBeforeRunResult | undefined {
 	if (!hookOutput.cancel) {
-		return undefined
+		const appendContext = hookOutput.contextModification?.trim()
+		return appendContext ? { appendContext } : undefined
 	}
 	// A cancelling hook's contextModification is never injected as context;
 	// it serves as the fallback explanation when no errorMessage was given.
@@ -68,7 +69,7 @@ function textFromMessageContent(content: readonly { type: string; text?: string 
 function latestUserPrompt(ctx: AgentRunLifecycleContext): string {
 	for (let index = ctx.snapshot.messages.length - 1; index >= 0; index -= 1) {
 		const message = ctx.snapshot.messages[index]
-		if (message?.role === "user") {
+		if (message?.role === "user" && message.metadata?.displayRole !== "system") {
 			return textFromMessageContent(message.content)
 		}
 	}
@@ -106,12 +107,15 @@ export function buildAgentHooks(
 	const createFactory = () => new HookFactory({ sessionWorkspaceRoot })
 
 	return {
-		async beforeRun(ctx: AgentRunLifecycleContext): Promise<AgentStopControl | undefined> {
+		async beforeRun(ctx: AgentRunLifecycleContext): Promise<AgentBeforeRunResult | undefined> {
 			const taskStartControl = await runTaskStart(ctx, hooksEnabled, createFactory, emitHookMessage)
-			if (taskStartControl) {
+			if (taskStartControl?.stop) {
 				return taskStartControl
 			}
-			return runUserPromptSubmit(ctx, hooksEnabled, createFactory, emitHookMessage)
+			const promptControl = await runUserPromptSubmit(ctx, hooksEnabled, createFactory, emitHookMessage)
+			if (promptControl?.stop) return promptControl
+			const appendContext = [taskStartControl?.appendContext, promptControl?.appendContext].filter(Boolean).join("\n\n")
+			return appendContext ? { appendContext } : undefined
 		},
 
 		async beforeTool(
@@ -151,15 +155,7 @@ export function buildAgentHooks(
 						ts: runningTs,
 					}),
 				)
-				const stopControl = mapStopControl(result)
-				if (stopControl) {
-					return stopControl
-				}
-				// The runtime injects appendContext into the conversation as a
-				// <hook_context> block, restoring the documented contextModification
-				// behavior. HookFactory already truncates it at 50KB.
-				const contextModification = result.contextModification?.trim()
-				return contextModification ? { appendContext: contextModification } : undefined
+				return mapHookResult(result)
 			} catch (error) {
 				emitHookMessage?.(
 					buildHookStatusMessage({
@@ -214,15 +210,7 @@ export function buildAgentHooks(
 						ts: runningTs,
 					}),
 				)
-				const stopControl = mapStopControl(result)
-				if (stopControl) {
-					return stopControl
-				}
-				// The runtime injects appendContext into the conversation as a
-				// <hook_context> block, restoring the documented contextModification
-				// behavior. HookFactory already truncates it at 50KB.
-				const contextModification = result.contextModification?.trim()
-				return contextModification ? { appendContext: contextModification } : undefined
+				return mapHookResult(result)
 			} catch (error) {
 				emitHookMessage?.(
 					buildHookStatusMessage({
@@ -308,7 +296,7 @@ async function runTaskStart(
 	hooksEnabled: () => boolean,
 	createFactory: () => HookFactory,
 	emitHookMessage?: HookMessageEmitter,
-): Promise<AgentStopControl | undefined> {
+): Promise<AgentBeforeRunResult | undefined> {
 	let runningTs: number | undefined
 	try {
 		if (!hooksEnabled()) {
@@ -344,7 +332,7 @@ async function runTaskStart(
 				ts: runningTs,
 			}),
 		)
-		return mapStopControl(result)
+		return mapHookResult(result)
 	} catch (error) {
 		emitHookMessage?.(buildHookStatusMessage({ hookName: "TaskStart", status: "failed", ts: runningTs }))
 		Logger.error("[HooksAdapter] beforeRun (TaskStart) hook failed:", error)
@@ -357,7 +345,7 @@ async function runUserPromptSubmit(
 	hooksEnabled: () => boolean,
 	createFactory: () => HookFactory,
 	emitHookMessage?: HookMessageEmitter,
-): Promise<AgentStopControl | undefined> {
+): Promise<AgentBeforeRunResult | undefined> {
 	let runningTs: number | undefined
 	try {
 		if (!hooksEnabled()) {
@@ -390,7 +378,7 @@ async function runUserPromptSubmit(
 				ts: runningTs,
 			}),
 		)
-		return mapStopControl(result)
+		return mapHookResult(result)
 	} catch (error) {
 		emitHookMessage?.(buildHookStatusMessage({ hookName: "UserPromptSubmit", status: "failed", ts: runningTs }))
 		Logger.error("[HooksAdapter] beforeRun (UserPromptSubmit) hook failed:", error)

--- a/apps/vscode/src/test/e2e/fixtures/server/index.ts
+++ b/apps/vscode/src/test/e2e/fixtures/server/index.ts
@@ -489,6 +489,14 @@ export class ClineApiServerMock {
 							messages.some((m: { role?: string }) => m?.role === "tool")
 
 						let responseText = E2E_MOCK_API_RESPONSES.DEFAULT
+						if (body.includes("hook context probe")) {
+							// Each turn requires a fresh fact; previous context cannot satisfy turn two.
+							const turn = body.includes("probe two") ? "two" : "one"
+							const fact = turn === "two" ? "HOOK_FACT_BETA" : "HOOK_FACT_ALPHA"
+							responseText = body.includes(fact)
+								? `Hook context received for turn ${turn}.`
+								: "Hook context missing."
+						}
 						let toolCall: typeof E2E_MOCK_EDITOR_TOOL_CALL | typeof E2E_MOCK_POWERSHELL_TOOL_CALL | undefined
 						log("Chat completion mock selection:", {
 							isEditRequest: body.includes("edit_request"),

--- a/apps/vscode/src/test/e2e/fixtures/workspace-hooks/.clinerules/hooks/UserPromptSubmit
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-hooks/.clinerules/hooks/UserPromptSubmit
@@ -3,5 +3,7 @@
 // given, so the test can assert workspace-scoped discovery and cwd selection.
 const fs = require("fs")
 const input = JSON.parse(fs.readFileSync(0, "utf-8"))
-fs.writeFileSync("hook-ran.json", JSON.stringify({ cwd: process.cwd(), workspaceRoots: input.workspaceRoots }))
-console.log(JSON.stringify({ cancel: false }))
+const prompt = input.userPromptSubmit?.prompt || ""
+fs.writeFileSync("hook-ran.json", JSON.stringify({ cwd: process.cwd(), workspaceRoots: input.workspaceRoots, prompt }))
+const fact = prompt.includes("probe two") ? "HOOK_FACT_BETA" : "HOOK_FACT_ALPHA"
+console.log(JSON.stringify({ cancel: false, contextModification: fact }))

--- a/apps/vscode/src/test/e2e/fixtures/workspace-hooks/.clinerules/hooks/UserPromptSubmit.ps1
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-hooks/.clinerules/hooks/UserPromptSubmit.ps1
@@ -2,5 +2,7 @@
 # it was given, so the test can assert workspace-scoped discovery and cwd.
 $ErrorActionPreference = 'Stop'
 $hookInput = [Console]::In.ReadToEnd() | ConvertFrom-Json
-@{ cwd = (Get-Location).Path; workspaceRoots = $hookInput.workspaceRoots } | ConvertTo-Json -Compress | Set-Content -Path "hook-ran.json"
-Write-Output '{"cancel": false}'
+$prompt = $hookInput.userPromptSubmit.prompt
+@{ cwd = (Get-Location).Path; workspaceRoots = $hookInput.workspaceRoots; prompt = $prompt } | ConvertTo-Json -Compress | Set-Content -Path "hook-ran.json"
+$fact = if ($prompt -like "*probe two*") { "HOOK_FACT_BETA" } else { "HOOK_FACT_ALPHA" }
+@{ cancel = $false; contextModification = $fact } | ConvertTo-Json -Compress

--- a/apps/vscode/src/test/e2e/hooks.test.ts
+++ b/apps/vscode/src/test/e2e/hooks.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test"
 import fs from "fs/promises"
 import path from "path"
-import { e2e, E2ETestHelper } from "./utils/helpers"
+import { E2ETestHelper, e2e } from "./utils/helpers"
 
 // This spec runs against its own fixture workspace: hooks execute on every
 // prompt once discovered (hooksEnabled defaults to true), so keeping the hook
@@ -20,7 +20,7 @@ const hooksE2e = e2e.extend({
 // the window's actual workspace folders, so the marker must land in this
 // window's workspace root and name it — regardless of what any other Cline
 // instance recorded in shared state.
-hooksE2e("Hooks - workspace hook runs from this window's workspace root", async ({ helper, sidebar, workspaceDir }) => {
+hooksE2e("Hooks - workspace hook injects fresh context on each turn", async ({ helper, sidebar, workspaceDir }) => {
 	const markerPath = path.join(workspaceDir, "hook-ran.json")
 	await fs.rm(markerPath, { force: true })
 
@@ -29,12 +29,12 @@ hooksE2e("Hooks - workspace hook runs from this window's workspace root", async 
 
 		const inputbox = sidebar.getByTestId("chat-input")
 		await expect(inputbox).toBeVisible()
-		await inputbox.fill("Trigger the prompt hook")
+		await inputbox.fill("hook context probe one")
 		await sidebar.getByTestId("send-button").click()
 
 		// The hook runs during beforeRun, ahead of the model call, so the
 		// marker exists by the time the mock response renders.
-		await expect(sidebar.getByText("mock Cline API response")).toBeVisible()
+		await expect(sidebar.getByText("Hook context received for turn one.").first()).toBeVisible()
 
 		let markerRaw: string | undefined
 		await expect
@@ -59,6 +59,22 @@ hooksE2e("Hooks - workspace hook runs from this window's workspace root", async 
 			reportedRoots.push(await fs.realpath(root))
 		}
 		expect(reportedRoots).toContain(expectedRoot)
+		expect(marker.prompt).toContain("hook context probe one")
+
+		await fs.rm(markerPath, { force: true })
+		await inputbox.fill("hook context probe two")
+		await sidebar.getByTestId("send-button").click()
+		await expect(sidebar.getByText("Hook context received for turn two.").first()).toBeVisible()
+		const secondMarker = JSON.parse(await fs.readFile(markerPath, "utf-8"))
+		expect(secondMarker.prompt).toContain("hook context probe two")
+		expect(secondMarker.prompt).not.toContain("HOOK_FACT_")
+		await expect(sidebar.getByText(/HOOK_FACT_(ALPHA|BETA)/)).toHaveCount(0)
+
+		await sidebar.getByRole("button", { name: "New Task", exact: true }).first().click()
+		await expect(sidebar.getByText("Recent")).toBeVisible()
+		await sidebar.getByText("hook context probe one").first().click()
+		await expect(sidebar.getByText("hook context probe two")).toBeVisible()
+		await expect(sidebar.getByText(/HOOK_FACT_(ALPHA|BETA)/)).toHaveCount(0)
 	} finally {
 		await fs.rm(markerPath, { force: true })
 	}

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -478,6 +478,12 @@ Extensibility is split deliberately:
 Design implication:
 
 - additive runtime behavior should usually enter through these extension points instead of bespoke special-case host code.
+- `beforeRun` may return `appendContext`. Core aggregates it across config and
+  extension hooks; the agent runtime appends it after run input, before the first
+  model request. Like tool-hook context, it persists as a user-role message with
+  `displayRole: "system"`. Prompt observers must skip these synthetic messages.
+  A stopping hook prevents injection. File-hook execution policy belongs to its
+  host adapter; this return channel does not make detached scripts blocking.
 
 ### 9. Context Compaction
 

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -2282,6 +2282,86 @@ describe("AgentRuntime", () => {
 		});
 	});
 
+	it.each([
+		false,
+		true,
+	])("injects run context after input (seeded: %s)", async (seeded) => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const prompt: AgentMessage = {
+			id: "prompt",
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			createdAt: 1,
+		};
+		const runtime = new AgentRuntime({
+			model,
+			initialMessages: seeded ? [prompt] : [],
+			hooks: {
+				beforeRun: () => ({
+					appendContext: "first <hook_context>note</hook_context>",
+				}),
+			},
+			plugins: [
+				{
+					name: "second",
+					setup: () => ({
+						hooks: { beforeRun: () => ({ appendContext: "second" }) },
+					}),
+				},
+			],
+		});
+		const result = await runtime.run(seeded ? "" : "hello");
+		expect(result.status).toBe("completed");
+		const messages = model.requests[0].messages;
+		expect(messages[0].content).toEqual(prompt.content);
+		expect(messages[1]).toMatchObject({
+			role: "user",
+			metadata: { displayRole: "system", userRunSpan: 0 },
+			content: [
+				{
+					type: "text",
+					text:
+						'<hook_context source="RunStart">\nfirst <\\hook_context>note<\\/hook_context>\n</hook_context>\n\n' +
+						'<hook_context source="RunStart">\nsecond\n</hook_context>',
+				},
+			],
+		});
+		expect(result.messages[1]).toEqual(messages[1]);
+	});
+
+	it("discards all run context on cancellation without leaking it into the next run", async () => {
+		const beforeRun = vi
+			.fn()
+			.mockReturnValueOnce({ appendContext: "discard me" })
+			.mockReturnValueOnce(undefined);
+		const stop = vi
+			.fn()
+			.mockReturnValueOnce({ stop: true, appendContext: "discard this too" })
+			.mockReturnValueOnce(undefined);
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			hooks: { beforeRun },
+			plugins: [
+				{ name: "stop", setup: () => ({ hooks: { beforeRun: stop } }) },
+			],
+		});
+		expect((await runtime.run("blocked")).status).toBe("aborted");
+		expect(model.requests).toHaveLength(0);
+		expect((await runtime.continue("retry")).status).toBe("completed");
+		expect(JSON.stringify(model.requests[0].messages)).not.toContain("discard");
+	});
+
 	it("sanitizes hook context markup against corrupting identity attributes", async () => {
 		const model = new ScriptedModel([
 			() => [

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -345,8 +345,8 @@ function sanitizeHookAttribute(value: string): string {
 }
 
 function formatHookContextBlock(
-	source: "PreToolUse" | "PostToolUse",
-	toolCall: AgentToolCallPart,
+	source: "PreToolUse" | "PostToolUse" | "RunStart",
+	toolCall: AgentToolCallPart | undefined,
 	text: string,
 ): string {
 	// Tool identity keeps each block attributable to its call: contexts are
@@ -356,10 +356,11 @@ function formatHookContextBlock(
 	// hook_context tags (opening and closing) neutralized so neither
 	// provider-supplied ids nor hook output can corrupt or spoof the block
 	// markup.
-	const toolName = sanitizeHookAttribute(toolCall.toolName);
-	const toolCallId = sanitizeHookAttribute(toolCall.toolCallId);
+	const identity = toolCall
+		? ` tool_name="${sanitizeHookAttribute(toolCall.toolName)}" tool_call_id="${sanitizeHookAttribute(toolCall.toolCallId)}"`
+		: "";
 	const body = text.trim().replace(/<(\/?)hook_context/gi, "<\\$1hook_context");
-	return `<hook_context source="${source}" tool_name="${toolName}" tool_call_id="${toolCallId}">\n${body}\n</hook_context>`;
+	return `<hook_context source="${source}"${identity}>\n${body}\n</hook_context>`;
 }
 
 function cloneMessages(messages: readonly AgentMessage[]): AgentMessage[] {
@@ -705,7 +706,7 @@ export class AgentRuntime {
 		this.overflowRecoveryAttempted = false;
 
 		try {
-			await this.callBeforeRunHooks();
+			const runHookContexts = await this.callBeforeRunHooks();
 			await this.emit({ type: "run-started", snapshot: this.snapshot() });
 
 			for (const message of input ? normalizeInput(input) : []) {
@@ -721,6 +722,8 @@ export class AgentRuntime {
 			if (completionToolReminder) {
 				await this.addUserReminderMessage(completionToolReminder);
 			}
+
+			await this.appendHookContexts(runHookContexts);
 
 			let finalAssistantMessage: AgentMessage | undefined;
 
@@ -823,24 +826,8 @@ export class AgentRuntime {
 						message: toolMessage,
 					});
 				}
-				if (this.pendingHookContexts.length > 0) {
-					const hookContextText = this.pendingHookContexts.join("\n\n");
-					this.pendingHookContexts = [];
-					// displayRole "system" keeps the injected block out of user-facing
-					// transcripts (live and replayed) while it still reaches the model,
-					// mirroring how compaction summaries are handled.
-					const hookContextMessage = createMessage(
-						"user",
-						[{ type: "text", text: hookContextText }],
-						{ userRunSpan: 0, displayRole: "system" },
-					);
-					this.state.messages.push(hookContextMessage);
-					await this.emit({
-						type: "message-added",
-						snapshot: this.snapshot(),
-						message: hookContextMessage,
-					});
-				}
+				await this.appendHookContexts(this.pendingHookContexts);
+				this.pendingHookContexts = [];
 				await this.emit({
 					type: "turn-finished",
 					snapshot: this.snapshot(),
@@ -937,13 +924,36 @@ export class AgentRuntime {
 		}
 	}
 
-	private async callBeforeRunHooks(): Promise<void> {
+	private async appendHookContexts(contexts: string[]): Promise<void> {
+		if (contexts.length === 0) return;
+		// Persist context for later requests while keeping it out of the transcript UI.
+		const message = createMessage(
+			"user",
+			[{ type: "text", text: contexts.join("\n\n") }],
+			{ userRunSpan: 0, displayRole: "system" },
+		);
+		this.state.messages.push(message);
+		await this.emit({
+			type: "message-added",
+			snapshot: this.snapshot(),
+			message,
+		});
+	}
+
+	private async callBeforeRunHooks(): Promise<string[]> {
+		const contexts: string[] = [];
 		for (const hook of this.hooks.beforeRun) {
-			const control = (await hook({
+			const control = await hook({
 				snapshot: this.snapshot(),
-			})) as AgentStopControl | undefined;
+			});
 			this.applyStopControl(control);
+			if (control?.appendContext?.trim()) {
+				contexts.push(
+					formatHookContextBlock("RunStart", undefined, control.appendContext),
+				);
+			}
 		}
+		return contexts;
 	}
 
 	private async callAfterRunHooks(result: AgentRunResult): Promise<void> {

--- a/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.test.ts
@@ -725,7 +725,7 @@ describe("createHookConfigFileHooks", () => {
 		});
 	});
 
-	it("dispatches agent_start and prompt_submit exactly once when both are configured", async () => {
+	it("dispatches agent_start and the real prompt once, ignoring synthetic context", async () => {
 		const outputPath = join(tmpdir(), `hooks-start-prompt-${Date.now()}.jsonl`);
 		const { workspace } = await createWorkspaceWithHook(
 			"TaskStart.js",
@@ -755,6 +755,17 @@ describe("createHookConfigFileHooks", () => {
 				},
 			});
 
+			await hooks?.onEvent?.({
+				type: "message-added",
+				snapshot,
+				message: {
+					id: "context",
+					role: "user",
+					createdAt: 0,
+					content: [{ type: "text", text: "hook context" }],
+					metadata: { displayRole: "system" },
+				},
+			});
 			const payloads = (await waitForJsonLines(outputPath, 2)).map(
 				(line) =>
 					JSON.parse(line) as {

--- a/sdk/packages/core/src/hooks/hook-file-hooks.ts
+++ b/sdk/packages/core/src/hooks/hook-file-hooks.ts
@@ -689,7 +689,11 @@ export function createHookAuditHooks(options: {
 			}
 		},
 		onEvent: async (event: AgentRuntimeEvent) => {
-			if (event.type !== "message-added" || event.message.role !== "user") {
+			if (
+				event.type !== "message-added" ||
+				event.message.role !== "user" ||
+				event.message.metadata?.displayRole === "system"
+			) {
 				return;
 			}
 			const commandCtx = runStartContext(
@@ -935,7 +939,11 @@ export function createHookConfigFileHooks(
 		}
 		if ((commandMap.prompt_submit?.length ?? 0) > 0) {
 			hooks.onEvent = async (event: AgentRuntimeEvent) => {
-				if (event.type !== "message-added" || event.message.role !== "user") {
+				if (
+					event.type !== "message-added" ||
+					event.message.role !== "user" ||
+					event.message.metadata?.displayRole === "system"
+				) {
 					return;
 				}
 				await runPromptSubmit(

--- a/sdk/packages/core/src/hooks/subprocess.ts
+++ b/sdk/packages/core/src/hooks/subprocess.ts
@@ -423,7 +423,11 @@ export function createSubprocessHooks(
 	};
 
 	const onEvent = async (event: AgentRuntimeEvent): Promise<void> => {
-		if (event.type !== "message-added" || event.message.role !== "user") {
+		if (
+			event.type !== "message-added" ||
+			event.message.role !== "user" ||
+			event.message.metadata?.displayRole === "system"
+		) {
 			return;
 		}
 		const base = {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -1638,6 +1638,106 @@ describe("SessionRuntime.addTools / updateConnection / clearHistory / restore", 
 // ---------------------------------------------------------------------------
 
 describe("SessionRuntime real AgentRuntime smoke", () => {
+	it("delivers config and extension run context on each turn and persists it", async () => {
+		const requests: AgentMessage[][] = [];
+		const model: AgentModel = {
+			async *stream(request) {
+				requests.push([...request.messages]);
+				yield { type: "text-delta", text: "done" };
+				yield { type: "finish", reason: "stop" };
+			},
+		};
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				hooks: {
+					beforeRun: () => ({ appendContext: `config-${requests.length + 1}` }),
+				},
+				extensions: [
+					{
+						name: "run-context",
+						manifest: { capabilities: ["hooks"] },
+						hooks: {
+							beforeRun: () => ({
+								appendContext: `extension-${requests.length + 1}`,
+							}),
+						},
+					},
+				],
+			}),
+			{
+				createAgentRuntimeImpl: (config) =>
+					createAgentRuntime({ ...config, model }),
+			},
+		);
+		expect((await session.run("first prompt")).finishReason).toBe("completed");
+		expect((await session.continue("second prompt")).finishReason).toBe(
+			"completed",
+		);
+		expect(requests).toHaveLength(2);
+		for (const [index, messages] of requests.entries()) {
+			const promptIndex = messages.findIndex((message) =>
+				JSON.stringify(message.content).includes(
+					index ? "second prompt" : "first prompt",
+				),
+			);
+			expect(promptIndex).toBeGreaterThanOrEqual(0);
+			expect(messages[promptIndex + 1]).toMatchObject({
+				role: "user",
+				content: [
+					{
+						type: "text",
+						text: `<hook_context source="RunStart">\nconfig-${index + 1}\n\nextension-${index + 1}\n</hook_context>`,
+					},
+				],
+			});
+		}
+		expect(JSON.stringify(requests[1])).toContain("config-1");
+		expect(JSON.stringify(session.getMessages())).toContain("extension-2");
+		expect(
+			session
+				.getMessages()
+				.filter((message) =>
+					JSON.stringify(message.content).includes("<hook_context"),
+				),
+		).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					metadata: expect.objectContaining({ displayRole: "system" }),
+				}),
+			]),
+		);
+	});
+
+	it("a stopping extension discards earlier run context and skips later hooks", async () => {
+		const laterHook = vi.fn();
+		const stream = vi.fn();
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				hooks: { beforeRun: () => ({ appendContext: "discard me" }) },
+				extensions: [
+					{
+						name: "stop",
+						manifest: { capabilities: ["hooks"] },
+						hooks: { beforeRun: () => ({ stop: true }) },
+					},
+					{
+						name: "later",
+						manifest: { capabilities: ["hooks"] },
+						hooks: { beforeRun: laterHook },
+					},
+				],
+			}),
+			{
+				createAgentRuntimeImpl: (config) =>
+					createAgentRuntime({ ...config, model: { stream } }),
+			},
+		);
+		await session.run("blocked");
+		expect(stream).not.toHaveBeenCalled();
+		expect(laterHook).not.toHaveBeenCalled();
+		expect(JSON.stringify(session.getMessages())).not.toContain("discard me");
+	});
+
 	it("does not replay ERROR: EMPTY CONTENT after an empty upstream failure", async () => {
 		const modelRequests: AgentMessage[][] = [];
 		const scriptedModel: AgentModel = {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -183,11 +183,15 @@ function mergeRuntimeHooks(
 
 	return {
 		beforeRun: async (ctx) => {
+			const contexts: string[] = [];
 			for (const hook of hooks) {
 				const result = await hook.beforeRun?.(ctx);
 				if (result?.stop) return result;
+				if (result?.appendContext?.trim()) contexts.push(result.appendContext);
 			}
-			return undefined;
+			return contexts.length
+				? { appendContext: contexts.join("\n\n") }
+				: undefined;
 		},
 		afterRun: async (ctx) => {
 			for (const hook of hooks) {

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -346,6 +346,14 @@ export interface AgentStopControl {
 	reason?: string;
 }
 
+export interface AgentBeforeRunResult extends AgentStopControl {
+	/** Context appended after run input and before the first model request.
+	 * Persisted as a user message with displayRole "system", like tool hook context.
+	 * Ignored when any beforeRun hook stops the run.
+	 */
+	appendContext?: string;
+}
+
 export interface AgentBeforeModelResult {
 	stop?: boolean;
 	reason?: string;
@@ -420,7 +428,10 @@ export interface AgentRunLifecycleContext {
 export interface AgentRuntimeHooks {
 	beforeRun?: (
 		context: AgentRunLifecycleContext,
-	) => AgentStopControl | undefined | Promise<AgentStopControl | undefined>;
+	) =>
+		| AgentBeforeRunResult
+		| undefined
+		| Promise<AgentBeforeRunResult | undefined>;
 	afterRun?: (
 		context: AgentRunLifecycleContext & { result: AgentRunResult },
 	) => void | Promise<void>;


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-3058 (VS Code TaskStart/UserPromptSubmit context injection). Supersedes #13524 for that scope.

### Description

On the SDK-backed VS Code engine, TaskStart and UserPromptSubmit scripts already run before the turn, but their `contextModification` output is discarded. This change delivers that output to the first model request and preserves it in conversation history for subsequent requests.

The change follows the existing tool-hook context mechanism:

- `beforeRun` returns `AgentBeforeRunResult`, extending the existing stop control with optional `appendContext`.
- The session orchestrator combines context from config and extension hooks in order. A stopping hook short-circuits the chain and prevents injection.
- The agent runtime collects run-start context in a local variable and appends it after the run input. Run and tool hooks share the existing escaped `<hook_context>` formatter and message insertion helper.
- The VS Code adapter maps TaskStart/UserPromptSubmit results through the same stop/context mapping as tool hooks. Synthetic context messages are excluded from prompt dispatch and latest-user-prompt lookup.

The context is a persisted user-role message with `displayRole: "system"`, matching tool-hook context. It reaches the model while the existing transcript projection keeps the raw block out of the UI.

Two details matter for correctness. Orchestrated sessions seed the submitted prompt into `initialMessages`, whereas a directly driven runtime appends its run input after `beforeRun`. Injection happens after either path has established the input. Also, adding a return field to the runtime alone is insufficient: the core orchestrator previously discarded every non-stopping `beforeRun` result. The integration test exercises the real orchestrator and agent runtime together to catch that failure.

Run-start context has no shared pending buffer with tool execution. It is injected once before the first request, and a cancelled run cannot leave it behind for a later run. Existing history normalization remains responsible for repairing incomplete tool pairs when loading an extension session.

### Test Procedure

- Built the SDK and typechecked shared, agents, core, and the VS Code extension.
- Runtime tests cover direct and seeded input, aggregation across runtime hooks, escaped context markup, hidden-message metadata, cancellation, and a subsequent run after cancellation.
- A real session-runtime integration test requires distinct config/extension context on each of two turns and checks history persistence. A cancellation test verifies later extension hooks and the model are not called.
- Adapter tests cover both hook outputs, cancellation by either hook, and selecting the real prompt after synthetic context. CLI and file-hook tests verify synthetic context does not dispatch another prompt hook.
- Existing transcript mapping and initial-message sanitizer tests pass.
- The VS Code E2E fixture returns a different hidden fact on each turn. The mock model requires the appropriate fact, so first-turn history cannot satisfy the second-turn assertion. The test also checks the prompt received by the script and verifies raw context stays hidden live and after reopening the task.

Local results: 358 focused tests passed, one existing test skipped. The packaged VS Code hooks E2E also passed (including setup) with `CI=true bun run e2e hooks.test.ts --retries=0 --timeout=60000` on a local Xvfb display. The first attempt found the advertised display unavailable; with a temporary display, the ordinary two-second expectation budget was too short during startup. The standard CI five-second expectation budget passed. SDK build/typechecks, extension production packaging (including webview, compatibility typechecks, and lint), and changed-file formatting/lint checks passed.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — scoped commands and results above
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No new UI. The E2E test verifies that injected context stays hidden in the transcript.

### Additional Notes

Thanks to the investigation in #13524 for identifying the missing return channel and the orchestrator merge requirement.

This replacement is scoped to the enabled VS Code behavior. It does not introduce blocking SDK file hooks, execution-mode flags, subprocess lifecycle changes, or detached-hook telemetry. CLI/desktop file-hook context injection and wiring the extension's TaskResume hook remain follow-up work; this PR does not close the broader CLINE-3058 issue. Those execution-policy changes need their own SDK design and rollout review.
