### PR TITLE
fix(vscode): show enabled skills in the slash command menu

### DIFF
--- a/apps/vscode/src/shared/slashCommands.ts
+++ b/apps/vscode/src/shared/slashCommands.ts
@@ -1,7 +1,7 @@
 export interface SlashCommand {
 	name: string
 	description?: string
-	section?: "default" | "custom" | "mcp"
+	section?: "default" | "custom" | "skill" | "mcp"
 	cliCompatible?: boolean
 }
 

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1,6 +1,6 @@
 import { mentionRegex, mentionRegexGlobal } from "@shared/context-mentions"
-import { StringRequest } from "@shared/proto/cline/common"
-import { FileSearchRequest, FileSearchType, RelativePathsRequest } from "@shared/proto/cline/file"
+import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
+import { FileSearchRequest, FileSearchType, RelativePathsRequest, type SkillInfo } from "@shared/proto/cline/file"
 import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/cline/state"
 import { type SlashCommand } from "@shared/slashCommands"
 import { Mode } from "@shared/storage/types"
@@ -232,6 +232,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [showSlashCommandsMenu, setShowSlashCommandsMenu] = useState(false)
 		const [selectedSlashCommandsIndex, setSelectedSlashCommandsIndex] = useState(0)
 		const [slashCommandsQuery, setSlashCommandsQuery] = useState("")
+		const [skills, setSkills] = useState<SkillInfo[]>([])
 		const slashCommandsMenuContainerRef = useRef<HTMLDivElement>(null)
 
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
@@ -326,6 +327,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			return () => {
 				document.removeEventListener("mousedown", handleClickOutsideSlashMenu)
 			}
+		}, [showSlashCommandsMenu])
+
+		// Skills aren't part of the extension state (only their explicit toggles are),
+		// so load them on mount and re-load whenever the slash menu toggles to pick up
+		// skills added, removed, or toggled since.
+		useEffect(() => {
+			FileServiceClient.refreshSkills(EmptyRequest.create())
+				.then((response) => setSkills([...(response.localSkills || []), ...(response.globalSkills || [])]))
+				.catch((error) => console.error("Failed to refresh skills:", error))
 		}, [showSlashCommandsMenu])
 
 		const handleMentionSelect = useCallback(
@@ -490,6 +500,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								remoteWorkflowToggles,
 								remoteConfigSettings?.remoteGlobalWorkflows,
 								mcpServers,
+								skills,
 							)
 
 							if (allCommands.length === 0) {
@@ -515,6 +526,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							remoteWorkflowToggles,
 							remoteConfigSettings?.remoteGlobalWorkflows,
 							mcpServers,
+							skills,
 						)
 						if (commands.length > 0) {
 							handleSlashCommandsSelect(commands[selectedSlashCommandsIndex])
@@ -678,6 +690,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				slashCommandsQuery,
 				handleSlashCommandsSelect,
 				sendingDisabled,
+				skills,
 			],
 		)
 
@@ -989,6 +1002,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					globalWorkflowToggles,
 					remoteWorkflowToggles,
 					remoteConfigSettings?.remoteGlobalWorkflows,
+					mcpServers,
+					skills,
 				)
 
 				if (isValidCommand) {
@@ -1002,7 +1017,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			highlightLayerRef.current.innerHTML = processedText
 			highlightLayerRef.current.scrollTop = textAreaRef.current.scrollTop
 			highlightLayerRef.current.scrollLeft = textAreaRef.current.scrollLeft
-		}, [localWorkflowToggles, globalWorkflowToggles, remoteWorkflowToggles, remoteConfigSettings])
+		}, [localWorkflowToggles, globalWorkflowToggles, remoteWorkflowToggles, remoteConfigSettings, mcpServers, skills])
 
 		useLayoutEffect(() => {
 			updateHighlights()
@@ -1437,6 +1452,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								remoteWorkflowToggles={remoteWorkflowToggles}
 								selectedIndex={selectedSlashCommandsIndex}
 								setSelectedIndex={setSelectedSlashCommandsIndex}
+								skills={skills}
 							/>
 						</div>
 					)}

--- a/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
@@ -1,4 +1,5 @@
 import type { McpServer } from "@shared/mcp"
+import type { SkillInfo } from "@shared/proto/cline/file"
 import React, { useCallback, useEffect, useRef } from "react"
 import ScreenReaderAnnounce from "@/components/common/ScreenReaderAnnounce"
 import { useMenuAnnouncement } from "@/hooks/useMenuAnnouncement"
@@ -16,6 +17,7 @@ interface SlashCommandMenuProps {
 	remoteWorkflowToggles?: Record<string, boolean>
 	remoteWorkflows?: any[]
 	mcpServers?: McpServer[]
+	skills?: SkillInfo[]
 }
 
 const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
@@ -29,6 +31,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 	remoteWorkflowToggles,
 	remoteWorkflows,
 	mcpServers = [],
+	skills = [],
 }) => {
 	const menuRef = useRef<HTMLDivElement>(null)
 
@@ -40,9 +43,11 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 		remoteWorkflowToggles,
 		remoteWorkflows,
 		mcpServers,
+		skills,
 	)
 	const defaultCommands = filteredCommands.filter((cmd) => cmd.section === "default" || !cmd.section)
 	const workflowCommands = filteredCommands.filter((cmd) => cmd.section === "custom")
+	const skillCommands = filteredCommands.filter((cmd) => cmd.section === "skill")
 	const mcpCommands = filteredCommands.filter((cmd) => cmd.section === "mcp")
 
 	// Screen reader announcements
@@ -145,7 +150,13 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 					<>
 						{renderCommandSection(defaultCommands, "Default Commands", 0, true)}
 						{renderCommandSection(workflowCommands, "Workflow Commands", defaultCommands.length, false)}
-						{renderCommandSection(mcpCommands, "MCP Prompts", defaultCommands.length + workflowCommands.length, true)}
+						{renderCommandSection(skillCommands, "Skills", defaultCommands.length + workflowCommands.length, true)}
+						{renderCommandSection(
+							mcpCommands,
+							"MCP Prompts",
+							defaultCommands.length + workflowCommands.length + skillCommands.length,
+							true,
+						)}
 					</>
 				) : (
 					<div aria-selected="false" className="py-2 px-3 cursor-default flex flex-col" role="option">

--- a/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
+++ b/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
@@ -1,6 +1,13 @@
 import type { McpServer } from "@shared/mcp"
+import { SkillInfo } from "@shared/proto/cline/file"
 import { describe, expect, it } from "vitest"
-import { getMatchingSlashCommands, getMcpPromptCommands, slashCommandRegex, validateSlashCommand } from "../slash-commands"
+import {
+	getMatchingSlashCommands,
+	getMcpPromptCommands,
+	getSkillCommands,
+	slashCommandRegex,
+	validateSlashCommand,
+} from "../slash-commands"
 
 // Helper to create a mock MCP server
 function createMockMcpServer(overrides: Partial<McpServer> = {}): McpServer {
@@ -213,6 +220,43 @@ describe("slash-commands", () => {
 		it("should return null for non-matching MCP command", () => {
 			const result = validateSlashCommand("mcp:unknown:cmd", {}, {}, undefined, undefined, mcpServers)
 			expect(result).toBe(null)
+		})
+	})
+
+	describe("skills", () => {
+		const skills = [
+			SkillInfo.create({
+				name: "aws-deploy",
+				description: "Deploy to AWS",
+				path: "/skills/aws-deploy/SKILL.md",
+				enabled: true,
+			}),
+			SkillInfo.create({ name: "disabled-skill", description: "Off", path: "/skills/disabled/SKILL.md", enabled: false }),
+			SkillInfo.create({
+				name: "aws-deploy",
+				description: "Global copy",
+				path: "/global/aws-deploy/SKILL.md",
+				enabled: true,
+			}),
+		]
+
+		it("lists enabled skills once under the skill section", () => {
+			const result = getSkillCommands(skills)
+			expect(result).toEqual([{ name: "aws-deploy", description: "Deploy to AWS", section: "skill" }])
+		})
+
+		it("includes skills in matching commands and filters by prefix", () => {
+			const all = getMatchingSlashCommands("", {}, {}, undefined, undefined, [], skills)
+			expect(all.filter((cmd) => cmd.section === "skill").map((cmd) => cmd.name)).toEqual(["aws-deploy"])
+
+			const filtered = getMatchingSlashCommands("aws", {}, {}, undefined, undefined, [], skills)
+			expect(filtered.map((cmd) => cmd.name)).toEqual(["aws-deploy"])
+		})
+
+		it("validates skill commands", () => {
+			expect(validateSlashCommand("aws-deploy", {}, {}, undefined, undefined, [], skills)).toBe("full")
+			expect(validateSlashCommand("aws", {}, {}, undefined, undefined, [], skills)).toBe("partial")
+			expect(validateSlashCommand("disabled-skill", {}, {}, undefined, undefined, [], skills)).toBe(null)
 		})
 	})
 

--- a/apps/vscode/webview-ui/src/utils/slash-commands.ts
+++ b/apps/vscode/webview-ui/src/utils/slash-commands.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@shared/mcp"
+import type { SkillInfo } from "@shared/proto/cline/file"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { BASE_SLASH_COMMANDS, type SlashCommand, VSCODE_ONLY_COMMANDS } from "../../../src/shared/slashCommands.ts"
 
@@ -68,6 +69,29 @@ function getWorkflowCommands(
 
 	const workflows = [...localWorkflows, ...globalWorkflows, ...remoteWorkflowCommands]
 	return workflows
+}
+
+/**
+ * Gets slash commands for enabled skills. Skill commands are sent as typed
+ * (not expanded), so the model loads the instructions through the skills tool.
+ */
+export function getSkillCommands(skills: SkillInfo[] = []): SlashCommand[] {
+	const seen = new Set<string>()
+	const commands: SlashCommand[] = []
+
+	for (const skill of skills) {
+		if (!skill.enabled || !skill.name || seen.has(skill.name)) {
+			continue
+		}
+		seen.add(skill.name)
+		commands.push({
+			name: skill.name,
+			description: skill.description || undefined,
+			section: "skill",
+		})
+	}
+
+	return commands
 }
 
 /**
@@ -181,6 +205,7 @@ export function getMatchingSlashCommands(
 	remoteWorkflowToggles?: Record<string, boolean>,
 	remoteWorkflows?: any[],
 	mcpServers: McpServer[] = [],
+	skills: SkillInfo[] = [],
 ): SlashCommand[] {
 	const workflowCommands = getWorkflowCommands(
 		localWorkflowToggles,
@@ -188,8 +213,9 @@ export function getMatchingSlashCommands(
 		remoteWorkflowToggles,
 		remoteWorkflows,
 	)
+	const skillCommands = getSkillCommands(skills)
 	const mcpPromptCommands = getMcpPromptCommands(mcpServers)
-	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands]
+	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...skillCommands, ...mcpPromptCommands]
 
 	if (!query) {
 		return allCommands
@@ -233,6 +259,7 @@ export function validateSlashCommand(
 	remoteWorkflowToggles?: Record<string, boolean>,
 	remoteWorkflows?: any[],
 	mcpServers: McpServer[] = [],
+	skills: SkillInfo[] = [],
 ): "full" | "partial" | null {
 	if (!command) {
 		return null
@@ -244,8 +271,9 @@ export function validateSlashCommand(
 		remoteWorkflowToggles,
 		remoteWorkflows,
 	)
+	const skillCommands = getSkillCommands(skills)
 	const mcpPromptCommands = getMcpPromptCommands(mcpServers)
-	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands]
+	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...skillCommands, ...mcpPromptCommands]
 
 	// case insensitive matching
 	const exactMatch = allCommands.some((cmd) => cmd.name.toLowerCase() === command.toLowerCase())


### PR DESCRIPTION
Fixes #13805

### Problem
In the VS Code extension, typing `/` in the chat input only listed built-in commands, workflows, and MCP prompts. Installed and enabled skills never appeared, even though the docs say they should and the send path already handles them: `SdkController.resolveSlashCommands` leaves a typed `/skill` as-is so the model loads it through the `skills` tool (#13327). The v4.1.4 changelog entry about showing skills in the slash menu came from the desktop app fix (#12894), not the extension.

The webview builds its slash command list locally from extension state. Workflows are covered because the full workflow list lives in the toggle maps, but `globalSkillsToggles`/`localSkillsToggles` only contain skills the user explicitly toggled and are keyed by `SKILL.md` path, so there was nothing to derive skill names from.

### Fix
- `ChatTextArea` loads skills through the existing `FileServiceClient.refreshSkills` RPC on mount and whenever the slash menu toggles, and passes them into the slash command helpers and `SlashCommandMenu`.
- `slash-commands.ts` gains `getSkillCommands()` (enabled skills, deduped by name, `section: "skill"`) and includes skills in `getMatchingSlashCommands` / `validateSlashCommand`.
- `SlashCommandMenu` renders a new "Skills" group between workflows and MCP prompts.
- `validateSlashCommand` in the input highlighter now also receives `mcpServers`, so MCP prompt commands highlight like other commands.

### Testing
- Added unit tests for `getSkillCommands`, matching, and validation in `webview-ui/src/utils/__tests__/slash-commands.test.ts`. Full webview suite passes (63 files, 483 tests) along with `tsc -b`.
- Manually verified in an Extension Development Host with a global skill (`~/.cline/skills/aws-deploy`) and a workspace skill (`.cline/skills/lint-fix`): both show under a "Skills" section, `/aws` filters to `/aws-deploy`, Enter inserts the highlighted command, and setting `disabled: true` in a skill's frontmatter (what the Skills panel toggle writes) drops it from the menu.

![Slash menu showing the Skills section with /lint-fix and /aws-deploy](https://cursor.com/artifacts/c/art-517ee47c-51a8-40c2-bf61-4a0cf1b30ac7)
![Slash menu filtered to /aws-deploy after typing /aws](https://cursor.com/artifacts/c/art-57423af0-231c-4681-81ba-24827abee585)