### PR TITLE
fix(shared): preserve repeated references in JSON serialization

### DIFF
--- a/sdk/packages/shared/src/parse/json.test.ts
+++ b/sdk/packages/shared/src/parse/json.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { normalizeJsonLikeStringsForSchema, parseJsonStream } from "./json";
+import {
+	normalizeJsonLikeStringsForSchema,
+	parseJsonStream,
+	safeJsonStringify,
+} from "./json";
+
+describe("safeJsonStringify", () => {
+	it("preserves shared objects in sibling properties and array entries", () => {
+		const shared = { message: "upstream failure" };
+		const value = { first: shared, second: shared, items: [shared, shared] };
+
+		expect(safeJsonStringify(value)).toBe(JSON.stringify(value));
+	});
+
+	it("preserves shared descendants across separate branches", () => {
+		const shared = { code: 429 };
+		const value = { first: { details: shared }, second: { details: shared } };
+
+		expect(safeJsonStringify(value)).toBe(JSON.stringify(value));
+	});
+
+	it("replaces ancestor cycles while preserving other shared references", () => {
+		const shared: { code: number; self?: unknown } = { code: 429 };
+		shared.self = shared;
+
+		expect(
+			JSON.parse(safeJsonStringify({ first: shared, second: shared })),
+		).toEqual({
+			first: { code: 429, self: "[Circular]" },
+			second: { code: 429, self: "[Circular]" },
+		});
+	});
+
+	it("handles an indirect cycle back to the root", () => {
+		const root: { child?: unknown } = {};
+		root.child = { parent: root };
+
+		expect(JSON.parse(safeJsonStringify(root))).toEqual({
+			child: { parent: "[Circular]" },
+		});
+	});
+
+	it("keeps bigint conversion and undefined fallback", () => {
+		expect(safeJsonStringify({ count: 123n })).toBe('{"count":"123"}');
+		expect(safeJsonStringify(undefined)).toBe("null");
+	});
+});
 
 describe("parseJsonStream", () => {
 	it("repairs a bare object value into a JSON string", () => {

--- a/sdk/packages/shared/src/parse/json.ts
+++ b/sdk/packages/shared/src/parse/json.ts
@@ -102,15 +102,19 @@ export function parseJsonStream(input: unknown): unknown {
 }
 
 export function safeJsonStringify(input: unknown): string {
-	const seen = new WeakSet<object>();
+	const ancestors: object[] = [];
 
 	try {
-		const result = JSON.stringify(input, (_key, value) => {
+		const result = JSON.stringify(input, function (this: unknown, _key, value) {
 			if (typeof value === "bigint") return value.toString();
 
 			if (value && typeof value === "object") {
-				if (seen.has(value as object)) return "[Circular]";
-				seen.add(value as object);
+				// Only ancestors form a cycle; siblings may share the same object.
+				while (ancestors.length > 0 && ancestors.at(-1) !== this) {
+					ancestors.pop();
+				}
+				if (ancestors.includes(value)) return "[Circular]";
+				ancestors.push(value);
 			}
 
 			return value;


### PR DESCRIPTION
### Related Issue

No existing issue. Small bug fix under the direct-submission exception in CONTRIBUTING.md.

### Description

`safeJsonStringify({ first: details, second: details })` replaces the second object with `"[Circular]"`, even though the input has no cycle. This can discard details when serializing provider errors.

Track the active ancestor chain instead of every object visited. Shared sibling objects and array entries are serialized normally; references back to an ancestor still become `"[Circular]"`.

### Test Procedure

From `sdk/`:
- `bun -F @cline/shared test`: 388 tests passed across 32 files. Three new cases failed before the fix.
- `bun -F @cline/shared build` and `bun -F @cline/shared typecheck`: passed.
- Biome formatting and checks passed for both changed files.

Coverage includes repeated references, shared descendants, direct and indirect cycles, bigint values, and the undefined fallback. Gitleaks and `git diff --check` also passed. The full monorepo and live-provider suites were not run.

### Type of Change

- [x] Bug fix

### Pre-flight Checklist

- [x] Changes are limited to one bug fix.
- [x] The affected package's tests, build, typecheck, formatting and lint checks pass.
- [x] I have reviewed the contributor guidelines.