### PR TITLE
fix(desktop): preserve Cline Pass model selection across new chats

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -4,11 +4,13 @@ import { act, type MouseEvent as ReactMouseEvent } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceProvider } from "@/contexts/workspace-context";
+import { getInitialChatConfig } from "@/hooks/chat-session/constants";
 import type { ChatSessionStatus } from "@/lib/chat-schema";
 import {
 	MODEL_SELECTION_STORAGE_KEY,
 	parseModelSelectionStorage,
 } from "@/lib/model-selection";
+import type { ProviderModel } from "@/lib/provider-schema";
 import {
 	buildUserInstructionSlashCommands,
 	ChatInputBar,
@@ -27,7 +29,11 @@ const {
 		current: null as MockSpeechInputProps | null,
 	},
 	startVercelStreamingTranscriptionMock: vi.fn(),
-	subscribeToProviderModelsMock: vi.fn(() => vi.fn()),
+	subscribeToProviderModelsMock: vi.fn<
+		(
+			listener: (providerId: string, models: ProviderModel[]) => void,
+		) => () => void
+	>(() => vi.fn()),
 }));
 
 type MockSpeechInputProps = {
@@ -817,7 +823,7 @@ describe("ChatInputBar", () => {
 			subscribeToProviderModelsMock.mock.calls[0]?.[0];
 		await act(async () => {
 			providerModelsListener?.("cline", [
-				{ id: "refreshed-model", name: "Refreshed model" },
+				{ id: "test-model", name: "Refreshed model" },
 			]);
 		});
 		await vi.waitFor(() => {
@@ -1551,6 +1557,185 @@ describe("ChatInputBar", () => {
 			window.localStorage.removeItem(MODEL_SELECTION_STORAGE_KEY);
 		});
 
+		const kimi: ProviderModel = {
+			id: "cline-pass/kimi-k3",
+			name: "Kimi K3",
+			featured: { tier: "subscribed", rank: 0, tags: [] },
+		};
+		const flash: ProviderModel = {
+			id: "deepseek/deepseek-v4-flash",
+			name: "DeepSeek V4 Flash",
+			featured: { tier: "free", rank: 0, tags: [] },
+		};
+
+		function mockBundledCatalog() {
+			loadProviderModelCatalogMock.mockResolvedValue({
+				providers: [],
+				enabledProviderIds: ["cline", "cline-pass"],
+				providerModels: {
+					cline: ["test-model"],
+					"cline-pass": [flash.id],
+				},
+				providerModelDetails: { "cline-pass": [flash] },
+				providerNames: { cline: "Cline", "cline-pass": "ClinePass" },
+				providerReasoningModels: { cline: [], "cline-pass": [] },
+			});
+		}
+
+		it.each([
+			"success",
+			"failure",
+		])("preserves the saved model through a delayed live catalog %s", async (outcome) => {
+			mockBundledCatalog();
+			const selection = {
+				lastProvider: "cline-pass",
+				lastModelByProvider: { "cline-pass": kimi.id },
+			};
+			window.localStorage.setItem(
+				MODEL_SELECTION_STORAGE_KEY,
+				JSON.stringify(selection),
+			);
+			let resolveModels!: (models: ProviderModel[]) => void;
+			let rejectModels!: (error: Error) => void;
+			loadProviderModelsMock.mockReturnValue(
+				new Promise<ProviderModel[]>((resolve, reject) => {
+					resolveModels = resolve;
+					rejectModels = reject;
+				}),
+			);
+			const onModelChange = vi.fn();
+			await renderComposer({
+				model: kimi.id,
+				provider: "cline-pass",
+				onModelChange,
+			});
+			expect(loadProviderModelsMock).toHaveBeenCalledWith("cline-pass");
+			expect(onModelChange).not.toHaveBeenCalled();
+			expect(
+				container.querySelector('[aria-label^="Model:"]')?.textContent,
+			).toContain(kimi.id);
+
+			await act(async () => {
+				if (outcome === "success") resolveModels([flash, kimi]);
+				else rejectModels(new Error("offline"));
+			});
+			expect(onModelChange).not.toHaveBeenCalled();
+			expect(
+				container.querySelector('[aria-label^="Model:"]')?.textContent,
+			).toContain(outcome === "success" ? kimi.name : kimi.id);
+			expect(
+				parseModelSelectionStorage(
+					window.localStorage.getItem(MODEL_SELECTION_STORAGE_KEY),
+				),
+			).toEqual(selection);
+		});
+
+		it.each([
+			"catalog refresh",
+			"new chat",
+		])("preserves an explicit pick through a %s with an incomplete catalog", async (transition) => {
+			mockBundledCatalog();
+			loadProviderModelsMock.mockResolvedValue([flash, kimi]);
+			let publishModels!: (providerId: string, models: ProviderModel[]) => void;
+			subscribeToProviderModelsMock.mockImplementation((listener) => {
+				publishModels = listener;
+				return vi.fn();
+			});
+			const onModelChange = vi.fn();
+			await renderComposer({
+				model: flash.id,
+				provider: "cline-pass",
+				onModelChange,
+			});
+			await act(async () =>
+				container
+					.querySelector<HTMLButtonElement>('[aria-label^="Model:"]')
+					?.click(),
+			);
+			const option = [
+				...document.querySelectorAll<HTMLButtonElement>('[role="option"]'),
+			].find((entry) => entry.textContent?.includes(kimi.name));
+			expect(option).toBeTruthy();
+			await act(async () => option?.click());
+			expect(onModelChange).toHaveBeenCalledWith(kimi.id);
+			await renderComposer({
+				model: kimi.id,
+				provider: "cline-pass",
+				onModelChange,
+			});
+			onModelChange.mockClear();
+			if (transition === "new chat") {
+				// New chat remounts the pane and seeds its config from storage.
+				// The app stays open, but this picker has to load live models again.
+				await act(async () => root.unmount());
+				root = createRoot(container);
+				const initial = getInitialChatConfig();
+				expect(initial).toMatchObject({
+					provider: "cline-pass",
+					model: kimi.id,
+				});
+				let resolveModels!: (models: ProviderModel[]) => void;
+				loadProviderModelsMock.mockReturnValue(
+					new Promise<ProviderModel[]>((resolve) => {
+						resolveModels = resolve;
+					}),
+				);
+				await renderComposer({
+					model: initial.model,
+					provider: initial.provider,
+					onModelChange,
+				});
+				expect(onModelChange).not.toHaveBeenCalled();
+				expect(
+					container.querySelector('[aria-label^="Model:"]')?.textContent,
+				).toContain(kimi.id);
+				await act(async () => resolveModels([flash, kimi]));
+			} else {
+				await act(async () => publishModels("cline-pass", [flash]));
+			}
+			expect(onModelChange).not.toHaveBeenCalled();
+			expect(
+				container.querySelector('[aria-label^="Model:"]')?.textContent,
+			).toContain(transition === "new chat" ? kimi.name : kimi.id);
+		});
+
+		it("restores a remembered live model when switching back before live models load", async () => {
+			mockBundledCatalog();
+			window.localStorage.setItem(
+				MODEL_SELECTION_STORAGE_KEY,
+				JSON.stringify({
+					lastProvider: "cline",
+					lastModelByProvider: { cline: "test-model", "cline-pass": kimi.id },
+				}),
+			);
+			const onModelChange = vi.fn();
+			const onProviderChange = vi.fn();
+			await renderComposer({
+				model: "test-model",
+				provider: "cline",
+				onModelChange,
+				onProviderChange,
+			});
+			await act(async () =>
+				container
+					.querySelector<HTMLButtonElement>('[aria-label^="Provider:"]')
+					?.click(),
+			);
+			const option = [
+				...document.querySelectorAll<HTMLButtonElement>('[role="option"]'),
+			].find((entry) => entry.textContent?.includes("ClinePass"));
+			expect(option).toBeTruthy();
+			await act(async () => option?.click());
+			expect(onProviderChange).toHaveBeenCalledWith("cline-pass");
+			expect(onModelChange).toHaveBeenCalledWith(kimi.id);
+			expect(onModelChange).not.toHaveBeenCalledWith(flash.id);
+			expect(
+				parseModelSelectionStorage(
+					window.localStorage.getItem(MODEL_SELECTION_STORAGE_KEY),
+				).lastModelByProvider["cline-pass"],
+			).toBe(kimi.id);
+		});
+
 		it("does not resurrect a stale remembered model the picker hides", async () => {
 			window.localStorage.setItem(
 				MODEL_SELECTION_STORAGE_KEY,
@@ -1580,6 +1765,25 @@ describe("ChatInputBar", () => {
 			const panel = document.querySelector('[role="dialog"]');
 			expect(panel?.textContent).not.toContain("Stale Legacy");
 			expect(panel?.textContent).not.toContain("Current model");
+		});
+
+		it("does not apply another provider's remembered model to an empty selection", async () => {
+			mockBundledCatalog();
+			window.localStorage.setItem(
+				MODEL_SELECTION_STORAGE_KEY,
+				JSON.stringify({
+					lastProvider: "cline",
+					lastModelByProvider: { cline: "test-model" },
+				}),
+			);
+			const onModelChange = vi.fn();
+			await renderComposer({
+				model: "",
+				provider: "cline-pass",
+				onModelChange,
+			});
+			expect(onModelChange).toHaveBeenCalledWith(flash.id);
+			expect(onModelChange).not.toHaveBeenCalledWith("test-model");
 		});
 
 		it("keeps an explicitly active out-of-offer model visible and selectable", async () => {

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -1618,21 +1618,29 @@ const ModelSelector = memo(function ModelSelector({
 		[modelPicker],
 	);
 	const resolvedModel = useMemo(() => {
-		if (modelsForProvider.length === 0) {
-			return "";
-		}
 		const rememberedModel =
 			lastSelection.lastModelByProvider[resolvedProvider] ??
-			lastSelection.lastModelByProvider[rememberedLastProvider];
-		// An explicitly configured model stays active even when the picker's
-		// offer hides it (the picker preserves it as a visible option below);
-		// remembered and default selections are our own bookkeeping, so they
-		// must resolve to a visible option — otherwise a stale remembered id
-		// gets silently resurrected into a selection the picker cannot show.
-		if (model && modelsForProvider.includes(model)) {
+			(normalizeProviderId(rememberedLastProvider) === resolvedProvider
+				? lastSelection.lastModelByProvider[rememberedLastProvider]
+				: undefined);
+		// Catalogs are discovery data, not validation: the bundled catalog can
+		// omit live ClinePass models, and refreshes can return partial lists.
+		// Keep the configured model for the current provider even if absent;
+		// otherwise loading the catalog silently changes the session's model.
+		if (
+			model &&
+			(normalizedProvider === resolvedProvider ||
+				modelsForProvider.includes(model))
+		) {
 			return model;
 		}
-		if (rememberedModel && pickerModelIds.has(rememberedModel)) {
+		// Missing remembered models may also be live-only. Models present in
+		// the catalog but deliberately hidden from the offer still fall back.
+		if (
+			rememberedModel &&
+			(pickerModelIds.has(rememberedModel) ||
+				!modelsForProvider.includes(rememberedModel))
+		) {
 			return rememberedModel;
 		}
 		return (
@@ -1644,6 +1652,7 @@ const ModelSelector = memo(function ModelSelector({
 		lastSelection.lastModelByProvider,
 		model,
 		modelsForProvider,
+		normalizedProvider,
 		pickerModelIds,
 		rememberedLastProvider,
 		resolvedProvider,
@@ -1651,8 +1660,8 @@ const ModelSelector = memo(function ModelSelector({
 	// The picker can intentionally hide catalog models (the ClinePass offer
 	// is exactly its subscribed/free tiers), but the active model must stay
 	// visible and selectable — e.g. a hydrated session configured with a
-	// model outside the current offer. Surface it under its own section
-	// rather than selecting a value that does not exist in the list.
+	// model outside the current offer or missing from the catalog. Surface it
+	// under its own section so the selected value always exists in the list.
 	const visibleModelPicker = useMemo((): ModelPickerData => {
 		if (!resolvedModel || pickerModelIds.has(resolvedModel)) {
 			return modelPicker;
@@ -1880,14 +1889,15 @@ const ModelSelector = memo(function ModelSelector({
 			onProviderChange(value);
 			const rememberedModel = lastSelection.lastModelByProvider[value];
 			const providerModelIds = visibleProviderModels[value] ?? [];
-			// Validate against the target provider's visible picker options,
-			// not its full catalog: a remembered model the picker hides (e.g.
-			// outside the ClinePass offer) must not become the selection.
+			// Preserve live-only remembered models missing from the bundled
+			// catalog. Only fall back when a known model is hidden by the offer.
 			const providerOptionIds = new Set(
 				pickerDataForProvider(value).options.map((option) => option.value),
 			);
 			const nextModel =
-				rememberedModel && providerOptionIds.has(rememberedModel)
+				rememberedModel &&
+				(providerOptionIds.has(rememberedModel) ||
+					!providerModelIds.includes(rememberedModel))
 					? rememberedModel
 					: (providerModelIds.find((id) => providerOptionIds.has(id)) ??
 						providerModelIds[0]);
@@ -1945,7 +1955,7 @@ const ModelSelector = memo(function ModelSelector({
 		<SearchCombobox
 			ariaLabel="Model"
 			className={triggerClassName}
-			disabled={isBusy || modelsForProvider.length === 0}
+			disabled={isBusy || visibleModelPicker.options.length === 0}
 			emptyText="No models found."
 			onValueChange={(value) => {
 				handleModelSelect(value);


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX — reported directly; no linked GitHub issue.

### Description

Fix the desktop composer silently changing Cline Pass from Kimi K3 to DeepSeek Flash when starting a new chat while the app is already open.

The model choice was saved correctly. Opening a new chat remounts the chat pane, which seeds its config from the remembered provider/model and creates a fresh model selector. That selector first loads the bundled provider catalog, then requests the active provider's live model list. The bundled catalog can omit live subscription models such as `cline-pass/kimi-k3` while containing `deepseek/deepseek-v4-flash`.

Previously, the selector required the configured model to appear in the current catalog. During the gap between those responses, it resolved Kimi to the first available model and called `onModelChange`. When the live response finally included Kimi, DeepSeek was already the configured model and remained selected. This can happen on each new chat, without restarting the app.

The selector now preserves a configured model for the active provider even when that model is missing from discovery results. Its existing current-model option also covers models absent from the catalog, keeping the selection visible until display metadata arrives. Switching back to a provider similarly preserves a remembered live model that is absent from the bundled list.

A missing model and an intentionally hidden model remain distinct: remembered models that are present in the catalog but hidden by the Cline Pass offer still fall back to a visible option. An explicitly active session model remains visible even outside that offer. Remembered selections are scoped to their provider so an empty selection cannot inherit another provider's saved model.

Simply waiting for the live request would only address the startup race. Preserving the selection also handles failed requests and later partial catalog refreshes. As a consequence, a genuinely unavailable configured model stays selected until the user changes it; discovery data no longer silently substitutes a different model.

### Test Procedure

Regression tests initially reproduced automatic `onModelChange("deepseek/deepseek-v4-flash")` calls with Kimi selected. Coverage now includes:

- A saved Kimi selection while a live-model request is delayed, then succeeds or fails.
- Picking Kimi in the dropdown, unmounting the composer, initializing a new chat from persisted selection, and remounting against the incomplete bundled catalog before the live list arrives.
- An explicit selection surviving a later catalog refresh that omits it.
- Switching back to Cline Pass with a remembered model absent from the bundled catalog.
- Preventing another provider's remembered model from filling an empty selection.
- Existing behavior for intentionally hidden remembered models and active models outside the offer.

The existing reasoning-level test now refreshes metadata for the same model ID. Its previous fixture implicitly relied on replacing the selected model when refreshing the list.

Run from the repository root:

```sh
bun run --cwd apps/examples/desktop-app vitest run webview/components/views/chat/chat-input-bar.test.tsx webview/lib/provider-model-catalog.test.ts webview/lib/featured-models.test.ts webview/hooks/use-chat-session.test.tsx --config vitest.config.ts
bun biome check --diagnostic-level=error apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
```

All 97 focused tests pass, along with changed-file Biome checks and the desktop `bun run typecheck` command. The pre-commit secret scan also passes. Full webview typechecking has existing failures in unrelated code and pre-existing test mock signatures; those are also present in the original checkout. No authenticated model request or native desktop session was run for this fix.

Manual verification:

1. Select Cline Pass and Kimi K3, then complete a task.
2. Open a new chat without closing the desktop app.
3. Confirm Kimi remains selected while model loading completes.
4. Switch to another provider and back to Cline Pass; confirm Kimi is restored.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual redesign. Regression tests verify the selected model before and after the new-chat transition.

### Additional Notes

The full-suite checklist remains unchecked because validation was targeted to the affected composer, model catalog, and chat-session behavior. This change applies at the shared desktop selector level so other providers also retain configured models absent from a partial catalog. It does not change provider catalogs or inference routing.
