### PR TITLE
fix(agents,core): nudge and count a reasoning-only turn instead of completing the run

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -330,6 +330,39 @@ describe("AgentRuntime", () => {
 		expect(JSON.stringify(assistant).split(data)).toHaveLength(2);
 	});
 
+	it("nudges a reasoning-only turn instead of completing the run", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{ type: "reasoning-delta", text: "thinking... cut mid-wo" },
+				{ type: "finish", reason: "stop" },
+			],
+			() => [
+				{ type: "text-delta", text: "Here is the answer." },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const turns: boolean[] = [];
+		const runtime = new AgentRuntime({ model });
+		runtime.subscribe((event) => {
+			if (event.type === "turn-finished") turns.push(event.emptyTurn === true);
+		});
+
+		const result = await runtime.run("Hi");
+
+		expect(result.status).toBe("completed");
+		expect(result.outputText).toBe("Here is the answer.");
+		expect(model.requests).toHaveLength(2);
+		expect(turns).toEqual([true, false]);
+		// user, reasoning-only assistant, nudge, answer
+		expect(result.messages.map((m) => m.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"assistant",
+		]);
+		expect(result.messages[2]?.metadata).toMatchObject({ userRunSpan: 0 });
+	});
+
 	it("fails a turn that hits the model output token limit before completion", async () => {
 		const logger = {
 			debug: vi.fn(),

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -51,6 +51,8 @@ import { nanoid } from "nanoid";
 
 const MAX_TOKENS_INCOMPLETE_TURN_MESSAGE =
 	"Model reached the maximum output token limit before completing the turn";
+const EMPTY_TURN_REMINDER_MESSAGE =
+	"[SYSTEM] Your previous turn ended without any visible response or tool call — reasoning alone is not shown to the user. Continue the task: call the next tool you need, or reply with your answer as text.";
 
 /**
  * Terminal message when a context-window overflow cannot be recovered because
@@ -423,6 +425,19 @@ function reasoningWasRequestedOff(request: AgentModelRequest): boolean {
 	return request.options?.thinking === false;
 }
 
+/** Non-whitespace text, a tool call, media, or provider-executed tool activity. */
+function hasVisibleContent(message: AgentMessage): boolean {
+	const activities = message.metadata?.modelToolActivities;
+	return (
+		message.content.some(
+			(part) =>
+				part.type !== "reasoning" &&
+				(part.type !== "text" || part.text.trim().length > 0),
+		) ||
+		(Array.isArray(activities) && activities.length > 0)
+	);
+}
+
 function textFromMessage(message: AgentMessage | undefined): string {
 	if (!message) {
 		return "";
@@ -789,12 +804,21 @@ export class AgentRuntime {
 				this.state.pendingToolCalls = toolCalls.map((part) => part.toolCallId);
 
 				if (toolCalls.length === 0) {
+					const emptyTurn = !hasVisibleContent(message);
 					await this.emit({
 						type: "turn-finished",
 						snapshot: this.snapshot(),
 						iteration: this.state.iteration,
 						toolCallCount: 0,
+						emptyTurn,
 					});
+					if (emptyTurn) {
+						// Reasoning-only (or whitespace-only) turn: the user sees
+						// nothing, so this is not a completion. Nudge and loop; the
+						// host counts it as a mistake via `emptyTurn` above.
+						await this.addUserReminderMessage(EMPTY_TURN_REMINDER_MESSAGE);
+						continue;
+					}
 					const completionReminderMessages =
 						this.getCompletionReminderMessages();
 					if (completionReminderMessages.length > 0) {

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -51,8 +51,8 @@ import { nanoid } from "nanoid";
 
 const MAX_TOKENS_INCOMPLETE_TURN_MESSAGE =
 	"Model reached the maximum output token limit before completing the turn";
-const EMPTY_TURN_REMINDER_MESSAGE =
-	"[SYSTEM] Your previous turn ended without any visible response or tool call — reasoning alone is not shown to the user. Continue the task: call the next tool you need, or reply with your answer as text.";
+const REASONING_ONLY_RESPONSE =
+	"Your previous turn ended without a response or tool call. Continue the task by calling the next tool you need or replying with an answer.";
 
 /**
  * Terminal message when a context-window overflow cannot be recovered because
@@ -816,7 +816,7 @@ export class AgentRuntime {
 						// Reasoning-only (or whitespace-only) turn: the user sees
 						// nothing, so this is not a completion. Nudge and loop; the
 						// host counts it as a mistake via `emptyTurn` above.
-						await this.addUserReminderMessage(EMPTY_TURN_REMINDER_MESSAGE);
+						await this.addUserReminderMessage(REASONING_ONLY_RESPONSE);
 						continue;
 					}
 					const completionReminderMessages =

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2468,6 +2468,29 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("counts empty (reasoning-only) turns as mistakes", async () => {
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: [
+				{ type: "turn-started", iteration: 1, snapshot: makeSnapshot() },
+				{
+					type: "turn-finished",
+					iteration: 1,
+					toolCallCount: 0,
+					emptyTurn: true,
+					snapshot: makeSnapshot(),
+				},
+			],
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({ execution: { maxConsecutiveMistakes: 2 } }),
+			deps,
+		);
+		await session.run("one");
+		expect(abortCalls).toHaveLength(0);
+		await session.continue("two");
+		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("serializes structured tool errors in mistake details", async () => {
 		const errors: string[] = [];
 		const { deps } = makeScriptedRuntime({

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1234,6 +1234,15 @@ export class SessionRuntime {
 					// Productive turn — reset the tracker so transient
 					// failures don't accumulate across unrelated turns.
 					this.mistakeTracker.reset();
+				} else if (event.emptyTurn) {
+					// The runtime nudges the model and loops; count it so a
+					// model that keeps returning nothing hits the limit.
+					this.enqueueMistakeRecord({
+						iteration: event.iteration,
+						reason: "invalid_tool_call",
+						details:
+							"Turn ended without a visible response or tool call (reasoning only)",
+					});
 				}
 				break;
 			}

--- a/sdk/packages/shared/src/agent.ts
+++ b/sdk/packages/shared/src/agent.ts
@@ -634,6 +634,8 @@ export type AgentRuntimeEvent =
 			snapshot: AgentRuntimeStateSnapshot;
 			iteration: number;
 			toolCallCount: number;
+			/** True when the turn produced nothing visible: no text, tool call, or media (e.g. reasoning only). */
+			emptyTurn?: boolean;
 	  }
 	| {
 			type: "status-notice";


### PR DESCRIPTION
### Related Issue

Follow-up to #13969. Supersedes #13165.

### Description

A desktop user's chat "just stopped" again after #13969 shipped. Their session ends on an assistant turn that is a thinking block cut off mid-word, with no text and no tool call, and the run went idle with no error.

This is not the mistake-limit path. `MistakeTracker` only counts failed tool calls and loop hard-stops. In `AgentRuntime`, a turn with no tool calls ends the run as `completed`, and a `reasoning` part counts as content, so a reasoning-only turn is a "successful" completion with empty output. (The AI SDK maps an unknown `finish_reason` to `other`, and `mapFinishReason` folds that into `stop`, so a provider-side truncation looks like a clean stop.)

Fix, treating it like a failed tool call:

- `AgentRuntime`: when a no-tool-call turn has nothing visible (no non-whitespace text, tool call, media, or model tool activity), mark `turn-finished` with `emptyTurn: true`, inject the `REASONING_ONLY_RESPONSE` reminder via the existing `addUserReminderMessage` path, and loop instead of completing.
- `SessionRuntime`: on an `emptyTurn` turn-finished, `enqueueMistakeRecord` (reason `invalid_tool_call`). A model that keeps doing it reaches the mistake limit and the host's `onConsecutiveMistakeLimitReached` (the desktop prompt from #13969), so the retry is bounded. There is no default `maxIterations` in core, so without this a model returning reasoning forever would loop until the user stops it.
- `emptyTurn?: boolean` added to the shared `turn-finished` event.

### Test Procedure

- agents: new test streams a reasoning-only turn then a text turn; asserts the run completes on the second turn, `turn-finished` reports `emptyTurn` `[true, false]`, and the transcript is user / reasoning-only assistant / nudge (`userRunSpan: 0`) / answer. 65/65.
- core: new orchestrator test feeds two `emptyTurn` turn-finished events with `maxConsecutiveMistakes: 2` and asserts the runtime is aborted on the second. 69/69.
- Typecheck clean for shared, agents, core. Biome clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjsGhbR3JgYZdU8thGoJQc
