### PR TITLE
feat(providers): add Melious as a built-in API provider

### DIFF
--- a/apps/vscode/src/sdk/model-catalog/effective-config.test.ts
+++ b/apps/vscode/src/sdk/model-catalog/effective-config.test.ts
@@ -202,6 +202,26 @@ describe("buildEffectiveProviderConfig", () => {
 		})
 	})
 
+	it("resolves Melious credentials from providers.json without a legacy state key", async () => {
+		const { buildEffectiveProviderConfig } = await import("./effective-config")
+		// Melious is providers.json-only: it has no entry in the legacy
+		// apiKeyFields/baseUrlFields maps, so the settings written by the generic
+		// provider form must be what reaches the SDK.
+		mocks.setProviderSettings({
+			melious: {
+				provider: "melious",
+				apiKey: "sk-mel-provider-json-key",
+				baseUrl: "https://api.melious.ai/v1",
+			},
+		})
+
+		expect(buildEffectiveProviderConfig(parseProviderId("melious"))).toEqual({
+			providerId: parseProviderId("melious"),
+			apiKey: "sk-mel-provider-json-key",
+			baseUrl: "https://api.melious.ai/v1",
+		})
+	})
+
 	it("keeps Cline account auth in the auth envelope", async () => {
 		const { buildEffectiveProviderConfig } = await import("./effective-config")
 		mocks.setApiConfiguration({ clineApiKey: "cline-access-token", clineAccountId: "account-123" })

--- a/apps/vscode/src/sdk/model-catalog/provider-id.ts
+++ b/apps/vscode/src/sdk/model-catalog/provider-id.ts
@@ -54,6 +54,7 @@ const KNOWN_API_PROVIDERS = {
 	aihubmix: true,
 	minimax: true,
 	hicap: true,
+	melious: true,
 	nousResearch: true,
 	wandb: true,
 	xiaomi: true,

--- a/apps/vscode/src/shared/api.ts
+++ b/apps/vscode/src/shared/api.ts
@@ -47,6 +47,7 @@ export type ApiProvider =
 	| "aihubmix"
 	| "minimax"
 	| "hicap"
+	| "melious"
 	| "nousResearch"
 	| "wandb"
 	| "xiaomi"

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.test.ts
@@ -126,6 +126,25 @@ describe("providerSettingsRegistry", () => {
 		})
 	})
 
+	it("builds Melious settings with its signup and base URL fields", () => {
+		expect(hasCustomProviderSettings("melious")).toBe(false)
+		expect(
+			getGenericProviderSettings(
+				"melious",
+				listing({ id: "melious", name: "Melious", protocol: "openai-chat", allowsCustomModelIds: false }),
+			),
+		).toEqual({
+			allowsCustomIds: false,
+			baseUrlField: {
+				label: "Base URL",
+				placeholder: "https://api.melious.ai/v1",
+			},
+			providerId: "melious",
+			providerName: "Melious",
+			signupUrl: "https://melious.ai/account/api/keys",
+		})
+	})
+
 	it("allows future simple SDK providers to use the generic fallback", () => {
 		const futureProvider = listing({
 			allowsCustomModelIds: true,

--- a/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
+++ b/apps/vscode/webview-ui/src/components/settings/providers/providerSettingsRegistry.ts
@@ -68,6 +68,13 @@ const GENERIC_PROVIDER_PRESENTATION_OVERRIDES: Record<string, GenericProviderPre
 	"huawei-cloud-maas": {
 		signupUrl: "https://support.huaweicloud.com/intl/zh-cn/usermanual-maas/maas_01_0001.html",
 	},
+	melious: {
+		signupUrl: "https://melious.ai/account/api/keys",
+		baseUrlField: {
+			label: "Base URL",
+			placeholder: "https://api.melious.ai/v1",
+		},
+	},
 	minimax: {
 		signupUrl: "https://www.minimax.io/platform/user-center/basic-information/interface-key",
 		baseUrlField: {
@@ -159,6 +166,7 @@ const FALLBACK_GENERIC_PROVIDER_NAMES = {
 	doubao: "Doubao",
 	gemini: "Gemini",
 	"huawei-cloud-maas": "Huawei Cloud MaaS",
+	melious: "Melious",
 	minimax: "MiniMax",
 	mistral: "Mistral",
 	nousResearch: "NousResearch",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1062,6 +1062,10 @@
 			"destination": "/provider-config/openai-compatible"
 		},
 		{
+			"source": "/provider-config/melious",
+			"destination": "/provider-config/other-30-plus-providers#melious"
+		},
+		{
 			"source": "/provider-config/mistral-ai",
 			"destination": "/provider-config/other-30-plus-providers#mistral"
 		},

--- a/docs/provider-config/other-30-plus-providers.mdx
+++ b/docs/provider-config/other-30-plus-providers.mdx
@@ -21,6 +21,7 @@ Use this page for providers that follow the same setup pattern.
   - [Hicap](#hicap)
   - [Huawei Cloud MaaS](#huawei-cloud-maas)
   - [Hugging Face](#hugging-face)
+  - [Melious](#melious)
   - [Mistral](#mistral)
   - [Moonshot](#moonshot)
   - [Nebius AI Studio](#nebius-ai-studio)
@@ -177,6 +178,17 @@ Hugging Face provides hosted inference access for open-source models.
 1. Sign in to Hugging Face.
 2. Create an access token with inference permissions.
 3. In Cline, select **Hugging Face** and paste the token.
+
+### Melious
+Melious provides OpenAI-compatible access to open-weight models hosted on EU infrastructure, with per-response energy and cost reporting.
+
+**Website:** [https://melious.ai](https://melious.ai)
+
+#### Basic Setup
+
+1. Create your Melious account.
+2. Generate an API key at [melious.ai/account/api/keys](https://melious.ai/account/api/keys).
+3. In Cline, choose **Melious** and paste the key. The model list loads from your account.
 
 ### Mistral
 Mistral provides direct API access to its model lineup.

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -18,6 +18,7 @@ describe("isPrivateModelCatalogProvider", () => {
 		"baseten",
 		"hicap",
 		"litellm",
+		"melious",
 		"poolside",
 	])("recognizes %s as an endpoint-specific catalog provider", (providerId) => {
 		expect(isPrivateModelCatalogProvider(providerId)).toBe(true);
@@ -589,6 +590,102 @@ describe("resolveProviderConfig", () => {
 				status: "active",
 			}),
 		);
+	});
+
+	it("loads Melious chat models from the authenticated models endpoint", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "glm-5.3",
+							_meta: {
+								type: "chat",
+								input_modalities: ["text"],
+								context_length: 1_000_000,
+								max_output_tokens: null,
+								reasoning_type: "hybrid",
+								capabilities: { function_calling: true },
+								pricing: {
+									input_cost_per_million_eur: 1,
+									output_cost_per_million_eur: 3,
+								},
+							},
+						},
+						{
+							id: "kimi-k2.7-code",
+							_meta: {
+								type: "chat",
+								input_modalities: ["text", "image"],
+								context_length: 262_144,
+								max_output_tokens: 8192,
+								reasoning_type: "reasoning",
+								capabilities: { function_calling: true },
+								pricing: {
+									input_cost_per_million_eur: 0.7,
+									output_cost_per_million_eur: 3,
+								},
+							},
+						},
+						{
+							id: "bge-m3",
+							_meta: { type: "embedding", context_length: 8192 },
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resolved = await resolveProviderConfig(
+			"melious",
+			{ failOnError: true, cacheTtlMs: 0 },
+			{
+				providerId: "melious",
+				modelId: "glm-5.3",
+				apiKey: "melious-key",
+				baseUrl: "https://api.melious.ai/v1",
+			},
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.melious.ai/v1/models?include_meta=true",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({
+					Authorization: "Bearer melious-key",
+				}),
+			}),
+		);
+		expect(resolved?.knownModels?.["glm-5.3"]).toEqual(
+			expect.objectContaining({
+				name: "glm-5.3",
+				contextWindow: 1_000_000,
+				maxInputTokens: 1_000_000,
+				maxTokens: undefined,
+				capabilities: expect.arrayContaining([
+					"streaming",
+					"tools",
+					"reasoning",
+					"prompt-cache",
+				]),
+				pricing: { input: 1, output: 3 },
+				status: "active",
+			}),
+		);
+		expect(resolved?.knownModels?.["glm-5.3"]?.capabilities).not.toContain(
+			"images",
+		);
+		expect(resolved?.knownModels?.["kimi-k2.7-code"]?.capabilities).toContain(
+			"images",
+		);
+		expect(resolved?.knownModels?.["kimi-k2.7-code"]?.maxTokens).toBe(8192);
+		// Embedding, image and transcription models are filtered out of the picker.
+		expect(resolved?.knownModels?.["bge-m3"]).toBeUndefined();
 	});
 
 	it("falls back to /model/info for LiteLLM private models", async () => {

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -457,6 +457,106 @@ async function fetchHicapPrivateModels(
 	return models;
 }
 
+interface MeliousModelResponse {
+	id?: string;
+	_meta?: {
+		type?: string;
+		input_modalities?: string[];
+		context_length?: number | null;
+		max_output_tokens?: number | null;
+		reasoning_type?: string | null;
+		capabilities?: {
+			function_calling?: boolean;
+		};
+		pricing?: {
+			input_cost_per_million_eur?: number | string | null;
+			output_cost_per_million_eur?: number | string | null;
+		};
+	};
+}
+
+async function fetchMeliousPrivateModels(
+	config: ProviderConfig,
+	token: string,
+): Promise<Record<string, ModelInfo>> {
+	const baseUrl =
+		normalizeBaseUrl(config.baseUrl) || "https://api.melious.ai/v1";
+	// `include_meta` returns context length, modalities, capability flags and
+	// per-million pricing alongside each id. Without it the response is bare ids.
+	const endpoint = `${baseUrl.replace(/\/+$/, "")}/models?include_meta=true`;
+	const response = await fetchWithTimeout(endpoint, {
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`Melious model refresh failed: HTTP ${response.status}`);
+	}
+
+	const payload = (await response.json()) as { data?: MeliousModelResponse[] };
+	const entries = payload?.data ?? [];
+	const models: Record<string, ModelInfo> = {};
+	for (const model of entries) {
+		const id = model.id?.trim();
+		if (!id) {
+			continue;
+		}
+		const meta = model._meta;
+		// The catalog also serves embedding, image and transcription models; only
+		// chat models belong in a coding-agent picker.
+		if (meta?.type !== "chat") {
+			continue;
+		}
+
+		const capabilities: NonNullable<ModelInfo["capabilities"]> = ["streaming"];
+		includeCapability(
+			capabilities,
+			"tools",
+			Boolean(meta.capabilities?.function_calling),
+		);
+		includeCapability(
+			capabilities,
+			"images",
+			(meta.input_modalities ?? []).includes("image"),
+		);
+		includeCapability(
+			capabilities,
+			"reasoning",
+			Boolean(meta.reasoning_type) && meta.reasoning_type !== "non_reasoning",
+		);
+		// Prefix caching is transparent on every Melious chat model — there is no
+		// per-request cache_control to opt into, and hits bill at the cache rate.
+		includeCapability(capabilities, "prompt-cache", true);
+
+		const contextWindow = parseOptionalNumber(meta.context_length ?? undefined);
+		const pricing = {
+			input: parseOptionalNumber(
+				meta.pricing?.input_cost_per_million_eur ?? undefined,
+			),
+			output: parseOptionalNumber(
+				meta.pricing?.output_cost_per_million_eur ?? undefined,
+			),
+		};
+
+		models[id] = {
+			id,
+			name: id,
+			contextWindow,
+			maxInputTokens: contextWindow,
+			maxTokens: parseOptionalNumber(meta.max_output_tokens ?? undefined),
+			capabilities,
+			pricing:
+				pricing.input !== undefined || pricing.output !== undefined
+					? pricing
+					: undefined,
+			status: "active",
+		};
+	}
+	return models;
+}
+
 async function fetchPoolsidePrivateModels(
 	config: ProviderConfig,
 	token: string,
@@ -655,6 +755,7 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	baseten: fetchBasetenPrivateModels,
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,
+	melious: fetchMeliousPrivateModels,
 	poolside: fetchPoolsidePrivateModels,
 };
 

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -309,6 +309,22 @@ describe("built-in provider metadata", () => {
 		);
 	});
 
+	it("registers Melious as an EU-hosted OpenAI-compatible provider", async () => {
+		await expect(getProvider("melious")).resolves.toMatchObject({
+			id: "melious",
+			name: "Melious",
+			baseUrl: "https://api.melious.ai/v1",
+			defaultModelId: "glm-5.3",
+			client: "openai-compatible",
+		});
+		// Melious is not on models.dev, so the bundled catalog is just the
+		// default-model fallback; the real list is fetched from /v1/models with
+		// the user's key at runtime.
+		await expect(getModelsForProvider("melious")).resolves.toHaveProperty(
+			"glm-5.3",
+		);
+	});
+
 	it("merges generated provider specs with handwritten built-in overrides", async () => {
 		const generatedIds = new Set(
 			GENERATED_PROVIDER_SPECS.map((spec) => spec.id),

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -869,6 +869,17 @@ const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		defaults: { baseUrl: "https://api.hicap.ai/v1" },
 	},
 	{
+		id: "melious",
+		name: "Melious",
+		description: "European inference on GDPR-compliant EU infrastructure",
+		family: "openai-compatible",
+		capabilities: ["tools", "reasoning", "prompt-cache"],
+		defaultModelId: "glm-5.3",
+		apiKeyEnv: ["MELIOUS_API_KEY"],
+		docsUrl: "https://melious.ai/docs/integrations/cline",
+		defaults: { baseUrl: "https://api.melious.ai/v1" },
+	},
+	{
 		id: "nousResearch",
 		name: "Nous Research",
 		description: "Open-source AI research lab",

--- a/sdk/packages/llms/src/providers/ids.ts
+++ b/sdk/packages/llms/src/providers/ids.ts
@@ -46,6 +46,7 @@ export enum BUILT_IN_PROVIDER {
 	V0 = "v0",
 	AIHUBMIX = "aihubmix",
 	HICAP = "hicap",
+	MELIOUS = "melious",
 	NOUS_RESEARCH = "nousResearch",
 	HUAWEI_CLOUD_MAAS = "huawei-cloud-maas",
 	WANDB = "wandb",


### PR DESCRIPTION
### Related Issue

**Issue:** #13987 

### Description

Adds [Melious](https://melious.ai) as a built-in API provider. Melious serves
open-weight models over an OpenAI-compatible API on EU infrastructure
(GDPR/TTDSG), which is the reason for the request — teams with a data-residency
requirement currently have to hand-configure the OpenAI Compatible provider and
type in context windows and prices by hand.

The provider is a declarative `BuiltinSpec`, modelled on `hicap`/`cerebras`, so
it reuses `vendors/openai-compatible.ts` and adds no transport code:

- `sdk/packages/llms/src/providers/ids.ts` — `MELIOUS = "melious"`
- `sdk/packages/llms/src/providers/builtins.ts` — the spec (base
  `https://api.melious.ai/v1`, default model `glm-5.3`, capabilities
  `tools`/`reasoning`/`prompt-cache`)
- `apps/vscode/src/shared/api.ts` + `sdk/model-catalog/provider-id.ts` — the
  `ApiProvider` union and its `satisfies Record<ApiProvider, true>` allowlist
- `webview-ui/.../providerSettingsRegistry.ts` — presentation entry so Melious
  renders the curated `GenericProviderSettings` form rather than being treated
  as a custom provider

One non-trivial piece: `/v1/models` requires an API key, so the keyless
`modelsSourceUrl` path can't be used. `provider-defaults.ts` gains
`fetchMeliousPrivateModels`, registered in `PRIVATE_PROVIDER_MODEL_FETCHERS`
next to the existing `baseten`/`hicap`/`litellm`/`poolside` fetchers. It maps
`_meta` (context length, modalities, `function_calling`, pricing) onto
`ModelInfo` and filters `type !== "chat"` so embedding, image and transcription
models stay out of the picker.

Melious is not on models.dev, so nothing generated is touched — the spec is
handwritten in `builtins.ts`, per the header note in `providers.generated.ts`.

No proto, `state-keys.ts` or secrets change: credentials round-trip through
`providers.json`, which `buildEffectiveProviderConfig` already falls back to
when a provider has no legacy state-key mapping.

### Test Procedure

**Automated** — added tests in four suites, all green:

| Suite | Coverage |
|---|---|
| `sdk/packages/llms/.../builtins.test.ts` | spec resolves with the right baseUrl/client/default model |
| `sdk/packages/core/.../provider-defaults.test.ts` | fetcher: request URL + bearer header, `_meta` mapping, and that a non-chat model is filtered out |
| `apps/vscode/.../effective-config.test.ts` | credentials resolve from `providers.json` with no legacy state key — the wiring that would silently break the provider |
| `webview-ui/.../providerSettingsRegistry.test.ts` | generic settings form is selected, with signup + base-URL fields |

Commands run: `bun run build:sdk`, `bun -F @cline/llms test`,
`bun -F @cline/core test`, `apps/vscode` `bun run check-types` (incl. proto
codegen), `bun run test:webview`, and biome across every changed file.

**Live** — drove the real gateway against the Melious API with a working key,
15 cases, all passing: streaming text, usage accounting, a two-turn tool loop
(verified on the wire with `CLINE_CAPTURE_PROVIDER_REQUEST=full` —
`toolResultCount: 1`), reasoning deltas, image input, non-default model ids,
mid-stream abort, error classification (bad key → `auth`; unknown model →
`Model not found`; bogus base URL → connect failure, proving the override
reaches the transport), the live catalog (47 chat models, 45 tool-capable), and
prompt caching (1280/1344 input tokens served from cache on a repeat).

Also replayed Cline's real system prompt and all 15 of its tools against
`glm-5.3`, `kimi-k2.7-code` and `qwen3-coder-next` — 5/5 produced valid tool
calls.

**What could break, and why I don't think it does:** the risky part is the
shared `PRIVATE_PROVIDER_MODEL_FETCHERS` map and the `ApiProvider` union. The
union is compile-enforced by `KNOWN_API_PROVIDERS`, and the fetcher map is
additive — the existing `isPrivateModelCatalogProvider` test table was extended
rather than replaced. A full `bun -F @cline/llms test` run showed 3 timeouts in
`gateway.test.ts`; those reproduce on a clean checkout and pass in isolation
both before and after this change, so they're unrelated flakes.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="725" height="903" alt="Screenshot 2026-09-09 175056" src="https://github.com/user-attachments/assets/e9e55b72-8050-4352-bd0e-74aa31f79d7b" />

### Additional Notes

Docs are included: a `### Melious` section in
`docs/provider-config/other-30-plus-providers.mdx` following the existing
per-provider template, plus the matching redirect in `docs.json`.

One known cosmetic limitation worth flagging: `formatCompactPrice` in
`ModelInfoView.tsx` hardcodes `$`. Melious prices in EUR, so the figures are
the correct per-million rates but carry a dollar sign. Left alone rather than
scope-creeping this PR into currency support — happy to open a follow-up.