### PR TITLE
fix: stop dead approval prompts after a cancel or plan/act switch mid-approval

### DIFF
--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -396,6 +396,9 @@ export class Controller {
 				})
 			},
 			onDidBecomeIdle: () => this.handleSessionBecameIdle(),
+			// A turn is starting, so approval/question requests are live again after a
+			// clearPending (cancel, mode switch) closed them.
+			onDidBecomeRunning: () => this.interactions.reopen(),
 			beforeStartSession: () => this.ensureRemoteConfigForSessionStart(),
 			getRemoteConfigIntegration: () => this.remoteConfigCoreIntegration,
 			foregroundCommands: this.foregroundCommands,
@@ -415,6 +418,7 @@ export class Controller {
 				return this._terminalManager
 			},
 			onSendStart: () => {
+				this.interactions.reopen()
 				this.beginProviderFailureTelemetryTurn()
 			},
 			// this.mode is assigned later in this constructor; the closure only

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -532,4 +532,128 @@ describe("SdkInteractionCoordinator", () => {
 		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
 		await expect(approvalPromise).resolves.toEqual({ approved: true })
 	})
+	it("denies every outstanding approval on clearPending, not just the latest", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const recordDeniedToolApproval = vi.fn()
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			recordDeniedToolApproval,
+		})
+		const request = (toolCallId: string, toolName: string) =>
+			coordinator.handleRequestToolApproval({
+				agentId: "agent",
+				conversationId: "conversation",
+				iteration: 1,
+				toolCallId,
+				toolName,
+				input: {},
+				policy: { autoApprove: false },
+			})
+
+		// Parallel tool execution can leave several approvals outstanding at once.
+		const first = request("call-1", "run_commands")
+		const second = request("call-2", "read_files")
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(2))
+
+		coordinator.clearPending("Mode changed")
+
+		await expect(first).resolves.toEqual({ approved: false, reason: "Mode changed" })
+		await expect(second).resolves.toEqual({ approved: false, reason: "Mode changed" })
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith("call-1", "run_commands", "Mode changed")
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith("call-2", "read_files", "Mode changed")
+		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(false)
+	})
+
+	it("refuses approval and question requests after clearPending until the next turn reopens them", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const messages = new SdkMessageCoordinator({ getTask: () => task })
+		const listener = vi.fn()
+		messages.onSessionEvent(listener)
+		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const setTurnPhase = vi.fn()
+		const recordDeniedToolApproval = vi.fn()
+		const coordinator = new SdkInteractionCoordinator({
+			messages,
+			getSessionId: () => "session-123",
+			postStateToWebview,
+			setTurnPhase,
+			recordDeniedToolApproval,
+		})
+		const request = (toolCallId: string) =>
+			coordinator.handleRequestToolApproval({
+				agentId: "agent",
+				conversationId: "conversation",
+				iteration: 1,
+				toolCallId,
+				toolName: "read_files",
+				input: {},
+				policy: { autoApprove: false },
+			})
+
+		// The SDK requests approval for every tool call of an assistant message in turn. A
+		// cancel (task cancel / plan-act switch) denies the pending one, and the runtime may
+		// immediately ask for the next one on the run that is being aborted.
+		const pending = request("call-1")
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(1))
+		coordinator.clearPending("Mode changed")
+		await expect(pending).resolves.toEqual({ approved: false, reason: "Mode changed" })
+		postStateToWebview.mockClear()
+		setTurnPhase.mockClear()
+		listener.mockClear()
+
+		// No ask row, no phase change, no state post: the Resume Task state the cancel
+		// path settled must survive, and the run must unwind instead of waiting.
+		await expect(request("call-2")).resolves.toEqual({ approved: false, reason: "Mode changed" })
+		expect(recordDeniedToolApproval).toHaveBeenCalledWith("call-2", "read_files", "Mode changed")
+		await expect(coordinator.handleAskQuestion("Which file?", [], undefined)).resolves.toBe("")
+		expect(task.messageStateHandler.getClineMessages()).toHaveLength(1)
+		expect(listener).not.toHaveBeenCalled()
+		expect(setTurnPhase).not.toHaveBeenCalled()
+		expect(postStateToWebview).not.toHaveBeenCalled()
+
+		// The next turn (prompt sent / queued prompt drained) makes approvals live again.
+		coordinator.reopen()
+		const live = request("call-3")
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(2))
+		expect(setTurnPhase).toHaveBeenCalledWith("awaiting_approval", task.messageStateHandler.getClineMessages()[1].ts)
+		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
+		await expect(live).resolves.toEqual({ approved: true })
+	})
+
+	it("answers the newest outstanding approval from the footer buttons", async () => {
+		const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+		const recordApprovedToolMessage = vi.fn()
+		const coordinator = new SdkInteractionCoordinator({
+			messages: new SdkMessageCoordinator({ getTask: () => task }),
+			getSessionId: () => "session-123",
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+			recordApprovedToolMessage,
+		})
+		const request = (toolCallId: string) =>
+			coordinator.handleRequestToolApproval({
+				agentId: "agent",
+				conversationId: "conversation",
+				iteration: 1,
+				toolCallId,
+				toolName: "read_files",
+				input: {},
+				policy: { autoApprove: false },
+			})
+
+		const first = request("call-1")
+		const second = request("call-2")
+		await vi.waitFor(() => expect(task.messageStateHandler.getClineMessages()).toHaveLength(2))
+		const [firstAsk, secondAsk] = task.messageStateHandler.getClineMessages()
+
+		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(true)
+		await expect(second).resolves.toEqual({ approved: true })
+		expect(recordApprovedToolMessage).toHaveBeenLastCalledWith("call-2", secondAsk.ts)
+
+		expect(coordinator.resolvePendingToolApproval(undefined, "noButtonClicked")).toBe(true)
+		await expect(first).resolves.toMatchObject({ approved: false })
+		expect(firstAsk.ts).not.toBe(secondAsk.ts)
+		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(false)
+	})
 })

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -49,16 +49,29 @@ export interface SdkInteractionCoordinatorOptions {
 	getCwd?: () => string | undefined
 }
 
+interface PendingToolApproval {
+	resolve: (result: { approved: boolean; reason?: string }) => void
+	messageTs: number
+	toolName: string
+}
+
 export class SdkInteractionCoordinator {
 	private pendingAskResolve: ((answer: string) => void) | undefined
-	private pendingToolApprovalResolve: ((result: { approved: boolean; reason?: string }) => void) | undefined
-	private pendingToolApprovalMessage:
-		| {
-				toolCallId: string
-				messageTs: number
-				toolName: string
-		  }
-		| undefined
+	/**
+	 * Every approval the agent is currently waiting on, keyed by toolCallId in request
+	 * order. The SDK requests approval for each tool call of an assistant message before
+	 * executing any of them, so more than one can be outstanding; tracking only the latest
+	 * used to orphan the earlier promise (its run could then never finish).
+	 */
+	private readonly pendingToolApprovals = new Map<string, PendingToolApproval>()
+	/**
+	 * Set by clearPending (task cancel, mode switch, task switch/clear) and lifted when the
+	 * next turn starts. While set, approval and question requests are answered with an
+	 * immediate denial instead of a UI ask: the run they belong to is being aborted, and an
+	 * ask emitted now would re-arm dead Approve/Reject buttons over the Resume Task state the
+	 * cancel path just settled, and park the session's teardown on that answer.
+	 */
+	private closedReason: string | undefined
 
 	constructor(private readonly options: SdkInteractionCoordinatorOptions) {}
 
@@ -92,6 +105,13 @@ export class SdkInteractionCoordinator {
 	}
 
 	async handleRequestToolApproval(request: ToolApprovalRequest): Promise<{ approved: boolean; reason?: string }> {
+		if (this.closedReason !== undefined) {
+			Logger.log(
+				`[SdkController] Denying tool approval requested after "${this.closedReason}" (run is being torn down): tool=${request.toolName}`,
+			)
+			this.options.recordDeniedToolApproval?.(request.toolCallId, request.toolName, this.closedReason)
+			return { approved: false, reason: this.closedReason }
+		}
 		if (request.policy.autoApprove === true || this.options.shouldAutoApproveTool?.(request) === true) {
 			Logger.log(`[SdkController] Auto-approving tool execution: tool=${request.toolName}`)
 			return { approved: true }
@@ -121,16 +141,19 @@ export class SdkInteractionCoordinator {
 		await this.options.postStateToWebview()
 
 		return new Promise<{ approved: boolean; reason?: string }>((resolve) => {
-			this.pendingToolApprovalResolve = resolve
-			this.pendingToolApprovalMessage = {
-				toolCallId: request.toolCallId,
+			this.pendingToolApprovals.set(request.toolCallId, {
+				resolve,
 				messageTs: toolAskMessage.ts,
 				toolName: request.toolName,
-			}
+			})
 		})
 	}
 
 	async handleAskQuestion(question: string, options: string[], _context: unknown): Promise<string> {
+		if (this.closedReason !== undefined) {
+			Logger.log(`[SdkController] Skipping ask_question requested after "${this.closedReason}" (run is being torn down)`)
+			return ""
+		}
 		const askData: ClineAskQuestion = {
 			question,
 			options: options?.length ? options : undefined,
@@ -161,26 +184,29 @@ export class SdkInteractionCoordinator {
 		images?: string[],
 		files?: string[],
 	): boolean {
-		if (!this.pendingToolApprovalResolve) {
+		// The footer buttons belong to the most recently emitted ask, so a click answers the
+		// newest pending approval.
+		const latest = Array.from(this.pendingToolApprovals.entries()).at(-1)
+		if (!latest) {
 			return false
 		}
 
-		const resolve = this.pendingToolApprovalResolve
-		const pendingMessage = this.pendingToolApprovalMessage
+		const [toolCallId, pending] = latest
+		const resolve = pending.resolve
+		const pendingMessage = { toolCallId, messageTs: pending.messageTs, toolName: pending.toolName }
 
 		if (responseType === "messageResponse") {
 			Logger.log("[SdkController] Leaving pending tool approval open and routing user message as queued follow-up")
-			this.options.setTurnPhase?.("awaiting_approval", pendingMessage?.messageTs)
+			this.options.setTurnPhase?.("awaiting_approval", pendingMessage.messageTs)
 			// The approval remains pending. The chat message still needs normal follow-up routing.
 			return false
 		}
 
-		this.pendingToolApprovalResolve = undefined
-		this.pendingToolApprovalMessage = undefined
+		this.pendingToolApprovals.delete(toolCallId)
 
 		const approved = responseType === "yesButtonClicked"
 		Logger.log(`[SdkController] Resolving pending tool approval: approved=${approved} (responseType=${responseType})`)
-		if (approved && pendingMessage) {
+		if (approved) {
 			this.options.recordApprovedToolMessage?.(pendingMessage.toolCallId, pendingMessage.messageTs)
 		}
 
@@ -189,7 +215,7 @@ export class SdkInteractionCoordinator {
 		this.options.setTurnPhase?.("streaming")
 		// The reason must state the operation did NOT happen (for edits: the file is
 		// unchanged) — raw feedback alone reads like iteration on an applied change.
-		const denialReason = buildToolApprovalDenialReason(pendingMessage?.toolName, prompt)
+		const denialReason = buildToolApprovalDenialReason(pendingMessage.toolName, prompt)
 		if (!approved && (prompt?.trim() || images?.length || files?.length)) {
 			const userMessage: ClineMessage = {
 				ts: this.nextMessageTs(),
@@ -205,7 +231,7 @@ export class SdkInteractionCoordinator {
 				payload: { sessionId: this.options.getSessionId(), status: "running" },
 			})
 		}
-		if (!approved && pendingMessage) {
+		if (!approved) {
 			this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, denialReason)
 		}
 		resolve({
@@ -245,7 +271,14 @@ export class SdkInteractionCoordinator {
 		return true
 	}
 
+	/**
+	 * Deny everything the outgoing run is waiting on and stop accepting new interaction
+	 * requests until {@link reopen} (the next turn start). Called on task cancel, plan/act
+	 * mode switch, task switch/clear, and edit-and-regenerate.
+	 */
 	clearPending(reason: string): void {
+		this.closedReason = reason
+
 		const resolveAsk = this.pendingAskResolve
 		this.pendingAskResolve = undefined
 		// ask_question is awaiting this promise inside the outgoing agent run. Settle it
@@ -253,19 +286,25 @@ export class SdkInteractionCoordinator {
 		// use an empty answer so the lifecycle reason is not presented as user input.
 		resolveAsk?.("")
 
-		const pendingMessage = this.pendingToolApprovalMessage
-		this.pendingToolApprovalMessage = undefined
-		if (this.pendingToolApprovalResolve) {
+		const pending = Array.from(this.pendingToolApprovals.entries())
+		this.pendingToolApprovals.clear()
+		for (const [toolCallId, { resolve, toolName }] of pending) {
 			// Record before resolving: the denial unblocks the core, which emits the
 			// tool's lifecycle events before the caller's abort lands. Unless the
 			// denial is already recorded, the translator renders those events as a
 			// second tool row next to the still-visible approval ask.
-			if (pendingMessage) {
-				this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, reason)
-			}
-			this.pendingToolApprovalResolve({ approved: false, reason })
-			this.pendingToolApprovalResolve = undefined
+			this.options.recordDeniedToolApproval?.(toolCallId, toolName, reason)
+			resolve({ approved: false, reason })
 		}
+	}
+
+	/**
+	 * Accept interaction requests again. Called when a turn starts (a prompt is sent to the
+	 * session or the SDK drains a queued prompt), which is the only time a live run can
+	 * legitimately ask for approval after a clearPending.
+	 */
+	reopen(): void {
+		this.closedReason = undefined
 	}
 
 	/**

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.test.ts
@@ -189,6 +189,24 @@ describe("SdkSessionLifecycle", () => {
 		expect(onDidBecomeIdle).toHaveBeenCalledOnce()
 	})
 
+	it("notifies running listeners only on an idle-to-running transition", async () => {
+		const onDidBecomeRunning = vi.fn()
+		const sdkHost = makeSdkHost()
+		mockCreateSessionHost.mockResolvedValueOnce(sdkHost)
+		const lifecycle = makeLifecycle({ onDidBecomeRunning })
+		await lifecycle.startNewSession({} as StartInput)
+
+		// startNewSession leaves the session running; only a real flip fires the hook.
+		lifecycle.setRunning(true)
+		expect(onDidBecomeRunning).not.toHaveBeenCalled()
+
+		lifecycle.setRunning(false)
+		lifecycle.setRunning(true)
+		lifecycle.setRunning(true)
+
+		expect(onDidBecomeRunning).toHaveBeenCalledOnce()
+	})
+
 	it("calls the send-start hook before sending to the SDK host", async () => {
 		const onSendStart = vi.fn()
 		const send = vi.fn().mockResolvedValue(undefined)

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -55,6 +55,8 @@ export interface SdkSessionLifecycleOptions {
 	 */
 	consumeModeSwitchNotice?: (sessionId: string) => ModeSwitchNotice | null
 	onDidBecomeIdle?: () => void
+	/** A turn started on the active session (queued prompt drained, follow-up, auto-continue). */
+	onDidBecomeRunning?: () => void
 }
 
 export class SdkSessionLifecycle {
@@ -84,7 +86,9 @@ export class SdkSessionLifecycle {
 			return
 		}
 		activeSession.isRunning = isRunning
-		if (!isRunning) {
+		if (isRunning) {
+			this.options.onDidBecomeRunning?.()
+		} else {
 			this.options.onDidBecomeIdle?.()
 		}
 	}

--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1150,6 +1150,64 @@ describe("AgentRuntime", () => {
 		expect(result.outputText).toBe("preserved");
 	});
 
+	it("stops requesting approvals for the remaining tool calls once the run is aborted", async () => {
+		// Approval waits are where a run can sit for minutes. A host cancel (task cancel,
+		// plan/act switch) arrives as abort() plus a denial of the pending approval; the
+		// runtime must not carry on to request approval for the next tool call of the
+		// aborted run - that surfaces a dead approval prompt and blocks the host's teardown.
+		const executeTool = vi.fn(async () => ({ echoed: "hi" }));
+		let runtime: AgentRuntime | undefined;
+		const requestToolApproval = vi.fn(async () => {
+			runtime?.abort("Mode changed");
+			return { approved: false, reason: "Mode changed" };
+		});
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_first",
+					toolName: "echo",
+					inputText: '{"text":"first"}',
+				},
+				{
+					type: "tool-call-delta",
+					toolCallId: "call_second",
+					toolName: "echo",
+					inputText: '{"text":"second"}',
+				},
+				{ type: "finish", reason: "tool-calls" },
+			],
+			() => {
+				throw new Error("the aborted run must not call the model again");
+			},
+		]);
+		runtime = new AgentRuntime({
+			sessionId: "session_test",
+			agentId: "agent_test",
+			conversationId: "conversation_test",
+			model,
+			tools: [
+				{
+					name: "echo",
+					description: "Echo input text",
+					inputSchema: { type: "object" },
+					execute: executeTool,
+				},
+			],
+			toolPolicies: { "*": { autoApprove: false } },
+			requestToolApproval,
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("aborted");
+		expect(requestToolApproval).toHaveBeenCalledTimes(1);
+		expect(requestToolApproval.mock.calls[0]?.[0]).toMatchObject({
+			toolCallId: "call_first",
+		});
+		expect(executeTool).not.toHaveBeenCalled();
+	});
+
 	it("requests approval when a tool policy disables auto-approval", async () => {
 		const executeTool = vi.fn(async () => ({ echoed: "hi" }));
 		const requestToolApproval = vi.fn(async () => ({

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1633,6 +1633,12 @@ export class AgentRuntime {
 		this.pendingHookContexts = [];
 		const prepared: PreparedToolExecution[] = [];
 		for (const toolCall of toolCalls) {
+			// Approval waits are the one place a run can sit for minutes. An abort
+			// that lands there is delivered as a denial of the pending approval;
+			// without this check the loop would go straight on to request approval
+			// for the next tool call of an already-aborted run, surfacing a dead
+			// approval prompt to the host and blocking its teardown on that prompt.
+			this.throwIfAborted();
 			prepared.push(await this.prepareToolExecution(toolCall));
 		}
 
@@ -1755,6 +1761,10 @@ export class AgentRuntime {
 					input,
 					policy,
 				);
+				// A denial that was really a cancellation (the host aborted the run
+				// while waiting) must end the run here, not feed the model a
+				// rejection and carry on.
+				this.throwIfAborted();
 				if (!approval.approved) {
 					const reason = approval.reason ?? "Tool was not executed";
 					skipReason = `${reason} -- ${TOOL_REJECTION_SUFFIX}`;

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -956,6 +956,90 @@ describe("LocalRuntimeHost", () => {
 		});
 	});
 
+	it("denies tool approval without asking the host once the session is aborting", async () => {
+		// A cancel arrives as abort() plus a denial of the pending approval; the agent may
+		// still request approval for the next tool call before it unwinds. Surfacing that
+		// to the host would show a dead prompt and park the teardown on its answer.
+		const sessionId = "sess-approval-while-aborting";
+		const manifest = createManifest(sessionId);
+		const requestToolApproval = vi.fn(async () => ({ approved: true }));
+		let capturedConfig: AgentConfig | undefined;
+		const updateSessionStatus = vi.fn().mockResolvedValue({ updated: true });
+		const runtimeBuilder = {
+			build: vi.fn().mockReturnValue({
+				tools: [],
+				shutdown: vi.fn(),
+			}),
+		};
+		let manager: RuntimeHostUnderTest | undefined;
+		let observedApproval: { approved: boolean; reason?: string } | undefined;
+		const agent = {
+			run: vi.fn(async () => {
+				await manager?.abort(sessionId, "Mode changed");
+				observedApproval = await capturedConfig?.requestToolApproval?.({
+					sessionId,
+					agentId: "agent-root-1",
+					conversationId: "conv-root-1",
+					iteration: 1,
+					toolCallId: "call-approval-2",
+					toolName: "read_files",
+					input: { path: "README.md" },
+					policy: { autoApprove: false },
+				});
+				return createResult();
+			}),
+			continue: vi.fn().mockResolvedValue(createResult()),
+			getMessages: vi.fn().mockReturnValue([]),
+			getAgentId: vi.fn().mockReturnValue("agent-root-1"),
+			getConversationId: vi.fn().mockReturnValue("conv-root-1"),
+			abort: vi.fn(),
+			subscribeEvents: vi.fn().mockReturnValue(() => {}),
+			canStartRun: vi.fn().mockReturnValue(true),
+			shutdown: vi.fn().mockResolvedValue(undefined),
+		};
+		manager = new RuntimeHostUnderTest({
+			distinctId,
+			sessionService: {
+				ensureSessionsDir: vi.fn().mockReturnValue("/tmp/sessions"),
+				createRootSessionWithArtifacts: vi.fn().mockResolvedValue({
+					manifestPath: "/tmp/manifest.json",
+					messagesPath: "/tmp/messages.json",
+					manifest,
+				}),
+				persistSessionMessages: vi.fn(),
+				updateSessionStatus,
+				writeSessionManifest: vi.fn(),
+				listSessions: vi.fn().mockResolvedValue([]),
+				deleteSession: vi.fn().mockResolvedValue({ deleted: true }),
+			} as never,
+			runtimeBuilder: runtimeBuilder as never,
+			createAgent: (config) => {
+				capturedConfig = config;
+				return agent as never;
+			},
+		});
+
+		await manager.startSession(
+			normalizeStartInput({
+				config: createConfig({ sessionId }),
+				prompt: "hello",
+				interactive: true,
+				capabilities: { requestToolApproval },
+			}),
+		);
+
+		expect(observedApproval).toEqual({
+			approved: false,
+			reason: "Session is aborting",
+		});
+		expect(requestToolApproval).not.toHaveBeenCalled();
+		expect(updateSessionStatus).not.toHaveBeenCalledWith(
+			sessionId,
+			"pending",
+			null,
+		);
+	});
+
 	it("ingests automation events emitted by sandbox plugins during setup", async () => {
 		const sessionId = "sess-plugin-automation-setup";
 		const ingestEvent = vi.fn().mockResolvedValue(undefined);

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -747,6 +747,15 @@ export class LocalRuntimeHost implements RuntimeHost {
 				? async (request) => {
 						const requestToolApproval = bootstrap.requestToolApproval;
 						const liveSession = this.sessions.get(sessionId);
+						if (liveSession?.aborting) {
+							// The run is being torn down; surfacing a new approval prompt
+							// to the host would show a dead prompt and park the teardown
+							// on its answer.
+							return {
+								approved: false,
+								reason: "Session is aborting",
+							};
+						}
 						if (liveSession) {
 							await this.markTurnPending(liveSession);
 						}


### PR DESCRIPTION
## Problem

[#13814](https://github.com/cline/cline/issues/13814) / [CLINE-3169](https://linear.app/cline-bot/issue/CLINE-3169): with a Run Command approval pending, switching Act → Plan leaves the footer on **Approve / Reject** instead of **Resume Task**.

Reproduced headlessly against the standalone core built from `main`. It only happens when the assistant message carries **more than one approval-gated tool call** (typical when the task has `@file`/`@folder` context: a command plus one or more reads). With a single pending tool call the existing fix from #13063 works.

Sequence on the unfixed code:

1. The mode switch (or Escape) calls `clearPending`, which denies the pending approval, then aborts the run and appends the Resume Task row / sets the `resumable` phase.
2. `AgentRuntime.executeToolCalls` requests approval for every tool call of the message sequentially before executing any, with no abort check in between. The denial just advances it to the next tool call, so it requests approval for that one on the already-aborted run.
3. The extension's interaction coordinator accepts that request: it emits a new `ask` row, sets `awaiting_approval` anchored on it, and posts state. The footer now reads Approve / Reject for a tool of a dead run.
4. The aborted session's stop waits on that orphaned approval promise, so the session rebuild never completes ("Waiting for session … to stop" until the user clicks the dead button; observed at 15 h in the repro). Clicking Approve then flips the phase to `streaming` on an idle session, leaving a permanent Cancel.

Escape / Cancel during a multi-tool approval has the same defect ("Task cancelled" followed by a dead Approve / Reject).

## Fix

Two independent layers, so neither surface depends on the other's timing:

- **`sdk/packages/agents` `agent-runtime.ts`** — `throwIfAborted()` before preparing each tool call and right after an approval returns. A denial delivered under abort ends the run (status `aborted`) instead of cascading to the next approval; this also lets the session stop promptly. Benefits CLI and hub as well.
- **`sdk/packages/core` `local-runtime-host.ts`** — the `requestToolApproval` wrapper denies without calling the host when `session.aborting` is set.
- **`apps/vscode` `sdk-interaction-coordinator.ts`** — pending approvals are tracked per `toolCallId` (parallel tool execution can leave several outstanding; the single-slot field orphaned earlier ones). `clearPending` denies all of them and closes the coordinator; while closed, approval and question requests get an immediate denial with no ask row, phase change, or state post. `reopen()` lifts the latch when a turn starts: on send start (`fireAndForgetSend`) and on the idle → running transition (new `onDidBecomeRunning` lifecycle hook, covers SDK-drained queued prompts and auto-continue).

## Tests

- `agent-runtime.test.ts`: abort during the first approval → second approval never requested, run ends `aborted`, no tool executed.
- `local-runtime-host.test.ts`: approval requested after `abort()` is denied with no host call and no `pending` status.
- `sdk-interaction-coordinator.test.ts`: `clearPending` denies every outstanding approval; approvals/questions after `clearPending` are refused until `reopen()`, with no ask/phase/state side effects; footer answers the newest outstanding approval.
- `sdk-session-lifecycle.test.ts`: `onDidBecomeRunning` fires only on the idle → running flip.

Each new test was run against the unfixed code and fails there. `bunx tsc --noEmit` on agents/core and `bun run check-types` on apps/vscode pass; touched vitest suites pass (agents 65, core host 85, apps/vscode 101).

Not yet re-verified in the live IDE with the rebuilt bundle; the headless run (standalone core + gRPC) is what confirmed the mechanism.
