### PR TITLE
fix(vscode): apply mid-task Reasoning Effort changes to the active session

### DIFF
--- a/.changeset/mid-task-reasoning-effort.md
+++ b/.changeset/mid-task-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Apply Reasoning Effort changes to the active task: changing the effort in provider settings now updates the running session's reasoning configuration for its next turn, instead of only taking effect on the next task

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -53,7 +53,7 @@ import { arePathsEqual, getDesktopDir } from "@/utils/path"
 import { ClineAccountService } from "./account-service"
 import { AuthService, LogoutReason } from "./auth-service"
 import { BUILTIN_SLASH_COMMANDS } from "./builtin-slash-commands"
-import { buildStartSessionInput, createHistoryItemFromSession } from "./cline-session-factory"
+import { buildStartSessionInput, createHistoryItemFromSession, resolveProviderReasoningConfig } from "./cline-session-factory"
 import { MessageTranslatorState, reshapeErrorForWebview } from "./message-translator"
 import { createProviderCatalog } from "./model-catalog/catalog"
 import type { Disposable, ProviderCatalog, ProviderConfigChange, ProviderConfigStore } from "./model-catalog/contracts"
@@ -716,10 +716,25 @@ export class Controller {
 	private handleProviderConfigChange(event: ProviderConfigChange): void {
 		this.scheduleProviderConfigStatePost()
 
-		if (event.kind === "selection" && this.isSelectionForActiveModeProvider(event)) {
+		if (!this.isChangeForActiveModeProvider(event)) {
+			return
+		}
+		if (event.kind === "selection") {
 			this.sessions
 				?.updateActiveSessionModel(event.selection.modelId)
 				.catch((error) => Logger.error("[SdkController] Failed to update active session model:", error))
+			return
+		}
+		// Provider fields write (e.g. Reasoning Effort). Sessions capture
+		// thinking/reasoningEffort at build time, so push the re-resolved
+		// reasoning to the live session; otherwise an effort change made
+		// mid-task only takes effect on the next task (#13668).
+		const activeSession = this.sessions?.getActiveSession()
+		const reasoning = resolveProviderReasoningConfig(event.providerId.toString())
+		if (activeSession?.sdkHost.updateSessionConnection && (reasoning.thinking ?? reasoning.reasoningEffort) !== undefined) {
+			activeSession.sdkHost
+				.updateSessionConnection(activeSession.sessionId, reasoning)
+				.catch((error) => Logger.error("[SdkController] Failed to update active session reasoning:", error))
 		}
 	}
 
@@ -735,11 +750,11 @@ export class Controller {
 		this.sessionRebuilds?.sessionBecameIdle()
 	}
 
-	private isSelectionForActiveModeProvider(event: Extract<ProviderConfigChange, { kind: "selection" }>): boolean {
+	private isChangeForActiveModeProvider(event: ProviderConfigChange): boolean {
 		try {
 			const modeValue = this.stateManager.getGlobalSettingsKey("mode")
 			const mode = modeValue === "plan" ? "plan" : "act"
-			if (event.mode !== mode) {
+			if (event.kind === "selection" && event.mode !== mode) {
 				return false
 			}
 

--- a/apps/vscode/src/sdk/cline-session-factory.ts
+++ b/apps/vscode/src/sdk/cline-session-factory.ts
@@ -194,7 +194,7 @@ export function normalizeProviderReasoningSettings(reasoning: ProviderReasoningS
 	return effort ? { thinking: true, reasoningEffort: effort } : {}
 }
 
-function resolveProviderReasoningConfig(providerId: string): SessionReasoningConfig {
+export function resolveProviderReasoningConfig(providerId: string): SessionReasoningConfig {
 	try {
 		const manager = getProviderSettingsManager(resolveDataDir())
 		const settings = manager.getProviderSettings(providerSettingsProviderId(providerId))

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -3,6 +3,7 @@ import type {
 	ClineCoreStartInput,
 	CompareCheckpointInput,
 	CompareCheckpointResult,
+	ConnectionUpdate,
 	CoreSessionEvent,
 	HookEventPayload,
 	PendingPromptMutationResult,
@@ -60,6 +61,8 @@ export interface SdkSessionHost {
 	pendingPrompts(action: "delete", input: PendingPromptsDeleteInput): Promise<PendingPromptMutationResult>
 	subscribe(listener: (event: CoreSessionEvent) => void): () => void
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void>
+	/** Applies provider/reasoning connection updates to subsequent turns of an active session. */
+	updateSessionConnection?(sessionId: string, updates: ConnectionUpdate): Promise<void>
 }
 
 export type SdkInitialMessages = NonNullable<StartSessionInput["initialMessages"]>

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -11,6 +11,7 @@ import {
 	type ClineCoreStartInput,
 	type CompareCheckpointInput,
 	type CompareCheckpointResult,
+	type ConnectionUpdate,
 	type CoreSessionEvent,
 	type EditorExecutor,
 	type HookEventPayload,
@@ -110,6 +111,10 @@ export class VscodeSessionHost implements SdkSessionHost {
 	}
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void> {
 		return this.inner.updateSessionModel(sessionId, modelId)
+	}
+
+	updateSessionConnection?(sessionId: string, updates: ConnectionUpdate): Promise<void> {
+		return this.inner.updateSessionConnection(sessionId, updates)
 	}
 
 	static async create(options: VscodeSessionHostOptions): Promise<VscodeSessionHost> {


### PR DESCRIPTION
### Related Issue

**Issue:** #13668

### Description

Investigation of #13668 with runtime evidence (fake OpenAI-compatible server logging every request body, driven through the real extension UI):

**The issue's claimed root cause does not reproduce.** With the exact post-migration state from the report (model `capabilities: ["streaming","tools","images"]` in both `models.json` and `globalState.json`, no `supportsReasoning`, provider `reasoning: {enabled: true, effort: "xhigh"}`), a new task's request carries `reasoning_effort: "xhigh"` on the wire, all tools are sent, and the Thinking section renders the streamed `reasoning_content`. There is no runtime capability gate that suppresses reasoning for the OpenAI-compatible path, so `toSdkModelInfo()` capability seeding is not the bug and no capability changes are needed.

**What does reproduce is the headline symptom, "setting Reasoning Effort is inert", for the running task.** The reasoning fields (`thinking`/`reasoningEffort`) are resolved once when a session is built. Changing the effort mid-task persists the setting and new tasks pick it up, but the active session keeps the stale values, so the change looks inert until you start a new task (likely why the reporter concluded a full extension host restart was needed).

The SDK already supports mid-session reasoning updates (`ClineCore.updateSessionConnection`, used by the CLI and desktop clients); the extension only pushed model-id changes. This PR is a minimal wiring change (28 insertions, 5 deletions across 4 files plus a changeset):

- `SdkController.handleProviderConfigChange` now also reacts to provider `fields` writes for the active mode's provider: it re-resolves the provider's reasoning settings (`resolveProviderReasoningConfig`, now exported) and pushes them to the live session; writes with no reasoning signal leave the session untouched
- the existing `isSelectionForActiveModeProvider` check is generalized to both event kinds as `isChangeForActiveModeProvider`
- `SdkSessionHost` gains an optional `updateSessionConnection`, implemented by `VscodeSessionHost` as a one-line delegation to `ClineCore.updateSessionConnection`

The other reported symptom (empty Thinking text with llama-server) did not reproduce here; reasoning text rendered correctly with a `reasoning_content`-streaming backend, so that part is likely #12247 or backend-specific.

### Test Procedure

- End-to-end against a fake OpenAI-compatible server that streams `reasoning_content` and logs request bodies, driving the real extension UI in an Extension Development Host:
  - Before the fix: changing effort mid-task left the same task's next request on the stale effort, while a new task picked up the new value.
  - After the fix: two consecutive mid-task changes both applied to the same task's next turn, and the Thinking text rendered each time:

```
request 1: reasoning_effort="low"   last_user="Say hello"
request 2: reasoning_effort="high"  last_user="Hello again at higher effort"   (changed Low -> High mid-task)
request 3: reasoning_effort="xhigh" last_user="And hello at xhigh effort"      (changed High -> Xhigh mid-task)
```

- Also verified the issue's original repro steps (custom model, edited Model Configuration fields, effort set, backend emitting `reasoning_content`) work on unmodified main, ruling out the claimed capability-gate suppression.
- `bun run test:unit` in `apps/vscode`: 1081 pass, 0 fail. `bunx tsc --noEmit` and biome lint clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

One task, three turns: effort was changed in settings between each turn (Low, then High, then Xhigh) and each follow-up request in the same task carried the new effort, with Thinking text rendering throughout. (Screenshot attached below.)

### Additional Notes

The issue also suggests adding a "Supports Reasoning" checkbox to the OpenAI Compatible settings; per the evidence above it is not needed for reasoning to work, so it is intentionally out of scope here.
