### PR TITLE
fix(desktop): let Claude Code and Codex CLI start a chat without an API key

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -47,6 +47,15 @@ describe("resolveCredentialError", () => {
 		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
 	});
 
+	it.each([
+		"claude-code",
+		"openai-codex-cli",
+	])("allows local-CLI provider %s without an API key", (provider) => {
+		// These authenticate from the CLI's own credential store; Cline
+		// never holds a key for them.
+		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
+	});
+
 	it("treats provider ids case-insensitively", () => {
 		expect(
 			resolveCredentialError(makeConfig({ provider: "Cline-Pass" })),

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -51,8 +51,8 @@ describe("resolveCredentialError", () => {
 		"claude-code",
 		"openai-codex-cli",
 	])("allows local-CLI provider %s without an API key", (provider) => {
-		// These authenticate from the CLI's own credential store; Cline
-		// never holds a key for them.
+		// Resolved from the catalog's `localCliCommand` metadata, so a new
+		// local-auth provider is exempt without touching the webview.
 		expect(resolveCredentialError(makeConfig({ provider }))).toBeNull();
 	});
 

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -8,6 +8,7 @@ import type {
 	ChatSessionConfig,
 	ChatSessionStatus,
 } from "@/lib/chat-schema";
+import { LOCAL_AUTH_PROVIDER_IDS } from "@/lib/provider-connection";
 import type { SessionHistoryStatus } from "@/lib/session-history";
 import { OAUTH_MANAGED_PROVIDERS } from "./constants";
 
@@ -168,7 +169,10 @@ export function resolveCredentialError(
 	if (!providerId) {
 		return "Provider is required before starting a chat session.";
 	}
-	if (OAUTH_MANAGED_PROVIDERS.has(providerId)) {
+	if (
+		OAUTH_MANAGED_PROVIDERS.has(providerId) ||
+		LOCAL_AUTH_PROVIDER_IDS.has(providerId)
+	) {
 		return null;
 	}
 	if (config.apiKey.trim().length > 0) {

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -1,3 +1,4 @@
+import { resolveProviderLocalCli } from "@cline/llms/browser";
 import {
 	createSessionId,
 	type GeneratedMedia,
@@ -8,7 +9,6 @@ import type {
 	ChatSessionConfig,
 	ChatSessionStatus,
 } from "@/lib/chat-schema";
-import { LOCAL_AUTH_PROVIDER_IDS } from "@/lib/provider-connection";
 import type { SessionHistoryStatus } from "@/lib/session-history";
 import { OAUTH_MANAGED_PROVIDERS } from "./constants";
 
@@ -169,10 +169,12 @@ export function resolveCredentialError(
 	if (!providerId) {
 		return "Provider is required before starting a chat session.";
 	}
-	if (
-		OAUTH_MANAGED_PROVIDERS.has(providerId) ||
-		LOCAL_AUTH_PROVIDER_IDS.has(providerId)
-	) {
+	if (OAUTH_MANAGED_PROVIDERS.has(providerId)) {
+		return null;
+	}
+	// Local-CLI providers (Claude Code, Codex CLI) authenticate from the
+	// CLI's own credential store; Cline never holds a key for them.
+	if (resolveProviderLocalCli(providerId)) {
 		return null;
 	}
 	if (config.apiKey.trim().length > 0) {

--- a/apps/examples/desktop-app/webview/lib/provider-connection.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-connection.ts
@@ -16,16 +16,6 @@ export const OAUTH_PROVIDER_IDS = new Set([
 	"openai-codex",
 ]);
 
-/**
- * Providers that authenticate through their own CLI installed on this machine
- * (`local-auth` in the SDK catalog). Cline never holds a key for them, so the
- * chat pre-flight must not demand one.
- */
-export const LOCAL_AUTH_PROVIDER_IDS = new Set([
-	"claude-code",
-	"openai-codex-cli",
-]);
-
 export type ProviderAuthKind = "oauth" | "local" | "api-key";
 
 /**

--- a/apps/examples/desktop-app/webview/lib/provider-connection.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-connection.ts
@@ -16,6 +16,16 @@ export const OAUTH_PROVIDER_IDS = new Set([
 	"openai-codex",
 ]);
 
+/**
+ * Providers that authenticate through their own CLI installed on this machine
+ * (`local-auth` in the SDK catalog). Cline never holds a key for them, so the
+ * chat pre-flight must not demand one.
+ */
+export const LOCAL_AUTH_PROVIDER_IDS = new Set([
+	"claude-code",
+	"openai-codex-cli",
+]);
+
 export type ProviderAuthKind = "oauth" | "local" | "api-key";
 
 /**


### PR DESCRIPTION
### Related Issue

N/A (reported directly)

### Description

Connecting Claude Code in Settings persists a keyless entry and shows it as Configured, but sending a message with it failed immediately:

> Missing API key for provider "claude-code". Add credentials in Settings, or switch providers.

The webview runs a pre-flight credential gate (`resolveCredentialError`) before the request reaches the sidecar. It only exempted OAuth providers, so every `local-auth` provider (Claude Code, OpenAI Codex CLI) was blocked client-side even though the backend never needs a key for them: the spawned CLI authenticates from its own credential store, and the hub-side gateway already handles an empty `apiKey` for these providers.

Fix: add a `LOCAL_AUTH_PROVIDER_IDS` set next to the existing `OAUTH_PROVIDER_IDS` mirror in `webview/lib/provider-connection.ts` and exempt those ids in the gate. Three small edits plus a test case.

### Test Procedure

- Reproduced in the headless desktop setup (`dev:sidecar` + `dev:web`): Settings -> Model Providers -> Claude Code -> Connect shows Configured; picking Claude Code / Claude Sonnet in the composer and sending a message produced the "Missing API key" banner (screenshot below).
- With the fix, the same flow sends the message and the reply comes back from the Claude Code CLI. The hub daemon log shows `session.create ... provider: "claude-code", model: "sonnet"` and the AI SDK Claude Code warning about `maxOutputTokens`, confirming the turn went through the actual `claude` binary. (The test VM has no Claude login, so `claude` was pointed at an Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`; that only affects where the CLI sends its requests, not the desktop code path.)
- `vitest run webview/hooks/chat-session/helpers.test.ts webview/lib/provider-connection.test.ts`: 17 passed, including the new `claude-code` / `openai-codex-cli` cases.
- `tsc -p tsconfig.dev.json --noEmit` passes; biome check passes on the changed files.
- API-key providers are unaffected: the existing "blocks API-key providers without a key" test still passes and the gate logic for them is unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (Claude Code connected, send blocked by the webview gate):

![Missing API key banner for claude-code before the fix](https://cursor.com/artifacts/c/art-4e362e3b-0392-4bc5-994a-c1150c88432d)

After (same composer state, reply from the Claude Code CLI):

![Claude Code reply after the fix](https://cursor.com/artifacts/c/art-ca66d815-923b-4815-bca7-a7898d5fa082)

### Additional Notes

Keyless endpoint providers such as Ollama still hit the same gate when no key is entered; that is a separate, pre-existing gap and is not addressed here.