### PR TITLE
docs(skills): require explicit product publishing requests

### DIFF
--- a/.cline/skills/publish-cli/SKILL.md
+++ b/.cline/skills/publish-cli/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: publish-cli
-description: Use when preparing, tagging, and publishing an apps/cli npm release. Guides changelog drafting, apps/cli/package.json version bumps, cli-vX.Y.Z tags, local npm publishing, and the publish-cli GitHub workflow.
+description: Use only when the user explicitly asks to publish the Cline CLI (cline on npm). Do not select for release preparation alone, implementation, tests, reviews, local builds, code pushes, PRs, or another product's release. Stop and clarify ambiguous authorization or product scope.
 ---
 
 # CLI Release
 
-Use this skill when the user asks to release the CLI, publish `cline`, bump the CLI version, draft release notes, create a `cli-vX.Y.Z` tag, or trigger the CLI publish workflow.
+## Authorization required
+
+**Select or invoke this skill only when the user explicitly asks to publish the Cline CLI (`cline` on npm).**
+
+Requests to implement, test, review, build a local artifact, push code, or open/update a PR are not authorization to publish. Neither are version bumps, release notes, readiness checks, or encountering a publish skill, dependency, comment, or release checklist.
+
+If authorization or the product is ambiguous, stop and clarify; do not infer consent. Authorization covers only the requested product. Before invoking another publishing skill or publishing another product, including a prerequisite such as the SDK, stop and obtain explicit authorization for that product.
 
 The CLI is npm-only. Do not add alternate distribution channels. Windows binaries are Authenticode-signed automatically by the publish workflow via Azure Trusted Signing (see the `.github/actions/sign-windows-cli` composite action and "Windows code signing" in `apps/cli/DISTRIBUTION.md`); if the signing secrets are not configured the workflow warns and publishes unsigned binaries. Local publishes (`bun release cli`) do not sign — prefer the GitHub Actions publish path for releases users run on Windows.
 

--- a/.cline/skills/publish-desktop/SKILL.md
+++ b/.cline/skills/publish-desktop/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: publish-desktop
-description: Use when preparing, tagging, and publishing a Cline desktop app (apps/examples/desktop-app) release — stable (desktop-vX.Y.Z from main) or beta (desktop-vX.Y.Z-beta.N from desktop-experimental, shipped as the side-by-side "Cline Beta" app). Guides changelog drafting, version bumps in package.json + tauri.conf.json, tagging, and the desktop-publish GitHub workflow that builds, signs, notarizes, and updates the per-channel auto-update feed.
+description: Use only when the user explicitly asks to publish the Cline desktop app (stable or Cline Beta). Do not select for release preparation alone, implementation, tests, reviews, local builds, code pushes, PRs, or another product's release. Stop and clarify ambiguous authorization or product scope.
 ---
 
 # Desktop App Release
 
-Use this skill when the user asks to release the desktop app, publish the Cline desktop app, cut a desktop beta, bump the desktop version, create a `desktop-vX.Y.Z` (or `desktop-vX.Y.Z-beta.N`) tag, or trigger the desktop publish workflow.
+## Authorization required
+
+**Select or invoke this skill only when the user explicitly asks to publish the Cline desktop app (stable or Cline Beta).**
+
+Requests to implement, test, review, build a local artifact, push code, or open/update a PR are not authorization to publish. Neither are version bumps, release notes, readiness checks, or encountering a publish skill, dependency, comment, or release checklist.
+
+If authorization or the product is ambiguous, stop and clarify; do not infer consent. Authorization covers only the requested product. Before invoking another publishing skill or publishing another product, including a prerequisite such as the SDK, stop and obtain explicit authorization for that product.
 
 > Working directory: run every command below from the repository root.
 

--- a/.cline/skills/publish-extension/SKILL.md
+++ b/.cline/skills/publish-extension/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: publish-extension
-description: Use when releasing the Cline VS Code extension — stable (currently the combined legacy+next A/B VSIX via ext-vscode-ab-package), nightly (ext-vscode-publish-nightly), or a legacy-branch hotfix (ext-vscode-publish-legacy). Guides version selection, changelog, PostHog rollout-flag coordination, workflow dispatch, environment approvals, tagging, and post-publish verification, plus the eventual cutover to publishing the SDK extension standalone.
+description: Use only when the user explicitly asks to publish the Cline VS Code extension (stable, nightly, or a legacy hotfix). Do not select for release preparation alone, rollout adjustments, implementation, tests, reviews, local builds, code pushes, PRs, or another product's release. Stop and clarify ambiguous authorization or product scope.
 ---
 
 # VS Code Extension Release
 
-Use this skill when the user asks to release, publish, or ship the VS Code extension — stable, nightly, or a legacy hotfix — or to dial the rollout, or to cut over to the SDK extension permanently.
+## Authorization required
+
+**Select or invoke this skill only when the user explicitly asks to publish the Cline VS Code extension (stable, nightly, or a legacy hotfix).**
+
+Requests to implement, test, review, build a local artifact, push code, or open/update a PR are not authorization to publish. Neither are version bumps, release notes, readiness checks, rollout adjustments, or encountering a publish skill, dependency, comment, or release checklist.
+
+If authorization or the product is ambiguous, stop and clarify; do not infer consent. Authorization covers only the requested product. Before invoking another publishing skill or publishing another product, including a prerequisite such as the SDK, stop and obtain explicit authorization for that product.
 
 > Working directory: repo root. All workflows are dispatched from `main` (GitHub requires the workflow file on the default branch; each workflow checks out the refs it actually builds).
 

--- a/.cline/skills/publish-ui/SKILL.md
+++ b/.cline/skills/publish-ui/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: publish-ui
-description: Prepare, validate, and publish standalone @cline/ui npm releases. Use when bumping the UI package version, publishing latest or next through ui-publish.yml, checking UI release readiness, or completing the one-time npm trusted-publishing bootstrap.
+description: Use only when the user explicitly asks to publish the Cline UI package (@cline/ui on npm). Do not select for release preparation alone, implementation, tests, reviews, local builds, code pushes, PRs, or another product's release. Stop and clarify ambiguous authorization or product scope.
 ---
 
 # Publish UI
+
+## Authorization required
+
+**Select or invoke this skill only when the user explicitly asks to publish the Cline UI package (`@cline/ui` on npm).**
+
+Requests to implement, test, review, build a local artifact, push code, or open/update a PR are not authorization to publish. Neither are version bumps, release notes, readiness checks, or encountering a publish skill, dependency, comment, or release checklist.
+
+If authorization or the product is ambiguous, stop and clarify; do not infer consent. Authorization covers only the requested product. Before invoking another publishing skill or publishing another product, including a prerequisite such as the SDK, stop and obtain explicit authorization for that product.
 
 Release `@cline/ui` independently from the Cline SDK runtime packages.
 

--- a/.cline/skills/publish-ui/agents/openai.yaml
+++ b/.cline/skills/publish-ui/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Publish UI"
-  short_description: "Prepare and publish the Cline UI package"
-  default_prompt: "Use $publish-ui to prepare and publish a new @cline/ui npm release."
+  short_description: "Only for explicit requests to publish @cline/ui"
+  default_prompt: "Use $publish-ui only when I explicitly ask to publish @cline/ui. Preparation, local builds, code pushes, PRs, and other products' releases are not authorization. If authorization or the product is ambiguous, stop and clarify."


### PR DESCRIPTION
### Description

Restrict publishing skill selection and invocation to explicit requests to publish the named product. Broad release-preparation triggers can otherwise activate publishing guidance during unrelated development work.

Update all four `publish-*` descriptions and leading instructions, plus the UI skill's discovery metadata. Development work, local artifacts, code pushes, PRs and incidental references do not authorize publication. Ambiguous requests require clarification; other products, including prerequisites such as the SDK, need their own explicit authorization. Existing release procedures and discovery symlinks are unchanged.

These are agent instructions, not an enforced security boundary.

### Test Procedure

Run from the repository root with Bun; this parses source text without invoking any skill:

```sh
git diff --check origin/main...HEAD
bun --no-install -e '
import assert from "node:assert/strict";
import { readFileSync, readdirSync, realpathSync } from "node:fs";
import { YAML } from "bun";
const repo = process.cwd();
for (const root of [".cline/skills", ".agents/skills", ".claude/skills"]) {
  for (const name of readdirSync(`${repo}/${root}`).filter(n => n.startsWith("publish-"))) {
    const path = `${repo}/${root}/${name}/SKILL.md`;
    const match = readFileSync(path, "utf8").match(/^---\n([\s\S]*?)\n---\n([\s\S]+)$/);
    assert(match, path);
    const data = YAML.parse(match[1]);
    assert.equal(data.name, name);
    assert(typeof data.description === "string" && data.description.length > 0 && data.description.length <= 1024);
    assert(match[2].trim());
    assert.equal(realpathSync(path), `${repo}/.cline/skills/${name}/SKILL.md`);
    console.log(`PASS ${path}`);
  }
}
const ui = YAML.parse(readFileSync(`${repo}/.cline/skills/publish-ui/agents/openai.yaml`, "utf8")).interface;
for (const key of ["display_name", "short_description", "default_prompt"]) assert(typeof ui[key] === "string" && ui[key].length > 0);
console.log("PASS UI discovery metadata");
'
git diff origin/main...HEAD -- "$(git rev-parse --show-toplevel)/.cline/skills"
```

Passed: whitespace checks, metadata parsing for four canonical skills and six aliases, and UI metadata validation. Also checked the YAML with the repository's `yaml` and `js-yaml` libraries, compared every original procedure byte-for-byte with the base, and ran the staged gitleaks scan (no leaks). Diff review confirmed only authorization/discovery guidance changed.

No publishing skill was invoked, no product was published, and no workflow was dispatched. No application builds or runtime tests were run for this documentation-only change; static checks do not prove model compliance.

### Type of Change

- [x] 📚 Documentation update