### PR TITLE
fix(desktop): distinguish model names and separate ClinePass tiers CLINE-3230 CLINE-3231

### DIFF
--- a/apps/examples/desktop-app/webview/lib/featured-models.test.ts
+++ b/apps/examples/desktop-app/webview/lib/featured-models.test.ts
@@ -133,6 +133,35 @@ describe("buildModelPickerData", () => {
 		expect(options[0]?.section).toBeUndefined();
 	});
 
+	it.each([
+		"cline-pass",
+		"cline",
+		"other-provider",
+	])("distinguishes colliding names in the %s fallback without hiding model routes", (providerId) => {
+		const models = [
+			model("cline-pass/deepseek-v4-flash", "DeepSeek V4 Flash"),
+			model("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash"),
+			model("cline-pass/glm-5.3-flash", "GLM-5.3-Flash"),
+			model("z-ai/glm-5.3-flash", "GLM-5.3-Flash"),
+			model("cline-pass/kimi-k3", "Kimi K3"),
+		];
+		const { options } = buildModelPickerData(providerId, models);
+		expect(options).toHaveLength(models.length);
+		expect(new Set(options.map((option) => option.label)).size).toBe(
+			models.length,
+		);
+		for (const entry of models.slice(0, 4)) {
+			expect(options).toContainEqual({
+				label: `${entry.name} (${entry.id})`,
+				value: entry.id,
+			});
+		}
+		expect(options).toContainEqual({
+			label: "Kimi K3",
+			value: "cline-pass/kimi-k3",
+		});
+	});
+
 	it("renders other providers as a flat list with display names", () => {
 		const { options, sections } = buildModelPickerData("anthropic", [
 			model("claude-sonnet-4-6", "Claude Sonnet 4.6"),

--- a/apps/examples/desktop-app/webview/lib/featured-models.test.ts
+++ b/apps/examples/desktop-app/webview/lib/featured-models.test.ts
@@ -102,25 +102,50 @@ describe("buildModelPickerData", () => {
 		).toBe(false);
 	});
 
-	it("falls back to the full cline-pass catalog when the subscribed tier is empty", () => {
+	it("keeps subscription and free fallback models separated with a partial feed", () => {
 		const { options, sections } = buildModelPickerData("cline-pass", [
 			model("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash", {
 				tier: "free",
 				rank: 0,
 				tags: [],
 			}),
+			model("cline-pass/kimi-k3", "Kimi K3"),
 			model("nvidia/nemotron-ultra", "Nemotron Ultra"),
 		]);
 		expect(sections?.map((section) => section.id)).toEqual([
 			"subscribed",
 			"free",
-			"all",
 		]);
-		expect(options.map((option) => option.value)).toEqual([
-			"deepseek/deepseek-v4-flash",
-			"nvidia/nemotron-ultra",
+		expect(options.map((option) => [option.value, option.section])).toEqual([
+			["cline-pass/kimi-k3", "subscribed"],
+			["deepseek/deepseek-v4-flash", "free"],
+			["nvidia/nemotron-ultra", "free"],
 		]);
-		expect(options[1]?.section).toBe("all");
+	});
+
+	it("groups the offline ClinePass catalog without confusing identical model names", () => {
+		const { options, sections } = buildModelPickerData("cline-pass", [
+			model("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash"),
+			model("cline-pass/glm-5.3-flash", "GLM-5.3-Flash"),
+			model("cline-free/longcat-2.0", "LongCat 2.0 (free)"),
+			model("cline-pass/deepseek-v4-flash", "DeepSeek V4 Flash"),
+			model("z-ai/glm-5.3-flash", "GLM-5.3-Flash"),
+		]);
+		expect(sections?.map((section) => section.label)).toEqual([
+			"Subscribed",
+			"Free",
+		]);
+		expect(options.map((option) => [option.value, option.section])).toEqual([
+			["cline-pass/deepseek-v4-flash", "subscribed"],
+			["cline-pass/glm-5.3-flash", "subscribed"],
+			["deepseek/deepseek-v4-flash", "free"],
+			["z-ai/glm-5.3-flash", "free"],
+			["cline-free/longcat-2.0", "free"],
+		]);
+		expect(options[0]?.label).toBe("DeepSeek V4 Flash");
+		expect(options.slice(2).every((option) => option.badge === "Free")).toBe(
+			true,
+		);
 	});
 
 	it("falls back to a flat name-sorted list when nothing is featured", () => {
@@ -134,7 +159,6 @@ describe("buildModelPickerData", () => {
 	});
 
 	it.each([
-		"cline-pass",
 		"cline",
 		"other-provider",
 	])("distinguishes colliding names in the %s fallback without hiding model routes", (providerId) => {

--- a/apps/examples/desktop-app/webview/lib/featured-models.ts
+++ b/apps/examples/desktop-app/webview/lib/featured-models.ts
@@ -25,8 +25,20 @@ function byLabel(a: SearchComboboxOption, b: SearchComboboxOption): number {
 }
 
 function flatOptions(models: ProviderModel[]): SearchComboboxOption[] {
+	const labelCounts = new Map<string, number>();
+	for (const model of models) {
+		const label = displayName(model);
+		labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+	}
 	return models
-		.map((model) => ({ label: displayName(model), value: model.id }))
+		.map((model) => {
+			const label = displayName(model);
+			return {
+				label:
+					(labelCounts.get(label) ?? 0) > 1 ? `${label} (${model.id})` : label,
+				value: model.id,
+			};
+		})
 		.sort(byLabel);
 }
 

--- a/apps/examples/desktop-app/webview/lib/featured-models.ts
+++ b/apps/examples/desktop-app/webview/lib/featured-models.ts
@@ -66,7 +66,7 @@ function tierOptions(
  * applyClineFeaturedModels). The `cline` provider gets Recommended / Free /
  * All models; `cline-pass` gets Subscribed / Free only — its offer is exactly
  * those tiers, and stale catalog leftovers must not be advertised (the full
- * catalog only returns when the subscribed tier is empty, so a subscriber is
+ * catalog returns in the same two groups when the subscribed tier is empty, so a subscriber is
  * never limited to free models offline). Every other provider renders its
  * catalog as a flat list ordered by display name.
  */
@@ -110,22 +110,24 @@ export function buildModelPickerData(
 	if (providerId === "cline-pass") {
 		const subscribed = tierOptions(models, "subscribed", "subscribed");
 		const free = tierOptions(models, "free", "free", () => "Free");
-		if (subscribed.length === 0 && free.length === 0) {
-			return { options: flatOptions(models) };
+		if (subscribed.length === 0) {
+			// ClinePass catalogs contain subscription routes under cline-pass/
+			// plus the free feed overlay (cline-free/ or upstream IDs). Keep those
+			// groups separate offline too; live featured tiers remain authoritative.
+			const fallback = models.filter((model) => !model.featured);
+			subscribed.push(
+				...flatOptions(
+					fallback.filter((model) => model.id.startsWith("cline-pass/")),
+				).map((option) => ({ ...option, section: "subscribed" })),
+			);
+			free.push(
+				...flatOptions(
+					fallback.filter((model) => !model.id.startsWith("cline-pass/")),
+				).map((option) => ({ ...option, section: "free", badge: "Free" })),
+			);
 		}
-		const rest =
-			subscribed.length === 0
-				? models
-						.filter((model) => !model.featured)
-						.map((model) => ({
-							label: displayName(model),
-							section: "all",
-							value: model.id,
-						}))
-						.sort(byLabel)
-				: [];
 		return {
-			options: [...subscribed, ...free, ...rest],
+			options: [...subscribed, ...free],
 			sections: [
 				{ id: "subscribed", label: "Subscribed" },
 				{
@@ -133,9 +135,6 @@ export function buildModelPickerData(
 					id: "free",
 					label: "Free",
 				},
-				...(rest.length > 0
-					? [{ id: "all", label: "All models" } as SearchComboboxSection]
-					: []),
 			],
 		};
 	}

--- a/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
+++ b/sdk/packages/llms/src/catalog/catalog-cline-recommended.ts
@@ -103,9 +103,11 @@ export function normalizeClineRecommendedProviderModels(
 		// pickers end up rendering raw model ids for the Free section.
 		const entryName =
 			capabilities.name?.trim() || entry.name?.trim() || entry.id;
-		const name = entry.id.startsWith("cline-free/")
-			? `${entryName} (free)`
-			: entryName;
+		// The feed bucket determines free access, regardless of the ID namespace.
+		// Keep this visible even when a client has no featured-tier metadata.
+		const name = /\(free\)$/i.test(entryName)
+			? entryName
+			: `${entryName} (free)`;
 
 		const modelInfo = {
 			...capabilities,

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -564,7 +564,10 @@ describe("models-dev-catalog", () => {
 		);
 	});
 
-	it("labels a Cline free model when its name matches a ClinePass model", () => {
+	it.each([
+		"cline-free/deepseek-v4-flash",
+		"deepseek/deepseek-v4-flash",
+	])("labels a free model with ID %s when its name matches a ClinePass model", (freeId) => {
 		const result = normalizeClineRecommendedProviderModels(
 			{
 				clinePass: [
@@ -575,7 +578,7 @@ describe("models-dev-catalog", () => {
 				],
 				free: [
 					{
-						id: "cline-free/deepseek-v4-flash",
+						id: freeId,
 						name: "DeepSeek V4 Flash",
 					},
 				],
@@ -586,12 +589,10 @@ describe("models-dev-catalog", () => {
 		expect(result["cline-pass"]?.["cline-pass/deepseek-v4-flash"]?.name).toBe(
 			"DeepSeek V4 Flash",
 		);
-		expect(result["cline-pass"]?.["cline-free/deepseek-v4-flash"]?.name).toBe(
+		expect(result["cline-pass"]?.[freeId]?.name).toBe(
 			"DeepSeek V4 Flash (free)",
 		);
-		expect(result.cline?.["cline-free/deepseek-v4-flash"]?.name).toBe(
-			"DeepSeek V4 Flash (free)",
-		);
+		expect(result.cline?.[freeId]?.name).toBe("DeepSeek V4 Flash (free)");
 	});
 
 	it("resolves free-model capabilities by slug and preserves free-only Cline catalog payloads", () => {
@@ -699,14 +700,16 @@ describe("models-dev-catalog", () => {
 
 		expect(result.cline?.["deepseek/deepseek-v4-flash"]).toMatchObject({
 			id: "deepseek/deepseek-v4-flash",
-			name: "DeepSeek V4 Flash",
+			name: "DeepSeek V4 Flash (free)",
 			pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		});
 		expect(result.cline?.["poolside/laguna-s-2.1:free"]?.name).toBe(
 			"Laguna S 2.1 (free)",
 		);
 		// Without a catalog match, fall back to the endpoint-provided name.
-		expect(result.cline?.["unknown/mystery-model"]?.name).toBe("mystery-model");
+		expect(result.cline?.["unknown/mystery-model"]?.name).toBe(
+			"mystery-model (free)",
+		);
 	});
 
 	it("uses input limits as the model request context window", () => {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

Small bug fix; no linked issue.

### Description

The desktop model selector can show DeepSeek V4 Flash and GLM-5.3-Flash twice under ClinePass because subscription and free routes share a display name. Without featured-tier metadata, the flat picker makes them indistinguishable.

Label every entry from the free feed bucket with `(free)`, regardless of its ID namespace, without duplicating an existing suffix. Keep ClinePass models in Subscribed and Free sections even without live tier metadata, using the subscription route namespace and free overlay in its catalog. Preserve authoritative live tiers and their ordering. In other desktop flat lists, append the model ID only when display names collide, preserving distinct selectable routes.

### Test Procedure

- SDK build: `bun run build:sdk` passed.
- Catalog regression suite: 27 tests passed, covering both free ID namespaces and existing free suffixes.
- Desktop picker and composer regression suites: 42 tests passed, covering offline and partial-feed ClinePass grouping, live-tier filtering, and colliding names for other flat lists.
- Desktop `bun run typecheck` passed.
- Changed files formatted with Biome; `git diff --check` passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Example: a refreshed free route reads `DeepSeek V4 Flash (free)` alongside the subscription entry `DeepSeek V4 Flash`. Cached ClinePass entries with matching names remain separated by the Subscribed and Free section headings. Other flat provider lists show IDs when names collide.

<img width="966" height="416" alt="image" src="https://github.com/user-attachments/assets/88fb8343-c6c9-4408-94a9-022011d8e834" />


### Additional Notes

Validation used focused suites and the SDK build/desktop typecheck rather than the full monorepo test and lint commands. Live featured-tier filtering and model routing IDs are unchanged.
