### PR TITLE
fix(webview): flag attached images the selected model can't use and offer a model switch

### DIFF
--- a/.changeset/text-only-model-image-warning.md
+++ b/.changeset/text-only-model-image-warning.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Warn when an image is pasted or dropped into the chat box while the selected model does not support image input, instead of attaching it and silently dropping it before the API call

--- a/.changeset/text-only-model-image-warning.md
+++ b/.changeset/text-only-model-image-warning.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Warn when an image is pasted or dropped into the chat box while the selected model does not support image input, instead of attaching it and silently dropping it before the API call
+Warn when attached images will be ignored because the selected model does not support image input: image thumbnails get a warning badge and the composer offers to switch to an image-capable model, instead of the images being silently dropped before the API call

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.test.ts
@@ -130,6 +130,28 @@ describe("adaptSdkModelInfo", () => {
 			expect(Object.hasOwn(model, "capabilities")).toBe(false)
 		})
 
+		it("treats declared text-only input modalities as no image support, even without capabilities", () => {
+			const model = adaptSdkModelInfo({ id: "m", modalities: { input: ["text"], output: ["text"] } })
+			expect(model.supportsImages).toBe(false)
+		})
+
+		it("lets declared input modalities override the capability-derived image flag", () => {
+			expect(
+				adaptSdkModelInfo({
+					id: "m",
+					capabilities: ["images"],
+					modalities: { input: ["text"], output: ["text"] },
+				}).supportsImages,
+			).toBe(false)
+			expect(
+				adaptSdkModelInfo({
+					id: "m",
+					capabilities: ["tools"],
+					modalities: { input: ["text", "image"], output: ["text"] },
+				}).supportsImages,
+			).toBe(true)
+		})
+
 		it("preserves SDK input and output modalities", () => {
 			const model = adaptSdkModelInfo({
 				id: "image-model",

--- a/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
+++ b/apps/vscode/src/sdk/model-catalog/shape-adapter.ts
@@ -32,7 +32,7 @@
  * | contextWindow | `sdk.contextWindow`, or positive `sdk.maxInputTokens` for legacy display compatibility | safe default: 128_000 |
  * | maxInputTokens | `sdk.maxInputTokens` if finite number (null = missing) | omitted (undefined) |
  * | maxTokens | `sdk.maxTokens` if finite number (null = missing) | safe default: -1 |
- * | supportsImages | capabilities includes `images` or `vision` | safe default: true when capabilities absent |
+ * | supportsImages | `modalities.input` includes `image` when declared, else capabilities includes `images` or `vision` | safe default: true when both absent |
  * | supportsPromptCache | capabilities includes `prompt-cache` | safe default: false when capabilities absent |
  * | supportsReasoning | capabilities includes `reasoning` | omitted (undefined) |
  * | inputPrice | `sdk.pricing.input` if finite number | safe default: 0 |
@@ -291,6 +291,12 @@ export function adaptSdkModelInfo(input: unknown): ModelInfo {
 		}
 	} else {
 		result.supportsImages = openAiModelInfoSafeDefaults.supportsImages
+	}
+	// Declared input modalities win over capabilities, matching what the provider
+	// layer sends (`supportedInputModalities`), so the UI never offers image input
+	// that the request formatter would strip.
+	if (modalities?.input) {
+		result.supportsImages = modalities.input.includes("image")
 	}
 
 	if (pricing?.cacheRead !== undefined) {

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import ChatTextArea from "./ChatTextArea"
+
+const mocks = vi.hoisted(() => ({
+	supportsImages: true as boolean | undefined,
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		mode: "act",
+		apiConfiguration: {},
+		openRouterModels: {},
+		platform: "darwin",
+		localWorkflowToggles: {},
+		globalWorkflowToggles: {},
+		remoteWorkflowToggles: {},
+		remoteConfigSettings: undefined,
+		navigateToSettingsModelPicker: vi.fn(),
+		mcpServers: [],
+	}),
+}))
+
+vi.mock("@/context/PlatformContext", () => ({
+	usePlatform: () => ({ togglePlanActKeys: "Meta+Shift+a" }),
+}))
+
+vi.mock("@/hooks/useNormalizedApiConfiguration", () => ({
+	useNormalizedApiConfiguration: () => ({
+		selectedProvider: "anthropic",
+		selectedModelId: "test-model",
+		selectedModelInfo: { supportsImages: mocks.supportsImages },
+	}),
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	FileServiceClient: {
+		searchCommits: vi.fn(async () => ({ commits: [] })),
+		searchFiles: vi.fn(async () => ({ results: [] })),
+		getRelativePaths: vi.fn(async () => ({ paths: [] })),
+	},
+	StateServiceClient: {
+		togglePlanActModeProto: vi.fn(async () => ({})),
+	},
+}))
+
+vi.mock("../cline-rules/ClineRulesToggleModal", () => ({ default: () => null }))
+vi.mock("./ServersToggleModal", () => ({ default: () => null }))
+
+const WARNING = /does not support images/
+
+function renderTextArea() {
+	const setSelectedImages = vi.fn()
+	render(
+		<ChatTextArea
+			activeQuote={null}
+			inputValue=""
+			onSelectFilesAndImages={vi.fn()}
+			onSend={vi.fn()}
+			placeholderText="Type a message"
+			selectedFiles={[]}
+			selectedImages={[]}
+			sendingDisabled={false}
+			setInputValue={vi.fn()}
+			setSelectedFiles={vi.fn()}
+			setSelectedImages={setSelectedImages}
+			shouldDisableFilesAndImages={false}
+		/>,
+	)
+	return { textarea: screen.getByPlaceholderText("Type a message"), setSelectedImages }
+}
+
+function pngFile() {
+	return new File(["png"], "screenshot.png", { type: "image/png" })
+}
+
+function pasteImage(target: HTMLElement) {
+	const file = pngFile()
+	fireEvent.paste(target, {
+		clipboardData: {
+			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+			getData: () => "",
+		},
+	})
+}
+
+function dropImage(target: HTMLElement) {
+	fireEvent.drop(target, {
+		dataTransfer: {
+			files: [pngFile()],
+			items: [],
+			types: ["Files"],
+			getData: () => "",
+		},
+	})
+}
+
+describe("ChatTextArea image attachments vs. model capability", () => {
+	beforeEach(() => {
+		mocks.supportsImages = true
+	})
+
+	it("refuses a pasted image and explains why when the model is text-only", () => {
+		mocks.supportsImages = false
+		const { textarea, setSelectedImages } = renderTextArea()
+
+		pasteImage(textarea)
+
+		expect(screen.getByText(WARNING)).toBeInTheDocument()
+		expect(setSelectedImages).not.toHaveBeenCalled()
+	})
+
+	it("refuses a dropped image and explains why when the model is text-only", () => {
+		mocks.supportsImages = false
+		const { textarea, setSelectedImages } = renderTextArea()
+
+		dropImage(textarea)
+
+		expect(screen.getByText(WARNING)).toBeInTheDocument()
+		expect(setSelectedImages).not.toHaveBeenCalled()
+	})
+
+	it("does not warn when the model supports images", () => {
+		const { textarea } = renderTextArea()
+
+		pasteImage(textarea)
+		dropImage(textarea)
+
+		expect(screen.queryByText(WARNING)).not.toBeInTheDocument()
+	})
+
+	it("fails open when the model's image support is unknown", () => {
+		mocks.supportsImages = undefined
+		const { textarea } = renderTextArea()
+
+		pasteImage(textarea)
+
+		expect(screen.queryByText(WARNING)).not.toBeInTheDocument()
+	})
+})

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
@@ -107,7 +107,10 @@ describe("ChatTextArea image attachments vs. model capability", () => {
 		expect(notice).toHaveTextContent("text-only-model doesn't support images, so the 2 attached images will be ignored.")
 		expect(screen.getAllByTestId("image-unsupported-badge")).toHaveLength(2)
 
-		fireEvent.click(screen.getByTestId("images-unsupported-choose-model"))
+		// A native button, so keyboard users get Enter/Space activation without extra handlers.
+		const chooseModel = screen.getByRole("button", { name: "Choose an image-capable model" })
+		expect(chooseModel.tagName).toBe("BUTTON")
+		fireEvent.click(chooseModel)
 		expect(mocks.navigateToSettingsModelPicker).toHaveBeenCalledWith({ targetSection: "api-config" })
 	})
 

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.test.tsx
@@ -4,6 +4,7 @@ import ChatTextArea from "./ChatTextArea"
 
 const mocks = vi.hoisted(() => ({
 	supportsImages: true as boolean | undefined,
+	navigateToSettingsModelPicker: vi.fn(),
 }))
 
 vi.mock("@/context/ExtensionStateContext", () => ({
@@ -16,7 +17,7 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 		globalWorkflowToggles: {},
 		remoteWorkflowToggles: {},
 		remoteConfigSettings: undefined,
-		navigateToSettingsModelPicker: vi.fn(),
+		navigateToSettingsModelPicker: mocks.navigateToSettingsModelPicker,
 		mcpServers: [],
 	}),
 }))
@@ -28,7 +29,7 @@ vi.mock("@/context/PlatformContext", () => ({
 vi.mock("@/hooks/useNormalizedApiConfiguration", () => ({
 	useNormalizedApiConfiguration: () => ({
 		selectedProvider: "anthropic",
-		selectedModelId: "test-model",
+		selectedModelId: "text-only-model",
 		selectedModelInfo: { supportsImages: mocks.supportsImages },
 	}),
 }))
@@ -38,6 +39,8 @@ vi.mock("@/services/grpc-client", () => ({
 		searchCommits: vi.fn(async () => ({ commits: [] })),
 		searchFiles: vi.fn(async () => ({ results: [] })),
 		getRelativePaths: vi.fn(async () => ({ paths: [] })),
+		openImage: vi.fn(async () => ({})),
+		openFile: vi.fn(async () => ({})),
 	},
 	StateServiceClient: {
 		togglePlanActModeProto: vi.fn(async () => ({})),
@@ -47,9 +50,9 @@ vi.mock("@/services/grpc-client", () => ({
 vi.mock("../cline-rules/ClineRulesToggleModal", () => ({ default: () => null }))
 vi.mock("./ServersToggleModal", () => ({ default: () => null }))
 
-const WARNING = /does not support images/
+const PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgo="
 
-function renderTextArea() {
+function renderTextArea(selectedImages: string[] = []) {
 	const setSelectedImages = vi.fn()
 	render(
 		<ChatTextArea
@@ -59,7 +62,7 @@ function renderTextArea() {
 			onSend={vi.fn()}
 			placeholderText="Type a message"
 			selectedFiles={[]}
-			selectedImages={[]}
+			selectedImages={selectedImages}
 			sendingDisabled={false}
 			setInputValue={vi.fn()}
 			setSelectedFiles={vi.fn()}
@@ -70,26 +73,11 @@ function renderTextArea() {
 	return { textarea: screen.getByPlaceholderText("Type a message"), setSelectedImages }
 }
 
-function pngFile() {
-	return new File(["png"], "screenshot.png", { type: "image/png" })
-}
-
 function pasteImage(target: HTMLElement) {
-	const file = pngFile()
-	fireEvent.paste(target, {
+	const file = new File(["png"], "screenshot.png", { type: "image/png" })
+	return fireEvent.paste(target, {
 		clipboardData: {
 			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
-			getData: () => "",
-		},
-	})
-}
-
-function dropImage(target: HTMLElement) {
-	fireEvent.drop(target, {
-		dataTransfer: {
-			files: [pngFile()],
-			items: [],
-			types: ["Files"],
 			getData: () => "",
 		},
 	})
@@ -98,43 +86,57 @@ function dropImage(target: HTMLElement) {
 describe("ChatTextArea image attachments vs. model capability", () => {
 	beforeEach(() => {
 		mocks.supportsImages = true
+		mocks.navigateToSettingsModelPicker.mockReset()
 	})
 
-	it("refuses a pasted image and explains why when the model is text-only", () => {
+	it("still takes the image attach path on paste for a text-only model, without a refusal message", () => {
 		mocks.supportsImages = false
-		const { textarea, setSelectedImages } = renderTextArea()
-
-		pasteImage(textarea)
-
-		expect(screen.getByText(WARNING)).toBeInTheDocument()
-		expect(setSelectedImages).not.toHaveBeenCalled()
-	})
-
-	it("refuses a dropped image and explains why when the model is text-only", () => {
-		mocks.supportsImages = false
-		const { textarea, setSelectedImages } = renderTextArea()
-
-		dropImage(textarea)
-
-		expect(screen.getByText(WARNING)).toBeInTheDocument()
-		expect(setSelectedImages).not.toHaveBeenCalled()
-	})
-
-	it("does not warn when the model supports images", () => {
 		const { textarea } = renderTextArea()
 
-		pasteImage(textarea)
-		dropImage(textarea)
+		const notCanceled = pasteImage(textarea)
 
-		expect(screen.queryByText(WARNING)).not.toBeInTheDocument()
+		expect(notCanceled).toBe(false) // preventDefault: the paste was handled as an image, not as text
+		expect(screen.queryByText(/ignored/)).not.toBeInTheDocument()
+	})
+
+	it("badges attached images and offers a model switch when the model is text-only", () => {
+		mocks.supportsImages = false
+		renderTextArea([PNG_DATA_URL, PNG_DATA_URL])
+
+		const notice = screen.getByTestId("images-unsupported-notice")
+		expect(notice).toHaveTextContent("text-only-model doesn't support images, so the 2 attached images will be ignored.")
+		expect(screen.getAllByTestId("image-unsupported-badge")).toHaveLength(2)
+
+		fireEvent.click(screen.getByTestId("images-unsupported-choose-model"))
+		expect(mocks.navigateToSettingsModelPicker).toHaveBeenCalledWith({ targetSection: "api-config" })
+	})
+
+	it("uses singular wording for one image", () => {
+		mocks.supportsImages = false
+		renderTextArea([PNG_DATA_URL])
+
+		expect(screen.getByTestId("images-unsupported-notice")).toHaveTextContent("the attached image will be ignored")
+		expect(screen.getByTestId("images-unsupported-notice")).toHaveTextContent("or remove it.")
+	})
+
+	it("shows nothing extra when the model supports images", () => {
+		renderTextArea([PNG_DATA_URL])
+
+		expect(screen.queryByTestId("images-unsupported-notice")).not.toBeInTheDocument()
+		expect(screen.queryByTestId("image-unsupported-badge")).not.toBeInTheDocument()
 	})
 
 	it("fails open when the model's image support is unknown", () => {
 		mocks.supportsImages = undefined
-		const { textarea } = renderTextArea()
+		renderTextArea([PNG_DATA_URL])
 
-		pasteImage(textarea)
+		expect(screen.queryByTestId("images-unsupported-notice")).not.toBeInTheDocument()
+	})
 
-		expect(screen.queryByText(WARNING)).not.toBeInTheDocument()
+	it("shows nothing for a text-only model while no images are attached", () => {
+		mocks.supportsImages = false
+		renderTextArea()
+
+		expect(screen.queryByTestId("images-unsupported-notice")).not.toBeInTheDocument()
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -5,7 +5,7 @@ import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/cline/state
 import { type SlashCommand } from "@shared/slashCommands"
 import { Mode } from "@shared/storage/types"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
-import { AtSignIcon, PlusIcon } from "lucide-react"
+import { AtSignIcon, PlusIcon, TriangleAlertIcon } from "lucide-react"
 import type React from "react"
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import DynamicTextArea from "react-textarea-autosize"
@@ -256,15 +256,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showDimensionError, setShowDimensionError] = useState(false)
 		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
-		const [showModelImagesError, setShowModelImagesError] = useState(false)
-		const modelImagesErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
 		const [, metaKeyChar] = useMetaKeyDetection(platform)
 		const { selectedProvider, selectedModelId, selectedModelInfo } = useNormalizedApiConfiguration(mode)
-		// Unknown capability data fails open, like core does before the API call.
+		// Images are attached regardless; when the selected model has no image input the thumbnails get a warning
+		// badge and a notice offers to switch models. Unknown capability data fails open, like core does.
 		const modelSupportsImages = selectedModelInfo.supportsImages !== false
+		const imagesUnsupported = selectedImages.length > 0 && !modelSupportsImages
 
 		// Fetch git commits when Git is selected or when typing a hash
 		useEffect(() => {
@@ -852,19 +852,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}, [])
 
-		// Shown when the user pastes or drops an image while the selected model is text-only.
-		// Without it the image would be attached, then silently replaced by a placeholder before the API call.
-		const showModelImagesErrorMessage = useCallback(() => {
-			setShowModelImagesError(true)
-			if (modelImagesErrorTimerRef.current) {
-				clearTimeout(modelImagesErrorTimerRef.current)
-			}
-			modelImagesErrorTimerRef.current = setTimeout(() => {
-				setShowModelImagesError(false)
-				modelImagesErrorTimerRef.current = null
-			}, 3000)
-		}, [])
-
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -900,11 +887,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
-				if (imageItems.length > 0 && !modelSupportsImages) {
-					e.preventDefault()
-					showModelImagesErrorMessage()
-					return
-				}
 				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
 					e.preventDefault()
 					const imagePromises = imageItems.map((item) => {
@@ -956,7 +938,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			},
 			[
 				shouldDisableFilesAndImages,
-				modelSupportsImages,
 				setSelectedImages,
 				selectedImages,
 				selectedFiles,
@@ -964,7 +945,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
-				showModelImagesErrorMessage,
 			],
 		)
 
@@ -1352,11 +1332,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
-			if (imageFiles.length > 0 && !modelSupportsImages) {
-				showModelImagesErrorMessage()
-				return
-			}
-
 			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
 				return
 			}
@@ -1453,13 +1428,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							<span className="text-error font-bold text-xs">Files other than images are currently disabled</span>
 						</div>
 					)}
-					{showModelImagesError && (
-						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
-							<span className="text-error font-bold text-xs text-center">
-								The selected model does not support images, so the image was ignored
-							</span>
-						</div>
-					)}
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
@@ -1542,9 +1510,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						onPaste={handlePaste}
 						onScroll={() => updateHighlights()}
 						onSelect={updateCursorPosition}
-						placeholder={
-							showUnsupportedFileError || showDimensionError || showModelImagesError ? "" : placeholderText
-						}
+						placeholder={showUnsupportedFileError || showDimensionError ? "" : placeholderText}
 						ref={(el) => {
 							if (typeof ref === "function") {
 								ref(el)
@@ -1601,6 +1567,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<Thumbnails
 							files={selectedFiles}
 							images={selectedImages}
+							imagesUnsupported={imagesUnsupported}
 							onHeightChange={handleThumbnailsHeightChange}
 							setFiles={setSelectedFiles}
 							setImages={setSelectedImages}
@@ -1630,6 +1597,29 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						</div>
 					</div>
 				</div>
+				{imagesUnsupported && (
+					<div
+						className="flex items-center gap-1.5 px-3.5 pb-1.5 text-xs"
+						data-testid="images-unsupported-notice"
+						role="status"
+						style={{ color: "var(--vscode-editorWarning-foreground)" }}>
+						<TriangleAlertIcon className="shrink-0" size={12} />
+						<span className="min-w-0">
+							{selectedModelId} doesn't support images, so{" "}
+							{selectedImages.length === 1 ? "the attached image" : `the ${selectedImages.length} attached images`}{" "}
+							will be ignored.{" "}
+							<a
+								className="underline cursor-pointer"
+								data-testid="images-unsupported-choose-model"
+								onClick={handleModelButtonClick}
+								role="button"
+								tabIndex={0}>
+								Choose an image-capable model
+							</a>{" "}
+							or remove {selectedImages.length === 1 ? "it" : "them"}.
+						</span>
+					</div>
+				)}
 				<div className="flex justify-between items-center -mt-[2px] px-3 pb-2">
 					{/* Always render both components, but control visibility with CSS */}
 					<div className="relative flex-1 min-w-0 h-5">

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1608,14 +1608,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							{selectedModelId} doesn't support images, so{" "}
 							{selectedImages.length === 1 ? "the attached image" : `the ${selectedImages.length} attached images`}{" "}
 							will be ignored.{" "}
-							<a
-								className="underline cursor-pointer"
+							<button
+								className="underline cursor-pointer bg-transparent border-0 p-0 m-0 text-inherit font-inherit"
 								data-testid="images-unsupported-choose-model"
 								onClick={handleModelButtonClick}
-								role="button"
-								tabIndex={0}>
+								type="button">
 								Choose an image-capable model
-							</a>{" "}
+							</button>{" "}
 							or remove {selectedImages.length === 1 ? "it" : "them"}.
 						</span>
 					</div>

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -264,7 +264,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		// Images are attached regardless; when the selected model has no image input the thumbnails get a warning
 		// badge and a notice offers to switch models. Unknown capability data fails open, like core does.
 		const modelSupportsImages = selectedModelInfo.supportsImages !== false
-		const imagesUnsupported = selectedImages.length > 0 && !modelSupportsImages
+		const unsupportedImagesAttached = selectedImages.length > 0 && !modelSupportsImages
 
 		// Fetch git commits when Git is selected or when typing a hash
 		useEffect(() => {
@@ -1567,7 +1567,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<Thumbnails
 							files={selectedFiles}
 							images={selectedImages}
-							imagesUnsupported={imagesUnsupported}
+							imagesUnsupported={unsupportedImagesAttached}
 							onHeightChange={handleThumbnailsHeightChange}
 							setFiles={setSelectedFiles}
 							setImages={setSelectedImages}
@@ -1597,7 +1597,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						</div>
 					</div>
 				</div>
-				{imagesUnsupported && (
+				{unsupportedImagesAttached && (
 					<div
 						className="flex items-center gap-1.5 px-3.5 pb-1.5 text-xs"
 						data-testid="images-unsupported-notice"

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1609,7 +1609,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							{selectedImages.length === 1 ? "the attached image" : `the ${selectedImages.length} attached images`}{" "}
 							will be ignored.{" "}
 							<button
-								className="underline cursor-pointer bg-transparent border-0 p-0 m-0 text-inherit font-inherit"
+								className="underline cursor-pointer bg-transparent border-0 p-0 m-0 text-[var(--vscode-textLink-foreground)] hover:text-[var(--vscode-textLink-activeForeground)]"
 								data-testid="images-unsupported-choose-model"
 								onClick={handleModelButtonClick}
 								type="button">

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -256,11 +256,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showDimensionError, setShowDimensionError] = useState(false)
 		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showModelImagesError, setShowModelImagesError] = useState(false)
+		const modelImagesErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
 		const [, metaKeyChar] = useMetaKeyDetection(platform)
-		const { selectedProvider, selectedModelId } = useNormalizedApiConfiguration(mode)
+		const { selectedProvider, selectedModelId, selectedModelInfo } = useNormalizedApiConfiguration(mode)
+		// Unknown capability data fails open, like core does before the API call.
+		const modelSupportsImages = selectedModelInfo.supportsImages !== false
 
 		// Fetch git commits when Git is selected or when typing a hash
 		useEffect(() => {
@@ -848,6 +852,19 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, 3000)
 		}, [])
 
+		// Shown when the user pastes or drops an image while the selected model is text-only.
+		// Without it the image would be attached, then silently replaced by a placeholder before the API call.
+		const showModelImagesErrorMessage = useCallback(() => {
+			setShowModelImagesError(true)
+			if (modelImagesErrorTimerRef.current) {
+				clearTimeout(modelImagesErrorTimerRef.current)
+			}
+			modelImagesErrorTimerRef.current = setTimeout(() => {
+				setShowModelImagesError(false)
+				modelImagesErrorTimerRef.current = null
+			}, 3000)
+		}, [])
+
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -883,6 +900,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
+				if (imageItems.length > 0 && !modelSupportsImages) {
+					e.preventDefault()
+					showModelImagesErrorMessage()
+					return
+				}
 				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
 					e.preventDefault()
 					const imagePromises = imageItems.map((item) => {
@@ -934,6 +956,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			},
 			[
 				shouldDisableFilesAndImages,
+				modelSupportsImages,
 				setSelectedImages,
 				selectedImages,
 				selectedFiles,
@@ -941,6 +964,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setInputValue,
 				inputValue,
 				showDimensionErrorMessage,
+				showModelImagesErrorMessage,
 			],
 		)
 
@@ -1328,6 +1352,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
+			if (imageFiles.length > 0 && !modelSupportsImages) {
+				showModelImagesErrorMessage()
+				return
+			}
+
 			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
 				return
 			}
@@ -1424,6 +1453,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							<span className="text-error font-bold text-xs">Files other than images are currently disabled</span>
 						</div>
 					)}
+					{showModelImagesError && (
+						<div className="absolute inset-2.5 bg-[rgba(var(--vscode-errorForeground-rgb),0.1)] border-2 border-error rounded-xs flex items-center justify-center z-10 pointer-events-none">
+							<span className="text-error font-bold text-xs text-center">
+								The selected model does not support images, so the image was ignored
+							</span>
+						</div>
+					)}
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
@@ -1506,7 +1542,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						onPaste={handlePaste}
 						onScroll={() => updateHighlights()}
 						onSelect={updateCursorPosition}
-						placeholder={showUnsupportedFileError || showDimensionError ? "" : placeholderText}
+						placeholder={
+							showUnsupportedFileError || showDimensionError || showModelImagesError ? "" : placeholderText
+						}
 						ref={(el) => {
 							if (typeof ref === "function") {
 								ref(el)

--- a/apps/vscode/webview-ui/src/components/common/Thumbnails.tsx
+++ b/apps/vscode/webview-ui/src/components/common/Thumbnails.tsx
@@ -12,9 +12,20 @@ interface ThumbnailsProps {
 	setFiles?: React.Dispatch<React.SetStateAction<string[]>>
 	onHeightChange?: (height: number) => void
 	className?: string
+	/** The selected model has no image input: mark image thumbnails as going to be ignored. */
+	imagesUnsupported?: boolean
 }
 
-const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange, className }: ThumbnailsProps) => {
+const Thumbnails = ({
+	images,
+	files,
+	style,
+	setImages,
+	setFiles,
+	onHeightChange,
+	className,
+	imagesUnsupported = false,
+}: ThumbnailsProps) => {
 	const [hoveredIndex, setHoveredIndex] = useState<string | null>(null)
 	const containerRef = useRef<HTMLDivElement>(null)
 	const { width } = useWindowSize()
@@ -79,8 +90,31 @@ const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange,
 							objectFit: "cover",
 							borderRadius: 4,
 							cursor: "pointer",
+							opacity: imagesUnsupported ? 0.55 : 1,
 						}}
 					/>
+					{imagesUnsupported && (
+						<div
+							data-testid="image-unsupported-badge"
+							style={{
+								position: "absolute",
+								top: -4,
+								left: -4,
+								width: 13,
+								height: 13,
+								borderRadius: "50%",
+								backgroundColor: "var(--vscode-editorWarning-foreground)",
+								display: "flex",
+								justifyContent: "center",
+								alignItems: "center",
+							}}
+							title="The selected model doesn't support images, so this image will be ignored.">
+							<span
+								className="codicon codicon-warning"
+								style={{ color: "var(--vscode-editor-background)", fontSize: 9, fontWeight: "bold" }}
+							/>
+						</div>
+					)}
 					{isDeletableImages && hoveredIndex === `image-${index}` && (
 						<div
 							onClick={() => handleDeleteImages(index)}
@@ -103,7 +137,8 @@ const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange,
 									color: "var(--vscode-foreground)",
 									fontSize: 10,
 									fontWeight: "bold",
-								}}></span>
+								}}
+							/>
 						</div>
 					)}
 				</div>
@@ -137,7 +172,8 @@ const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange,
 								style={{
 									fontSize: 16,
 									color: "var(--vscode-foreground)",
-								}}></span>
+								}}
+							/>
 							<span
 								style={{
 									fontSize: 7,
@@ -174,7 +210,8 @@ const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange,
 										color: "var(--vscode-foreground)",
 										fontSize: 10,
 										fontWeight: "bold",
-									}}></span>
+									}}
+								/>
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
### Related Issue

**Issue:** cline/intellij-plugin#598 — [CLINE-387](https://linear.app/cline-bot/issue/CLINE-387/cant-attach-images)

### Description

Pasting or dropping an image into the chat box never checked whether the selected model accepts image input. The image was attached and shown as a thumbnail, and only right before the API call the shared formatter replaced it with a text placeholder. The user got no signal that the image was ignored.

Images stay attached regardless of the model (dropping user content was the wrong shape). While the selected model has no image input:

- every image thumbnail gets a warning badge (tooltip: "The selected model doesn't support images, so this image will be ignored.") and is dimmed;
- a notice under the composer says "`<model>` doesn't support images, so the attached image(s) will be ignored. Choose an image-capable model or remove them", with the link opening the model picker.

Both derive from the currently selected model, not from the paste/drop moment, so they also cover attaching images on an image-capable model and then switching to a text-only one, and they clear as soon as the model changes back or the images are removed.

The flag comes from the model info the text area already resolves through `useNormalizedApiConfiguration`. On the host side, `shape-adapter.ts` lets declared `modalities.input` override the capability-derived `supportsImages`, matching the precedence the provider layer uses, so modalities-only text models are covered too. Unknown capability data fails open, matching `modelSupportsImageInput` in core.

The `+` button path is unchanged: it already omits image extensions from the file dialog for text-only models.

### Test Procedure

- `ChatTextArea.test.tsx` (6 tests): paste on a text-only model still takes the image path with no refusal message; two attached images on a text-only model render two badges and the notice, and the notice link opens the model picker; singular wording for one image; nothing extra for image-capable or unknown-capability models; nothing while no images are attached.
- `shape-adapter.test.ts`: text-only input modalities without capabilities yield `supportsImages: false`; declared modalities override the capability-derived flag both ways.
- `bunx vitest run` on both files passes; `biome check` reports only the pre-existing unused `openRouterModels` warning; `tsc --noEmit` clean.
- VS Code extension-development host and the JetBrains sandbox: paste and drop with an image-capable model attach thumbnails as before (probed via CDP).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Drag-and-drop into the JetBrains plugin was a separate issue (the IDE renders JCEF off-screen and never forwarded external file drops to the page); fixed on the plugin side in cline/intellij-plugin#1168, so the badge and notice apply to drops there too.

### Follow-ups (not in this PR, no tickets yet)

- **Image support is only discoverable after attaching an image.** Nothing in the model picker says whether a model accepts images, so the first signal a user gets is this badge. A small "vision" marker per model in the picker would let people choose knowingly. Touches the picker for every provider, so it should be its own change.
- **The `+` button still filters images out of the file picker for text-only models.** With the badge in place the filter could be dropped so users can attach and be told, consistently with paste and drop. That changes today's VS Code behavior as well as the JetBrains native chooser (cline/intellij-plugin#1167), so it's a deliberate decision rather than part of this fix.
