### PR TITLE
fix(cli): surface tool failures reported inside the result payload

### DIFF
--- a/apps/cli/src/tui/utils/hydrate-messages.ts
+++ b/apps/cli/src/tui/utils/hydrate-messages.ts
@@ -1,4 +1,8 @@
-import { type AgentMode, projectSessionMessagesForDisplay } from "@cline/core";
+import {
+	type AgentMode,
+	extractToolPayloadError,
+	projectSessionMessagesForDisplay,
+} from "@cline/core";
 import {
 	formatDisplayUserInput,
 	type GeneratedMedia,
@@ -180,9 +184,12 @@ export function hydrateSessionMessages(
 								| string
 								| Array<{ type: string; text?: string; path?: string }>,
 						);
+						// `is_error` is only set when the tool threw. Tools that
+						// report failure inside their payload leave it unset, so a
+						// replayed session would otherwise render them as successes.
 						const error = block.is_error
 							? stringifyToolError(block.content)
-							: undefined;
+							: extractToolPayloadError(block.content);
 						entry.result = error
 							? { outputSummary: "", rawOutput: undefined, error }
 							: {

--- a/apps/cli/src/utils/events.test.ts
+++ b/apps/cli/src/utils/events.test.ts
@@ -97,6 +97,43 @@ describe("handleEvent text formatting", () => {
 		expect(output).toMatch(/⎿.*ok/s);
 	});
 
+	it("prints the error instead of ok when a read_files operation failed", () => {
+		handleEvent(
+			{
+				type: "content_start",
+				contentType: "tool",
+				toolName: "read_files",
+				input: { path: "/tmp/missing.txt" },
+			} as unknown as AgentEvent,
+			{} as Config,
+		);
+		handleEvent(
+			{
+				type: "content_end",
+				contentType: "tool",
+				toolName: "read_files",
+				// A failed read reports success:false inside the payload and
+				// leaves `result` empty; the error is derived from the payload.
+				output: [
+					{
+						query: "/tmp/missing.txt",
+						result: "",
+						error:
+							"Error reading file: ENOENT: no such file or directory, statx '/tmp/missing.txt'",
+						success: false,
+					},
+				],
+				error:
+					"Error reading file: ENOENT: no such file or directory, statx '/tmp/missing.txt'",
+			} as unknown as AgentEvent,
+			{} as Config,
+		);
+
+		expect(output).toContain("error:");
+		expect(output).toContain("ENOENT");
+		expect(output).not.toMatch(/⎿.*ok/s);
+	});
+
 	it("prints adjacent tool starts on separate lines", () => {
 		handleEvent(
 			{

--- a/sdk/packages/core/src/extensions/tools/index.ts
+++ b/sdk/packages/core/src/extensions/tools/index.ts
@@ -60,6 +60,7 @@ export {
 	resolveToolRoutingConfig,
 	type ToolRoutingRule,
 } from "./model-tool-routing";
+export { extractToolPayloadError } from "./payload-error";
 // Presets
 export {
 	createDefaultToolsWithPreset,

--- a/sdk/packages/core/src/extensions/tools/payload-error.test.ts
+++ b/sdk/packages/core/src/extensions/tools/payload-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { extractToolPayloadError } from "./payload-error";
+
+describe("extractToolPayloadError", () => {
+	it("returns the error verbatim for a single failed operation", () => {
+		expect(
+			extractToolPayloadError([
+				{
+					query: "/tmp/missing.txt",
+					result: "",
+					error:
+						"Error reading file: ENOENT: no such file or directory, statx '/tmp/missing.txt'",
+					success: false,
+				},
+			]),
+		).toBe(
+			"Error reading file: ENOENT: no such file or directory, statx '/tmp/missing.txt'",
+		);
+	});
+
+	it("reports how many failed when every operation fails", () => {
+		expect(
+			extractToolPayloadError([
+				{ query: "a", result: "", error: "boom a", success: false },
+				{ query: "b", result: "", error: "boom b", success: false },
+			]),
+		).toBe("All 2 items failed: boom a (+1 more)");
+	});
+
+	it("distinguishes a partial failure from a total one", () => {
+		expect(
+			extractToolPayloadError([
+				{ query: "a", result: "contents", success: true },
+				{ query: "b", result: "", error: "boom b", success: false },
+				{ query: "c", result: "contents", success: true },
+			]),
+		).toBe("1 of 3 items failed: boom b");
+	});
+
+	it("returns undefined when every operation succeeded", () => {
+		expect(
+			extractToolPayloadError([
+				{ query: "a", result: "contents", success: true },
+			]),
+		).toBeUndefined();
+	});
+
+	it("falls back to the query when a failure carries no message", () => {
+		expect(
+			extractToolPayloadError([{ query: "a", result: "", success: false }]),
+		).toBe("a: failed");
+	});
+
+	it("ignores payloads that are not operation results", () => {
+		// MCP content blocks and plain text must not be mistaken for failures.
+		expect(
+			extractToolPayloadError([{ type: "text", text: "hello" }]),
+		).toBeUndefined();
+		expect(extractToolPayloadError("plain string")).toBeUndefined();
+		expect(extractToolPayloadError([])).toBeUndefined();
+		expect(extractToolPayloadError(undefined)).toBeUndefined();
+	});
+});

--- a/sdk/packages/core/src/extensions/tools/payload-error.ts
+++ b/sdk/packages/core/src/extensions/tools/payload-error.ts
@@ -1,0 +1,64 @@
+/**
+ * Some tools report failure *inside* their output payload rather than by
+ * throwing, so the tool-result envelope is never flagged as an error.
+ *
+ * `read_files` is the common case: a missing file produces
+ * `{ query, result: "", error: "Error reading file: ...", success: false }`
+ * while the call itself is considered to have completed. Consumers that only
+ * inspect the envelope (`isError` / `is_error`) therefore render such a result
+ * as a success.
+ *
+ * This lifts payload-level failures into a single error string so the existing
+ * error paths can present them.
+ */
+export function extractToolPayloadError(output: unknown): string | undefined {
+	if (!Array.isArray(output) || output.length === 0) {
+		return undefined;
+	}
+
+	let considered = 0;
+	const failures: string[] = [];
+
+	for (const item of output) {
+		if (!item || typeof item !== "object" || Array.isArray(item)) {
+			continue;
+		}
+		const record = item as Record<string, unknown>;
+		if (typeof record.success !== "boolean") {
+			continue;
+		}
+		considered += 1;
+		if (record.success) {
+			continue;
+		}
+		failures.push(describeFailure(record));
+	}
+
+	if (considered === 0 || failures.length === 0) {
+		return undefined;
+	}
+
+	const [first, ...rest] = failures;
+	const more = rest.length > 0 ? ` (+${rest.length} more)` : "";
+
+	// A partial failure is deliberately worded so it can be presented as a
+	// warning rather than a hard error: the call itself did useful work.
+	if (failures.length < considered) {
+		return `${failures.length} of ${considered} items failed: ${first}${more}`;
+	}
+
+	return considered === 1
+		? first
+		: `All ${considered} items failed: ${first}${more}`;
+}
+
+function describeFailure(record: Record<string, unknown>): string {
+	const error = typeof record.error === "string" ? record.error.trim() : "";
+	if (error) {
+		return error;
+	}
+	const query = typeof record.query === "string" ? record.query.trim() : "";
+	return query
+		? `${query}: failed`
+		: "Tool reported failure without an error message.";
+}

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -948,6 +948,7 @@ export {
 	type EditFileInput,
 	type EditorExecutor,
 	type EditorExecutorOptions,
+	extractToolPayloadError,
 	getCoreAcpToolNames,
 	getCoreBuiltinToolCatalog,
 	getCoreDefaultEnabledToolIds,

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.test.ts
@@ -554,6 +554,71 @@ describe("RuntimeEventAdapter — tool lifecycle", () => {
 		]);
 	});
 
+	// Tools such as read_files / search_codebase / fetch_web_content report
+	// failure inside their `ToolOperationResult[]` payload and leave the
+	// envelope unflagged, so the error must be derived from the payload.
+	it("derives content_end error from a failed tool payload when isError is unset", () => {
+		const toolCall = makeToolCall({ toolCallId: "call_read" });
+		const out = adapter.translate({
+			type: "tool-finished",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+			toolCall,
+			message: {
+				id: "msg_tool",
+				role: "tool",
+				createdAt: 1_700_000_000_000,
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_read",
+						toolName: "read_file",
+						output: [
+							{
+								query: "/tmp/missing.txt",
+								result: "",
+								error:
+									"Error reading file: ENOENT: no such file or directory, statx '/tmp/missing.txt'",
+								success: false,
+							},
+						],
+					},
+				],
+			},
+		});
+		expect(out).toHaveLength(1);
+		const event = out[0] as { error?: string };
+		expect(event.error).toContain("ENOENT");
+	});
+
+	it("leaves content_end error unset when every payload operation succeeded", () => {
+		const toolCall = makeToolCall({ toolCallId: "call_ok" });
+		const out = adapter.translate({
+			type: "tool-finished",
+			snapshot: makeSnapshot(),
+			iteration: 1,
+			toolCall,
+			message: {
+				id: "msg_tool",
+				role: "tool",
+				createdAt: 1_700_000_000_000,
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: "call_ok",
+						toolName: "read_file",
+						output: [
+							{ query: "/tmp/a.txt", result: "contents", success: true },
+						],
+					},
+				],
+			},
+		});
+		expect(out).toHaveLength(1);
+		const event = out[0] as { error?: string };
+		expect(event.error).toBeUndefined();
+	});
+
 	it("maps tool-finished with tracked timing → content_end(tool) with durationMs", () => {
 		vi.useFakeTimers();
 		try {

--- a/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-event-adapter.ts
@@ -63,6 +63,7 @@ import type {
 	AgentUsage,
 	LegacyAgentUsage,
 } from "@cline/shared";
+import { extractToolPayloadError } from "../../extensions/tools/payload-error";
 
 // =============================================================================
 // Helpers
@@ -139,8 +140,16 @@ function statusToLegacyFinishReason(
 function deriveToolError(
 	result: AgentToolResultPart | undefined,
 ): string | undefined {
-	if (!result || result.isError !== true) {
+	if (!result) {
 		return undefined;
+	}
+	if (result.isError !== true) {
+		// Tools that report failure inside their payload rather than by
+		// throwing (the `ToolOperationResult[]` shape returned by read_files,
+		// search_codebase, fetch_web_content and run_commands) leave the
+		// envelope unflagged. Without this the event carries no error and
+		// every renderer presents the call as a success.
+		return extractToolPayloadError(result.output);
 	}
 	if (typeof result.output === "string") {
 		return result.output;


### PR DESCRIPTION
Fixes the display half of #13941.

## Problem

Tools that return the `ToolOperationResult[]` shape — `read_files`,
`search_codebase`, `fetch_web_content`, `run_commands` — report failure with
`success: false` and an `error` string *inside* their payload rather than by
throwing. The tool-result envelope is therefore never flagged, and
`deriveToolError` returned early unless `isError === true`. With
`event.error` unset, every display path presented the call as a success:

```
[read_files] {"files":["/tmp/missing.txt"]}
   ⎿ ok
```

The TUI rendered an accent-coloured `*` with `⎿ 1 lines`, and session replay
did the same because it keys off the persisted `is_error`. Only the JSON in
`~/.cline/data/sessions/` was accurate.

The model was never misled — it receives the raw payload and correctly reports
the failure. This only affected the human reading the terminal, which is
awkward precisely when you are supervising an agent.

Reproduce with any provider:

```bash
cline 'Call read_files on the single path /tmp/definitely-missing-xyz.txt exactly once, then stop.'
```

## Change

Derive the error from the payload when the envelope is unflagged:

- `deriveToolError` (`runtime-event-adapter.ts`) — covers the non-interactive
  stream renderer and the live TUI, both of which read `event.error`.
- `hydrateSessionMessages` (`hydrate-messages.ts`) — covers session replay,
  which reads the persisted `is_error`.

The new `extractToolPayloadError` lives next to the `ToolOperationResult` type
it interprets, in `sdk/packages/core/src/extensions/tools/`. It is generic over
the payload shape, so all four tools are covered rather than `read_files`
alone. Partial failures read `1 of 3 items failed: …`; total failures return
the error verbatim. Payloads that are not operation results (MCP content
blocks, plain strings) are ignored.

Nothing about wire semantics changes: `isError` / `is_error` are untouched, so
what reaches the provider is unchanged. This is display-only.

## Tests

- `payload-error.test.ts` — new: single failure, all-failed, partial, all-success,
  missing error message, and non-payload inputs.
- `runtime-event-adapter.test.ts` — two cases added beside the existing
  `tool-finished` tests: a failed payload with `isError` unset yields
  `content_end.error`; an all-success payload still yields `undefined`.
- `events.test.ts` — one case added directly beneath the existing
  `⎿ ok` test, asserting a failed `read_files` prints `error:` and `ENOENT`
  and does not print `⎿ ok`.

Local runs: 45 tests pass in `sdk/packages/core` (2 new + 37 existing adapter
tests + 6 new helper tests), 86 pass across `apps/cli` `events` / `helpers` /
`hydrate-messages` / `tool-parsing` / `tool-errors`. `biome check` is clean on
all touched files.

Two things I want to flag honestly rather than bury:

- **The replay fix has no test.** `hydrate-messages.test.ts` still passes, but I
  did not add a case covering the new branch. Happy to add one if you'd like it.
- I could not run `definitions.test.ts` or `message-builder.test.ts` locally —
  they need a built `@cline/shared`, which I could not produce in my
  environment. With my changes stashed they fail identically, so this is not a
  regression, but CI is the real check.

## Deliberately out of scope

Three related cosmetic issues left alone to keep this reviewable:

1. `ReadOutput` renders `1 lines` for genuinely empty content, because
   `"".split("\n")` has length 1. Failed reads no longer reach it, but a 0-byte
   file still reads oddly.
2. Partial failures currently present as a hard error. A `severity: "warning"`
   rule for the `N of M items failed:` wording would fit the existing warning
   path better.
3. `Error: Error reading file: …` reads redundantly, since
   `summarizeErrorDetail` only strips a bare `Error:` prefix.

Happy to fold any of these in if you'd prefer them here.
