### PR TITLE
chore(desktop): bump beta to 0.0.24-beta.1

### DIFF
--- a/apps/examples/desktop-app/CHANGELOG.md
+++ b/apps/examples/desktop-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cline Desktop Changelog
 
+## 0.0.24-beta.1
+
+- Beta: continue eligible local, git-backed sessions in Cline Cloud with `/handoff`, including optional follow-up text and image attachments.
+- Cloud sessions recover more reliably from provisioning, reconnect, and handoff failures without losing pending follow-up content.
+- Includes all stable desktop improvements through 0.0.23.
+
 ## 0.0.23-beta.1
 
 - Beta: configure and opt in to image generation under Customize → Tools. Provider credentials stay server-side, and generated images remain available in session history.

--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cline/code",
-	"version": "0.0.23-beta.1",
+	"version": "0.0.24-beta.1",
 	"private": true,
 	"scripts": {
 		"build:ui": "bun -F @cline/ui build",

--- a/apps/examples/desktop-app/src-tauri/tauri.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Cline",
-	"version": "0.0.23-beta.1",
+	"version": "0.0.24-beta.1",
 	"identifier": "bot.cline.app",
 	"build": {
 		"beforeDevCommand": "bun run build:sidecar:bin && bun run dev:web",

--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
     },
     "apps/examples/desktop-app": {
       "name": "@cline/code",
-      "version": "0.0.23-beta.1",
+      "version": "0.0.24-beta.1",
       "dependencies": {
         "@ai-sdk/gateway": "4.0.31",
         "@ai-sdk/google": "4.0.44",


### PR DESCRIPTION
## Summary

- bump the desktop beta version to `0.0.24-beta.1`
- add release notes for Cloud Sessions and local-to-cloud handoff
- keep package, Tauri, and lockfile versions aligned

## Stack

Depends on #13853. After #13853 merges, retarget this PR to `desktop-experimental` before merging.

## Validation

- package and Tauri versions match
- `bun install --lockfile-only --frozen-lockfile`
- formatting check for changed JSON files
- `git diff --check`

This PR only prepares version metadata. It does not tag, publish, or deploy a release.