### PR TITLE
Add computer user reliability tools

### DIFF
--- a/apps/cli/src/runtime/interactive/computer-user.test.ts
+++ b/apps/cli/src/runtime/interactive/computer-user.test.ts
@@ -157,7 +157,7 @@ describe("createInteractiveComputerUser", () => {
 		expect(result).toBeUndefined();
 	});
 
-	it("exposes the four driver tools when enabled and configured", async () => {
+	it("exposes the driver tools when enabled and configured", async () => {
 		const started = await startStubBackend();
 		server = started.server;
 		destroyConnections = started.destroyConnections;
@@ -177,13 +177,41 @@ describe("createInteractiveComputerUser", () => {
 		expect(result?.driverTools.map((tool) => tool.name).sort()).toEqual([
 			"computer_user_interrupt",
 			"computer_user_message",
+			"computer_user_restart",
 			"computer_user_start",
 			"computer_user_status",
+			"computer_user_transcript",
 		]);
 		// The raw computer tool must not be among the driver's tools.
 		expect(result?.driverTools.some((tool) => tool.name === "computer")).toBe(
 			false,
 		);
+		await result?.dispose();
+	});
+
+	it("adds the backend restart tool only when a launch command is configured", async () => {
+		const started = await startStubBackend();
+		server = started.server;
+		destroyConnections = started.destroyConnections;
+
+		const result = await createInteractiveComputerUser({
+			config: makeConfig(),
+			providerSettingsManager: makeSettings({
+				apiKey: "sk-ant-x",
+				model: "claude-sonnet-4-6",
+			}),
+			notifyDriver: () => {},
+			env: {
+				CLINE_COMPUTER_USE_PORT: String(started.port),
+				CLINE_COMPUTER_USE_BACKEND_COMMAND: "echo start-the-backend",
+			} as NodeJS.ProcessEnv,
+		});
+		expect(result).toBeDefined();
+		expect(
+			result?.driverTools
+				.map((tool) => tool.name)
+				.includes("computer_user_restart_backend"),
+		).toBe(true);
 		await result?.dispose();
 	});
 

--- a/apps/cli/src/runtime/interactive/computer-user.ts
+++ b/apps/cli/src/runtime/interactive/computer-user.ts
@@ -2,23 +2,22 @@ import {
 	type AgentHooks,
 	type ClineCore,
 	COMPUTER_USER_SYSTEM_PROMPT,
+	ComputerBackendRestart,
 	ComputerTaskArtifactRecorder,
 	ComputerUseClient,
 	ComputerUserCoordinator,
+	ComputerUserTranscriptLog,
 	createComputerUserCollaborationTools,
 	createComputerUserDriverTools,
 	createComputerUseTool,
 	createJournalEventSink,
 	createTranscriptRecordingHooks,
 	type ProviderSettingsManager,
+	resolveComputerUseBackendCommandFromEnv,
 	resolveComputerUseTargetFromEnv,
 	toProviderConfig,
 } from "@cline/core";
-import type {
-	AgentTool,
-	ModelInfo,
-	ModelReasoningOption,
-} from "@cline/shared";
+import type { AgentTool, ModelInfo, ModelReasoningOption } from "@cline/shared";
 import { nanoid } from "nanoid";
 import { createCliCore } from "../../session/session";
 import type { Config } from "../../utils/types";
@@ -169,6 +168,21 @@ export async function createInteractiveComputerUser(input: {
 		...target,
 		client: computerClient,
 	});
+
+	// In-process tail of the helper's transcript. The driver's
+	// computer_user_transcript tool reads it, so peeking works even while
+	// the backend is down; the tee shares the recording hooks' reduction, so
+	// what the tool shows is identical to what the observatory journals.
+	const transcriptLog = new ComputerUserTranscriptLog();
+	const backendRestart = (() => {
+		const command = resolveComputerUseBackendCommandFromEnv(
+			input.env ?? process.env,
+		);
+		return command
+			? new ComputerBackendRestart({ ...target, command })
+			: undefined;
+	})();
+
 	const helperModelId = resolveHelperModelId(
 		helperSettings,
 		input.env ?? process.env,
@@ -240,10 +254,13 @@ export async function createInteractiveComputerUser(input: {
 		// the driver waiting with no report.
 		completionPolicy: { requireCompletionTool: true },
 		// Record the helper's transcript and run status to the backend
-		// journal for the observatory.
-		hooks: createTranscriptRecordingHooks(recorder, {
-			kind: "computer_user",
-		}),
+		// journal for the observatory, and tee the same events into the
+		// in-process transcript log the driver's peek tool reads.
+		hooks: createTranscriptRecordingHooks(
+			recorder,
+			{ kind: "computer_user" },
+			(event) => transcriptLog.append(event),
+		),
 	};
 
 	// Lazy: the helper ClineCore spawns only when the driver first delegates.
@@ -310,11 +327,14 @@ export async function createInteractiveComputerUser(input: {
 		notifyDriver: ({ prompt, delivery }) =>
 			input.notifyDriver(prompt, delivery),
 		recorder,
+		transcriptLog,
 	});
 	helperExtraTools.push(...createComputerUserCollaborationTools(coordinator));
 
 	return {
-		driverTools: createComputerUserDriverTools(coordinator),
+		driverTools: createComputerUserDriverTools(coordinator, {
+			backendRestart,
+		}),
 		driverRecordingHooks: createTranscriptRecordingHooks(recorder, {
 			kind: "driver",
 		}),
@@ -328,6 +348,9 @@ export async function createInteractiveComputerUser(input: {
 			// backend connection.
 			await recorder.flush().catch(() => {});
 			computerClient.close();
+			// Release a backend this process spawned; a backend someone else
+			// owns is left running.
+			await backendRestart?.dispose();
 		},
 	};
 }

--- a/sdk/packages/core/src/extensions/computer-observability/index.ts
+++ b/sdk/packages/core/src/extensions/computer-observability/index.ts
@@ -24,4 +24,7 @@ export {
 	type JournalPublishTransport,
 } from "./journal-sink";
 export { ComputerTaskArtifactRecorder } from "./recorder";
-export { createTranscriptRecordingHooks } from "./transcript-observer";
+export {
+	createTranscriptRecordingHooks,
+	type TranscriptRecordingTee,
+} from "./transcript-observer";

--- a/sdk/packages/core/src/extensions/computer-observability/transcript-observer.test.ts
+++ b/sdk/packages/core/src/extensions/computer-observability/transcript-observer.test.ts
@@ -126,4 +126,3 @@ describe("createTranscriptRecordingHooks", () => {
 		]);
 	});
 });
-

--- a/sdk/packages/core/src/extensions/computer-observability/transcript-observer.ts
+++ b/sdk/packages/core/src/extensions/computer-observability/transcript-observer.ts
@@ -1,9 +1,8 @@
+import type { AgentHooks, AgentMessage, AgentMessagePart } from "@cline/shared";
 import type {
-	AgentHooks,
-	AgentMessage,
-	AgentMessagePart,
-} from "@cline/shared";
-import type { ArtifactEventSource } from "./artifact-events";
+	ArtifactEventSource,
+	ComputerTaskArtifactEvent,
+} from "./artifact-events";
 import type { ComputerTaskArtifactRecorder } from "./recorder";
 
 const TEXT_PREVIEW_LIMIT = 4000;
@@ -83,9 +82,18 @@ function partPayload(
  * transcript message, on every host (local or hub), for user, assistant,
  * and tool messages alike.
  */
+/**
+ * Optional second sink for the reduced transcript events. The tee receives
+ * the exact artifact event the recorder built — one reduction, two sinks —
+ * so an in-process reader (e.g. the driver's `computer_user_transcript`
+ * tool) never re-implements this file's payload shape.
+ */
+export type TranscriptRecordingTee = (event: ComputerTaskArtifactEvent) => void;
+
 export function createTranscriptRecordingHooks(
 	recorder: ComputerTaskArtifactRecorder,
 	source: ArtifactEventSource,
+	tee?: TranscriptRecordingTee,
 ): AgentHooks {
 	return {
 		beforeRun: async () => {
@@ -112,7 +120,7 @@ export function createTranscriptRecordingHooks(
 				if (!reduced) {
 					continue;
 				}
-				recorder.record({
+				const artifact = recorder.record({
 					type: "transcript.message_committed",
 					source,
 					...(reduced.toolCallId
@@ -120,9 +128,8 @@ export function createTranscriptRecordingHooks(
 						: {}),
 					payload: reduced.payload,
 				});
+				tee?.(artifact);
 			}
 		},
 	};
 }
-
-

--- a/sdk/packages/core/src/extensions/computer-use/README.md
+++ b/sdk/packages/core/src/extensions/computer-use/README.md
@@ -146,6 +146,7 @@ also `async` for the same reason:
 | `CLINE_COMPUTER_USE_PORT` | yes (enables the tool) | — | Backend TCP port |
 | `CLINE_COMPUTER_USE_HOST` | no | `127.0.0.1` | Backend host |
 | `CLINE_COMPUTER_USER_MODEL` | no | Anthropic entry's saved model, else `claude-sonnet-4-6` | Helper (computer user) model. Independent of the driver's model; always on the direct `anthropic` provider (CLI host) |
+| `CLINE_COMPUTER_USE_BACKEND_COMMAND` | no | — | Shell command that starts the backend. When set, the driver gets `computer_user_restart_backend`, which launches it if the backend is unreachable (probes first; never kills a backend this process didn't spawn) |
 
 Display size is deliberately not configurable — see "Display size" above.
 

--- a/sdk/packages/core/src/extensions/computer-use/backend-restart.test.ts
+++ b/sdk/packages/core/src/extensions/computer-use/backend-restart.test.ts
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ComputerBackendRestart } from "./backend-restart";
+import { ComputerUseClient } from "./client";
+
+const fixturePath = fileURLToPath(
+	new URL("./test-fixtures/fake-backend.mjs", import.meta.url),
+);
+
+function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as net.AddressInfo;
+			server.close(() => resolve(port));
+		});
+		server.on("error", reject);
+	});
+}
+
+function shellQuote(value: string): string {
+	return JSON.stringify(value);
+}
+
+/** The launch command shape a host would configure, quoted for the shell. */
+function fixtureLaunchCommand(port: number): string {
+	return `${shellQuote(process.execPath)} ${shellQuote(fixturePath)} ${port}`;
+}
+
+async function probePort(port: number, timeoutMs: number): Promise<boolean> {
+	const client = new ComputerUseClient({
+		port,
+		connectTimeoutMs: timeoutMs,
+		requestTimeoutMs: timeoutMs,
+	});
+	try {
+		await client.getDisplayInfo();
+		return true;
+	} catch {
+		return false;
+	} finally {
+		client.close();
+	}
+}
+
+/** Spawns the fake backend directly (not via ComputerBackendRestart). */
+async function startFakeBackend(port: number) {
+	const child = spawn(process.execPath, [fixturePath, String(port)], {
+		stdio: "ignore",
+	});
+	await (async function waitForReady(attempt = 0): Promise<void> {
+		if (await probePort(port, 500)) {
+			return;
+		}
+		if (attempt > 40) {
+			throw new Error("fake backend never became ready");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		return waitForReady(attempt + 1);
+	})();
+	return child;
+}
+
+describe("ComputerBackendRestart", () => {
+	it("reports already_running and does not spawn or adopt the backend", async () => {
+		const port = await freePort();
+		const child = await startFakeBackend(port);
+		try {
+			const restart = new ComputerBackendRestart({
+				port,
+				command: fixtureLaunchCommand(port),
+				readyTimeoutMs: 15_000,
+				pollIntervalMs: 200,
+			});
+			await expect(restart.ensureRunning()).resolves.toMatchObject({
+				status: "already_running",
+			});
+			// Dispose must not kill a backend it did not spawn.
+			await restart.dispose();
+			expect(await probePort(port, 500)).toBe(true);
+		} finally {
+			child.kill();
+		}
+	});
+
+	it("launches the configured command when the backend is down", async () => {
+		const port = await freePort();
+		const restart = new ComputerBackendRestart({
+			port,
+			command: fixtureLaunchCommand(port),
+			readyTimeoutMs: 30_000,
+			pollIntervalMs: 200,
+		});
+		await expect(restart.ensureRunning()).resolves.toMatchObject({
+			status: "started",
+		});
+		// A real client connects to the restarted backend.
+		expect(await probePort(port, 1_000)).toBe(true);
+		// Dispose kills the backend this module spawned.
+		await restart.dispose();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(await probePort(port, 500)).toBe(false);
+	});
+
+	it("reports failed_to_start when the launch command exits immediately", async () => {
+		const port = await freePort();
+		const restart = new ComputerBackendRestart({
+			port,
+			command: `${shellQuote(process.execPath)} -e "process.exit(3)"`,
+			readyTimeoutMs: 15_000,
+			pollIntervalMs: 200,
+		});
+		const result = await restart.ensureRunning();
+		expect(result.status).toBe("failed_to_start");
+		if (result.status === "failed_to_start") {
+			expect(result.error).toContain("exited with code 3");
+		}
+	});
+
+	it("kills its own spawn and reports failure when the backend never answers", async () => {
+		const port = await freePort();
+		const restart = new ComputerBackendRestart({
+			port,
+			command: `${shellQuote(process.execPath)} -e "setInterval(() => {}, 60000)"`,
+			readyTimeoutMs: 1_000,
+			pollIntervalMs: 200,
+		});
+		const result = await restart.ensureRunning();
+		expect(result).toMatchObject({
+			status: "failed_to_start",
+			error: expect.stringContaining("did not answer"),
+		});
+		await restart.dispose();
+	});
+
+	it("reports started for launch commands that daemonize and exit", async () => {
+		const port = await freePort();
+		const launcherPath = fileURLToPath(
+			new URL("./test-fixtures/launcher-exits.mjs", import.meta.url),
+		);
+		const restart = new ComputerBackendRestart({
+			port,
+			// The launcher spawns the backend and exits immediately; the
+			// backend it started must still be recognized as up.
+			command: `${shellQuote(process.execPath)} ${shellQuote(launcherPath)} ${port} 15000`,
+			readyTimeoutMs: 15_000,
+			pollIntervalMs: 200,
+		});
+		await expect(restart.ensureRunning()).resolves.toMatchObject({
+			status: "started",
+		});
+		expect(await probePort(port, 1_000)).toBe(true);
+		// The backend was daemonized, so dispose has no owned child to kill —
+		// and must not hunt for pids it never spawned. The fixture's lifetime
+		// cleans up.
+		await restart.dispose();
+	});
+
+	it("shares one run between concurrent ensureRunning calls", async () => {
+		const port = await freePort();
+		const restart = new ComputerBackendRestart({
+			port,
+			command: fixtureLaunchCommand(port),
+			readyTimeoutMs: 30_000,
+			pollIntervalMs: 200,
+		});
+		const results = await Promise.all([
+			restart.ensureRunning(),
+			restart.ensureRunning(),
+		]);
+		expect(results[0]).toEqual(results[1]);
+		await restart.dispose();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(await probePort(port, 500)).toBe(false);
+	}, 30_000);
+});

--- a/sdk/packages/core/src/extensions/computer-use/backend-restart.ts
+++ b/sdk/packages/core/src/extensions/computer-use/backend-restart.ts
@@ -1,0 +1,155 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { ComputerUseClient } from "./client";
+
+/**
+ * Brings the computer-use backend back when its process is gone.
+ *
+ * The backend (qwanban's qbt) is a separate process the agent host does not
+ * own: it may be started by a human, a service, or this module. The single
+ * rule that keeps ownership unambiguous: this module only ever terminates a
+ * backend it spawned itself. `ensureRunning` therefore probes first and
+ * returns `already_running` when the backend answers, spawns the configured
+ * launch command only when it does not, and kills its own spawn if it never
+ * becomes ready.
+ *
+ * Readiness is the same query tool construction uses (`get_display_info`):
+ * the port accepting is not enough — the backend must actually answer.
+ */
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+const DEFAULT_READY_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+export interface ComputerBackendRestartOptions {
+	/** Backend host, defaults to loopback. */
+	host?: string;
+	/** Backend TCP port, the same target the tools dial. */
+	port: number;
+	/**
+	 * Shell command that starts the backend, e.g.
+	 * `cargo run -- serve 1234 5678`. Runs via the platform shell, so a cd
+	 * prefix or env vars are allowed; the backend must end up answering on
+	 * `host`:`port`.
+	 */
+	command: string;
+	/** Per-probe budget. Default 3 s. */
+	probeTimeoutMs?: number;
+	/** Overall wait for the spawned backend to answer. Default 120 s. */
+	readyTimeoutMs?: number;
+	/** Delay between readiness probes while waiting. Default 1 s. */
+	pollIntervalMs?: number;
+}
+
+export type ComputerBackendEnsureResult =
+	| { status: "already_running" }
+	| { status: "started" }
+	| { status: "failed_to_start"; error: string };
+
+export class ComputerBackendRestart {
+	private readonly options: ComputerBackendRestartOptions;
+	private readonly probeTimeoutMs: number;
+	private readonly readyTimeoutMs: number;
+	private readonly pollIntervalMs: number;
+	private ensurePromise: Promise<ComputerBackendEnsureResult> | undefined;
+	private child: ChildProcess | undefined;
+
+	constructor(options: ComputerBackendRestartOptions) {
+		this.options = options;
+		this.probeTimeoutMs = options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+		this.readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+		this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	}
+
+	/** Overall wait budget for a spawned backend to answer; hosts use it to size tool timeouts. */
+	get budgetMs(): number {
+		return this.readyTimeoutMs;
+	}
+
+	/**
+	 * Probes the backend; spawns the launch command only when it is down.
+	 * Concurrent calls share one run, so the backend is never spawned twice.
+	 */
+	async ensureRunning(): Promise<ComputerBackendEnsureResult> {
+		this.ensurePromise ??= this.ensureRunningUncached().finally(() => {
+			this.ensurePromise = undefined;
+		});
+		return this.ensurePromise;
+	}
+
+	/**
+	 * Terminates a backend this module spawned. Never touches a backend it
+	 * did not spawn: a human- or service-owned backend outlives this process.
+	 */
+	async dispose(): Promise<void> {
+		this.killSpawned();
+	}
+
+	private async ensureRunningUncached(): Promise<ComputerBackendEnsureResult> {
+		if (await this.probe()) {
+			return { status: "already_running" };
+		}
+		const child = spawn(this.options.command, {
+			shell: true,
+			detached: true,
+			stdio: "ignore",
+		});
+		child.unref();
+		this.child = child;
+		const deadline = Date.now() + this.readyTimeoutMs;
+		while (Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, this.pollIntervalMs));
+			// Probe before checking the launcher's exit: commands that
+			// daemonize (spawn the backend and exit) must not be misreported
+			// as failures while the backend they started is coming up.
+			if (await this.probe()) {
+				return { status: "started" };
+			}
+			if (child.exitCode !== null) {
+				return {
+					status: "failed_to_start",
+					error: `launch command exited with code ${child.exitCode} before the backend answered`,
+				};
+			}
+		}
+		// We own the spawn and it never became ready; do not leave it behind.
+		this.killSpawned();
+		return {
+			status: "failed_to_start",
+			error: `backend did not answer within ${this.readyTimeoutMs}ms`,
+		};
+	}
+
+	private async probe(): Promise<boolean> {
+		const client = new ComputerUseClient({
+			host: this.options.host,
+			port: this.options.port,
+			connectTimeoutMs: this.probeTimeoutMs,
+			requestTimeoutMs: this.probeTimeoutMs,
+		});
+		try {
+			await client.getDisplayInfo();
+			return true;
+		} catch {
+			return false;
+		} finally {
+			client.close();
+		}
+	}
+
+	private killSpawned(): void {
+		const child = this.child;
+		this.child = undefined;
+		if (!child || child.exitCode !== null) {
+			return;
+		}
+		if (process.platform === "win32" && child.pid) {
+			// shell:true spawns cmd.exe wrapping the real backend: kill the
+			// whole tree, not just the wrapper.
+			spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+				stdio: "ignore",
+			});
+			return;
+		}
+		child.kill("SIGTERM");
+	}
+}

--- a/sdk/packages/core/src/extensions/computer-use/env.test.ts
+++ b/sdk/packages/core/src/extensions/computer-use/env.test.ts
@@ -1,4 +1,9 @@
-import { type AddressInfo, createServer, type Server, type Socket } from "node:net";
+import {
+	type AddressInfo,
+	createServer,
+	type Server,
+	type Socket,
+} from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { createComputerUseToolFromEnv } from "./env";
 import type { ComputerUseResponse } from "./protocol";

--- a/sdk/packages/core/src/extensions/computer-use/env.ts
+++ b/sdk/packages/core/src/extensions/computer-use/env.ts
@@ -3,6 +3,7 @@ import { createComputerUseTool } from "./tool";
 
 const PORT_ENV_VAR = "CLINE_COMPUTER_USE_PORT";
 const HOST_ENV_VAR = "CLINE_COMPUTER_USE_HOST";
+const BACKEND_COMMAND_ENV_VAR = "CLINE_COMPUTER_USE_BACKEND_COMMAND";
 
 function parsePositiveInt(value: string | undefined): number | undefined {
 	if (!value) {
@@ -26,6 +27,18 @@ export function resolveComputerUseTargetFromEnv(
 		return undefined;
 	}
 	return { host: env[HOST_ENV_VAR] || undefined, port };
+}
+
+/**
+ * Reads the shell command that starts the computer-use backend, for the
+ * backend restart capability. Set together with `CLINE_COMPUTER_USE_PORT`;
+ * the backend must end up answering on that target.
+ */
+export function resolveComputerUseBackendCommandFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	const command = env[BACKEND_COMMAND_ENV_VAR]?.trim();
+	return command || undefined;
 }
 
 /**

--- a/sdk/packages/core/src/extensions/computer-use/index.ts
+++ b/sdk/packages/core/src/extensions/computer-use/index.ts
@@ -9,6 +9,11 @@
  * contract and design rationale.
  */
 export {
+	type ComputerBackendEnsureResult,
+	ComputerBackendRestart,
+	type ComputerBackendRestartOptions,
+} from "./backend-restart";
+export {
 	ComputerUseClient,
 	type ComputerUseClientEvent,
 	type ComputerUseClientObserver,
@@ -17,6 +22,7 @@ export {
 } from "./client";
 export {
 	createComputerUseToolFromEnv,
+	resolveComputerUseBackendCommandFromEnv,
 	resolveComputerUseTargetFromEnv,
 } from "./env";
 export type {

--- a/sdk/packages/core/src/extensions/computer-use/test-fixtures/fake-backend.mjs
+++ b/sdk/packages/core/src/extensions/computer-use/test-fixtures/fake-backend.mjs
@@ -1,0 +1,32 @@
+// Minimal computer-use backend for tests: answers every request line with a
+// get_display_info response. Usage: node fake-backend.mjs <port> [lifetimeMs]
+// (exits itself after lifetimeMs, so tests never leak it).
+import net from "node:net";
+
+const port = Number.parseInt(process.argv[2] ?? "0", 10);
+const lifetimeMs = Number.parseInt(process.argv[3] ?? "0", 10);
+const server = net.createServer((socket) => {
+	let buffer = "";
+	socket.on("data", (chunk) => {
+		buffer += chunk;
+		const lines = buffer.split("\n");
+		buffer = lines.pop() ?? "";
+		for (const line of lines) {
+			if (!line.trim()) {
+				continue;
+			}
+			const request = JSON.parse(line);
+			socket.write(
+				`${JSON.stringify({
+					id: request.id,
+					ok: true,
+					display: { widthPx: 100, heightPx: 100 },
+				})}\n`,
+			);
+		}
+	});
+});
+server.listen(port, "127.0.0.1");
+if (lifetimeMs > 0) {
+	setTimeout(() => process.exit(0), lifetimeMs).unref();
+}

--- a/sdk/packages/core/src/extensions/computer-use/test-fixtures/launcher-exits.mjs
+++ b/sdk/packages/core/src/extensions/computer-use/test-fixtures/launcher-exits.mjs
@@ -1,0 +1,15 @@
+// Daemonizing launcher for tests: spawns the fake backend detached and then
+// exits, like real launch commands that hand the backend off to a service.
+// Usage: node launcher-exits.mjs <port> <lifetimeMs>
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const port = process.argv[2] ?? "0";
+const lifetimeMs = process.argv[3] ?? "0";
+const backend = fileURLToPath(new URL("./fake-backend.mjs", import.meta.url));
+const child = spawn(process.execPath, [backend, port, lifetimeMs], {
+	detached: true,
+	stdio: "ignore",
+});
+child.unref();
+process.exit(0);

--- a/sdk/packages/core/src/extensions/computer-user/coordinator.ts
+++ b/sdk/packages/core/src/extensions/computer-user/coordinator.ts
@@ -1,6 +1,10 @@
 import type { AgentResult } from "@cline/shared";
 import { nanoid } from "nanoid";
 import type { ComputerTaskArtifactRecorder } from "../computer-observability/recorder";
+import type {
+	ComputerUserTranscriptEntry,
+	ComputerUserTranscriptLog,
+} from "./transcript-log";
 
 /**
  * Owns the asynchronous "computer user" helper on behalf of a driver agent.
@@ -102,6 +106,8 @@ export interface ComputerUserCoordinatorOptions {
 	helperConfig: Record<string, unknown>;
 	notifyDriver: DriverNotifier;
 	recorder?: ComputerTaskArtifactRecorder;
+	/** In-process tail of the helper's transcript, for the driver's peek tool. */
+	transcriptLog?: ComputerUserTranscriptLog;
 	now?: () => number;
 }
 
@@ -346,6 +352,61 @@ export class ComputerUserCoordinator {
 			this.state = { kind: "disposed" };
 			this.recordStatusChange("disposed");
 		});
+	}
+
+	/**
+	 * Resets the helper for a degraded session: aborts any active run, stops
+	 * the helper session, and returns the coordinator to `uninitialized`. The
+	 * next start/message creates a fresh session — the helper retains no
+	 * memory of previous tasks, and its transcript log keeps the old
+	 * session's entries (tagged with the old session id) as history.
+	 *
+	 * Like `dispose`, the run's in-flight settlement is ignored afterwards by
+	 * state-kind check in `settleRun`, so a wedged turn cannot resurrect old
+	 * state. This restarts the helper session, not the computer-use backend.
+	 */
+	async restart(reason?: string): Promise<{ restarted: boolean }> {
+		return this.transition(async () => {
+			if (this.state.kind === "disposed") {
+				return { restarted: false };
+			}
+			const sessionId =
+				"sessionId" in this.state ? this.state.sessionId : undefined;
+			if (sessionId) {
+				if (this.state.kind === "running") {
+					await this.options.host
+						.abort(sessionId, new Error(reason ?? "Restarted by driver"))
+						.catch(() => {});
+				}
+				await this.options.host.stop(sessionId).catch(() => {});
+				this.record(
+					"session.ended",
+					{ reason: reason ?? "restarted_by_driver" },
+					sessionId,
+				);
+			}
+			this.state = { kind: "uninitialized" };
+			this.lastReport = undefined;
+			this.latestNote = undefined;
+			this.lastMeaningfulProgressAt = undefined;
+			this.pendingQuestion = undefined;
+			this.finalReport = undefined;
+			this.recordStatusChange("uninitialized");
+			return { restarted: true };
+		});
+	}
+
+	/**
+	 * Recent helper transcript entries from the in-process log, or undefined
+	 * when the host did not enable transcript recording.
+	 */
+	transcriptTail(options?: {
+		limit?: number;
+		sinceSeq?: number;
+	}):
+		| { entries: ComputerUserTranscriptEntry[]; latestSeq: number }
+		| undefined {
+		return this.options.transcriptLog?.tail(options);
 	}
 
 	// -----------------------------------------------------------------------

--- a/sdk/packages/core/src/extensions/computer-user/driver-tools.test.ts
+++ b/sdk/packages/core/src/extensions/computer-user/driver-tools.test.ts
@@ -4,7 +4,14 @@ import {
 	ComputerUserCoordinator,
 	type ComputerUserSessionHost,
 } from "./coordinator";
-import { createComputerUserDriverTools } from "./driver-tools";
+import {
+	type ComputerBackendRestartCapability,
+	createComputerUserDriverTools,
+} from "./driver-tools";
+import {
+	type ComputerUserTranscriptEntry,
+	ComputerUserTranscriptLog,
+} from "./transcript-log";
 
 const ctx: AgentToolContext = {
 	agentId: "driver-agent",
@@ -168,5 +175,213 @@ describe("computer-user driver tools", () => {
 		await expect(
 			byName.get("computer_user_start")?.execute({ task: "two" }, ctx),
 		).rejects.toThrow(/busy/);
+	});
+
+	it("restart returns the helper to uninitialized and the next start binds a fresh session", async () => {
+		const calls: string[] = [];
+		let nextSession = 0;
+		const host: ComputerUserSessionHost = {
+			start: async () => {
+				nextSession += 1;
+				calls.push(`start:${nextSession}`);
+				return { sessionId: `helper-session-${nextSession}` };
+			},
+			send: (input) => {
+				if (input.delivery === "steer") {
+					return Promise.resolve(undefined);
+				}
+				return new Promise(() => {});
+			},
+			abort: async (sessionId) => {
+				calls.push(`abort:${sessionId}`);
+			},
+			stop: async (sessionId) => {
+				calls.push(`stop:${sessionId}`);
+			},
+		};
+		const coordinator = new ComputerUserCoordinator({
+			host,
+			helperConfig: {},
+			notifyDriver: () => {},
+		});
+		const tools = createComputerUserDriverTools(coordinator);
+		const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+		await byName.get("computer_user_start")?.execute({ task: "one" }, ctx);
+		expect(calls).toEqual(["start:1"]);
+
+		const output = (await byName
+			.get("computer_user_restart")
+			?.execute({ reason: "degraded" }, ctx)) as { status: string };
+		expect(output.status).toBe("restarted");
+		expect(calls).toEqual([
+			"start:1",
+			"abort:helper-session-1",
+			"stop:helper-session-1",
+		]);
+		expect(coordinator.getState().kind).toBe("uninitialized");
+
+		const second = (await byName
+			.get("computer_user_start")
+			?.execute({ task: "two" }, ctx)) as { sessionId: string };
+		expect(second.sessionId).toBe("helper-session-2");
+		expect(calls).toEqual([
+			"start:1",
+			"abort:helper-session-1",
+			"stop:helper-session-1",
+			"start:2",
+		]);
+	});
+
+	it("restart ignores a stale run settlement, so a wedged turn cannot resurrect state", async () => {
+		const pendingSends: Array<{
+			resolve: (result: AgentResult | undefined) => void;
+		}> = [];
+		const host: ComputerUserSessionHost = {
+			start: async () => ({ sessionId: "helper-session" }),
+			send: (input) => {
+				if (input.delivery === "steer") {
+					return Promise.resolve(undefined);
+				}
+				return new Promise((resolve) => {
+					pendingSends.push({ resolve });
+				});
+			},
+			abort: async () => {},
+			stop: async () => {},
+		};
+		const coordinator = new ComputerUserCoordinator({
+			host,
+			helperConfig: {},
+			notifyDriver: () => {},
+		});
+		const tools = createComputerUserDriverTools(coordinator);
+		const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+		await byName.get("computer_user_start")?.execute({ task: "one" }, ctx);
+		await byName.get("computer_user_restart")?.execute({}, ctx);
+		expect(coordinator.getState().kind).toBe("uninitialized");
+
+		// The aborted run settles late; the reset state must survive it.
+		pendingSends[0]?.resolve(makeResult());
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(coordinator.getState().kind).toBe("uninitialized");
+	});
+
+	it("restart reports not_restarted once disposed", async () => {
+		const { byName, coordinator } = makeHarness();
+		await coordinator.dispose();
+		const output = (await byName
+			.get("computer_user_restart")
+			?.execute({}, ctx)) as { status: string };
+		expect(output.status).toBe("not_restarted");
+	});
+
+	it("transcript pages entries through the coordinator's log with sinceSeq", async () => {
+		const transcriptLog = new ComputerUserTranscriptLog();
+		const host: ComputerUserSessionHost = {
+			start: async () => ({ sessionId: "helper-session" }),
+			send: async () => undefined,
+			abort: async () => {},
+			stop: async () => {},
+		};
+		const coordinator = new ComputerUserCoordinator({
+			host,
+			helperConfig: {},
+			notifyDriver: () => {},
+			transcriptLog,
+		});
+		const tools = createComputerUserDriverTools(coordinator);
+		const transcriptTool = tools.find(
+			(tool) => tool.name === "computer_user_transcript",
+		);
+		expect(transcriptTool).toBeDefined();
+
+		const append = (text: string) => {
+			transcriptLog.append({
+				version: 1,
+				artifactId: "art_test",
+				eventId: `evt_${text}`,
+				clientSequence: 1,
+				occurredAt: new Date().toISOString(),
+				source: { kind: "computer_user", sessionId: "helper-session" },
+				type: "transcript.message_committed",
+				payload: { role: "assistant", text },
+			});
+		};
+		append("first");
+		append("second");
+
+		const first = (await transcriptTool?.execute({}, ctx)) as {
+			entries: ComputerUserTranscriptEntry[];
+			latestSeq: number;
+		};
+		expect(first.entries.map((entry) => entry.text)).toEqual([
+			"first",
+			"second",
+		]);
+
+		append("third");
+		const next = (await transcriptTool?.execute(
+			{ sinceSeq: first.latestSeq },
+			ctx,
+		)) as { entries: ComputerUserTranscriptEntry[] };
+		expect(next.entries.map((entry) => entry.text)).toEqual(["third"]);
+	});
+
+	it("transcript reports when recording is not enabled", async () => {
+		const { byName } = makeHarness();
+		const output = (await byName
+			.get("computer_user_transcript")
+			?.execute({}, ctx)) as { entries: unknown[]; note: string };
+		expect(output.entries).toEqual([]);
+		expect(output.note).toContain("not enabled");
+	});
+
+	it("restarts the backend only when the capability is wired in", async () => {
+		const { byName } = makeHarness();
+		expect(byName.has("computer_user_restart_backend")).toBe(false);
+
+		const results: string[] = [];
+		const capability: ComputerBackendRestartCapability = {
+			budgetMs: 1_000,
+			ensureRunning: async () => {
+				const status = results.length === 0 ? "started" : "already_running";
+				results.push(status);
+				return { status } as
+					| { status: "started" }
+					| { status: "already_running" };
+			},
+			dispose: async () => {},
+		};
+		const host: ComputerUserSessionHost = {
+			start: async () => ({ sessionId: "helper-session" }),
+			send: async () => undefined,
+			abort: async () => {},
+			stop: async () => {},
+		};
+		const coordinator = new ComputerUserCoordinator({
+			host,
+			helperConfig: {},
+			notifyDriver: () => {},
+		});
+		const tools = createComputerUserDriverTools(coordinator, {
+			backendRestart: capability,
+		});
+		const backendTool = tools.find(
+			(tool) => tool.name === "computer_user_restart_backend",
+		);
+		expect(backendTool).toBeDefined();
+		expect(backendTool?.timeoutMs).toBe(61_000);
+
+		const started = (await backendTool?.execute({}, ctx)) as {
+			status: string;
+		};
+		expect(started.status).toBe("started");
+		const second = (await backendTool?.execute({}, ctx)) as {
+			status: string;
+		};
+		expect(second.status).toBe("already_running");
+		expect(backendTool?.retryable).toBe(false);
 	});
 });

--- a/sdk/packages/core/src/extensions/computer-user/driver-tools.ts
+++ b/sdk/packages/core/src/extensions/computer-user/driver-tools.ts
@@ -1,17 +1,20 @@
 import type { AgentTool } from "@cline/shared";
 import { createTool, zodToJsonSchema } from "@cline/shared";
 import { z } from "zod";
+import type { ComputerBackendEnsureResult } from "../computer-use/backend-restart";
 import type { ComputerUserCoordinator } from "./coordinator";
 
 /**
  * Driver-facing tools for delegating GUI work to the asynchronous computer
  * user. Start and message return without waiting for the helper's turn;
  * interrupt returns after the active turn is quiescent. Status can return
- * immediately or wait for a bounded change. Results, questions, and warnings
- * also arrive as steer messages injected into the driver's conversation. The
- * tools are separate (rather than one action union) because their approval
- * semantics differ: hosts typically auto-approve status checks while gating
- * start/interrupt.
+ * immediately or wait for a bounded change. Transcript peeks the helper's
+ * recent activity; restart recreates a degraded helper session. Results,
+ * questions, and warnings also arrive as steer messages injected into the
+ * driver's conversation. The tools are separate (rather than one action
+ * union) because their approval semantics differ: hosts typically
+ * auto-approve status and transcript checks while gating start/interrupt/
+ * restart.
  */
 
 const StartInput = z
@@ -75,9 +78,69 @@ const StatusInput = z
 		path: ["timeout"],
 	});
 
+const MAX_TRANSCRIPT_LIMIT = 100;
+const TranscriptInput = z
+	.object({
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(MAX_TRANSCRIPT_LIMIT)
+			.optional()
+			.describe(
+				`Maximum entries to return (1-${MAX_TRANSCRIPT_LIMIT}). Default 50.`,
+			),
+		sinceSeq: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe(
+				"Sequence cursor from a previous transcript call: skip entries up to and including it, returning only newer activity.",
+			),
+	})
+	.strict();
+
+const RestartInput = z
+	.object({
+		reason: z
+			.string()
+			.trim()
+			.min(1)
+			.optional()
+			.describe(
+				"Why the helper is being restarted. Kept with the session's ended record.",
+			),
+	})
+	.strict();
+
+const BackendRestartInput = z.object({}).strict();
+
+/**
+ * The backend restart capability the tool needs. `ComputerBackendRestart`
+ * satisfies this structurally; hosts and tests may substitute their own.
+ */
+export interface ComputerBackendRestartCapability {
+	/** Overall wait budget; the tool's timeout is sized from it. */
+	budgetMs: number;
+	ensureRunning(): Promise<ComputerBackendEnsureResult>;
+	dispose(): Promise<void>;
+}
+
+/** Optional capabilities the host can wire into the driver tool set. */
+export interface ComputerUserDriverToolOptions {
+	/**
+	 * Backend restart support. Provided only when the host also configured a
+	 * launch command; when present the driver gets
+	 * `computer_user_restart_backend`.
+	 */
+	backendRestart?: ComputerBackendRestartCapability;
+}
+
 /** Builds the driver-facing computer-user tools bound to one coordinator. */
 export function createComputerUserDriverTools(
 	coordinator: ComputerUserCoordinator,
+	options?: ComputerUserDriverToolOptions,
 ): AgentTool[] {
 	const start = createTool({
 		name: "computer_user_start",
@@ -157,5 +220,91 @@ export function createComputerUserDriverTools(
 		},
 	});
 
-	return [start, status, message, interrupt];
+	const transcript = createTool({
+		name: "computer_user_transcript",
+		description:
+			"Read the computer user's recent transcript: its reasoning, the tool calls it made (name and input), their results, its messages to the user, and its final reports. Use this to see what it actually did (including when a run ends without a structured report), to answer 'is it done?', or to page new activity with sinceSeq. Entries keep the session id they belong to, so history before a restart is distinguishable from the new session.",
+		inputSchema: zodToJsonSchema(TranscriptInput),
+		retryable: true,
+		execute: async (input: unknown) => {
+			const parsed = TranscriptInput.parse(input);
+			const tail = coordinator.transcriptTail(parsed);
+			return (
+				tail ?? {
+					entries: [],
+					latestSeq: 0,
+					note: "Transcript recording is not enabled on this host.",
+				}
+			);
+		},
+	});
+
+	const restart = createTool({
+		name: "computer_user_restart",
+		description:
+			"Recreate the computer user: abort its active run, stop its session, and reset it to a clean state for when it degrades (e.g. turns that end in seconds without acting, or reports that never arrive). The next start or message creates a fresh session that retains no memory of previous tasks. Its transcript history survives, tagged with the old session id. This restarts the helper, not the computer-use backend — use computer_user_restart_backend for that.",
+		inputSchema: zodToJsonSchema(RestartInput),
+		retryable: false,
+		execute: async (input: unknown) => {
+			const parsed = RestartInput.parse(input);
+			const { restarted } = await coordinator.restart(parsed.reason);
+			return restarted
+				? {
+						status: "restarted",
+						note: "The computer user is clean and uninitialized. The next start or message creates a fresh session with no memory of previous tasks.",
+					}
+				: {
+						status: "not_restarted",
+						note: "The computer user has been disposed; nothing to restart.",
+					};
+		},
+	});
+
+	const tools: AgentTool[] = [
+		start,
+		status,
+		message,
+		interrupt,
+		transcript,
+		restart,
+	];
+
+	if (options?.backendRestart) {
+		const backendRestart = options.backendRestart;
+		tools.push(
+			createTool({
+				name: "computer_user_restart_backend",
+				description:
+					"Bring the computer-use backend (the process behind the computer tool and the computer user) back when it is unreachable — e.g. after it crashed or was killed. Probes it first: if it answers, reports already_running without touching it. If it is down, launches the configured backend command and waits for it to answer. Does not kill a backend it did not spawn.",
+				inputSchema: zodToJsonSchema(BackendRestartInput),
+				// The wait budget plus probe slack, so the tool outlives a slow launch (e.g. a cargo build).
+				timeoutMs: backendRestart.budgetMs + 60_000,
+				retryable: false,
+				execute: async (input: unknown) => {
+					BackendRestartInput.parse(input);
+					const result = await backendRestart.ensureRunning();
+					switch (result.status) {
+						case "already_running":
+							return {
+								status: result.status,
+								note: "The backend answered a probe; it is running. Nothing was launched.",
+							};
+						case "started":
+							return {
+								status: result.status,
+								note: "The backend was down and has been launched. The next computer action reconnects automatically.",
+							};
+						case "failed_to_start":
+							return {
+								status: result.status,
+								error: result.error,
+								note: "The launch command was run but the backend never answered. Check the command (it must make the backend answer on the configured port) and try again.",
+							};
+					}
+				},
+			}),
+		);
+	}
+
+	return tools;
 }

--- a/sdk/packages/core/src/extensions/computer-user/helper-prompt.ts
+++ b/sdk/packages/core/src/extensions/computer-user/helper-prompt.ts
@@ -7,7 +7,7 @@
  * artifacts record exactly which helper behavior was active.
  */
 
-export const COMPUTER_USER_PROMPT_VERSION = 1;
+export const COMPUTER_USER_PROMPT_VERSION = 2;
 
 export const COMPUTER_USER_SYSTEM_PROMPT = `You are the computer user for another agent, called the driver.
 
@@ -44,6 +44,23 @@ Coordination:
   materially different actions, call ask_driver with what you observed, what
   you attempted, and the specific decision needed. Questions go to the
   driver, not to a human.
+
+Scope and environment ownership:
+- The driver's latest instructions supersede every earlier briefing. When
+  the driver tells you to stop, wait, or stand down, comply immediately and
+  remain waiting for the driver's next message; do not resume or continue an
+  earlier plan on your own initiative in later turns.
+- Work on the driver's current task only. Extra scenarios, re-runs, and
+  follow-ups are the driver's call, not yours.
+- Shell and scripting tools may do what the computer tool cannot express —
+  for example managing windows or inspecting processes. Keep such
+  out-of-band actions within the current task, and mention them in your next
+  update.
+- If the computer tool is unreachable or its actions fail repeatedly (for
+  example the backend connection is refused), stop retrying and report the
+  exact error via ask_driver or a "warning" update. Do not try to repair,
+  restart, or replace the computer-use backend or other infrastructure —
+  the driver owns the environment.
 
 Completion:
 - Before finishing, verify the requested outcome and inspect the final

--- a/sdk/packages/core/src/extensions/computer-user/index.ts
+++ b/sdk/packages/core/src/extensions/computer-user/index.ts
@@ -19,9 +19,14 @@ export {
 	type HelperNote,
 	type HelperRun,
 } from "./coordinator";
+export type { ComputerUserDriverToolOptions } from "./driver-tools";
 export { createComputerUserDriverTools } from "./driver-tools";
 export {
 	COMPUTER_USER_PROMPT_VERSION,
 	COMPUTER_USER_SYSTEM_PROMPT,
 } from "./helper-prompt";
 export { createComputerUserCollaborationTools } from "./helper-tools";
+export {
+	type ComputerUserTranscriptEntry,
+	ComputerUserTranscriptLog,
+} from "./transcript-log";

--- a/sdk/packages/core/src/extensions/computer-user/transcript-log.test.ts
+++ b/sdk/packages/core/src/extensions/computer-user/transcript-log.test.ts
@@ -1,0 +1,157 @@
+import type { AgentMessage } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import type {
+	ArtifactSinkStatus,
+	ComputerTaskArtifactEvent,
+} from "../computer-observability/artifact-events";
+import { ComputerTaskArtifactRecorder } from "../computer-observability/recorder";
+import { createTranscriptRecordingHooks } from "../computer-observability/transcript-observer";
+import { ComputerUserTranscriptLog } from "./transcript-log";
+
+const snapshot = { agentId: "agent-1" } as never;
+
+function makeMessage(
+	role: AgentMessage["role"],
+	content: AgentMessage["content"],
+): AgentMessage {
+	return { id: "msg_1", role, content, createdAt: 0 };
+}
+
+/**
+ * Drives the real recording hooks with a recorder whose sink collects
+ * journal events — the same path production uses — so the log's content is
+ * proven identical to what the observatory would journal.
+ */
+function commitThroughHooks(
+	log: ComputerUserTranscriptLog,
+	messages: AgentMessage[],
+): ComputerTaskArtifactEvent[] {
+	const events: ComputerTaskArtifactEvent[] = [];
+	const recorder = new ComputerTaskArtifactRecorder("art_test", {
+		emit: (event) => {
+			events.push(event);
+		},
+		flush: async (): Promise<ArtifactSinkStatus> => ({
+			status: "complete",
+			lastClientSequence: events.length,
+			lastAcknowledgedSequence: events.length,
+		}),
+	});
+	const hooks = createTranscriptRecordingHooks(
+		recorder,
+		{ kind: "computer_user", sessionId: "helper-session" },
+		(event) => log.append(event),
+	);
+	for (const message of messages) {
+		void hooks.onEvent?.({ type: "message-added", snapshot, message });
+	}
+	return events;
+}
+
+describe("ComputerUserTranscriptLog", () => {
+	it("records the same reduced entries the journal sink receives", () => {
+		const log = new ComputerUserTranscriptLog();
+		const events = commitThroughHooks(log, [
+			makeMessage("user", [{ type: "text", text: "Open the settings page" }]),
+			makeMessage("assistant", [
+				{ type: "reasoning", text: "Find the window first." },
+				{ type: "text", text: "Opening it now." },
+				{
+					type: "tool-call",
+					toolCallId: "call_1",
+					toolName: "computer",
+					input: { action: "left_click", coordinate: [10, 20] },
+				},
+			]),
+			makeMessage("tool", [
+				{
+					type: "tool-result",
+					toolCallId: "call_1",
+					toolName: "computer",
+					output: "clicked",
+				},
+			]),
+		]);
+
+		const { entries, latestSeq } = log.tail({ limit: 100 });
+		const journalTranscript = events
+			.filter((event) => event.type === "transcript.message_committed")
+			.map((event) => event.payload);
+		expect(entries.map((entry) => entry.role)).toEqual(
+			journalTranscript.map((payload) => payload.role),
+		);
+		expect(entries).toHaveLength(5);
+		expect(entries[0]).toMatchObject({
+			role: "user",
+			text: "Open the settings page",
+			sessionId: "helper-session",
+		});
+		expect(entries[1]).toMatchObject({ role: "reasoning" });
+		expect(entries[2]).toMatchObject({
+			role: "assistant",
+			text: "Opening it now.",
+		});
+		expect(entries[3]).toMatchObject({
+			role: "tool_call",
+			toolName: "computer",
+			toolCallId: "call_1",
+		});
+		expect(entries[3].input).toContain("left_click");
+		expect(entries[4]).toMatchObject({
+			role: "tool_result",
+			toolName: "computer",
+			ok: true,
+		});
+		expect(entries[0].seq).toBe(1);
+		expect(latestSeq).toBe(entries[entries.length - 1].seq);
+	});
+
+	it("pages new activity with sinceSeq", () => {
+		const log = new ComputerUserTranscriptLog();
+		commitThroughHooks(log, [
+			makeMessage("user", [{ type: "text", text: "first" }]),
+			makeMessage("user", [{ type: "text", text: "second" }]),
+		]);
+		const first = log.tail({ limit: 100 });
+		expect(first.entries.map((entry) => entry.text)).toEqual([
+			"first",
+			"second",
+		]);
+
+		commitThroughHooks(log, [
+			makeMessage("user", [{ type: "text", text: "third" }]),
+		]);
+		const next = log.tail({ limit: 100, sinceSeq: first.latestSeq });
+		expect(next.entries.map((entry) => entry.text)).toEqual(["third"]);
+		expect(next.latestSeq).toBe(first.latestSeq + 1);
+	});
+
+	it("keeps only the last capacity entries", () => {
+		const log = new ComputerUserTranscriptLog(3);
+		commitThroughHooks(
+			log,
+			[1, 2, 3, 4, 5].map((n) =>
+				makeMessage("user", [{ type: "text", text: `m${n}` }]),
+			),
+		);
+		const { entries, latestSeq } = log.tail({ limit: 100 });
+		expect(entries.map((entry) => entry.text)).toEqual(["m3", "m4", "m5"]);
+		expect(entries[0].seq).toBe(3);
+		expect(latestSeq).toBe(5);
+	});
+
+	it("ignores non-transcript events the tee may see", () => {
+		const log = new ComputerUserTranscriptLog();
+		log.append({
+			version: 1,
+			artifactId: "art_test",
+			eventId: "evt_x",
+			clientSequence: 1,
+			occurredAt: new Date().toISOString(),
+			source: { kind: "coordinator" },
+			type: "session.status_changed",
+			payload: { status: "running" },
+		});
+		expect(log.tail()).toMatchObject({ entries: [], latestSeq: 0 });
+	});
+});

--- a/sdk/packages/core/src/extensions/computer-user/transcript-log.ts
+++ b/sdk/packages/core/src/extensions/computer-user/transcript-log.ts
@@ -1,0 +1,101 @@
+import type { ComputerTaskArtifactEvent } from "../computer-observability/artifact-events";
+
+/**
+ * In-process tail of the computer user's transcript.
+ *
+ * The recording hooks already reduce every committed helper message to a
+ * journal payload (see transcript-observer.ts); this log is a second sink for
+ * exactly those events, so the driver's `computer_user_transcript` tool sees
+ * byte-identical content to the observatory without dialing the backend —
+ * crucially including while the backend is down. Entries keep the session id
+ * they belong to, so history survives a helper restart without being
+ * mistaken for the new session's activity. The buffer is bounded: peeking can
+ * never grow the driver process unboundedly.
+ */
+
+export interface ComputerUserTranscriptEntry {
+	/** Monotonic sequence, unique per log instance. Cursor for `sinceSeq`. */
+	seq: number;
+	/** Epoch milliseconds when the message was committed. */
+	at: number;
+	/** The session the message belongs to; undefined until the first run. */
+	sessionId?: string;
+	role: string;
+	text?: string;
+	toolName?: string;
+	/** Truncated tool input, as reduced by the recording hooks. */
+	input?: string;
+	ok?: boolean;
+	toolCallId?: string;
+}
+
+const DEFAULT_CAPACITY = 200;
+
+function entryFromEvent(
+	event: ComputerTaskArtifactEvent,
+): ComputerUserTranscriptEntry | undefined {
+	if (event.type !== "transcript.message_committed") {
+		return undefined;
+	}
+	const payload = event.payload as Record<string, unknown>;
+	const correlation = event.correlation as { toolCallId?: string } | undefined;
+	const sessionId =
+		typeof event.source === "object" &&
+		event.source !== null &&
+		"sessionId" in event.source
+			? (event.source as { sessionId?: unknown }).sessionId
+			: undefined;
+	return {
+		seq: -1, // assigned by append
+		at: Date.parse(event.occurredAt),
+		sessionId: typeof sessionId === "string" ? sessionId : undefined,
+		role: String(payload.role ?? ""),
+		...(typeof payload.text === "string" ? { text: payload.text } : {}),
+		...(typeof payload.toolName === "string"
+			? { toolName: payload.toolName }
+			: {}),
+		...(typeof payload.input === "string" ? { input: payload.input } : {}),
+		...(typeof payload.ok === "boolean" ? { ok: payload.ok } : {}),
+		...(correlation?.toolCallId ? { toolCallId: correlation.toolCallId } : {}),
+	};
+}
+
+export class ComputerUserTranscriptLog {
+	private readonly entries: ComputerUserTranscriptEntry[] = [];
+	private nextSeq = 1;
+
+	constructor(private readonly capacity: number = DEFAULT_CAPACITY) {}
+
+	/** Tee target for the recording hooks: keeps the last `capacity` events. */
+	append(event: ComputerTaskArtifactEvent): void {
+		const entry = entryFromEvent(event);
+		if (!entry) {
+			return;
+		}
+		entry.seq = this.nextSeq++;
+		this.entries.push(entry);
+		if (this.entries.length > this.capacity) {
+			this.entries.splice(0, this.entries.length - this.capacity);
+		}
+	}
+
+	/**
+	 * Returns up to `limit` entries in commit order. `sinceSeq` skips entries
+	 * up to and including that sequence, so a driver can page through new
+	 * activity without re-reading what it has already seen.
+	 */
+	tail(options?: { limit?: number; sinceSeq?: number }): {
+		entries: ComputerUserTranscriptEntry[];
+		latestSeq: number;
+	} {
+		const limit = Math.min(Math.max(options?.limit ?? 50, 1), 100);
+		const sinceSeq = options?.sinceSeq ?? 0;
+		const selected = this.entries
+			.filter((entry) => entry.seq > sinceSeq)
+			.slice(-limit);
+		return {
+			entries: selected,
+			latestSeq: this.nextSeq - 1,
+		};
+	}
+}

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -974,7 +974,10 @@ export {
 	truncateCommandOutput,
 } from "./extensions/tools";
 export {
+	ComputerBackendRestart,
 	ComputerUseClient,
+	type ComputerBackendEnsureResult,
+	type ComputerBackendRestartOptions,
 	type ComputerUseClientEvent,
 	type ComputerUseClientObserver,
 	type ComputerUseClientOptions,
@@ -990,6 +993,7 @@ export {
 	GET_DISPLAY_INFO_ACTION,
 	isComputerUseResponse,
 	PUBLISH_EVENT_ACTION,
+	resolveComputerUseBackendCommandFromEnv,
 	resolveComputerUseTargetFromEnv,
 	type ComputerUseToolOptions,
 } from "./extensions/computer-use";
@@ -1007,6 +1011,7 @@ export {
 	createJournalEventSink,
 	createTranscriptRecordingHooks,
 	type JournalPublishTransport,
+	type TranscriptRecordingTee,
 } from "./extensions/computer-observability";
 export {
 	COMPUTER_USER_PROMPT_VERSION,
@@ -1018,10 +1023,13 @@ export {
 	type ComputerUserStatus,
 	createComputerUserCollaborationTools,
 	createComputerUserDriverTools,
+	type ComputerUserDriverToolOptions,
 	type DriverNotifier,
 	type DriverQuestion,
 	type HelperNote,
 	type HelperRun,
+	ComputerUserTranscriptLog,
+	type ComputerUserTranscriptEntry,
 } from "./extensions/computer-user";
 export {
 	applyClineFeaturedModels,


### PR DESCRIPTION
## The driver can finally see — and fix — a degraded computer user

The computer user works asynchronously, but when it degraded we had neither
visibility nor recovery: helper turns ended with "finished without a
structured report" so neither the driver nor the human knew what it had done
(the human had to peek at its window — and today that peeking corrupted a
verification run), a wedged helper kept mis-firing on stale briefings, and a
dead backend (qbt) needed a human at the console. Today all three happened
in a single afternoon.

This adds three driver tools and tightens the helper prompt:

- **`computer_user_transcript`** — peeks the helper's recent transcript
  (reasoning, tool calls, results, final reports) from an in-process ring
  buffer that tees off the exact reduction the observatory journal uses
  (one reduction, two sinks), so it works even while the backend is down.
  Entries carry their session id, so history before a restart stays
  distinguishable; `sinceSeq` pages new activity.
- **`computer_user_restart`** — recreates a degraded helper: aborts the
  active run, stops the session, and resets the coordinator to
  `uninitialized` through the same serialized transition queue (and the same
  stale-settlement guards) that `dispose` uses. The next start binds a
  fresh session.
- **`computer_user_restart_backend`** — brings the computer-use backend
  back when it is unreachable. Probes first (`already_running` no-ops),
  launches the configured `CLINE_COMPUTER_USE_BACKEND_COMMAND` only when
  down, waits until it answers `get_display_info`, and only ever terminates
  a backend it spawned itself. Daemonizing launch commands (spawn-and-exit)
  are probed before their exit is treated as failure.
- **Helper prompt v2** — the driver's latest instructions supersede every
  earlier briefing (stand-down means stand down), work stays on the current
  task, and backend failures are reported via `ask_driver` instead of the
  helper improvising infrastructure repairs. Out-of-band shell automation
  stays sanctioned for what the computer tool cannot express (e.g. window
  management) — capability preserved, discipline added.

## Test plan

```sh
cd sdk/packages/core && bun x vitest run \
  src/extensions/computer-user src/extensions/computer-use \
  src/extensions/computer-observability   # 74 passed
cd apps/cli && bun x vitest run \
  src/runtime/interactive/computer-user.test.ts src/runtime/interactive/mode.test.ts  # 27 passed
bun run build:sdk   # clean
bun x tsc -p apps/cli/tsconfig.json --noEmit   # clean
```

The backend-restart suite runs against a real child process: a fixture
fake-backend speaks the JSON-L protocol, and the tests cover
already-running no-op, launch-when-down (plus a real client connecting to
the restarted backend), daemonizing launchers, immediate-exit failures,
never-answers timeout with self-spawn cleanup, and single-flight
concurrency. The transcript suite drives the real recording hooks +
recorder and asserts the log sees the same reduced events the journal sink
sees.

Stacked on `dpc/computer-use` — base branch `dpc/computer-use`.
