### PR TITLE
fix(desktop): gate the observer stream on ClineCore's subscription, not a timer

### DIFF
--- a/apps/examples/desktop-app/sidecar/chat-session.test.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.test.ts
@@ -338,7 +338,6 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -460,7 +459,6 @@ describe("session forks", () => {
 				send,
 			},
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -544,7 +542,6 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 		} as unknown as SidecarContext;
 
@@ -620,7 +617,6 @@ describe("session forks", () => {
 				start,
 			},
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 			pendingQuestions: new Map(),
 		} as unknown as SidecarContext;
@@ -802,7 +798,6 @@ describe("session forks", () => {
 				]),
 				restoringWorkspacePaths: new Set(),
 				streamIndices: new Map(),
-				coreStreamActivity: new Map(),
 				wsClients: new Set(),
 				sessionManager: { restore },
 			} as unknown as SidecarContext;
@@ -926,7 +921,6 @@ describe("first-send connection updates", () => {
 			]),
 			restoringWorkspacePaths: new Set(),
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 			sessionManager: {
 				readMessages,
@@ -1650,7 +1644,6 @@ Follow the desktop send workflow instructions.`,
 			liveSessions: new Map([[sessionId, session]]),
 			restoringWorkspacePaths: new Set(),
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			wsClients: new Set(),
 			sessionManager: {
 				send,
@@ -1811,7 +1804,6 @@ describe("mistake-limit prompt", () => {
 		const ctx = {
 			wsClients: new Set([{ send }]),
 			streamIndices: new Map(),
-			coreStreamActivity: new Map(),
 			pendingQuestions: new Map(),
 			liveSessions: new Map(),
 			sessionManager: {

--- a/apps/examples/desktop-app/sidecar/chat-session.ts
+++ b/apps/examples/desktop-app/sidecar/chat-session.ts
@@ -38,7 +38,6 @@ import { createDesktopExtensionContext } from "./client-context";
 import {
 	cancelSidecarMistakeQuestions,
 	emitChunk,
-	forgetCorePipe,
 	nowMs,
 	requestSidecarAskQuestion,
 	sendEvent,
@@ -1053,7 +1052,6 @@ async function rebuildSessionForProviderChange(
 
 	cancelSidecarMistakeQuestions(ctx, sessionId, "Session provider changed");
 	await manager.stop(sessionId);
-	forgetCorePipe(ctx, sessionId);
 	let replacementStarted = false;
 	try {
 		await startRebuiltSession(
@@ -1077,7 +1075,6 @@ async function rebuildSessionForProviderChange(
 		try {
 			if (replacementStarted) {
 				await manager.stop(sessionId);
-				forgetCorePipe(ctx, sessionId);
 			}
 			await startRebuiltSession(
 				manager,
@@ -1198,9 +1195,9 @@ async function handleSend(
 			request.attachments?.userFiles,
 		);
 		if (session?.attachedViaHub) {
-			// Once ClineCore sends a turn, its HubRuntimeHost owns the session
-			// subscription. Stop projecting the observer stream as well or every
-			// assistant/tool update (including command chunks) is emitted twice.
+			// Once ClineCore sends a turn it owns the session: the attach-time
+			// connection refresh above has happened and the observer projection is
+			// muted by its subscription, so the session is no longer attach-only.
 			session.attachedViaHub = false;
 		}
 		if (delivery === "queue") {
@@ -1337,9 +1334,6 @@ async function handleStop(
 	if (!sessionId) throw new Error("sessionId is required");
 	cancelSidecarMistakeQuestions(ctx, sessionId, "Session stopped");
 	await getSessionManager(ctx).stop(sessionId);
-	// stop() disposes the ClineCore subscription; the observer must be free to
-	// serve any later run another client starts on this session.
-	forgetCorePipe(ctx, sessionId);
 	const session = ctx.liveSessions.get(sessionId);
 	if (session) {
 		session.busy = false;
@@ -1605,7 +1599,6 @@ async function handleReset(
 		) {
 			await getSessionManager(ctx).stop(sessionId);
 		}
-		forgetCorePipe(ctx, sessionId);
 		discardAllTrackedAttachments(sessionId, session);
 		ctx.liveSessions.delete(sessionId);
 		sendPromptsInQueueSnapshot(ctx, sessionId);

--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -1273,7 +1273,10 @@ describe("disposeSidecarContext attachment cleanup", () => {
 });
 
 describe("Chat chunk pipe selection", () => {
-	async function createStreamingContext(sessionId: string) {
+	async function createStreamingContext(
+		sessionId: string,
+		coreSubscriptions: Set<string> = new Set(),
+	) {
 		const { createSidecarContext } = await import("./context");
 		const ctx = createSidecarContext("/workspace/project");
 		ctx.wsClients.add({ send: vi.fn() });
@@ -1286,6 +1289,9 @@ describe("Chat chunk pipe selection", () => {
 			status: "running",
 			attachedViaHub: true,
 		});
+		ctx.sessionManager = {
+			hasSessionSubscription: (id: string) => coreSubscriptions.has(id),
+		} as never;
 		return ctx;
 	}
 
@@ -1299,38 +1305,42 @@ describe("Chat chunk pipe selection", () => {
 		} as never;
 	}
 
-	function chunksFor(ctx: SidecarContext, stream: string): string[] {
+	function eventsFor(ctx: SidecarContext, name: string) {
 		return readEvents(ctx)
-			.filter(
-				(message) =>
-					message.event.name === "chat_event" &&
-					(message.event.payload as { stream?: string }).stream === stream,
-			)
-			.map((message) =>
-				String((message.event.payload as { chunk?: string }).chunk),
-			);
+			.filter((message) => message.event.name === name)
+			.map((message) => message.event.payload);
+	}
+
+	function chunksFor(ctx: SidecarContext, stream: string): string[] {
+		return eventsFor(ctx, "chat_event")
+			.filter((payload) => (payload as { stream?: string }).stream === stream)
+			.map((payload) => String((payload as { chunk?: string }).chunk));
 	}
 
 	it("emits one copy when both pipes carry the same delta", async () => {
 		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
 			"./context"
 		);
-		const ctx = await createStreamingContext("session-1");
+		// Opening a session arms both pipes: ClineCore subscribes to the session
+		// and `attach` enables the observer projection, so the hub publishes each
+		// delta to both sockets.
+		const ctx = await createStreamingContext(
+			"session-1",
+			new Set(["session-1"]),
+		);
 
-		// Opening a session arms both pipes, so the hub publishes each delta to
-		// the ClineCore session subscription and to the observer client.
-		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "Pack "));
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
 			payload: { text: "Pack " },
 		});
-		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "my box"));
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "Pack "));
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
 			payload: { text: "my box" },
 		});
+		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "my box"));
 
 		expect(chunksFor(ctx, "chat_text")).toEqual(["Pack ", "my box"]);
 	});
@@ -1353,138 +1363,71 @@ describe("Chat chunk pipe selection", () => {
 		expect(chunksFor(ctx, "chat_text")).toEqual(["remote ", "run"]);
 	});
 
-	it("stands down for every stream the core pipe serves, not just text", async () => {
-		const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
-			"./context"
+	it("mutes the whole observer projection, not just text", async () => {
+		const { handleHubLiveEvent } = await import("./context");
+		const ctx = await createStreamingContext(
+			"session-1",
+			new Set(["session-1"]),
 		);
-		const ctx = await createStreamingContext("session-1");
 
-		// One text delta on the core pipe is enough to prove it is subscribed,
-		// so the observer's tool rows are duplicates too.
-		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "working"));
 		handleHubLiveEvent(ctx, {
 			event: "tool.started",
 			sessionId: "session-1",
 			payload: { toolCallId: "call-1", toolName: "run_commands" },
 		});
-
-		expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
-	});
-
-	it("stays stood down through a quiet gap while the run is busy", async () => {
-		vi.useFakeTimers();
-		try {
-			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
-				"./context"
-			);
-			const ctx = await createStreamingContext("session-1");
-
-			handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
-
-			// A long command or an unanswered tool approval stalls both pipes.
-			// The observer's copy of the first event afterwards still arrives
-			// ahead of the core copy, so it must stay muted for the whole run.
-			vi.advanceTimersByTime(60_000);
-			handleHubLiveEvent(ctx, {
-				event: "tool.started",
-				sessionId: "session-1",
-				payload: { toolCallId: "call-1", toolName: "run_commands" },
-			});
-			handleHubLiveEvent(ctx, {
-				event: "assistant.delta",
-				sessionId: "session-1",
-				payload: { text: "after gap" },
-			});
-
-			expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
-			expect(chunksFor(ctx, "chat_text")).toEqual(["local"]);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("takes over after stop when another client starts the next run", async () => {
-		const { forgetCorePipe, handleCoreSessionEvent, handleHubLiveEvent } =
-			await import("./context");
-		const ctx = await createStreamingContext("session-1");
-
-		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
-
-		// The desktop stops the session: ClineCore disposes its subscription
-		// without any local `ended` event, so the stop path forgets the mark.
-		forgetCorePipe(ctx, "session-1");
-		const stopped = ctx.liveSessions.get("session-1");
-		if (stopped) stopped.busy = false;
-
-		// Another client (CLI, schedule) runs the session; the observer is the
-		// only pipe left and its run.started marks the session busy again.
 		handleHubLiveEvent(ctx, {
-			event: "run.started",
+			event: "run.completed",
 			sessionId: "session-1",
 			payload: {},
 		});
-		handleHubLiveEvent(ctx, {
-			event: "assistant.delta",
-			sessionId: "session-1",
-			payload: { text: "remote run" },
+
+		expect(chunksFor(ctx, "chat_tool_call_start")).toEqual([]);
+		expect(eventsFor(ctx, "chat_session_ended")).toEqual([]);
+		expect(ctx.liveSessions.get("session-1")?.busy).toBe(true);
+	});
+
+	it("follows the subscription as it comes and goes", async () => {
+		const { handleHubLiveEvent } = await import("./context");
+		const coreSubscriptions = new Set<string>();
+		const ctx = await createStreamingContext("session-1", coreSubscriptions);
+		const delta = (text: string) =>
+			handleHubLiveEvent(ctx, {
+				event: "assistant.delta",
+				sessionId: "session-1",
+				payload: { text },
+			});
+
+		delta("observer first");
+		// A send (or pending-prompt list) subscribes ClineCore.
+		coreSubscriptions.add("session-1");
+		delta("muted");
+		// `stop` drops the subscription; a run another client starts on the
+		// same session is the observer's to render again.
+		coreSubscriptions.delete("session-1");
+		delta("observer again");
+
+		expect(chunksFor(ctx, "chat_text")).toEqual([
+			"observer first",
+			"observer again",
+		]);
+	});
+
+	it("decides per session", async () => {
+		const { handleHubLiveEvent } = await import("./context");
+		const ctx = await createStreamingContext(
+			"session-1",
+			new Set(["session-1"]),
+		);
+		ctx.liveSessions.set("session-2", {
+			config: {},
+			messages: [],
+			promptsInQueue: [],
+			busy: true,
+			startedAt: Date.now(),
+			status: "running",
+			attachedViaHub: true,
 		});
 
-		expect(ctx.liveSessions.get("session-1")?.busy).toBe(true);
-		expect(chunksFor(ctx, "chat_text")).toEqual(["local", "remote run"]);
-	});
-
-	it("takes over once the run has ended and the core pipe goes silent", async () => {
-		vi.useFakeTimers();
-		try {
-			const { handleCoreSessionEvent, handleHubLiveEvent } = await import(
-				"./context"
-			);
-			const ctx = await createStreamingContext("session-1");
-
-			handleCoreSessionEvent(ctx, coreTextEvent("session-1", "local"));
-			handleHubLiveEvent(ctx, {
-				event: "assistant.delta",
-				sessionId: "session-1",
-				payload: { text: "muted" },
-			});
-			expect(chunksFor(ctx, "chat_text")).toEqual(["local"]);
-
-			handleCoreSessionEvent(ctx, {
-				type: "status",
-				payload: { sessionId: "session-1", status: "completed" },
-			} as never);
-			vi.advanceTimersByTime(6_000);
-			handleHubLiveEvent(ctx, {
-				event: "assistant.delta",
-				sessionId: "session-1",
-				payload: { text: "takeover" },
-			});
-
-			expect(chunksFor(ctx, "chat_text")).toEqual(["local", "takeover"]);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("tracks the core pipe per session", async () => {
-		const { createSidecarContext, handleCoreSessionEvent, handleHubLiveEvent } =
-			await import("./context");
-		const ctx = createSidecarContext("/workspace/project");
-		ctx.wsClients.add({ send: vi.fn() });
-		for (const sessionId of ["session-1", "session-2"]) {
-			ctx.liveSessions.set(sessionId, {
-				config: {},
-				messages: [],
-				promptsInQueue: [],
-				busy: true,
-				startedAt: Date.now(),
-				status: "running",
-				attachedViaHub: true,
-			});
-		}
-
-		// ClineCore serves session-1; session-2 is still observer-only.
-		handleCoreSessionEvent(ctx, coreTextEvent("session-1", "one"));
 		handleHubLiveEvent(ctx, {
 			event: "assistant.delta",
 			sessionId: "session-1",
@@ -1496,20 +1439,16 @@ describe("Chat chunk pipe selection", () => {
 			payload: { text: "two" },
 		});
 
-		expect(chunksFor(ctx, "chat_text")).toEqual(["one", "two"]);
+		expect(chunksFor(ctx, "chat_text")).toEqual(["two"]);
 	});
 
 	it("never drops chunks the sidecar produces itself", async () => {
-		const { broadcastChunk, handleHubLiveEvent } = await import("./context");
-		const ctx = await createStreamingContext("session-1");
+		const { broadcastChunk } = await import("./context");
+		const ctx = await createStreamingContext(
+			"session-1",
+			new Set(["session-1"]),
+		);
 
-		// The observer is serving this session; a locally synthesized chunk is
-		// not part of either relay and must always reach the webview.
-		handleHubLiveEvent(ctx, {
-			event: "assistant.delta",
-			sessionId: "session-1",
-			payload: { text: "remote" },
-		});
 		broadcastChunk(ctx, "session-1", "chat_queued_prompt_start", "{}");
 
 		expect(chunksFor(ctx, "chat_queued_prompt_start")).toEqual(["{}"]);

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -32,7 +32,6 @@ import {
 } from "./feature-flags";
 import { sessionLogPath } from "./paths";
 import type {
-	ChunkSource,
 	LiveSession,
 	PendingAskQuestion,
 	PendingToolApproval,
@@ -172,76 +171,13 @@ function appendSessionChunk(
 	});
 }
 
-/**
- * How long an idle session stays "served by ClineCore" after its last event
- * before the observer projection may take over.
- *
- * This window only applies between runs. While a run is busy, silence on the
- * core pipe is not evidence that its subscription died: a long command, a
- * slow first token, or a tool-approval prompt the user takes a while to answer
- * all stall both pipes together. Expiring the mark mid-turn let the observer's
- * copy of the first post-gap event through ahead of the core copy, doubling a
- * delta or orphaning a duplicate tool row every time a turn paused for longer
- * than the window.
- */
-const CORE_PIPE_ACTIVE_MS = 5_000;
-
-/**
- * Records that the ClineCore subscription is serving this session.
- *
- * The sidecar has two pipes into `emitChunk`: the ClineCore session
- * subscription and the hub observer client. Opening a session arms both (the
- * hydrate's `pending_prompts` call makes ClineCore subscribe to the session,
- * and `attach` sets `attachedViaHub`), so for a session streaming through the
- * hub each delta arrived twice — and since both copies go through `emitChunk`
- * each gets its own increasing `index`, which is exactly what the webview's
- * replay guard compares, so it could not tell them apart.
- *
- * The two pipes are not peers: ClineCore's subscription is the primary, and
- * the observer projection exists to cover sessions ClineCore is not subscribed
- * to. Any event on the primary proves it is subscribed, so it is the primary
- * that decides — no list of which streams happen to overlap.
- */
-function markCorePipeActive(ctx: SidecarContext, sessionId: string): void {
-	ctx.coreStreamActivity.set(sessionId, nowMs());
-}
-
-/**
- * Forget that the ClineCore subscription served this session. Called when the
- * session ends and wherever the sidecar stops a session: `stop` disposes the
- * core subscription without any local `ended` event, and a stale mark would
- * otherwise mute the observer for the next run another client starts on the
- * same session, since that run's `run.started` marks the session busy.
- */
-export function forgetCorePipe(ctx: SidecarContext, sessionId: string): void {
-	ctx.coreStreamActivity.delete(sessionId);
-}
-
-function isCorePipeActive(
-	ctx: SidecarContext,
-	sessionId: string,
-	now: number,
-): boolean {
-	const lastEventAt = ctx.coreStreamActivity.get(sessionId);
-	if (lastEventAt === undefined) return false;
-	// The mark is cleared when the session ends, so during a busy run it means
-	// the core subscription served this session and is still the pipe to trust
-	// even when neither pipe has had anything to deliver for a while.
-	if (ctx.liveSessions.get(sessionId)?.busy) return true;
-	return now - lastEventAt <= CORE_PIPE_ACTIVE_MS;
-}
-
 function emitChunk(
 	ctx: SidecarContext,
 	sessionId: string,
 	stream: string,
 	chunk: string,
-	source: ChunkSource = "core",
 ): void {
 	const ts = nowMs();
-	if (source === "observer" && isCorePipeActive(ctx, sessionId, ts)) {
-		return;
-	}
 	appendSessionChunk(sessionId, stream, chunk, ts);
 	const nextIndex = (ctx.streamIndices.get(sessionId) ?? 0) + 1;
 	ctx.streamIndices.set(sessionId, nextIndex);
@@ -523,29 +459,6 @@ export function handleCoreSessionEvent(
 	ctx: SidecarContext,
 	event: CoreSessionEvent,
 ): void {
-	// Reaching here at all means ClineCore is subscribed to the session, so its
-	// projection is live and the observer's copy of the same hub events would
-	// be a duplicate. Marked from the pipe itself rather than from `emitChunk`,
-	// so chunks the sidecar synthesizes locally never claim to be this pipe.
-	//
-	// Deliberately every event, not just the content-bearing ones: the hub
-	// fans out to listeners in registration order, and the observer's global
-	// subscription is registered at sidecar boot while this per-session one
-	// arrives at hydrate — so the observer sees each delta first. Waiting for
-	// core content to mark the pipe would let the observer's copy of a turn's
-	// first delta through before the mark existed, doubling it every turn.
-	// The cost is the reverse case: if this pipe delivers a status or queue
-	// event and then stops while the observer keeps streaming, the observer is
-	// held off for the rest of the run (and `CORE_PIPE_ACTIVE_MS` after it).
-	// That needs the subscription torn down mid-turn, which only stop and
-	// detach do, and the turn-end reconcile restores the gap from canonical
-	// history — where doubling would be visible on every turn.
-	const eventSessionId = (event.payload as { sessionId?: string } | undefined)
-		?.sessionId;
-	if (eventSessionId) {
-		markCorePipeActive(ctx, eventSessionId);
-	}
-
 	switch (event.type) {
 		case "chunk": {
 			const { sessionId, stream, chunk } = event.payload;
@@ -630,8 +543,6 @@ export function handleCoreSessionEvent(
 				session.status = reason || "ended";
 			}
 			discardAllTrackedAttachments(sessionId, session);
-			// The next run decides afresh which pipe is serving the session.
-			forgetCorePipe(ctx, sessionId);
 			sendEvent(ctx, "chat_session_ended", { sessionId, reason });
 			break;
 		}
@@ -682,7 +593,6 @@ export function createSidecarContext(
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
-		coreStreamActivity: new Map(),
 		bootId: randomUUID(),
 		wsClients: new Set(),
 		pendingApprovals: new Map(),
@@ -955,26 +865,29 @@ export function handleHubLiveEvent(
 	if (!session?.attachedViaHub) {
 		return;
 	}
+	// The observer client and ClineCore's own hub client are separate sockets
+	// that both receive this session's events. This projection only exists for
+	// sessions ClineCore is not subscribed to (it subscribes as a side effect
+	// of start/send/pending_prompts and unsubscribes on stop); once it is,
+	// `handleCoreSessionEvent` carries everything below and a second copy here
+	// would double every delta, tool row, and status change.
+	if (ctx.sessionManager?.hasSessionSubscription(sessionId)) {
+		return;
+	}
 
 	switch (event.event) {
 		case "assistant.delta": {
 			const text =
 				typeof event.payload?.text === "string" ? event.payload.text : "";
 			if (text) {
-				emitChunk(ctx, sessionId, "chat_text", text, "observer");
+				emitChunk(ctx, sessionId, "chat_text", text);
 			}
 			return;
 		}
 		case "assistant.media": {
 			const media = event.payload?.media;
 			if (isGeneratedMedia(media)) {
-				emitChunk(
-					ctx,
-					sessionId,
-					"chat_media",
-					JSON.stringify(media),
-					"observer",
-				);
+				emitChunk(ctx, sessionId, "chat_media", JSON.stringify(media));
 			}
 			return;
 		}
@@ -990,7 +903,6 @@ export function handleHubLiveEvent(
 				sessionId,
 				"chat_reasoning",
 				JSON.stringify({ text, redacted }),
-				"observer",
 			);
 			return;
 		}
@@ -1010,7 +922,6 @@ export function handleHubLiveEvent(
 							: "tool",
 					input: event.payload?.input,
 				}),
-				"observer",
 			);
 			return;
 		}
@@ -1030,7 +941,6 @@ export function handleHubLiveEvent(
 							: "tool",
 					update: event.payload?.update,
 				}),
-				"observer",
 			);
 			return;
 		}
@@ -1054,7 +964,6 @@ export function handleHubLiveEvent(
 							? event.payload.error
 							: undefined,
 				}),
-				"observer",
 			);
 			return;
 		}

--- a/apps/examples/desktop-app/sidecar/mcp.test.ts
+++ b/apps/examples/desktop-app/sidecar/mcp.test.ts
@@ -14,7 +14,6 @@ function createContext(workspaceRoot: string): SidecarContext {
 		liveSessions: new Map(),
 		restoringWorkspacePaths: new Set(),
 		streamIndices: new Map(),
-		coreStreamActivity: new Map(),
 		bootId: "test-boot",
 		wsClients: new Set(),
 		pendingApprovals: new Map(),

--- a/apps/examples/desktop-app/sidecar/types.ts
+++ b/apps/examples/desktop-app/sidecar/types.ts
@@ -117,23 +117,10 @@ export type SidecarWebSocketClient = {
 	close?: () => void;
 };
 
-/**
- * Which pipe produced a chat chunk. Both feed `emitChunk`, and for a session
- * streaming through the hub both carry the same events, so the observer's copy
- * is dropped while the ClineCore subscription is serving that session.
- */
-export type ChunkSource = "core" | "observer";
-
 export type SidecarContext = {
 	liveSessions: Map<string, LiveSession>;
 	restoringWorkspacePaths: Set<string>;
 	streamIndices: Map<string, number>;
-	/**
-	 * When the ClineCore subscription last delivered an event for a session, so
-	 * the observer projection can stand down while it is serving and take over
-	 * again if it stops.
-	 */
-	coreStreamActivity: Map<string, number>;
 	/**
 	 * Identifies this sidecar process. `streamIndices` restarts whenever the
 	 * sidecar does, so the webview needs to tell "index 1 of a new process"

--- a/sdk/packages/core/src/ClineCore.ts
+++ b/sdk/packages/core/src/ClineCore.ts
@@ -640,6 +640,17 @@ export class ClineCore {
 		return this.host.subscribe(listener, options);
 	}
 	/**
+	 * Whether this instance is subscribed to a session's live events.
+	 *
+	 * In hub mode ClineCore subscribes to a session when it starts, sends to,
+	 * or lists pending prompts for it, and unsubscribes on stop. A client that
+	 * also observes the hub directly can use this to render one copy of the
+	 * session's events instead of both.
+	 */
+	hasSessionSubscription(sessionId: string): boolean {
+		return this.host.hasSessionSubscription?.(sessionId) ?? false;
+	}
+	/**
 	 * Updates the AI model used by an active session.
 	 *
 	 * Switches the session to use a different AI model while maintaining the session state

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.test.ts
@@ -925,10 +925,12 @@ describe("HubRuntimeHost", () => {
 			source: SessionSource.CLI,
 			prompt: "Hey",
 		});
+		expect(host.hasSessionSubscription("sess-1")).toBe(true);
 
 		commandMock.mockResolvedValue({ ok: true, payload: {} });
 		await host.stopSession("sess-1");
 
+		expect(host.hasSessionSubscription("sess-1")).toBe(false);
 		expect(unsubscribe).toHaveBeenCalledTimes(1);
 		expect(commandMock).toHaveBeenLastCalledWith(
 			"session.detach",

--- a/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
+++ b/sdk/packages/core/src/hub/runtime-host/hub-runtime-host.ts
@@ -1520,6 +1520,10 @@ export class HubRuntimeHost implements RuntimeHost {
 		return this.events.subscribe(listener, options);
 	}
 
+	hasSessionSubscription(sessionId: string): boolean {
+		return this.sessionSubscriptions.has(sessionId.trim());
+	}
+
 	private ensureSessionSubscription(sessionId: string): void {
 		const target = sessionId.trim();
 		if (!target || this.sessionSubscriptions.has(target)) {

--- a/sdk/packages/core/src/runtime/host/runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/runtime-host.ts
@@ -414,6 +414,12 @@ export interface RuntimeHost {
 		listener: (event: CoreSessionEvent) => void,
 		options?: RuntimeHostSubscribeOptions,
 	): () => void;
+	/**
+	 * Whether this host currently holds a live-event subscription for the
+	 * session. Optional: only hosts that subscribe to sessions individually
+	 * (e.g. hub clients) have anything to report.
+	 */
+	hasSessionSubscription?(sessionId: string): boolean;
 }
 
 export type RuntimeHostMode = "auto" | "local" | "hub" | "remote";


### PR DESCRIPTION
### Related Issue

**Issue:** N/A. Follow-up to #13968 and #13976 (doubled text and missing rows in the desktop live stream). Replaces the dedupe mechanism those PRs introduced with a deterministic one; keeps their boot-id fix.

### Description

The sidecar holds two `NodeHubClient` sockets to the same hub: ClineCore's own (`code-sidecar`, via `HubRuntimeHost`) and the observer (`code-sidecar-observer`, in `ensureSharedHubClient`). The hub delivers a session's events to every `stream.subscribe`r, so once ClineCore subscribes to a session both sockets receive identical deltas, and `handleHubLiveEvent` re-projected the observer's copy on top of `handleCoreSessionEvent`'s.

#13968 and #13976 muted the observer's copy by *inferring* whether ClineCore was serving the session: a per-session timestamp refreshed on every core event, expired after 5 s, then held open while `busy`, then manually cleared (`forgetCorePipe`) at four `manager.stop` call sites because `stop` disposes the subscription without an `ended` event. Each layer patched a hole in the previous one, and the design still raced the first event of each run (the mark is cleared on `ended`, so an observer delta that beats core's `run.started` across the two sockets gets through; it only works because time-to-first-token dwarfs socket skew).

This PR asks ClineCore instead of guessing.

- `@cline/core`: `RuntimeHost.hasSessionSubscription?(sessionId)` (optional, like `readLiveSessionMessages`), implemented on `HubRuntimeHost` as `sessionSubscriptions.has(...)`, exposed as `ClineCore.hasSessionSubscription(sessionId)`.
- Sidecar: `handleHubLiveEvent` returns early for a session ClineCore is subscribed to. That is the fact the timestamp was approximating. `ensureSessionSubscription` sets it synchronously before the subscribe frame is even sent, and the same `stopSession` that disposes the subscription clears it, so there is nothing to refresh, expire, or forget.

Deleted: `CORE_PIPE_ACTIVE_MS`, `markCorePipeActive`, `isCorePipeActive`, `forgetCorePipe` and its four call sites, `coreStreamActivity`, and the `ChunkSource` parameter on `emitChunk`. Net: 31 insertions, 131 deletions across source files.

Two deliberate behavior changes:

- The gate skips the observer's **whole** session projection, including its `run.started`/`session.*` status and `run.completed|failed|aborted` ended handlers, which the previous fix left doubled. `HubRuntimeHost.handleHubEvent` translates every one of those into `status`/`ended` events on the core pipe (`run.started` at L1631, `session.*` at L1932, `run.*` terminal at L1992), so nothing is lost.
- The observer follows the subscription as it comes and goes. After a desktop `stop` the observer serves any run another client (CLI, schedule) starts on the same open session, and the next desktop `send` hands it back. No bookkeeping either way.

The `attachedViaHub = false` on first send (from #13154) is kept. It still has a second job, forcing one `updateSessionConnection` refresh after attach (`refreshes hub-attached sessions even when the cached config matches`). Only its comment changes, since it no longer needs to exist for dedupe.

### Test Procedure

- `sidecar/context.test.ts` "Chat chunk pipe selection" rewritten to assert the deterministic behavior: one copy when both pipes carry a delta; observer-only sessions still stream; the whole projection (tool rows, `ended`, `busy`) is muted, not just text; the observer follows the subscription through subscribe then stop; per-session decisions; locally synthesized chunks never dropped; boot id unchanged. Disabling the gate makes 4 of these red.
- `hub-runtime-host.test.ts` "tears down session stream subscriptions when a session stops" now also asserts `hasSessionSubscription` flips true after `startSession` and false after `stopSession`, pinning the contract the sidecar relies on.
- `sidecar/context.test.ts` + `chat-session.test.ts` + `mcp.test.ts` + `webview/hooks/use-chat-session.test.tsx`: 165 passed (vitest). Note these are Vitest files; running them under `bun test` fails on `vi.waitFor` and is not a regression.
- `@cline/core` `src/hub/runtime-host/` + `ClineCore.test.ts`: 43 passed.
- `tsc -p apps/examples/desktop-app/tsconfig.json --noEmit`: 914 errors, identical count to `main`, none in touched files.
- `biome check` clean on all touched files.

Not verified on a running stack, same caveat as the two PRs this replaces. The manual repro worth running before the next desktop release: open a task already streaming through the hub without typing, let a tool approval sit 10+ s, approve, and confirm no doubled text or duplicate tool row.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ♻️ Refactor Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (two commits: the SDK getter, then the desktop change that uses it)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Requires `bun run build:sdk` before running the sidecar against source, since the desktop resolves `@cline/core` through `dist/`.

The fully structural fix (one hub socket in the sidecar; delete the observer's chat projection and `attachedViaHub` entirely) remains open and is still the right long-term shape. This PR makes the two-socket design correct without a heuristic, which is the smaller change that closes the bug.