### PR TITLE
fix(desktop): keep a new task on "starting" while the hub reports the fresh session idle

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -179,6 +179,46 @@ describe("useChatSession", () => {
 		expect(current.status).toBe("idle");
 	});
 
+	it("still applies a terminal status that lands while a submission is in flight", async () => {
+		// Only the transient "idle" is held back; a failed session must unstick
+		// the UI even if the send response never arrives.
+		const startResponse = deferred<{ cwd: string; workspaceRoot: string }>();
+		let plannedSessionId = "";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						plannedSessionId = request.config?.sessionId ?? "";
+						return {
+							...(await startResponse.promise),
+							sessionId: plannedSessionId,
+						};
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => {
+			void current.sendPrompt("hello");
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(current.status).toBe("starting");
+		const statusHandler = handlerFor("chat_session_status");
+
+		await act(async () => {
+			statusHandler({ sessionId: plannedSessionId, status: "failed" });
+		});
+		expect(current.status).toBe("failed");
+	});
+
 	it("preserves authoritative completion across abort races", async () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -112,6 +112,73 @@ describe("useChatSession", () => {
 		expect(current.status).toBe("idle");
 	});
 
+	it("keeps a new task on starting while the hub reports the just-created session idle", async () => {
+		// The hub publishes session.created / session.updated with the record's
+		// "idle" status during the start RPC, before the first prompt's run
+		// begins. Applying it over "starting" flipped the composer placeholder
+		// and hid the request indicator for a frame on every new task.
+		const startResponse = deferred<{ cwd: string; workspaceRoot: string }>();
+		let plannedSessionId = "";
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						// The sidecar reuses the planned id the webview passes.
+						plannedSessionId = request.config?.sessionId ?? "";
+						return {
+							...(await startResponse.promise),
+							sessionId: plannedSessionId,
+						};
+					}
+					if (request?.action === "send") {
+						return {
+							ok: true,
+							queued: true,
+							promptsInQueue: [{ id: "p1", prompt: "hello", steer: false }],
+						};
+					}
+				}
+				return [];
+			},
+		);
+
+		let sendTask: Promise<void> | undefined;
+		await act(async () => {
+			sendTask = current.sendPrompt("hello");
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+		expect(current.status).toBe("starting");
+		const statusHandler = handlerFor("chat_session_status");
+
+		await act(async () => {
+			statusHandler({ sessionId: plannedSessionId, status: "idle" });
+			statusHandler({ sessionId: plannedSessionId, status: "idle" });
+		});
+		expect(current.status).toBe("starting");
+
+		await act(async () => {
+			startResponse.resolve({
+				cwd: "/workspace/cline",
+				workspaceRoot: "/workspace/cline",
+			});
+			await sendTask;
+		});
+		expect(current.status).toBe("running");
+
+		// Once nothing is in flight, the hub's status applies as before.
+		await act(async () => {
+			statusHandler({ sessionId: plannedSessionId, status: "idle" });
+		});
+		expect(current.status).toBe("idle");
+	});
+
 	it("preserves authoritative completion across abort races", async () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -1838,11 +1838,11 @@ export function useChatSession() {
 				// it flipped the composer and the request indicator from
 				// "starting" to idle and back for a frame on every new task. The
 				// submission owns status until it hands off (the queued-start
-				// event, or its own completion for a blocking send).
-				if (
-					!BUSY_STATUSES.has(nextStatus as ChatSessionStatus) &&
-					activePromptSubmissionsRef.current > 0
-				) {
+				// event, or its own completion for a blocking send). Only "idle"
+				// is held back: a terminal status (failed, aborted) during a
+				// submission is real and must still unstick the UI even if the
+				// send response never arrives.
+				if (nextStatus === "idle" && activePromptSubmissionsRef.current > 0) {
 					return;
 				}
 				authoritativeStatusRevisionRef.current += 1;

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -1831,6 +1831,20 @@ export function useChatSession() {
 				) {
 					return;
 				}
+				// The reverse case: the hub publishes the session record's status
+				// as soon as the session is created, before the first prompt's
+				// run starts, so an "idle" that lands while a local submission is
+				// still in flight predates the run it is about to start. Applying
+				// it flipped the composer and the request indicator from
+				// "starting" to idle and back for a frame on every new task. The
+				// submission owns status until it hands off (the queued-start
+				// event, or its own completion for a blocking send).
+				if (
+					!BUSY_STATUSES.has(nextStatus as ChatSessionStatus) &&
+					activePromptSubmissionsRef.current > 0
+				) {
+					return;
+				}
 				authoritativeStatusRevisionRef.current += 1;
 				setStatus(nextStatus as ChatSessionStatus);
 			},


### PR DESCRIPTION
### Related Issue

**Issue:** N/A. Field report: on every new task, the composer placeholder and the "Thinking..." request indicator flicker for a frame right after the first prompt is sent.

### Description

**What happens.** Sending the first prompt of a new task sets the session to `starting` and issues the `start` RPC. While that RPC is in flight, the hub publishes `session.created` plus two `session.updated` events carrying the new record's status, `idle`. `HubRuntimeHost` maps each to a `status` event, the sidecar forwards each as `chat_session_status`, and the webview's handler applied them over `starting`. `run.started` then flips it back to `running`. Net effect per new task: `starting → idle → running`, which the composer renders as busy placeholder → idle placeholder → busy placeholder, and the pre-first-output spinner row hides and reappears.

Confirmed two ways: the hub's durable event log for a fresh desktop session shows `session.updated(idle) ×2, session.created(idle), run.started, session.updated(running)` in that order, and replaying that sequence through the hook harness (with the sidecar reusing the planned session id the webview passes, as it does) shows status `starting → idle → running`.

**The fix.** The status handler already drops a `running` that trails a settled turn as stale. This adds the reverse guard: while a local prompt submission is in flight (`activePromptSubmissionsRef > 0`), an `idle` predates the run it is about to start and is dropped. Only `idle` is held back: a terminal status (`failed`, `aborted`) during a submission is real and still applies, so a hung send response cannot leave the UI falsely busy. The submission owns status until it hands off, to the queued-start event or to its own completion path for a blocking send. Once nothing is in flight the hub's status applies exactly as before, so the idle that a queue-drained turn relies on to leave the busy state (those turns get no `chat_done`, see #13979) is unaffected. Webview only, about 10 lines.

**Why not fix it in the sidecar or SDK.** The events are correct: the session *is* idle when created. Only the webview knows it has a submission in flight that will make it busy, so the webview is the right place to decide the status is stale.

### Test Procedure

- New test `keeps a new task on starting while the hub reports the just-created session idle`: fresh `sendPrompt` with the start RPC deferred, two idle statuses for the planned session id during it, assert `starting`; resolve start and the queued send, assert `running`; an idle afterwards applies. Disabling the guard fails it with `expected "starting", received "idle"`.
- `still applies a terminal status that lands while a submission is in flight`: a `failed` during the start RPC is applied.
- `webview/hooks/use-chat-session.test.tsx`: 55 passed. `biome check` clean. Webview `tsc` reports the same 62 pre-existing errors as `main`, none in the changed lines (the webview is not typechecked in CI).
- Manual: from the welcome screen, send a prompt and watch the composer placeholder and the spinner row during the first second. They should go straight to the busy state and stay there until the first token.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (splitting larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnz9AtY5MrXddi9sfdzJnr

