### PR TITLE
feat(settings): allow editing cacheReadsPrice and cacheWritesPrice for OpenAI-compatible models

### DIFF
--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx
@@ -488,6 +488,8 @@ describe("OpenAICompatibleProvider", () => {
 		["Context Window Size", "contextWindow", "64000", 64_000],
 		["Max Output Tokens", "maxTokens", "4096", 4_096],
 		["Output Price / 1M tokens", "outputPrice", "2.5", 2.5],
+		["Cache Reads Price / 1M tokens", "cacheReadsPrice", "0.25", 0.25],
+		["Cache Writes Price / 1M tokens", "cacheWritesPrice", "1.0", 1.0],
 	] as const)("maps %s only to the %s override", async (label, key, input, expected) => {
 		renderProvider()
 		await act(async () => {})

--- a/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -608,6 +608,26 @@ export const OpenAICompatibleProvider = ({
 					</div>
 
 					<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.cacheReadsPrice)}
+								onChange={(value) => updateNumericModelOverride("cacheReadsPrice", "Cache Reads Price", value)}>
+								<span style={{ fontWeight: 500 }}>Cache Reads Price / 1M tokens</span>
+							</DebouncedTextField>
+							{modelFieldErrors.cacheReadsPrice && <div role="alert">{modelFieldErrors.cacheReadsPrice}</div>}
+						</div>
+
+						<div style={{ flex: 1 }}>
+							<DebouncedTextField
+								initialValue={formatOptionalModelNumber(openAiModelInfo?.cacheWritesPrice)}
+								onChange={(value) => updateNumericModelOverride("cacheWritesPrice", "Cache Writes Price", value)}>
+								<span style={{ fontWeight: 500 }}>Cache Writes Price / 1M tokens</span>
+							</DebouncedTextField>
+							{modelFieldErrors.cacheWritesPrice && <div role="alert">{modelFieldErrors.cacheWritesPrice}</div>}
+						</div>
+					</div>
+
+					<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
 						<div>
 							<DebouncedTextField
 								initialValue={formatOptionalModelNumber(openAiModelInfo?.temperature)}
@@ -654,7 +674,14 @@ export const OpenAICompatibleProvider = ({
 	)
 }
 
-type NumericModelOverrideKey = "contextWindow" | "maxTokens" | "inputPrice" | "outputPrice" | "temperature"
+type NumericModelOverrideKey =
+	| "contextWindow"
+	| "maxTokens"
+	| "inputPrice"
+	| "outputPrice"
+	| "cacheReadsPrice"
+	| "cacheWritesPrice"
+	| "temperature"
 
 type PendingModelSelection = { modelId: string | undefined; overrides: ProviderModelOverrides }
 


### PR DESCRIPTION
### Related Issue

**Issue:** #13944

### Description

OpenAI-compatible endpoints often support prompt caching with distinct pricing for cache reads and cache writes (such as DeepSeek, OpenRouter, and others). Previously, the OpenAI-compatible provider settings UI only exposed input and output pricing inputs, leaving `cacheReadsPrice` and `cacheWritesPrice` unconfigurable in the UI.

This change adds `cacheReadsPrice` and `cacheWritesPrice` input fields to the OpenAICompatible model configuration settings view alongside the existing prompt and completion pricing inputs.

### Test Procedure

1. Extended the test cases in `apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx` to include `cacheReadsPrice` and `cacheWritesPrice`.
2. Verified tests pass with `bun test apps/vscode/webview-ui/src/components/settings/providers/OpenAICompatible.test.tsx`.
3. Verified numeric inputs update model configuration state appropriately.

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing
- [x] I have reviewed contributor guidelines