### PR TITLE
feat(desktop): Enable web search by default outside YOLO mode CLINE-3214

### DIFF
--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -90,9 +90,9 @@ export type ModelToolName = "web_search"
 export function isModelToolEnabledGlobally(name: ModelToolName): boolean {
 	try {
 		const settings = JSON.parse(readFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH ?? "", "utf8"))
-		return settings.tools?.[name]?.enabled === true
+		return settings.tools?.[name]?.enabled ?? true
 	} catch {
-		return false
+		return true
 	}
 }
 

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { getGeneratedModelsForProvider, MODEL_COLLECTIONS_BY_PROVIDER_ID } from "@cline/llms"
 import { createFileReadExecutor } from "../../../../sdk/packages/core/src/extensions/tools/executors/file-read"
 
@@ -88,11 +88,12 @@ export function setCompactionStrategyGlobally(compactionStrategy: GlobalCompacti
 export type ModelToolName = "web_search"
 
 export function isModelToolEnabledGlobally(name: ModelToolName): boolean {
+	const filePath = process.env.CLINE_GLOBAL_SETTINGS_PATH ?? ""
 	try {
-		const settings = JSON.parse(readFileSync(process.env.CLINE_GLOBAL_SETTINGS_PATH ?? "", "utf8"))
+		const settings = JSON.parse(readFileSync(filePath, "utf8"))
 		return settings.tools?.[name]?.enabled ?? true
 	} catch {
-		return true
+		return !existsSync(filePath)
 	}
 }
 

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -85,16 +85,12 @@ describe("DefaultRuntimeBuilder", () => {
 		expect(names).not.toContain("spawn_agent");
 	});
 
-	it("derives enabled provider tools without registering a local executor", async () => {
+	it("enables provider web search by default without a local executor", async () => {
 		const settingsRoot = mkdtempSync(join(tmpdir(), "cline-model-tools-"));
 		tempDirs.push(settingsRoot);
 		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
 			settingsRoot,
 			"global-settings.json",
-		);
-		writeFileSync(
-			process.env.CLINE_GLOBAL_SETTINGS_PATH,
-			JSON.stringify({ tools: { web_search: { enabled: true } } }),
 		);
 
 		const runtime = await new DefaultRuntimeBuilder().build({
@@ -105,6 +101,40 @@ describe("DefaultRuntimeBuilder", () => {
 		expect(runtime.tools.some((tool) => tool.name === "web_search")).toBe(
 			false,
 		);
+	});
+
+	it("excludes provider web search in yolo mode", async () => {
+		const settingsRoot = mkdtempSync(join(tmpdir(), "cline-model-tools-"));
+		tempDirs.push(settingsRoot);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			settingsRoot,
+			"global-settings.json",
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig({ mode: "yolo" }),
+		});
+
+		expect(runtime.modelTools).not.toContainEqual({ name: "web_search" });
+	});
+
+	it("honors an explicit web search opt-out", async () => {
+		const settingsRoot = mkdtempSync(join(tmpdir(), "cline-model-tools-"));
+		tempDirs.push(settingsRoot);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			settingsRoot,
+			"global-settings.json",
+		);
+		writeFileSync(
+			process.env.CLINE_GLOBAL_SETTINGS_PATH,
+			JSON.stringify({ tools: { web_search: { enabled: false } } }),
+		);
+
+		const runtime = await new DefaultRuntimeBuilder().build({
+			config: makeBaseConfig(),
+		});
+
+		expect(runtime.modelTools).not.toContainEqual({ name: "web_search" });
 	});
 
 	it("requests provider image generation for supported language models", async () => {

--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.ts
@@ -418,6 +418,7 @@ export class DefaultRuntimeBuilder implements RuntimeBuilder {
 		const modelTools: ModelTool[] = [];
 		if (
 			normalized.enableTools &&
+			normalized.mode !== "yolo" &&
 			isModelToolEnabledGlobally("web_search") &&
 			supportsModelTool(
 				{ providerId: config.providerId, modelId: config.modelId },

--- a/sdk/packages/core/src/services/global-settings.test.ts
+++ b/sdk/packages/core/src/services/global-settings.test.ts
@@ -201,6 +201,21 @@ describe("global-settings", () => {
 		}
 	});
 
+	it("fails closed for web search when persisted settings cannot be loaded", async () => {
+		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
+		try {
+			const malformedSettingsPath = join(root, "malformed.json");
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = malformedSettingsPath;
+			await writeFile(malformedSettingsPath, "{not json");
+			expect(isModelToolEnabledGlobally("web_search")).toBe(false);
+
+			process.env.CLINE_GLOBAL_SETTINGS_PATH = root;
+			expect(isModelToolEnabledGlobally("web_search")).toBe(false);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("records telemetry opt-out once when the setting changes to true", async () => {
 		const root = await mkdtemp(join(tmpdir(), "core-global-settings-"));
 		try {

--- a/sdk/packages/core/src/services/global-settings.test.ts
+++ b/sdk/packages/core/src/services/global-settings.test.ts
@@ -185,16 +185,16 @@ describe("global-settings", () => {
 				"global-settings.json",
 			);
 
-			expect(isModelToolEnabledGlobally("web_search")).toBe(false);
-			setModelToolEnabledGlobally("web_search", true);
 			expect(isModelToolEnabledGlobally("web_search")).toBe(true);
-			expect(readGlobalSettings().tools).toEqual({
-				web_search: { enabled: true },
-			});
-
-			setDisabledTools(["web_search"], true);
+			setModelToolEnabledGlobally("web_search", false);
+			expect(isModelToolEnabledGlobally("web_search")).toBe(false);
 			expect(readGlobalSettings().tools).toEqual({
 				web_search: { enabled: false },
+			});
+
+			setDisabledTools(["web_search"], false);
+			expect(readGlobalSettings().tools).toEqual({
+				web_search: { enabled: true },
 			});
 		} finally {
 			await rm(root, { recursive: true, force: true });

--- a/sdk/packages/core/src/services/global-settings.ts
+++ b/sdk/packages/core/src/services/global-settings.ts
@@ -135,6 +135,7 @@ interface CachedSettings {
 	mtimeMs: number;
 	size: number;
 	value: GlobalSettings;
+	loadFailed: boolean;
 }
 
 let settingsCache: CachedSettings | undefined;
@@ -162,18 +163,23 @@ function freezeSettings(value: GlobalSettings): GlobalSettings {
 	return Object.freeze(value);
 }
 
-function loadSettingsFromDisk(filePath: string): GlobalSettings {
+function loadSettingsFromDisk(filePath: string): {
+	value: GlobalSettings;
+	loadFailed: boolean;
+} {
 	let raw: string;
 	try {
 		raw = readFileSync(filePath, "utf8");
 	} catch {
-		return defaultGlobalSettings();
+		return { value: defaultGlobalSettings(), loadFailed: true };
 	}
 	try {
 		const result = GlobalSettingsSchema.safeParse(JSON.parse(raw));
-		return result.success ? result.data : defaultGlobalSettings();
+		return result.success
+			? { value: result.data, loadFailed: false }
+			: { value: defaultGlobalSettings(), loadFailed: true };
 	} catch {
-		return defaultGlobalSettings();
+		return { value: defaultGlobalSettings(), loadFailed: true };
 	}
 }
 
@@ -193,10 +199,17 @@ function getCachedSettings(): CachedSettings {
 		return cached;
 	}
 
-	const value = freezeSettings(
-		stats ? loadSettingsFromDisk(filePath) : defaultGlobalSettings(),
-	);
-	settingsCache = { path: filePath, mtimeMs, size, value };
+	const loaded = stats
+		? loadSettingsFromDisk(filePath)
+		: { value: defaultGlobalSettings(), loadFailed: false };
+	const value = freezeSettings(loaded.value);
+	settingsCache = {
+		path: filePath,
+		mtimeMs,
+		size,
+		value,
+		loadFailed: loaded.loadFailed,
+	};
 	return settingsCache;
 }
 
@@ -354,9 +367,10 @@ function isModelToolName(value: string): value is ConfigurableModelToolName {
 }
 
 export function resolveModelToolSettings(): ModelToolSettings {
+	const cached = getCachedSettings();
 	return {
-		web_search: { enabled: true },
-		...readGlobalSettings().tools,
+		web_search: { enabled: !cached.loadFailed },
+		...cached.value.tools,
 	};
 }
 

--- a/sdk/packages/core/src/services/global-settings.ts
+++ b/sdk/packages/core/src/services/global-settings.ts
@@ -354,7 +354,10 @@ function isModelToolName(value: string): value is ConfigurableModelToolName {
 }
 
 export function resolveModelToolSettings(): ModelToolSettings {
-	return readGlobalSettings().tools ?? {};
+	return {
+		web_search: { enabled: true },
+		...readGlobalSettings().tools,
+	};
 }
 
 export function isModelToolEnabledGlobally(


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Enable provider-native web search by default when no explicit preference has been stored. Explicit user opt-outs remain respected, and YOLO sessions exclude web search even when the global preference is enabled.

This also updates the VS Code test stub to match the production default.

### Test Procedure

- Ran `bun run build:sdk`.
- Ran the focused Vitest suite for global settings, runtime construction, and the builtin tool catalog (64 tests).
- Ran `bun run format` and `bun run lint`; lint completed with only pre-existing accessibility warnings in CLI TUI files.
- Verified coverage for default-on Act mode, excluded YOLO mode, and explicit opt-out behavior.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this changes runtime defaults without altering UI layout.

### Additional Notes

Web search is still only included for providers and models that advertise native support.
