### PR TITLE
fix(core): make read_files description reflect model image support (#13922)

### DIFF
--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1735,6 +1735,30 @@ describe("default read_files tool", () => {
 			}),
 		);
 	});
+
+	it("describes image support by default (modelSupportsImages unknown)", () => {
+		const tool = createReadFilesTool(async () => "ok");
+		expect(tool.description).toContain("text or image files");
+		expect(tool.description).not.toContain("cannot be read by the current model");
+	});
+
+	it("removes image wording when the model lacks image support", () => {
+		const tool = createReadFilesTool(async () => "ok", {
+			modelSupportsImages: false,
+		});
+		expect(tool.description).toContain("text files");
+		expect(tool.description).not.toContain("text or image files");
+		expect(tool.description).toContain(
+			"image files cannot be read by the current model",
+		);
+	});
+
+	it("keeps image wording when the model supports images", () => {
+		const tool = createReadFilesTool(async () => "ok", {
+			modelSupportsImages: true,
+		});
+		expect(tool.description).toContain("text or image files");
+	});
 });
 
 describe("zod schema conversion", () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -264,14 +264,18 @@ async function executeShellCommands(
  */
 export function createReadFilesTool(
 	executor: FileReadExecutor,
-	config: Pick<DefaultToolsConfig, "fileReadTimeoutMs"> = {},
+	config: Pick<DefaultToolsConfig, "fileReadTimeoutMs" | "modelSupportsImages"> = {},
 ): AgentTool<ReadFilesInput, ToolOperationResult[]> {
 	const timeoutMs = config.fileReadTimeoutMs ?? 10000;
+	const supportsImages = config.modelSupportsImages !== false;
+	const fileKindWording = supportsImages
+		? "text or image files"
+		: "text files (image files cannot be read by the current model)";
 
 	return createTool<ReadFilesInput, ToolOperationResult[]>({
 		name: "read_files",
 		description:
-			"Read the content of text or image files at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided on the same file entry as its path. " +
+			`Read the content of ${fileKindWording} at the provided absolute paths, or return only an inclusive one-based line range when start_line/end_line are provided on the same file entry as its path. ` +
 			"When you already know multiple files you need, read them together in one call, and call this tool in the same response as other independent tool calls. " +
 			`Each read returns at most ${MAX_READ_LINES} lines / ~${Math.round(MAX_READ_OUTPUT_CHARS / 1024)}k characters; longer files report their total line count, page through them with start_line/end_line on that file's entry. ` +
 			"Binary files that are not image and large files are not supported. " +

--- a/sdk/packages/core/src/extensions/tools/types.ts
+++ b/sdk/packages/core/src/extensions/tools/types.ts
@@ -248,6 +248,16 @@ export interface DefaultToolsConfig {
 	telemetry?: ITelemetryService;
 
 	/**
+	 * Whether the primary model supports image input. Gates the image
+	 * wording in the read_files tool description so vision-less models are
+	 * never instructed to read image files (which would fail in the
+	 * executor). See cline/cline#13922.
+	 * @default undefined — description keeps the full "text or image files"
+	 * wording, matching the executor's per-call modelSupportsImages gate.
+	 */
+	modelSupportsImages?: boolean;
+
+	/**
 	 * Enable the read_files tool
 	 * @default true
 	 */

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -1,5 +1,6 @@
 import { supportsModelTool } from "@cline/llms";
 import type {
+	AgentConfig,
 	AgentTool,
 	BasicLogger,
 	ITelemetryService,
@@ -9,6 +10,7 @@ import type {
 } from "@cline/shared";
 import {
 	hasRuntimeConfigExtension,
+	modelSupportsImageInput,
 	resolveMcpTimeoutSeconds,
 } from "@cline/shared";
 import { nanoid } from "nanoid";
@@ -52,6 +54,7 @@ import {
 	isModelToolEnabledGlobally,
 	resolveDisabledToolNames,
 } from "../../services/global-settings";
+import { resolveKnownModelsFromConfig } from "../../services/llms/handler-factory";
 import { createLocalTeamStore } from "../../services/storage/team-store";
 import type { CoreAgentMode, CoreSessionConfig } from "../../types/config";
 import type {
@@ -137,6 +140,22 @@ export function createTeamName(): string {
 	return `team-${nanoid(5)}`;
 }
 
+/**
+ * Resolve whether the session's primary model supports image input, using
+ * the same known-models resolution the session orchestrator applies when it
+ * gates image reads at execution time (tryGetModelInfo). Returns undefined
+ * when the model is unknown so the read_files description keeps its default
+ * full-capability wording instead of wrongly stripping image support.
+ */
+function resolveModelSupportsImages(
+	config: Pick<AgentConfig, "modelId" | "knownModels" | "providerConfig">,
+): boolean | undefined {
+	const known =
+		config.knownModels ?? resolveKnownModelsFromConfig(config as AgentConfig);
+	const modelInfo = known?.[config.modelId];
+	return modelInfo ? modelSupportsImageInput(modelInfo) : undefined;
+}
+
 function createBuiltinToolsList(
 	cwd: string,
 	providerId: string,
@@ -148,6 +167,7 @@ function createBuiltinToolsList(
 	executorOverrides?: Partial<ToolExecutors>,
 	telemetry?: ITelemetryService,
 	runCommandExecutionController?: RunCommandExecutionController,
+	modelSupportsImages?: boolean,
 ): AgentTool[] {
 	const preset = ToolPresets[resolveToolPresetName({ mode })];
 	const toolRoutingConfig = resolveToolRoutingConfig(
@@ -161,6 +181,7 @@ function createBuiltinToolsList(
 		createBuiltinTools({
 			cwd,
 			telemetry,
+			...(modelSupportsImages !== undefined ? { modelSupportsImages } : {}),
 			executorOptions: {
 				bash: { executionController: runCommandExecutionController },
 			},
@@ -576,6 +597,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 					toolExecutors,
 					telemetry ?? config.telemetry,
 					input.runCommandExecutionController,
+					resolveModelSupportsImages(config),
 				),
 			);
 			const agentPluginMcpServers = pluginsEnabled
@@ -662,6 +684,9 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 												toolExecutors,
 												telemetry ?? config.telemetry,
 												input.runCommandExecutionController,
+											agent.modelId === config.modelId
+												? resolveModelSupportsImages(config)
+												: undefined,
 											),
 											agent,
 										)
@@ -768,6 +793,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 									toolExecutors,
 									telemetry ?? config.telemetry,
 									input.runCommandExecutionController,
+									resolveModelSupportsImages(config),
 								)
 						: undefined,
 					teammateConfigProvider: delegatedAgentConfigProvider,


### PR DESCRIPTION
## What Problem This Solves

The \`read_files\` tool description was a static string advertising \"text or image files\" to every model. But the built-in file-read executor throws \`Current model does not support image input\` when the primary model lacks vision (\`context.metadata?.modelSupportsImages !== true\`). A vision-less model that follows the description into an image read therefore fails hard mid-session — exactly the report in [cline/cline#13922](https://github.com/cline/cline/issues/13922).

## Why This Change Was Made

Make the \`read_files\` description capability-aware so the model is never instructed to read an image it cannot process:

- Add a \`modelSupportsImages\` flag to \`DefaultToolsConfig\`.
- \`createReadFilesTool\` now emits \`text files (image files cannot be read by the current model)\` when the flag is \`false\`, and keeps the original \`text or image files\` wording otherwise — including the \`undefined\` \"unknown model\" default, so the existing full-capability wording is preserved when model info is unavailable.
- The runtime builder resolves the flag using the same known-models resolution the session orchestrator already applies for the executor-side image gate, threading it through the built-in tools list for the lead agent, same-model sub-agents, and teammates.

The executor-side runtime gate (\`executors/file-read.ts\`) is intentionally left unchanged as defense in depth for direct tool calls.

## User Impact

Models without vision capability will no longer be told they can read images, avoiding a hard session-breaking failure when the tool description and model capability disagree. No behavior change for vision-capable models or when model info is unknown.

## Evidence

- \`bunx vitest run src/extensions/tools/definitions.test.ts\` → 66 passed (including 3 new wording assertions).
- \`bun tsc -p tsconfig.dev.json --noEmit\` clean in \`@cline/core\`.
- \`bunx biome lint\` clean on all four changed files.
- Note: the full \`@cline/core\` \`test:unit\` suite has a few unrelated, non-deterministic timeouts in this container (e.g. \`runtime-builder.team-persistence.test.ts\`, \`hub/daemon\`, \`plugin-uninstall\`) that reproduce on an unmodified \`main\` checkout; the changed files themselves pass in isolation.

Fixes #13922