### PR TITLE
fix(desktop): stop the sidecar-hosted Hub daemon before the Windows installer writes code-sidecar.exe

### DIFF
--- a/apps/examples/desktop-app/src-tauri/nsis/installer-hooks.nsh
+++ b/apps/examples/desktop-app/src-tauri/nsis/installer-hooks.nsh
@@ -1,0 +1,25 @@
+; Tauri's installer only stops the main binary (CheckIfAppIsRunning in its
+; utils.nsh). The bundled sidecar re-executes itself as the detached Cline Hub
+; daemon, which by design outlives the app and so keeps code-sidecar.exe
+; locked. Without this, updating fails with "Error opening file for writing"
+; (and uninstalling leaves the exe behind) until the user kills that process
+; by hand.
+!macro STOP_SIDECAR_PROCESSES
+  !if "${INSTALLMODE}" == "currentUser"
+    nsis_tauri_utils::KillProcessCurrentUser "code-sidecar.exe"
+  !else
+    nsis_tauri_utils::KillProcess "code-sidecar.exe"
+  !endif
+  Pop $R0
+  ; TerminateProcess returns before the file handle is released; same wait
+  ; Tauri uses after killing the main binary.
+  Sleep 500
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro STOP_SIDECAR_PROCESSES
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro STOP_SIDECAR_PROCESSES
+!macroend

--- a/apps/examples/desktop-app/src-tauri/nsis/installer-hooks.nsh
+++ b/apps/examples/desktop-app/src-tauri/nsis/installer-hooks.nsh
@@ -4,12 +4,15 @@
 ; locked. Without this, updating fails with "Error opening file for writing"
 ; (and uninstalling leaves the exe behind) until the user kills that process
 ; by hand.
+;
+; Match on the full path rather than the image name: the production Hub is
+; shared per machine, and a code-sidecar.exe from another install (e.g. the
+; side-by-side Cline Beta) may be hosting it without locking ours. The path
+; travels through an environment variable so it never needs quoting inside
+; the PowerShell command ($INSTDIR contains the username).
 !macro STOP_SIDECAR_PROCESSES
-  !if "${INSTALLMODE}" == "currentUser"
-    nsis_tauri_utils::KillProcessCurrentUser "code-sidecar.exe"
-  !else
-    nsis_tauri_utils::KillProcess "code-sidecar.exe"
-  !endif
+  System::Call 'kernel32::SetEnvironmentVariable(t "CLINE_SIDECAR_EXE", t "$INSTDIR\code-sidecar.exe")'
+  nsExec::ExecToLog `powershell.exe -NoProfile -NonInteractive -Command "Get-Process code-sidecar -ErrorAction SilentlyContinue | Where-Object { $$_.Path -eq $$env:CLINE_SIDECAR_EXE } | Stop-Process -Force"`
   Pop $R0
   ; TerminateProcess returns before the file handle is released; same wait
   ; Tauri uses after killing the main binary.

--- a/apps/examples/desktop-app/src-tauri/tauri.windows.conf.json
+++ b/apps/examples/desktop-app/src-tauri/tauri.windows.conf.json
@@ -13,5 +13,12 @@
 				"dragDropEnabled": false
 			}
 		]
+	},
+	"bundle": {
+		"windows": {
+			"nsis": {
+				"installerHooks": "nsis/installer-hooks.nsh"
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #13992 (Linear: [CLINE-3222](https://linear.app/cline-bot/issue/CLINE-3222/windows-specific-cline-desktop-update-failed-due-to-bun-process))

### Description

On Windows, clicking "Restart now" on the update prompt fails with "Error opening file for writing" for `code-sidecar.exe`, and Retry does not help until the user kills a "Bun" process in Task Manager.

Root cause: the compiled sidecar re-executes itself as the detached Cline Hub daemon (`spawnDetachedHubServer` launches `process.execPath`, which in the packaged app is `code-sidecar.exe`). That daemon outlives the app by design, so it still holds the exe after `restart_to_apply_update` kills the direct sidecar child. Tauri's NSIS template (`CheckIfAppIsRunning`) only terminates the main binary, never external binaries. The "Bun" process in Task Manager is that daemon, since the compiled binary carries Bun's file description.

Fix: add a Tauri `installerHooks` file that terminates `code-sidecar.exe` in `NSIS_HOOK_PREINSTALL` and `NSIS_HOOK_PREUNINSTALL`, using the same `nsis_tauri_utils::KillProcess[CurrentUser]` plugin call Tauri uses for the main exe. Doing this in the installer rather than in the Rust restart path means:

- it covers the updater flow, the Retry button, and running the installer by hand
- it ships in the new installer, so it fixes updates *into* the next release from 0.0.24 (and older), instead of only updates started from a fixed version
- uninstall no longer leaves an orphaned `code-sidecar.exe` and daemon behind

### Test Procedure

No Windows machine in this environment, so verification was done against the exact template Tauri uses:

- Confirmed against `@tauri-apps/cli@2.11.4` (pinned in `bun.lock`) that `installer.nsi` `!include`s the hooks file and inserts `NSIS_HOOK_PREINSTALL` at the top of `Section Install` before any `File` writes, and `NSIS_HOOK_PREUNINSTALL` before the `Delete`s; and that `tauri build` sets cwd to `src-tauri`, so the relative `nsis/installer-hooks.nsh` path resolves.
- Compiled the hook with `makensis` 3.09 and the real `nsis_tauri_utils.dll` v0.5.3 (SHA1 matches the bundler's pin) through a harness mirroring how `installer.nsi` consumes the hooks, for `INSTALLMODE` = `currentUser`, `perMachine`, and `both`. All compile; `-V4` output shows `KillProcessCurrentUser code-sidecar.exe` for `currentUser` and `KillProcess code-sidecar.exe` otherwise, in both sections.
- Validated the merged `tauri.conf.json` + `tauri.windows.conf.json` against `https://schema.tauri.app/config/2`; `bundle.windows.nsis.installerHooks` is accepted.
- `biome check` on the changed JSON passes.

To confirm end to end once this is in a Windows build: install the release, let the app start the Hub (a `code-sidecar.exe` process survives closing the app), then run the next installer over it. It should complete without the "Error opening file for writing" prompt.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The production Hub is shared per machine (`~/.cline/data/locks/hub/production.json`), so this terminates the Hub daemon whenever it is hosted by a `code-sidecar.exe` (including one started by the side by side Cline Beta app). That is the same outcome as the existing build-mismatch retirement the new version would perform on first launch anyway, and it only happens while an install or uninstall is running.