### PR TITLE
fix(desktop): keep the observer stream stood down for the whole busy run

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -30,7 +30,7 @@ import {
 	trackQueuedAttachments,
 } from "./attachments";
 import { createDesktopExtensionContext } from "./client-context";
-import { emitChunk, nowMs, sendEvent } from "./context";
+import { emitChunk, forgetCorePipe, nowMs, sendEvent } from "./context";
 import { readSessionManifest, sharedSessionDataDir } from "./paths";
 import { persistSessionMessages } from "./session-data/messages";
 import type {
@@ -864,6 +864,7 @@ async function rebuildSessionForProviderChange(
 		]);
 
 	await manager.stop(sessionId);
+	forgetCorePipe(ctx, sessionId);
 	let replacementStarted = false;
 	try {
 		await startRebuiltSession(
@@ -887,6 +888,7 @@ async function rebuildSessionForProviderChange(
 		try {
 			if (replacementStarted) {
 				await manager.stop(sessionId);
+				forgetCorePipe(ctx, sessionId);
 			}
 			await startRebuiltSession(
 				manager,
@@ -1145,6 +1147,9 @@ async function handleStop(
 	const sessionId = request.sessionId?.trim();
 	if (!sessionId) throw new Error("sessionId is required");
 	await getSessionManager(ctx).stop(sessionId);
+	// stop() disposes the ClineCore subscription; the observer must be free to
+	// serve any later run another client starts on this session.
+	forgetCorePipe(ctx, sessionId);
 	const session = ctx.liveSessions.get(sessionId);
 	if (session) {
 		session.busy = false;
@@ -1401,6 +1406,7 @@ async function handleReset(
 		) {
 			await getSessionManager(ctx).stop(sessionId);
 		}
+		forgetCorePipe(ctx, sessionId);
 		discardAllTrackedAttachments(sessionId, session);
 		ctx.liveSessions.delete(sessionId);
 		sendPromptsInQueueSnapshot(ctx, sessionId);

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1403,6 +1403,36 @@ describe("Chat chunk pipe selection", () => {
 		}
 	});
 
+	it("takes over after stop when another client starts the next run", async () => {
+		const { forgetCorePipe, handleCoreSessionEvent, handleHubLiveEvent } =
+			await import("./context");
+		const ctx = await createStreamingContext("session-1");
+
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
+
+		// The desktop stops the session: ClineCore disposes its subscription
+		// without any local `ended` event, so the stop path forgets the mark.
+		forgetCorePipe(ctx, "session-1");
+		const stopped = ctx.liveSessions.get("session-1");
+		if (stopped) stopped.busy = false;
+
+		// Another client (CLI, schedule) runs the session; the observer is the
+		// only pipe left and its run.started marks the session busy again.
+		handleHubLiveEvent(ctx, {
+			event: "run.started",
+			sessionId: "session-1",
+			payload: {},
+		});
+		handleHubLiveEvent(ctx, {
+			event: "assistant.delta",
+			sessionId: "session-1",
+			payload: { text: "remote run" },
+		});
+
+		expect(ctx.liveSessions.get("session-1")?.busy).toBe(true);
+		expect(chunksFor(ctx, "chat_text")).toEqual(["local", "remote run"]);
+	});
+
 	it("takes over once the run has ended and the core pipe goes silent", async () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1371,7 +1371,39 @@ describe("Chat chunk pipe selection", () => {
 		expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
 	});
 
-	it("takes over once the core pipe goes silent", async () => {
+	it("stays stood down through a quiet gap while the run is busy", async () => {
+		vi.useFakeTimers();
+		try {
+			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
+				"./context"
+			);
+			const ctx = await createStreamingContext("session-1");
+
+			handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
+
+			// A long command or an unanswered tool approval stalls both pipes.
+			// The observer's copy of the first event afterwards still arrives
+			// ahead of the core copy, so it must stay muted for the whole run.
+			vi.advanceTimersByTime(60_000);
+			handleHubLiveEvent(ctx, {
+				event: "tool.started",
+				sessionId: "session-1",
+				payload: { toolCallId: "call-1", toolName: "run_commands" },
+			});
+			handleHubLiveEvent(ctx, {
+				event: "assistant.delta",
+				sessionId: "session-1",
+				payload: { text: "after gap" },
+			});
+
+			expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
+			expect(chunksFor(ctx, "chat_text")).toEqual(["local"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("takes over once the run has ended and the core pipe goes silent", async () => {
 		vi.useFakeTimers();
 		try {
 			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
@@ -1387,6 +1419,10 @@ describe("Chat chunk pipe selection", () => {
 			});
 			expect(chunksFor(ctx, "chat_text")).toEqual(["local"]);
 
+			handleCoreSessionEvent(ctx, {
+				type: "status",
+				payload: { sessionId: "session-1", status: "completed" },
+			} as never);
 			vi.advanceTimersByTime(6_000);
 			handleHubLiveEvent(ctx, {
 				event: "assistant.delta",

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -173,10 +173,16 @@ function appendSessionChunk(
 }
 
 /**
- * How long a session stays "served by ClineCore" after its last event. Events
- * arrive many times a second while a turn streams, so a subscription silent
- * for this long has stopped delivering rather than paused, and the observer
- * projection is allowed to take over.
+ * How long an idle session stays "served by ClineCore" after its last event
+ * before the observer projection may take over.
+ *
+ * This window only applies between runs. While a run is busy, silence on the
+ * core pipe is not evidence that its subscription died: a long command, a
+ * slow first token, or a tool-approval prompt the user takes a while to answer
+ * all stall both pipes together. Expiring the mark mid-turn let the observer's
+ * copy of the first post-gap event through ahead of the core copy, doubling a
+ * delta or orphaning a duplicate tool row every time a turn paused for longer
+ * than the window.
  */
 const CORE_PIPE_ACTIVE_MS = 5_000;
 
@@ -206,7 +212,12 @@ function isCorePipeActive(
 	now: number,
 ): boolean {
 	const lastEventAt = ctx.coreStreamActivity.get(sessionId);
-	return lastEventAt !== undefined && now - lastEventAt <= CORE_PIPE_ACTIVE_MS;
+	if (lastEventAt === undefined) return false;
+	// The mark is cleared when the session ends, so during a busy run it means
+	// the core subscription served this session and is still the pipe to trust
+	// even when neither pipe has had anything to deliver for a while.
+	if (ctx.liveSessions.get(sessionId)?.busy) return true;
+	return now - lastEventAt <= CORE_PIPE_ACTIVE_MS;
 }
 
 function emitChunk(
@@ -501,8 +512,9 @@ export function handleCoreSessionEvent(
 	// first delta through before the mark existed, doubling it every turn.
 	// The cost is the reverse case: if this pipe delivers a status or queue
 	// event and then stops while the observer keeps streaming, the observer is
-	// held off for `CORE_PIPE_ACTIVE_MS`. That needs the subscription torn down
-	// mid-turn, and the turn-end reconcile restores the gap from canonical
+	// held off for the rest of the run (and `CORE_PIPE_ACTIVE_MS` after it).
+	// That needs the subscription torn down mid-turn, which only stop and
+	// detach do, and the turn-end reconcile restores the gap from canonical
 	// history — where doubling would be visible on every turn.
 	const eventSessionId = (event.payload as { sessionId?: string } | undefined)
 		?.sessionId;

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -206,6 +206,17 @@ function markCorePipeActive(ctx: SidecarContext, sessionId: string): void {
 	ctx.coreStreamActivity.set(sessionId, nowMs());
 }
 
+/**
+ * Forget that the ClineCore subscription served this session. Called when the
+ * session ends and wherever the sidecar stops a session: `stop` disposes the
+ * core subscription without any local `ended` event, and a stale mark would
+ * otherwise mute the observer for the next run another client starts on the
+ * same session, since that run's `run.started` marks the session busy.
+ */
+export function forgetCorePipe(ctx: SidecarContext, sessionId: string): void {
+	ctx.coreStreamActivity.delete(sessionId);
+}
+
 function isCorePipeActive(
 	ctx: SidecarContext,
 	sessionId: string,
@@ -606,7 +617,7 @@ export function handleCoreSessionEvent(
 			}
 			discardAllTrackedAttachments(sessionId, session);
 			// The next run decides afresh which pipe is serving the session.
-			ctx.coreStreamActivity.delete(sessionId);
+			forgetCorePipe(ctx, sessionId);
 			sendEvent(ctx, "chat_session_ended", { sessionId, reason });
 			break;
 		}


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — follow-up to #13968 (same user report: doubled text and missing rows in the desktop live stream).

### Description

#13968 fixed the doubled-text half of that report by letting the ClineCore session subscription ("core pipe") mute the hub observer's copy of the same events. The mute is a per-session timestamp: every event on the core pipe refreshes it, and the observer is muted while the timestamp is younger than 5 seconds. The idea was that a subscription silent for 5 seconds has died and the observer should take over.

That expiry has a hole in it, and it is a hole the PR's own reasoning predicts. The PR marks liveness on *every* core event, not just content, precisely because the observer's copy of an event tends to arrive **before** the core copy (the observer client is registered at sidecar boot; the per-session core subscription is registered at hydrate). So the mark has to already exist when the observer copy shows up, or that copy gets through.

Mid-turn silences longer than 5 seconds are routine, and they stall **both** pipes together because both are fed by the same hub:

- a `run_commands` call that takes a while
- a slow time-to-first-token from the model
- a tool-approval prompt the user takes more than 5 seconds to answer

The first event after any such gap hits an expired mark. The observer copy passes, then the core copy passes. For text that is one doubled delta. For `tool.started` it is worse: the webview keys its live tool rows by `toolCallId` and overwrites the mapping on the second start, so the first row is orphaned at "tool_call_start" until the turn-end reconcile repairs it from canonical history. That is the same "it fixes itself when the turn finishes" symptom the original report described.

#### Fix

Six lines in `isCorePipeActive`. While the live session is **busy**, an existing mark is treated as active regardless of age; the 5-second window now only applies to idle sessions. Nothing else from #13968 moves: the mark is still refreshed by every core event, still cleared on `ended`, and the boot-id fix is untouched.

Why this is sound: the mark is cleared when the session ends, so during a busy run its mere presence means the core subscription served this session in its current life. Silence during a run is not evidence the subscription died, it is evidence the model or a tool is quiet, and the observer is quiet for the same reason. Between runs the original timer still lets the observer take over if core really went away.

Two side benefits fall out of gating on `busy`:

- The run-start race gets narrower too. Both pipes see `run.started`, and the observer's handler sets `busy = true`. If the session already has a mark from an earlier core event (hydrate's `pending_prompts` list always produces one), an observer delta that beats the core `run.started` across the two sockets is now muted as well.
- No new state. `busy` is already maintained by both pipes' status handlers.

#### What I considered and did not do

The structural fix is to have one pipe: make `HubRuntimeHost.subscribe({ sessionId })` actually subscribe to the hub (today it only registers a local listener and the hub subscription is a side effect of `pendingPrompts.list`), then delete the observer's chat projection and `attachedViaHub` entirely. That is the right long-term shape and mirrors how the CLI works, but it touches the SDK hub runtime host and every attach path, which is a much bigger blast radius than this bug warrants right now. Noting it here so the next person who trips over the two-pipe design knows it was a deliberate deferral, not an oversight.

#### Review finding folded in (second commit)

A reviewer caught a regression the busy gate introduced. `HubRuntimeHost.stopSession` disposes the core subscription and sends a hub detach, but nothing emits a local `ended` event for it, so the activity mark from the previous run survived a desktop stop. If another client (CLI, schedule) then started a run on the same session while it was still open in the app, the observer's `run.started` set `busy = true`, the stale mark counted as active, and every observer chunk was dropped with no core subscription left to serve it. The old 5-second expiry would have let the observer through here, so this scenario used to work.

Fix: a `forgetCorePipe` helper next to `markCorePipeActive`, called on every sidecar path that calls `manager.stop` (the stop command, the provider-change rebuild and its rollback, and reset). The `ended` handler uses it too. Abort keeps the subscription and needs nothing. New test: mark core, forget, observer `run.started`, observer delta, assert the delta is emitted. Note the test exercises the helper directly; `chat-session.test.ts` has no stop-command coverage, so the call-site wiring is verified by reading, not by a test.

#### Known trade-off

If the core subscription is torn down mid-turn while the observer keeps streaming, the observer stays muted until the run ends rather than for 5 seconds. Only `stop` and `detach` dispose a session subscription, and both end the run from the sidecar's point of view, so this is theoretical. The handler comment in `handleCoreSessionEvent` is updated to say so.

### Test Procedure

- New test `stays stood down through a quiet gap while the run is busy`: one core text delta, then 60 seconds of fake-timer silence, then an observer `tool.started` and `assistant.delta`. Asserts neither is emitted. This test is red on `main`.
- The existing `takes over once the core pipe goes silent` test now ends the run (core `status: completed`) before advancing the clock, and is renamed to say so. Takeover during a busy run is exactly what we no longer want, so the old form of the test was asserting the bug.
- `sidecar/context.test.ts` + `sidecar/chat-session.test.ts`: 90 passed (2 new context tests). `biome check` clean on all three files.

Not verified on a running stack, same caveat as #13968. The manual repro worth running before the next desktop release: open a task already streaming through the hub without typing anything, let a tool-approval prompt sit for 10+ seconds, approve, and confirm there is no duplicate tool row or doubled text right after.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kHp3XEsLYaZ1Bgp4yUxf3
