### PR TITLE
fix(mcp): spawn stdio commands that name a real executable without a shell on Windows

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/client.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.test.ts
@@ -164,12 +164,7 @@ function fakeServerRegistration(options: {
 		name: "fake-server",
 		transport: {
 			type: "stdio",
-			// Quoted for the win32 shell:true spawn path, where the runtime may
-			// live under a directory containing spaces.
-			command:
-				process.platform === "win32"
-					? `"${process.execPath}"`
-					: process.execPath,
+			command: process.execPath,
 			args: [join(tempRoot, "fake-server.js")],
 			env: {
 				FAKE_MCP_DELAY_MS: String(options.delayMs),

--- a/sdk/packages/core/src/extensions/mcp/client.ts
+++ b/sdk/packages/core/src/extensions/mcp/client.ts
@@ -1,4 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { StringDecoder } from "node:string_decoder";
 import {
@@ -406,11 +407,18 @@ class StdioMcpClient implements McpServerClient {
 		this.stderrBuffer = "";
 		this.protocolMode = protocolMode;
 
+		// Spawning through a shell concatenates the command and args without
+		// escaping (node DEP0190): a command path containing spaces, e.g.
+		// C:\Program Files\nodejs\node.exe, is split by cmd.exe and the child
+		// never starts. When the command already names a real executable on
+		// disk, spawn it directly so argv reaches the child losslessly; keep
+		// the shell for bare command names such as "npx", whose .cmd shims on
+		// Windows can only be resolved through it.
 		const platformOptions =
 			process.platform === "win32"
 				? {
 						windowsHide: true,
-						shell: true,
+						shell: !commandNamesExecutableFile(transport.command),
 					}
 				: {};
 		const child = spawn(transport.command, transport.args ?? [], {
@@ -861,6 +869,22 @@ class SdkUrlMcpClient implements McpServerClient {
 		}
 		throw new Error(message);
 	}
+}
+
+/**
+ * Whether the command is a path to an executable that exists on disk. Such
+ * commands can be spawned directly on Windows; the shell is only needed to
+ * resolve bare command names through PATH and .cmd/.bat shims.
+ */
+function commandNamesExecutableFile(command: string): boolean {
+	if (command.length === 0) {
+		return false;
+	}
+	const lower = command.toLowerCase();
+	if (lower.endsWith(".cmd") || lower.endsWith(".bat")) {
+		return false;
+	}
+	return existsSync(command);
 }
 
 export function createDefaultMcpServerClientFactory(


### PR DESCRIPTION
### Related Issue

**Issue:** #13898

### Description

The two runtime-builder MCP tests fail on Windows because `StdioMcpClient.spawnProcess` always spawns through a shell there (`shell: true`). With the shell enabled, node and bun hand the command line to `cmd.exe` without escaping it (node DEP0190): a command whose path contains spaces — exactly what `process.execPath` resolves to inside the test workers (`C:\Program Files\nodejs\node.exe`) — is split at the first space, and cmd.exe reports `'C:\Program' is not recognized as an internal or external command`. The mock MCP server never starts, so `mock__echo` never appears in the advertised tool list.

This is not a test-only problem: `client.test.ts` has been working around it by manually quoting `process.execPath` ("Quoted for the win32 shell:true spawn path, where the runtime may live under a directory containing spaces"), which means any user configuration with an unquoted absolute command path containing spaces hits the same failure at runtime — the stdio server silently fails to spawn and its tools never load.

The fix: when the configured command names a real executable on disk, spawn it directly without a shell, so argv reaches the child losslessly. Bare command names (`npx`, `uvx`, …) and `.cmd`/`.bat` shims keep using the shell, which they need for PATH and shim resolution (node refuses to spawn .cmd/.bat without a shell). Direct spawning is also strictly safer, since paths and args are no longer interpreted as shell metacharacters. The manual quoting workaround in `client.test.ts` is removed; the unquoted form now exercises the fixed path.

### Test Procedure

- Reproduced #13898 on Windows x64 (Node 24.13, Bun 1.4.2) at `dac3b35`: `bun -F @cline/core test:unit -- src/runtime/orchestration/runtime-builder.test.ts` → 34 passed / 2 failed, with the MCP server stderr showing `'C:\Program' is not recognized...` — matching the issue report.
- Instrumented the rejection path during diagnosis to capture the child's stderr, which confirmed the cmd.exe split at `C:\Program`.
- After the fix: the same file passes **36/36**.
- Regression sweep: `client.test.ts`, `manager.test.ts`, `config-loader.test.ts`, `plugin-server-registration.test.ts`, `runtime-parity.test.ts`, `session-runtime-orchestrator.test.ts` → **123/123 passed** across 6 files, with `client.test.ts` now running its fake-server spawn without the quoting workaround.
- `bun -F @cline/core typecheck` passes; both changed files pass `bun biome check`.
- Behavior preserved: bare commands and `.cmd`/`.bat` targets still route through the shell, so `npx`-style MCP servers are unaffected; non-Windows platforms are untouched.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`) — the affected suites were run explicitly (see Test Procedure); formatting verified with `bun biome check` on the changed files
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change — no UI. Evidence is the test output in the Test Procedure section: before, 2 failures with `'C:\Program' is not recognized` on the spawned server's stderr; after, 36/36 and 123/123 green.

### Additional Notes

While diagnosing I confirmed the reporter's environment detail: the failure reproduces under `bun -F @cline/core test:unit` even though bun itself is installed on a space-free path, because the test workers resolve `process.execPath` to the space-containing node.exe. Users on POSIX are unaffected (the shell was only enabled on win32).