### PR TITLE
docs: fix contributing setup commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,17 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     ```bash
     code cline
     ```
-3. Install [bun](https://bun.com)
-4. Install the necessary dependencies for the extension and webview-gui:
+3. Install [Bun 1.3.13](https://bun.com) and [Node.js 22 or later](https://nodejs.org/).
+4. Install the workspace dependencies and build the SDK packages from the repository root:
     ```bash
-    cd apps/vscode && bun run install:all && cd ../..
-    cd sdk && bun run build && cd ..
+    bun install
+    bun run build:sdk
     ```
 5. Generate Protocol Buffer files (required before first build):
+    ```bash
+    cd apps/vscode
+    bun run protos
+    ```
 6. Launch by pressing `F5` (or `Run`->`Start Debugging`) to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
 
 
@@ -62,7 +66,7 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
    - Run tests and checks
 3. Testing
     - Run `cd apps/vscode && bun run test` to run tests locally. 
-    - Before submitting PR, run `bun run format:fix` to format your code
+    - Before submitting a PR, run `cd apps/vscode && bun run format:fix` to format your code
 
 ### Extension
 
@@ -136,7 +140,7 @@ Anyone can contribute code to Cline, but we ask that you follow these guidelines
 2. **Code Quality**
 
     - Run `bun run lint` to check code style
-    - Run `bun run format` to automatically format code
+    - Run `bun run format` to check code formatting
     - All PRs must pass CI checks which include both linting and formatting
     - Address any warnings or errors from linter before submitting
     - Follow TypeScript best practices and maintain type safety


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small documentation correction

### Description

This PR updates the local development instructions in the root `CONTRIBUTING.md` to match the current monorepo configuration.

It:

- Documents the required Bun and Node.js versions.
- Replaces the obsolete `cd sdk && bun run build` command with `bun run build:sdk` from the repository root.
- Adds the missing `bun run protos` command.
- Clarifies that `bun run format` checks formatting, while `bun run format:fix` applies formatting changes.
- Specifies the correct working directory for the VS Code formatting command.

These changes prevent new contributors from encountering missing commands or running workspace-specific commands from the wrong directory.

### Test Procedure

- Compared the documented commands with the scripts in the root and `apps/vscode` package files.
- Verified that the documented Bun and Node.js requirements match the root `package.json`.
- Ran `git diff --check`.
- The commit passed the repository's Gitleaks pre-commit scan.
- Runtime tests were not run because this change only updates documentation.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes.

### Additional Notes

This change does not overlap with #9716, which only corrects the documentation directory path.