### PR TITLE
fix(llms): encode Bedrock OpenAI reasoning for inference profiles

### DIFF
--- a/.changeset/tidy-pandas-think.md
+++ b/.changeset/tidy-pandas-think.md
@@ -1,0 +1,5 @@
+---
+"@cline/llms": patch
+---
+
+Fix Bedrock requests failing when reasoning effort is set for models without reasoning support. Portable top-level reasoning is now suppressed for Bedrock catalog models whose capabilities lack `reasoning` (e.g. Llama, Nova Pro/Lite/Micro), effort levels are clamped to each Bedrock model's advertised values (e.g. GPT-OSS `low`/`medium`/`high`), and reasoning normalization strips intent for known non-reasoning models instead of forwarding it to an API that rejects it.

--- a/.changeset/tidy-pandas-think.md
+++ b/.changeset/tidy-pandas-think.md
@@ -2,4 +2,4 @@
 "@cline/llms": patch
 ---
 
-Fix Bedrock requests failing when reasoning effort is set for models without reasoning support. Portable top-level reasoning is now suppressed for Bedrock catalog models whose capabilities lack `reasoning` (e.g. Llama, Nova Pro/Lite/Micro), effort levels are clamped to each Bedrock model's advertised values (e.g. GPT-OSS `low`/`medium`/`high`), and reasoning normalization strips intent for known non-reasoning models instead of forwarding it to an API that rejects it.
+Fix Bedrock OpenAI inference profiles sending `reasoningConfig` instead of `reasoning_effort`. Preserve supported reasoning controls, normalize effort against advertised values, and suppress reasoning for Bedrock models known not to support it.

--- a/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
@@ -1,10 +1,14 @@
-import type { GatewayStreamRequest } from "@cline/shared";
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { buildAiSdkStreamConfig } from "./ai-sdk";
 import {
 	resolvePortableReasoning,
 	withoutPortableReasoning,
 } from "./routing/portable-reasoning";
+import { normalizeReasoningRequest } from "./routing/reasoning-options";
 
 function request(
 	reasoning?: GatewayStreamRequest["reasoning"],
@@ -15,6 +19,41 @@ function request(
 		messages: [],
 		reasoning,
 	};
+}
+
+function bedrockRequest(
+	reasoning?: GatewayStreamRequest["reasoning"],
+	modelId = "openai.gpt-oss-120b-1:0",
+): GatewayStreamRequest {
+	return {
+		providerId: "bedrock",
+		modelId,
+		messages: [],
+		reasoning,
+	};
+}
+
+function bedrockContext(
+	overrides: Partial<GatewayProviderContext["model"]> = {},
+): GatewayProviderContext {
+	return {
+		provider: {
+			id: "bedrock",
+			name: "AWS Bedrock",
+			defaultModelId: "openai.gpt-oss-120b-1:0",
+			models: [],
+		},
+		model: {
+			id: "openai.gpt-oss-120b-1:0",
+			name: "gpt-oss-120b",
+			providerId: "bedrock",
+			capabilities: ["reasoning"],
+			reasoningOptions: [
+				{ type: "effort", values: ["low", "medium", "high"] },
+			],
+			...overrides,
+		},
+	} as unknown as GatewayProviderContext;
 }
 
 describe("resolvePortableReasoning", () => {
@@ -74,5 +113,75 @@ describe("resolvePortableReasoning", () => {
 		expect(
 			buildAiSdkStreamConfig(ollamaRequest, undefined as never),
 		).toHaveProperty("reasoning", "high");
+	});
+
+	it("suppresses Bedrock portable reasoning for models without reasoning support", () => {
+		const nonReasoning = bedrockContext({
+			id: "meta.llama3-3-70b-instruct-v1:0",
+			capabilities: ["tools", "temperature"],
+			reasoningOptions: undefined,
+		});
+		expect(
+			resolvePortableReasoning(
+				bedrockRequest({ effort: "medium" }, "meta.llama3-3-70b-instruct-v1:0"),
+				nonReasoning,
+			),
+		).toBeUndefined();
+		expect(
+			resolvePortableReasoning(
+				bedrockRequest({ enabled: true }, "meta.llama3-3-70b-instruct-v1:0"),
+				nonReasoning,
+			),
+		).toBeUndefined();
+		expect(
+			buildAiSdkStreamConfig(
+				bedrockRequest({ effort: "medium" }, "meta.llama3-3-70b-instruct-v1:0"),
+				nonReasoning,
+			),
+		).not.toHaveProperty("reasoning");
+	});
+
+	it("clamps Bedrock GPT-OSS effort to advertised low/medium/high", () => {
+		const context = bedrockContext();
+		expect(
+			resolvePortableReasoning(bedrockRequest({ effort: "xhigh" }), context),
+		).toBe("high");
+		expect(
+			resolvePortableReasoning(bedrockRequest({ effort: "max" }), context),
+		).toBe("high");
+		expect(
+			resolvePortableReasoning(bedrockRequest({ effort: "medium" }), context),
+		).toBe("medium");
+	});
+
+	it("keeps Bedrock portable reasoning for unknown custom models (fail open)", () => {
+		const unknown = bedrockContext({
+			id: "custom-astra-model",
+			capabilities: undefined,
+			reasoningOptions: undefined,
+		});
+		expect(
+			resolvePortableReasoning(
+				bedrockRequest({ effort: "medium" }, "custom-astra-model"),
+				unknown,
+			),
+		).toBe("medium");
+	});
+
+	it("leaves Bedrock reasoning in place for normalize to strip on non-reasoning models", () => {
+		const nonReasoning = bedrockContext({
+			id: "amazon.nova-pro-v1:0",
+			capabilities: ["images", "tools", "temperature"],
+			reasoningOptions: undefined,
+		});
+		// Portable is suppressed, so the intent stays for the normalized
+		// provider-options path — which must then strip it.
+		const kept = withoutPortableReasoning(
+			bedrockRequest({ effort: "medium" }, "amazon.nova-pro-v1:0"),
+			nonReasoning,
+		);
+		expect(kept.reasoning).toBeDefined();
+		const normalized = normalizeReasoningRequest(kept, nonReasoning);
+		expect(normalized.reasoning).toBeUndefined();
 	});
 });

--- a/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk-reasoning.test.ts
@@ -8,6 +8,7 @@ import {
 	resolvePortableReasoning,
 	withoutPortableReasoning,
 } from "./routing/portable-reasoning";
+import { composeAiSdkProviderOptions } from "./routing/provider-options";
 import { normalizeReasoningRequest } from "./routing/reasoning-options";
 
 function request(
@@ -48,12 +49,11 @@ function bedrockContext(
 			name: "gpt-oss-120b",
 			providerId: "bedrock",
 			capabilities: ["reasoning"],
-			reasoningOptions: [
-				{ type: "effort", values: ["low", "medium", "high"] },
-			],
+			reasoningOptions: [{ type: "effort", values: ["low", "medium", "high"] }],
 			...overrides,
 		},
-	} as unknown as GatewayProviderContext;
+		config: { providerId: "bedrock" },
+	};
 }
 
 describe("resolvePortableReasoning", () => {
@@ -144,14 +144,26 @@ describe("resolvePortableReasoning", () => {
 	it("clamps Bedrock GPT-OSS effort to advertised low/medium/high", () => {
 		const context = bedrockContext();
 		expect(
-			resolvePortableReasoning(bedrockRequest({ effort: "xhigh" }), context),
-		).toBe("high");
+			composeAiSdkProviderOptions(bedrockRequest({ effort: "xhigh" }), context),
+		).toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+			"high",
+		);
 		expect(
-			resolvePortableReasoning(bedrockRequest({ effort: "max" }), context),
-		).toBe("high");
+			composeAiSdkProviderOptions(bedrockRequest({ effort: "max" }), context),
+		).toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+			"high",
+		);
 		expect(
-			resolvePortableReasoning(bedrockRequest({ effort: "medium" }), context),
-		).toBe("medium");
+			composeAiSdkProviderOptions(
+				bedrockRequest({ effort: "medium" }),
+				context,
+			),
+		).toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+			"medium",
+		);
 	});
 
 	it("keeps Bedrock portable reasoning for unknown custom models (fail open)", () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -325,9 +325,9 @@ function summarizeProjectedMedia(media: readonly GeneratedMedia[]): unknown {
 
 export function buildAiSdkStreamConfig(
 	request: GatewayStreamRequest,
-	_context: GatewayProviderContext,
+	context: GatewayProviderContext,
 ): Partial<CallSettings> {
-	const reasoning = resolvePortableReasoning(request);
+	const reasoning = resolvePortableReasoning(request, context);
 	return {
 		...(request.maxTokens !== undefined
 			? { maxOutputTokens: request.maxTokens }
@@ -2189,7 +2189,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 					context,
 					messagesSystemPrompt,
 				);
-				const portableReasoning = resolvePortableReasoning(request);
+				const portableReasoning = resolvePortableReasoning(request, context);
 				const requestConfig = provider.buildStreamConfig
 					? provider.buildStreamConfig(request, context)
 					: buildAiSdkStreamConfig(request, context);

--- a/sdk/packages/llms/src/providers/bedrock-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/bedrock-reasoning.test.ts
@@ -1,0 +1,241 @@
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import { buildAiSdkStreamConfig } from "./ai-sdk";
+import { resolvePortableReasoning } from "./routing/portable-reasoning";
+import { composeAiSdkProviderOptions } from "./routing/provider-options";
+import { normalizeReasoningRequest } from "./routing/reasoning-options";
+
+function context(
+	modelId: string,
+	model: Partial<GatewayProviderContext["model"]> = {},
+): GatewayProviderContext {
+	return {
+		provider: {
+			id: "bedrock",
+			name: "Bedrock",
+			defaultModelId: modelId,
+			models: [],
+		},
+		model: {
+			id: modelId,
+			name: modelId,
+			providerId: "bedrock",
+			capabilities: ["reasoning"],
+			reasoningOptions: [{ type: "effort", values: ["low", "medium", "high"] }],
+			...model,
+		},
+		config: { providerId: "bedrock" },
+	};
+}
+
+describe("Bedrock OpenAI reasoning request encoding", () => {
+	it("preserves provider-default effort and supported disable semantics", () => {
+		const modelId = "global.openai.gpt-6-astra";
+		const resolved = context(modelId, {
+			reasoningOptions: [
+				{ type: "effort", values: ["none", "default", "high"] },
+			],
+		});
+		const request: GatewayStreamRequest = {
+			providerId: "bedrock",
+			modelId,
+			messages: [],
+			reasoning: { enabled: true },
+		};
+		expect(composeAiSdkProviderOptions(request, resolved)).not.toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+		);
+		expect(
+			composeAiSdkProviderOptions(
+				{ ...request, reasoning: { enabled: false, effort: "high" } },
+				resolved,
+			),
+		).toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+			"none",
+		);
+	});
+
+	it("supports unlisted OpenAI IDs without inferring an effort from a token budget", () => {
+		const modelId = "global.openai.gpt-6-astra";
+		const resolved = context(modelId, {
+			capabilities: undefined,
+			reasoningOptions: undefined,
+		});
+		const request: GatewayStreamRequest = {
+			providerId: "bedrock",
+			modelId,
+			messages: [],
+			reasoning: { enabled: true },
+		};
+		expect(composeAiSdkProviderOptions(request, resolved)).toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+			"medium",
+		);
+		expect(
+			composeAiSdkProviderOptions(
+				{ ...request, reasoning: { enabled: true, budgetTokens: 2048 } },
+				resolved,
+			),
+		).not.toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+		);
+	});
+	it.each([
+		"openai.gpt-6-astra",
+		"global.openai.gpt-6-astra",
+		"us.openai.gpt-6-astra",
+		"eu.openai.gpt-6-astra",
+		"openai.gpt-oss-120b-1:0",
+	])("encodes %s without reasoningConfig for generation and streaming", async (modelId) => {
+		for (const streaming of [false, true]) {
+			let body: Record<string, unknown> | undefined;
+			const provider = createAmazonBedrock({
+				region: "us-east-1",
+				apiKey: "test-only",
+				fetch: async (_url, init) => {
+					body = JSON.parse(String(init?.body));
+					return streaming
+						? new Response(new Uint8Array(), {
+								headers: {
+									"content-type": "application/vnd.amazon.eventstream",
+								},
+							})
+						: new Response(
+								JSON.stringify({
+									output: {
+										message: { role: "assistant", content: [{ text: "ok" }] },
+									},
+									stopReason: "end_turn",
+									usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+									metrics: { latencyMs: 1 },
+								}),
+								{ headers: { "content-type": "application/json" } },
+							);
+				},
+			});
+			const request: GatewayStreamRequest = {
+				providerId: "bedrock",
+				modelId,
+				messages: [],
+				reasoning: { effort: "medium" },
+				maxTokens: 100,
+			};
+			const resolved = context(modelId);
+			const settings = buildAiSdkStreamConfig(request, resolved);
+			const options = {
+				...settings,
+				prompt: [
+					{
+						role: "user" as const,
+						content: [{ type: "text" as const, text: "hi" }],
+					},
+				],
+				providerOptions: composeAiSdkProviderOptions(
+					request,
+					resolved,
+				) as never,
+			};
+			if (streaming) {
+				const result = await provider(modelId).doStream(options);
+				await result.stream.cancel();
+			} else {
+				await provider(modelId).doGenerate(options);
+			}
+			expect(body).toHaveProperty(
+				"additionalModelRequestFields.reasoning_effort",
+				"medium",
+			);
+			expect(body?.additionalModelRequestFields).not.toHaveProperty(
+				"reasoningConfig",
+			);
+			expect(body).toHaveProperty("inferenceConfig.maxTokens", 100);
+			expect(settings).not.toHaveProperty("reasoning");
+		}
+	});
+
+	it.each([
+		undefined,
+		{},
+		{ enabled: false },
+		{ budgetTokens: 2048 },
+	] as const)("does not invent an effort for %o", (reasoning) => {
+		const modelId = "global.openai.gpt-6-astra";
+		const request: GatewayStreamRequest = {
+			providerId: "bedrock",
+			modelId,
+			messages: [],
+			reasoning,
+		};
+		expect(
+			composeAiSdkProviderOptions(request, context(modelId)),
+		).not.toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+		);
+	});
+
+	it("clamps enabled-only reasoning to the advertised effort", () => {
+		for (const modelId of [
+			"global.openai.gpt-6-astra",
+			"amazon.nova-2-lite-v1:0",
+		]) {
+			const request: GatewayStreamRequest = {
+				providerId: "bedrock",
+				modelId,
+				messages: [],
+				reasoning: { enabled: true },
+			};
+			const resolved = context(modelId, {
+				reasoningOptions: [{ type: "effort", values: ["high"] }],
+			});
+			if (modelId.startsWith("global.openai.")) {
+				expect(composeAiSdkProviderOptions(request, resolved)).toHaveProperty(
+					"bedrock.additionalModelRequestFields.reasoning_effort",
+					"high",
+				);
+			} else {
+				expect(resolvePortableReasoning(request, resolved)).toBe("high");
+			}
+		}
+	});
+
+	it.each([
+		"anthropic.claude-sonnet-4-6",
+		"custom-openai.model",
+		"arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/example",
+	])("does not reroute unrelated or opaque model %s", (modelId) => {
+		const request: GatewayStreamRequest = {
+			providerId: "bedrock",
+			modelId,
+			messages: [],
+			reasoning: { effort: "high" },
+		};
+		expect(resolvePortableReasoning(request, context(modelId))).toBe("high");
+		expect(
+			composeAiSdkProviderOptions(request, context(modelId)),
+		).not.toHaveProperty(
+			"bedrock.additionalModelRequestFields.reasoning_effort",
+		);
+	});
+
+	it("does not strip reasoning for other providers with incomplete capabilities", () => {
+		const request: GatewayStreamRequest = {
+			providerId: "custom-provider",
+			modelId: "openai.gpt-6-astra",
+			messages: [],
+			reasoning: { effort: "high" },
+		};
+		const resolved = context(request.modelId, {
+			capabilities: ["tools"],
+			reasoningOptions: undefined,
+		});
+		expect(normalizeReasoningRequest(request, resolved).reasoning?.effort).toBe(
+			"high",
+		);
+		expect(resolvePortableReasoning(request, resolved)).toBe("high");
+	});
+});

--- a/sdk/packages/llms/src/providers/bedrock-reasoning.test.ts
+++ b/sdk/packages/llms/src/providers/bedrock-reasoning.test.ts
@@ -88,6 +88,8 @@ describe("Bedrock OpenAI reasoning request encoding", () => {
 	it.each([
 		"openai.gpt-6-astra",
 		"global.openai.gpt-6-astra",
+		"Global.OpenAI.gpt-6-astra",
+		"OpenAI.gpt-6-astra",
 		"us.openai.gpt-6-astra",
 		"eu.openai.gpt-6-astra",
 		"openai.gpt-oss-120b-1:0",

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -25,7 +25,7 @@ export function isBedrockOpenAIRequest(
 	return (
 		request.providerId === "bedrock" &&
 		/^(?:(?:us|us-gov|eu|apac|jp|au|ca|sa|global)\.)?openai\./.test(
-			request.modelId,
+			normalizedModelId(request),
 		)
 	);
 }

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -13,6 +13,23 @@ const ACTIVE_REASONING_EFFORTS = REASONING_LEVELS.filter(
 	(level): level is ReasoningEffort => level !== "none",
 );
 
+/**
+ * Narrow fallback for Bedrock OpenAI IDs, including inference profiles.
+ * The AI SDK only recognizes bare `openai.` IDs when encoding reasoning.
+ * Keep this route independent of catalog membership so new/custom selections
+ * work; opaque ARNs and unrelated providers must not be inferred as OpenAI.
+ */
+export function isBedrockOpenAIRequest(
+	request: Pick<GatewayStreamRequest, "providerId" | "modelId">,
+): boolean {
+	return (
+		request.providerId === "bedrock" &&
+		/^(?:(?:us|us-gov|eu|apac|jp|au|ca|sa|global)\.)?openai\./.test(
+			request.modelId,
+		)
+	);
+}
+
 interface ModelReasoningControls {
 	effort?: Extract<ModelReasoningOption, { type: "effort" }>;
 	budget?: Extract<ModelReasoningOption, { type: "budget_tokens" }>;

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -5,6 +5,7 @@ import type {
 import type { CallSettings } from "ai";
 import {
 	getModelReasoningControls,
+	isBedrockOpenAIRequest,
 	normalizeReasoningEffort,
 } from "../model-facts";
 
@@ -107,7 +108,7 @@ export function resolvePortableReasoning(
 	context?: GatewayProviderContext,
 ): AiSdkReasoning | undefined {
 	const reasoning = request.reasoning;
-	if (!reasoning) {
+	if (!reasoning || isBedrockOpenAIRequest(request)) {
 		return undefined;
 	}
 	const fullySupported = PORTABLE_REASONING_PROVIDERS.has(request.providerId);
@@ -139,17 +140,8 @@ export function resolvePortableReasoning(
 		if (bedrockModelLacksReasoning(request, context)) {
 			return undefined;
 		}
-		if (request.providerId === "bedrock" && context) {
-			const reasoningOptions = context.model.reasoningOptions;
-			if (reasoningOptions !== undefined) {
-				if (reasoningOptions.length === 0) {
-					return undefined;
-				}
-				const controls = getModelReasoningControls(reasoningOptions);
-				if (!controls || controls.efforts.length === 0) {
-					return undefined;
-				}
-			}
+		if (request.providerId === "bedrock") {
+			return normalizeBedrockPortableEffort("medium", context);
 		}
 		return "medium";
 	}

--- a/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
+++ b/sdk/packages/llms/src/providers/routing/portable-reasoning.ts
@@ -1,5 +1,12 @@
-import type { GatewayStreamRequest } from "@cline/shared";
+import type {
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
 import type { CallSettings } from "ai";
+import {
+	getModelReasoningControls,
+	normalizeReasoningEffort,
+} from "../model-facts";
 
 export type AiSdkReasoning = NonNullable<CallSettings["reasoning"]>;
 
@@ -26,9 +33,78 @@ const NON_PORTABLE_REASONING_PROVIDERS = new Set([
 	"sapaicore",
 ]);
 
+/**
+ * Whether the resolved Bedrock model is known to lack reasoning support.
+ *
+ * `@ai-sdk/amazon-bedrock` unconditionally maps top-level reasoning into a
+ * native `reasoningConfig`/`reasoning_effort` field for every non-Anthropic
+ * model id — including models without reasoning support (Llama, Nova Pro,
+ * Titan, custom ids). Bedrock rejects those requests, so portable reasoning
+ * must be suppressed when the catalog explicitly reports no reasoning
+ * capability. Unknown/custom models (absent capabilities) fail open so
+ * reasoning-capable custom ids keep working.
+ */
+function bedrockModelLacksReasoning(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext | undefined,
+): boolean {
+	if (request.providerId !== "bedrock" || !context) {
+		return false;
+	}
+	const capabilities = context.model.capabilities;
+	if (capabilities === undefined) {
+		return false;
+	}
+	if (capabilities.includes("reasoning")) {
+		return false;
+	}
+	const reasoningOptions = context.model.reasoningOptions;
+	if (reasoningOptions !== undefined && reasoningOptions.length > 0) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Clamp a Bedrock effort to the model's advertised controls so catalog-known
+ * models (e.g. GPT-OSS with low/medium/high) never emit an unsupported level
+ * like `xhigh`/`max` that Bedrock rejects. Returns undefined when the model
+ * advertises no usable effort values. Unknown/custom models fail open.
+ */
+function normalizeBedrockPortableEffort(
+	effort: string,
+	context: GatewayProviderContext | undefined,
+): AiSdkReasoning | undefined {
+	const fallback: AiSdkReasoning =
+		effort === "max" ? "xhigh" : (effort as AiSdkReasoning);
+	if (!context) {
+		return fallback;
+	}
+	const reasoningOptions = context.model.reasoningOptions;
+	if (reasoningOptions === undefined) {
+		return fallback;
+	}
+	if (reasoningOptions.length === 0) {
+		return undefined;
+	}
+	const controls = getModelReasoningControls(reasoningOptions);
+	if (!controls || controls.efforts.length === 0) {
+		return undefined;
+	}
+	const normalized = normalizeReasoningEffort(
+		effort as Parameters<typeof normalizeReasoningEffort>[0],
+		controls.efforts,
+	);
+	if (!normalized) {
+		return undefined;
+	}
+	return normalized === "max" ? "xhigh" : (normalized as AiSdkReasoning);
+}
+
 /** Resolve reasoning intent owned by the AI SDK's portable top-level option. */
 export function resolvePortableReasoning(
 	request: GatewayStreamRequest,
+	context?: GatewayProviderContext,
 ): AiSdkReasoning | undefined {
 	const reasoning = request.reasoning;
 	if (!reasoning) {
@@ -36,7 +112,10 @@ export function resolvePortableReasoning(
 	}
 	const fullySupported = PORTABLE_REASONING_PROVIDERS.has(request.providerId);
 	if (reasoning.enabled === false) {
-		return fullySupported ? "none" : undefined;
+		if (!fullySupported) {
+			return undefined;
+		}
+		return bedrockModelLacksReasoning(request, context) ? undefined : "none";
 	}
 	if (typeof reasoning.budgetTokens === "number") {
 		return undefined;
@@ -45,12 +124,36 @@ export function resolvePortableReasoning(
 		if (NON_PORTABLE_REASONING_PROVIDERS.has(request.providerId)) {
 			return undefined;
 		}
+		if (bedrockModelLacksReasoning(request, context)) {
+			return undefined;
+		}
+		if (request.providerId === "bedrock") {
+			return normalizeBedrockPortableEffort(reasoning.effort, context);
+		}
 		return reasoning.effort === "max" ? "xhigh" : reasoning.effort;
 	}
-	return reasoning.enabled === true &&
+	if (
+		reasoning.enabled === true &&
 		!NON_PORTABLE_REASONING_PROVIDERS.has(request.providerId)
-		? "medium"
-		: undefined;
+	) {
+		if (bedrockModelLacksReasoning(request, context)) {
+			return undefined;
+		}
+		if (request.providerId === "bedrock" && context) {
+			const reasoningOptions = context.model.reasoningOptions;
+			if (reasoningOptions !== undefined) {
+				if (reasoningOptions.length === 0) {
+					return undefined;
+				}
+				const controls = getModelReasoningControls(reasoningOptions);
+				if (!controls || controls.efforts.length === 0) {
+					return undefined;
+				}
+			}
+		}
+		return "medium";
+	}
+	return undefined;
 }
 
 /**
@@ -59,6 +162,7 @@ export function resolvePortableReasoning(
  */
 export function withoutPortableReasoning(
 	request: GatewayStreamRequest,
+	context?: GatewayProviderContext,
 ): GatewayStreamRequest {
 	const normalizedRequest =
 		request.reasoning?.enabled === false &&
@@ -66,7 +170,7 @@ export function withoutPortableReasoning(
 			request.reasoning.budgetTokens !== undefined)
 			? { ...request, reasoning: { enabled: false } }
 			: request;
-	return resolvePortableReasoning(normalizedRequest)
+	return resolvePortableReasoning(normalizedRequest, context)
 		? { ...normalizedRequest, reasoning: undefined }
 		: normalizedRequest;
 }

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -2,6 +2,7 @@ import { isClineProvider } from "@cline/shared";
 import { OLLAMA_DEFAULT_CONTEXT_WINDOW } from "../builtins";
 import {
 	getModelReasoningControls,
+	isBedrockOpenAIRequest,
 	isDeepSeekFamily,
 	isGlmModel,
 	isKimiK26Family as isKimiK26FamilyFact,
@@ -502,6 +503,37 @@ const routedGlmReasoningRule: ProviderOptionRule = {
 		),
 };
 
+const bedrockOpenAIReasoningRule: ProviderOptionRule = {
+	id: "provider.bedrock.openai-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Bedrock OpenAI inference profiles use reasoning_effort, not reasoningConfig.",
+	applies: (input) => isBedrockOpenAIRequest(input.request),
+	suppresses: { genericFanout: true, genericThinking: true },
+	build: ({ request, context }) => {
+		const reasoning = request.reasoning;
+		const controls = getModelReasoningControls(context.model.reasoningOptions);
+		const effort =
+			reasoning?.enabled === false
+				? controls?.effort?.values.includes("none")
+					? "none"
+					: undefined
+				: (reasoning?.effort ??
+					(reasoning?.enabled === true &&
+					!controls &&
+					reasoning.budgetTokens === undefined
+						? "medium"
+						: undefined));
+		return effort
+			? {
+					bedrock: {
+						additionalModelRequestFields: { reasoning_effort: effort },
+					},
+				}
+			: undefined;
+	},
+};
+
 /**
  * The table is the provider/family behavior matrix. Adding a new exception
  * should mean adding a named rule here, not adding a branch in the composer.
@@ -509,6 +541,7 @@ const routedGlmReasoningRule: ProviderOptionRule = {
  * `sdk/packages/llms/AGENTS.md` for the sources-of-truth boundary.
  */
 export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
+	bedrockOpenAIReasoningRule,
 	directAnthropicProviderRule,
 	directGoogleProviderRule,
 	openAiAdapterRule,

--- a/sdk/packages/llms/src/providers/routing/provider-options.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.ts
@@ -74,7 +74,7 @@ export function composeAiSdkProviderOptions(
 	),
 ): Record<string, unknown> {
 	const normalizedRequest = normalizeReasoningRequest(
-		withoutPortableReasoning(request),
+		withoutPortableReasoning(request, context),
 		context,
 	);
 	const providerOptionsKey = toProviderOptionsKey(normalizedRequest.providerId);

--- a/sdk/packages/llms/src/providers/routing/reasoning-options.ts
+++ b/sdk/packages/llms/src/providers/routing/reasoning-options.ts
@@ -57,6 +57,19 @@ export function normalizeReasoningRequest(
 
 	const options = context.model.reasoningOptions;
 	if (options === undefined) {
+		// Catalog-known models without reasoning support (e.g. Bedrock Llama,
+		// Nova Pro/Lite/Micro) carry capabilities without "reasoning" and no
+		// reasoningOptions. Forwarding effort there makes Bedrock reject the
+		// request with a validation error, so strip it. Unknown/custom models
+		// (absent capabilities) fail open so reasoning-capable custom ids
+		// keep working.
+		const capabilities = context.model.capabilities;
+		if (
+			capabilities !== undefined &&
+			!capabilities.includes("reasoning")
+		) {
+			return { ...request, reasoning: undefined };
+		}
 		const modelId = request.modelId.toLowerCase();
 		if (
 			reasoning.enabled === false &&

--- a/sdk/packages/llms/src/providers/routing/reasoning-options.ts
+++ b/sdk/packages/llms/src/providers/routing/reasoning-options.ts
@@ -65,6 +65,7 @@ export function normalizeReasoningRequest(
 		// keep working.
 		const capabilities = context.model.capabilities;
 		if (
+			request.providerId === "bedrock" &&
 			capabilities !== undefined &&
 			!capabilities.includes("reasoning")
 		) {


### PR DESCRIPTION
### Related Issue

No linked Cline issue. Submitted under the small bug-fix exception in CONTRIBUTING.md.

### Description

Selecting GPT-6 Astra through Bedrock can fail with `unknown_parameter` and `Unknown parameter: reasoningConfig`. The installed AI SDK Bedrock adapter recognizes OpenAI models using `startsWith("openai.")`. An inference profile such as `global.openai.gpt-6-astra` misses that check and receives `reasoningConfig` instead of `reasoning_effort`.

Route bare and geographic/global OpenAI model IDs through a named provider-option rule that writes normalized `additionalModelRequestFields.reasoning_effort`. Omit portable reasoning for this route so the adapter cannot reconstruct the invalid field. Preserve GPT-OSS effort controls and leave opaque ARNs and other providers outside this fallback.

Also keep the Bedrock capability guard confined to Bedrock, and normalize enabled-only effort against the advertised values. The shared SDK change applies to hosts using this gateway; no UI changes are included.

### Test Procedure

Windows, Node 24.15.0, Bun 1.3.13:

- `cd sdk && bun -F @cline/llms test --maxWorkers=2`: 808 passed, 4 skipped.
- `cd sdk && bun -F @cline/llms typecheck`: passed.
- `cd sdk && bun run build:sdk`: passed for all SDK packages after restoring missing files in the local OpenTelemetry dependency.
- Biome check of all changed TypeScript files: passed.
- `bun run lint`: passed, with warnings and informational diagnostics in unchanged files.
- Repository pre-commit secret scan: passed.

The new tests intercept the real Bedrock adapter's HTTP requests for both generation and streaming. They assert `reasoning_effort`, absence of `reasoningConfig`, and preservation of the output-token limit. Cases cover bare/global/regional OpenAI IDs and GPT-OSS, advertised defaults and disable support, unlisted models, token budgets, Claude/opaque IDs, and non-Bedrock isolation. The global Astra request-body regression fails on upstream main and passes with this change.

An earlier unrestricted local suite run hit a five-second gateway test timeout. The isolated baseline check passed; the complete final suite passed with two workers. No test timeout was changed.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

The full-repository test checkbox remains unchecked: package tests and changed-file formatting passed, but the full monorepo test suite and extension-host tests were not run locally.

### Screenshots

Not applicable to the code change. The reported UI error was `unknown_parameter`, with `param: "reasoningConfig"` and `type: "invalid_request_error"`.

### Additional Notes

HTTP tests use a fake credential and intercepted requests. A live AWS invocation has not been performed, so this verifies request encoding rather than model availability or account permissions. Maintainer authorization is needed for external-contributor CI workflows, followed by maintainer review.
