### PR TITLE
fix(hub): exclude subagent rows from session.list by default

### DIFF
--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { HubCommandEnvelope, SessionRecord } from "@cline/shared";
 import {
+	handleSessionList,
 	readHubClientContext,
 	readHubUserContext,
 	readSessionConnectionUpdate,
@@ -139,4 +141,48 @@ describe("resolveSessionAutoApproveTools", () => {
 			resolveSessionAutoApproveTools(undefined, { autoApproveTools: true }),
 		).toBe(true);
 	});
+});
+
+describe("handleSessionList", () => {
+	function makeCtx(listSessions: (limit?: number, opts?: { rootOnly?: boolean }) => Promise<SessionRecord[]>) {
+		return {
+			sessionSearch: { search: () => [] },
+			clients: new Map(),
+			sessionState: new Map(),
+			pendingApprovals: new Map(),
+			pendingCapabilityRequests: new Map(),
+			suppressNextTerminalEventBySession: new Map(),
+			activeRpcTurnCountBySession: new Map(),
+			sessionHost: { listSessions },
+			publish: () => {},
+			buildEvent: () => ({ event: "session.created", payload: {} }),
+		} as any;
+	}
+
+	function env(payload?: Record<string, unknown>): HubCommandEnvelope {
+		return { version: "v1", command: "session.list", payload } as HubCommandEnvelope;
+	}
+
+	it("defaults to root sessions only, excluding subagent rows", async () => {
+		const listSessions = vi.fn(async (_limit?: number, opts?: { rootOnly?: boolean }) => {
+			return rootOnlyArgList(opts);
+		});
+		await handleSessionList(makeCtx(listSessions), env());
+		expect(listSessions).toHaveBeenCalledWith(200, { rootOnly: true });
+	});
+
+	it("includes subagent rows when includeSubagents is requested", async () => {
+		const listSessions = vi.fn(async (_limit?: number, opts?: { rootOnly?: boolean }) => {
+			return rootOnlyArgList(opts);
+		});
+		await handleSessionList(
+			makeCtx(listSessions),
+			env({ includeSubagents: true }),
+		);
+		expect(listSessions).toHaveBeenCalledWith(200, { rootOnly: false });
+	});
+
+	function rootOnlyArgList(opts?: { rootOnly?: boolean }) {
+		return [] as SessionRecord[];
+	}
 });

--- a/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
+++ b/sdk/packages/core/src/hub/server/handlers/session-handlers.ts
@@ -1011,8 +1011,9 @@ export async function handleSessionList(
 ): Promise<HubReplyEnvelope> {
 	const limit =
 		typeof envelope.payload?.limit === "number" ? envelope.payload.limit : 200;
+	const includeSubagents = envelope.payload?.includeSubagents === true;
 	const records = await ctx.sessionHost.listSessions(limit, {
-		rootOnly: envelope.payload?.rootOnly === true,
+		rootOnly: !includeSubagents,
 	});
 	const sessions = records.map((session) =>
 		toHubSessionRecord(session, ctx.sessionState.get(session.sessionId)),


### PR DESCRIPTION
Fixes cline/cline#13481.

## Problem

Subagent and team-task child session rows (ids like `<root>__teamtask__<agent>__<id>`) are persistence-only history records. They are never registered in the runtime host's live session map, so clients cannot send input to them. When the hub's `session.list` returned all rows, clients that rely on `session.list` for recent history (e.g. after a hub reconnect) could list these unresponsive rows and then fail when trying to run against them.

The hub's `handleSessionList` previously defaulted `rootOnly` to `false`, returning every row including subagents.

## Fix

Default `session.list` to root-only (`rootOnly: true`). Callers that need subagent rows can opt in with `{ includeSubagents: true }`.

This matches how the runtime history path (`sdk/packages/core/src/runtime/host/history.ts`) already calls `listSessions` with `{ rootOnly: true }`.

## Changes

- `sdk/packages/core/src/hub/server/handlers/session-handlers.ts`: derive `rootOnly` from `!includeSubagents` (default true)
- `sdk/packages/core/src/hub/server/handlers/session-handlers.test.ts`: 2 new tests covering default exclusion and explicit inclusion

## Validation

- `bunx tsc -p tsconfig.dev.json --noEmit` — clean
- `bunx vitest run src/hub/server/handlers/session-handlers.test.ts` — 12/12 pass (10 existing + 2 new)
