### PR TITLE
fix(desktop): show Codex-only model list for ChatGPT Subscription provider

### DIFF
--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -109,7 +109,9 @@ export async function handleDesktopCommand(
 		const provider = String(args?.provider ?? "").trim();
 		return await getLocalProviderModels(
 			provider,
-			providerSettingsManager.getProviderConfig(provider),
+			providerSettingsManager.getProviderConfig(provider, {
+				includeKnownModels: false,
+			}),
 		);
 	}
 	if (command === "save_provider_settings") {

--- a/apps/cline-hub/src/server/providers.ts
+++ b/apps/cline-hub/src/server/providers.ts
@@ -85,7 +85,9 @@ export async function loadModels(
 	if (!provider) return;
 	const payload = await getLocalProviderModels(
 		provider,
-		providerSettingsManager.getProviderConfig(provider),
+		providerSettingsManager.getProviderConfig(provider, {
+			includeKnownModels: false,
+		}),
 	);
 	const models: WebviewProviderModel[] = payload.models
 		.filter((model) =>

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1929,9 +1929,13 @@ export async function handleCommand(
 	}
 	if (command === "list_provider_models") {
 		const manager = new ProviderSettingsManager();
+		const provider = String(args?.provider ?? "").trim();
+		// Known models are merged in unfiltered after the provider's own model
+		// rules run, so including them here would leak e.g. the full OpenAI
+		// catalog into the ChatGPT Subscription (codex) picker.
 		return await getLocalProviderModels(
-			String(args?.provider ?? ""),
-			manager.getProviderConfig(String(args?.provider ?? "").trim()),
+			provider,
+			manager.getProviderConfig(provider, { includeKnownModels: false }),
 		);
 	}
 	if (command === "list_cline_recommended_models") {


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-3232](https://linear.app/cline-bot/issue/CLINE-3232/codex-subscription-plan-shows-wrong-model-list) (Codex subscription plan shows wrong model list)

### Description

In the desktop app, selecting the **OpenAI ChatGPT Subscription** (`openai-codex`) provider and opening the model picker showed the full OpenAI catalog (`chatgpt-image-latest`, GPT-4.1, GPT-4o, GPT-5, o3, ...) instead of the Codex-supported models.

Root cause: the `list_provider_models` path called `manager.getProviderConfig(provider)` with the default `includeKnownModels: true`. For `openai-codex`, `toProviderConfig` falls back to filling `knownModels` with the raw `openai-native` generated catalog (the two providers share a models.dev catalog key). `mergeKnownModels` then spreads `config.knownModels` in **after** `filterOpenAICodexModels` runs, so the unfiltered OpenAI list leaked into the picker.

The CLI already avoids this by passing `{ includeKnownModels: false }` on its model-listing path (`use-model-selector.tsx`), as does `local-provider-service.ts` internally. This PR applies the same option at the three equivalent model-listing call sites: the desktop sidecar `list_provider_models` command, and the hub's `list_provider_models` / `loadModels` handlers.

### Test Procedure

- Reproduced with a script that writes a signed-in `openai-codex` entry to a temp `providers.json` and calls `getLocalProviderModels("openai-codex", manager.getProviderConfig(...))`:
  - default options (old behavior): **34 models**, including `chatgpt-image-latest, gpt-4.1, gpt-4.1-mini, gpt-4o, gpt-4o-2024-08-06, ...` (matches the screenshot in the Linear issue)
  - `{ includeKnownModels: false }` (new behavior): **7 models**: `gpt-5.4, gpt-5.4-mini, gpt-5.5, gpt-5.6, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra`
- Ran the desktop app headlessly (`bun run dev:sidecar` + `bun run dev:web`) with a Codex provider configured, selected OpenAI ChatGPT Subscription, and opened the model picker: only the 7 Codex models are listed (screenshot below).
- `bun run typecheck` passes for `apps/cline-hub` and the desktop sidecar (`tsc -p tsconfig.dev.json --noEmit`); `biome check` is clean on the touched files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

After the fix, OpenAI ChatGPT Subscription model picker in the desktop UI:

![Codex model picker showing only GPT-5.4/5.5/5.6 models](https://cursor.com/artifacts/c/art-befad852-bbc9-4bfc-a978-4a9c288cab4d)

### Additional Notes

`knownModels` on the config produced by `toProviderConfig` is never user-supplied; it is only the bundled generated catalog, which `mergeKnownModels` already incorporates on its own. Dropping it on the listing path is therefore lossless for other providers and matches the CLI's behavior.