### PR TITLE
fix(model-catalog): let an explicit vision opt-out reach the capability list

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/store.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.test.ts
@@ -632,6 +632,39 @@ describe("createProviderConfigStore", () => {
 		expect(syncStoredProviderRegistration).not.toHaveBeenCalled()
 	})
 
+	it("lets an explicit vision opt-out strip images from the resolved capability list", async () => {
+		// The scalar and the array are two spellings of one claim, and the SDK
+		// runtime reads the array when it is present. Flipping only the scalar
+		// left `supportsImages: false` beside `capabilities: [..., "images"]`,
+		// so a text-only local model kept being handed image blocks (#13694).
+		mocks.setGeneratedModels("openai-compatible", {
+			"vision-model": {
+				name: "Vision Model",
+				contextWindow: 256_000,
+				supportsPromptCache: false,
+				supportsImages: true,
+				capabilities: ["tools", "images"],
+			},
+		})
+		mocks.setModelsFile({
+			version: 1,
+			providers: {
+				"openai-compatible": { models: { "vision-model": { supportsVision: false } } },
+			},
+		})
+		mocks.setApiConfiguration({ actModeOpenAiModelId: "vision-model" })
+		const { createProviderConfigStore } = await import("./store")
+		const store = createProviderConfigStore()
+		const providerId = parseProviderId("openai")
+
+		const selection = store.readSelection(providerId, "act")
+
+		expect(selection?.modelInfo.supportsImages).toBe(false)
+		expect(selection?.modelInfo.capabilities ?? []).not.toContain("images")
+		// Only the capability the user turned off moves.
+		expect(selection?.modelInfo.capabilities ?? []).toContain("tools")
+	})
+
 	it("migrates separate Plan and Act legacy custom models independently", async () => {
 		mocks.setApiConfiguration({
 			planActSeparateModelsSetting: true,

--- a/apps/vscode/src/sdk/model-catalog/store.ts
+++ b/apps/vscode/src/sdk/model-catalog/store.ts
@@ -360,6 +360,30 @@ function writeModelOverrides(providerId: ProviderId, modelId: string, overrides:
 	syncStoredProviderRegistration(provider, state.providers[provider], nextProviderEntry)
 }
 
+/**
+ * Carry an explicit boolean into the capability array, which is the other
+ * spelling of the same claim. The array is what SDK checks read when it is
+ * present, so flipping only the scalar published two answers and let the wrong
+ * one win: `supportsImages: false` beside `capabilities: [..., "images"]`.
+ *
+ * An absent list stays absent. Checks fail open without one, and building a
+ * list here would make an override authoritative about every capability the
+ * user never mentioned.
+ */
+function withCapability(
+	capabilities: readonly string[] | undefined,
+	capability: string,
+	enabled: boolean,
+): readonly string[] | undefined {
+	if (capabilities === undefined) {
+		return undefined
+	}
+	if (capabilities.includes(capability) === enabled) {
+		return capabilities
+	}
+	return enabled ? [...capabilities, capability] : capabilities.filter((entry) => entry !== capability)
+}
+
 function applyModelOverrides(modelInfo: ModelInfo, overrides: ModelSelectionOverrides | undefined): ModelInfo {
 	if (!overrides) {
 		return modelInfo
@@ -394,8 +418,14 @@ function applyModelOverrides(modelInfo: ModelInfo, overrides: ModelSelectionOver
 			next.capabilities = [...new Set([...next.capabilities, ...overrides.capabilities])]
 		}
 	}
-	if (overrides.supportsVision !== undefined) next.supportsImages = overrides.supportsVision
-	if (overrides.supportsReasoning !== undefined) next.supportsReasoning = overrides.supportsReasoning
+	if (overrides.supportsVision !== undefined) {
+		next.supportsImages = overrides.supportsVision
+		next.capabilities = withCapability(next.capabilities, "images", overrides.supportsVision)
+	}
+	if (overrides.supportsReasoning !== undefined) {
+		next.supportsReasoning = overrides.supportsReasoning
+		next.capabilities = withCapability(next.capabilities, "reasoning", overrides.supportsReasoning)
+	}
 	return next
 }
 


### PR DESCRIPTION
Fixes the half of #13694 that is still live on `main`. The trace in that issue by @gregtakacs is accurate; I verified each part against `main` before touching anything.

## What was already fixed

The read/write key mismatch on the checkbox is gone. `OpenAICompatible.tsx` now reads `overrides.supportsVision ?? !!openAiModelInfo?.supportsImages` and writes `supportsVision`, so the control round-trips its own override.

## What was not

`applyModelOverrides` in `apps/vscode/src/sdk/model-catalog/store.ts` carried an explicit boolean into the scalar and stopped there:

```ts
if (overrides.supportsVision !== undefined) next.supportsImages = overrides.supportsVision
```

The comment directly above that block already states the intended contract, "Explicit booleans win when both representations are present", and the same comment notes that SDK checks "fail open only when the list is absent" — meaning the array is authoritative whenever it exists. So a `supportsVision: false` override produced a model that answered the question two ways:

```
supportsImages: false
capabilities:  ["tools", "images"]
```

and the array is the one downstream reads. A text-only local model kept being advertised as vision-capable and handed image blocks, with the UI switch appearing to work.

## The change

The boolean now carries into the array too, via a small `withCapability` helper. Two properties it deliberately keeps:

- **An absent array stays absent.** Checks fail open without one, and building a list here would make an override authoritative about every capability the user never mentioned. That is the same reasoning the existing union already applies.
- **Only the named capability moves.** Turning vision off does not disturb `tools` or anything else.

`supportsReasoning` gets the same treatment, because it is the identical shape and the contract in that comment is not specific to vision. That is not a claim to close #13668, which is about reasoning *effort* rather than the capability flag; I have not investigated that one.

## Verification

From `apps/vscode`:

- `npx vitest run src/sdk/model-catalog/store.test.ts` — 48 passed, the 47 that existed plus one new.
- `npx vitest run src/sdk/model-catalog/ src/core/controller/models/__tests__/providerCatalogHandlers.test.ts src/sdk/cline-session-factory.test.ts` — 249 passed across 12 files. Those are the suites that touch `supportsVision` or the catalog store.
- `biome lint` and `biome format` with the repo config on both changed files: clean.
- `node ../../node_modules/typescript/bin/tsc --noEmit`: clean.

The new test fails without the change and says so plainly:

```
AssertionError: expected [ 'tools', 'images' ] to not include 'images'
```

Note that `supportsImages: false` already passed at that point. The test asserts both, so it pins the contradiction rather than just the outcome.

Worth stating plainly: `ext-vscode-test` and `ext-vscode-test-e2e` are sitting at `action_required` on this pull request, so the repository has not run its own suites against it. Every number above is from running them locally.

## Not verified

I did not reproduce this through the extension UI. I have no self-hosted OpenAI-compatible endpoint set up, and the reporter's repro depends on one. The store-level behaviour is what I tested, and that is where the contradiction is produced.

Refs #13694

---

AI help was taken for this change.
