### PR TITLE
ci(desktop): stop Tauri from skipping the DMG layout AppleScript on Actions

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -319,6 +319,12 @@ jobs:
           # Updater artifact signing (minisign keypair, independent of Apple)
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The DMG background, window size, and icon positions from
+          # tauri.conf.json are applied by a Finder AppleScript in Tauri's
+          # bundle_dmg.sh. When CI=true (always set on Actions) the bundler
+          # passes --skip-jenkins and silently skips that script, shipping a
+          # bare DMG. macOS runners have a GUI session, so opt out of the skip.
+          TAURI_BUNDLER_DMG_IGNORE_CI: "true"
 
       # Tauri lipos the main binary itself but sidecars are merged by our own
       # build-sidecar-bin.ts, so assert every Mach-O in the bundle really


### PR DESCRIPTION
### Related Issue

**Issue:** N/A. Follow-up to #13563, whose custom DMG install window has not appeared in any published build.

### Description

Since #13563 merged, every desktop release (v0.0.18 through v0.0.24) has shipped a macOS DMG with the stock Finder window: no background artwork, default icon layout. Nothing in the repo was lost. `tauri.conf.json` still has the `bundle.macOS.dmg` background/window/icon config, `beforeBuildCommand` still runs `bun run dmg:background`, and the v0.0.24 publish log shows `Generated src-tauri/dmg/background.gen.tiff.` followed by `Running bundle_dmg.sh`.

The cause is inside Tauri's DMG bundler (`crates/tauri-bundler/src/bundle/macos/dmg/mod.rs`, verified at the `tauri-cli-v2.11.4` tag that `bun.lock` pins):

```rust
if env::var_os("TAURI_BUNDLER_DMG_IGNORE_CI").unwrap_or_default() != "true" {
  if let Some(value) = env::var_os("CI") {
    if value == "true" {
      bundle_dmg_cmd.arg("--skip-jenkins");
    }
  }
}
```

GitHub Actions always sets `CI=true`, so the bundler passes `--skip-jenkins` to `bundle_dmg.sh`, which then skips the Finder AppleScript that applies the background, window size, and icon positions ("This will result in a DMG without any custom background or icons positioning"). The generated TIFF is validated and then never used. Tauri only surfaces the script's stdout on failure, so the skip message never appears in the Actions log.

This did not reproduce locally because `tauri build --ci` only suppresses prompts; it does not export `CI=true`, so the AppleScript ran on the author's machine and the DMG looked correct there.

The fix sets `TAURI_BUNDLER_DMG_IGNORE_CI: "true"` on the "Build, sign, and notarize desktop bundle" step. Tauri added that env var for exactly this case (tauri-apps/tauri#11799). GitHub-hosted macOS runners have a logged-in Finder session, so the AppleScript can run there, and `bundle_dmg.sh` already includes a pause/retry for the occasional "Can't get disk (-1728)" Finder flake. The beta channel uses the same build step, so it is covered too.

### Test Procedure

- Confirmed the root cause against the Tauri bundler source at the pinned CLI version and against the `desktop-v0.0.24` publish run log (TIFF generated, `bundle_dmg.sh` run, no visual applied).
- Parsed the edited workflow YAML and confirmed the new env value is the string `"true"`, which is what the bundler compares against.
- `git diff --check` passes.
- This only takes effect in the `PublishDesktop` job, so real verification happens on the next desktop release: mount the resulting DMG and confirm the background and icon layout from #13563 appear.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (workflow-only change).

### Additional Notes

If a Finder flake ever makes the AppleScript step fail on a runner, the publish job will fail loudly rather than ship a bare DMG, which is the preferable failure mode here.