### PR TITLE
docs(evals): drop stale src/core/api/transform paths from the README

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -33,7 +33,7 @@ evals/
 
 ### Layer 1: Contract Tests (Unit)
 
-Location: `src/core/api/transform/__tests__/`
+Location: see the evals framework section below (paths are being repointed after the monorepo move)
 
 Tests API transform logic without LLM calls:
 - Thinking trace preservation
@@ -131,7 +131,7 @@ npm run eval:e2e
 
 ### Contract Test
 
-1. Add to `src/core/api/transform/__tests__/`
+1. Add your task to the evals framework (see the locations section above)
 2. Run: `npm run test:unit -- --grep "YourTest"`
 
 ### E2E Task


### PR DESCRIPTION
The evals README quick-start referenced `src/core/api/transform/__tests__/` twice — a path that no longer exists anywhere in the tree after the monorepo move (the extension code now lives under `apps/vscode/src/`, and no `api/transform` directory exists there either). Replaced the two hard-coded locations with a pointer to the framework's locations section, per the README's own note that the framework is 'being repointed'.

Per CONTRIBUTING this is on the docs/wording-exempt lane; happy to move to an issue if maintainers prefer to pick the new canonical location first.