### PR TITLE
feat(vscode): import Cursor Agent sessions into History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Everything here lands through the SDK bundle, so it applies to windows running t
 
 ### Added
 
+- Import Cursor Agent JSONL sessions from the session history import flow. Imported sessions preserve supported conversation content and can be continued with the current Cline provider and model.
 - ClinePass is now surfaced across the app: a card on the account page describing what the plan covers, a hint in provider settings, and a banner on the home screen. Dismissed banners stay dismissed.
 
 ### Fixed

--- a/apps/examples/desktop-app/webview/lib/session-import.ts
+++ b/apps/examples/desktop-app/webview/lib/session-import.ts
@@ -5,18 +5,20 @@
  * copy so the client bundle never imports node-only core code.
  */
 
-export type SessionImportTool = "claude-code" | "codex" | "opencode";
+export type SessionImportTool = "claude-code" | "codex" | "opencode" | "cursor";
 
 export const SESSION_IMPORT_TOOL_ORDER: SessionImportTool[] = [
 	"claude-code",
 	"codex",
 	"opencode",
+	"cursor",
 ];
 
 export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	opencode: "opencode",
+	cursor: "Cursor",
 };
 
 export interface ImportableSession {

--- a/apps/vscode/proto/cline/task.proto
+++ b/apps/vscode/proto/cline/task.proto
@@ -113,6 +113,16 @@ message TaskItem {
   // Provider id the task ran on. Empty for tasks recorded before this
   // field existed and for legacy imports; consumers show cost in that case.
   string api_provider = 13;
+  // True when this row is discovered in an external session store and has not
+  // necessarily been copied into Cline's native history yet.
+  bool is_importable = 14;
+  string source_tool = 15;
+  string source_id = 16;
+  string source_path = 17;
+  string cwd = 18;
+  int32 message_count = 19;
+  string preview = 20;
+  string imported_session_id = 21;
 }
 
 // Request for ask response operation

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -12,10 +12,14 @@ import {
 	createUserInstructionConfigService,
 	ensureChatWorkspace,
 	getProviderAuthStorageId,
+	type ImportableSessionSummary,
+	importSummaryBelongsToWorkspace,
 	type PreparedRemoteConfigCoreIntegration,
 	readSessionCheckpointHistory,
 	resolveDefaultMcpSettingsPath,
 	type SessionHistoryRecord,
+	type SessionImportOptions,
+	type SessionImportRequest,
 	setTelemetryOptOutGlobally,
 	type UserInstructionConfigService,
 } from "@cline/core"
@@ -26,7 +30,13 @@ import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@shared/ClineAccount"
 import { mentionRegexGlobal } from "@shared/context-mentions"
 import type { ClineApiReqInfo, ClineMessage, ExtensionState } from "@shared/ExtensionMessage"
 import type { HistoryItem } from "@shared/HistoryItem"
-import { DeleteAllTaskHistoryCount, type GetTaskHistoryRequest, TaskHistoryArray, TaskResponse } from "@shared/proto/cline/task"
+import {
+	DeleteAllTaskHistoryCount,
+	type GetTaskHistoryRequest,
+	TaskHistoryArray,
+	type TaskItem,
+	TaskResponse,
+} from "@shared/proto/cline/task"
 import type { Settings } from "@shared/storage/state-keys"
 import type { Mode } from "@shared/storage/types"
 import type { TelemetrySetting } from "@shared/TelemetrySetting"
@@ -49,11 +59,13 @@ import { toLegacyApiProvider } from "@/shared/model-catalog/provider-helpers"
 import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { isClineManagedProvider } from "@/shared/utils/cline"
-import { arePathsEqual, getDesktopDir } from "@/utils/path"
+import { arePathsEqual, getDesktopDir, isLocatedInPath } from "@/utils/path"
+
 import { ClineAccountService } from "./account-service"
 import { AuthService, LogoutReason } from "./auth-service"
 import { BUILTIN_SLASH_COMMANDS } from "./builtin-slash-commands"
 import { buildStartSessionInput, createHistoryItemFromSession } from "./cline-session-factory"
+import { sortTaskItemsByRecency } from "./history-order"
 import { MessageTranslatorState, reshapeErrorForWebview } from "./message-translator"
 import { createProviderCatalog } from "./model-catalog/catalog"
 import type { Disposable, ProviderCatalog, ProviderConfigChange, ProviderConfigStore } from "./model-catalog/contracts"
@@ -108,6 +120,8 @@ import { VscodeSessionHost } from "./vscode-session-host"
 import type { VscodeTerminalExecutionMode } from "./vscode-terminal-execution-mode"
 import { WebviewGrpcBridge } from "./webview-grpc-bridge"
 import { resolveWorkspaceManagerPaths, resolveWorkspaceRootPath } from "./workspace-root"
+
+const IMPORT_TASK_PREFIX = "import:"
 
 /**
  * Log a stub warning and return undefined.
@@ -1087,6 +1101,25 @@ export class Controller {
 
 	// ---- Workspace root resolution ----
 
+	private async getOpenWorkspacePaths(): Promise<string[]> {
+		try {
+			const { paths } = await HostProvider.workspace.getWorkspacePaths({})
+			return paths?.filter((workspacePath) => workspacePath.trim().length > 0) ?? []
+		} catch (error) {
+			Logger.warn("[SdkController] Failed to get workspace paths:", error)
+			return []
+		}
+	}
+
+	private sessionBelongsToWorkspaceRoots(sessionWorkspacePath: string | undefined, workspaceRoots: string[]): boolean {
+		if (!sessionWorkspacePath?.trim() || workspaceRoots.length === 0) {
+			return false
+		}
+		return workspaceRoots.some(
+			(root) => arePathsEqual(sessionWorkspacePath, root) || isLocatedInPath(root, sessionWorkspacePath),
+		)
+	}
+
 	/**
 	 * Get the user's workspace root directory.
 	 *
@@ -1099,11 +1132,23 @@ export class Controller {
 	 */
 	private async getWorkspaceRoot(): Promise<string> {
 		try {
-			const { paths } = await HostProvider.workspace.getWorkspacePaths({})
-			const workspaceRoot = paths?.find((workspacePath) => workspacePath.trim().length > 0)
-			if (workspaceRoot) {
-				this.lastKnownWorkspaceRoot = workspaceRoot
-				return workspaceRoot
+			const openPaths = await this.getOpenWorkspacePaths()
+			if (openPaths.length > 0) {
+				try {
+					const { filePath } = await HostProvider.window.getActiveEditor({})
+					if (filePath) {
+						for (const workspacePath of openPaths) {
+							if (isLocatedInPath(workspacePath, filePath)) {
+								this.lastKnownWorkspaceRoot = workspacePath
+								return workspacePath
+							}
+						}
+					}
+				} catch {
+					// Active editor lookup is best-effort.
+				}
+				this.lastKnownWorkspaceRoot = openPaths[0]
+				return openPaths[0]
 			}
 		} catch (error) {
 			Logger.warn("[SdkController] Failed to get workspace paths, using the no-workspace fallback:", error)
@@ -1871,11 +1916,34 @@ export class Controller {
 	 * replace it.
 	 */
 	async showTaskWithId(taskId: string): Promise<TaskResponse> {
-		const historyItem = await this.taskControl.showTaskWithId(taskId)
+		const materializedTaskId = await this.materializeImportTask(taskId)
+		const historyItem = await this.taskControl.showTaskWithId(materializedTaskId)
 		if (!historyItem) {
 			throw new Error(`Task not found in history: ${taskId}`)
 		}
 		return historyItemToTaskResponse(historyItem)
+	}
+
+	private async materializeImportTask(taskId: string): Promise<string> {
+		if (!taskId.startsWith(IMPORT_TASK_PREFIX)) return taskId
+		const [, tool, ...sourceParts] = taskId.split(":")
+		const sourceId = sourceParts.join(":")
+		if (!tool || !sourceId) throw new Error(`Invalid import task id: ${taskId}`)
+		const config = this.stateManager.getApiConfiguration()
+		const mode = this.stateManager.getGlobalSettingsKey("mode") === "plan" ? "plan" : "act"
+		const provider = mode === "plan" ? config.planModeApiProvider : config.actModeApiProvider
+		const model = mode === "plan" ? config.planModeApiModelId : config.actModeApiModelId
+		const requests: SessionImportRequest[] = [{ tool: tool as SessionImportRequest["tool"], sourceId }]
+		const options: SessionImportOptions = {
+			provider: provider ?? undefined,
+			model: model ?? undefined,
+			workspaceRoot: await this.getWorkspaceRoot(),
+		}
+		const [result] = await this.sessions.importSessions({ requests, options })
+		if (!result?.ok || !result.sessionId) {
+			throw new Error(result?.error ?? "Could not import the Cursor session")
+		}
+		return result.sessionId
 	}
 
 	// ---- Mode switching ----
@@ -1968,7 +2036,10 @@ export class Controller {
 		const { favoritesOnly, currentWorkspaceOnly, searchQuery, sortBy } = request
 		const limit = request.limit > 0 ? Math.min(request.limit, 100) : 50
 		const offset = request.offset > 0 ? request.offset : 0
-		const workspacePath = currentWorkspaceOnly ? await this.getWorkspaceRoot() : undefined
+		const openWorkspacePaths = await this.getOpenWorkspacePaths()
+		const workspacePath = currentWorkspaceOnly ? (openWorkspacePaths[0] ?? (await this.getWorkspaceRoot())) : undefined
+		const workspaceRootsForFilter =
+			currentWorkspaceOnly && openWorkspacePaths.length > 0 ? openWorkspacePaths : workspacePath ? [workspacePath] : []
 		const sessionHistory = await this.taskHistory.listHistory({
 			hydrate: false,
 			limit: limit + 1,
@@ -1989,9 +2060,9 @@ export class Controller {
 				return false
 			}
 
-			if (currentWorkspaceOnly && workspacePath) {
+			if (currentWorkspaceOnly && workspaceRootsForFilter.length > 0) {
 				const sessionWorkspacePath = item.cwd ?? item.workspaceRoot
-				if (!sessionWorkspacePath || !arePathsEqual(sessionWorkspacePath, workspacePath)) {
+				if (!this.sessionBelongsToWorkspaceRoots(sessionWorkspacePath, workspaceRootsForFilter)) {
 					return false
 				}
 			}
@@ -2036,7 +2107,7 @@ export class Controller {
 		})
 
 		const hasMore = sessionHistory.length > limit
-		const tasks = filteredTasks.slice(0, limit).map((item) => {
+		const tasks: TaskItem[] = filteredTasks.slice(0, limit).map((item) => {
 			const metadata = item.metadata
 			return {
 				id: item.sessionId,
@@ -2054,8 +2125,68 @@ export class Controller {
 				isLegacy:
 					metadataBoolean(metadata, "legacyTask") === true ||
 					metadataBoolean(metadata, "migratedFromLegacyTask") === true,
+				isImportable: false,
+				sourceTool: "",
+				sourceId: "",
+				sourcePath: "",
+				cwd: item.cwd ?? "",
+				messageCount: 0,
+				preview: "",
+				importedSessionId: "",
 			}
 		})
+
+		if (offset === 0 && !favoritesOnly && openWorkspacePaths.length > 0) {
+			const importRoots = currentWorkspaceOnly ? openWorkspacePaths : [await this.getWorkspaceRoot()]
+			const importableByKey = new Map<string, ImportableSessionSummary>()
+			for (const importWorkspaceRoot of importRoots) {
+				if (!importWorkspaceRoot?.trim()) continue
+				const importable = await this.sessions.listImportableSessions({
+					workspaceRoot: importWorkspaceRoot,
+				})
+				for (const summary of importable) {
+					importableByKey.set(`${summary.tool}:${summary.sourceId}`, summary)
+				}
+			}
+			const importedTasks: TaskItem[] = [...importableByKey.values()]
+				.filter((summary) => !summary.alreadyImportedSessionId)
+				.filter(
+					(summary) =>
+						!currentWorkspaceOnly ||
+						workspaceRootsForFilter.some((root) => importSummaryBelongsToWorkspace(summary, root)),
+				)
+				.filter(
+					(summary) =>
+						!searchQuery ||
+						`${summary.title} ${summary.preview ?? ""}`.toLowerCase().includes(searchQuery.toLowerCase()),
+				)
+				.map((summary: ImportableSessionSummary) => ({
+					id: `${IMPORT_TASK_PREFIX}${summary.tool}:${summary.sourceId}`,
+					task: formatDisplayUserInput(summary.title),
+					ts: summary.updatedAtMs,
+					isFavorited: false,
+					size: 0,
+					totalCost: 0,
+					tokensIn: 0,
+					tokensOut: 0,
+					cacheWrites: 0,
+					cacheReads: 0,
+					modelId: "",
+					apiProvider: "",
+					isLegacy: false,
+					isImportable: true,
+					sourceTool: summary.tool,
+					sourceId: summary.sourceId,
+					sourcePath: summary.sourcePath,
+					cwd: summary.cwd,
+					messageCount: summary.messageCount,
+					preview: summary.preview ?? "",
+					importedSessionId: summary.alreadyImportedSessionId ?? "",
+				}))
+			tasks.push(...importedTasks)
+		}
+
+		tasks.sort((a, b) => (sortBy === "oldest" ? a.ts - b.ts : b.ts - a.ts))
 
 		if (offset === 0 && !favoritesOnly && this.task?.taskId && !tasks.some((task) => task.id === this.task?.taskId)) {
 			const taskMessage = this.task.messageStateHandler
@@ -2077,11 +2208,20 @@ export class Controller {
 					modelId: this.task.api?.getModel?.().id ?? "",
 					apiProvider: "",
 					isLegacy: false,
+					isImportable: false,
+					sourceTool: "",
+					sourceId: "",
+					sourcePath: "",
+					cwd: "",
+					messageCount: 0,
+					preview: "",
+					importedSessionId: "",
 				})
 			}
 		}
 
-		return TaskHistoryArray.create({ tasks: tasks.slice(0, limit), hasMore })
+		const orderedTasks = sortTaskItemsByRecency(tasks, sortBy === "oldest")
+		return TaskHistoryArray.create({ tasks: orderedTasks.slice(0, limit), hasMore })
 	}
 
 	async exportTaskWithId(id: string): Promise<void> {

--- a/apps/vscode/src/sdk/history-order.test.ts
+++ b/apps/vscode/src/sdk/history-order.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test"
+import { sortTaskItemsByRecency } from "./history-order"
+
+describe("sortTaskItemsByRecency", () => {
+	it("puts the newest chat first after native and imported rows are merged", () => {
+		const items = [
+			{ id: "older", ts: 100 },
+			{ id: "newest", ts: 300 },
+			{ id: "middle", ts: 200 },
+		]
+
+		expect(sortTaskItemsByRecency(items).map((item) => item.id)).toEqual(["newest", "middle", "older"])
+	})
+
+	it("supports the explicit oldest sort", () => {
+		const items = [
+			{ id: "older", ts: 100 },
+			{ id: "newest", ts: 300 },
+		]
+
+		expect(sortTaskItemsByRecency(items, true).map((item) => item.id)).toEqual(["older", "newest"])
+	})
+})

--- a/apps/vscode/src/sdk/history-order.ts
+++ b/apps/vscode/src/sdk/history-order.ts
@@ -1,0 +1,3 @@
+export function sortTaskItemsByRecency<T extends { ts: number }>(items: T[], oldest = false): T[] {
+	return [...items].sort((left, right) => (oldest ? left.ts - right.ts : right.ts - left.ts))
+}

--- a/apps/vscode/src/sdk/sdk-session-lifecycle.ts
+++ b/apps/vscode/src/sdk/sdk-session-lifecycle.ts
@@ -1,9 +1,13 @@
 import type {
 	CoreSessionEvent,
+	ImportableSessionSummary,
 	ITelemetryService,
 	PreparedRemoteConfigCoreIntegration,
 	RestoreInput,
 	RestoreResult,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
 	StartSessionResult,
 } from "@cline/core"
 import { formatModeSwitchNotice, type ModeSwitchNotice } from "@cline/shared"
@@ -73,6 +77,21 @@ export class SdkSessionLifecycle {
 	private readonly pendingStops = new Map<string, Promise<void>>()
 
 	constructor(private readonly options: SdkSessionLifecycleOptions) {}
+
+	async listImportableSessions(options: Pick<SessionImportOptions, "workspaceRoot"> = {}): Promise<ImportableSessionSummary[]> {
+		const host = await this.getOrCreateSharedHost()
+		if (!host.listImportableSessions) throw new Error("Session import is unavailable")
+		return host.listImportableSessions(options)
+	}
+
+	async importSessions(input: {
+		requests: SessionImportRequest[]
+		options?: SessionImportOptions
+	}): Promise<SessionImportResult[]> {
+		const host = await this.getOrCreateSharedHost()
+		if (!host.importSessions) throw new Error("Session import is unavailable")
+		return host.importSessions(input)
+	}
 
 	getActiveSession(): ActiveSession | undefined {
 		return this.activeSession

--- a/apps/vscode/src/sdk/sdk-task-history-import.test.ts
+++ b/apps/vscode/src/sdk/sdk-task-history-import.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test"
+import { importSummaryBelongsToWorkspace } from "../../../../sdk/packages/core/src/services/session-import/service"
+import type { ImportableSessionSummary } from "../../../../sdk/packages/core/src/services/session-import/types"
+
+function filterImportablesForWorkspaceRoots(summaries: ImportableSessionSummary[], roots: string[]): ImportableSessionSummary[] {
+	return summaries.filter((summary) => roots.some((root) => importSummaryBelongsToWorkspace(summary, root)))
+}
+
+describe("Cursor History import workspace filtering", () => {
+	it("keeps importable rows that match any open workspace root", () => {
+		const summaries: ImportableSessionSummary[] = [
+			{
+				tool: "cursor",
+				sourceId: "Users-ue-projects-hermes-cloud/agent-transcripts/a/a",
+				sourcePath: "/tmp/hermes.jsonl",
+				title: "Hermes chat",
+				cwd: "",
+				startedAtMs: 1,
+				updatedAtMs: 2,
+				messageCount: 1,
+			},
+			{
+				tool: "cursor",
+				sourceId: "Users-ue-projects-cline/agent-transcripts/b/b",
+				sourcePath: "/tmp/cline.jsonl",
+				title: "Cline chat",
+				cwd: "",
+				startedAtMs: 3,
+				updatedAtMs: 4,
+				messageCount: 1,
+			},
+		]
+
+		const filtered = filterImportablesForWorkspaceRoots(summaries, [
+			"/Users/ue/projects/hermes-cloud",
+			"/Users/ue/projects/cline",
+		])
+
+		expect(filtered.map((summary) => summary.title)).toEqual(["Hermes chat", "Cline chat"])
+	})
+
+	it("excludes Cursor rows from other workspace folders when Workspace Only is on", () => {
+		const summaries: ImportableSessionSummary[] = [
+			{
+				tool: "cursor",
+				sourceId: "Users-ue-projects-hermes-cloud/agent-transcripts/a/a",
+				sourcePath: "/tmp/hermes.jsonl",
+				title: "Hermes chat",
+				cwd: "",
+				startedAtMs: 1,
+				updatedAtMs: 2,
+				messageCount: 1,
+			},
+			{
+				tool: "cursor",
+				sourceId: "Users-ue-projects-cline/agent-transcripts/b/b",
+				sourcePath: "/tmp/cline.jsonl",
+				title: "Cline chat",
+				cwd: "",
+				startedAtMs: 3,
+				updatedAtMs: 4,
+				messageCount: 1,
+			},
+		]
+
+		const filtered = filterImportablesForWorkspaceRoots(summaries, ["/Users/ue/projects/hermes-cloud"])
+
+		expect(filtered.map((summary) => summary.title)).toEqual(["Hermes chat"])
+	})
+})

--- a/apps/vscode/src/sdk/session-host.ts
+++ b/apps/vscode/src/sdk/session-host.ts
@@ -5,6 +5,7 @@ import type {
 	CompareCheckpointResult,
 	CoreSessionEvent,
 	HookEventPayload,
+	ImportableSessionSummary,
 	PendingPromptMutationResult,
 	PendingPromptsDeleteInput,
 	PendingPromptsListInput,
@@ -15,6 +16,9 @@ import type {
 	SessionAccumulatedUsage,
 	SessionCompactionState,
 	SessionHistoryRecord,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
 	SessionPendingPrompt,
 	SessionRecord,
 	StartSessionInput,
@@ -36,6 +40,8 @@ export interface SdkSessionHost {
 	listHistory(options?: ClineCoreListHistoryOptions): Promise<SessionHistoryRecord[]>
 	delete(sessionId: string): Promise<boolean>
 	readMessages(sessionId: string): Promise<SdkInitialMessages>
+	listImportableSessions?(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]>
+	importSessions?(input: { requests: SessionImportRequest[]; options?: SessionImportOptions }): Promise<SessionImportResult[]>
 	/**
 	 * Like readMessages, but prefers the live in-memory conversation when the
 	 * session is still resident, so an in-flight (or just-aborted) turn is not

--- a/apps/vscode/src/sdk/vscode-session-host.ts
+++ b/apps/vscode/src/sdk/vscode-session-host.ts
@@ -14,6 +14,7 @@ import {
 	type CoreSessionEvent,
 	type EditorExecutor,
 	type HookEventPayload,
+	type ImportableSessionSummary,
 	type ITelemetryService,
 	type PendingPromptMutationResult,
 	type PendingPromptsDeleteInput,
@@ -26,6 +27,9 @@ import {
 	type SessionAccumulatedUsage,
 	type SessionCompactionState,
 	type SessionHistoryRecord,
+	type SessionImportOptions,
+	type SessionImportRequest,
+	type SessionImportResult,
 	type SessionPendingPrompt,
 	type SessionRecord,
 	type StartSessionInput,
@@ -110,6 +114,12 @@ export class VscodeSessionHost implements SdkSessionHost {
 	}
 	updateSessionModel?(sessionId: string, modelId: string): Promise<void> {
 		return this.inner.updateSessionModel(sessionId, modelId)
+	}
+	listImportableSessions(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]> {
+		return this.inner.listImportableSessions(options)
+	}
+	importSessions(input: { requests: SessionImportRequest[]; options?: SessionImportOptions }): Promise<SessionImportResult[]> {
+		return this.inner.importSessions(input)
 	}
 
 	static async create(options: VscodeSessionHostOptions): Promise<VscodeSessionHost> {

--- a/apps/vscode/src/shared/HistoryItem.ts
+++ b/apps/vscode/src/shared/HistoryItem.ts
@@ -23,4 +23,14 @@ export type HistoryItem = {
 	 */
 	apiProvider?: string
 	isLegacy?: boolean
+
+	/** External session not yet imported into native Cline history. */
+	isImportable?: boolean
+	sourceTool?: string
+	sourceId?: string
+	sourcePath?: string
+	cwd?: string
+	messageCount?: number
+	preview?: string
+	importedSessionId?: string
 }

--- a/apps/vscode/webview-ui/src/components/history/HistoryView.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryView.tsx
@@ -46,7 +46,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	const [deleteAllDisabled, setDeleteAllDisabled] = useState(false)
 	const [selectedItems, setSelectedItems] = useState<string[]>([])
 	const [showFavoritesOnly, setShowFavoritesOnly] = useState(false)
-	const [showCurrentWorkspaceOnly, setShowCurrentWorkspaceOnly] = useState(false)
+	const [showCurrentWorkspaceOnly, setShowCurrentWorkspaceOnly] = useState(true)
 
 	// Keep track of pending favorite toggle operations
 	const [pendingFavoriteToggles, setPendingFavoriteToggles] = useState<Record<string, boolean>>({})

--- a/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/apps/vscode/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -105,6 +105,11 @@ const HistoryViewItem = ({
 							Legacy
 						</span>
 					)}
+					{item.isImportable && (
+						<span className="text-xs uppercase rounded px-1.5 py-0.5 bg-accent/20 text-description flex-shrink-0">
+							{item.sourceTool ?? "Imported"}
+						</span>
+					)}
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
@@ -228,6 +233,9 @@ const HistoryViewItem = ({
 							</div>
 						</div>
 					</Button>
+				)}
+				{item.isImportable && item.preview && !expanded && (
+					<div className="text-description text-xs line-clamp-2">{item.preview}</div>
 				)}
 			</div>
 		</div>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
 						"group": "Usage",
 						"pages": [
 							"usage/ide",
+							"usage/importing-cursor-sessions",
 							"usage/tui",
 							{
 								"group": "CLI",

--- a/docs/usage/importing-cursor-sessions.mdx
+++ b/docs/usage/importing-cursor-sessions.mdx
@@ -16,6 +16,25 @@ Cline can discover Cursor Agent transcript files for a project and show them in 
 
 The next Cline turn uses the provider and model currently configured in Cline. The original Cursor provider and model, when available, remain session metadata.
 
+## Where transcripts live
+
+Cursor writes Agent JSONL transcripts under a per-user projects directory:
+
+| Platform | Typical path |
+|----------|--------------|
+| macOS / Linux | `~/.cursor/projects/` |
+| Windows | `%USERPROFILE%\.cursor\projects\` |
+
+Layout when present:
+
+```text
+{cursorProjectsDir}/{project-folder}/agent-transcripts/{uuid}/{uuid}.jsonl
+```
+
+Project folder names are heterogeneous (path slugs such as `Users-jane-projects-app`, numeric IDs, and other Cursor-specific encodings). Cline scans all project folders and filters to the open workspace after parsing each transcript.
+
+Set `CURSOR_PROJECTS_DIR` to override the default projects directory for non-standard installs.
+
 ## What is preserved
 
 Cline imports user and assistant text, timestamps, titles, working-directory metadata, standard tool calls and results, and inline images when the source transcript contains them in a supported form. Cline's import sanitizer repairs incomplete tool-call pairs and removes provider-specific signatures before the conversation is resumed.
@@ -24,7 +43,11 @@ Malformed lines and unsupported event types are skipped when the rest of the tra
 
 ## Workspace matching and limitations
 
-Discovery is scoped to the open project when the workspace path is available. Cursor's local storage format is not a public stable API and can vary by Cursor version, platform, profile, and workspace type. The current adapter reads JSONL Agent transcript files under Cursor's project data directory. Cursor SQLite indexes and chats stored only in opaque database values are not treated as reliable transcript sources yet.
+History defaults to **Workspace Only**, which shows native Cline sessions and importable Cursor rows that belong to an open workspace folder. Discovery scans all Cursor project folders on disk, then filters rows by transcript `cwd` when present, or by path-slug folder name when `cwd` is missing. Numeric or otherwise unrecognizable project folders with empty `cwd` are excluded when workspace filtering is on.
+
+Cursor's local storage format is not a public stable API and can vary by Cursor version, platform, profile, and workspace type. The current adapter reads JSONL Agent transcript files only. Cursor SQLite indexes and composer sidebar titles are not used as transcript sources.
+
+When the projects directory or `agent-transcripts/` tree is absent, discovery returns no Cursor rows. This is expected when Cursor has never been used on the machine, the workspace was moved or renamed, or transcripts are stored on another profile or host.
 
 Cursor may be running while a transcript is being written. Cline reads source files without modifying them and tolerates a partial final line; repeat the scan after the conversation is complete if a chat is not shown.
 

--- a/docs/usage/importing-cursor-sessions.mdx
+++ b/docs/usage/importing-cursor-sessions.mdx
@@ -1,0 +1,31 @@
+---
+title: "Importing Cursor sessions"
+description: "Bring Cursor Agent conversations into Cline and continue them with your Cline configuration."
+---
+
+# Importing Cursor sessions
+
+Cline can discover Cursor Agent transcript files for a project and show them in the VS Code History view or session import dialog. Opening or importing one creates a native Cline session. Imported sessions are copies: Cline never writes to Cursor's files.
+
+## Import a session
+
+1. Open the project folder in Cline.
+2. Open History. Matching unimported Cursor conversations are labeled `Cursor`.
+3. Select a Cursor conversation to import it lazily, or use the session import dialog to import several.
+4. Send a new prompt in the imported session.
+
+The next Cline turn uses the provider and model currently configured in Cline. The original Cursor provider and model, when available, remain session metadata.
+
+## What is preserved
+
+Cline imports user and assistant text, timestamps, titles, working-directory metadata, standard tool calls and results, and inline images when the source transcript contains them in a supported form. Cline's import sanitizer repairs incomplete tool-call pairs and removes provider-specific signatures before the conversation is resumed.
+
+Malformed lines and unsupported event types are skipped when the rest of the transcript is usable. A transcript with no usable conversational messages is not imported.
+
+## Workspace matching and limitations
+
+Discovery is scoped to the open project when the workspace path is available. Cursor's local storage format is not a public stable API and can vary by Cursor version, platform, profile, and workspace type. The current adapter reads JSONL Agent transcript files under Cursor's project data directory. Cursor SQLite indexes and chats stored only in opaque database values are not treated as reliable transcript sources yet.
+
+Cursor may be running while a transcript is being written. Cline reads source files without modifying them and tolerates a partial final line; repeat the scan after the conversation is complete if a chat is not shown.
+
+Imported sessions are deduplicated by their Cursor source path and session identifier. Repeating an import does not create another Cline session.

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -526,6 +526,22 @@ export class ClineCore {
 	 */
 	readMessages: RuntimeHost["readSessionMessages"] = (...args) =>
 		this.host.readSessionMessages(...args);
+	listImportableSessions = async (
+		options: Parameters<NonNullable<RuntimeHost["listImportableSessions"]>>[0] = {},
+	) => {
+		if (!this.host.listImportableSessions) {
+			throw new Error("Session import is only available on a local runtime");
+		}
+		return this.host.listImportableSessions(options);
+	};
+	importSessions = async (
+		input: Parameters<NonNullable<RuntimeHost["importSessions"]>>[0],
+	) => {
+		if (!this.host.importSessions) {
+			throw new Error("Session import is only available on a local runtime");
+		}
+		return this.host.importSessions(input);
+	};
 
 	/**
 	 * Reads a transcript projected for presentation. Observational model-tool

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.session-import.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.session-import.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setClineDir, setHomeDir } from "@cline/shared/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FileSessionService } from "../../session/services/file-session-service";
+import { LocalRuntimeHost } from "./local-runtime-host";
+
+function writeCursorTranscript(
+	projectsDir: string,
+	projectId: string,
+	sessionId: string,
+	content: string,
+): void {
+	const chatDir = join(
+		projectsDir,
+		projectId,
+		"agent-transcripts",
+		sessionId,
+	);
+	mkdirSync(chatDir, { recursive: true });
+	writeFileSync(join(chatDir, `${sessionId}.jsonl`), content);
+}
+
+describe("LocalRuntimeHost session import", () => {
+	const envSnapshot = {
+		HOME: process.env.HOME,
+		CLINE_DIR: process.env.CLINE_DIR,
+		CURSOR_PROJECTS_DIR: process.env.CURSOR_PROJECTS_DIR,
+	};
+	let isolatedHomeDir = "";
+	let projectsDir = "";
+
+	beforeEach(() => {
+		isolatedHomeDir = mkdtempSync(join(tmpdir(), "core-session-import-home-"));
+		projectsDir = join(isolatedHomeDir, ".cursor", "projects");
+		process.env.HOME = isolatedHomeDir;
+		process.env.CLINE_DIR = join(isolatedHomeDir, ".cline");
+		process.env.CURSOR_PROJECTS_DIR = projectsDir;
+		setHomeDir(isolatedHomeDir);
+		setClineDir(process.env.CLINE_DIR);
+	});
+
+	afterEach(() => {
+		process.env.HOME = envSnapshot.HOME;
+		process.env.CLINE_DIR = envSnapshot.CLINE_DIR;
+		if (envSnapshot.CURSOR_PROJECTS_DIR === undefined) {
+			delete process.env.CURSOR_PROJECTS_DIR;
+		} else {
+			process.env.CURSOR_PROJECTS_DIR = envSnapshot.CURSOR_PROJECTS_DIR;
+		}
+		setHomeDir(envSnapshot.HOME ?? "~");
+		setClineDir(envSnapshot.CLINE_DIR ?? join("~", ".cline"));
+		rmSync(isolatedHomeDir, { recursive: true, force: true });
+	});
+
+	it("lists importable Cursor sessions through the runtime host", async () => {
+		writeCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-demo",
+			"session-1",
+			`${JSON.stringify({
+				cwd: "/Users/ue/projects/demo",
+				role: "user",
+				content: "hello from cursor",
+			})}\n`,
+		);
+
+		const host = new LocalRuntimeHost({
+			distinctId: "test-machine-id",
+			sessionService: new FileSessionService(join(isolatedHomeDir, "sessions")),
+		});
+
+		try {
+			const discovered = await host.listImportableSessions({
+				workspaceRoot: "/Users/ue/projects/demo",
+			});
+			expect(discovered).toHaveLength(1);
+			expect(discovered[0].tool).toBe("cursor");
+			expect(discovered[0].title).toBe("hello from cursor");
+		} finally {
+			await host.dispose();
+		}
+	});
+});

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -49,6 +49,13 @@ import {
 } from "../../services/telemetry/core-events";
 import { resolveCoreDistinctId } from "../../services/telemetry/distinct-id";
 import {
+	SessionImportService,
+	type ImportableSessionSummary,
+	type SessionImportOptions,
+	type SessionImportRequest,
+	type SessionImportResult,
+} from "../../services/session-import";
+import {
 	accumulateUsageTotals,
 	createInitialAccumulatedUsage,
 	summarizeUsageFromMessages,
@@ -364,6 +371,19 @@ export class LocalRuntimeHost implements RuntimeHost {
 			invokeBackendOptional: (method, ...args) =>
 				this.invokeOptional(method, ...args),
 		});
+	}
+
+	async listImportableSessions(
+		options: Pick<SessionImportOptions, "workspaceRoot"> = {},
+	): Promise<ImportableSessionSummary[]> {
+		return new SessionImportService(this.sessionService).discover(options);
+	}
+
+	async importSessions(input: {
+		requests: SessionImportRequest[];
+		options?: SessionImportOptions;
+	}): Promise<SessionImportResult[]> {
+		return new SessionImportService(this.sessionService).importMany(input.requests, undefined, input.options);
 	}
 
 	private async applyInitialOAuthCredentials(

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -19,6 +19,12 @@ import type {
 	SessionPendingPrompt,
 } from "../../types/events";
 import type { SessionRecord } from "../../types/sessions";
+import type {
+	ImportableSessionSummary,
+	SessionImportOptions,
+	SessionImportRequest,
+	SessionImportResult,
+} from "../../services/session-import";
 import type { RuntimeCapabilities } from "../capabilities";
 import type { ConnectionUpdate } from "../config/connection-update";
 
@@ -389,6 +395,11 @@ export interface RuntimeHost {
 	readSessionMessages(
 		sessionId: string,
 	): Promise<LlmsProviders.MessageWithMetadata[]>;
+	listImportableSessions?(options?: Pick<SessionImportOptions, "workspaceRoot">): Promise<ImportableSessionSummary[]>;
+	importSessions?(input: {
+		requests: SessionImportRequest[];
+		options?: SessionImportOptions;
+	}): Promise<SessionImportResult[]>;
 	/**
 	 * Like {@link readSessionMessages}, but prefers the resident session's
 	 * in-memory conversation over the persisted transcript. Disk persistence

--- a/sdk/packages/core/src/services/session-import/cursor.ts
+++ b/sdk/packages/core/src/services/session-import/cursor.ts
@@ -1,0 +1,325 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, relative } from "node:path";
+import type * as LlmsProviders from "@cline/llms";
+import {
+	type ConvertedImportedSession,
+	type ImportableSessionSummary,
+	type SessionImportAdapter,
+	truncateForDisplay,
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface CursorAdapterOptions {
+	/** Defaults to ~/.cursor/projects. */
+	projectsDir?: string;
+	/** Restrict discovery to a workspace when provided. */
+	workspaceRoot?: string;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	try {
+		return JSON.parse(value) as unknown;
+	} catch {
+		return value;
+	}
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function timestamp(value: unknown): number | undefined {
+	if (typeof value === "string" && value.includes("-")) {
+		const parsed = Date.parse(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed < 10_000_000_000 ? parsed * 1000 : parsed;
+}
+
+function normalizedPath(value: string): string {
+	return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
+	const normalizedCwd = normalizedPath(cwd);
+	const normalizedRoot = normalizedPath(workspaceRoot);
+	return (
+		normalizedCwd === normalizedRoot ||
+		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
+		normalizedRoot.startsWith(`${normalizedCwd}/`)
+	);
+}
+
+function blocksFromContent(
+	content: unknown,
+	role: "user" | "assistant",
+): LlmsProviders.ContentBlock[] {
+	const parsed = parseJson(content);
+	if (typeof parsed === "string") {
+		return parsed.trim() ? [{ type: "text", text: parsed }] : [];
+	}
+	if (!Array.isArray(parsed)) return [];
+	const blocks: LlmsProviders.ContentBlock[] = [];
+	for (const value of parsed) {
+		if (typeof value === "string") {
+			if (value.trim()) blocks.push({ type: "text", text: value });
+			continue;
+		}
+		if (!isRecord(value)) continue;
+		const type = stringValue(value.type);
+		if (
+			(type === "text" || type === "input_text" || type === "output_text") &&
+			stringValue(value.text)
+		) {
+			blocks.push({ type: "text", text: value.text as string });
+		} else if (type === "thinking" || type === "reasoning") {
+			const thinking = stringValue(value.thinking) ?? stringValue(value.text);
+			if (thinking) blocks.push({ type: "thinking", thinking });
+		} else if (
+			role === "assistant" &&
+			(type === "tool_use" || type === "function_call")
+		) {
+			const id = stringValue(value.id) ?? stringValue(value.call_id);
+			if (!id) continue;
+			const parsedArguments = parseJson(value.arguments);
+			blocks.push({
+				type: "tool_use",
+				id,
+				name: stringValue(value.name) ?? "tool",
+				input: isRecord(value.input)
+					? value.input
+					: isRecord(parsedArguments)
+						? parsedArguments
+						: {},
+			});
+		} else if (
+			role === "user" &&
+			(type === "tool_result" || type === "function_call_output")
+		) {
+			const toolUseId =
+				stringValue(value.tool_use_id) ?? stringValue(value.call_id);
+			if (!toolUseId) continue;
+			const result = value.content ?? value.output ?? "";
+			blocks.push({
+				type: "tool_result",
+				tool_use_id: toolUseId,
+				name: stringValue(value.name) ?? "tool",
+				content: typeof result === "string" ? result : JSON.stringify(result),
+			});
+		} else if (type === "image_url" && isRecord(value.image_url)) {
+			const url = stringValue(value.image_url.url);
+			const comma = url?.indexOf(",") ?? -1;
+			if (url?.startsWith("data:image/") && comma > 0) {
+				blocks.push({
+					type: "image",
+					data: url.slice(comma + 1),
+					mediaType: url.slice(5, url.indexOf(";")),
+				});
+			}
+		}
+	}
+	return blocks;
+}
+
+function messageFromRecord(
+	record: JsonRecord,
+): LlmsProviders.MessageWithMetadata | undefined {
+	const message = isRecord(record.message) ? record.message : record;
+	const roleValue = stringValue(message.role) ?? stringValue(record.role);
+	const role =
+		roleValue === "assistant" || roleValue === "user" ? roleValue : undefined;
+	if (!role) return undefined;
+	const blocks = blocksFromContent(
+		message.content ?? message.text ?? record.content ?? record.text,
+		role,
+	);
+	if (blocks.length === 0) return undefined;
+	const provider =
+		stringValue(message.provider) ?? stringValue(record.provider);
+	const model = stringValue(message.model) ?? stringValue(record.model);
+	const ts = timestamp(record.timestamp) ?? timestamp(message.timestamp);
+	return {
+		role,
+		content: blocks,
+		...(ts ? { ts } : {}),
+		...(provider && model ? { modelInfo: { id: model, provider } } : {}),
+	};
+}
+
+function messageFromEvent(
+	record: JsonRecord,
+): LlmsProviders.MessageWithMetadata | undefined {
+	const direct = messageFromRecord(record);
+	if (direct) return direct;
+	for (const key of ["data", "payload", "event", "item"]) {
+		const nested = parseJson(record[key]);
+		if (isRecord(nested)) {
+			const message = messageFromRecord(nested);
+			if (message) return message;
+		}
+	}
+	return undefined;
+}
+
+interface ParsedCursorSession {
+	messages: LlmsProviders.MessageWithMetadata[];
+	cwd: string;
+	title?: string;
+	provider?: string;
+	model?: string;
+	startedAtMs: number;
+	updatedAtMs: number;
+}
+
+export class CursorImportAdapter implements SessionImportAdapter {
+	readonly tool = "cursor" as const;
+	private readonly projectsDir: string;
+	private readonly workspaceRoot?: string;
+
+	constructor(options: CursorAdapterOptions = {}) {
+		this.projectsDir =
+			options.projectsDir ?? join(homedir(), ".cursor", "projects");
+		this.workspaceRoot = options.workspaceRoot;
+	}
+
+	isInstalled(): boolean {
+		return existsSync(this.projectsDir);
+	}
+
+	private transcriptFiles(): string[] {
+		if (!this.isInstalled()) return [];
+		const files: string[] = [];
+		const visit = (directory: string): void => {
+			for (const entry of readdirSync(directory, { withFileTypes: true })) {
+				const file = join(directory, entry.name);
+				if (entry.isDirectory()) visit(file);
+				else if (entry.isFile() && entry.name.endsWith(".jsonl"))
+					files.push(file);
+			}
+		};
+		visit(this.projectsDir);
+		return files;
+	}
+
+	private parseFile(file: string): ParsedCursorSession {
+		const result: ParsedCursorSession = {
+			messages: [],
+			cwd: "",
+			startedAtMs: 0,
+			updatedAtMs: 0,
+		};
+		for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+			if (!line.trim()) continue;
+			const record = parseJson(line);
+			if (!isRecord(record)) continue;
+			result.cwd ||=
+				stringValue(record.cwd) ?? stringValue(record.workspace) ?? "";
+			result.title ||= stringValue(record.title) ?? stringValue(record.name);
+			result.provider ||= stringValue(record.provider);
+			result.model ||= stringValue(record.model);
+			const time =
+				timestamp(record.timestamp) ??
+				timestamp(record.createdAt) ??
+				timestamp(record.created_at);
+			if (time) {
+				result.startedAtMs ||= time;
+				result.updatedAtMs = Math.max(result.updatedAtMs, time);
+			}
+			const message = messageFromEvent(record);
+			if (!message) continue;
+			result.messages.push(message);
+			if (message.modelInfo) {
+				result.provider ||= message.modelInfo.provider;
+				result.model ||= message.modelInfo.id;
+			}
+		}
+		const now = Date.now();
+		result.startedAtMs ||= now;
+		result.updatedAtMs ||= result.startedAtMs;
+		return result;
+	}
+
+	private sourceId(file: string): string {
+		return relative(this.projectsDir, file)
+			.replace(/\\/g, "/")
+			.replace(/\.jsonl$/, "");
+	}
+
+	discover(): ImportableSessionSummary[] {
+		const sessions: ImportableSessionSummary[] = [];
+		for (const file of this.transcriptFiles()) {
+			try {
+				const parsed = this.parseFile(file);
+				if (parsed.messages.length === 0) continue;
+				if (
+					this.workspaceRoot &&
+					parsed.cwd &&
+					!workspaceMatches(parsed.cwd, this.workspaceRoot)
+				)
+					continue;
+				const firstUser = parsed.messages.find(
+					(message) => message.role === "user",
+				);
+				const preview = Array.isArray(firstUser?.content)
+					? firstUser.content.find((block) => block.type === "text")?.text
+					: undefined;
+				sessions.push({
+					tool: this.tool,
+					sourceId: this.sourceId(file),
+					sourcePath: file,
+					title:
+						truncateForDisplay(parsed.title ?? preview, 120) ??
+						"Untitled Cursor chat",
+					cwd: parsed.cwd,
+					startedAtMs: parsed.startedAtMs,
+					updatedAtMs: parsed.updatedAtMs,
+					messageCount: parsed.messages.length,
+					...(preview ? { preview: truncateForDisplay(preview) } : {}),
+				});
+			} catch {
+				// A malformed or active transcript must not hide other sessions.
+			}
+		}
+		return sessions.sort((left, right) => right.updatedAtMs - left.updatedAtMs);
+	}
+
+	convert(sourceId: string): ConvertedImportedSession {
+		const file = this.transcriptFiles().find(
+			(candidate) => this.sourceId(candidate) === sourceId,
+		);
+		if (!file) throw new Error(`Cursor session ${sourceId} not found`);
+		const parsed = this.parseFile(file);
+		if (parsed.messages.length === 0)
+			throw new Error("Cursor session has no importable messages");
+		const firstUser = parsed.messages.find(
+			(message) => message.role === "user",
+		);
+		const prompt = Array.isArray(firstUser?.content)
+			? firstUser.content.find((block) => block.type === "text")?.text
+			: undefined;
+		return {
+			tool: this.tool,
+			sourceId,
+			sourcePath: file,
+			title:
+				truncateForDisplay(parsed.title ?? prompt, 120) ??
+				"Untitled Cursor chat",
+			...(prompt ? { prompt } : {}),
+			provider: parsed.provider ?? "cursor",
+			model: parsed.model ?? "cursor-imported",
+			cwd: parsed.cwd,
+			startedAtMs: parsed.startedAtMs,
+			endedAtMs: parsed.updatedAtMs,
+			messages: parsed.messages,
+		};
+	}
+}

--- a/sdk/packages/core/src/services/session-import/cursor.ts
+++ b/sdk/packages/core/src/services/session-import/cursor.ts
@@ -1,6 +1,39 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
+
+function resolveDefaultHomeDirForCursor(): string {
+	const envHome = process.env.HOME?.trim();
+	if (envHome && envHome !== "~") {
+		return envHome;
+	}
+	const envUserProfile = process.env.USERPROFILE?.trim();
+	if (envUserProfile) {
+		return envUserProfile;
+	}
+	const envHomeDrive = process.env.HOMEDRIVE?.trim();
+	const envHomePath = process.env.HOMEPATH?.trim();
+	if (envHomeDrive && envHomePath) {
+		return `${envHomeDrive}${envHomePath}`;
+	}
+	const osHomeDir = homedir().trim();
+	if (osHomeDir && osHomeDir !== "~") {
+		return osHomeDir;
+	}
+	return "~";
+}
+
+/** Resolve Cursor's per-user projects directory (macOS/Linux/Windows). */
+export function resolveCursorProjectsDir(options?: {
+	projectsDir?: string;
+}): string {
+	const override =
+		options?.projectsDir ?? process.env.CURSOR_PROJECTS_DIR?.trim();
+	if (override) {
+		return override;
+	}
+	return join(resolveDefaultHomeDirForCursor(), ".cursor", "projects");
+}
 import type * as LlmsProviders from "@cline/llms";
 import {
 	type ConvertedImportedSession,
@@ -56,6 +89,99 @@ function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
 		normalizedCwd === normalizedRoot ||
 		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
 		normalizedRoot.startsWith(`${normalizedCwd}/`)
+	);
+}
+
+/**
+ * Cursor stores per-project data under `~/.cursor/projects/<id>/…` where
+ * `<id>` is the workspace path with leading slashes stripped and remaining
+ * separators replaced by `-` (e.g. `/Users/ue/projects/hermes-cloud` →
+ * `Users-ue-projects-hermes-cloud`). Agent transcripts often omit `cwd`, so
+ * workspace scoping must use this folder id when filtering.
+ */
+export function cursorProjectId(workspaceRoot: string): string {
+	return normalizedPath(workspaceRoot)
+		.replace(/^\/+/, "")
+		.replace(/^[A-Za-z]:/, (drive) => drive[0])
+		.replace(/:/g, "")
+		.replace(/\//g, "-");
+}
+
+function sourceBelongsToWorkspace(
+	sourceIdOrPath: string,
+	projectsDir: string,
+	workspaceRoot: string,
+): boolean {
+	const projectId = cursorProjectId(workspaceRoot);
+	const relativeId = sourceIdOrPath.startsWith(projectsDir)
+		? relative(projectsDir, sourceIdOrPath).replace(/\\/g, "/")
+		: sourceIdOrPath.replace(/\\/g, "/");
+	return relativeId === projectId || relativeId.startsWith(`${projectId}/`);
+}
+
+/** Strip Cursor transcript envelope tags so History shows the real prompt. */
+export function cursorTranscriptDisplayText(
+	raw: string | undefined,
+): string | undefined {
+	if (!raw?.trim()) return undefined;
+	let text = raw.trim();
+	const userQuery = text.match(
+		/<user_query>\s*([\s\S]*?)(?:<\/user_query>|$)/i,
+	);
+	if (userQuery?.[1]) {
+		text = userQuery[1];
+	}
+	text = text.replace(/<[^>]+>/g, " ");
+	text = text.replace(
+		/^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),[^]*?\(UTC[^)]*\)\s*/i,
+		"",
+	);
+	const compact = text.replace(/\s+/g, " ").trim();
+	return compact || undefined;
+}
+
+function promptTitle(
+	storedTitle: string | undefined,
+	firstUserText: string | undefined,
+	max = 120,
+): string {
+	return (
+		truncateForDisplay(
+			cursorTranscriptDisplayText(storedTitle) ??
+				cursorTranscriptDisplayText(firstUserText) ??
+				storedTitle ??
+				firstUserText,
+			max,
+		) ?? "Untitled Cursor chat"
+	);
+}
+
+function firstUserText(
+	messages: LlmsProviders.MessageWithMetadata[],
+): string | undefined {
+	const firstUser = messages.find((message) => message.role === "user");
+	if (!firstUser || !Array.isArray(firstUser.content)) return undefined;
+	return firstUser.content.find((block) => block.type === "text")?.text;
+}
+
+/**
+ * Cursor Agents store one parent transcript at
+ * `agent-transcripts/<uuid>/<uuid>.jsonl`. Subagent runs live under
+ * `…/subagents/*.jsonl` and must not appear as separate History rows.
+ */
+export function isParentAgentTranscriptFile(file: string): boolean {
+	const normalized = normalizedPath(file);
+	if (!normalized.endsWith(".jsonl")) return false;
+	if (normalized.includes("/subagents/")) return false;
+	const base = normalized.slice(0, -".jsonl".length);
+	const sessionId = base.slice(base.lastIndexOf("/") + 1);
+	const parentDir = base.slice(0, base.lastIndexOf("/"));
+	const parentName = parentDir.slice(parentDir.lastIndexOf("/") + 1);
+	if (parentName !== sessionId) return false;
+	const agentTranscriptsDir = parentDir.slice(0, parentDir.lastIndexOf("/"));
+	return (
+		agentTranscriptsDir.slice(agentTranscriptsDir.lastIndexOf("/") + 1) ===
+		"agent-transcripts"
 	);
 }
 
@@ -186,8 +312,7 @@ export class CursorImportAdapter implements SessionImportAdapter {
 	private readonly workspaceRoot?: string;
 
 	constructor(options: CursorAdapterOptions = {}) {
-		this.projectsDir =
-			options.projectsDir ?? join(homedir(), ".cursor", "projects");
+		this.projectsDir = resolveCursorProjectsDir(options);
 		this.workspaceRoot = options.workspaceRoot;
 	}
 
@@ -195,18 +320,29 @@ export class CursorImportAdapter implements SessionImportAdapter {
 		return existsSync(this.projectsDir);
 	}
 
+	private projectDirs(): string[] {
+		if (!existsSync(this.projectsDir)) return [];
+		return readdirSync(this.projectsDir, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => join(this.projectsDir, entry.name));
+	}
+
 	private transcriptFiles(): string[] {
 		if (!this.isInstalled()) return [];
 		const files: string[] = [];
-		const visit = (directory: string): void => {
-			for (const entry of readdirSync(directory, { withFileTypes: true })) {
-				const file = join(directory, entry.name);
-				if (entry.isDirectory()) visit(file);
-				else if (entry.isFile() && entry.name.endsWith(".jsonl"))
-					files.push(file);
+		for (const projectDir of this.projectDirs()) {
+			const transcriptsDir = join(projectDir, "agent-transcripts");
+			if (!existsSync(transcriptsDir)) continue;
+			for (const entry of readdirSync(transcriptsDir, { withFileTypes: true })) {
+				if (!entry.isDirectory() || entry.name === "subagents") continue;
+				const sessionFile = join(
+					transcriptsDir,
+					entry.name,
+					`${entry.name}.jsonl`,
+				);
+				if (existsSync(sessionFile)) files.push(sessionFile);
 			}
-		};
-		visit(this.projectsDir);
+		}
 		return files;
 	}
 
@@ -260,30 +396,32 @@ export class CursorImportAdapter implements SessionImportAdapter {
 			try {
 				const parsed = this.parseFile(file);
 				if (parsed.messages.length === 0) continue;
-				if (
-					this.workspaceRoot &&
-					parsed.cwd &&
-					!workspaceMatches(parsed.cwd, this.workspaceRoot)
-				)
-					continue;
-				const firstUser = parsed.messages.find(
-					(message) => message.role === "user",
-				);
-				const preview = Array.isArray(firstUser?.content)
-					? firstUser.content.find((block) => block.type === "text")?.text
-					: undefined;
+				if (this.workspaceRoot) {
+					if (parsed.cwd) {
+						if (!workspaceMatches(parsed.cwd, this.workspaceRoot)) continue;
+					} else if (
+						!sourceBelongsToWorkspace(file, this.projectsDir, this.workspaceRoot)
+					) {
+						continue;
+					}
+				}
+				const previewRaw = firstUserText(parsed.messages);
+				const preview =
+					truncateForDisplay(
+						cursorTranscriptDisplayText(previewRaw) ?? previewRaw,
+					);
+				const fileTimes = statSync(file);
+				const updatedAtMs = fileTimes.mtimeMs;
 				sessions.push({
 					tool: this.tool,
 					sourceId: this.sourceId(file),
 					sourcePath: file,
-					title:
-						truncateForDisplay(parsed.title ?? preview, 120) ??
-						"Untitled Cursor chat",
+					title: promptTitle(parsed.title, previewRaw),
 					cwd: parsed.cwd,
-					startedAtMs: parsed.startedAtMs,
-					updatedAtMs: parsed.updatedAtMs,
+					startedAtMs: parsed.startedAtMs || fileTimes.birthtimeMs || updatedAtMs,
+					updatedAtMs,
 					messageCount: parsed.messages.length,
-					...(preview ? { preview: truncateForDisplay(preview) } : {}),
+					...(preview ? { preview } : {}),
 				});
 			} catch {
 				// A malformed or active transcript must not hide other sessions.
@@ -300,19 +438,14 @@ export class CursorImportAdapter implements SessionImportAdapter {
 		const parsed = this.parseFile(file);
 		if (parsed.messages.length === 0)
 			throw new Error("Cursor session has no importable messages");
-		const firstUser = parsed.messages.find(
-			(message) => message.role === "user",
-		);
-		const prompt = Array.isArray(firstUser?.content)
-			? firstUser.content.find((block) => block.type === "text")?.text
-			: undefined;
+		const promptRaw = firstUserText(parsed.messages);
+		const prompt =
+			cursorTranscriptDisplayText(promptRaw) ?? promptRaw;
 		return {
 			tool: this.tool,
 			sourceId,
 			sourcePath: file,
-			title:
-				truncateForDisplay(parsed.title ?? prompt, 120) ??
-				"Untitled Cursor chat",
+			title: promptTitle(parsed.title, promptRaw),
 			...(prompt ? { prompt } : {}),
 			provider: parsed.provider ?? "cursor",
 			model: parsed.model ?? "cursor-imported",

--- a/sdk/packages/core/src/services/session-import/fixtures/cursor-agent-session.jsonl
+++ b/sdk/packages/core/src/services/session-import/fixtures/cursor-agent-session.jsonl
@@ -1,0 +1,6 @@
+{"type":"session","cwd":"/workspace/demo","title":"Fix parser bug","timestamp":"2026-01-03T10:00:00.000Z"}
+{"role":"user","content":"fix the parser","timestamp":"2026-01-03T10:00:01.000Z"}
+{"role":"assistant","provider":"anthropic","model":"claude-sonnet","content":[{"type":"text","text":"I will inspect it."},{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\"path\":\"parser.ts\"}"}],"timestamp":"2026-01-03T10:00:02.000Z"}
+{"role":"user","content":[{"type":"function_call_output","call_id":"call_1","output":"export function parse() {}"}],"timestamp":"2026-01-03T10:00:03.000Z"}
+{"role":"assistant","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,ZmFrZQ=="}}],"timestamp":"2026-01-03T10:00:04.000Z"}
+not json

--- a/sdk/packages/core/src/services/session-import/index.ts
+++ b/sdk/packages/core/src/services/session-import/index.ts
@@ -4,6 +4,10 @@ export {
 } from "./claude-code";
 export { type CodexAdapterOptions, CodexImportAdapter } from "./codex";
 export {
+	type CursorAdapterOptions,
+	CursorImportAdapter,
+} from "./cursor";
+export {
 	type OpencodeAdapterOptions,
 	OpencodeImportAdapter,
 } from "./opencode";

--- a/sdk/packages/core/src/services/session-import/index.ts
+++ b/sdk/packages/core/src/services/session-import/index.ts
@@ -6,6 +6,10 @@ export { type CodexAdapterOptions, CodexImportAdapter } from "./codex";
 export {
 	type CursorAdapterOptions,
 	CursorImportAdapter,
+	cursorProjectId,
+	cursorTranscriptDisplayText,
+	isParentAgentTranscriptFile,
+	resolveCursorProjectsDir,
 } from "./cursor";
 export {
 	type OpencodeAdapterOptions,
@@ -17,6 +21,7 @@ export {
 } from "./sanitize";
 export {
 	type ImportedFromMetadata,
+	importSummaryBelongsToWorkspace,
 	readImportedFromMetadata,
 	SessionImportService,
 } from "./service";

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -4,7 +4,7 @@ import { SessionSource } from "../../types/common";
 import { ensureChatWorkspace } from "../workspace/chat-workspace";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
-import { CursorImportAdapter } from "./cursor";
+import { CursorImportAdapter, cursorProjectId } from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import { sanitizeImportedMessages } from "./sanitize";
 import type {
@@ -128,9 +128,18 @@ export class SessionImportService {
 		try {
 			for (const adapter of this.adapters) {
 				try {
-					if (!adapter.isInstalled()) continue;
-					for (const summary of adapter.discover()) {
-						if (options.workspaceRoot && summary.cwd && !workspaceMatches(summary.cwd, options.workspaceRoot)) {
+					// Cursor transcripts often omit cwd; scan all project folders
+					// and apply workspace filtering after parsing each transcript.
+					const active =
+						adapter.tool === "cursor" && options.workspaceRoot
+							? new CursorImportAdapter({ workspaceRoot: options.workspaceRoot })
+							: adapter;
+					if (!active.isInstalled()) continue;
+					for (const summary of active.discover()) {
+						if (
+							options.workspaceRoot &&
+							!importSummaryBelongsToWorkspace(summary, options.workspaceRoot)
+						) {
 							continue;
 						}
 						const alreadyImportedSessionId = existing.get(
@@ -381,4 +390,20 @@ function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
 		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
 		normalizedRoot.startsWith(`${normalizedCwd}/`)
 	);
+}
+
+export function importSummaryBelongsToWorkspace(
+	summary: ImportableSessionSummary,
+	workspaceRoot: string,
+): boolean {
+	if (summary.cwd) {
+		return workspaceMatches(summary.cwd, workspaceRoot);
+	}
+	if (summary.tool === "cursor") {
+		const projectId = cursorProjectId(workspaceRoot);
+		const sourceId = summary.sourceId.replace(/\\/g, "/");
+		return sourceId === projectId || sourceId.startsWith(`${projectId}/`);
+	}
+	// Other importers either stamp cwd or already scoped their scan.
+	return true;
 }

--- a/sdk/packages/core/src/services/session-import/service.ts
+++ b/sdk/packages/core/src/services/session-import/service.ts
@@ -4,6 +4,7 @@ import { SessionSource } from "../../types/common";
 import { ensureChatWorkspace } from "../workspace/chat-workspace";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
+import { CursorImportAdapter } from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import { sanitizeImportedMessages } from "./sanitize";
 import type {
@@ -71,6 +72,7 @@ export class SessionImportService {
 		this.adapters = adapters ?? [
 			new ClaudeCodeImportAdapter(),
 			new CodexImportAdapter(),
+			new CursorImportAdapter(),
 			new OpencodeImportAdapter(),
 		];
 	}
@@ -120,7 +122,7 @@ export class SessionImportService {
 		}
 	}
 
-	async discover(): Promise<ImportableSessionSummary[]> {
+	async discover(options: Pick<SessionImportOptions, "workspaceRoot"> = {}): Promise<ImportableSessionSummary[]> {
 		const existing = await this.existingImports();
 		const out: ImportableSessionSummary[] = [];
 		try {
@@ -128,6 +130,9 @@ export class SessionImportService {
 				try {
 					if (!adapter.isInstalled()) continue;
 					for (const summary of adapter.discover()) {
+						if (options.workspaceRoot && summary.cwd && !workspaceMatches(summary.cwd, options.workspaceRoot)) {
+							continue;
+						}
 						const alreadyImportedSessionId = existing.get(
 							importKey(summary.tool, summary.sourceId),
 						);
@@ -366,4 +371,14 @@ export class SessionImportService {
 
 		return sessionId;
 	}
+}
+
+function workspaceMatches(cwd: string, workspaceRoot: string): boolean {
+	const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+	const normalizedRoot = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+	return (
+		normalizedCwd === normalizedRoot ||
+		normalizedCwd.startsWith(`${normalizedRoot}/`) ||
+		normalizedRoot.startsWith(`${normalizedCwd}/`)
+	);
 }

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -13,6 +13,7 @@ import { CoreSessionService } from "../../session/services/session-service";
 import { SqliteSessionStore } from "../storage/sqlite-session-store";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
+import { CursorImportAdapter } from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import {
 	IMPORT_MISSING_TOOL_RESULT_TEXT,
@@ -258,6 +259,138 @@ describe("ClaudeCodeImportAdapter", () => {
 		);
 		const adapter = new ClaudeCodeImportAdapter({ projectsDir });
 		expect(adapter.discover()).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cursor fixtures
+// ---------------------------------------------------------------------------
+
+function writeCursorFixture(projectsDir: string): void {
+	const projectDir = join(projectsDir, "workspace-demo", "agent-transcripts");
+	mkdirSync(projectDir, { recursive: true });
+	writeFileSync(
+		join(projectDir, "cursor-chat.jsonl"),
+		[
+			{
+				type: "session",
+				cwd: "/workspace/demo",
+				title: "Fix parser bug",
+				timestamp: "2026-01-03T10:00:00.000Z",
+			},
+			{
+				role: "user",
+				content: "fix the parser",
+				timestamp: "2026-01-03T10:00:01.000Z",
+			},
+			{
+				role: "assistant",
+				provider: "anthropic",
+				model: "claude-sonnet",
+				content: [
+					{ type: "text", text: "I will inspect it." },
+					{
+						type: "function_call",
+						call_id: "call_1",
+						name: "read_file",
+						arguments: '{"path":"parser.ts"}',
+					},
+				],
+				timestamp: "2026-01-03T10:00:02.000Z",
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "function_call_output",
+						call_id: "call_1",
+						output: "export function parse() {}",
+					},
+				],
+				timestamp: "2026-01-03T10:00:03.000Z",
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "image_url",
+						image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+					},
+				],
+				timestamp: "2026-01-03T10:00:04.000Z",
+			},
+			"not json",
+		]
+			.map((line) => (typeof line === "string" ? line : JSON.stringify(line)))
+			.join("\n") + "\n",
+	);
+
+	const otherProjectDir = join(projectsDir, "other-project");
+	mkdirSync(otherProjectDir, { recursive: true });
+	writeFileSync(
+		join(otherProjectDir, "other.jsonl"),
+		JSON.stringify({
+			cwd: "/workspace/other",
+			role: "user",
+			content: "other",
+		}) + "\n",
+	);
+}
+
+describe("CursorImportAdapter", () => {
+	it("discovers matching JSONL chats and preserves standard content blocks", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeCursorFixture(projectsDir);
+		const adapter = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/workspace/demo",
+		});
+
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].sourceId).toBe(
+			"workspace-demo/agent-transcripts/cursor-chat",
+		);
+		expect(discovered[0].title).toBe("Fix parser bug");
+		expect(discovered[0].preview).toBe("fix the parser");
+
+		const converted = adapter.convert(discovered[0].sourceId);
+		expect(converted.provider).toBe("anthropic");
+		expect(converted.model).toBe("claude-sonnet");
+		expect(converted.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+		]);
+		expect(blocks(converted.messages[1])).toEqual([
+			{ type: "text", text: "I will inspect it." },
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "read_file",
+				input: { path: "parser.ts" },
+			},
+		]);
+		expect(blocks(converted.messages[2])[0]).toMatchObject({
+			type: "tool_result",
+			tool_use_id: "call_1",
+		});
+		expect(blocks(converted.messages[3])[0]).toMatchObject({
+			type: "image",
+			mediaType: "image/png",
+			data: "ZmFrZQ==",
+		});
+	});
+
+	it("isolates malformed files and supports an unfiltered workspace", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeCursorFixture(projectsDir);
+		const adapter = new CursorImportAdapter({ projectsDir });
+		expect(adapter.discover()).toHaveLength(2);
+		expect(() => adapter.convert("missing")).toThrow(
+			"Cursor session missing not found",
+		);
 	});
 });
 

--- a/sdk/packages/core/src/services/session-import/session-import.test.ts
+++ b/sdk/packages/core/src/services/session-import/session-import.test.ts
@@ -3,6 +3,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	rmSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,13 +14,17 @@ import { CoreSessionService } from "../../session/services/session-service";
 import { SqliteSessionStore } from "../storage/sqlite-session-store";
 import { ClaudeCodeImportAdapter } from "./claude-code";
 import { CodexImportAdapter } from "./codex";
-import { CursorImportAdapter } from "./cursor";
+import {
+	CursorImportAdapter,
+	cursorTranscriptDisplayText,
+	resolveCursorProjectsDir,
+} from "./cursor";
 import { OpencodeImportAdapter } from "./opencode";
 import {
 	IMPORT_MISSING_TOOL_RESULT_TEXT,
 	sanitizeImportedMessages,
 } from "./sanitize";
-import { SessionImportService } from "./service";
+import { SessionImportService, importSummaryBelongsToWorkspace } from "./service";
 
 const tempDirs: string[] = [];
 const openStores: SqliteSessionStore[] = [];
@@ -266,75 +271,92 @@ describe("ClaudeCodeImportAdapter", () => {
 // Cursor fixtures
 // ---------------------------------------------------------------------------
 
-function writeCursorFixture(projectsDir: string): void {
-	const projectDir = join(projectsDir, "workspace-demo", "agent-transcripts");
-	mkdirSync(projectDir, { recursive: true });
+function writeParentCursorTranscript(
+	projectsDir: string,
+	projectId: string,
+	sessionId: string,
+	lines: unknown[],
+): string {
+	const chatDir = join(
+		projectsDir,
+		projectId,
+		"agent-transcripts",
+		sessionId,
+	);
+	mkdirSync(chatDir, { recursive: true });
+	const file = join(chatDir, `${sessionId}.jsonl`);
 	writeFileSync(
-		join(projectDir, "cursor-chat.jsonl"),
+		file,
+		lines.map((line) => JSON.stringify(line)).join("\n") + "\n",
+	);
+	return file;
+}
+
+function writeCursorFixture(projectsDir: string): void {
+	writeParentCursorTranscript(projectsDir, "workspace-demo", "cursor-chat", [
+		{
+			type: "session",
+			cwd: "/workspace/demo",
+			title: "Fix parser bug",
+			timestamp: "2026-01-03T10:00:00.000Z",
+		},
+		{
+			role: "user",
+			content: "fix the parser",
+			timestamp: "2026-01-03T10:00:01.000Z",
+		},
+		{
+			role: "assistant",
+			provider: "anthropic",
+			model: "claude-sonnet",
+			content: [
+				{ type: "text", text: "I will inspect it." },
+				{
+					type: "function_call",
+					call_id: "call_1",
+					name: "read_file",
+					arguments: '{"path":"parser.ts"}',
+				},
+			],
+			timestamp: "2026-01-03T10:00:02.000Z",
+		},
+		{
+			role: "user",
+			content: [
+				{
+					type: "function_call_output",
+					call_id: "call_1",
+					output: "export function parse() {}",
+				},
+			],
+			timestamp: "2026-01-03T10:00:03.000Z",
+		},
+		{
+			role: "assistant",
+			content: [
+				{
+					type: "image_url",
+					image_url: { url: "data:image/png;base64,ZmFrZQ==" },
+				},
+			],
+			timestamp: "2026-01-03T10:00:04.000Z",
+		},
+	]);
+
+	const otherFile = writeParentCursorTranscript(
+		projectsDir,
+		"other-project",
+		"other-session",
 		[
 			{
-				type: "session",
-				cwd: "/workspace/demo",
-				title: "Fix parser bug",
-				timestamp: "2026-01-03T10:00:00.000Z",
-			},
-			{
+				cwd: "/workspace/other",
 				role: "user",
-				content: "fix the parser",
-				timestamp: "2026-01-03T10:00:01.000Z",
+				content: "other",
+				timestamp: "2026-01-04T10:00:00.000Z",
 			},
-			{
-				role: "assistant",
-				provider: "anthropic",
-				model: "claude-sonnet",
-				content: [
-					{ type: "text", text: "I will inspect it." },
-					{
-						type: "function_call",
-						call_id: "call_1",
-						name: "read_file",
-						arguments: '{"path":"parser.ts"}',
-					},
-				],
-				timestamp: "2026-01-03T10:00:02.000Z",
-			},
-			{
-				role: "user",
-				content: [
-					{
-						type: "function_call_output",
-						call_id: "call_1",
-						output: "export function parse() {}",
-					},
-				],
-				timestamp: "2026-01-03T10:00:03.000Z",
-			},
-			{
-				role: "assistant",
-				content: [
-					{
-						type: "image_url",
-						image_url: { url: "data:image/png;base64,ZmFrZQ==" },
-					},
-				],
-				timestamp: "2026-01-03T10:00:04.000Z",
-			},
-			"not json",
-		]
-			.map((line) => (typeof line === "string" ? line : JSON.stringify(line)))
-			.join("\n") + "\n",
+		],
 	);
-
-	const otherProjectDir = join(projectsDir, "other-project");
-	mkdirSync(otherProjectDir, { recursive: true });
-	writeFileSync(
-		join(otherProjectDir, "other.jsonl"),
-		JSON.stringify({
-			cwd: "/workspace/other",
-			role: "user",
-			content: "other",
-		}) + "\n",
-	);
+	writeFileSync(otherFile, readFileSync(otherFile, "utf8") + "not json\n");
 }
 
 describe("CursorImportAdapter", () => {
@@ -349,7 +371,7 @@ describe("CursorImportAdapter", () => {
 		const discovered = adapter.discover();
 		expect(discovered).toHaveLength(1);
 		expect(discovered[0].sourceId).toBe(
-			"workspace-demo/agent-transcripts/cursor-chat",
+			"workspace-demo/agent-transcripts/cursor-chat/cursor-chat",
 		);
 		expect(discovered[0].title).toBe("Fix parser bug");
 		expect(discovered[0].preview).toBe("fix the parser");
@@ -383,6 +405,222 @@ describe("CursorImportAdapter", () => {
 		});
 	});
 
+	it("scopes empty-cwd transcripts to the Cursor project folder for the workspace", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			"hermes-chat",
+			[
+				{
+					role: "user",
+					content: "hermes only prompt",
+					timestamp: "2026-01-04T10:00:00.000Z",
+				},
+			],
+		);
+		writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-cline",
+			"cline-chat",
+			[
+				{
+					role: "user",
+					content: "cline only prompt",
+					timestamp: "2026-01-04T11:00:00.000Z",
+				},
+			],
+		);
+
+		const adapter = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/hermes-cloud",
+		});
+		const discovered = adapter.discover();
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].preview).toBe("hermes only prompt");
+		expect(discovered[0].sourceId).toContain("Users-ue-projects-hermes-cloud");
+	});
+
+	it("strips Cursor transcript envelope tags from imported titles", () => {
+		expect(
+			cursorTranscriptDisplayText(
+				"<timestamp>Monday, Sep 7, 2026, 1:12 AM (UTC+3)</timestamp> <user_query>why in hermes production only 1 task is running at a time?</user_query>",
+			),
+		).toBe("why in hermes production only 1 task is running at a time?");
+
+		const projectsDir = tempDir("cursor-import-");
+		const chatDir = join(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			"agent-transcripts",
+			"ef8f7409-f7fa-4c69-91b5-31bcd70f7c41",
+		);
+		mkdirSync(chatDir, { recursive: true });
+		writeFileSync(
+			join(chatDir, "ef8f7409-f7fa-4c69-91b5-31bcd70f7c41.jsonl"),
+			JSON.stringify({
+				role: "user",
+				message: {
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "<timestamp>Sunday, Sep 6, 2026, 11:57 PM (UTC+3)</timestamp> <user_query>why in hermes production only 1 task is running at a time?</user_query>",
+						},
+					],
+				},
+			}) + "\n",
+		);
+
+		const discovered = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/hermes-cloud",
+		}).discover();
+
+		expect(discovered).toHaveLength(1);
+		expect(discovered[0].title).toBe(
+			"why in hermes production only 1 task is running at a time?",
+		);
+		expect(discovered[0].preview).toBe(
+			"why in hermes production only 1 task is running at a time?",
+		);
+	});
+
+	it("keeps Cursor imports out of other workspace folders at discovery time", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			"hermes-chat",
+			[
+				{
+					role: "user",
+					content: "hermes only prompt",
+					timestamp: "2026-01-04T10:00:00.000Z",
+				},
+			],
+		);
+		writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-cline",
+			"cline-chat",
+			[
+				{
+					role: "user",
+					content: "cline only prompt",
+					timestamp: "2026-01-04T11:00:00.000Z",
+				},
+			],
+		);
+
+		const hermesSummary = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/hermes-cloud",
+		})
+			.discover()
+			.find((summary) => summary.preview === "hermes only prompt");
+		const clineSummary = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/cline",
+		})
+			.discover()
+			.find((summary) => summary.preview === "cline only prompt");
+
+		expect(hermesSummary).toBeDefined();
+		expect(clineSummary).toBeDefined();
+		expect(
+			importSummaryBelongsToWorkspace(
+				hermesSummary!,
+				"/Users/ue/projects/hermes-cloud",
+			),
+		).toBe(true);
+		expect(
+			importSummaryBelongsToWorkspace(
+				hermesSummary!,
+				"/Users/ue/projects/cline",
+			),
+		).toBe(false);
+		expect(
+			importSummaryBelongsToWorkspace(
+				clineSummary!,
+				"/Users/ue/projects/cline",
+			),
+		).toBe(true);
+		expect(
+			importSummaryBelongsToWorkspace(
+				clineSummary!,
+				"/Users/ue/projects/hermes-cloud",
+			),
+		).toBe(false);
+	});
+
+	it("excludes numeric Cursor project folders with empty cwd when workspace filter is on", () => {
+		const projectsDir = tempDir("cursor-import-");
+		writeParentCursorTranscript(
+			projectsDir,
+			"1780466345848",
+			"numeric-chat",
+			[{ role: "user", content: "numeric folder prompt" }],
+		);
+
+		const filtered = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/hermes-cloud",
+		}).discover();
+		expect(filtered).toHaveLength(0);
+
+		expect(new CursorImportAdapter({ projectsDir }).discover()).toHaveLength(1);
+	});
+
+	it("ignores subagent transcripts and sorts parent sessions by file mtime", () => {
+		const projectsDir = tempDir("cursor-import-");
+		const parentId = "11111111-1111-1111-1111-111111111111";
+		const parentFile = writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			parentId,
+			[{ role: "user", content: "parent prompt" }],
+		);
+		const subagentsDir = join(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			"agent-transcripts",
+			parentId,
+			"subagents",
+		);
+		mkdirSync(subagentsDir, { recursive: true });
+		writeFileSync(
+			join(subagentsDir, "22222222-2222-2222-2222-222222222222.jsonl"),
+			JSON.stringify({ role: "user", content: "subagent prompt" }) + "\n",
+		);
+
+		const newerId = "33333333-3333-3333-3333-333333333333";
+		const newerFile = writeParentCursorTranscript(
+			projectsDir,
+			"Users-ue-projects-hermes-cloud",
+			newerId,
+			[{ role: "user", content: "newer parent prompt" }],
+		);
+
+		const olderTime = new Date("2026-01-01T10:00:00.000Z");
+		const newerTime = new Date("2026-01-02T10:00:00.000Z");
+		utimesSync(parentFile, olderTime, olderTime);
+		utimesSync(newerFile, newerTime, newerTime);
+
+		const discovered = new CursorImportAdapter({
+			projectsDir,
+			workspaceRoot: "/Users/ue/projects/hermes-cloud",
+		}).discover();
+
+		expect(discovered).toHaveLength(2);
+		expect(discovered[0].title).toBe("newer parent prompt");
+		expect(discovered[1].title).toBe("parent prompt");
+		expect(discovered.some((item) => item.title === "subagent prompt")).toBe(
+			false,
+		);
+	});
+
 	it("isolates malformed files and supports an unfiltered workspace", () => {
 		const projectsDir = tempDir("cursor-import-");
 		writeCursorFixture(projectsDir);
@@ -391,6 +629,30 @@ describe("CursorImportAdapter", () => {
 		expect(() => adapter.convert("missing")).toThrow(
 			"Cursor session missing not found",
 		);
+	});
+
+	it("returns an empty discover result when the projects directory is missing", () => {
+		const projectsDir = join(tempDir("cursor-import-"), "missing-cursor-projects");
+		const adapter = new CursorImportAdapter({ projectsDir });
+		expect(adapter.isInstalled()).toBe(false);
+		expect(adapter.discover()).toEqual([]);
+	});
+
+	it("resolves Cursor projects dir from options and env override", () => {
+		const customDir = join(tempDir("cursor-import-"), "custom-projects");
+		expect(resolveCursorProjectsDir({ projectsDir: customDir })).toBe(customDir);
+
+		const previous = process.env.CURSOR_PROJECTS_DIR;
+		process.env.CURSOR_PROJECTS_DIR = customDir;
+		try {
+			expect(resolveCursorProjectsDir()).toBe(customDir);
+		} finally {
+			if (previous === undefined) {
+				delete process.env.CURSOR_PROJECTS_DIR;
+			} else {
+				process.env.CURSOR_PROJECTS_DIR = previous;
+			}
+		}
 	});
 });
 

--- a/sdk/packages/core/src/services/session-import/types.ts
+++ b/sdk/packages/core/src/services/session-import/types.ts
@@ -5,6 +5,7 @@ export const SESSION_IMPORT_TOOLS = [
 	"claude-code",
 	"codex",
 	"opencode",
+	"cursor",
 ] as const;
 
 export type SessionImportTool = (typeof SESSION_IMPORT_TOOLS)[number];
@@ -13,6 +14,7 @@ export const SESSION_IMPORT_TOOL_LABELS: Record<SessionImportTool, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	opencode: "opencode",
+	cursor: "Cursor",
 };
 
 /**
@@ -76,6 +78,8 @@ export interface SessionImportRequest {
 }
 
 export interface SessionImportOptions {
+	/** Optional workspace filter used during source discovery. */
+	workspaceRoot?: string;
 	/**
 	 * Cline provider/model the imported sessions should resume with. Opening a
 	 * history session adopts the row's provider/model, so without this the


### PR DESCRIPTION
## Summary

- Add a Cursor Agent JSONL transcript importer in `@cline/core` that discovers parent `agent-transcripts/<uuid>/<uuid>.jsonl` files under `{home}/.cursor/projects/`
- Show unimported Cursor sessions in the VS Code History view with a `CURSOR` badge, transcript-derived titles, and lazy import on open
- Scan all Cursor project folders (path slugs and numeric IDs), then filter to open workspace folder(s); History defaults to **Workspace Only**

## Design notes

- Transcript-only titles via `cursorTranscriptDisplayText()` — no Cursor SQLite / composer DB join
- Workspace filter prefers transcript `cwd`; falls back to path-slug folder name; excludes numeric folders with empty `cwd` when filtering
- Fail-soft when `~/.cursor/projects` is missing; optional `CURSOR_PROJECTS_DIR` override

## Test plan

- [x] `bun run build:sdk`
- [x] `bunx vitest run src/services/session-import/session-import.test.ts src/runtime/host/local-runtime-host.session-import.test.ts` in `sdk/packages/core` (25 passed)
- [x] `bun test src/sdk/sdk-task-history-import.test.ts src/sdk/history-order.test.ts` in `apps/vscode` (4 passed)
- [ ] Manual: open History in EDH with a workspace that has local Cursor Agent transcripts; confirm CURSOR rows, Workspace Only default, and lazy import


Made with [Cursor](https://cursor.com)