### PR TITLE
feat(cli): add GPT-6 Astra catalog fallback

### DIFF
--- a/sdk/packages/llms/src/catalog/catalog.generated-access.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated-access.ts
@@ -2,6 +2,7 @@ import {
 	builtinProviderSupportsModelOperation,
 	normalizeBuiltinModelOperationModalities,
 } from "../providers/model-operations";
+import { withAstra } from "../providers/openai-astra";
 import { GENERATED_PROVIDER_MODELS } from "./catalog.generated";
 import { sortModelsByReleaseDate } from "./catalog-live";
 import {
@@ -23,7 +24,9 @@ function normalizeGeneratedModels(
 	models: Record<string, ModelInfo>,
 ): Record<string, ModelInfo> {
 	return Object.fromEntries(
-		Object.entries(models).flatMap(([modelId, model]) => {
+		Object.entries(
+			providerId === "openai-native" ? withAstra(models) : models,
+		).flatMap(([modelId, model]) => {
 			const operation = resolveCatalogModelOperation(model);
 			const operationModes =
 				model.operationModes ??

--- a/sdk/packages/llms/src/providers/openai-astra.ts
+++ b/sdk/packages/llms/src/providers/openai-astra.ts
@@ -1,0 +1,37 @@
+import type { ModelInfo } from "../catalog/types";
+
+/** Fallback until the generated catalog includes Astra. Catalog entries win.
+ * https://developers.openai.com/api/docs/models/gpt-6-astra
+ */
+export function astraFallback(): ModelInfo {
+	return {
+		id: "gpt-6-astra",
+		name: "GPT-6 Astra",
+		contextWindow: 1_050_000,
+		// Reserve the maximum output budget within the shared context window.
+		maxInputTokens: 1_050_000 - 128_000,
+		maxTokens: 128_000,
+		capabilities: [
+			"images",
+			"tools",
+			"reasoning",
+			"structured_output",
+			"prompt-cache",
+		],
+		family: "gpt-astra",
+		reasoningOptions: [
+			{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] },
+		],
+		metadata: {
+			source: "https://developers.openai.com/api/docs/models/gpt-6-astra",
+		},
+	};
+}
+
+export function withAstra(
+	models: Record<string, ModelInfo>,
+): Record<string, ModelInfo> {
+	return Object.hasOwn(models, "gpt-6-astra")
+		? models
+		: { ...models, "gpt-6-astra": astraFallback() };
+}

--- a/sdk/packages/llms/src/providers/openai-codex-models.test.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+	getGeneratedModelsForProvider,
+	getGeneratedProviderModels,
+} from "../catalog/catalog.generated-access";
 import type { ModelInfo } from "../catalog/types";
 import {
 	CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
@@ -26,20 +30,28 @@ function filterOne(
 describe("filterOpenAICodexModels", () => {
 	describe("model eligibility", () => {
 		it.each([
+			["gpt-5", false],
+			["gpt-5.1", false],
+			["gpt-5.3-codex", false],
+			["gpt-5.10", false],
+			["gpt-6", true],
 			["gpt-5.4", true],
 			["gpt-5.5", true],
 			["gpt-5.5-codex", true],
 			["gpt-6.0", true],
 			["gpt-10.1", true],
-		])("allows %s (newer than 5.3)", (id, allowed) => {
+		])("eligibility for %s (strictly > 5.3)", (id, allowed) => {
 			expect(filterOne(id) !== undefined).toBe(allowed);
 		});
 
 		it.each([
-			["gpt-5.3", "at the 5.3 cutoff"],
-			["gpt-5.1", "older than 5.3"],
 			["gpt-4.1", "older major version"],
-			["gpt-5", "no minor version"],
+			["gpt-4.99-codex", "older major with large minor"],
+			["gpt-5.4oops", "incomplete version token"],
+			["gpt-5.4.1", "unsupported patch version"],
+			["gpt-5.", "missing minor"],
+			["gpt-99999999999999999999", "unsafe version number"],
+			["astra-preview", "missing GPT version"],
 			["chatgpt-5.5", "id does not start with gpt-"],
 			["davinci", "not a gpt model"],
 		])("rejects %s (%s)", (id) => {
@@ -56,7 +68,105 @@ describe("filterOpenAICodexModels", () => {
 
 		it("falls back to the id version check when family is missing", () => {
 			expect(filterOne("gpt-6.0", { family: undefined })).toBeDefined();
-			expect(filterOne("gpt-5.0", { family: undefined })).toBeUndefined();
+			expect(filterOne("gpt-4.0", { family: undefined })).toBeUndefined();
+		});
+	});
+
+	it.each([
+		"gpt-5-pro",
+		"gpt-5.4-nano",
+		"gpt-6-codex-pro",
+		"gpt-6-PRO",
+	])("rejects %s by id even with missing or generic family", (id) => {
+		for (const family of [undefined, "gpt5"]) {
+			expect(filterOne(id, { family })).toBeUndefined();
+		}
+	});
+
+	it("also rejects a variant in the model id when the catalog key is generic", () => {
+		expect(
+			filterOne("gpt-6", { id: "gpt-6-nano", family: "gpt6" }),
+		).toBeUndefined();
+	});
+
+	describe("Astra catalog fallback", () => {
+		it("exposes Astra in native and derived Codex catalogs", () => {
+			const native = getGeneratedModelsForProvider("openai-native");
+			const astra = native["gpt-6-astra"];
+			expect(astra).toMatchObject({
+				id: "gpt-6-astra",
+				name: "GPT-6 Astra",
+				family: "gpt-astra",
+				contextWindow: 1_050_000,
+				maxInputTokens: 922_000,
+				maxTokens: 128_000,
+				capabilities: [
+					"images",
+					"tools",
+					"reasoning",
+					"structured_output",
+					"prompt-cache",
+				],
+			});
+			expect(
+				getGeneratedProviderModels()["openai-native"]["gpt-6-astra"],
+			).toEqual(astra);
+			expect(filterOpenAICodexModels(native)["gpt-6-astra"]).toEqual({
+				...astra,
+				maxInputTokens: 922_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+			});
+			expect(native).not.toHaveProperty("astra");
+			expect(filterOne("astra")).toBeUndefined();
+		});
+		it("supplies documented limits with the Codex input adjustment for an empty catalog", () => {
+			expect(filterOpenAICodexModels({})).toEqual({
+				"gpt-6-astra": expect.objectContaining({
+					id: "gpt-6-astra",
+					name: "GPT-6 Astra",
+					contextWindow: 1_050_000,
+					maxInputTokens: 922_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+					maxTokens: 128_000,
+					reasoningOptions: [
+						{
+							type: "effort",
+							values: ["low", "medium", "high", "xhigh", "max"],
+						},
+					],
+					metadata: {
+						source: "https://developers.openai.com/api/docs/models/gpt-6-astra",
+					},
+				}),
+			});
+		});
+
+		it("preserves supplied Astra metadata and applies the Codex input budget", () => {
+			const astra = makeModel("gpt-6-astra", {
+				metadata: { source: "catalog" },
+			});
+			const snapshot = structuredClone(astra);
+			expect(
+				filterOpenAICodexModels({ "gpt-6-astra": astra })["gpt-6-astra"],
+			).toEqual({
+				...snapshot,
+				maxInputTokens: 300_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+			});
+			expect(astra).toEqual(snapshot);
+		});
+
+		it("does not resurrect a rejected Astra entry", () => {
+			expect(
+				filterOpenAICodexModels({
+					"gpt-6-astra": makeModel("gpt-6-astra", { family: "gpt-pro" }),
+				}),
+			).toEqual({});
+		});
+
+		it("does not share mutable fallback metadata or reasoning options between calls", () => {
+			const first = filterOpenAICodexModels({})["gpt-6-astra"];
+			const snapshot = structuredClone(first);
+			first.metadata!.source = "changed";
+			first.reasoningOptions!.length = 0;
+			expect(filterOpenAICodexModels({})["gpt-6-astra"]).toEqual(snapshot);
 		});
 	});
 
@@ -71,6 +181,18 @@ describe("filterOpenAICodexModels", () => {
 			expect(result?.maxInputTokens).toBe(
 				maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 			);
+		});
+
+		it.each([
+			"gpt-5.50",
+			"gpt-5.51-codex",
+			"gpt-6-gpt-5.5",
+		])("does not apply GPT-5.5 caps to %s", (id) => {
+			expect(filterOne(id)).toMatchObject({
+				contextWindow: 400_000,
+				maxInputTokens: 300_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+				maxTokens: 100_000,
+			});
 		});
 
 		it("leaves other limits untouched for non-5.5 models", () => {
@@ -117,6 +239,7 @@ describe("filterOpenAICodexModels", () => {
 		};
 		expect(Object.keys(filterOpenAICodexModels(models)).sort()).toEqual([
 			"gpt-5.5",
+			"gpt-6-astra",
 			"gpt-6.0",
 		]);
 	});

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,4 +1,5 @@
 import type { ModelInfo } from "../catalog/types";
+import { withAstra } from "./openai-astra";
 
 /**
  * The ChatGPT/Codex backend starts rejecting requests around 95% of a
@@ -9,32 +10,37 @@ import type { ModelInfo } from "../catalog/types";
  */
 export const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
-const GPT_VERSION_REGEX = /^gpt-(\d+\.\d+)/;
+// Accept integer majors while preserving the original numeric > 5.3 threshold.
+const GPT_VERSION_REGEX = /^gpt-(\d+)(?:\.(\d+))?(?=-|$)/;
+const UNSUPPORTED_VARIANT_REGEX = /(?:^|[-_.])(pro|nano)(?:[-_.]|$)/i;
 
 function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	// O, pro, and nano variants are not supported
 	const family = model.family;
 	if (
-		family &&
-		(family.startsWith("o") ||
-			family.includes("pro") ||
-			family.includes("nano"))
+		UNSUPPORTED_VARIANT_REGEX.test(id) ||
+		UNSUPPORTED_VARIANT_REGEX.test(model.id) ||
+		(family &&
+			(family.startsWith("o") ||
+				family.includes("pro") ||
+				family.includes("nano")))
 	) {
 		return false;
 	}
-	// Must be newer than 5.3
 	const match = id.match(GPT_VERSION_REGEX);
-	return match ? Number.parseFloat(match[1]) > 5.3 : false;
+	if (!match) return false;
+	const version = Number(`${match[1]}.${match[2] ?? 0}`);
+	return Number.isSafeInteger(Number(match[1])) && version > 5.3;
 }
 
 /**
- * Applies the effective input budget to every allowed model. GPT-5.5
+ * Applies the effective input budget to allowed GPT models. GPT-5.5
  * additionally gets hardcoded limits because the ChatGPT/Codex backend
  * enforces a 272K input / 128K output cap that is lower than what the
  * generated OpenAI API catalog reports.
  */
 function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
-	if (id.includes("gpt-5.5")) {
+	if (/^gpt-5\.5(?:-|$)/.test(id)) {
 		return {
 			...model,
 			contextWindow: 400_000,
@@ -54,7 +60,7 @@ export function filterOpenAICodexModels(
 	models: Record<string, ModelInfo>,
 ): Record<string, ModelInfo> {
 	const result: Record<string, ModelInfo> = {};
-	for (const [id, model] of Object.entries(models)) {
+	for (const [id, model] of Object.entries(withAstra(models))) {
 		if (isOpenAICodexAllowedModel(id, model)) {
 			result[id] = toOpenAICodexModel(id, model);
 		}


### PR DESCRIPTION
### Related Issue

Catalog-only split of #13897. The interactive Fast/Thinking changes are being submitted independently.

### Description

Add a GPT-6 Astra fallback while the generated OpenAI catalog catches up. Existing catalog entries take precedence. Accept integer GPT major versions in the subscription filter without admitting unsupported pro/nano variants or malformed version strings. Keep the existing subscription input-budget adjustment.

Model reference: https://developers.openai.com/api/docs/models/gpt-6-astra

No Fast settings, persistence, runtime or TUI changes in this PR.

### Test Procedure

- 44 catalog/filter tests passed during original validation.
- SDK build passed during original validation.
- Catalog-only branch validation is recorded below after the split.
- Pre-commit secret scan passed. Full monorepo suite and live backend availability are not claimed.

### Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed contributor guidelines

### Additional Notes

This branch is independent of the Fast settings PR. Draft pending maintainer scope review and CI; no feature approval is implied.