### PR TITLE
docs: fix links written from the wrong directory in sdk and examples READMEs

### DIFF
--- a/apps/examples/README.md
+++ b/apps/examples/README.md
@@ -63,6 +63,6 @@ npm add @cline/sdk
 ## Learn more
 
 - [SDK package docs](../../sdk/packages/README.md)
-- [Architecture guide](../../ARCHITECTURE.md)
-- [Plugin examples](../../examples/plugins) - extend the Cline SDK and CLI with custom tools and event hooks
-- [Hook examples](../../examples/hooks) - lifecycle hooks for logging, blocking, and injection for Cline SDK and CLI
+- [Architecture guide](../../sdk/ARCHITECTURE.md)
+- [Plugin examples](./plugins) - extend the Cline SDK and CLI with custom tools and event hooks
+- [Hook examples](./hooks) - lifecycle hooks for logging, blocking, and injection for Cline SDK and CLI

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -80,7 +80,7 @@ async function handleMessage(threadId: string, message: string) {
 }
 ```
 
-Explore full working examples in [`examples/`](examples) and app examples in [`apps/examples/`](apps/examples):
+Explore full working examples in [`examples/`](examples) and app examples in [`apps/examples/`](../apps/examples):
 
 | Example | Description |
 |---------|-------------|
@@ -88,8 +88,8 @@ Explore full working examples in [`examples/`](examples) and app examples in [`a
 | [Subagent Orchestration](examples/plugins/agents-squad) | Spawn and manage background agents with presets, skills, and cross-agent handoffs |
 | [Hooks](examples/hooks) | File-based and runtime hooks for logging, review gates, context injection, and lifecycle automation |
 | [Cron Automations](examples/cron) | Recurring and event-driven automation specs for scheduled quality checks and PR workflows |
-| [Desktop App](apps/examples/desktop-app) | Tauri desktop shell with a Bun sidecar backend and Next.js UI |
-| [VS Code Extension App](apps/examples/vscode) | VS Code extension example that runs Cline sessions over the RPC runtime |
+| [Desktop App](../apps/examples/desktop-app) | Tauri desktop shell with a Bun sidecar backend and Next.js UI |
+| [VS Code Extension App](../apps/examples/vscode) | VS Code extension example that runs Cline sessions over the RPC runtime |
 
 ## Custom Tools
 
@@ -305,4 +305,4 @@ To contribute to the project, start with our [Contributing Guide](CONTRIBUTING.m
 
 ## License
 
-[Apache 2.0 © 2026 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2026 Cline Bot Inc.](../LICENSE)


### PR DESCRIPTION
Small docs fixes (typo/link category, exempt per CONTRIBUTING):

1. `sdk/README.md`: 4 links written as if from the repo root (`apps/examples`, `apps/examples/desktop-app`, `apps/examples/vscode`, `./LICENSE`) — from `sdk/` they need `../` prefixes (LICENSE lives at the repo root)
2. `apps/examples/README.md`: 3 links copied from `sdk/README.md` (`../../ARCHITECTURE.md`, `../../examples/plugins`, `../../examples/hooks`) — from inside `apps/examples/` the real targets are `../../sdk/ARCHITECTURE.md` and `./plugins`, `./hooks`

All targets verified via `git ls-files`.