### PR TITLE
fix(shared): resolve combined Unicode screenshot path variants

### DIFF
--- a/sdk/packages/shared/src/storage/path-resolution.test.ts
+++ b/sdk/packages/shared/src/storage/path-resolution.test.ts
@@ -60,4 +60,25 @@ describe("resolveExistingFilePath", () => {
 
 		expect(resolveExistingFilePath(requested)).toBe(join(dir, onDisk));
 	});
+
+	it.each([
+		"\u202F",
+		"\u00A0",
+	])("resolves a curly apostrophe combined with Unicode space %j and decomposed accents", (space) => {
+		const dir = mkdtempSync(join(tmpdir(), "path-resolution-combined-"));
+		const onDisk = `Capture d’écran${space}2026-05-12.png`.normalize("NFD");
+		writeFileSync(join(dir, onDisk), "hello");
+		const requested = join(dir, "Capture d'écran 2026-05-12.png");
+
+		expect(resolveExistingFilePath(requested)).toBe(join(dir, onDisk));
+	});
+
+	it("prefers the exact filename when a normalized variant also exists", () => {
+		const dir = mkdtempSync(join(tmpdir(), "path-resolution-exact-priority-"));
+		const requested = join(dir, "Capture d'écran 2026-05-12.png");
+		writeFileSync(requested, "exact");
+		writeFileSync(join(dir, "Capture d’écran\u202F2026-05-12.png"), "variant");
+
+		expect(resolveExistingFilePath(requested)).toBe(requested);
+	});
 });

--- a/sdk/packages/shared/src/storage/path-resolution.ts
+++ b/sdk/packages/shared/src/storage/path-resolution.ts
@@ -110,5 +110,10 @@ export function resolveExistingFilePath(filePath: string): string | undefined {
 		return nfdCurlyVariant;
 	}
 
-	return scanDirForCanonicalMatch(filePath);
+	return (
+		scanDirForCanonicalMatch(filePath) ??
+		(curlyVariant !== filePath
+			? scanDirForCanonicalMatch(curlyVariant)
+			: undefined)
+	);
 }


### PR DESCRIPTION
### Related Issue

Follow-up to #10691. Small bug fix under the direct-submission exception in CONTRIBUTING.md.

### Description

A pasted screenshot path can lose both its curly apostrophe and its Unicode spaces. The resolver handles those substitutions separately, but fails when they occur together. For example, `Capture d'écran 2026-05-12.png` does not resolve to the existing `Capture d’écran\u202F2026-05-12.png` (where `\u202F` represents a narrow no-break space).

After the existing lookup attempts fail, apply the directory's canonical whitespace matching to the curly-apostrophe variant as well. Exact filenames and the existing fallback order retain priority.

### Test Procedure

From `sdk/`:
- `bun -F @cline/shared test`: 386 tests passed across 32 files.
- `bun -F @cline/shared build` and `bun -F @cline/shared typecheck`: passed.
- Biome formatting and checks passed for both changed files.

Two new cases reproduce the failure using real temporary files with curly apostrophes, decomposed accents, and U+202F/U+00A0 spaces; both failed before the fix. A third case verifies that an exact filename wins when a normalized variant also exists. These tests ran on Windows without requiring a macOS host.

Gitleaks and `git diff --check` passed. The full monorepo and interactive UI suites were not run.

### Type of Change

- [x] Bug fix

### Pre-flight Checklist

- [x] Changes are limited to one bug fix.
- [x] The affected package's tests, build, typecheck, formatting and lint checks pass.
- [x] I have reviewed the contributor guidelines.