### PR TITLE
fix(desktop): stop the live chat stream from doubling and dropping chunks

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -332,6 +332,7 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -453,6 +454,7 @@ describe("session forks", () => {
 				send,
 			},
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -536,6 +538,7 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -611,6 +614,7 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -779,6 +783,7 @@ describe("session forks", () => {
 				]),
 				restoringWorkspacePaths: new Set(),
 				streamIndices: new Map(),
+				coreStreamActivity: new Map(),
 				wsClients: new Set(),
 				sessionManager: { restore },
 			} as unknown as SidecarContext;
@@ -902,6 +907,7 @@ describe("first-send connection updates", () => {
 			]),
 			restoringWorkspacePaths: new Set(),
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 			sessionManager: {
 				readMessages,
@@ -1625,6 +1631,7 @@ Follow the desktop send workflow instructions.`,
 			liveSessions: new Map([[sessionId, session]]),
 			restoringWorkspacePaths: new Set(),
 			streamIndices: new Map(),
+			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 			sessionManager: {
 				send,

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1272,31 +1272,39 @@ describe("disposeSidecarContext attachment cleanup", () => {
 	});
 });
 
-describe("Chat chunk stream arbitration", () => {
-	function createStreamingContext(sessionId: string) {
-		return async () => {
-			const { createSidecarContext } = await import("./context");
-			const ctx = createSidecarContext("/workspace/project");
-			ctx.wsClients.add({ send: vi.fn() });
-			ctx.liveSessions.set(sessionId, {
-				config: {},
-				messages: [],
-				promptsInQueue: [],
-				busy: true,
-				startedAt: Date.now(),
-				status: "running",
-				attachedViaHub: true,
-			});
-			return ctx;
-		};
+describe("Chat chunk pipe selection", () => {
+	async function createStreamingContext(sessionId: string) {
+		const { createSidecarContext } = await import("./context");
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() });
+		ctx.liveSessions.set(sessionId, {
+			config: {},
+			messages: [],
+			promptsInQueue: [],
+			busy: true,
+			startedAt: Date.now(),
+			status: "running",
+			attachedViaHub: true,
+		});
+		return ctx;
 	}
 
-	function chatTextChunks(ctx: SidecarContext): string[] {
+	function coreTextEvent(sessionId: string, text: string) {
+		return {
+			type: "agent_event",
+			payload: {
+				sessionId,
+				event: { type: "content_start", contentType: "text", text },
+			},
+		} as never;
+	}
+
+	function chunksFor(ctx: SidecarContext, stream: string): string[] {
 		return readEvents(ctx)
 			.filter(
 				(message) =>
 					message.event.name === "chat_event" &&
-					(message.event.payload as { stream?: string }).stream === "chat_text",
+					(message.event.payload as { stream?: string }).stream === stream,
 			)
 			.map((message) =>
 				String((message.event.payload as { chunk?: string }).chunk),
@@ -1307,41 +1315,29 @@ describe("Chat chunk stream arbitration", () => {
 		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
 			"./context"
 		);
-		const ctx = await createStreamingContext("session-1")();
+		const ctx = await createStreamingContext("session-1");
 
 		// Opening a session arms both pipes, so the hub publishes each delta to
 		// the ClineCore session subscription and to the observer client.
-		handleCoreSessionEvent(ctx, {
-			type: "agent_event",
-			payload: {
-				sessionId: "session-1",
-				event: { type: "content_start", contentType: "text", text: "Pack " },
-			},
-		} as never);
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "Pack "));
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
 			payload: { text: "Pack " },
 		});
-		handleCoreSessionEvent(ctx, {
-			type: "agent_event",
-			payload: {
-				sessionId: "session-1",
-				event: { type: "content_start", contentType: "text", text: "my box" },
-			},
-		} as never);
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "my box"));
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
 			payload: { text: "my box" },
 		});
 
-		expect(chatTextChunks(ctx)).toEqual(["Pack ", "my box"]);
+		expect(chunksFor(ctx, "chat_text")).toEqual(["Pack ", "my box"]);
 	});
 
 	it("still streams sessions only the observer delivers", async () => {
 		const { handleHubLiveEvent } = await import("./context");
-		const ctx = await createStreamingContext("session-1")();
+		const ctx = await createStreamingContext("session-1");
 
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
@@ -1354,30 +1350,42 @@ describe("Chat chunk stream arbitration", () => {
 			payload: { text: "run" },
 		});
 
-		expect(chatTextChunks(ctx)).toEqual(["remote ", "run"]);
+		expect(chunksFor(ctx, "chat_text")).toEqual(["remote ", "run"]);
 	});
 
-	it("lets the other pipe take over once the owner goes silent", async () => {
+	it("stands down for every stream the core pipe serves, not just text", async () => {
+		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = await createStreamingContext("session-1");
+
+		// One text delta on the core pipe is enough to prove it is subscribed,
+		// so the observer's tool rows are duplicates too.
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "working"));
+		handleHubLiveEvent(ctx, {
+			event: "tool.started",
+			sessionId: "session-1",
+			payload: { toolCallId: "call-1", toolName: "run_commands" },
+		});
+
+		expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
+	});
+
+	it("takes over once the core pipe goes silent", async () => {
 		vi.useFakeTimers();
 		try {
 			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
 				"./context"
 			);
-			const ctx = await createStreamingContext("session-1")();
+			const ctx = await createStreamingContext("session-1");
 
-			handleCoreSessionEvent(ctx, {
-				type: "agent_event",
-				payload: {
-					sessionId: "session-1",
-					event: { type: "content_start", contentType: "text", text: "local" },
-				},
-			} as never);
+			handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
 			handleHubLiveEvent(ctx, {
 				event: "assistant.delta",
 				sessionId: "session-1",
 				payload: { text: "muted" },
 			});
-			expect(chatTextChunks(ctx)).toEqual(["local"]);
+			expect(chunksFor(ctx, "chat_text")).toEqual(["local"]);
 
 			vi.advanceTimersByTime(6_000);
 			handleHubLiveEvent(ctx, {
@@ -1386,13 +1394,13 @@ describe("Chat chunk stream arbitration", () => {
 				payload: { text: "takeover" },
 			});
 
-			expect(chatTextChunks(ctx)).toEqual(["local", "takeover"]);
+			expect(chunksFor(ctx, "chat_text")).toEqual(["local", "takeover"]);
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	it("arbitrates each session independently", async () => {
+	it("tracks the core pipe per session", async () => {
 		const { createSidecarContext, handleCoreSessionEvent, handleHubLiveEvent } =
 			await import("./context");
 		const ctx = createSidecarContext("/workspace/project");
@@ -1409,53 +1417,43 @@ describe("Chat chunk stream arbitration", () => {
 			});
 		}
 
-		handleCoreSessionEvent(ctx, {
-			type: "agent_event",
-			payload: {
-				sessionId: "session-1",
-				event: { type: "content_start", contentType: "text", text: "one" },
-			},
-		} as never);
+		// ClineCore serves session-1; session-2 is still observer-only.
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "one"));
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "one" },
+		});
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-2",
 			payload: { text: "two" },
 		});
 
-		expect(chatTextChunks(ctx)).toEqual(["one", "two"]);
+		expect(chunksFor(ctx, "chat_text")).toEqual(["one", "two"]);
 	});
 
-	it("never suppresses streams only one pipe produces", async () => {
-		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
-			"./context"
-		);
-		const ctx = await createStreamingContext("session-1")();
+	it("never drops chunks the sidecar produces itself", async () => {
+		const { broadcastChunk, handleHubLiveEvent } = await import("./context");
+		const ctx = await createStreamingContext("session-1");
 
-		// The observer takes ownership of the contended chat streams...
+		// The observer is serving this session; a locally synthesized chunk is
+		// not part of either relay and must always reach the webview.
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
 			payload: { text: "remote" },
 		});
-		// ...which must not mute a hook chunk, which only ClineCore emits.
-		handleCoreSessionEvent(ctx, {
-			type: "hook",
-			payload: { sessionId: "session-1", hookEventName: "pre_tool_use" },
-		} as never);
+		broadcastChunk(ctx, "session-1", "chat_queued_prompt_start", "{}");
 
-		const hookChunk = readEvents(ctx).find(
-			(message) =>
-				message.event.name === "chat_event" &&
-				(message.event.payload as { stream?: string }).stream === "chat_hook",
-		);
-		expect(hookChunk).toBeDefined();
+		expect(chunksFor(ctx, "chat_queued_prompt_start")).toEqual(["{}"]);
 	});
 
 	it("stamps chunks with a stable per-process boot id", async () => {
 		const { createSidecarContext, handleHubLiveEvent } = await import(
 			"./context"
 		);
-		const first = await createStreamingContext("session-1")();
+		const first = await createStreamingContext("session-1");
 		handleHubLiveEvent(first, {
 			event: "assistant.delta",
 			sessionId: "session-1",
@@ -1478,36 +1476,5 @@ describe("Chat chunk stream arbitration", () => {
 		// distinguishable by boot id.
 		const second = createSidecarContext("/workspace/project");
 		expect(second.bootId).not.toBe(first.bootId);
-	});
-
-	it("arbitrates each stream separately", async () => {
-		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
-			"./context"
-		);
-		const ctx = await createStreamingContext("session-1")();
-
-		// ClineCore wins the text stream...
-		handleCoreSessionEvent(ctx, {
-			type: "agent_event",
-			payload: {
-				sessionId: "session-1",
-				event: { type: "content_start", contentType: "text", text: "local" },
-			},
-		} as never);
-		// ...which must not mute tool rows that only the observer carries.
-		handleHubLiveEvent(ctx, {
-			event: "tool.started",
-			sessionId: "session-1",
-			payload: { toolCallId: "call-1", toolName: "run_commands" },
-		});
-
-		const toolStart = readEvents(ctx).find(
-			(message) =>
-				message.event.name === "chat_event" &&
-				(message.event.payload as { stream?: string }).stream ===
-					"chat_tool_call_start",
-		);
-		expect(toolStart).toBeDefined();
-		expect(chatTextChunks(ctx)).toEqual(["local"]);
 	});
 });

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1271,3 +1271,243 @@ describe("disposeSidecarContext attachment cleanup", () => {
 		expect(ctx.liveSessions.size).toBe(0);
 	});
 });
+
+describe("Chat chunk stream arbitration", () => {
+	function createStreamingContext(sessionId: string) {
+		return async () => {
+			const { createSidecarContext } = await import("./context");
+			const ctx = createSidecarContext("/workspace/project");
+			ctx.wsClients.add({ send: vi.fn() });
+			ctx.liveSessions.set(sessionId, {
+				config: {},
+				messages: [],
+				promptsInQueue: [],
+				busy: true,
+				startedAt: Date.now(),
+				status: "running",
+				attachedViaHub: true,
+			});
+			return ctx;
+		};
+	}
+
+	function chatTextChunks(ctx: SidecarContext): string[] {
+		return readEvents(ctx)
+			.filter(
+				(message) =>
+					message.event.name === "chat_event" &&
+					(message.event.payload as { stream?: string }).stream === "chat_text",
+			)
+			.map((message) =>
+				String((message.event.payload as { chunk?: string }).chunk),
+			);
+	}
+
+	it("emits one copy when both pipes carry the same delta", async () => {
+		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = await createStreamingContext("session-1")();
+
+		// Opening a session arms both pipes, so the hub publishes each delta to
+		// the ClineCore session subscription and to the observer client.
+		handleCoreSessionEvent(ctx, {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: { type: "content_start", contentType: "text", text: "Pack " },
+			},
+		} as never);
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "Pack " },
+		});
+		handleCoreSessionEvent(ctx, {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: { type: "content_start", contentType: "text", text: "my box" },
+			},
+		} as never);
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "my box" },
+		});
+
+		expect(chatTextChunks(ctx)).toEqual(["Pack ", "my box"]);
+	});
+
+	it("still streams sessions only the observer delivers", async () => {
+		const { handleHubLiveEvent } = await import("./context");
+		const ctx = await createStreamingContext("session-1")();
+
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "remote " },
+		});
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "run" },
+		});
+
+		expect(chatTextChunks(ctx)).toEqual(["remote ", "run"]);
+	});
+
+	it("lets the other pipe take over once the owner goes silent", async () => {
+		vi.useFakeTimers();
+		try {
+			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+				"./context"
+			);
+			const ctx = await createStreamingContext("session-1")();
+
+			handleCoreSessionEvent(ctx, {
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: { type: "content_start", contentType: "text", text: "local" },
+				},
+			} as never);
+			handleHubLiveEvent(ctx, {
+				event: "assistant.delta",
+				sessionId: "session-1",
+				payload: { text: "muted" },
+			});
+			expect(chatTextChunks(ctx)).toEqual(["local"]);
+
+			vi.advanceTimersByTime(6_000);
+			handleHubLiveEvent(ctx, {
+				event: "assistant.delta",
+				sessionId: "session-1",
+				payload: { text: "takeover" },
+			});
+
+			expect(chatTextChunks(ctx)).toEqual(["local", "takeover"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("arbitrates each session independently", async () => {
+		const { createSidecarContext, handleCoreSessionEvent, handleHubLiveEvent } =
+			await import("./context");
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() });
+		for (const sessionId of ["session-1", "session-2"]) {
+			ctx.liveSessions.set(sessionId, {
+				config: {},
+				messages: [],
+				promptsInQueue: [],
+				busy: true,
+				startedAt: Date.now(),
+				status: "running",
+				attachedViaHub: true,
+			});
+		}
+
+		handleCoreSessionEvent(ctx, {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: { type: "content_start", contentType: "text", text: "one" },
+			},
+		} as never);
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-2",
+			payload: { text: "two" },
+		});
+
+		expect(chatTextChunks(ctx)).toEqual(["one", "two"]);
+	});
+
+	it("never suppresses streams only one pipe produces", async () => {
+		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = await createStreamingContext("session-1")();
+
+		// The observer takes ownership of the contended chat streams...
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "remote" },
+		});
+		// ...which must not mute a hook chunk, which only ClineCore emits.
+		handleCoreSessionEvent(ctx, {
+			type: "hook",
+			payload: { sessionId: "session-1", hookEventName: "pre_tool_use" },
+		} as never);
+
+		const hookChunk = readEvents(ctx).find(
+			(message) =>
+				message.event.name === "chat_event" &&
+				(message.event.payload as { stream?: string }).stream === "chat_hook",
+		);
+		expect(hookChunk).toBeDefined();
+	});
+
+	it("stamps chunks with a stable per-process boot id", async () => {
+		const { createSidecarContext, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const first = await createStreamingContext("session-1")();
+		handleHubLiveEvent(first, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "a" },
+		});
+		handleHubLiveEvent(first, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "b" },
+		});
+
+		const boots = readEvents(first)
+			.filter((message) => message.event.name === "chat_event")
+			.map((message) => (message.event.payload as { boot?: string }).boot);
+		expect(boots).toHaveLength(2);
+		expect(boots[0]).toBeTruthy();
+		expect(boots[1]).toBe(boots[0]);
+
+		// A replacement sidecar restarts `index` at 1, so it must be
+		// distinguishable by boot id.
+		const second = createSidecarContext("/workspace/project");
+		expect(second.bootId).not.toBe(first.bootId);
+	});
+
+	it("arbitrates each stream separately", async () => {
+		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+			"./context"
+		);
+		const ctx = await createStreamingContext("session-1")();
+
+		// ClineCore wins the text stream...
+		handleCoreSessionEvent(ctx, {
+			type: "agent_event",
+			payload: {
+				sessionId: "session-1",
+				event: { type: "content_start", contentType: "text", text: "local" },
+			},
+		} as never);
+		// ...which must not mute tool rows that only the observer carries.
+		handleHubLiveEvent(ctx, {
+			event: "tool.started",
+			sessionId: "session-1",
+			payload: { toolCallId: "call-1", toolName: "run_commands" },
+		});
+
+		const toolStart = readEvents(ctx).find(
+			(message) =>
+				message.event.name === "chat_event" &&
+				(message.event.payload as { stream?: string }).stream ===
+					"chat_tool_call_start",
+		);
+		expect(toolStart).toBeDefined();
+		expect(chatTextChunks(ctx)).toEqual(["local"]);
+	});
+});

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -32,6 +32,7 @@ import {
 } from "./feature-flags";
 import { sessionLogPath } from "./paths";
 import type {
+	ChunkSource,
 	LiveSession,
 	PendingAskQuestion,
 	PendingToolApproval,
@@ -171,13 +172,81 @@ function appendSessionChunk(
 	});
 }
 
+/**
+ * Streams that both the ClineCore subscription and the hub observer project.
+ * Everything else has a single producer and is never arbitrated.
+ */
+const CONTENDED_CHUNK_STREAMS = new Set([
+	"chat_text",
+	"chat_reasoning",
+	"chat_media",
+	"chat_tool_call_start",
+	"chat_tool_call_update",
+	"chat_tool_call_end",
+]);
+
+/**
+ * How long the owning source may be silent before the other one may take over.
+ * Deltas arrive many times a second while a turn streams, so an owner that has
+ * said nothing for this long has stopped delivering rather than paused.
+ */
+const CHUNK_STREAM_TAKEOVER_MS = 5_000;
+
+/**
+ * Decides whether `source` may emit a contended chat stream for this session.
+ *
+ * The sidecar has two pipes into `emitChunk`: the ClineCore session
+ * subscription and the hub observer client. Opening a session arms both (the
+ * hydrate's `pending_prompts` call makes ClineCore subscribe to the session,
+ * and `attach` sets `attachedViaHub`), so for a session streaming through the
+ * hub each delta arrives twice — and since both copies are emitted through
+ * this function each gets its own increasing `index`, which is exactly what
+ * the webview's replay guard uses, so it cannot tell them apart. Rather than
+ * guess which pipe owns a session up front, let the first one to deliver win
+ * and mute the other until it stalls.
+ *
+ * Ownership is per stream rather than per session: that dedupes each stream
+ * just as strictly, while a pipe that wins one stream cannot mute another it
+ * does not itself carry.
+ */
+function claimChunkStream(
+	ctx: SidecarContext,
+	sessionId: string,
+	stream: string,
+	source: ChunkSource,
+	now: number,
+): boolean {
+	if (!CONTENDED_CHUNK_STREAMS.has(stream)) {
+		return true;
+	}
+	let owners = ctx.chunkStreamOwners.get(sessionId);
+	const owner = owners?.get(stream);
+	if (
+		owner &&
+		owner.source !== source &&
+		now - owner.lastEmittedAt <= CHUNK_STREAM_TAKEOVER_MS
+	) {
+		return false;
+	}
+	if (!owners) {
+		owners = new Map();
+		ctx.chunkStreamOwners.set(sessionId, owners);
+	}
+	owners.set(stream, { source, lastEmittedAt: now });
+	return true;
+}
+
 function emitChunk(
 	ctx: SidecarContext,
 	sessionId: string,
 	stream: string,
 	chunk: string,
+	source: ChunkSource = "core",
 ): void {
 	const ts = nowMs();
+	if (!claimChunkStream(ctx, sessionId, stream, source, ts)) {
+		return;
+	}
 	appendSessionChunk(sessionId, stream, chunk, ts);
 	const nextIndex = (ctx.streamIndices.get(sessionId) ?? 0) + 1;
 	ctx.streamIndices.set(sessionId, nextIndex);
@@ -187,6 +256,7 @@ function emitChunk(
 		chunk,
 		ts,
 		index: nextIndex,
+		boot: ctx.bootId,
 	});
 }
 
@@ -527,6 +597,9 @@ export function handleCoreSessionEvent(
 				session.status = reason || "ended";
 			}
 			discardAllTrackedAttachments(sessionId, session);
+			// The next run re-arbitrates from scratch rather than inheriting a
+			// pipe that may no longer be the one delivering.
+			ctx.chunkStreamOwners.delete(sessionId);
 			sendEvent(ctx, "chat_session_ended", { sessionId, reason });
 			break;
 		}
@@ -577,6 +650,8 @@ export function createSidecarContext(
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
+		chunkStreamOwners: new Map(),
+		bootId: randomUUID(),
 		wsClients: new Set(),
 		pendingApprovals: new Map(),
 		pendingQuestions: new Map(),
@@ -832,14 +907,20 @@ export function handleHubLiveEvent(
 			const text =
 				typeof event.payload?.text === "string" ? event.payload.text : "";
 			if (text) {
-				emitChunk(ctx, sessionId, "chat_text", text);
+				emitChunk(ctx, sessionId, "chat_text", text, "observer");
 			}
 			return;
 		}
 		case "assistant.media": {
 			const media = event.payload?.media;
 			if (isGeneratedMedia(media)) {
-				emitChunk(ctx, sessionId, "chat_media", JSON.stringify(media));
+				emitChunk(
+					ctx,
+					sessionId,
+					"chat_media",
+					JSON.stringify(media),
+					"observer",
+				);
 			}
 			return;
 		}
@@ -855,6 +936,7 @@ export function handleHubLiveEvent(
 				sessionId,
 				"chat_reasoning",
 				JSON.stringify({ text, redacted }),
+				"observer",
 			);
 			return;
 		}
@@ -874,6 +956,7 @@ export function handleHubLiveEvent(
 							: "tool",
 					input: event.payload?.input,
 				}),
+				"observer",
 			);
 			return;
 		}
@@ -893,6 +976,7 @@ export function handleHubLiveEvent(
 							: "tool",
 					update: event.payload?.update,
 				}),
+				"observer",
 			);
 			return;
 		}
@@ -916,6 +1000,7 @@ export function handleHubLiveEvent(
 							? event.payload.error
 							: undefined,
 				}),
+				"observer",
 			);
 			return;
 		}

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -491,6 +491,18 @@ export function handleCoreSessionEvent(
 	// projection is live and the observer's copy of the same hub events would
 	// be a duplicate. Marked from the pipe itself rather than from `emitChunk`,
 	// so chunks the sidecar synthesizes locally never claim to be this pipe.
+	//
+	// Deliberately every event, not just the content-bearing ones: the hub
+	// fans out to listeners in registration order, and the observer's global
+	// subscription is registered at sidecar boot while this per-session one
+	// arrives at hydrate — so the observer sees each delta first. Waiting for
+	// core content to mark the pipe would let the observer's copy of a turn's
+	// first delta through before the mark existed, doubling it every turn.
+	// The cost is the reverse case: if this pipe delivers a status or queue
+	// event and then stops while the observer keeps streaming, the observer is
+	// held off for `CORE_PIPE_ACTIVE_MS`. That needs the subscription torn down
+	// mid-turn, and the turn-end reconcile restores the gap from canonical
+	// history — where doubling would be visible on every turn.
 	const eventSessionId = (event.payload as { sessionId?: string } | undefined)
 		?.sessionId;
 	if (eventSessionId) {

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -173,67 +173,40 @@ function appendSessionChunk(
 }
 
 /**
- * Streams that both the ClineCore subscription and the hub observer project.
- * Everything else has a single producer and is never arbitrated.
+ * How long a session stays "served by ClineCore" after its last event. Events
+ * arrive many times a second while a turn streams, so a subscription silent
+ * for this long has stopped delivering rather than paused, and the observer
+ * projection is allowed to take over.
  */
-const CONTENDED_CHUNK_STREAMS = new Set([
-	"chat_text",
-	"chat_reasoning",
-	"chat_media",
-	"chat_tool_call_start",
-	"chat_tool_call_update",
-	"chat_tool_call_end",
-]);
+const CORE_PIPE_ACTIVE_MS = 5_000;
 
 /**
- * How long the owning source may be silent before the other one may take over.
- * Deltas arrive many times a second while a turn streams, so an owner that has
- * said nothing for this long has stopped delivering rather than paused.
- */
-const CHUNK_STREAM_TAKEOVER_MS = 5_000;
-
-/**
- * Decides whether `source` may emit a contended chat stream for this session.
+ * Records that the ClineCore subscription is serving this session.
  *
  * The sidecar has two pipes into `emitChunk`: the ClineCore session
  * subscription and the hub observer client. Opening a session arms both (the
  * hydrate's `pending_prompts` call makes ClineCore subscribe to the session,
  * and `attach` sets `attachedViaHub`), so for a session streaming through the
- * hub each delta arrives twice — and since both copies are emitted through
- * this function each gets its own increasing `index`, which is exactly what
- * the webview's replay guard uses, so it cannot tell them apart. Rather than
- * guess which pipe owns a session up front, let the first one to deliver win
- * and mute the other until it stalls.
+ * hub each delta arrived twice — and since both copies go through `emitChunk`
+ * each gets its own increasing `index`, which is exactly what the webview's
+ * replay guard compares, so it could not tell them apart.
  *
- * Ownership is per stream rather than per session: that dedupes each stream
- * just as strictly, while a pipe that wins one stream cannot mute another it
- * does not itself carry.
+ * The two pipes are not peers: ClineCore's subscription is the primary, and
+ * the observer projection exists to cover sessions ClineCore is not subscribed
+ * to. Any event on the primary proves it is subscribed, so it is the primary
+ * that decides — no list of which streams happen to overlap.
  */
-function claimChunkStream(
+function markCorePipeActive(ctx: SidecarContext, sessionId: string): void {
+	ctx.coreStreamActivity.set(sessionId, nowMs());
+}
+
+function isCorePipeActive(
 	ctx: SidecarContext,
 	sessionId: string,
-	stream: string,
-	source: ChunkSource,
 	now: number,
 ): boolean {
-	if (!CONTENDED_CHUNK_STREAMS.has(stream)) {
-		return true;
-	}
-	let owners = ctx.chunkStreamOwners.get(sessionId);
-	const owner = owners?.get(stream);
-	if (
-		owner &&
-		owner.source !== source &&
-		now - owner.lastEmittedAt <= CHUNK_STREAM_TAKEOVER_MS
-	) {
-		return false;
-	}
-	if (!owners) {
-		owners = new Map();
-		ctx.chunkStreamOwners.set(sessionId, owners);
-	}
-	owners.set(stream, { source, lastEmittedAt: now });
-	return true;
+	const lastEventAt = ctx.coreStreamActivity.get(sessionId);
+	return lastEventAt !== undefined && now - lastEventAt <= CORE_PIPE_ACTIVE_MS;
 }
 
 function emitChunk(
@@ -244,7 +217,7 @@ function emitChunk(
 	source: ChunkSource = "core",
 ): void {
 	const ts = nowMs();
-	if (!claimChunkStream(ctx, sessionId, stream, source, ts)) {
+	if (source === "observer" && isCorePipeActive(ctx, sessionId, ts)) {
 		return;
 	}
 	appendSessionChunk(sessionId, stream, chunk, ts);
@@ -514,6 +487,16 @@ export function handleCoreSessionEvent(
 	ctx: SidecarContext,
 	event: CoreSessionEvent,
 ): void {
+	// Reaching here at all means ClineCore is subscribed to the session, so its
+	// projection is live and the observer's copy of the same hub events would
+	// be a duplicate. Marked from the pipe itself rather than from `emitChunk`,
+	// so chunks the sidecar synthesizes locally never claim to be this pipe.
+	const eventSessionId = (event.payload as { sessionId?: string } | undefined)
+		?.sessionId;
+	if (eventSessionId) {
+		markCorePipeActive(ctx, eventSessionId);
+	}
+
 	switch (event.type) {
 		case "chunk": {
 			const { sessionId, stream, chunk } = event.payload;
@@ -597,9 +580,8 @@ export function handleCoreSessionEvent(
 				session.status = reason || "ended";
 			}
 			discardAllTrackedAttachments(sessionId, session);
-			// The next run re-arbitrates from scratch rather than inheriting a
-			// pipe that may no longer be the one delivering.
-			ctx.chunkStreamOwners.delete(sessionId);
+			// The next run decides afresh which pipe is serving the session.
+			ctx.coreStreamActivity.delete(sessionId);
 			sendEvent(ctx, "chat_session_ended", { sessionId, reason });
 			break;
 		}
@@ -650,7 +632,7 @@ export function createSidecarContext(
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
-		chunkStreamOwners: new Map(),
+		coreStreamActivity: new Map(),
 		bootId: randomUUID(),
 		wsClients: new Set(),
 		pendingApprovals: new Map(),

--- a/apps/examples/desktop-app/sidecar/mcp.test.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.test.ts
@@ -14,7 +14,7 @@ function createContext(workspaceRoot: string): SidecarContext {
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
-		chunkStreamOwners: new Map(),
+		coreStreamActivity: new Map(),
 		bootId: "test-boot",
 		wsClients: new Set(),
 		pendingApprovals: new Map(),

--- a/apps/examples/desktop-app/sidecar/mcp.test.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.test.ts
@@ -14,6 +14,8 @@ function createContext(workspaceRoot: string): SidecarContext {
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
+		chunkStreamOwners: new Map(),
+		bootId: "test-boot",
 		wsClients: new Set(),
 		pendingApprovals: new Map(),
 		pendingQuestions: new Map(),

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -114,26 +114,21 @@ export type SidecarWebSocketClient = {
 
 /**
  * Which pipe produced a chat chunk. Both feed `emitChunk`, and for a session
- * that is streaming through the hub both can carry the same event, so the
- * chat streams they share are arbitrated per session (see `claimChunkStream`).
+ * streaming through the hub both carry the same events, so the observer's copy
+ * is dropped while the ClineCore subscription is serving that session.
  */
 export type ChunkSource = "core" | "observer";
-
-export type ChunkStreamOwner = {
-	source: ChunkSource;
-	lastEmittedAt: number;
-};
 
 export type SidecarContext = {
 	liveSessions: Map<string, LiveSession>;
 	restoringWorkspacePaths: Set<string>;
 	streamIndices: Map<string, number>;
 	/**
-	 * Which source currently owns each duplicated chat stream, keyed by session
-	 * then stream, with the time it last delivered so a stalled owner can be
-	 * replaced.
+	 * When the ClineCore subscription last delivered an event for a session, so
+	 * the observer projection can stand down while it is serving and take over
+	 * again if it stops.
 	 */
-	chunkStreamOwners: Map<string, Map<string, ChunkStreamOwner>>;
+	coreStreamActivity: Map<string, number>;
 	/**
 	 * Identifies this sidecar process. `streamIndices` restarts whenever the
 	 * sidecar does, so the webview needs to tell "index 1 of a new process"

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -112,10 +112,34 @@ export type SidecarWebSocketClient = {
 	close?: () => void;
 };
 
+/**
+ * Which pipe produced a chat chunk. Both feed `emitChunk`, and for a session
+ * that is streaming through the hub both can carry the same event, so the
+ * chat streams they share are arbitrated per session (see `claimChunkStream`).
+ */
+export type ChunkSource = "core" | "observer";
+
+export type ChunkStreamOwner = {
+	source: ChunkSource;
+	lastEmittedAt: number;
+};
+
 export type SidecarContext = {
 	liveSessions: Map<string, LiveSession>;
 	restoringWorkspacePaths: Set<string>;
 	streamIndices: Map<string, number>;
+	/**
+	 * Which source currently owns each duplicated chat stream, keyed by session
+	 * then stream, with the time it last delivered so a stalled owner can be
+	 * replaced.
+	 */
+	chunkStreamOwners: Map<string, Map<string, ChunkStreamOwner>>;
+	/**
+	 * Identifies this sidecar process. `streamIndices` restarts whenever the
+	 * sidecar does, so the webview needs to tell "index 1 of a new process"
+	 * apart from a replay of the run it already rendered.
+	 */
+	bootId: string;
 	wsClients: Set<SidecarWebSocketClient>;
 	pendingApprovals: Map<string, PendingToolApproval>;
 	pendingQuestions: Map<string, PendingAskQuestion>;

--- a/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/types.ts
@@ -14,6 +14,12 @@ export type AgentChunkEvent = {
 	chunk: string;
 	ts: number;
 	index?: number;
+	/**
+	 * Identifies the sidecar process that numbered this chunk. `index` restarts
+	 * whenever the sidecar does, so a changed `boot` means the counter reset
+	 * rather than the stream replaying.
+	 */
+	boot?: string;
 };
 
 export type ReasoningDeltaEvent = {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -3368,4 +3368,102 @@ describe("coerced-queue first turn vs stale send response", () => {
 		expect(current.promptsInQueue).toHaveLength(1);
 		expect(current.promptsInQueue[0]?.prompt).toBe("second prompt");
 	});
+
+	it("keeps rendering the live stream after the sidecar restarts its chunk index", async () => {
+		const sessionId = "session-sidecar-restart";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "start") return { sessionId };
+				}
+				return [];
+			},
+		);
+
+		await act(async () => current.start(current.config));
+		const chatEventHandler = handlerFor("chat_event");
+
+		await act(async () => {
+			chatEventHandler({
+				sessionId,
+				stream: "chat_text",
+				chunk: "before ",
+				ts: Date.now(),
+				index: 42,
+				boot: "boot-a",
+			});
+			await new Promise((resolve) => setTimeout(resolve, 60));
+		});
+
+		// A replacement sidecar numbers its chunks from 1 again. Without the
+		// boot id the high-water mark would swallow the rest of the session.
+		await act(async () => {
+			chatEventHandler({
+				sessionId,
+				stream: "chat_text",
+				chunk: "after",
+				ts: Date.now(),
+				index: 1,
+				boot: "boot-b",
+			});
+			await new Promise((resolve) => setTimeout(resolve, 60));
+		});
+
+		const assistantText = current.messages
+			.filter((message) => message.role === "assistant")
+			.map((message) => message.content)
+			.join("");
+		expect(assistantText).toContain("before ");
+		expect(assistantText).toContain("after");
+	});
+
+	it("still drops a chunk the same sidecar already delivered", async () => {
+		const sessionId = "session-replayed-chunk";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as { action?: string } | undefined;
+					if (request?.action === "start") return { sessionId };
+				}
+				return [];
+			},
+		);
+
+		await act(async () => current.start(current.config));
+		const chatEventHandler = handlerFor("chat_event");
+
+		await act(async () => {
+			chatEventHandler({
+				sessionId,
+				stream: "chat_text",
+				chunk: "kept",
+				ts: Date.now(),
+				index: 7,
+				boot: "boot-a",
+			});
+			chatEventHandler({
+				sessionId,
+				stream: "chat_text",
+				chunk: "replayed",
+				ts: Date.now(),
+				index: 7,
+				boot: "boot-a",
+			});
+			await new Promise((resolve) => setTimeout(resolve, 60));
+		});
+
+		const assistantText = current.messages
+			.filter((message) => message.role === "assistant")
+			.map((message) => message.content)
+			.join("");
+		expect(assistantText).toContain("kept");
+		expect(assistantText).not.toContain("replayed");
+	});
 });

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -408,6 +408,7 @@ export function useChatSession() {
 	const activeSessionIdRef = useRef<string | null>(null);
 	const activeAssistantMessageIdRef = useRef<string | null>(null);
 	const lastStreamIndexBySessionRef = useRef<Record<string, number>>({});
+	const lastStreamBootBySessionRef = useRef<Record<string, string>>({});
 	const abortedRef = useRef(false);
 	const abortFallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
@@ -518,9 +519,11 @@ export function useChatSession() {
 	const resetStreamDedupe = useCallback((targetSessionId?: string | null) => {
 		if (targetSessionId) {
 			delete lastStreamIndexBySessionRef.current[targetSessionId];
+			delete lastStreamBootBySessionRef.current[targetSessionId];
 			return;
 		}
 		lastStreamIndexBySessionRef.current = {};
+		lastStreamBootBySessionRef.current = {};
 	}, []);
 
 	const clearAbortFallbackTimeout = useCallback(() => {
@@ -815,6 +818,21 @@ export function useChatSession() {
 		const index = payload.index;
 		if (typeof index !== "number") {
 			return true;
+		}
+		// `index` counts up inside one sidecar process. When the sidecar is
+		// replaced under a live webview the counter restarts at 1, and without
+		// this the high-water mark below would silently discard the whole
+		// stream — user messages and tool rows included — until the new
+		// process counted past the old run.
+		const boot = payload.boot;
+		if (boot !== undefined) {
+			const previousBoot =
+				lastStreamBootBySessionRef.current[payload.sessionId];
+			if (previousBoot !== boot) {
+				lastStreamBootBySessionRef.current[payload.sessionId] = boot;
+				lastStreamIndexBySessionRef.current[payload.sessionId] = index;
+				return true;
+			}
 		}
 		const previous = lastStreamIndexBySessionRef.current[payload.sessionId];
 		if (previous !== undefined && index <= previous) {


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — reported directly by a user: during a streaming turn some of her messages and tool calls were missing, and text rendered doubled; switching to another task and back, or letting the turn finish, made everything render correctly.

### Description

That report is two separate bugs in the desktop app's **live** stream path. They share a tell: only the live view is ever wrong. Two things re-read the canonical store and repair it — `hydrateSession` (switching tasks) and `finalizeSettledTurn` (turn end) — which is exactly when she saw it fix itself. Persisted history was never affected.

Neither bug exists in the CLI: both are in desktop-only code (`sidecar/`, `webview/`). Nothing in `sdk/` changed.

#### 1. Doubled text — two pipes emitting the same delta

The sidecar has two paths into `emitChunk`:

- `handleCoreSessionEvent` — the ClineCore session subscription
- `handleHubLiveEvent` — the hub observer client, gated on `session.attachedViaHub`

Opening a session arms **both**. `handleAttach` sets `attachedViaHub: true` unconditionally, and the same hydrate calls `refreshPromptsInQueue` → `pendingPrompts.list()` → `HubRuntimeHost.requestPendingPromptsList`, which calls `ensureSessionSubscription` as a side effect. So for a session streaming through the hub, every delta arrived twice.

Both existing guards miss it:

- The webview's replay guard compares `payload.index`. Both copies are emitted through `emitChunk`, so **each duplicate gets its own increasing index** — indistinguishable from real progress.
- `appendMessageContent`'s `existing.endsWith(chunk)` fallback is defeated by the 50 ms coalescing buffer, which concatenates `a,a,b,b` into `"aabb"` before comparing.

`attachedViaHub` is cleared when the webview *sends* (the #13154 fix), which is why this survived: the common "open a task and type" flow disarms it. It only shows when a session streams **without** a local send first — a run already in flight when you open the task, a resumed or scheduled run, or any re-hydrate mid-turn.

**Fix:** the two pipes aren't peers, so they don't need symmetric arbitration. ClineCore's subscription is the primary; the observer projection exists to cover sessions ClineCore *isn't* subscribed to. Any event reaching `handleCoreSessionEvent` proves it is subscribed — so that pipe records its own liveness, and the observer stands down while it's serving, taking over again if it goes silent for 5 s.

Guessing at attach time doesn't work (ownership isn't knowable there — the local pipe is armed by an unrelated call's side effect), and an earlier pass that arbitrated a hardcoded list of the six `chat_*` streams was worse: a third copy of knowledge already encoded in the two switch statements, which a later stream would silently drift out of. Dropping an observer chunk for a stream the observer never produces is a no-op, so the list has nothing to do. Liveness is marked from the pipe rather than from `emitChunk`, so chunks the sidecar synthesizes locally never claim to be the core subscription.

For reference, the CLI has neither problem because it subscribes **once** (`apps/cli/src/runtime/session-events.ts` → `sessionManager.subscribe`), consumes `AgentEvent` objects directly, and never re-tags them into a `chat_*` wire vocabulary. Those stream names are a desktop-only translation layer, and the bug is that both pipes translate into it independently.

#### 2. Missing messages and tool calls — a one-way index ratchet

`shouldApplyStreamChunk` drops any chunk whose `index` isn't above the highest seen for that session. That counter lives in the **sidecar process** (`ctx.streamIndices`), but the webview only cleared its high-water mark in `hydrateSession` — never on reconnect.

So when a sidecar is replaced under a live webview (crash-respawn, hub drain-and-replace, stale-sidecar swap), the replacement starts numbering at 1 while the webview still holds e.g. 4000, and **silently discards everything for that session** until the new process counts past the old run.

The guard runs *ahead* of any per-stream handling, so this drops far more than assistant text: `chat_queued_prompt_start` (the user's own message bubbles) and the tool-call rows go with it. That's the "my messages and tool calls are missing" half of the report, and it self-heals at turn end because the reconcile re-reads canonical history.

**Fix:** stamp each chunk with the emitting sidecar's boot id, so a counter reset is a fact rather than an inference. A changed boot id rebases the mark instead of swallowing the stream; replays from the same process are still dropped exactly as before.

### Test Procedure

Both fixes have regression tests, and I verified each is genuinely red without its fix rather than trusting that it passes:

- Disabling the observer stand-down → four tests fail, including *"emits one copy when both pipes carry the same delta"* and *"takes over once the core pipe goes silent"*.
- Disabling the boot-id branch → *"keeps rendering the live stream after the sidecar restarts its chunk index"* fails.

Coverage added (7 sidecar + 2 webview):

- both pipes carry the same delta → one copy reaches the client
- observer-only sessions still stream (the case the observer pipe exists for)
- one core text delta stands the observer down for tool rows too, not just text
- the observer takes over once the core pipe goes silent
- core-pipe liveness is tracked per session
- chunks the sidecar synthesizes itself are never dropped
- boot id is stable within a process and differs across processes
- a sidecar restart doesn't blackhole the stream; a same-process replay is still dropped

Suites:

- `sidecar/context.test.ts` — 39 passed (7 new)
- `sidecar/` + `webview/hooks` — 337 passed
- Full desktop suite — 877 passed. The 6 failures in `commands-account` / `commands-hub-upgrade` / `commands-integrations` / `context` / `observability` are **pre-existing**: I ran the same suite on untouched `main` and got the identical set (a parallel-load mock flake).
- `tsc -p apps/examples/desktop-app/tsconfig.json --noEmit` — output identical to baseline on `main`. Adding `SidecarContext` fields broke partial fixtures in `mcp.test.ts` and `chat-session.test.ts` — they use `as unknown as SidecarContext`, so a missing field bypasses the type checker and only surfaces as a runtime crash. Both are updated here.

**Suite counts above are from the final design;** earlier numbers in the commit history reflect a first pass that arbitrated the stream-name list.

**What could break:** the observer is muted, so the risk is muting it when it's actually the only live source. Two things bound that. The mute is gated on the core pipe having delivered for *that session* within 5 s — and a core event means core is subscribed, which means core carries that session's chat events too. And a core pipe that stops is stood down after 5 s (events arrive many times a second while a turn streams, so 5 s of silence means stopped, not paused). Liveness is also dropped on session end, so the next run decides afresh.

**Not verified on a running stack.** This was root-caused by reading the code, not by reproducing it live. The predicted repro for the doubling half — start a long turn, switch to another task and back mid-stream, watch text double, then send any message and watch it stop — is worth confirming before release.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (one commit per defect, plus a follow-up simplifying the first)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

Diagnostics for anyone confirming this in the field: the sidecar persists every emitted chunk at `~/.cline/apps/kanban/sessions/<id>.jsonl`, and `appendSessionChunk` runs *inside* `emitChunk` — so pre-fix, consecutive identical chunks in that file are the duplicate on the wire.

Related to the dual-relay work in #13154, which fixed the send path; this closes the attach path it left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNoho8fGgnh71xjQF5xMqy
