### PR TITLE
docs: fix more broken links and an overridden typo across READMEs

### DIFF
--- a/apps/cli/DEVELOPMENT.md
+++ b/apps/cli/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 This guide covers everything you need to build and run the Cline CLI locally after cloning the repository. It includes setup instructions, a tech stack overview, and a walkthrough of the TUI architecture.
 
-For CLI command reference and usage, see [DOC.md](./DOC.md) and [README.md](./README.md).
+For CLI command reference and usage, see [README.md](./README.md).
 
 ## Prerequisites
 

--- a/apps/vscode/README.marketplace.md
+++ b/apps/vscode/README.marketplace.md
@@ -130,7 +130,7 @@ For example, when working with a local web server, you can use 'Restore Workspac
 
 ## Contributing
 
-To contribute to the project, start with our [Contributing Guide](CONTRIBUTING.md) to learn the basics. You can also join our [Discord](https://discord.gg/cline) to chat with other contributors in the `#contributors` channel. If you're looking for full-time work, check out our open positions on our [careers page](https://cline.bot/join-us)!
+To contribute to the project, start with our [Contributing Guide](../../CONTRIBUTING.md) to learn the basics. You can also join our [Discord](https://discord.gg/cline) to chat with other contributors in the `#contributors` channel. If you're looking for full-time work, check out our open positions on our [careers page](https://cline.bot/join-us)!
 
 ## Enterprise
 

--- a/apps/vscode/src/core/storage/remote-config/utils.ts
+++ b/apps/vscode/src/core/storage/remote-config/utils.ts
@@ -400,7 +400,7 @@ const isProviderValid = (provider?: ApiProvider, remoteConfig?: Partial<RemoteCo
 }
 
 /**
- * Receives a config and returns the subset of fields that can be overriden in the cache
+ * Receives a config and returns the subset of fields that can be overridden in the cache
  */
 export function filterAllowedRemoteConfigFields(config: Partial<GlobalStateAndSettings>): Partial<GlobalStateAndSettings> {
 	const updatedFields: Partial<GlobalStateAndSettings> = {}

--- a/evals/README.md
+++ b/evals/README.md
@@ -140,8 +140,8 @@ Contribute to [cline/cline-bench](https://github.com/cline/cline-bench)
 
 ## Resources
 
-- [cline-bench tasks](evals/cline-bench/README.md)
-- [Smoke test scenarios](evals/smoke-tests/README.md)
+- [cline-bench tasks](https://github.com/cline/cline-bench)
+- [Smoke test scenarios](./smoke-tests/README.md)
 
 ## TODO
 

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -6,7 +6,7 @@ alwaysApply: true
 
 # Cline SDK — Development Reference
 
-Quick-reference for active development. For onboarding, workspace setup, publishing, and detailed workflow see [CONTRIBUTING.md](./CONTRIBUTING.md). For architecture and runtime flows see [ARCHITECTURE.md](./ARCHITECTURE.md). For API details see [DOC.md](./DOC.md).
+Quick-reference for active development. For onboarding, workspace setup, publishing, and detailed workflow see [CONTRIBUTING.md](./CONTRIBUTING.md). For architecture and runtime flows see [ARCHITECTURE.md](./ARCHITECTURE.md). For API details see the [agents package DOC.md](./packages/agents/DOC.md).
 
 ## Repository Scope
 

--- a/sdk/packages/README.md
+++ b/sdk/packages/README.md
@@ -3,7 +3,7 @@
 This directory is the single documentation source for package-level responsibilities.
 
 - High-level package roles: this file (`packages/README.md`)
-- Package interaction and runtime flows: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- Package interaction and runtime flows: [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 
 ## Package Responsibilities
 

--- a/sdk/packages/shared/README.md
+++ b/sdk/packages/shared/README.md
@@ -3,7 +3,7 @@
 Package-level docs are centralized:
 
 - Overview: [`packages/README.md`](../README.md)
-- Architecture and interactions: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+- Architecture and interactions: [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 
 `@cline/shared` owns shared cross-package primitives (session common types/utilities).
 


### PR DESCRIPTION
Small docs fixes in the typo-correction/link-fix category (exempt per CONTRIBUTING), each verified via `git ls-files`:

1. `evals/README.md`: the cline-bench link doubled the `evals/` prefix and pointed into a submodule path that is empty unless initialized — linked the `cline/cline-bench` GitHub repo instead; the smoke-tests link needed its prefix corrected to `./smoke-tests/README.md`
2. `apps/vscode/README.marketplace.md`: the Contributing Guide link resolved to `apps/vscode/CONTRIBUTING.md`, which doesn't exist; repointed at the repo-root `../../CONTRIBUTING.md`
3. `apps/cli/DEVELOPMENT.md` + `sdk/AGENTS.md`: both linked a `DOC.md` that no longer exists at those locations; the only tracked DOC.md is `sdk/packages/agents/DOC.md` — dropped the first and repointed the second
4. `sdk/packages/README.md` + `sdk/packages/shared/README.md`: `ARCHITECTURE.md` links were one directory short → `../ARCHITECTURE.md`
5. `remote-config/utils.ts` TSDoc: `overriden` → `overridden`