### PR TITLE
feat: import Cursor Agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Everything here lands through the SDK bundle, so it applies to windows running t
 
 ### Added
 
+- Import Cursor Agent JSONL sessions from the session history import flow. Imported sessions preserve supported conversation content and can be continued with the current Cline provider and model.
 - ClinePass is now surfaced across the app: a card on the account page describing what the plan covers, a hint in provider settings, and a banner on the home screen. Dismissed banners stay dismissed.
 
 ### Fixed

--- a/apps/examples/desktop-app/webview/lib/session-import.ts
+++ b/apps/examples/desktop-app/webview/lib/session-import.ts
@@ -5,18 +5,20 @@
  * copy so the client bundle never imports node-only core code.
  */
 
-export type SessionImportTool = "claude-code" | "codex" | "opencode";
+export type SessionImportTool = "claude-code" | "codex" | "opencode" | "cursor";
 
 export const SESSION_IMPORT_TOOL_ORDER: SessionImportTool[] = [
 	"claude-code",
 	"codex",
 	"opencode",
+	"cursor",
 ];
 
 export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	opencode: "opencode",
+	cursor: "Cursor",
 };
 
 export interface ImportableSession {

--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -113,6 +113,16 @@ message TaskItem {
   // Provider id the task ran on. Empty for tasks recorded before this
   // field existed and for legacy imports; consumers show cost in that case.
   string api_provider = 13;
+  // True when this row is discovered in an external session store and has not
+  // necessarily been copied into Cline's native history yet.
+  bool is_importable = 14;
+  string source_tool = 15;
+  string source_id = 16;
+  string source_path = 17;
+  string cwd = 18;
+  int32 message_count = 19;
+  string preview = 20;
+  string imported_session_id = 21;
 }
 
 // Request for ask response operation

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -12,10 +12,13 @@ import {
 	createUserInstructionConfigService,
 	ensureChatWorkspace,
 	getProviderAuthStorageId,
+	type ImportableSessionSummary,
 	type PreparedRemoteConfigCoreIntegration,
 	readSessionCheckpointHistory,
 	resolveDefaultMcpSettingsPath,
 	type SessionHistoryRecord,
+	type SessionImportOptions,
+	type SessionImportRequest,
 	setTelemetryOptOutGlobally,
 	type UserInstructionConfigService,
 } from "@cline/core"
@@ -26,7 +29,13 @@ import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@shared/ClineAccount"
 import { mentionRegexGlobal } from "@shared/context-mentions"
 import type { ClineApiReqInfo, ClineMessage, ExtensionState } from "@shared/ExtensionMessage"
 import type { HistoryItem } from "@shared/HistoryItem"
-import { DeleteAllTaskHistoryCount, type GetTaskHistoryRequest, TaskHistoryArray, TaskResponse } from "@shared/proto/cline/task"
+import {
+	DeleteAllTaskHistoryCount,
+	type GetTaskHistoryRequest,
+	TaskHistoryArray,
+	type TaskItem,
+	TaskResponse,
+} from "@shared/proto/cline/task"
 import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import type { TelemetrySetting } from "@shared/TelemetrySetting"
@@ -50,6 +59,9 @@ import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { isClineManagedProvider } from "@/shared/utils/cline"
 import { arePathsEqual, getDesktopDir } from "@/utils/path"
+
+const IMPORT_TASK_PREFIX = "import:"
+
 import { ClineAccountService } from "./account-service"
 import { AuthService, LogoutReason } from "./auth-service"
 import { BUILTIN_SLASH_COMMANDS } from "./builtin-slash-commands"
@@ -1871,11 +1883,34 @@ export class Controller {
 	 * replace it.
 	 */
 	async showTaskWithId(taskId: string): Promise<TaskResponse> {
-		const historyItem = await this.taskControl.showTaskWithId(taskId)
+		const materializedTaskId = await this.materializeImportTask(taskId)
+		const historyItem = await this.taskControl.showTaskWithId(materializedTaskId)
 		if (!historyItem) {
 			throw new Error(`Task not found in history: ${taskId}`)
 		}
 		return historyItemToTaskResponse(historyItem)
+	}
+
+	private async materializeImportTask(taskId: string): Promise<string> {
+		if (!taskId.startsWith(IMPORT_TASK_PREFIX)) return taskId
+		const [, tool, ...sourceParts] = taskId.split(":")
+		const sourceId = sourceParts.join(":")
+		if (!tool || !sourceId) throw new Error(`Invalid import task id: ${taskId}`)
+		const config = this.stateManager.getApiConfiguration()
+		const mode = this.stateManager.getGlobalSettingsKey("mode") === "plan" ? "plan" : "act"
+		const provider = mode === "plan" ? config.planModeApiProvider : config.actModeApiProvider
+		const model = mode === "plan" ? config.planModeApiModelId : config.actModeApiModelId
+		const requests: SessionImportRequest[] = [{ tool: tool as SessionImportRequest["tool"], sourceId }]
+		const options: SessionImportOptions = {
+			provider: provider ?? undefined,
+			model: model ?? undefined,
+			workspaceRoot: await this.getWorkspaceRoot(),
+		}
+		const [result] = await this.sessions.importSessions({ requests, options })
+		if (!result?.ok || !result.sessionId) {
+			throw new Error(result?.error ?? "Could not import the Cursor session")
+		}
+		return result.sessionId
 	}
 
 	// ---- Mode switching ----
@@ -2036,7 +2071,7 @@ export class Controller {
 		})
 
 		const hasMore = sessionHistory.length > limit
-		const tasks = filteredTasks.slice(0, limit).map((item) => {
+		const tasks: TaskItem[] = filteredTasks.slice(0, limit).map((item) => {
 			const metadata = item.metadata
 			return {
 				id: item.sessionId,
@@ -2054,8 +2089,53 @@ export class Controller {
 				isLegacy:
 					metadataBoolean(metadata, "legacyTask") === true ||
 					metadataBoolean(metadata, "migratedFromLegacyTask") === true,
+				isImportable: false,
+				sourceTool: "",
+				sourceId: "",
+				sourcePath: "",
+				cwd: item.cwd ?? "",
+				messageCount: 0,
+				preview: "",
+				importedSessionId: "",
 			}
 		})
+
+		if (offset === 0 && !favoritesOnly) {
+			const importable = await this.sessions.listImportableSessions({ workspaceRoot: workspacePath })
+			const importedTasks: TaskItem[] = importable
+				.filter((summary) => !summary.alreadyImportedSessionId)
+				.filter(
+					(summary) =>
+						!searchQuery ||
+						`${summary.title} ${summary.preview ?? ""}`.toLowerCase().includes(searchQuery.toLowerCase()),
+				)
+				.map((summary: ImportableSessionSummary) => ({
+					id: `${IMPORT_TASK_PREFIX}${summary.tool}:${summary.sourceId}`,
+					task: formatDisplayUserInput(summary.title),
+					ts: summary.updatedAtMs,
+					isFavorited: false,
+					size: 0,
+					totalCost: 0,
+					tokensIn: 0,
+					tokensOut: 0,
+					cacheWrites: 0,
+					cacheReads: 0,
+					modelId: "",
+					apiProvider: "",
+					isLegacy: false,
+					isImportable: true,
+					sourceTool: summary.tool,
+					sourceId: summary.sourceId,
+					sourcePath: summary.sourcePath,
+					cwd: summary.cwd,
+					messageCount: summary.messageCount,
+					preview: summary.preview ?? "",
+					importedSessionId: summary.alreadyImportedSessionId ?? "",
+				}))
+			tasks.push(...importedTasks)
+		}
+
+		tasks.sort((a, b) => (sortBy === "oldest" ? a.ts - b.ts : b.ts - a.ts))
 
 		if (offset === 0 && !favoritesOnly && this.task?.taskId && !tasks.some((task) => task.id === this.task?.taskId)) {
 			const taskMessage = this.task.messageStateHandler
@@ -2077,6 +2157,14 @@ export class Controller {
 					modelId: this.task.api?.getModel?.().id ?? "",
 					apiProvider: "",
 					isLegacy: false,
+					isImportable: false,
+					sourceTool: "",
+					sourceId: "",
+					sourcePath: "",
+					cwd: "",
+					messageCount: 0,
+					preview: "",
+					importedSessionId: "",
 				})
 			}
 		}

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -1,9 +1,13 @@
 import type {
 	CoreSessionEvent,
+	ImportableSessionSummary,
 	ITelemetryService,
 	PreparedRemoteConfigCoreIntegration,
 	RestoreInput,
 	RestoreResult,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
 	StartSessionResult,
 } from "@cline/core"
 import { formatModeSwitchNotice, type ModeSwitchNotice } from "@cline/shared"
@@ -73,6 +77,21 @@ export class SdkSessionLifecycle {
 	private readonly pendingStops = new Map<string, Promise<void>>()
 
 	constructor(private readonly options: SdkSessionLifecycleOptions) {}
+
+	async listImportableSessions(options: Pick<SessionImportOptions, "workspaceRoot"> = {}): Promise<ImportableSessionSummary[]> {
+		const host = await this.getOrCreateSharedHost()
+		if (!host.listImportableSessions) throw new Error("Session import is unavailable")
+		return host.listImportableSessions(options)
+	}
+
+	async importSessions(input: {
+		requests: SessionImportRequest[]
+		options?: SessionImportOptions
+	}): Promise<SessionImportResult[]> {
+		const host = await this.getOrCreateSharedHost()
+		if (!host.importSessions) throw new Error("Session import is unavailable")
+		return host.importSessions(input)
+	}
 
 	getActiveSession(): ActiveSession | undefined {
 		return this.activeSession

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -5,6 +5,7 @@ import type {
 	CompareCheckpointResult,
 	CoreSessionEvent,
 	HookEventPayload,
+	ImportableSessionSummary,
 	PendingPromptMutationResult,
 	PendingPromptsDeleteInput,
 	PendingPromptsListInput,
@@ -15,6 +16,9 @@ import type {
 	SessionAccumulatedUsage,
 	SessionCompactionState,
 	SessionHistoryRecord,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
 	SessionPendingPrompt,
 	SessionRecord,
 	StartSessionInput,
@@ -36,6 +40,8 @@ export interface SdkSessionHost {
 	listHistory(options?: ClineCoreListHistoryOptions): Promise<SessionHistoryRecord[]>
 	delete(sessionId: string): Promise<boolean>
 	readMessages(sessionId: string): Promise<SdkInitialMessages>
+	listImportableSessions?(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]>
+	importSessions?(input: { requests: SessionImportRequest[]; options?: SessionImportOptions }): Promise<SessionImportResult[]>
 	/**
 	 * Like readMessages, but prefers the live in-memory conversation when the
 	 * session is still resident, so an in-flight (or just-aborted) turn is not

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -14,6 +14,7 @@ import {
 	type CoreSessionEvent,
 	type EditorExecutor,
 	type HookEventPayload,
+	type ImportableSessionSummary,
 	type ITelemetryService,
 	type PendingPromptMutationResult,
 	type PendingPromptsDeleteInput,
@@ -26,6 +27,9 @@ import {
 	type SessionAccumulatedUsage,
 	type SessionCompactionState,
 	type SessionHistoryRecord,
+	type SessionImportOptions,
+	type SessionImportRequest,
+	type SessionImportResult,
 	type SessionPendingPrompt,
 	type SessionRecord,
 	type StartSessionInput,
@@ -110,6 +114,12 @@ export class VscodeSessionHost implements SdkSessionHost {
 	}
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void> {
 		return this.inner.updateSessionModel(sessionId, modelId)
+	}
+	listImportableSessions(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]> {
+		return this.inner.listImportableSessions(options)
+	}
+	importSessions(input: { requests: SessionImportRequest[]; options?: SessionImportOptions }): Promise<SessionImportResult[]> {
+		return this.inner.importSessions(input)
 	}
 
 	static async create(options: VscodeSessionHostOptions): Promise<VscodeSessionHost> {

--- a/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -105,6 +105,11 @@ const HistoryViewItem = ({
 							Legacy
 						</span>
 					)}
+					{item.isImportable && (
+						<span className="text-xs uppercase rounded px-1.5 py-0.5 bg-accent/20 text-description flex-shrink-0">
+							{item.sourceTool ?? "Imported"}
+						</span>
+					)}
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
@@ -228,6 +233,9 @@ const HistoryViewItem = ({
 							</div>
 						</div>
 					</Button>
+				)}
+				{item.isImportable && item.preview && !expanded && (
+					<div className="text-description text-xs line-clamp-2">{item.preview}</div>
 				)}
 			</div>
 		</div>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
 						"group": "Usage",
 						"pages": [
 							"usage/ide",
+							"usage/importing-cursor-sessions",
 							"usage/tui",
 							{
 								"group": "CLI",

--- a/docs/usage/importing-cursor-sessions.mdx
+++ b/docs/usage/importing-cursor-sessions.mdx
@@ -1,0 +1,31 @@
+---
+title: "Importing Cursor sessions"
+description: "Bring Cursor Agent conversations into Cline and continue them with your Cline configuration."
+---
+
+# Importing Cursor sessions
+
+Cline can discover Cursor Agent transcript files for a project and show them in the VS Code History view or session import dialog. Opening or importing one creates a native Cline session. Imported sessions are copies: Cline never writes to Cursor's files.
+
+## Import a session
+
+1. Open the project folder in Cline.
+2. Open History. Matching unimported Cursor conversations are labeled `Cursor`.
+3. Select a Cursor conversation to import it lazily, or use the session import dialog to import several.
+4. Send a new prompt in the imported session.
+
+The next Cline turn uses the provider and model currently configured in Cline. The original Cursor provider and model, when available, remain session metadata.
+
+## What is preserved
+
+Cline imports user and assistant text, timestamps, titles, working-directory metadata, standard tool calls and results, and inline images when the source transcript contains them in a supported form. Cline's import sanitizer repairs incomplete tool-call pairs and removes provider-specific signatures before the conversation is resumed.
+
+Malformed lines and unsupported event types are skipped when the rest of the transcript is usable. A transcript with no usable conversational messages is not imported.
+
+## Workspace matching and limitations
+
+Discovery is scoped to the open project when the workspace path is available. Cursor's local storage format is not a public stable API and can vary by Cursor version, platform, profile, and workspace type. The current adapter reads JSONL Agent transcript files under Cursor's project data directory. Cursor SQLite indexes and chats stored only in opaque database values are not treated as reliable transcript sources yet.
+
+Cursor may be running while a transcript is being written. Cline reads source files without modifying them and tolerates a partial final line; repeat the scan after the conversation is complete if a chat is not shown.
+
+Imported sessions are deduplicated by their Cursor source path and session identifier. Repeating an import does not create another Cline session.

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -526,6 +526,22 @@ export class ClineCore {
 	 */
 	readMessages: RuntimeHost["readSessionMessages"] = (...args) =>
 		this.host.readSessionMessages(...args);
+	listImportableSessions = async (
+		options: Parameters<NonNullable<RuntimeHost["listImportableSessions"]>>[0] = {},
+	) => {
+		if (!this.host.listImportableSessions) {
+			throw new Error("Session import is only available on a local runtime");
+		}
+		return this.host.listImportableSessions(options);
+	};
+	importSessions = async (
+		input: Parameters<NonNullable<RuntimeHost["importSessions"]>>[0],
+	) => {
+		if (!this.host.importSessions) {
+			throw new Error("Session import is only available on a local runtime");
+		}
+		return this.host.importSessions(input);
+	};
 
 	/**
 	 * Reads a transcript projected for presentation. Observational model-tool

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -49,6 +49,13 @@ import {
 } from "../../services/telemetry/core-events";
 import { resolveCoreDistinctId } from "../../services/telemetry/distinct-id";
 import {
+	SessionImportService,
+	type ImportableSessionSummary,
+	type SessionImportOptions,
+	type SessionImportRequest,
+	type SessionImportResult,
+} from "../../services/session-import";
+import {
 	accumulateUsageTotals,
 	createInitialAccumulatedUsage,
 	summarizeUsageFromMessages,
@@ -364,6 +371,19 @@ export class LocalRuntimeHost implements RuntimeHost {
 			invokeBackendOptional: (method, ...args) =>
 				this.invokeOptional(method, ...args),
 		});
+	}
+
+	async listImportableSessions(
+		options: Pick<SessionImportOptions, "workspaceRoot"> = {},
+	): Promise<ImportableSessionSummary[]> {
+		return new SessionImportService(this.sessionService).discover(options);
+	}
+
+	async importSessions(input: {
+		requests: SessionImportRequest[];
+		options?: SessionImportOptions;
+	}): Promise<SessionImportResult[]> {
+		return new SessionImportService(this.sessionService).importMany(input.requests, undefined, input.options);
 	}
 
 	private async applyInitialOAuthCredentials(

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -19,6 +19,12 @@ import type {
 	SessionPendingPrompt,
 } from "../../types/events";
 import type { SessionRecord } from "../../types/sessions";
+import type {
+	ImportableSessionSummary,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
+} from "../../services/session-import";
 import type { RuntimeCapabilities } from "../capabilities";
 import type { ConnectionUpdate } from "../config/connection-update";
 
@@ -389,6 +395,11 @@ export interface RuntimeHost {
 	readSessionMessages(
 		sessionId: string,
 	): Promise<LlmsProviders.MessageWithMetadata[]>;
+	listImportableSessions?(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]>;
+	importSessions?(input: {
+		requests: SessionImportRequest[];
+		options?: SessionImportOptions;
+	}): Promise<SessionImportResult[]>;
 	/**
 	 * Like {@link readSessionMessages}, but prefers the resident session's
 	 * in-memory conversation over the persisted transcript. Disk persistence

--- a/sdk/packages/core/src/services/session-import/cursor.ts
+++ b/sdk/packages/core/src/services/session-import/cursor.ts
@@ -1,0 +1,325 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, relative } from "node:path";
+import type * as LlmsProviders from "@cline/llms";
+import {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	type SessionImportAdapter,
+	truncateForDisplay,
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface CursorAdapterOptions {
+	/** Defaults to ~/.cursor/projects. */
+	projectsDir?: string;
+	/** Restrict discovery to a workspace when provided. */
+	workspaceRoot?: string;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	try {
+		return JSON.parse(value) as unknown;
+	} catch {
+		return value;
+	}
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function timestamp(value: unknown): number | undefined {
+	if (typeof value === "string" && value.includes("-")) {
+		const parsed = Date.parse(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed < 10_000_000_000 ? parsed * 1000 : parsed;
+}
+
+function normalizedPath(value: string): string {
+	return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
+	const normalizedCwd = normalizedPath(cwd);
+	const normalizedRoot = normalizedPath(workspaceRoot);
+	return (
+		normalizedCwd === normalizedRoot ||
+		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
+		normalizedRoot.startsWith(`${normalizedCwd}/`)
+	);
+}
+
+function blocksFromContent(
+	content: unknown,
+	role: "user" | "assistant",
+): LlmsProviders.ContentBlock[] {
+	const parsed = parseJson(content);
+	if (typeof parsed === "string") {
+		return parsed.trim() ? [{ type: "text", text: parsed }] : [];
+	}
+	if (!Array.isArray(parsed)) return [];
+	const blocks: LlmsProviders.ContentBlock[] = [];
+	for (const value of parsed) {
+		if (typeof value === "string") {
+			if (value.trim()) blocks.push({ type: "text", text: value });
+			continue;
+		}
+		if (!isRecord(value)) continue;
+		const type = stringValue(value.type);
+		if (
+			(type === "text" || type === "input_text" || type === "output_text") &&
+			stringValue(value.text)
+		) {
+			blocks.push({ type: "text", text: value.text as string });
+		} else if (type === "thinking" || type === "reasoning") {
+			const thinking = stringValue(value.thinking) ?? stringValue(value.text);
+			if (thinking) blocks.push({ type: "thinking", thinking });
+		} else if (
+			role === "assistant" &&
+			(type === "tool_use" || type === "function_call")
+		) {
+			const id = stringValue(value.id) ?? stringValue(value.call_id);
+			if (!id) continue;
+			const parsedArguments = parseJson(value.arguments);
+			blocks.push({
+				type: "tool_use",
+				id,
+				name: stringValue(value.name) ?? "tool",
+				input: isRecord(value.input)
+					? value.input
+					: isRecord(parsedArguments)
+						? parsedArguments
+						: {},
+			});
+		} else if (
+			role === "user" &&
+			(type === "tool_result" || type === "function_call_output")
+		) {
+			const toolUseId =
+				stringValue(value.tool_use_id) ?? stringValue(value.call_id);
+			if (!toolUseId) continue;
+			const result = value.content ?? value.output ?? "";
+			blocks.push({
+				type: "tool_result",
+				tool_use_id: toolUseId,
+				name: stringValue(value.name) ?? "tool",
+				content: typeof result === "string" ? result : JSON.stringify(result),
+			});
+		} else if (type === "image_url" && isRecord(value.image_url)) {
+			const url = stringValue(value.image_url.url);
+			const comma = url?.indexOf(",") ?? -1;
+			if (url?.startsWith("data:image/") && comma > 0) {
+				blocks.push({
+					type: "image",
+					data: url.slice(comma + 1),
+					mediaType: url.slice(5, url.indexOf(";")),
+				});
+			}
+		}
+	}
+	return blocks;
+}
+
+function messageFromRecord(
+	record: JsonRecord,
+): LlmsProviders.MessageWithMetadata | undefined {
+	const message = isRecord(record.message) ? record.message : record;
+	const roleValue = stringValue(message.role) ?? stringValue(record.role);
+	const role =
+		roleValue === "assistant" || roleValue === "user" ? roleValue : undefined;
+	if (!role) return undefined;
+	const blocks = blocksFromContent(
+		message.content ?? message.text ?? record.content ?? record.text,
+		role,
+	);
+	if (blocks.length === 0) return undefined;
+	const provider =
+		stringValue(message.provider) ?? stringValue(record.provider);
+	const model = stringValue(message.model) ?? stringValue(record.model);
+	const ts = timestamp(record.timestamp) ?? timestamp(message.timestamp);
+	return {
+		role,
+		content: blocks,
+		...(ts ? { ts } : {}),
+		...(provider && model ? { modelInfo: { id: model, provider } } : {}),
+	};
+}
+
+function messageFromEvent(
+	record: JsonRecord,
+): LlmsProviders.MessageWithMetadata | undefined {
+	const direct = messageFromRecord(record);
+	if (direct) return direct;
+	for (const key of ["data", "payload", "event", "item"]) {
+		const nested = parseJson(record[key]);
+		if (isRecord(nested)) {
+			const message = messageFromRecord(nested);
+			if (message) return message;
+		}
+	}
+	return undefined;
+}
+
+interface ParsedCursorSession {
+	messages: LlmsProviders.MessageWithMetadata[];
+	cwd: string;
+	title?: string;
+	provider?: string;
+	model?: string;
+	startedAtMs: number;
+	updatedAtMs: number;
+}
+
+export class CursorImportAdapter implements SessionImportAdapter {
+	readonly tool = "cursor" as const;
+	private readonly projectsDir: string;
+	private readonly workspaceRoot?: string;
+
+	constructor(options: CursorAdapterOptions = {}) {
+		this.projectsDir =
+			options.projectsDir ?? join(homedir(), ".cursor", "projects");
+		this.workspaceRoot = options.workspaceRoot;
+	}
+
+	isInstalled(): boolean {
+		return existsSync(this.projectsDir);
+	}
+
+	private transcriptFiles(): string[] {
+		if (!this.isInstalled()) return [];
+		const files: string[] = [];
+		const visit = (directory: string): void => {
+			for (const entry of readdirSync(directory, { withFileTypes: true })) {
+				const file = join(directory, entry.name);
+				if (entry.isDirectory()) visit(file);
+				else if (entry.isFile() && entry.name.endsWith(".jsonl"))
+					files.push(file);
+			}
+		};
+		visit(this.projectsDir);
+		return files;
+	}
+
+	private parseFile(file: string): ParsedCursorSession {
+		const result: ParsedCursorSession = {
+			messages: [],
+			cwd: "",
+			startedAtMs: 0,
+			updatedAtMs: 0,
+		};
+		for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+			if (!line.trim()) continue;
+			const record = parseJson(line);
+			if (!isRecord(record)) continue;
+			result.cwd ||=
+				stringValue(record.cwd) ?? stringValue(record.workspace) ?? "";
+			result.title ||= stringValue(record.title) ?? stringValue(record.name);
+			result.provider ||= stringValue(record.provider);
+			result.model ||= stringValue(record.model);
+			const time =
+				timestamp(record.timestamp) ??
+				timestamp(record.createdAt) ??
+				timestamp(record.created_at);
+			if (time) {
+				result.startedAtMs ||= time;
+				result.updatedAtMs = Math.max(result.updatedAtMs, time);
+			}
+			const message = messageFromEvent(record);
+			if (!message) continue;
+			result.messages.push(message);
+			if (message.modelInfo) {
+				result.provider ||= message.modelInfo.provider;
+				result.model ||= message.modelInfo.id;
+			}
+		}
+		const now = Date.now();
+		result.startedAtMs ||= now;
+		result.updatedAtMs ||= result.startedAtMs;
+		return result;
+	}
+
+	private sourceId(file: string): string {
+		return relative(this.projectsDir, file)
+			.replace(/\\/g, "/")
+			.replace(/\.jsonl$/, "");
+	}
+
+	discover(): ImportableSessionSummary[] {
+		const sessions: ImportableSessionSummary[] = [];
+		for (const file of this.transcriptFiles()) {
+			try {
+				const parsed = this.parseFile(file);
+				if (parsed.messages.length === 0) continue;
+				if (
+					this.workspaceRoot &&
+					parsed.cwd &&
+					!workspaceMatches(parsed.cwd, this.workspaceRoot)
+				)
+					continue;
+				const firstUser = parsed.messages.find(
+					(message) => message.role === "user",
+				);
+				const preview = Array.isArray(firstUser?.content)
+					? firstUser.content.find((block) => block.type === "text")?.text
+					: undefined;
+				sessions.push({
+					tool: this.tool,
+					sourceId: this.sourceId(file),
+					sourcePath: file,
+					title:
+						truncateForDisplay(parsed.title ?? preview, 120) ??
+						"Untitled Cursor chat",
+					cwd: parsed.cwd,
+					startedAtMs: parsed.startedAtMs,
+					updatedAtMs: parsed.updatedAtMs,
+					messageCount: parsed.messages.length,
+					...(preview ? { preview: truncateForDisplay(preview) } : {}),
+				});
+			} catch {
+				// A malformed or active transcript must not hide other sessions.
+			}
+		}
+		return sessions.sort((left, right) => right.updatedAtMs - left.updatedAtMs);
+	}
+
+	convert(sourceId: string): ConvertedImportedSession {
+		const file = this.transcriptFiles().find(
+			(candidate) => this.sourceId(candidate) === sourceId,
+		);
+		if (!file) throw new Error(`Cursor session ${sourceId} not found`);
+		const parsed = this.parseFile(file);
+		if (parsed.messages.length === 0)
+			throw new Error("Cursor session has no importable messages");
+		const firstUser = parsed.messages.find(
+			(message) => message.role === "user",
+		);
+		const prompt = Array.isArray(firstUser?.content)
+			? firstUser.content.find((block) => block.type === "text")?.text
+			: undefined;
+		return {
+			tool: this.tool,
+			sourceId,
+			sourcePath: file,
+			title:
+				truncateForDisplay(parsed.title ?? prompt, 120) ??
+				"Untitled Cursor chat",
+			...(prompt ? { prompt } : {}),
+			provider: parsed.provider ?? "cursor",
+			model: parsed.model ?? "cursor-imported",
+			cwd: parsed.cwd,
+			startedAtMs: parsed.startedAtMs,
+			endedAtMs: parsed.updatedAtMs,
+			messages: parsed.messages,
+		};
+	}
+}

--- a/sdk/packages/core/src/services/session-import/fixtures/cursor-agent-session.jsonl
+++ b/sdk/packages/core/src/services/session-import/fixtures/cursor-agent-session.jsonl
@@ -1,0 +1,6 @@
+{"type":"session","cwd":"/workspace/demo","title":"Fix parser bug","timestamp":"2026-01-03T10:00:00.000Z"}
+{"role":"user","content":"fix the parser","timestamp":"2026-01-03T10:00:01.000Z"}
+{"role":"assistant","provider":"anthropic","model":"claude-sonnet","content":[{"type":"text","text":"I will inspect it."},{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\"path\":\"parser.ts\"}"}],"timestamp":"2026-01-03T10:00:02.000Z"}
+{"role":"user","content":[{"type":"function_call_output","call_id":"call_1","output":"export function parse() {}"}],"timestamp":"2026-01-03T10:00:03.000Z"}
+{"role":"assistant","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,ZmFrZQ=="}}],"timestamp":"2026-01-03T10:00:04.000Z"}
+not json

--- a/sdk/packages/core/src/services/session-import/index.ts
+++ b/sdk/packages/core/src/services/session-import/index.ts
@@ -4,6 +4,10 @@ export {
 } from "./claude-code";
 export { type CodexAdapterOptions, CodexImportAdapter } from "./codex";
 export {
+	type CursorAdapterOptions,
+	CursorImportAdapter,
+} from "./cursor";
+export {
 	type OpencodeAdapterOptions,
 	OpencodeImportAdapter,
 } from "./opencode";

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -4,6 +4,7 @@ import { SessionSource } from "../../types/common";
 import { ensureChatWorkspace } from "../workspace/chat-workspace";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
+import { CursorImportAdapter } from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import { sanitizeImportedMessages } from "./sanitize";
 import type {
@@ -71,6 +72,7 @@ export class SessionImportService {
 		this.adapters = adapters ?? [
 			new ClaudeCodeImportAdapter(),
 			new CodexImportAdapter(),
+			new CursorImportAdapter(),
 			new OpencodeImportAdapter(),
 		];
 	}
@@ -120,7 +122,7 @@ export class SessionImportService {
 		}
 	}
 
-	async discover(): Promise<ImportableSessionSummary[]> {
+	async discover(options: Pick<SessionImportOptions, "workspaceRoot"> = {}): Promise<ImportableSessionSummary[]> {
 		const existing = await this.existingImports();
 		const out: ImportableSessionSummary[] = [];
 		try {
@@ -128,6 +130,9 @@ export class SessionImportService {
 				try {
 					if (!adapter.isInstalled()) continue;
 					for (const summary of adapter.discover()) {
+						if (options.workspaceRoot && summary.cwd && !workspaceMatches(summary.cwd, options.workspaceRoot)) {
+							continue;
+						}
 						const alreadyImportedSessionId = existing.get(
 							importKey(summary.tool, summary.sourceId),
 						);
@@ -366,4 +371,14 @@ export class SessionImportService {
 
 		return sessionId;
 	}
+}
+
+function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
+	const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+	const normalizedRoot = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+	return (
+		normalizedCwd === normalizedRoot ||
+		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
+		normalizedRoot.startsWith(`${normalizedCwd}/`)
+	);
 }

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -13,6 +13,7 @@ import { CoreSessionService } from "../../session/services/session-service";
 import { SqliteSessionStore } from "../storage/sqlite-session-store";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
+import { CursorImportAdapter } from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import {
 	IMPORT_MISSING_TOOL_RESULT_TEXT,
@@ -258,6 +259,138 @@ describe("ClaudeCodeImportAdapter", () => {
 		);
 		const adapter = new ClaudeCodeImportAdapter({ projectsDir });
 		expect(adapter.discover()).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cursor fixtures
+// ---------------------------------------------------------------------------
+
+function writeCursorFixture(projectsDir: string): void {
+	const projectDir = join(projectsDir, "workspace-demo", "agent-transcripts");
+	mkdirSync(projectDir, { recursive: true });
+	writeFileSync(
+		join(projectDir, "cursor-chat.jsonl"),
+		[
+			{
+				type: "session",
+				cwd: "/workspace/demo",
+				title: "Fix parser bug",
+				timestamp: "2026-01-03T10:00:00.000Z",
+			},
+			{
+				role: "user",
+				content: "fix the parser",
+				timestamp: "2026-01-03T10:00:01.000Z",
+			},
+			{
+				role: "assistant",
+				provider: "anthropic",
+				model: "claude-sonnet",
+				content: [
+					{ type: "text", text: "I will inspect it." },
+					{
+						type: "function_call",
+						call_id: "call_1",
+						name: "read_file",
+						arguments: '{"path":"parser.ts"}',
+					},
+				],
+				timestamp: "2026-01-03T10:00:02.000Z",
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "function_call_output",
+						call_id: "call_1",
+						output: "export function parse() {}",
+					},
+				],
+				timestamp: "2026-01-03T10:00:03.000Z",
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "image_url",
+						image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+					},
+				],
+				timestamp: "2026-01-03T10:00:04.000Z",
+			},
+			"not json",
+		]
+			.map((line) => (typeof line === "string" ? line : JSON.stringify(line)))
+			.join("\n") + "\n",
+	);
+
+	const otherProjectDir = join(projectsDir, "other-project");
+	mkdirSync(otherProjectDir, { recursive: true });
+	writeFileSync(
+		join(otherProjectDir, "other.jsonl"),
+		JSON.stringify({
+			cwd: "/workspace/other",
+			role: "user",
+			content: "other",
+		}) + "\n",
+	);
+}
+
+describe("CursorImportAdapter", () => {
+	it("discovers matching JSONL chats and preserves standard content blocks", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeCursorFixture(projectsDir);
+		const adapter = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/workspace/demo",
+		});
+
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].sourceId).toBe(
+			"workspace-demo/agent-transcripts/cursor-chat",
+		);
+		expect(discovered[0].title).toBe("Fix parser bug");
+		expect(discovered[0].preview).toBe("fix the parser");
+
+		const converted = adapter.convert(discovered[0].sourceId);
+		expect(converted.provider).toBe("anthropic");
+		expect(converted.model).toBe("claude-sonnet");
+		expect(converted.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+		]);
+		expect(blocks(converted.messages[1])).toEqual([
+			{ type: "text", text: "I will inspect it." },
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "read_file",
+				input: { path: "parser.ts" },
+			},
+		]);
+		expect(blocks(converted.messages[2])[0]).toMatchObject({
+			type: "tool_result",
+			tool_use_id: "call_1",
+		});
+		expect(blocks(converted.messages[3])[0]).toMatchObject({
+			type: "image",
+			mediaType: "image/png",
+			data: "ZmFrZQ==",
+		});
+	});
+
+	it("isolates malformed files and supports an unfiltered workspace", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeCursorFixture(projectsDir);
+		const adapter = new CursorImportAdapter({ projectsDir });
+		expect(adapter.discover()).toHaveLength(2);
+		expect(() => adapter.convert("missing")).toThrow(
+			"Cursor session missing not found",
+		);
 	});
 });
 

--- a/sdk/packages/core/src/services/session-import/types.ts
+++ b/sdk/packages/core/src/services/session-import/types.ts
@@ -5,6 +5,7 @@ export const SESSION_IMPORT_TOOLS = [
 	"claude-code",
 	"codex",
 	"opencode",
+	"cursor",
 ] as const;
 
 export type SessionImportTool = (typeof SESSION_IMPORT_TOOLS)[number];
@@ -13,6 +14,7 @@ export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	opencode: "opencode",
+	cursor: "Cursor",
 };
 
 /**
@@ -76,6 +78,8 @@ export interface SessionImportRequest {
 }
 
 export interface SessionImportOptions {
+	/** Optional workspace filter used during source discovery. */
+	workspaceRoot?: string;
 	/**
 	 * Cline provider/model the imported sessions should resume with. Opening a
 	 * history session adopts the row's provider/model, so without this the


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR adds Cursor Agent conversation continuity to Cline's existing session-import architecture.

It discovers Cursor Agent JSONL transcripts for the active workspace, exposes unimported conversations through the existing VS Code History RPC, labels them as Cursor sessions, and lazily materializes a selected row into native Cline storage before normal resume. The desktop import flow also recognizes Cursor as a source.

Supported content includes user and assistant text, timestamps, titles, working-directory metadata, standard tool calls/results, and inline images when representable. Existing import sanitization repairs incomplete tool-call pairs and removes provider-specific signatures before resume.

Imported sessions are copied into native Cline storage and deduplicated using `importedFrom` metadata. They resume with the current Cline provider/model rather than attempting to reproduce Cursor's provider state. Cursor files are read-only from Cline's perspective.

The VS Code History payload now carries tagged import metadata without changing native session IDs. Opening an external row routes through the existing generation-safe task coordinator after import, preserving normal resume behavior.

Cursor's local storage format is undocumented and version-dependent. This increment supports JSONL Agent transcript shapes and tolerates unknown or malformed records. Cursor SQLite indexes and chats stored only in opaque database values are not treated as reliable transcript sources yet.

### Test Procedure

- `bun run build:sdk`
- `bun run test:unit -- src/services/session-import/session-import.test.ts` in `sdk/packages/core` (17 tests passed)
- `bun run typecheck` in `sdk/packages/core`
- `bun run check-types` in `apps/vscode`, including protobuf regeneration and webview compatibility types
- `bun run typecheck` in `apps/examples/desktop-app`
- Biome formatting/checks on touched files
- `git diff --check`
- Gitleaks pre-commit scan passed
- Added a sanitized checked-in Cursor JSONL fixture covering plain text, tool calls/results, inline image data, timestamps, metadata, and a malformed final line.

Potential follow-up risk is Cursor format drift across versions and profiles. The adapter isolates malformed files and has injectable roots so additional real, redacted Cursor fixtures can expand coverage without changing persistence semantics.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Full repository tests and format/lint suite (focused importer tests, SDK/VS Code/desktop typechecks, and touched-file checks passed; full suite not run)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. The History change uses the existing list surface and adds a source badge/preview rather than a new screen.

### Additional Notes

This PR is based on sanitized fixture data because Cursor does not publish a stable local transcript contract. SQLite/index reconciliation remains intentionally excluded until real versioned fixtures establish safe parsing rules.
