### PR TITLE
Render reloaded detached commands from host-resolved state

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -1069,9 +1069,11 @@ describe("useChatSession", () => {
 
 	it("settles a reloaded detached command row on its completion", async () => {
 		// A client that reloads mid-flight hydrates the detached command's
-		// persisted row from disk. The row must claim no outcome but stay
-		// routable, so the detached-completion event for the still-running
-		// process settles it in place instead of being dropped.
+		// row from disk; the sidecar resolved the state while serving the
+		// read (the markers could not prove anything here) and stamped the
+		// row claiming no outcome. The webview enrolls that stamp so the
+		// detached-completion event for the still-running process settles
+		// the row in place instead of being dropped.
 		const sessionId = "session-reloaded-detached";
 		invokeMock.mockImplementation(
 			async (command: string, args?: Record<string, unknown>) => {
@@ -1102,7 +1104,9 @@ describe("useChatSession", () => {
 							meta: {
 								toolName: "run_commands",
 								toolCallId: "call-reloaded",
-								hookEventName: "history_tool_result",
+								toolBackgroundStatus: "indeterminate",
+								toolBackgroundLogPath: "/tmp/output.log",
+								hookEventName: "tool_call_end",
 							},
 						},
 						{
@@ -1159,7 +1163,8 @@ describe("useChatSession", () => {
 			toolBackgroundLogPath: "/tmp/output.log",
 			hookEventName: "tool_call_end",
 		});
-		// A row whose result never detached is not stamped and not enrolled.
+		// A row whose result never detached is untouched by enrichment and
+		// not enrolled.
 		const plainRow = current.messages.find(
 			(message) => message.id === "history-tool-plain",
 		);
@@ -1228,6 +1233,246 @@ describe("useChatSession", () => {
 			(message) => message.id === "history-tool-plain",
 		);
 		expect(untouchedRow?.meta?.toolBackgroundStatus).toBeUndefined();
+	});
+
+	it("renders a reloaded running detached row and settles it on completion", async () => {
+		// The sidecar confirmed the process behind this row is still alive
+		// while serving the hydration read, so the reloaded client renders it
+		// running — spinner, expanded turn — with the execution id enrolled;
+		// the completion event then settles it in place.
+		const sessionId = "session-reloaded-running";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "read_session_messages") {
+					return [
+						{
+							id: "history-user",
+							sessionId,
+							role: "user",
+							content: "Run it",
+							createdAt: 1,
+						},
+						{
+							id: "history-tool-running",
+							sessionId,
+							role: "tool",
+							content: JSON.stringify({
+								toolName: "run_commands",
+								input: { commands: ["sleep 60"] },
+								result:
+									"[Command is still running. Output will continue in /tmp/output.log]",
+								isError: false,
+							}),
+							createdAt: 2,
+							meta: {
+								toolName: "run_commands",
+								toolCallId: "call-running",
+								toolBackgroundStatus: "running",
+								toolBackgroundLogPath: "/tmp/output.log",
+								toolExecutionIds: ["execution-running"],
+								hookEventName: "tool_call_start",
+							},
+						},
+						{
+							id: "history-assistant",
+							sessionId,
+							role: "assistant",
+							content: "It is running in the background.",
+							createdAt: 3,
+						},
+					];
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "attach") {
+						return {
+							sessionId,
+							status: "running",
+							provider: "cline",
+							model: "test-model",
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+				}
+				return { promptsInQueue: [] };
+			},
+		);
+		await act(async () => {
+			await current.hydrateSession({
+				sessionId,
+				status: "running",
+				provider: "cline",
+				model: "test-model",
+				cwd: "/workspace/cline",
+				workspaceRoot: "/workspace/cline",
+				startedAt: "2026-09-07T00:00:00.000Z",
+			});
+		});
+		const runningRow = current.messages.find(
+			(message) => message.id === "history-tool-running",
+		);
+		expect(runningRow?.meta).toMatchObject({
+			toolBackgroundStatus: "running",
+			toolBackgroundLogPath: "/tmp/output.log",
+			toolExecutionIds: ["execution-running"],
+			hookEventName: "tool_call_start",
+		});
+
+		// The enrolled execution id keeps the row running through a post-turn
+		// canonical reconcile, and the completion event — carrying that same
+		// execution id — settles it.
+		const chatEventHandler = handlerFor("chat_event");
+		await act(async () => {
+			chatEventHandler({
+				sessionId,
+				stream: "chat_tool_call_update",
+				chunk: JSON.stringify({
+					toolCallId: "call-running",
+					toolName: "run_commands",
+					update: {
+						executionId: "execution-running",
+						detached: true,
+						completed: true,
+						logPath: "/tmp/output.log",
+						outcome: { kind: "exited", exitCode: 0 },
+					},
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 60));
+		});
+		const settledRow = current.messages.find(
+			(message) => message.id === "history-tool-running",
+		);
+		expect(settledRow?.meta).toMatchObject({
+			toolBackgroundStatus: "succeeded",
+			toolBackgroundLogPath: "/tmp/output.log",
+			hookEventName: "tool_call_end",
+		});
+		expect(settledRow?.meta?.toolOutput).toContain(
+			"[Detached command completed with exit code 0]",
+		);
+	});
+
+	it("hydrates a row that completed while the client was away already settled", async () => {
+		// The sidecar reconstructed the outcome from the detached log's
+		// completion marker, so the reloaded client sees the row settled with
+		// its note instead of a stale still-running notice.
+		const sessionId = "session-reloaded-settled";
+		const note = "[Detached command completed with exit code 0]";
+		const notice =
+			"[Command is still running. Output will continue in /tmp/output.log]";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "read_session_messages") {
+					return [
+						{
+							id: "history-user",
+							sessionId,
+							role: "user",
+							content: "Run it",
+							createdAt: 1,
+						},
+						{
+							id: "history-tool-settled",
+							sessionId,
+							role: "tool",
+							content: JSON.stringify({
+								toolName: "run_commands",
+								input: { commands: ["sleep 60"] },
+								result: notice,
+								isError: false,
+							}),
+							createdAt: 2,
+							meta: {
+								toolName: "run_commands",
+								toolCallId: "call-settled",
+								toolBackgroundStatus: "succeeded",
+								toolBackgroundLogPath: "/tmp/output.log",
+								toolOutput: `${notice}\n${note}`,
+								hookEventName: "tool_call_end",
+							},
+						},
+						{
+							id: "history-assistant",
+							sessionId,
+							role: "assistant",
+							content: "It is running in the background.",
+							createdAt: 3,
+						},
+					];
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "attach") {
+						return {
+							sessionId,
+							status: "completed",
+							provider: "cline",
+							model: "test-model",
+							cwd: "/workspace/cline",
+							workspaceRoot: "/workspace/cline",
+						};
+					}
+				}
+				return { promptsInQueue: [] };
+			},
+		);
+		await act(async () => {
+			await current.hydrateSession({
+				sessionId,
+				status: "completed",
+				provider: "cline",
+				model: "test-model",
+				cwd: "/workspace/cline",
+				workspaceRoot: "/workspace/cline",
+				startedAt: "2026-09-07T00:00:00.000Z",
+			});
+		});
+		const settledRow = current.messages.find(
+			(message) => message.id === "history-tool-settled",
+		);
+		expect(settledRow?.meta).toMatchObject({
+			toolBackgroundStatus: "succeeded",
+			toolBackgroundLogPath: "/tmp/output.log",
+			hookEventName: "tool_call_end",
+		});
+		expect(settledRow?.meta?.toolOutput).toBe(`${notice}\n${note}`);
+		// A settled row is not enrolled, so a stray duplicate completion for
+		// it goes nowhere.
+		const chatEventHandler = handlerFor("chat_event");
+		await act(async () => {
+			chatEventHandler({
+				sessionId,
+				stream: "chat_tool_call_update",
+				chunk: JSON.stringify({
+					toolCallId: "call-settled",
+					toolName: "run_commands",
+					update: {
+						executionId: "execution-settled",
+						detached: true,
+						completed: true,
+						logPath: "/tmp/output.log",
+						outcome: { kind: "exited", exitCode: 0 },
+					},
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 60));
+		});
+		const afterRow = current.messages.find(
+			(message) => message.id === "history-tool-settled",
+		);
+		expect(afterRow?.meta?.toolOutput).toBe(`${notice}\n${note}`);
 	});
 
 	it("heals a running attached session with a dead event stream by polling history", async () => {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+	DetachedCommandOutcomeSchema,
+	detachedCommandBackgroundStatus,
+	formatDetachedCompletionNote,
+} from "@cline/shared/browser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	serializeAttachments,
@@ -117,26 +122,6 @@ type PendingToolOutput = {
 
 function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
-}
-
-/**
- * Renders a detached command's process outcome as the row's completion note.
- * Matches the completion notes VS Code's message-translator appends to detached
- * command rows so both hosts describe outcomes with the same vocabulary.
- */
-function formatDetachedCompletionNote(
-	outcome: Record<string, unknown>,
-): string {
-	if (outcome.kind === "exited") {
-		return `[Detached command completed with exit code ${outcome.exitCode}]`;
-	}
-	if (outcome.kind === "signaled") {
-		return `[Detached command ended from signal ${outcome.signal}]`;
-	}
-	if (outcome.kind === "hard_killed") {
-		return "[Detached command reached its hard deadline and was terminated]";
-	}
-	return `[Detached command failed: ${outcome.error}]`;
 }
 
 function makeErrorChatMessage(
@@ -268,74 +253,42 @@ function deriveLiveToolState(messages: ChatMessage[]): {
 	return { messageIds, inputs };
 }
 
-// The notice a command executor writes into a detached command's partial
-// output — the only persisted trace that a tool call ended by detaching
-// rather than completing. The SDK executor and VS Code's message-translator
-// use the same vocabulary.
-const DETACHED_COMMAND_NOTICE_PATTERN =
-	/\[Command is still running\. Output will continue in ([^\]]+)\]/;
-
 /**
- * Rebuilds detached-command routing from persisted history for a client that
- * did not watch the command detach — it reloaded mid-flight or reattached
- * while the process kept running. A marker row claims no outcome: persisted
- * history cannot tell a live process from one that finished while nobody was
- * listening, so the row is only marked running when this client still holds
- * the tool call's pending executions — the same predicate the live update,
- * tool-end, and canonical-hydration paths use, so a row cannot flip state
- * depending on which path ran last. Enrolling the row in the detached
- * routing refs means a later detached-completion event settles it in place,
- * exactly like a client that watched the detach.
+ * Derives the webview's detached-command bookkeeping from the row meta the
+ * sidecar resolved while serving the hydration read (see
+ * enrichDetachedCommandRows in the sidecar, and queryDetachedCommandState in
+ * core): the host reads the detached-log markers and stamps the row's
+ * background status, log path, and — for a process it confirmed still alive —
+ * the execution ids. This only enrolls that stamp in the routing refs so a
+ * later detached-completion event settles the row in place, exactly like a
+ * client that watched the detach; the webview never re-derives state from the
+ * tool result text.
  *
- * Only persisted-origin rows (history_* hook event names) are enrolled, so a
- * live row's routing can never be shadowed, and only rows without a
- * background status are stamped, so an existing claim is never overwritten.
+ * Live rows also carry these fields; enrolling them is idempotent because
+ * the live paths recorded the same routing and execution ids already.
  */
-function deriveDetachedToolRouting(
-	messages: ChatMessage[],
-	hasPendingDetachedExecutions: (toolCallId: string) => boolean,
-): {
-	stamped: ChatMessage[];
+function deriveDetachedToolEnrollment(messages: ChatMessage[]): {
 	routingIds: Record<string, string>;
 	endedToolCallIds: string[];
+	executionIdsByToolCall: Record<string, string[]>;
 } {
 	const routingIds: Record<string, string> = {};
 	const endedToolCallIds: string[] = [];
-	let changed = false;
-	const stamped = messages.map((message) => {
+	const executionIdsByToolCall: Record<string, string[]> = {};
+	for (const message of messages) {
 		const toolCallId = message.meta?.toolCallId;
-		const hookEventName = message.meta?.hookEventName;
-		if (
-			!toolCallId ||
-			(hookEventName !== "history_tool_result" &&
-				hookEventName !== "history_tool_use")
-		) {
-			return message;
-		}
-		const notice = DETACHED_COMMAND_NOTICE_PATTERN.exec(message.content);
-		if (!notice) return message;
+		if (!toolCallId) continue;
+		const status = message.meta?.toolBackgroundStatus;
+		if (status !== "running" && status !== "indeterminate") continue;
+		if (!message.meta?.toolBackgroundLogPath) continue;
 		routingIds[toolCallId] = message.id;
 		endedToolCallIds.push(toolCallId);
-		if (message.meta?.toolBackgroundStatus !== undefined) return message;
-		changed = true;
-		const running = hasPendingDetachedExecutions(toolCallId);
-		return {
-			...message,
-			meta: {
-				...message.meta,
-				toolBackgroundStatus: running
-					? ("running" as const)
-					: ("indeterminate" as const),
-				toolBackgroundLogPath: notice[1],
-				hookEventName: running ? "tool_call_start" : "tool_call_end",
-			},
-		};
-	});
-	return {
-		stamped: changed ? stamped : messages,
-		routingIds,
-		endedToolCallIds,
-	};
+		const executionIds = message.meta?.toolExecutionIds;
+		if (Array.isArray(executionIds) && executionIds.length > 0) {
+			executionIdsByToolCall[toolCallId] = executionIds;
+		}
+	}
+	return { routingIds, endedToolCallIds, executionIdsByToolCall };
 }
 
 function updateMessageById(
@@ -784,16 +737,17 @@ export function useChatSession() {
 					// its completion knows it is still alive, so the row stays
 					// running and its turn stays expanded until the completion
 					// event settles it. Without pending executions — a client
-					// that reloaded mid-flight, or a row already reconstructed
-					// as unsettled — persisted history cannot tell a running
-					// process from one that finished while nobody was listening,
-					// so the row claims no outcome. Hydration re-enrolls such
-					// rows in the detached routing refs (see
-					// deriveDetachedToolRouting), so a later completion event
-					// settles them in place.
-					// TODO: Mark reloaded rows as running, with their execution
-					// ids, when the hub exposes an active-command query over the
-					// detached-log markers.
+					// that reloaded mid-flight, or a row the hydration snapshot
+					// could not resolve — the row claims no outcome. Hydration
+					// enrolls such rows in the detached routing refs (see
+					// deriveDetachedToolEnrollment), so a later completion event
+					// settles them in place. The sidecar resolves the underlying
+					// state from the detached-log markers while serving the read;
+					// rows whose process it confirmed alive hydrate as running,
+					// with their execution ids.
+					// TODO: Sessions driven through a hub on another host keep
+					// claiming no outcome until the hub can relay the
+					// active-command query.
 					const running = hasPendingDetachedExecutions(toolCallId);
 					return {
 						...message,
@@ -1571,17 +1525,14 @@ export function useChatSession() {
 						executionId,
 					);
 				}
+				// An outcome that does not parse is as good as none: the row
+				// reports failure rather than trusting a malformed payload.
+				const parsedOutcome = DetachedCommandOutcomeSchema.safeParse(outcome);
 				if (toolCallId && executionId && completed) {
 					detachedExecutionIdsRef.current[toolCallId]?.delete(executionId);
-					// Matches VS Code's commandStatus mapping in message-translator.
-					const nextStatus =
-						outcome?.kind === "exited" && outcome.exitCode === 0
-							? "succeeded"
-							: outcome?.kind === "hard_killed"
-								? "killed"
-								: outcome?.kind === "signaled"
-									? "indeterminate"
-									: "failed";
+					const nextStatus = parsedOutcome.success
+						? detachedCommandBackgroundStatus(parsedOutcome.data)
+						: "failed";
 					const previousStatus = detachedOutcomeStatusRef.current[toolCallId];
 					detachedOutcomeStatusRef.current[toolCallId] =
 						previousStatus === "killed" || nextStatus === "killed"
@@ -1623,11 +1574,11 @@ export function useChatSession() {
 				// both observation paths may deliver the same completion.
 				const completionNote =
 					completed &&
-					outcome &&
+					parsedOutcome.success &&
 					toolCallId &&
 					executionId &&
 					!detachedNotedExecutionIdsRef.current[toolCallId]?.has(executionId)
-						? formatDetachedCompletionNote(outcome)
+						? formatDetachedCompletionNote(parsedOutcome.data)
 						: "";
 				if (completionNote && toolCallId && executionId) {
 					(detachedNotedExecutionIdsRef.current[toolCallId] ??= new Set()).add(
@@ -2257,22 +2208,28 @@ export function useChatSession() {
 					const liveToolState = deriveLiveToolState(mergedMessages);
 					liveToolMessageIdsRef.current = liveToolState.messageIds;
 					liveToolInputsRef.current = liveToolState.inputs;
-					// Re-enroll detached-command rows for the same reason as
-					// hydration: this snapshot came from disk, where a
-					// detached row is an ended row.
-					const detachedToolState = deriveDetachedToolRouting(
-						mergedMessages,
-						hasPendingDetachedExecutions,
-					);
+					// Enroll the detached state this disk snapshot carries, for
+					// the same reason as hydration.
+					const detachedEnrollment =
+						deriveDetachedToolEnrollment(mergedMessages);
 					for (const [toolCallId, messageId] of Object.entries(
-						detachedToolState.routingIds,
+						detachedEnrollment.routingIds,
 					)) {
 						detachedToolMessageIdsRef.current[toolCallId] = messageId;
 					}
-					for (const toolCallId of detachedToolState.endedToolCallIds) {
+					for (const toolCallId of detachedEnrollment.endedToolCallIds) {
 						detachedToolEndedRef.current.add(toolCallId);
 					}
-					setMessages(detachedToolState.stamped);
+					for (const [toolCallId, executionIds] of Object.entries(
+						detachedEnrollment.executionIdsByToolCall,
+					)) {
+						const pending = (detachedExecutionIdsRef.current[toolCallId] ??=
+							new Set());
+						for (const executionId of executionIds) {
+							pending.add(executionId);
+						}
+					}
+					setMessages(mergedMessages);
 				}
 				// The record is the authority here: the sessions this poll
 				// serves have a live host maintaining their record, and it
@@ -2303,12 +2260,7 @@ export function useChatSession() {
 			cancelled = true;
 			window.clearInterval(interval);
 		};
-	}, [
-		hydratedHistorySessionId,
-		sessionId,
-		status,
-		hasPendingDetachedExecutions,
-	]);
+	}, [hydratedHistorySessionId, sessionId, status]);
 
 	// ---- Shared: start a new session via RPC ----
 
@@ -3304,24 +3256,31 @@ export function useChatSession() {
 				const liveToolState = deriveLiveToolState(mergedMessages);
 				liveToolMessageIdsRef.current = liveToolState.messageIds;
 				liveToolInputsRef.current = liveToolState.inputs;
-				// A detached command's persisted row is an ended row, so the
-				// derivation above drops it: without re-enrolling it here, a
-				// detached-completion event for a client that reloaded
-				// mid-flight resolves no message id and is dropped, leaving
-				// the row unsettled forever.
-				const detachedToolState = deriveDetachedToolRouting(
-					mergedMessages,
-					hasPendingDetachedExecutions,
-				);
+				// The sidecar resolved each detached row's lifecycle state while
+				// serving this read; enroll its stamp so a detached-completion
+				// event settles the row in place — without re-deriving anything
+				// here, a client that reloaded mid-flight would have no routing
+				// for its detached commands (an ended row gets none from the
+				// live derivation above) and the completion would be dropped.
+				const detachedEnrollment = deriveDetachedToolEnrollment(mergedMessages);
 				for (const [toolCallId, messageId] of Object.entries(
-					detachedToolState.routingIds,
+					detachedEnrollment.routingIds,
 				)) {
 					detachedToolMessageIdsRef.current[toolCallId] = messageId;
 				}
-				for (const toolCallId of detachedToolState.endedToolCallIds) {
+				for (const toolCallId of detachedEnrollment.endedToolCallIds) {
 					detachedToolEndedRef.current.add(toolCallId);
 				}
-				setMessages(detachedToolState.stamped);
+				for (const [toolCallId, executionIds] of Object.entries(
+					detachedEnrollment.executionIdsByToolCall,
+				)) {
+					const pending = (detachedExecutionIdsRef.current[toolCallId] ??=
+						new Set());
+					for (const executionId of executionIds) {
+						pending.add(executionId);
+					}
+				}
+				setMessages(mergedMessages);
 				setRawTranscript("");
 				resetCounters();
 				setStatus(inferHydratedChatStatus(sessionStatus, msgs));
@@ -3427,7 +3386,6 @@ export function useChatSession() {
 			clearAbortFallbackTimeout,
 			clearLiveToolRefs,
 			discardPendingStream,
-			hasPendingDetachedExecutions,
 			refreshPromptsInQueue,
 			refreshSessionDiffSummary,
 			resetStreamDedupe,

--- a/apps/examples/desktop-app/webview/lib/chat-schema.ts
+++ b/apps/examples/desktop-app/webview/lib/chat-schema.ts
@@ -70,6 +70,10 @@ export const ChatMessageSchema = z.object({
 				.enum(["running", "succeeded", "failed", "killed", "indeterminate"])
 				.optional(),
 			toolBackgroundLogPath: z.string().optional(),
+			// Set by the sidecar at hydration for a detached command whose
+			// process it confirmed still alive; the webview enrolls these so
+			// the completion event settles the row in place.
+			toolExecutionIds: z.array(z.string().min(1)).optional(),
 			iteration: z.number().int().nonnegative().optional(),
 			agentId: z.string().optional(),
 			conversationId: z.string().optional(),

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -1,5 +1,16 @@
 export * from "./agent";
 export * from "./agents";
+export {
+	DETACHED_COMMAND_NOTICE_PATTERN,
+	DetachedCommandOutcomeSchema,
+	detachedCommandBackgroundStatus,
+	formatDetachedCompletionNote,
+	matchDetachedCommandNotice,
+} from "./commands/detached";
+export type {
+	DetachedCommandBackgroundStatus,
+	DetachedCommandOutcome,
+} from "./commands/detached";
 export type {
 	ConnectorAuthorizationDecision,
 	ConnectorAuthorizationRequest,


### PR DESCRIPTION
Completes the TODO from #13731 using the host-resolved state from the PR below: the webview now consumes the sidecar's stamp instead of re-deriving state from the tool result text.

`deriveDetachedToolEnrollment` replaces the client-side notice matcher and stamping: rows the backend marked running or no-outcome are enrolled in the routing refs, and rows the backend confirmed alive also enroll their execution ids. A client that reloads mid-flight therefore renders a live detached command running — spinner, expanded turn — and the completion event settles it in place; a row that completed while nobody was listening arrives settled with its note, ending the stale "Command is still running" rendering. The completion-note formatter and outcome-to-status mapping now come from `@cline/shared` (same module the sidecar uses), and the completion event path validates the outcome payload before mapping it.

## Test plan

```
cd apps/examples/desktop-app && bun x vitest run webview/hooks/use-chat-session.test.tsx --config vitest.config.ts
cd apps/examples/desktop-app && bun x vitest run webview/components/views/chat webview/hooks --config vitest.config.ts
cd apps/examples/desktop-app && bun x tsc -p tsconfig.dev.json --noEmit
```

- 57/57 hook tests pass, including three new hydration tests: a running row (backend-stamped, with execution ids) stays running and settles when the completion event arrives carrying the enrolled id; a row that completed while away arrives settled with its note and ignores a stray duplicate completion; an unresolvable row claims no outcome and still settles on the event.
- Full suite across the stack (hooks + chat views + sidecar session-data): 222/222.
- Typecheck clean; biome clean.

Manual (desktop app built from this stack, with a long command that detaches at 30 s):

1. Reload mid-flight: start `Start-Sleep -Seconds 45`, proceed while running, then switch sessions and back at ~35 s. Expect the command row to show a spinner and the turn to stay expanded (not folded, not "no outcome"). At ~45 s expect "[Detached command completed with exit code 0]" in the row's output and the turn to fold.
2. Reload after completion: repeat but switch away and back at ~60 s, after the process exited. Expect the row to arrive settled (no spinner) with the completion note already in its output, and no stale "Command is still running" text.
3. Continuously connected (regression): proceed while running and stay. Expect unchanged behavior: row running through the reply, note at exit, fold after.
