### PR TITLE
fix(desktop): let local-auth providers (Claude Code, Codex CLI) start sessions without an API key

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -47,6 +47,21 @@ describe("resolveCredentialError", () => {
 		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
 	});
 
+	it.each([
+		"claude-code",
+		"openai-codex-cli",
+	])("allows local-auth provider %s without an API key", (provider) => {
+		// Local CLI providers authenticate from the CLI's own credential
+		// store; the catalog marks them `local-auth` and the key is inert.
+		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
+	});
+
+	it("allows a catalog-declared OAuth provider outside the fallback id set", () => {
+		expect(
+			resolveCredentialError(makeConfig({ provider: "opencode" })),
+		).toBeNull();
+	});
+
 	it("treats provider ids case-insensitively", () => {
 		expect(
 			resolveCredentialError(makeConfig({ provider: "Cline-Pass" })),

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -1,3 +1,4 @@
+import { getProviderCollectionSync } from "@cline/llms/browser";
 import {
 	createSessionId,
 	type GeneratedMedia,
@@ -8,6 +9,7 @@ import type {
 	ChatSessionConfig,
 	ChatSessionStatus,
 } from "@/lib/chat-schema";
+import { normalizeProviderId } from "@/lib/provider-id";
 import type { SessionHistoryStatus } from "@/lib/session-history";
 import { OAUTH_MANAGED_PROVIDERS } from "./constants";
 
@@ -169,6 +171,14 @@ export function resolveCredentialError(
 		return "Provider is required before starting a chat session.";
 	}
 	if (OAUTH_MANAGED_PROVIDERS.has(providerId)) {
+		return null;
+	}
+	// OAuth and local-auth providers (Claude Code, Codex CLI) keep their
+	// credentials outside the webview config and never read an API key.
+	const capabilities = getProviderCollectionSync(
+		normalizeProviderId(providerId),
+	)?.provider.capabilities;
+	if (capabilities?.includes("oauth") || capabilities?.includes("local-auth")) {
 		return null;
 	}
 	if (config.apiKey.trim().length > 0) {


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-3238](https://linear.app/cline-bot/issue/CLINE-3238/claude-code-shows-configured-but-fails-to-work), [ENG-2466](https://linear.app/cline-bot/issue/ENG-2466/desktop-app-credential-gate-ignores-local-auth-blocks-claude-code-and)

### Description

Claude Code shows as Configured in the desktop app after clicking Connect, but sending a message fails with `Missing API key for provider "claude-code". Add credentials in Settings, or switch providers.`

The Configured badge became correct in #13407, which marked `claude-code` as `local-auth` in the provider catalog. But the webview's pre-flight gate `resolveCredentialError` (in `hooks/chat-session/helpers.ts`) only exempted a hardcoded OAuth id set (`cline`, `cline-pass`, `oca`, `openai-codex`) and demanded an `apiKey` for everything else. Local CLI providers authenticate from the CLI's own credential store and never read a key, so the session was refused before the sidecar was ever asked. This was called out as the known follow-up in that PR and is the same gap for `openai-codex-cli`.

The fix keeps the existing id-set fallback and additionally consults the catalog via `getProviderCollectionSync` from `@cline/llms/browser` (already used elsewhere in the webview): a provider whose capabilities include `oauth` or `local-auth` passes the gate without a key. This is the same capability signal `getProviderAuthKind` in `lib/provider-connection.ts` already uses to pick the connect UI, so the gate and the badge now agree.

### Test Procedure

- Added `resolveCredentialError` cases for `claude-code`, `openai-codex-cli`, and `opencode` (a catalog OAuth provider not in the fallback set). Against the previous `helpers.ts` all three fail with the exact error from the bug report; with the fix they pass.
- `vitest run webview/hooks webview/lib/provider-connection webview/components/views/onboarding`: 8 files, 142 tests pass.
- `tsc -p tsconfig.dev.json --noEmit` in `apps/examples/desktop-app` is clean; `biome check` on the changed files is clean.

What could break: API-key providers must still be blocked without a key, and OAuth providers in the fallback set must still pass. The existing tests for `anthropic` (blocked), `anthropic` with a key (allowed), and the four fallback OAuth ids (allowed) all still pass. Unknown provider ids return `undefined` from the catalog lookup and fall through to the API-key check exactly as before.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable (pre-flight gate logic; covered by unit tests above).

### Additional Notes

The user-facing error the gate produces is now reserved for providers that genuinely need a key. If a local-auth CLI is not actually logged in, that failure now surfaces from the provider itself at turn time instead of being pre-empted here.