### PR TITLE
feat(vscode): list skills in the slash command menu

### DIFF
--- a/apps/vscode/proto/cline/slash.proto
+++ b/apps/vscode/proto/cline/slash.proto
@@ -14,7 +14,8 @@ service SlashService {
   rpc reportBug(StringRequest) returns (Empty);
   rpc condense(StringRequest) returns (Empty);
 
-  // Get available slash commands for autocomplete (used by CLI)
+  // Get available slash commands for autocomplete: built-ins plus the skills and
+  // workflows the SDK runtime discovered (already filtered by the user's toggles).
   rpc getAvailableSlashCommands(EmptyRequest) returns (SlashCommandsResponse);
 }
 
@@ -22,8 +23,9 @@ service SlashService {
 message SlashCommandInfo {
   string name = 1; // Command name without slash, e.g., "newtask", "smol"
   string description = 2; // Human-readable description
-  string section = 3; // "default", "custom", or "cli"
+  string section = 3; // Menu group: "default" (built-in), "skill", "custom" (workflow), or "cli"
   bool cli_compatible = 4; // false for VS Code-only commands
+  string kind = 5; // "builtin", "skill", or "workflow"
 }
 
 // Response containing all available slash commands

--- a/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/apps/vscode/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -4,85 +4,40 @@ import { BASE_SLASH_COMMANDS } from "@/shared/slashCommands"
 import { Controller } from ".."
 
 /**
- * Returns all available slash commands for autocomplete.
+ * Returns all available slash commands for autocomplete: the built-in commands,
+ * then every skill and workflow the SDK runtime discovered — spelled exactly as
+ * the send path resolves them and already filtered by the user's toggles.
+ * Skills are listed before workflows so the menu can group them. MCP prompt
+ * commands are added webview-side from the live MCP server list.
  */
 export async function getAvailableSlashCommands(controller: Controller, _request: EmptyRequest): Promise<SlashCommandsResponse> {
-	const commands: SlashCommandInfo[] = []
+	const commands: SlashCommandInfo[] = BASE_SLASH_COMMANDS.map((cmd) =>
+		SlashCommandInfo.create({
+			name: cmd.name,
+			description: cmd.description,
+			section: "default",
+			cliCompatible: cmd.cliCompatible,
+			kind: "builtin",
+		}),
+	)
 
-	// Add built-in commands
-	for (const cmd of [...BASE_SLASH_COMMANDS]) {
-		commands.push(
-			SlashCommandInfo.create({
-				name: cmd.name,
-				description: cmd.description,
-				section: "default",
-				cliCompatible: cmd.cliCompatible,
-			}),
-		)
-	}
-
-	// Get workflow toggles from state
-	const localWorkflowToggles = controller.stateManager.getWorkspaceStateKey("workflowToggles") ?? {}
-	const globalWorkflowToggles = controller.stateManager.getGlobalSettingsKey("globalWorkflowToggles") ?? {}
-	const remoteWorkflowToggles = controller.stateManager.getGlobalStateKey("remoteWorkflowToggles") ?? {}
-	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
-	const remoteWorkflows = remoteConfigSettings?.remoteGlobalWorkflows ?? []
-
-	// Track local workflow names to avoid duplicates from global
-	const localNames = new Set<string>()
-
-	// Add local workflows (enabled only)
-	for (const [path, enabled] of Object.entries(localWorkflowToggles)) {
-		if (enabled) {
-			const fileName = fullPathToFileName(path)
-			localNames.add(fileName)
-			commands.push(
-				SlashCommandInfo.create({
-					name: fileName,
-					description: `Custom workflow: ${fileName}`,
-					section: "custom",
-					cliCompatible: true,
-				}),
-			)
-		}
-	}
-
-	// Add global workflows (enabled only, skip if local exists with same name)
-	for (const [path, enabled] of Object.entries(globalWorkflowToggles)) {
-		if (enabled) {
-			const fileName = fullPathToFileName(path)
-			if (!localNames.has(fileName)) {
-				commands.push(
-					SlashCommandInfo.create({
-						name: fileName,
-						description: `Custom workflow: ${fileName}`,
-						section: "custom",
-						cliCompatible: true,
-					}),
-				)
+	const runtimeCommands = await controller.listRuntimeSlashCommands()
+	for (const kind of ["skill", "workflow"] as const) {
+		for (const command of runtimeCommands) {
+			if (command.kind !== kind) {
+				continue
 			}
-		}
-	}
-
-	// Add remote workflows that are enabled
-	for (const workflow of remoteWorkflows) {
-		const enabled = workflow.alwaysEnabled || remoteWorkflowToggles[workflow.name] !== false
-		if (enabled) {
 			commands.push(
 				SlashCommandInfo.create({
-					name: workflow.name,
-					description: `Remote workflow: ${workflow.name}`,
-					section: "custom",
+					name: command.name,
+					description: command.description ?? "",
+					section: kind === "skill" ? "skill" : "custom",
 					cliCompatible: true,
+					kind,
 				}),
 			)
 		}
 	}
 
 	return SlashCommandsResponse.create({ commands })
-}
-
-function fullPathToFileName(path: string): string {
-	// e.g. replace /path/to/workflow.md with workflow.md
-	return path.replace(/^.*[/\\]/, "")
 }

--- a/apps/vscode/src/sdk/SdkController.ts
+++ b/apps/vscode/src/sdk/SdkController.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import {
+	type AvailableRuntimeCommand,
 	type CompareCheckpointResult,
 	createRestoredCheckpointMetadata,
 	createUserInstructionConfigService,
@@ -98,7 +99,15 @@ import {
 	isSyntheticSdkUserMessage,
 	type SdkUserMessage,
 } from "./sdk-user-message-mapping"
-import { buildDisabledWorkflowNames, expandSlashCommands } from "./slash-command-expansion"
+import {
+	buildDisabledSkillNames,
+	buildDisabledWorkflowNames,
+	expandSlashCommands,
+	isBuiltinCommand,
+	isRuntimeCommandDisabled,
+	listSlashCommandsInText,
+	type RuntimeSlashCommandContext,
+} from "./slash-command-expansion"
 import { StatePostDebouncer } from "./state-post-debouncer"
 import { createTaskProxy, type TaskProxy } from "./task-proxy"
 import { syncTelemetrySettingFromSharedGlobalSettings } from "./telemetry-settings-sync"
@@ -1008,29 +1017,82 @@ export class Controller {
 			return text
 		}
 		try {
-			const workspaceRoot = await this.getWorkspaceRoot()
-			const service = await this.ensureUserInstructionService(workspaceRoot)
-			const remoteWorkflows = this.stateManager.getRemoteConfigSettings()?.remoteGlobalWorkflows ?? []
-			const workflowRecords = service.listRecords("workflow").map((record) => ({
-				id: record.id,
-				name: record.item.name,
-				filePath: record.filePath,
-			}))
-			const disabledWorkflowNames = buildDisabledWorkflowNames({
-				records: workflowRecords,
-				globalToggles: this.stateManager.getGlobalSettingsKey("globalWorkflowToggles"),
-				workspaceToggles: this.stateManager.getWorkspaceStateKey("workflowToggles"),
-				remoteToggles: this.stateManager.getGlobalStateKey("remoteWorkflowToggles"),
-				remoteAlwaysEnabledNames: remoteWorkflows.filter((workflow) => workflow.alwaysEnabled).map((w) => w.name),
-			})
-			return expandSlashCommands(text, [...service.listRuntimeCommands(), ...BUILTIN_SLASH_COMMANDS], {
-				disabledWorkflowNames,
-				workflowRecords,
-			})
+			const context = await this.getRuntimeSlashCommandContext()
+			this.captureSlashCommandUsed(listSlashCommandsInText(text, context.commands, context)[0]?.command)
+			return expandSlashCommands(text, context.commands, context)
 		} catch (error) {
 			Logger.warn("[SdkController] Slash command resolution failed, using raw text:", error)
 			return text
 		}
+	}
+
+	/**
+	 * The skills and workflows currently available as slash commands, filtered
+	 * by the user's toggles — what the chat input's autocomplete should offer,
+	 * spelled exactly as {@link resolveSlashCommands} resolves them. Builtin
+	 * pseudo-skills are excluded: the webview lists builtins itself.
+	 */
+	async listRuntimeSlashCommands(): Promise<AvailableRuntimeCommand[]> {
+		if (this.isDisposed) {
+			return []
+		}
+		try {
+			const context = await this.getRuntimeSlashCommandContext()
+			return context.commands.filter((command) => !isBuiltinCommand(command) && !isRuntimeCommandDisabled(command, context))
+		} catch (error) {
+			Logger.warn("[SdkController] Listing slash commands failed:", error)
+			return []
+		}
+	}
+
+	/**
+	 * Everything needed to list or expand runtime slash commands: the skills and
+	 * workflows the SDK discovered plus the extension's builtin pseudo-skills,
+	 * with the toggle state that governs them. Shared by the send path and the
+	 * autocomplete RPC so the menu offers exactly what the send path resolves.
+	 */
+	private async getRuntimeSlashCommandContext(): Promise<RuntimeSlashCommandContext> {
+		const workspaceRoot = await this.getWorkspaceRoot()
+		const service = await this.ensureUserInstructionService(workspaceRoot)
+		const remoteConfig = this.stateManager.getRemoteConfigSettings()
+		const toRecordRef = <R extends { id: string; item: { name: string }; filePath: string }>(record: R) => ({
+			id: record.id,
+			name: record.item.name,
+			filePath: record.filePath,
+		})
+		const lockedNames = (files: ReadonlyArray<{ name: string; alwaysEnabled?: boolean }> | undefined) =>
+			(files ?? []).filter((file) => file.alwaysEnabled).map((file) => file.name)
+		const workflowRecords = service.listRecords("workflow").map(toRecordRef)
+		const skillRecords = service.listRecords("skill").map(toRecordRef)
+		return {
+			commands: [...service.listRuntimeCommands(), ...BUILTIN_SLASH_COMMANDS],
+			workflowRecords,
+			skillRecords,
+			disabledWorkflowNames: buildDisabledWorkflowNames({
+				records: workflowRecords,
+				globalToggles: this.stateManager.getGlobalSettingsKey("globalWorkflowToggles"),
+				workspaceToggles: this.stateManager.getWorkspaceStateKey("workflowToggles"),
+				remoteToggles: this.stateManager.getGlobalStateKey("remoteWorkflowToggles"),
+				remoteAlwaysEnabledNames: lockedNames(remoteConfig?.remoteGlobalWorkflows),
+			}),
+			disabledSkillNames: buildDisabledSkillNames({
+				records: skillRecords,
+				remoteToggles: this.stateManager.getGlobalStateKey("remoteSkillsToggles"),
+				remoteAlwaysEnabledNames: lockedNames(remoteConfig?.remoteGlobalSkills),
+			}),
+		}
+	}
+
+	/**
+	 * Records that the user invoked a slash command. The first message of a new
+	 * task is resolved before its session exists, so the task id is best-effort.
+	 */
+	private captureSlashCommandUsed(command: AvailableRuntimeCommand | undefined): void {
+		if (!command) {
+			return
+		}
+		const ulid = this.task?.taskId ?? this.sessions.getActiveSession()?.sessionId ?? ""
+		telemetryService.captureSlashCommandUsed(ulid, command.name, isBuiltinCommand(command) ? "builtin" : command.kind)
 	}
 
 	/**

--- a/apps/vscode/src/sdk/slash-command-expansion.test.ts
+++ b/apps/vscode/src/sdk/slash-command-expansion.test.ts
@@ -364,6 +364,25 @@ describe("buildDisabledSkillNames", () => {
 		expect(disabled).toEqual(new Set(["org-standards"]))
 	})
 
+	it("honors a toggle keyed by the frontmatter name when it differs from the materialized entry name", () => {
+		// The dashboard entry is "Org Deploy" (directory org-deploy) but SKILL.md says
+		// name: deploy-prod; the Skills panel keys the toggle by the frontmatter name.
+		const disabled = buildDisabledSkillNames({
+			records: [{ name: "deploy-prod", filePath: "/repo/.cline/remote-config/skills/org-deploy/SKILL.md" }],
+			remoteToggles: { "deploy-prod": false },
+		})
+		expect(disabled).toEqual(new Set(["deploy-prod"]))
+	})
+
+	it("treats a lock on either identity as enabled", () => {
+		const disabled = buildDisabledSkillNames({
+			records: [{ name: "deploy-prod", filePath: "/repo/.cline/remote-config/skills/org-deploy/SKILL.md" }],
+			remoteToggles: { "deploy-prod": false },
+			remoteAlwaysEnabledNames: ["Org Deploy"],
+		})
+		expect(disabled).toEqual(new Set())
+	})
+
 	it("treats locked (alwaysEnabled) remote skills as enabled despite stale toggles", () => {
 		const disabled = buildDisabledSkillNames({
 			records: [{ name: "org-locked", filePath: "/repo/.cline/remote-config/skills/org-locked/SKILL.md" }],

--- a/apps/vscode/src/sdk/slash-command-expansion.test.ts
+++ b/apps/vscode/src/sdk/slash-command-expansion.test.ts
@@ -1,6 +1,12 @@
 import type { AvailableRuntimeCommand } from "@cline/core"
 import { describe, expect, it } from "vitest"
-import { buildDisabledWorkflowNames, expandSlashCommands } from "./slash-command-expansion"
+import {
+	buildDisabledSkillNames,
+	buildDisabledWorkflowNames,
+	expandSlashCommands,
+	isRuntimeCommandDisabled,
+	listSlashCommandsInText,
+} from "./slash-command-expansion"
 
 function workflow(name: string, instructions: string): AvailableRuntimeCommand {
 	return { id: name, name, instructions, kind: "workflow" }
@@ -277,5 +283,104 @@ describe("buildDisabledWorkflowNames", () => {
 			remoteToggles: { "org-standards": false },
 		})
 		expect(disabled).toEqual(new Set(["deploy", "hotfix", "org-standards"]))
+	})
+})
+
+describe("listSlashCommandsInText", () => {
+	const commands = [workflow("release", "Run the release workflow."), skill("debug", "Use the debugging skill.")]
+
+	it("lists every resolvable command in text order with its token offsets", () => {
+		const matches = listSlashCommandsInText("/release then /debug", commands)
+		expect(matches.map((match) => match.command.name)).toEqual(["release", "debug"])
+		expect(matches[0]).toMatchObject({ start: 0, end: 8 })
+		expect(matches[1]).toMatchObject({ start: 14, end: 20 })
+	})
+
+	it("includes skills, unlike expansion, so callers can see what the user invoked", () => {
+		expect(listSlashCommandsInText("/debug this", commands)[0]?.command.kind).toBe("skill")
+	})
+
+	it("skips unknown tokens, path segments, and disabled commands", () => {
+		expect(listSlashCommandsInText("/missing and /release/notes.txt", commands)).toEqual([])
+		expect(listSlashCommandsInText("/release", commands, { disabledWorkflowNames: new Set(["release"]) })).toEqual([])
+		expect(listSlashCommandsInText("/debug", commands, { disabledSkillNames: new Set(["debug"]) })).toEqual([])
+	})
+
+	it("accepts the legacy .md spelling and mid-message commands like expansion does", () => {
+		const matches = listSlashCommandsInText("please /release.md now", commands)
+		expect(matches).toHaveLength(1)
+		expect(matches[0]).toMatchObject({ start: 7, end: 18 })
+	})
+
+	it("returns nothing when there is no slash or no commands", () => {
+		expect(listSlashCommandsInText("plain text", commands)).toEqual([])
+		expect(listSlashCommandsInText("/release", [])).toEqual([])
+	})
+})
+
+describe("isRuntimeCommandDisabled", () => {
+	it("maps a normalized skill token back to its configured name through the record id", () => {
+		const command = skill("publish-ui", "Publish.")
+		command.id = "publish ui"
+		const options = {
+			skillRecords: [
+				{ id: "publish ui", name: "Publish UI", filePath: "/repo/.cline/remote-config/skills/publish-ui/SKILL.md" },
+			],
+			disabledSkillNames: new Set(["Publish UI"]),
+		}
+		expect(isRuntimeCommandDisabled(command, options)).toBe(true)
+		expect(isRuntimeCommandDisabled(skill("other", "x"), options)).toBe(false)
+	})
+
+	it("never disables builtin pseudo-skills", () => {
+		const builtin: AvailableRuntimeCommand = {
+			id: "builtin:deep-planning",
+			name: "deep-planning",
+			instructions: "",
+			kind: "skill",
+		}
+		expect(isRuntimeCommandDisabled(builtin, { disabledSkillNames: new Set(["deep-planning"]) })).toBe(false)
+	})
+})
+
+describe("buildDisabledSkillNames", () => {
+	it("disables remote skills whose name-keyed toggle is off", () => {
+		const disabled = buildDisabledSkillNames({
+			records: [
+				{ name: "org-deploy", filePath: "/repo/.cline/remote-config/skills/org-deploy/SKILL.md" },
+				{ name: "org-review", filePath: "/repo/.cline/remote-config/skills/org-review/SKILL.md" },
+				{ name: "org-default", filePath: "C:\\repo\\.cline\\remote-config\\skills\\org-default\\SKILL.md" },
+			],
+			remoteToggles: { "org-deploy": false, "org-review": true },
+		})
+		expect(disabled).toEqual(new Set(["org-deploy"]))
+	})
+
+	it("matches toggles keyed by the configured name against the sanitized directory name", () => {
+		const disabled = buildDisabledSkillNames({
+			records: [{ name: "org-standards", filePath: "/repo/.cline/remote-config/skills/org-standards/SKILL.md" }],
+			remoteToggles: { "Org Standards": false },
+		})
+		expect(disabled).toEqual(new Set(["org-standards"]))
+	})
+
+	it("treats locked (alwaysEnabled) remote skills as enabled despite stale toggles", () => {
+		const disabled = buildDisabledSkillNames({
+			records: [{ name: "org-locked", filePath: "/repo/.cline/remote-config/skills/org-locked/SKILL.md" }],
+			remoteToggles: { "org-locked": false },
+			remoteAlwaysEnabledNames: ["Org Locked"],
+		})
+		expect(disabled).toEqual(new Set())
+	})
+
+	it("leaves local and global skills to their frontmatter, even when a toggle name matches", () => {
+		const disabled = buildDisabledSkillNames({
+			records: [
+				{ name: "debug", filePath: "/home/me/.cline/skills/debug/SKILL.md" },
+				{ name: "review", filePath: "/repo/.cline/skills/review/SKILL.md" },
+			],
+			remoteToggles: { debug: false, review: false },
+		})
+		expect(disabled).toEqual(new Set())
 	})
 })

--- a/apps/vscode/src/sdk/slash-command-expansion.ts
+++ b/apps/vscode/src/sdk/slash-command-expansion.ts
@@ -1,12 +1,5 @@
 import type { AvailableRuntimeCommand } from "@cline/core"
-
-/**
- * Matches a slash-command token that is either at the start of the message or
- * preceded by whitespace, and followed by whitespace or end-of-string. Kept in
- * sync with the webview's `slashCommandRegex` (webview-ui/src/utils/slash-commands.ts)
- * so anything the chat input highlights/autocompletes as a command can be expanded.
- */
-const SLASH_COMMAND_TOKEN_REGEX = /(^|\s)(\/[a-zA-Z0-9_.:@-]+)(?=\s|$)/g
+import { createSlashCommandTokenRegex } from "@cline/shared"
 
 /**
  * File extensions the SDK's workflow discovery accepts (`MARKDOWN_EXTENSIONS`
@@ -89,6 +82,9 @@ export interface WorkflowRecordRef {
 	filePath: string
 }
 
+/** Discovered skill records (`listRecords("skill")`), same shape as workflows. */
+export type SkillRecordRef = WorkflowRecordRef
+
 export interface ExpandSlashCommandsOptions {
 	/**
 	 * Exact command names of workflows the user disabled via the Workflows
@@ -102,6 +98,14 @@ export interface ExpandSlashCommandsOptions {
 	 * whose frontmatter `name` differs from its filename.
 	 */
 	workflowRecords?: ReadonlyArray<WorkflowRecordRef>
+	/**
+	 * Exact command names of skills the user disabled via the Skills toggles,
+	 * from {@link buildDisabledSkillNames}. Disabled skills are treated as
+	 * unknown commands.
+	 */
+	disabledSkillNames?: ReadonlySet<string>
+	/** Discovered skill records, used to map commands back to their toggle state. */
+	skillRecords?: ReadonlyArray<SkillRecordRef>
 }
 
 /**
@@ -170,24 +174,7 @@ export function expandSlashCommands(
 	commands: readonly AvailableRuntimeCommand[],
 	options: ExpandSlashCommandsOptions = {},
 ): string {
-	if (!text.includes("/") || commands.length === 0) {
-		return text
-	}
-	const disabledWorkflowNames = options.disabledWorkflowNames ?? new Set()
-	const workflowRecords = options.workflowRecords ?? []
-	for (const match of text.matchAll(SLASH_COMMAND_TOKEN_REGEX)) {
-		const token = match[2]
-		const typedName = token.slice(1)
-		const command = findRuntimeCommand(commands, typedName, workflowRecords)
-		if (!command) {
-			continue
-		}
-		if (command.kind === "workflow") {
-			const configuredName = workflowRecords.find((record) => record.id === command.id)?.name ?? command.name
-			if (disabledWorkflowNames.has(configuredName)) {
-				continue
-			}
-		}
+	for (const { command, start, end } of listSlashCommandsInText(text, commands, options)) {
 		// Configured skills are not expanded into the prompt: the SDK session
 		// registers the `skills` tool, whose description requires the model to
 		// invoke it when the user references a slash command, so the
@@ -195,14 +182,78 @@ export function expandSlashCommands(
 		// typed command. Builtins (e.g. /deep-planning) are declared as kind
 		// "skill" but are not served by that tool, so they keep expanding —
 		// as do workflows.
-		if (command.kind === "skill" && !command.id.startsWith("builtin:")) {
+		if (command.kind === "skill" && !isBuiltinCommand(command)) {
 			continue
 		}
-		const start = (match.index ?? 0) + match[1].length
-		const end = start + token.length
 		return text.slice(0, start) + command.instructions + text.slice(end)
 	}
 	return text
+}
+
+/** Builtin pseudo-skills the extension declares itself (e.g. /deep-planning). */
+export function isBuiltinCommand(command: AvailableRuntimeCommand): boolean {
+	return command.id.startsWith("builtin:")
+}
+
+export interface SlashCommandMatch {
+	command: AvailableRuntimeCommand
+	/** Offset of the token's leading slash in the text. */
+	start: number
+	/** Offset just past the token. */
+	end: number
+}
+
+/**
+ * List every slash command in `text` that resolves to a known, enabled runtime
+ * command, in text order. Uses the token regex shared with the webview
+ * (`@cline/shared`), so anything the chat input highlights as a command is
+ * found here. Unknown tokens and commands the user disabled via toggles are
+ * skipped.
+ */
+export function listSlashCommandsInText(
+	text: string,
+	commands: readonly AvailableRuntimeCommand[],
+	options: ExpandSlashCommandsOptions = {},
+): SlashCommandMatch[] {
+	if (!text.includes("/") || commands.length === 0) {
+		return []
+	}
+	const workflowRecords = options.workflowRecords ?? []
+	const matches: SlashCommandMatch[] = []
+	for (const match of text.matchAll(createSlashCommandTokenRegex("g"))) {
+		const token = match[2]
+		const command = findRuntimeCommand(commands, token.slice(1), workflowRecords)
+		if (!command || isRuntimeCommandDisabled(command, options)) {
+			continue
+		}
+		const start = (match.index ?? 0) + match[1].length
+		matches.push({ command, start, end: start + token.length })
+	}
+	return matches
+}
+
+/**
+ * Whether the user disabled this command via the Workflows/Skills toggles.
+ * The disabled sets hold *configured* names (frontmatter `name` or file name),
+ * so the command is mapped back to its record by the stable id first; the
+ * normalized command name is the fallback for callers without records.
+ */
+export function isRuntimeCommandDisabled(
+	command: AvailableRuntimeCommand,
+	options: Pick<
+		ExpandSlashCommandsOptions,
+		"disabledWorkflowNames" | "workflowRecords" | "disabledSkillNames" | "skillRecords"
+	>,
+): boolean {
+	if (command.kind === "workflow") {
+		const configuredName = options.workflowRecords?.find((record) => record.id === command.id)?.name ?? command.name
+		return options.disabledWorkflowNames?.has(configuredName) ?? false
+	}
+	if (command.kind === "skill" && !isBuiltinCommand(command)) {
+		const configuredName = options.skillRecords?.find((record) => record.id === command.id)?.name ?? command.name
+		return options.disabledSkillNames?.has(configuredName) ?? false
+	}
+	return false
 }
 
 export interface BuildDisabledWorkflowNamesOptions {
@@ -280,3 +331,58 @@ export function buildDisabledWorkflowNames(options: BuildDisabledWorkflowNamesOp
 	}
 	return disabled
 }
+
+export interface BuildDisabledSkillNamesOptions {
+	/** Discovered skill records from `listRecords("skill")`. */
+	records: ReadonlyArray<SkillRecordRef>
+	/** `remoteSkillsToggles` (global state) — keyed by remote skill name. */
+	remoteToggles?: Record<string, boolean>
+	/** Names of remote skills the organization locks on (`alwaysEnabled`). */
+	remoteAlwaysEnabledNames?: Iterable<string>
+}
+
+/**
+ * Build the set of exact command names whose skills the user disabled via the
+ * Skills toggles.
+ *
+ * Local and global skills persist their toggle in SKILL.md frontmatter
+ * (`disabled`), which the SDK already honors when listing runtime commands, so
+ * only the enterprise/remote scope needs handling here: remote skills have no
+ * writable frontmatter, and the extension keeps their toggle in name-keyed
+ * `remoteSkillsToggles` instead. Mirrors the remote branch of
+ * {@link buildDisabledWorkflowNames}: the materializer writes a remote skill to
+ * `.cline/remote-config/skills/<sanitized name>/SKILL.md`, so the directory
+ * name is compared against the sanitized toggle key.
+ */
+export function buildDisabledSkillNames(options: BuildDisabledSkillNamesOptions): Set<string> {
+	const remoteToggles = new Map<string, boolean>()
+	for (const [name, enabled] of Object.entries(options.remoteToggles ?? {})) {
+		const key = sanitizeRemoteSegment(name)
+		remoteToggles.set(key, (remoteToggles.get(key) ?? false) || enabled)
+	}
+	const remoteAlwaysEnabled = new Set([...(options.remoteAlwaysEnabledNames ?? [])].map(sanitizeRemoteSegment))
+
+	const disabled = new Set<string>()
+	for (const record of options.records) {
+		if (!record.name || !REMOTE_CONFIG_PATH_REGEX.test(record.filePath)) {
+			continue
+		}
+		const skillDirectory = fileBasename(record.filePath.replace(/[/\\][^/\\]*$/, ""))
+		const remoteKey = sanitizeRemoteSegment(skillDirectory)
+		const enabled = remoteAlwaysEnabled.has(remoteKey) || remoteToggles.get(remoteKey) !== false
+		if (!enabled) {
+			disabled.add(record.name)
+		}
+	}
+	return disabled
+}
+
+/**
+ * The runtime commands a host resolves plus the toggle state governing them —
+ * the same object feeds both expansion and the autocomplete listing.
+ */
+export type RuntimeSlashCommandContext = {
+	commands: AvailableRuntimeCommand[]
+} & Required<
+	Pick<ExpandSlashCommandsOptions, "workflowRecords" | "skillRecords" | "disabledWorkflowNames" | "disabledSkillNames">
+>

--- a/apps/vscode/src/sdk/slash-command-expansion.ts
+++ b/apps/vscode/src/sdk/slash-command-expansion.ts
@@ -350,9 +350,14 @@ export interface BuildDisabledSkillNamesOptions {
  * only the enterprise/remote scope needs handling here: remote skills have no
  * writable frontmatter, and the extension keeps their toggle in name-keyed
  * `remoteSkillsToggles` instead. Mirrors the remote branch of
- * {@link buildDisabledWorkflowNames}: the materializer writes a remote skill to
- * `.cline/remote-config/skills/<sanitized name>/SKILL.md`, so the directory
- * name is compared against the sanitized toggle key.
+ * {@link buildDisabledWorkflowNames}, with one twist: a remote skill has two
+ * identities. The materializer names its directory after the remote config
+ * *entry* name (`.cline/remote-config/skills/<sanitized entry name>/SKILL.md`),
+ * while the Skills panel (`parseRemoteSkillEntries`) keys the toggle by the
+ * SKILL.md *frontmatter* name, which is also the discovered record's name. The
+ * dashboard is supposed to keep the two in sync but drift is tolerated, so both
+ * keys are checked: a skill counts as disabled when a toggle for either is off,
+ * and as locked when the organization's `alwaysEnabled` list names either.
  */
 export function buildDisabledSkillNames(options: BuildDisabledSkillNamesOptions): Set<string> {
 	const remoteToggles = new Map<string, boolean>()
@@ -368,9 +373,10 @@ export function buildDisabledSkillNames(options: BuildDisabledSkillNamesOptions)
 			continue
 		}
 		const skillDirectory = fileBasename(record.filePath.replace(/[/\\][^/\\]*$/, ""))
-		const remoteKey = sanitizeRemoteSegment(skillDirectory)
-		const enabled = remoteAlwaysEnabled.has(remoteKey) || remoteToggles.get(remoteKey) !== false
-		if (!enabled) {
+		const keys = new Set([sanitizeRemoteSegment(record.name), sanitizeRemoteSegment(skillDirectory)])
+		const locked = [...keys].some((key) => remoteAlwaysEnabled.has(key))
+		const toggledOff = [...keys].some((key) => remoteToggles.get(key) === false)
+		if (!locked && toggledOff) {
 			disabled.add(record.name)
 		}
 	}

--- a/apps/vscode/src/services/telemetry/TelemetryService.ts
+++ b/apps/vscode/src/services/telemetry/TelemetryService.ts
@@ -1136,9 +1136,13 @@ export class TelemetryService {
 	 * Records when slash commands or workflows are activated
 	 * @param ulid Unique identifier for the task
 	 * @param commandName The name of the command (e.g., "newtask", "reportbug", or custom workflow name)
-	 * @param commandType Whether it's a built-in command, custom workflow, or MCP prompt
+	 * @param commandType Whether it's a built-in command, custom workflow, skill, or MCP prompt
 	 */
-	public captureSlashCommandUsed(ulid: string, commandName: string, commandType: "builtin" | "workflow" | "mcp_prompt") {
+	public captureSlashCommandUsed(
+		ulid: string,
+		commandName: string,
+		commandType: "builtin" | "workflow" | "skill" | "mcp_prompt",
+	) {
 		this.capture({
 			event: TelemetryService.EVENTS.TASK.SLASH_COMMAND_USED,
 			properties: {

--- a/apps/vscode/src/shared/slashCommands.ts
+++ b/apps/vscode/src/shared/slashCommands.ts
@@ -1,8 +1,10 @@
 export interface SlashCommand {
 	name: string
 	description?: string
-	section?: "default" | "custom" | "mcp"
+	/** Menu group: built-ins, skills, workflows ("custom"), or MCP prompts. */
+	section?: "default" | "skill" | "custom" | "mcp"
 	cliCompatible?: boolean
+	kind?: "builtin" | "skill" | "workflow" | "mcp-prompt"
 }
 
 export const BASE_SLASH_COMMANDS: SlashCommand[] = [

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/.cline/skills/aws-deploy/SKILL.md
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/.cline/skills/aws-deploy/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: aws-deploy
+description: Deploy the sandbox app to AWS. Use when the user asks to ship or deploy.
+---
+
+# AWS deploy
+
+1. Run the test suite.
+2. Build the release bundle.
+3. Upload it to the staging bucket and print the URL.

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/.cline/skills/ship-it/SKILL.md
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/.cline/skills/ship-it/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: Ship It
+description: Cut a release tag and push it. The frontmatter name has a space so the command token is normalized to /ship-it.
+---
+
+# Ship It
+
+Tag the current commit with the next semver version and push the tag.

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/.clinerules/workflows/release-notes.md
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/.clinerules/workflows/release-notes.md
@@ -1,0 +1,5 @@
+---
+description: Draft release notes from the commits since the last tag.
+---
+
+Summarize every commit since the last git tag as user-facing release notes.

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/.gitignore
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/.gitignore
@@ -1,0 +1,2 @@
+# Written by slash-commands.test.ts while it runs, removed on teardown.
+.cline/skills/fresh-skill/

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/README.md
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/README.md
@@ -1,0 +1,4 @@
+# Dedicated e2e fixture for slash-commands.test.ts — a workspace with two
+# project skills (.cline/skills) and one workflow (.clinerules/workflows) so the
+# slash-command menu has runtime commands to list. Kept out of the shared
+# workspace fixture so other specs' menus stay minimal.

--- a/apps/vscode/src/test/e2e/fixtures/workspace-skills/src/app.ts
+++ b/apps/vscode/src/test/e2e/fixtures/workspace-skills/src/app.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+	return `Hello, ${name}!`
+}

--- a/apps/vscode/src/test/e2e/slash-commands.test.ts
+++ b/apps/vscode/src/test/e2e/slash-commands.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "@playwright/test"
+import fs from "fs/promises"
+import path from "path"
+import { e2e, E2ETestHelper } from "./utils/helpers"
+
+// This spec runs against its own fixture workspace, which ships two project
+// skills (.cline/skills/aws-deploy, .cline/skills/ship-it) and one workflow
+// (.clinerules/workflows/release-notes.md), so the slash menu has runtime
+// commands to list without polluting the shared workspace fixture.
+const skillsE2e = e2e.extend({
+	workspaceDir: async ({}, use) => {
+		await use(path.join(E2ETestHelper.E2E_TESTS_DIR, "fixtures", "workspace-skills"))
+	},
+})
+
+skillsE2e(
+	"Slash menu - lists workspace skills and workflows, inserts the skill token",
+	async ({ helper, sidebar, page, workspaceDir }, testInfo) => {
+		// Watcher discovery of a skill written mid-test needs more than the 20s default.
+		testInfo.setTimeout(90_000)
+		const freshSkillDir = path.join(workspaceDir, ".cline", "skills", "fresh-skill")
+		await fs.rm(freshSkillDir, { recursive: true, force: true })
+
+		try {
+			await helper.signin(sidebar)
+
+			const inputbox = sidebar.getByTestId("chat-input")
+			await expect(inputbox).toBeVisible()
+			const menu = sidebar.getByTestId("slash-commands-menu")
+
+			// Typing "/" opens the menu with the built-ins, a Skills group, and a Workflow group.
+			await inputbox.fill("/")
+			await expect(menu).toBeVisible()
+			await expect(menu.getByText("Default Commands", { exact: true })).toBeVisible()
+			await expect(menu.getByText("/newtask", { exact: true })).toBeVisible()
+			await expect(menu.getByText("Skills", { exact: true })).toBeVisible({ timeout: 15_000 })
+			await expect(menu.getByText("/aws-deploy", { exact: true })).toBeVisible()
+			await expect(menu.getByText("Deploy the sandbox app to AWS", { exact: false })).toBeVisible()
+			// Frontmatter name "Ship It" is offered as the normalized token core resolves.
+			await expect(menu.getByText("/ship-it", { exact: true })).toBeVisible()
+			await expect(menu.getByText("Workflow Commands", { exact: true })).toBeVisible()
+			await expect(menu.getByText("/release-notes", { exact: true })).toBeVisible()
+			// The menu is a 200px scroll box; bring the skill and workflow groups into view for the screenshot.
+			await menu.getByText("/release-notes", { exact: true }).scrollIntoViewIfNeeded()
+			const { height } = await page.evaluate(() => ({ height: window.innerHeight }))
+			await page.screenshot({
+				path: path.join(E2ETestHelper.getResultsDir(testInfo.title), "slash-menu-skills.png"),
+				clip: { x: 0, y: Math.max(0, height - 620), width: 500, height: 600 },
+			})
+
+			// Skills come after the built-ins and before workflows.
+			const rows = await menu.locator(".slash-command-menu-item .font-bold").allInnerTexts()
+			expect(rows.indexOf("/aws-deploy")).toBeGreaterThan(rows.indexOf("/newtask"))
+			expect(rows.indexOf("/aws-deploy")).toBeLessThan(rows.indexOf("/release-notes"))
+
+			// The typed prefix filters the menu down to the skill.
+			await inputbox.fill("/aws")
+			await expect(menu.getByText("/aws-deploy", { exact: true })).toBeVisible()
+			await expect(menu.getByText("/newtask", { exact: true })).not.toBeVisible()
+			await expect(menu.getByText("/release-notes", { exact: true })).not.toBeVisible()
+
+			// Selecting the skill inserts its token and the input highlights it as a known command.
+			await menu.getByText("/aws-deploy", { exact: true }).click()
+			await expect(inputbox).toHaveValue("/aws-deploy ")
+			await expect(sidebar.locator("mark.mention-context-textarea-highlight", { hasText: "/aws-deploy" })).toBeVisible()
+			await inputbox.pressSequentially("to staging")
+			await expect(inputbox).toHaveValue("/aws-deploy to staging")
+			await page.screenshot({
+				path: path.join(E2ETestHelper.getResultsDir(testInfo.title), "slash-skill-inserted.png"),
+				clip: { x: 0, y: Math.max(0, height - 320), width: 500, height: 300 },
+			})
+
+			// A skill installed while the window is open shows up on a later menu open:
+			// the host's file watcher discovers it and the menu re-fetches when it opens.
+			await fs.mkdir(freshSkillDir, { recursive: true })
+			await fs.writeFile(
+				path.join(freshSkillDir, "SKILL.md"),
+				"---\nname: fresh-skill\ndescription: Installed while the window was open.\n---\n\nSay hello.\n",
+			)
+			await expect
+				.poll(
+					async () => {
+						await inputbox.fill("")
+						await inputbox.fill("/fresh")
+						return await menu.getByText("/fresh-skill", { exact: true }).isVisible()
+					},
+					{ timeout: 30_000, intervals: [1_000, 2_000, 3_000] },
+				)
+				.toBe(true)
+		} finally {
+			await fs.rm(freshSkillDir, { recursive: true, force: true })
+		}
+	},
+)

--- a/apps/vscode/src/test/slash-commands.test.ts
+++ b/apps/vscode/src/test/slash-commands.test.ts
@@ -1,3 +1,4 @@
+import type { AvailableRuntimeCommand } from "@cline/core"
 import { afterEach, beforeEach, describe, it } from "mocha"
 import "should"
 import * as sinon from "sinon"
@@ -6,36 +7,25 @@ import { getAvailableSlashCommands } from "../core/controller/slash/getAvailable
 import { EmptyRequest } from "../shared/proto/cline/common"
 import { BASE_SLASH_COMMANDS } from "../shared/slashCommands"
 
+function skill(name: string, description?: string): AvailableRuntimeCommand {
+	return { id: `skill:${name}`, name, instructions: `Skill ${name}`, description, kind: "skill" }
+}
+
+function workflow(name: string, description?: string): AvailableRuntimeCommand {
+	return { id: `workflow:${name}`, name, instructions: `Workflow ${name}`, description, kind: "workflow" }
+}
+
 /**
- * Unit tests for getAvailableSlashCommands RPC endpoint
- * Tests the slash command discovery and filtering functionality
+ * Unit tests for the getAvailableSlashCommands RPC endpoint: built-ins plus the
+ * runtime skills/workflows the SdkController already filtered by toggles.
  */
 describe("getAvailableSlashCommands", () => {
+	let listRuntimeSlashCommands: sinon.SinonStub
 	let mockController: Partial<Controller>
-	let mockStateManager: {
-		getWorkspaceStateKey: sinon.SinonStub
-		getGlobalSettingsKey: sinon.SinonStub
-		getGlobalStateKey: sinon.SinonStub
-		getRemoteConfigSettings: sinon.SinonStub
-	}
 
 	beforeEach(() => {
-		mockStateManager = {
-			getWorkspaceStateKey: sinon.stub(),
-			getGlobalSettingsKey: sinon.stub(),
-			getGlobalStateKey: sinon.stub(),
-			getRemoteConfigSettings: sinon.stub(),
-		}
-
-		// Default stubs return empty/null values
-		mockStateManager.getWorkspaceStateKey.returns(null)
-		mockStateManager.getGlobalSettingsKey.returns(null)
-		mockStateManager.getGlobalStateKey.returns(null)
-		mockStateManager.getRemoteConfigSettings.returns(null)
-
-		mockController = {
-			stateManager: mockStateManager as any,
-		}
+		listRuntimeSlashCommands = sinon.stub().resolves([])
+		mockController = { listRuntimeSlashCommands } as Partial<Controller>
 	})
 
 	afterEach(() => {
@@ -43,18 +33,16 @@ describe("getAvailableSlashCommands", () => {
 	})
 
 	describe("Base Slash Commands", () => {
-		it("should return all base slash commands", async () => {
+		it("should return all base slash commands with section 'default' and kind 'builtin'", async () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			// Should have at least all base commands
-			response.commands.length.should.be.greaterThanOrEqual(BASE_SLASH_COMMANDS.length)
-
-			// Verify each base command is present
+			response.commands.length.should.equal(BASE_SLASH_COMMANDS.length)
 			for (const baseCmd of BASE_SLASH_COMMANDS) {
 				const found = response.commands.find((cmd) => cmd.name === baseCmd.name)
 				found!.should.not.be.undefined()
 				found!.description.should.equal(baseCmd.description)
 				found!.section.should.equal("default")
+				found!.kind.should.equal("builtin")
 				found!.cliCompatible.should.equal(baseCmd.cliCompatible ?? false)
 			}
 		})
@@ -64,222 +52,64 @@ describe("getAvailableSlashCommands", () => {
 			const deprecatedCommand = response.commands.find((cmd) => cmd.name === "subagent")
 			;(deprecatedCommand === undefined).should.be.true()
 		})
-
-		it("should mark base commands with section 'default'", async () => {
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const baseCommandNames = BASE_SLASH_COMMANDS.map((cmd) => cmd.name)
-			for (const cmd of response.commands) {
-				if (baseCommandNames.includes(cmd.name)) {
-					cmd.section.should.equal("default")
-				}
-			}
-		})
 	})
 
-	describe("Local Workflow Toggles", () => {
-		it("should include enabled local workflows", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"/path/to/my-workflow.md": true,
-				"/path/to/another-workflow.md": true,
-			})
+	describe("Runtime commands", () => {
+		it("should list skills with section 'skill' and their description", async () => {
+			listRuntimeSlashCommands.resolves([skill("aws-deploy", "Deploy to AWS.")])
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const myWorkflow = response.commands.find((cmd) => cmd.name === "my-workflow.md")
-			myWorkflow!.should.not.be.undefined()
-			myWorkflow!.section.should.equal("custom")
-			myWorkflow!.cliCompatible.should.equal(true)
-
-			const anotherWorkflow = response.commands.find((cmd) => cmd.name === "another-workflow.md")
-			anotherWorkflow!.should.not.be.undefined()
+			const command = response.commands.find((cmd) => cmd.name === "aws-deploy")
+			command!.should.not.be.undefined()
+			command!.section.should.equal("skill")
+			command!.kind.should.equal("skill")
+			command!.description.should.equal("Deploy to AWS.")
+			command!.cliCompatible.should.be.true()
 		})
 
-		it("should exclude disabled local workflows", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"/path/to/enabled-workflow.md": true,
-				"/path/to/disabled-workflow.md": false,
-			})
+		it("should list workflows with section 'custom'", async () => {
+			listRuntimeSlashCommands.resolves([workflow("release")])
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const enabled = response.commands.find((cmd) => cmd.name === "enabled-workflow.md")
-			enabled!.should.not.be.undefined()
-
-			const disabled = response.commands.find((cmd) => cmd.name === "disabled-workflow.md")
-			;(disabled === undefined).should.be.true()
+			const command = response.commands.find((cmd) => cmd.name === "release")
+			command!.should.not.be.undefined()
+			command!.section.should.equal("custom")
+			command!.kind.should.equal("workflow")
+			command!.description.should.equal("")
 		})
 
-		it("should extract filename from full path", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"/Users/test/project/.clinerules/workflows/deep-analysis.md": true,
-			})
+		it("should order built-ins, then skills, then workflows regardless of runtime order", async () => {
+			listRuntimeSlashCommands.resolves([
+				workflow("a-workflow"),
+				skill("z-skill"),
+				workflow("b-workflow"),
+				skill("y-skill"),
+			])
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "deep-analysis.md")
-			workflow!.should.not.be.undefined()
+			const names = response.commands.map((cmd) => cmd.name)
+			names.slice(0, BASE_SLASH_COMMANDS.length).should.deepEqual(BASE_SLASH_COMMANDS.map((cmd) => cmd.name))
+			names.slice(BASE_SLASH_COMMANDS.length).should.deepEqual(["z-skill", "y-skill", "a-workflow", "b-workflow"])
 		})
 
-		it("should handle Windows-style paths", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"C:\\Users\\test\\project\\.clinerules\\workflows\\windows-workflow.md": true,
-			})
+		it("should use the runtime token verbatim, since that is what the send path resolves", async () => {
+			listRuntimeSlashCommands.resolves([skill("ship-it"), workflow("my-workflow")])
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "windows-workflow.md")
-			workflow!.should.not.be.undefined()
-		})
-	})
-
-	describe("Global Workflow Toggles", () => {
-		it("should include enabled global workflows", async () => {
-			mockStateManager.getGlobalSettingsKey.withArgs("globalWorkflowToggles").returns({
-				"/global/path/global-workflow.md": true,
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "global-workflow.md")
-			workflow!.should.not.be.undefined()
-			workflow!.section.should.equal("custom")
+			const names = response.commands.map((cmd) => cmd.name)
+			names.should.containEql("ship-it")
+			names.should.containEql("my-workflow")
+			names.should.not.containEql("my-workflow.md")
 		})
 
-		it("should exclude disabled global workflows", async () => {
-			mockStateManager.getGlobalSettingsKey.withArgs("globalWorkflowToggles").returns({
-				"/global/path/disabled-global.md": false,
-			})
-
+		it("should return only built-ins when the runtime lists nothing", async () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "disabled-global.md")
-			;(workflow === undefined).should.be.true()
-		})
-	})
-
-	describe("Workflow Deduplication", () => {
-		it("should prefer local workflows over global workflows with same name", async () => {
-			// Same filename in both local and global
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"/local/path/shared-workflow.md": true,
-			})
-			mockStateManager.getGlobalSettingsKey.withArgs("globalWorkflowToggles").returns({
-				"/global/path/shared-workflow.md": true,
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			// Should only appear once
-			const matches = response.commands.filter((cmd) => cmd.name === "shared-workflow.md")
-			matches.length.should.equal(1)
-		})
-
-		it("should include global workflow if local with same name is disabled", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
-				"/local/path/shared-workflow.md": false, // disabled locally
-			})
-			mockStateManager.getGlobalSettingsKey.withArgs("globalWorkflowToggles").returns({
-				"/global/path/shared-workflow.md": true, // enabled globally
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			// Global should appear since local is disabled
-			const workflow = response.commands.find((cmd) => cmd.name === "shared-workflow.md")
-			workflow!.should.not.be.undefined()
-		})
-	})
-
-	describe("Remote Workflows", () => {
-		it("should include alwaysEnabled remote workflows", async () => {
-			mockStateManager.getRemoteConfigSettings.returns({
-				remoteGlobalWorkflows: [{ name: "always-on-workflow", alwaysEnabled: true }],
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "always-on-workflow")
-			workflow!.should.not.be.undefined()
-			workflow!.section.should.equal("custom")
-		})
-
-		it("should include remote workflows enabled by toggle", async () => {
-			mockStateManager.getRemoteConfigSettings.returns({
-				remoteGlobalWorkflows: [{ name: "toggle-workflow", alwaysEnabled: false }],
-			})
-			mockStateManager.getGlobalStateKey.withArgs("remoteWorkflowToggles").returns({
-				"toggle-workflow": true, // not explicitly disabled
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "toggle-workflow")
-			workflow!.should.not.be.undefined()
-		})
-
-		it("should exclude remote workflows explicitly disabled by toggle", async () => {
-			mockStateManager.getRemoteConfigSettings.returns({
-				remoteGlobalWorkflows: [{ name: "disabled-remote", alwaysEnabled: false }],
-			})
-			mockStateManager.getGlobalStateKey.withArgs("remoteWorkflowToggles").returns({
-				"disabled-remote": false,
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "disabled-remote")
-			;(workflow === undefined).should.be.true()
-		})
-
-		it("should include remote workflows by default if not explicitly disabled", async () => {
-			mockStateManager.getRemoteConfigSettings.returns({
-				remoteGlobalWorkflows: [{ name: "default-enabled", alwaysEnabled: false }],
-			})
-			// No toggle entry for this workflow
-			mockStateManager.getGlobalStateKey.withArgs("remoteWorkflowToggles").returns({})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			const workflow = response.commands.find((cmd) => cmd.name === "default-enabled")
-			workflow!.should.not.be.undefined()
-		})
-	})
-
-	describe("Edge Cases", () => {
-		it("should handle null/undefined state values gracefully", async () => {
-			mockStateManager.getWorkspaceStateKey.returns(null)
-			mockStateManager.getGlobalSettingsKey.returns(undefined)
-			mockStateManager.getGlobalStateKey.returns(null)
-			mockStateManager.getRemoteConfigSettings.returns(null)
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			// Should still return base commands
-			response.commands.length.should.be.greaterThanOrEqual(BASE_SLASH_COMMANDS.length)
-		})
-
-		it("should handle empty workflow toggle objects", async () => {
-			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({})
-			mockStateManager.getGlobalSettingsKey.withArgs("globalWorkflowToggles").returns({})
-			mockStateManager.getGlobalStateKey.withArgs("remoteWorkflowToggles").returns({})
-			mockStateManager.getRemoteConfigSettings.returns({
-				remoteGlobalWorkflows: [],
-			})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			// Should only have base commands
 			response.commands.length.should.equal(BASE_SLASH_COMMANDS.length)
-		})
-
-		it("should handle remote config with no remoteGlobalWorkflows property", async () => {
-			mockStateManager.getRemoteConfigSettings.returns({})
-
-			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
-
-			// Should not throw, just return base commands
-			response.commands.length.should.be.greaterThanOrEqual(BASE_SLASH_COMMANDS.length)
+			listRuntimeSlashCommands.calledOnce.should.be.true()
 		})
 	})
 })

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -35,6 +35,7 @@ import { useMetaKeyDetection, useShortcut } from "@/utils/hooks"
 import { isSafari } from "@/utils/platformUtils"
 import {
 	getMatchingSlashCommands,
+	getSlashCommandsQuery,
 	insertSlashCommand,
 	removeSlashCommand,
 	shouldShowSlashCommandsMenu,
@@ -219,12 +220,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			apiConfiguration,
 			openRouterModels,
 			platform,
-			localWorkflowToggles,
-			globalWorkflowToggles,
-			remoteWorkflowToggles,
-			remoteConfigSettings,
 			navigateToSettingsModelPicker,
 			mcpServers,
+			slashCommands,
+			refreshSlashCommands,
 		} = useExtensionState()
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
 		const [isDraggingOver, setIsDraggingOver] = useState(false)
@@ -233,6 +232,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [selectedSlashCommandsIndex, setSelectedSlashCommandsIndex] = useState(0)
 		const [slashCommandsQuery, setSlashCommandsQuery] = useState("")
 		const slashCommandsMenuContainerRef = useRef<HTMLDivElement>(null)
+
+		// Re-fetch the host's skills/workflows each time the menu opens so a skill
+		// installed or toggled since the last open shows up (stale-while-revalidate:
+		// the cached list renders immediately and the refresh replaces it).
+		useEffect(() => {
+			if (showSlashCommandsMenu) {
+				void refreshSlashCommands()
+			}
+		}, [showSlashCommandsMenu, refreshSlashCommands])
 
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
 		const [textAreaBaseHeight, setTextAreaBaseHeight] = useState<number | undefined>(undefined)
@@ -486,15 +494,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						event.preventDefault()
 						setSelectedSlashCommandsIndex((prevIndex) => {
 							const direction = event.key === "ArrowUp" ? -1 : 1
-							// Get commands with workflow toggles
-							const allCommands = getMatchingSlashCommands(
-								slashCommandsQuery,
-								localWorkflowToggles,
-								globalWorkflowToggles,
-								remoteWorkflowToggles,
-								remoteConfigSettings?.remoteGlobalWorkflows,
-								mcpServers,
-							)
+							// Commands the menu currently offers, in display order
+							const allCommands = getMatchingSlashCommands(slashCommandsQuery, slashCommands, mcpServers)
 
 							if (allCommands.length === 0) {
 								return prevIndex
@@ -512,14 +513,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 					if ((event.key === "Enter" || event.key === "Tab") && selectedSlashCommandsIndex !== -1) {
 						event.preventDefault()
-						const commands = getMatchingSlashCommands(
-							slashCommandsQuery,
-							localWorkflowToggles,
-							globalWorkflowToggles,
-							remoteWorkflowToggles,
-							remoteConfigSettings?.remoteGlobalWorkflows,
-							mcpServers,
-						)
+						const commands = getMatchingSlashCommands(slashCommandsQuery, slashCommands, mcpServers)
 						if (commands.length > 0) {
 							handleSlashCommandsSelect(commands[selectedSlashCommandsIndex])
 						}
@@ -743,11 +737,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				setShowContextMenu(showMenu)
 
 				if (showSlashCommandsMenu) {
-					// Find the slash nearest to cursor (before cursor position)
-					const beforeCursor = newValue.slice(0, newCursorPosition)
-					const slashIndex = beforeCursor.lastIndexOf("/")
-					const query = newValue.slice(slashIndex + 1, newCursorPosition)
-					setSlashCommandsQuery(query)
+					setSlashCommandsQuery(getSlashCommandsQuery(newValue, newCursorPosition))
 					setSelectedSlashCommandsIndex(0)
 				} else {
 					setSlashCommandsQuery("")
@@ -987,13 +977,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 				// Extract just the command name (without the slash)
 				const commandName = command.substring(1)
-				const isValidCommand = validateSlashCommand(
-					commandName,
-					localWorkflowToggles,
-					globalWorkflowToggles,
-					remoteWorkflowToggles,
-					remoteConfigSettings?.remoteGlobalWorkflows,
-				)
+				const isValidCommand = validateSlashCommand(commandName, slashCommands, mcpServers)
 
 				if (isValidCommand) {
 					hasHighlightedSlashCommand = true
@@ -1006,7 +990,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			highlightLayerRef.current.innerHTML = processedText
 			highlightLayerRef.current.scrollTop = textAreaRef.current.scrollTop
 			highlightLayerRef.current.scrollLeft = textAreaRef.current.scrollLeft
-		}, [localWorkflowToggles, globalWorkflowToggles, remoteWorkflowToggles, remoteConfigSettings])
+		}, [slashCommands, mcpServers])
 
 		useLayoutEffect(() => {
 			updateHighlights()
@@ -1431,14 +1415,11 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					{showSlashCommandsMenu && (
 						<div ref={slashCommandsMenuContainerRef}>
 							<SlashCommandMenu
-								globalWorkflowToggles={globalWorkflowToggles}
-								localWorkflowToggles={localWorkflowToggles}
 								mcpServers={mcpServers}
 								onMouseDown={handleMenuMouseDown}
 								onSelect={handleSlashCommandsSelect}
 								query={slashCommandsQuery}
-								remoteWorkflows={remoteConfigSettings?.remoteGlobalWorkflows}
-								remoteWorkflowToggles={remoteWorkflowToggles}
+								runtimeCommands={slashCommands}
 								selectedIndex={selectedSlashCommandsIndex}
 								setSelectedIndex={setSelectedSlashCommandsIndex}
 							/>

--- a/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -242,6 +242,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 		}, [showSlashCommandsMenu, refreshSlashCommands])
 
+		// The refresh (or an MCP server update) can shrink the list under an open
+		// menu; keep the keyboard selection inside the new list so Enter/Tab never
+		// picks a row that no longer exists.
+		useEffect(() => {
+			if (!showSlashCommandsMenu) {
+				return
+			}
+			const count = getMatchingSlashCommands(slashCommandsQuery, slashCommands, mcpServers).length
+			setSelectedSlashCommandsIndex((prev) => (count === 0 ? 0 : Math.min(prev, count - 1)))
+		}, [showSlashCommandsMenu, slashCommandsQuery, slashCommands, mcpServers])
+
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
 		const [textAreaBaseHeight, setTextAreaBaseHeight] = useState<number | undefined>(undefined)
 		const [showContextMenu, setShowContextMenu] = useState(false)
@@ -514,8 +525,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if ((event.key === "Enter" || event.key === "Tab") && selectedSlashCommandsIndex !== -1) {
 						event.preventDefault()
 						const commands = getMatchingSlashCommands(slashCommandsQuery, slashCommands, mcpServers)
-						if (commands.length > 0) {
-							handleSlashCommandsSelect(commands[selectedSlashCommandsIndex])
+						// The list may have been replaced since the index was set (async refresh).
+						const command = commands[selectedSlashCommandsIndex] ?? commands[commands.length - 1]
+						if (command) {
+							handleSlashCommandsSelect(command)
 						}
 						return
 					}

--- a/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/SlashCommandMenu.tsx
@@ -1,4 +1,5 @@
 import type { McpServer } from "@shared/mcp"
+import type { SlashCommandInfo } from "@shared/proto/cline/slash"
 import React, { useCallback, useEffect, useRef } from "react"
 import ScreenReaderAnnounce from "@/components/common/ScreenReaderAnnounce"
 import { useMenuAnnouncement } from "@/hooks/useMenuAnnouncement"
@@ -11,12 +12,21 @@ interface SlashCommandMenuProps {
 	setSelectedIndex: (index: number) => void
 	onMouseDown: () => void
 	query: string
-	localWorkflowToggles?: Record<string, boolean>
-	globalWorkflowToggles?: Record<string, boolean>
-	remoteWorkflowToggles?: Record<string, boolean>
-	remoteWorkflows?: any[]
+	/** Skills and workflows served by the extension host, already filtered by the user's toggles. */
+	runtimeCommands?: SlashCommandInfo[]
 	mcpServers?: McpServer[]
 }
+
+/**
+ * Menu groups in display order. Must match the order `getAllSlashCommands`
+ * produces so keyboard navigation indexes line up with the rendered rows.
+ */
+const SECTIONS: Array<{ section: NonNullable<SlashCommand["section"]>; title: string }> = [
+	{ section: "default", title: "Default Commands" },
+	{ section: "skill", title: "Skills" },
+	{ section: "custom", title: "Workflow Commands" },
+	{ section: "mcp", title: "MCP Prompts" },
+]
 
 const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 	onSelect,
@@ -24,26 +34,13 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 	setSelectedIndex,
 	onMouseDown,
 	query,
-	localWorkflowToggles = {},
-	globalWorkflowToggles = {},
-	remoteWorkflowToggles,
-	remoteWorkflows,
+	runtimeCommands = [],
 	mcpServers = [],
 }) => {
 	const menuRef = useRef<HTMLDivElement>(null)
 
 	// Filter commands based on query
-	const filteredCommands = getMatchingSlashCommands(
-		query,
-		localWorkflowToggles,
-		globalWorkflowToggles,
-		remoteWorkflowToggles,
-		remoteWorkflows,
-		mcpServers,
-	)
-	const defaultCommands = filteredCommands.filter((cmd) => cmd.section === "default" || !cmd.section)
-	const workflowCommands = filteredCommands.filter((cmd) => cmd.section === "custom")
-	const mcpCommands = filteredCommands.filter((cmd) => cmd.section === "mcp")
+	const filteredCommands = getMatchingSlashCommands(query, runtimeCommands, mcpServers)
 
 	// Screen reader announcements
 	const getCommandLabel = useCallback((command: SlashCommand) => {
@@ -81,13 +78,13 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 	}, [selectedIndex])
 
 	// Create a reusable function for rendering a command section
-	const renderCommandSection = (commands: SlashCommand[], title: string, indexOffset: number, showDescriptions: boolean) => {
+	const renderCommandSection = (commands: SlashCommand[], title: string, indexOffset: number) => {
 		if (commands.length === 0) {
 			return null
 		}
 
 		return (
-			<>
+			<React.Fragment key={title}>
 				<div
 					className="text-xs text-(--vscode-descriptionForeground) px-3 py-1 font-bold border-b border-(--vscode-editorGroup-border)"
 					role="presentation">
@@ -111,7 +108,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 							<div className="font-bold whitespace-nowrap overflow-hidden text-ellipsis">
 								<span className="ph-no-capture">/{command.name}</span>
 							</div>
-							{showDescriptions && command.description && (
+							{command.description && (
 								<div
 									className={`text-[0.85em] ${
 										itemIndex === selectedIndex
@@ -124,8 +121,20 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 						</div>
 					)
 				})}
-			</>
+			</React.Fragment>
 		)
+	}
+
+	const renderSections = () => {
+		let indexOffset = 0
+		return SECTIONS.map(({ section, title }) => {
+			const commands = filteredCommands.filter((cmd) =>
+				section === "default" ? cmd.section === "default" || !cmd.section : cmd.section === section,
+			)
+			const rendered = renderCommandSection(commands, title, indexOffset)
+			indexOffset += commands.length
+			return rendered
+		})
 	}
 
 	return (
@@ -142,11 +151,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 				role="listbox"
 				style={{ maxHeight: "min(200px, calc(50vh))", overscrollBehavior: "contain" }}>
 				{filteredCommands.length > 0 ? (
-					<>
-						{renderCommandSection(defaultCommands, "Default Commands", 0, true)}
-						{renderCommandSection(workflowCommands, "Workflow Commands", defaultCommands.length, false)}
-						{renderCommandSection(mcpCommands, "MCP Prompts", defaultCommands.length + workflowCommands.length, true)}
-					</>
+					renderSections()
 				) : (
 					<div aria-selected="false" className="py-2 px-3 cursor-default flex flex-col" role="option">
 						<div className="text-[0.85em] text-(--vscode-descriptionForeground)">No matching commands found</div>

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -368,9 +368,16 @@ export const ExtensionStateContextProvider: React.FC<{
 	const latestModelRequestIdByProviderRef = useRef<Partial<Record<ProviderId, string>>>({})
 	const [mcpServers, setMcpServers] = useState<McpServer[]>([])
 	const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([])
+	// Monotonic request id so an older refresh that completes late cannot
+	// overwrite the result of a newer one (rapid menu reopenings race).
+	const slashCommandsRequestRef = useRef(0)
 	const refreshSlashCommands = useCallback(async () => {
+		const requestId = ++slashCommandsRequestRef.current
 		try {
 			const response = await SlashServiceClient.getAvailableSlashCommands(EmptyRequest.create({}))
+			if (requestId !== slashCommandsRequestRef.current) {
+				return
+			}
 			setSlashCommands(response.commands ?? [])
 		} catch (error) {
 			console.error("Failed to fetch slash commands:", error)

--- a/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/apps/vscode/webview-ui/src/context/ExtensionStateContext.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_MCP_DISPLAY_MODE } from "@shared/McpDisplayMode"
 import type { UserInfo } from "@shared/proto/cline/account"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import type { OpenRouterCompatibleModelInfo, ProviderModelsResponse } from "@shared/proto/cline/models"
+import type { SlashCommandInfo } from "@shared/proto/cline/slash"
 import { OnboardingModelGroup, type TerminalProfile } from "@shared/proto/cline/state"
 import { convertProtoToClineMessage } from "@shared/proto-conversions/cline-message"
 import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
@@ -26,7 +27,13 @@ import {
 	applyMessage as reducerApplyMessage,
 	applyStateSnapshot as reducerApplyStateSnapshot,
 } from "../components/chat/chat-view/messageReducer"
-import { McpServiceClient, ModelsServiceClient, StateServiceClient, UiServiceClient } from "../services/grpc-client"
+import {
+	McpServiceClient,
+	ModelsServiceClient,
+	SlashServiceClient,
+	StateServiceClient,
+	UiServiceClient,
+} from "../services/grpc-client"
 
 export type ProviderId = string
 
@@ -59,6 +66,10 @@ export interface ExtensionStateContextType extends ExtensionState {
 	providerModelsByProvider: Partial<Record<ProviderId, ProviderModelsState>>
 	latestModelRequestIdByProvider: Partial<Record<ProviderId, string>>
 	mcpServers: McpServer[]
+	/** Slash commands served by the extension host: built-ins plus the skills and workflows toggled on. */
+	slashCommands: SlashCommandInfo[]
+	/** Re-fetch {@link slashCommands}; the chat input calls it whenever the slash menu opens. */
+	refreshSlashCommands: () => Promise<void>
 	totalTasksSize: number | null
 	lastDismissedCliBannerVersion: number
 	dismissedBanners?: Array<{ bannerId: string; dismissedAt: number }>
@@ -356,6 +367,15 @@ export const ExtensionStateContextProvider: React.FC<{
 	const [latestModelRequestIdByProvider, setLatestModelRequestIdByProvider] = useState<Partial<Record<ProviderId, string>>>({})
 	const latestModelRequestIdByProviderRef = useRef<Partial<Record<ProviderId, string>>>({})
 	const [mcpServers, setMcpServers] = useState<McpServer[]>([])
+	const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([])
+	const refreshSlashCommands = useCallback(async () => {
+		try {
+			const response = await SlashServiceClient.getAvailableSlashCommands(EmptyRequest.create({}))
+			setSlashCommands(response.commands ?? [])
+		} catch (error) {
+			console.error("Failed to fetch slash commands:", error)
+		}
+	}, [])
 
 	const startProviderModelsRequest = useCallback((providerId: ProviderId, requestId: string) => {
 		latestModelRequestIdByProviderRef.current = { ...latestModelRequestIdByProviderRef.current, [providerId]: requestId }
@@ -587,6 +607,9 @@ export const ExtensionStateContextProvider: React.FC<{
 				console.log("MCP servers subscription completed")
 			},
 		})
+
+		// Prime the slash-command menu; the chat input re-fetches whenever the menu opens.
+		void refreshSlashCommands()
 
 		// Set up settings button clicked subscription
 		settingsButtonClickedSubscriptionRef.current = UiServiceClient.subscribeToSettingsButtonClicked(EmptyRequest.create({}), {
@@ -887,6 +910,8 @@ export const ExtensionStateContextProvider: React.FC<{
 		providerModelsByProvider,
 		latestModelRequestIdByProvider,
 		mcpServers,
+		slashCommands,
+		refreshSlashCommands,
 		totalTasksSize,
 		availableTerminalProfiles,
 		showMarketplace,

--- a/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
+++ b/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
@@ -293,6 +293,18 @@ describe("slash-commands", () => {
 			expect(validateSlashCommand("aws-deploy", [])).toBeNull()
 		})
 
+		it("lists a skill once when the host reports the same token from two scopes", () => {
+			// Mirrors the local/global dedupe case from #13890: a project and a global
+			// skill with the same name must not produce two menu rows.
+			const duplicated = [
+				runtimeCommand({ name: "aws-deploy", kind: "skill", description: "Project copy" }),
+				runtimeCommand({ name: "aws-deploy", kind: "skill", description: "Global copy" }),
+			]
+			const rows = getMatchingSlashCommands("aws", duplicated)
+			expect(rows).toHaveLength(1)
+			expect(rows[0].description).toBe("Project copy")
+		})
+
 		it("never lets a user command shadow a built-in or an MCP prompt shadow a skill", () => {
 			const shadowing = [runtimeCommand({ name: "compact", kind: "skill", description: "a skill named compact" })]
 			const mcpServers = [createMockMcpServer({ name: "s", prompts: [{ name: "p" }] })]

--- a/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
+++ b/apps/vscode/webview-ui/src/utils/__tests__/slash-commands.test.ts
@@ -1,6 +1,26 @@
 import type { McpServer } from "@shared/mcp"
+import type { SlashCommandInfo } from "@shared/proto/cline/slash"
 import { describe, expect, it } from "vitest"
-import { getMatchingSlashCommands, getMcpPromptCommands, slashCommandRegex, validateSlashCommand } from "../slash-commands"
+import {
+	getAllSlashCommands,
+	getMatchingSlashCommands,
+	getMcpPromptCommands,
+	getRuntimeSlashCommands,
+	getSlashCommandsQuery,
+	shouldShowSlashCommandsMenu,
+	slashCommandRegex,
+	validateSlashCommand,
+} from "../slash-commands"
+
+// Helper to create a host-served runtime command (what getAvailableSlashCommands returns)
+function runtimeCommand(overrides: Partial<SlashCommandInfo> & Pick<SlashCommandInfo, "name" | "kind">): SlashCommandInfo {
+	return {
+		description: "",
+		section: overrides.kind === "skill" ? "skill" : "custom",
+		cliCompatible: true,
+		...overrides,
+	}
+}
 
 // Helper to create a mock MCP server
 function createMockMcpServer(overrides: Partial<McpServer> = {}): McpServer {
@@ -64,6 +84,7 @@ describe("slash-commands", () => {
 					name: "mcp:my-server:summarize",
 					description: "Summarize text",
 					section: "mcp",
+					kind: "mcp-prompt",
 				},
 			])
 		})
@@ -164,25 +185,25 @@ describe("slash-commands", () => {
 		]
 
 		it("should include MCP commands in results when no query", () => {
-			const result = getMatchingSlashCommands("", {}, {}, undefined, undefined, mcpServers)
+			const result = getMatchingSlashCommands("", [], mcpServers)
 			const mcpCommands = result.filter((cmd) => cmd.section === "mcp")
 			expect(mcpCommands).toHaveLength(2)
 		})
 
 		it("should filter MCP commands by query prefix", () => {
-			const result = getMatchingSlashCommands("mcp:test", {}, {}, undefined, undefined, mcpServers)
+			const result = getMatchingSlashCommands("mcp:test", [], mcpServers)
 			const mcpCommands = result.filter((cmd) => cmd.section === "mcp")
 			expect(mcpCommands).toHaveLength(2)
 		})
 
 		it("should filter to specific MCP prompt", () => {
-			const result = getMatchingSlashCommands("mcp:test-server:sum", {}, {}, undefined, undefined, mcpServers)
+			const result = getMatchingSlashCommands("mcp:test-server:sum", [], mcpServers)
 			expect(result).toHaveLength(1)
 			expect(result[0].name).toBe("mcp:test-server:summarize")
 		})
 
 		it("should return empty for non-matching MCP query", () => {
-			const result = getMatchingSlashCommands("mcp:nonexistent", {}, {}, undefined, undefined, mcpServers)
+			const result = getMatchingSlashCommands("mcp:nonexistent", [], mcpServers)
 			expect(result).toHaveLength(0)
 		})
 	})
@@ -196,22 +217,22 @@ describe("slash-commands", () => {
 		]
 
 		it("should return full for exact MCP command match", () => {
-			const result = validateSlashCommand("mcp:server:prompt", {}, {}, undefined, undefined, mcpServers)
+			const result = validateSlashCommand("mcp:server:prompt", [], mcpServers)
 			expect(result).toBe("full")
 		})
 
 		it("should return partial for partial MCP command match", () => {
-			const result = validateSlashCommand("mcp:server:pro", {}, {}, undefined, undefined, mcpServers)
+			const result = validateSlashCommand("mcp:server:pro", [], mcpServers)
 			expect(result).toBe("partial")
 		})
 
 		it("should return partial for server prefix only", () => {
-			const result = validateSlashCommand("mcp:serv", {}, {}, undefined, undefined, mcpServers)
+			const result = validateSlashCommand("mcp:serv", [], mcpServers)
 			expect(result).toBe("partial")
 		})
 
 		it("should return null for non-matching MCP command", () => {
-			const result = validateSlashCommand("mcp:unknown:cmd", {}, {}, undefined, undefined, mcpServers)
+			const result = validateSlashCommand("mcp:unknown:cmd", [], mcpServers)
 			expect(result).toBe(null)
 		})
 	})
@@ -236,6 +257,72 @@ describe("slash-commands", () => {
 			const match = text.match(slashCommandRegex)
 			// Should not match because / is not preceded by whitespace or start
 			expect(match).toBeNull()
+		})
+	})
+
+	describe("runtime skills and workflows from the host", () => {
+		const runtime = [
+			runtimeCommand({ name: "aws-deploy", kind: "skill", description: "Deploy to AWS." }),
+			runtimeCommand({ name: "release", kind: "workflow" }),
+			runtimeCommand({ name: "compact", kind: "builtin", description: "host copy of a builtin" }),
+		]
+
+		it("converts host skills and workflows into menu entries and ignores host builtins", () => {
+			expect(getRuntimeSlashCommands(runtime)).toEqual([
+				{ name: "aws-deploy", description: "Deploy to AWS.", section: "skill", kind: "skill", cliCompatible: true },
+				{ name: "release", description: undefined, section: "custom", kind: "workflow", cliCompatible: true },
+			])
+		})
+
+		it("lists skills in the menu, between built-ins and workflows", () => {
+			const names = getMatchingSlashCommands("", runtime).map((cmd) => cmd.name)
+			const skillIndex = names.indexOf("aws-deploy")
+			expect(skillIndex).toBeGreaterThan(names.indexOf("compact"))
+			expect(skillIndex).toBeLessThan(names.indexOf("release"))
+			expect(getMatchingSlashCommands("", runtime).find((cmd) => cmd.name === "aws-deploy")?.section).toBe("skill")
+		})
+
+		it("filters skills by typed prefix, case-insensitively", () => {
+			expect(getMatchingSlashCommands("AWS", runtime).map((cmd) => cmd.name)).toEqual(["aws-deploy"])
+			expect(getMatchingSlashCommands("rel", runtime).map((cmd) => cmd.name)).toEqual(["release"])
+		})
+
+		it("validates a typed skill as full or partial so the input highlights it", () => {
+			expect(validateSlashCommand("aws-deploy", runtime)).toBe("full")
+			expect(validateSlashCommand("aws", runtime)).toBe("partial")
+			expect(validateSlashCommand("aws-deploy", [])).toBeNull()
+		})
+
+		it("never lets a user command shadow a built-in or an MCP prompt shadow a skill", () => {
+			const shadowing = [runtimeCommand({ name: "compact", kind: "skill", description: "a skill named compact" })]
+			const mcpServers = [createMockMcpServer({ name: "s", prompts: [{ name: "p" }] })]
+			const skillLikeMcp = [
+				runtimeCommand({ name: "mcp:s:p", kind: "skill", description: "skill spelled like an MCP prompt" }),
+			]
+
+			const compact = getAllSlashCommands(shadowing).filter((cmd) => cmd.name === "compact")
+			expect(compact).toHaveLength(1)
+			expect(compact[0].section).toBe("default")
+
+			const mcp = getAllSlashCommands(skillLikeMcp, mcpServers).filter((cmd) => cmd.name === "mcp:s:p")
+			expect(mcp).toHaveLength(1)
+			expect(mcp[0].section).toBe("skill")
+		})
+	})
+
+	describe("shouldShowSlashCommandsMenu / getSlashCommandsQuery", () => {
+		it("opens for a command being typed and reports the typed prefix", () => {
+			expect(shouldShowSlashCommandsMenu("/aws", 4)).toBe(true)
+			expect(getSlashCommandsQuery("/aws", 4)).toBe("aws")
+			expect(shouldShowSlashCommandsMenu("run /aws", 8)).toBe(true)
+			expect(getSlashCommandsQuery("run /aws", 8)).toBe("aws")
+		})
+
+		it("stays closed for paths, completed commands, and second commands", () => {
+			expect(shouldShowSlashCommandsMenu("src/utils", 9)).toBe(false)
+			expect(shouldShowSlashCommandsMenu("/aws-deploy now", 15)).toBe(false)
+			expect(shouldShowSlashCommandsMenu("/aws-deploy then /rel", 21)).toBe(false)
+			expect(getSlashCommandsQuery("/aws-deploy now", 15)).toBe("")
 		})
 	})
 })

--- a/apps/vscode/webview-ui/src/utils/slash-commands.ts
+++ b/apps/vscode/webview-ui/src/utils/slash-commands.ts
@@ -1,4 +1,13 @@
+import {
+	buildSlashCommandCatalog,
+	createSlashCommandTokenRegex,
+	detectSlashQuery,
+	matchSlashCommands,
+	SLASH_COMMAND_TOKEN_CHARS,
+	validateSlashCommandInput,
+} from "@cline/shared"
 import type { McpServer } from "@shared/mcp"
+import type { SlashCommandInfo } from "@shared/proto/cline/slash"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { BASE_SLASH_COMMANDS, type SlashCommand, VSCODE_ONLY_COMMANDS } from "../../../src/shared/slashCommands.ts"
 
@@ -7,67 +16,28 @@ export type { SlashCommand }
 const DEFAULT_SLASH_COMMANDS: SlashCommand[] =
 	PLATFORM_CONFIG.type === PlatformType.VSCODE ? [...BASE_SLASH_COMMANDS, ...VSCODE_ONLY_COMMANDS] : BASE_SLASH_COMMANDS
 
-function getWorkflowCommands(
-	localWorkflowToggles: Record<string, boolean>,
-	globalWorkflowToggles: Record<string, boolean>,
-	remoteWorkflowToggles?: Record<string, boolean>,
-	remoteWorkflows?: any[],
-): SlashCommand[] {
-	const { workflows: localWorkflows, nameSet: localWorkflowNames } = Object.entries(localWorkflowToggles)
-		.filter(([_, enabled]) => enabled)
-		.reduce(
-			(acc, [filePath, _]) => {
-				const fileName = filePath.replace(/^.*[/\\]/, "")
-
-				// Add to array of workflows
-				acc.workflows.push({
-					name: fileName,
-					section: "custom",
-				} as SlashCommand)
-
-				// Add to set of names
-				acc.nameSet.add(fileName)
-
-				return acc
-			},
-			{ workflows: [] as SlashCommand[], nameSet: new Set<string>() },
-		)
-
-	const globalWorkflows = Object.entries(globalWorkflowToggles)
-		.filter(([_, enabled]) => enabled)
-		.flatMap(([filePath, _]) => {
-			const fileName = filePath.replace(/^.*[/\\]/, "")
-
-			// skip if a local workflow with the same name exists
-			if (localWorkflowNames.has(fileName)) {
-				return []
-			}
-
-			return [
-				{
-					name: fileName,
-					section: "custom",
-				},
-			] as SlashCommand[]
-		})
-
-	// Add remote workflows that are enabled
-	const remoteWorkflowCommands: SlashCommand[] = []
-	if (remoteWorkflows && remoteWorkflowToggles) {
-		for (const workflow of remoteWorkflows) {
-			// Include if alwaysEnabled or if toggle is not explicitly false
-			const enabled = workflow.alwaysEnabled || remoteWorkflowToggles[workflow.name] !== false
-			if (enabled) {
-				remoteWorkflowCommands.push({
-					name: workflow.name,
-					section: "custom",
-				})
-			}
+/**
+ * Skills and workflows served by the extension host (`getAvailableSlashCommands`),
+ * converted to menu entries. The host already spelled each token the way the
+ * send path resolves it and applied the user's toggles, so nothing is renamed
+ * or filtered here. Built-ins in the host list are ignored: the webview owns
+ * its own (platform-specific) built-in list.
+ */
+export function getRuntimeSlashCommands(runtimeCommands: readonly SlashCommandInfo[] = []): SlashCommand[] {
+	const commands: SlashCommand[] = []
+	for (const command of runtimeCommands) {
+		if (command.kind !== "skill" && command.kind !== "workflow") {
+			continue
 		}
+		commands.push({
+			name: command.name,
+			description: command.description || undefined,
+			section: command.kind === "skill" ? "skill" : "custom",
+			kind: command.kind,
+			cliCompatible: command.cliCompatible,
+		})
 	}
-
-	const workflows = [...localWorkflows, ...globalWorkflows, ...remoteWorkflowCommands]
-	return workflows
+	return commands
 }
 
 /**
@@ -87,6 +57,7 @@ export function getMcpPromptCommands(mcpServers: McpServer[] = []): SlashCommand
 				name: `mcp:${server.name}:${prompt.name}`,
 				description: prompt.description || prompt.title || `MCP prompt from ${server.name}`,
 				section: "mcp",
+				kind: "mcp-prompt",
 			})
 		}
 	}
@@ -94,15 +65,35 @@ export function getMcpPromptCommands(mcpServers: McpServer[] = []): SlashCommand
 	return commands
 }
 
-// Regex for detecting slash commands in text
+/**
+ * Every command the menu can offer, in display order: built-ins, skills,
+ * workflows, then MCP prompts. Earlier groups win name collisions, so a user
+ * command can never shadow a built-in and a skill always beats a same-named
+ * MCP prompt (core already resolves skill/workflow collisions host-side).
+ */
+export function getAllSlashCommands(
+	runtimeCommands: readonly SlashCommandInfo[] = [],
+	mcpServers: McpServer[] = [],
+): SlashCommand[] {
+	const runtime = getRuntimeSlashCommands(runtimeCommands)
+	return buildSlashCommandCatalog([
+		DEFAULT_SLASH_COMMANDS,
+		runtime.filter((command) => command.section === "skill"),
+		runtime.filter((command) => command.section === "custom"),
+		getMcpPromptCommands(mcpServers),
+	])
+}
+
+// Regex for detecting slash commands in text, shared with the extension host's
+// expansion via @cline/shared so anything highlighted here is expandable there.
 // Must be at start of string OR preceded by whitespace to avoid matching URLs/paths
 // e.g., matches "/newtask" or "text /newtask" but not "http://example.com/newtask"
 // Note: Colons are allowed to support MCP prompt commands like /mcp:server:prompt
-export const slashCommandRegex = /(^|\s)(\/[a-zA-Z0-9_.:@-]+)(?=\s|$)/
-export const slashCommandRegexGlobal = new RegExp(slashCommandRegex.source, "g")
+export const slashCommandRegex = createSlashCommandTokenRegex()
+export const slashCommandRegexGlobal = createSlashCommandTokenRegex("g")
 // Regex for detecting a slash command at the end of text (for deletion)
 // Must be at start OR preceded by whitespace, captures the whole command including slash
-export const slashCommandDeleteRegex = /(^|\s)(\/[a-zA-Z0-9_.:@-]+)$/
+export const slashCommandDeleteRegex = new RegExp(String.raw`(^|\s)(\/${SLASH_COMMAND_TOKEN_CHARS}+)$`, "u")
 
 /**
  * Removes a slash command at the cursor position
@@ -133,42 +124,12 @@ export function removeSlashCommand(text: string, position: number): { newText: s
  * slash commands won't trigger suggestions since only one is processed per message.
  */
 export function shouldShowSlashCommandsMenu(text: string, cursorPosition: number): boolean {
-	const beforeCursor = text.slice(0, cursorPosition)
+	return detectSlashQuery(text, cursorPosition) !== null
+}
 
-	// first check if there is a slash before the cursor
-	const slashIndex = beforeCursor.lastIndexOf("/")
-
-	if (slashIndex === -1) {
-		return false
-	}
-
-	// Check if slash is preceded by whitespace or is at the beginning
-	// This allows slash commands anywhere in the message, similar to @ mentions
-	const charBeforeSlash = slashIndex > 0 ? beforeCursor[slashIndex - 1] : null
-	if (charBeforeSlash !== null && !/\s/.test(charBeforeSlash)) {
-		return false
-	}
-
-	// potential partial or full command
-	const textAfterSlash = beforeCursor.slice(slashIndex + 1)
-
-	// don't show menu if there's whitespace after the slash but before the cursor
-	if (/\s/.test(textAfterSlash)) {
-		return false
-	}
-
-	// Only show suggestions for the FIRST slash command in the message.
-	// Check if there's already a valid slash command earlier in the text.
-	// A valid earlier slash command is one that: starts at beginning or after whitespace,
-	// and is followed by whitespace (meaning it's complete).
-	// Note: Colons are allowed to support MCP prompt commands like /mcp:server:prompt
-	const firstSlashCommandRegex = /(^|\s)\/[a-zA-Z0-9_.:@-]+\s/
-	const textBeforeCurrentSlash = text.slice(0, slashIndex)
-	if (firstSlashCommandRegex.test(textBeforeCurrentSlash)) {
-		return false
-	}
-
-	return true
+/** The prefix typed after the slash the menu is open for (empty when the menu should be closed). */
+export function getSlashCommandsQuery(text: string, cursorPosition: number): string {
+	return detectSlashQuery(text, cursorPosition)?.query ?? ""
 }
 
 /**
@@ -176,27 +137,10 @@ export function shouldShowSlashCommandsMenu(text: string, cursorPosition: number
  */
 export function getMatchingSlashCommands(
 	query: string,
-	localWorkflowToggles: Record<string, boolean> = {},
-	globalWorkflowToggles: Record<string, boolean> = {},
-	remoteWorkflowToggles?: Record<string, boolean>,
-	remoteWorkflows?: any[],
+	runtimeCommands: readonly SlashCommandInfo[] = [],
 	mcpServers: McpServer[] = [],
 ): SlashCommand[] {
-	const workflowCommands = getWorkflowCommands(
-		localWorkflowToggles,
-		globalWorkflowToggles,
-		remoteWorkflowToggles,
-		remoteWorkflows,
-	)
-	const mcpPromptCommands = getMcpPromptCommands(mcpServers)
-	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands]
-
-	if (!query) {
-		return allCommands
-	}
-
-	// filter commands that start with the query (case insensitive)
-	return allCommands.filter((cmd) => cmd.name.toLowerCase().startsWith(query.toLowerCase()))
+	return matchSlashCommands(getAllSlashCommands(runtimeCommands, mcpServers), query)
 }
 
 /**
@@ -228,37 +172,8 @@ export function insertSlashCommand(
  */
 export function validateSlashCommand(
 	command: string,
-	localWorkflowToggles: Record<string, boolean> = {},
-	globalWorkflowToggles: Record<string, boolean> = {},
-	remoteWorkflowToggles?: Record<string, boolean>,
-	remoteWorkflows?: any[],
+	runtimeCommands: readonly SlashCommandInfo[] = [],
 	mcpServers: McpServer[] = [],
 ): "full" | "partial" | null {
-	if (!command) {
-		return null
-	}
-
-	const workflowCommands = getWorkflowCommands(
-		localWorkflowToggles,
-		globalWorkflowToggles,
-		remoteWorkflowToggles,
-		remoteWorkflows,
-	)
-	const mcpPromptCommands = getMcpPromptCommands(mcpServers)
-	const allCommands = [...DEFAULT_SLASH_COMMANDS, ...workflowCommands, ...mcpPromptCommands]
-
-	// case insensitive matching
-	const exactMatch = allCommands.some((cmd) => cmd.name.toLowerCase() === command.toLowerCase())
-
-	if (exactMatch) {
-		return "full"
-	}
-
-	const partialMatch = allCommands.some((cmd) => cmd.name.toLowerCase().startsWith(command.toLowerCase()))
-
-	if (partialMatch) {
-		return "partial"
-	}
-
-	return null // no match
+	return validateSlashCommandInput(getAllSlashCommands(runtimeCommands, mcpServers), command)
 }

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -502,6 +502,7 @@ export {
 } from "./session/runtime-config";
 export type { RuntimeEnv } from "./session/runtime-env";
 export * from "./session/workspace";
+export * from "./slash-commands";
 export {
 	CLINE_CHAT_WORKSPACE_DIRECTORY_NAME,
 	CLINE_WORKSPACES_DIRECTORY_NAME,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -581,6 +581,7 @@ export {
 } from "./session/runtime-config";
 export type { RuntimeEnv } from "./session/runtime-env";
 export * from "./session/workspace";
+export * from "./slash-commands";
 export {
 	CLINE_CHAT_WORKSPACE_DIRECTORY_NAME,
 	CLINE_WORKSPACES_DIRECTORY_NAME,

--- a/sdk/packages/shared/src/slash-commands.test.ts
+++ b/sdk/packages/shared/src/slash-commands.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSlashCommandCatalog,
+	createSlashCommandTokenRegex,
+	detectSlashQuery,
+	findSlashCommand,
+	matchSlashCommands,
+	SLASH_COMMAND_TOKEN_PATTERN,
+	slashCommandKey,
+	validateSlashCommandInput,
+} from "./slash-commands";
+
+describe("createSlashCommandTokenRegex", () => {
+	it("matches a command at the start of the text", () => {
+		const match = "/deploy now".match(createSlashCommandTokenRegex());
+		expect(match?.[1]).toBe("");
+		expect(match?.[2]).toBe("/deploy");
+	});
+
+	it("matches a command after whitespace, capturing the whitespace", () => {
+		const match = "please /deploy now".match(createSlashCommandTokenRegex());
+		expect(match?.[1]).toBe(" ");
+		expect(match?.[2]).toBe("/deploy");
+	});
+
+	it("does not match a slash inside a URL or path", () => {
+		expect(
+			"http://example.com/deploy".match(createSlashCommandTokenRegex()),
+		).toBeNull();
+		expect("src/utils/deploy".match(createSlashCommandTokenRegex())).toBeNull();
+	});
+
+	it("accepts MCP prompt tokens with colons and Unicode skill names", () => {
+		expect(
+			"/mcp:server:prompt".match(createSlashCommandTokenRegex())?.[2],
+		).toBe("/mcp:server:prompt");
+		expect("/发布 docs".match(createSlashCommandTokenRegex())?.[2]).toBe(
+			"/发布",
+		);
+	});
+
+	it("always builds a Unicode-aware regex and never shares lastIndex state", () => {
+		expect(createSlashCommandTokenRegex().flags).toContain("u");
+		expect(createSlashCommandTokenRegex("gu").flags).toBe("gu");
+		const first = createSlashCommandTokenRegex("g");
+		const second = createSlashCommandTokenRegex("g");
+		expect(first).not.toBe(second);
+		expect(first.source).toBe(SLASH_COMMAND_TOKEN_PATTERN);
+	});
+});
+
+describe("detectSlashQuery", () => {
+	it("returns the typed prefix for a command being typed at the start", () => {
+		expect(detectSlashQuery("/dep", 4)).toEqual({
+			slashIndex: 0,
+			query: "dep",
+		});
+	});
+
+	it("returns an empty query right after the slash", () => {
+		expect(detectSlashQuery("/")).toEqual({ slashIndex: 0, query: "" });
+	});
+
+	it("detects a command being typed mid-message after whitespace", () => {
+		expect(detectSlashQuery("run this /rev", 13)).toEqual({
+			slashIndex: 9,
+			query: "rev",
+		});
+	});
+
+	it("ignores slashes inside paths and URLs", () => {
+		expect(detectSlashQuery("see src/utils")).toBeNull();
+		expect(detectSlashQuery("open http://example.com/x")).toBeNull();
+	});
+
+	it("closes once the command is followed by whitespace", () => {
+		expect(detectSlashQuery("/deploy now", 11)).toBeNull();
+	});
+
+	it("only offers suggestions for the first command in a message", () => {
+		expect(detectSlashQuery("/deploy then /rev", 17)).toBeNull();
+	});
+
+	it("uses the cursor position, not the end of the text", () => {
+		expect(detectSlashQuery("/dep later text", 4)).toEqual({
+			slashIndex: 0,
+			query: "dep",
+		});
+	});
+});
+
+describe("slashCommandKey", () => {
+	it("trims, strips leading slashes and lower-cases", () => {
+		expect(slashCommandKey("  //Deploy ")).toBe("deploy");
+	});
+});
+
+describe("buildSlashCommandCatalog", () => {
+	const builtins = [{ name: "compact", description: "Compact  context" }];
+	const runtime = [
+		{ name: "deploy", description: "Deploy\n  the app" },
+		{ name: "Compact", description: "user command shadowing a builtin" },
+		{ name: "", description: "nameless" },
+	];
+
+	it("keeps the earlier list's entry on collisions and drops empty names", () => {
+		const catalog = buildSlashCommandCatalog([builtins, runtime]);
+		expect(catalog.map((entry) => entry.name)).toEqual(["compact", "deploy"]);
+		expect(catalog[0].description).toBe("Compact context");
+	});
+
+	it("collapses description whitespace without renaming the token", () => {
+		const catalog = buildSlashCommandCatalog([runtime]);
+		expect(catalog.find((entry) => entry.name === "deploy")?.description).toBe(
+			"Deploy the app",
+		);
+		expect(catalog.map((entry) => entry.name)).toEqual(["deploy", "Compact"]);
+	});
+
+	it("preserves extra fields on entries", () => {
+		const catalog = buildSlashCommandCatalog([
+			[{ name: "x", kind: "skill" as const, section: "skill" }],
+		]);
+		expect(catalog[0]).toEqual({ name: "x", kind: "skill", section: "skill" });
+	});
+});
+
+describe("matchSlashCommands / findSlashCommand / validateSlashCommandInput", () => {
+	const catalog = [
+		{ name: "compact" },
+		{ name: "deploy" },
+		{ name: "deep-planning" },
+		{ name: "mcp:server:prompt" },
+	];
+
+	it("returns the whole catalog for an empty query", () => {
+		expect(matchSlashCommands(catalog, "")).toEqual(catalog);
+		expect(matchSlashCommands(catalog, "/")).toEqual(catalog);
+	});
+
+	it("filters by case-insensitive prefix", () => {
+		expect(
+			matchSlashCommands(catalog, "De").map((entry) => entry.name),
+		).toEqual(["deploy", "deep-planning"]);
+		expect(matchSlashCommands(catalog, "mcp:ser")).toHaveLength(1);
+	});
+
+	it("finds exact matches case-insensitively", () => {
+		expect(findSlashCommand(catalog, "DEPLOY")?.name).toBe("deploy");
+		expect(findSlashCommand(catalog, "dep")).toBeUndefined();
+		expect(findSlashCommand(catalog, "")).toBeUndefined();
+	});
+
+	it("classifies typed input as full, partial or unknown", () => {
+		expect(validateSlashCommandInput(catalog, "deploy")).toBe("full");
+		expect(validateSlashCommandInput(catalog, "dep")).toBe("partial");
+		expect(validateSlashCommandInput(catalog, "nope")).toBeNull();
+		expect(validateSlashCommandInput(catalog, "")).toBeNull();
+	});
+});

--- a/sdk/packages/shared/src/slash-commands.ts
+++ b/sdk/packages/shared/src/slash-commands.ts
@@ -1,0 +1,204 @@
+/**
+ * Browser-safe slash-command helpers shared by every chat surface (VS Code /
+ * JetBrains webview, CLI TUI, desktop webview, hub dashboard).
+ *
+ * Core mints the command tokens (see `normalizeRuntimeCommandName` in
+ * `@cline/core`'s runtime-commands): a surface never renames a command, it only
+ * detects where the user is typing one, merges the lists it knows about into
+ * one catalog, and filters that catalog by the typed prefix. Keeping those
+ * three steps here means a skill or workflow shows up — and is spelled the same
+ * way — on every surface the moment core knows about it.
+ */
+
+export type SlashCommandKind =
+	| "builtin"
+	| "skill"
+	| "workflow"
+	| "mcp-prompt"
+	| "plugin";
+
+/**
+ * The shape a surface's slash-command catalog entry should carry. Surfaces
+ * may extend it with presentation fields (section, cliCompatible, ...); the
+ * helpers below are generic over anything with a `name`.
+ */
+export interface SlashCommandCatalogEntry {
+	/** Command token without the leading slash, exactly as the surface should insert it. */
+	name: string;
+	description?: string;
+	kind: SlashCommandKind;
+	/** Stable identifier from the source (runtime command id, MCP server + prompt), when known. */
+	id?: string;
+}
+
+/**
+ * Character class of a slash-command token (the part after `/`).
+ *
+ * A superset of every surface's historical alphabet and of the tokens core's
+ * normalizer produces: Unicode letters and digits (so `/发布` works), `_ . -`,
+ * and `: @` for MCP prompt commands (`/mcp:server:prompt`). Requires the `u`
+ * regex flag.
+ */
+export const SLASH_COMMAND_TOKEN_CHARS = String.raw`[\p{L}\p{N}_.:@-]`;
+
+/**
+ * Regex source matching a slash-command token that is at the start of the
+ * text or preceded by whitespace, and followed by whitespace or end-of-text.
+ * The `/` must be preceded by whitespace so URL paths (`http://x.com/foo`) and
+ * file paths never read as commands.
+ *
+ * Capture groups: `[1]` the leading whitespace (or empty), `[2]` the token
+ * including its slash.
+ */
+export const SLASH_COMMAND_TOKEN_PATTERN = String.raw`(^|\s)(\/${SLASH_COMMAND_TOKEN_CHARS}+)(?=\s|$)`;
+
+/**
+ * Build a fresh regex for {@link SLASH_COMMAND_TOKEN_PATTERN}. Always returns
+ * a new instance so callers using the `g` flag never share `lastIndex` state.
+ * The `u` flag is added when missing because the token class uses `\p{…}`.
+ */
+export function createSlashCommandTokenRegex(flags = ""): RegExp {
+	return new RegExp(
+		SLASH_COMMAND_TOKEN_PATTERN,
+		flags.includes("u") ? flags : `${flags}u`,
+	);
+}
+
+/** Matches a completed slash command (token followed by whitespace) anywhere in the text. */
+const COMPLETED_SLASH_COMMAND_REGEX = new RegExp(
+	String.raw`(^|\s)\/${SLASH_COMMAND_TOKEN_CHARS}+\s`,
+	"u",
+);
+
+export interface SlashQuery {
+	/** Index of the `/` that opens the command being typed. */
+	slashIndex: number;
+	/** Text typed after the slash, up to the cursor. */
+	query: string;
+}
+
+/**
+ * Detect whether the cursor sits inside a slash command the user is still
+ * typing, and if so which prefix they have typed.
+ *
+ * Rules, shared by every surface's autocomplete:
+ * - the nearest `/` before the cursor must be at the start of the text or
+ *   preceded by whitespace (so paths and URLs never open the menu);
+ * - there must be no whitespace between that `/` and the cursor (the command
+ *   is still being typed);
+ * - no completed slash command may appear earlier in the text — only the first
+ *   command in a message is processed, so later ones get no suggestions.
+ *
+ * Returns `null` when the cursor is not inside a slash command.
+ */
+export function detectSlashQuery(
+	text: string,
+	cursor: number = text.length,
+): SlashQuery | null {
+	const beforeCursor = text.slice(0, cursor);
+	const slashIndex = beforeCursor.lastIndexOf("/");
+	if (slashIndex === -1) {
+		return null;
+	}
+	if (slashIndex > 0 && !/\s/u.test(beforeCursor[slashIndex - 1] ?? "")) {
+		return null;
+	}
+	const query = beforeCursor.slice(slashIndex + 1);
+	if (/\s/u.test(query)) {
+		return null;
+	}
+	if (COMPLETED_SLASH_COMMAND_REGEX.test(text.slice(0, slashIndex))) {
+		return null;
+	}
+	return { slashIndex, query };
+}
+
+/**
+ * Comparison key for a command token: trimmed, leading slashes removed,
+ * lower-cased. Deliberately light — the token itself is never rewritten here,
+ * since core owns the spelling users type.
+ */
+export function slashCommandKey(name: string): string {
+	return name.trim().replace(/^\/+/u, "").toLowerCase();
+}
+
+/**
+ * Merge several command lists into one catalog.
+ *
+ * Lists are given in precedence order: when two entries share a
+ * {@link slashCommandKey}, the entry from the earlier list wins and later ones
+ * are dropped, so a surface's builtins can never be shadowed by a user
+ * command and a skill can never be shadowed by an MCP prompt. Entries with an
+ * empty name are dropped; descriptions have their whitespace collapsed. Order
+ * within a list is preserved.
+ */
+export function buildSlashCommandCatalog<
+	T extends { name: string; description?: string },
+>(lists: ReadonlyArray<ReadonlyArray<T>>): T[] {
+	const byKey = new Map<string, T>();
+	for (const list of lists) {
+		for (const entry of list) {
+			const key = slashCommandKey(entry.name);
+			if (!key || byKey.has(key)) {
+				continue;
+			}
+			const description = entry.description?.replace(/\s+/gu, " ").trim();
+			byKey.set(
+				key,
+				description === entry.description
+					? entry
+					: { ...entry, description: description || undefined },
+			);
+		}
+	}
+	return [...byKey.values()];
+}
+
+/**
+ * Filter a catalog to the entries whose token starts with the typed query
+ * (case-insensitive). An empty query returns the whole catalog.
+ */
+export function matchSlashCommands<T extends { name: string }>(
+	catalog: ReadonlyArray<T>,
+	query: string,
+): T[] {
+	const prefix = slashCommandKey(query);
+	if (!prefix) {
+		return [...catalog];
+	}
+	return catalog.filter((entry) =>
+		slashCommandKey(entry.name).startsWith(prefix),
+	);
+}
+
+/** Find the catalog entry whose token equals the typed name (case-insensitive). */
+export function findSlashCommand<T extends { name: string }>(
+	catalog: ReadonlyArray<T>,
+	typedName: string,
+): T | undefined {
+	const key = slashCommandKey(typedName);
+	if (!key) {
+		return undefined;
+	}
+	return catalog.find((entry) => slashCommandKey(entry.name) === key);
+}
+
+export type SlashCommandValidation = "full" | "partial" | null;
+
+/**
+ * Classify typed text against a catalog: `"full"` when it names a command
+ * exactly, `"partial"` when it is a prefix of at least one command, `null`
+ * otherwise. Surfaces use this to highlight a typed command as recognized.
+ */
+export function validateSlashCommandInput<T extends { name: string }>(
+	catalog: ReadonlyArray<T>,
+	typedName: string,
+): SlashCommandValidation {
+	if (!slashCommandKey(typedName)) {
+		return null;
+	}
+	if (findSlashCommand(catalog, typedName)) {
+		return "full";
+	}
+	return matchSlashCommands(catalog, typedName).length > 0 ? "partial" : null;
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #13805
**Linear:** [CLINE-3166](https://linear.app/cline-bot/issue/CLINE-3166/skills-never-appear-in-the-slash-command-menu-in-the-vs-code-extension)
Overlaps with #13890, which fixes the same symptom webview-side; see "Additional Notes".

### Description

Skills never appeared in the VS Code / JetBrains slash menu. The webview built its own command list from workflow toggles and MCP prompts, while the send path (`SdkController.resolveSlashCommands`) resolved commands from the SDK's user-instruction service, which does know about skills. The v4.1.4 changelog line describing this feature came from a desktop-only change (#12894), so the docs promised something the extension had never shipped. Legacy never listed skills either, so this is not a regression.

The menu now comes from the same source the send path uses:

- **Extension host.** `SdkController.listRuntimeSlashCommands()` returns the SDK's runtime commands (skills and workflows, tokens already normalized by core, skills winning name collisions) filtered by the workflow toggles and, new, the remote-skill toggles (`buildDisabledSkillNames`, mirroring the workflow one; local/global skill toggles already live in SKILL.md frontmatter, which core honors). The existing `getAvailableSlashCommands` RPC serves that list; `SlashCommandInfo` gains a `kind` field.
- **Webview.** The list is fetched into `ExtensionStateContext.slashCommands` on mount and re-fetched every time the menu opens, so a skill installed or toggled since the last open shows up without touching the toggle maps. `SlashCommandMenu` gets a **Skills** group (with descriptions) between built-ins and workflows; a typed skill token now highlights in the input.
- **Shared.** Query detection at the cursor, catalog merge with first-list-wins collision handling, prefix matching and full/partial validation move to `@cline/shared` (browser entry) as `slash-commands.ts`. The extension host's token regex is now the shared one, so Unicode skill names highlight and expand consistently. The CLI and desktop keep their own copies for now and are the next step (see below).
- **Telemetry.** `task.slash_command_used` had no caller on the SDK extension. It now fires for skills, workflows and built-ins, with a new `skill` command type, so the feature is measurable.

Behavior notes: workflows now display as `/my-workflow` (the token core resolves) instead of `/my-workflow.md`; expansion still accepts both spellings. Built-ins are still owned by the webview. MCP prompts are unchanged and now also highlight in the input.

Why source from the host instead of `refreshSkills`: the frontmatter `name` is not the command token. A skill named "Ship It" is offered as `/ship-it` here, which is what the send path resolves; the raw name would produce `/Ship It`, which never fires. Reading the host's in-memory watcher snapshot also avoids a disk scan per menu open.

Follow-ups planned as separate PRs: (2) CLI and desktop adopt the shared helpers and the four slash expanders unify in core behind a flag; (3) plugin chat commands move into core so the extension lists them too.

### Test Procedure

- New unit tests: `@cline/shared` `slash-commands.test.ts` (20), extension `slash-command-expansion.test.ts` (38, incl. `listSlashCommandsInText`, `isRuntimeCommandDisabled`, `buildDisabledSkillNames`), webview `slash-commands.test.ts` (30, incl. skills grouping, prefix filter, built-in shadowing, local/global dedupe), mocha `slash-commands.test.ts` for the RPC.
- Full suites: extension vitest 90 files / 1186 tests, webview vitest 63 files / 487 tests, `tsc` host + compat + webview clean, biome clean.
- New Playwright e2e `slash-commands.test.ts` runs against a dedicated fixture workspace (two project skills, one whose frontmatter name normalizes, plus a workflow) in real VS Code: asserts the Skills and Workflow groups, ordering, prefix filtering, token insertion with highlight, and that a skill written to `.cline/skills` while the window is open appears on the next menu open. Passes locally.
- JetBrains: verified in the `./gradlew runIde` sandbox (IU 2025.1.7) by driving the JCEF webview over CDP with the same checks; the plugin ships this webview and standalone core, so one fix covers both IDEs.
- What could break: keyboard navigation indexes depend on menu order, so `getAllSlashCommands` and `SlashCommandMenu` share one ordering (built-ins, skills, workflows, MCP) and the e2e asserts it. Workflow toggles and remote workflow locks are exercised by the existing `buildDisabledWorkflowNames` tests, now shared by listing and expansion.
- Not covered by automation: sending the message and watching the model call the `skills` tool. That path is unchanged by this PR (#13327) and was checked manually.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Menu with the new Skills group (VS Code, Playwright run) and the inserted, highlighted token; JetBrains equivalents captured from the JCEF page. To be attached.

### Additional Notes

#13890 by @saoudrizwan reaches the same diagnosis and fixes the symptom in the webview via `refreshSkills`. This PR is proposed as the superseding change because the host-sourced list keeps tokens identical to what the send path resolves and lays the shared groundwork for the CLI/desktop follow-ups; its local/global dedupe test case is folded in here. Happy to rebase on top instead if #13890 lands first.

Docs: the "Triggering Skills with Slash Commands" page should stop being CLI/desktop-only once this ships.
