### PR TITLE
fix: Codex subscription model list and picker

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -724,13 +724,17 @@ describe("resolveProviderConfig", () => {
 		const openAiResolved = await resolveProviderConfig("openai-native");
 		const modelIds = Object.keys(resolved?.knownModels ?? {});
 
-		expect(modelIds).toEqual(expect.arrayContaining(["gpt-5.5", "gpt-5.4"]));
+		expect(modelIds).toEqual(
+			expect.arrayContaining(["gpt-5.5", "gpt-5.6-terra", "gpt-6-astra"]),
+		);
 		expect(modelIds).not.toContain("gpt-5.5-pro");
 		expect(modelIds).not.toContain("gpt-5.1-codex-max");
 		expect(modelIds).not.toContain("gpt-5.2-codex");
+		expect(modelIds).not.toContain("gpt-5.4");
+		expect(modelIds).not.toContain("gpt-5.4-mini");
 		expect(modelIds).not.toContain("gpt-5.4-nano");
+		expect(modelIds).not.toContain("gpt-5.6");
 		expect(modelIds).not.toContain("o3");
-		expect(resolved?.knownModels?.["gpt-5.4"]).toBeDefined();
 		expect(resolved?.knownModels?.["gpt-5.5"]).toEqual(
 			expect.objectContaining({
 				...openAiResolved?.knownModels?.["gpt-5.5"],
@@ -748,23 +752,24 @@ describe("resolveProviderConfig", () => {
 			{ cacheTtlMs: 1 },
 			{
 				providerId: "openai-codex",
-				modelId: "gpt-5.4",
+				modelId: "gpt-5.6-terra",
 				apiKey: "oauth-token",
 				accountId: "acct_123",
 			},
 		);
 
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(
-			expect.arrayContaining(["gpt-5.4", "gpt-5.4-mini", "gpt-5.5"]),
+			expect.arrayContaining(["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]),
 		);
-		expect(resolved?.knownModels?.["gpt-5.4-mini"]).toEqual(
+		expect(resolved?.knownModels?.["gpt-5.6-luna"]).toEqual(
 			expect.objectContaining({
-				name: "GPT-5.4 mini",
-				// catalog input cap scaled to the 95% effective Codex budget
+				name: "GPT-5.6 Luna",
+				// Codex backend caps, scaled to the 95% effective budget
 				maxInputTokens: 272_000 * 0.95,
 				contextWindow: 400_000,
 			}),
 		);
+		expect(resolved?.knownModels?.["gpt-5.4"]).toBeUndefined();
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
 	});
 });

--- a/sdk/packages/core/src/services/llms/provider-settings.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.test.ts
@@ -76,7 +76,9 @@ describe("provider settings", () => {
 		}).knownModels;
 		const modelIds = Object.keys(knownModels ?? {});
 
-		expect(modelIds).toEqual(expect.arrayContaining(["gpt-5.4", "gpt-5.5"]));
+		expect(modelIds).toEqual(
+			expect.arrayContaining(["gpt-5.5", "gpt-5.6-terra"]),
+		);
 		expect(modelIds).not.toContain("gpt-4o");
 		expect(modelIds).not.toContain("gpt-4.1");
 		expect(modelIds).not.toContain("chatgpt-image-latest");

--- a/sdk/packages/core/src/services/llms/provider-settings.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.test.ts
@@ -70,6 +70,23 @@ describe("provider settings", () => {
 		});
 	});
 
+	it("limits ChatGPT subscription known models to the Codex catalog", () => {
+		const knownModels = toProviderConfig({
+			provider: "openai-codex",
+		}).knownModels;
+		const modelIds = Object.keys(knownModels ?? {});
+
+		expect(modelIds).toEqual(expect.arrayContaining(["gpt-5.4", "gpt-5.5"]));
+		expect(modelIds).not.toContain("gpt-4o");
+		expect(modelIds).not.toContain("gpt-4.1");
+		expect(modelIds).not.toContain("chatgpt-image-latest");
+		expect(modelIds).not.toContain("gpt-5.4-nano");
+		expect(knownModels?.["gpt-5.5"]).toMatchObject({
+			contextWindow: 400_000,
+			maxInputTokens: 272_000 * 0.95,
+		});
+	});
+
 	it("keeps the provider default base URL when no apiLine is set", () => {
 		expect(toProviderConfig({ provider: "zai" })).toMatchObject({
 			baseUrl: "https://api.z.ai/api/paas/v4",

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -212,18 +212,8 @@ export function toProviderConfig(
 		unifiedReasoningLevel === "none" ? undefined : unifiedReasoningLevel;
 
 	const providerDefaults = OPENAI_COMPATIBLE_PROVIDERS[normalizedProviderId];
-	const catalogKnownModels = Object.assign(
-		{},
-		...Llms.resolveProviderModelCatalogKeys(normalizedProviderId).map(
-			(catalogKey) => Llms.getGeneratedModelsForProvider(catalogKey),
-		),
-	);
-	// The ChatGPT subscription backend shares the OpenAI API catalog but only
-	// serves a subset of it, with tighter context budgets.
 	const generatedKnownModels =
-		normalizedProviderId === BUILT_IN_PROVIDER.OPENAI_CODEX
-			? Llms.filterOpenAICodexModels(catalogKnownModels)
-			: catalogKnownModels;
+		Llms.getGeneratedModelsForRuntimeProvider(normalizedProviderId);
 	const generatedDefaultModelId = Object.keys(generatedKnownModels)[0];
 
 	const apiKey = getPersistedProviderApiKey(normalizedProviderId, settings);

--- a/sdk/packages/core/src/services/llms/provider-settings.ts
+++ b/sdk/packages/core/src/services/llms/provider-settings.ts
@@ -212,12 +212,18 @@ export function toProviderConfig(
 		unifiedReasoningLevel === "none" ? undefined : unifiedReasoningLevel;
 
 	const providerDefaults = OPENAI_COMPATIBLE_PROVIDERS[normalizedProviderId];
-	const generatedKnownModels = Object.assign(
+	const catalogKnownModels = Object.assign(
 		{},
 		...Llms.resolveProviderModelCatalogKeys(normalizedProviderId).map(
 			(catalogKey) => Llms.getGeneratedModelsForProvider(catalogKey),
 		),
 	);
+	// The ChatGPT subscription backend shares the OpenAI API catalog but only
+	// serves a subset of it, with tighter context budgets.
+	const generatedKnownModels =
+		normalizedProviderId === BUILT_IN_PROVIDER.OPENAI_CODEX
+			? Llms.filterOpenAICodexModels(catalogKnownModels)
+			: catalogKnownModels;
 	const generatedDefaultModelId = Object.keys(generatedKnownModels)[0];
 
 	const apiKey = getPersistedProviderApiKey(normalizedProviderId, settings);

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -76,6 +76,7 @@ export {
 	getClineNotSubscribedMessage,
 	getClineOrgIndividualInferenceSubscriptionMessage,
 	getClinePassSubscriptionUrl,
+	getGeneratedModelsForRuntimeProvider,
 	getRegisteredHandler,
 	getRegisteredHandlerAsync,
 	hasRegisteredHandler,

--- a/sdk/packages/llms/src/providers.ts
+++ b/sdk/packages/llms/src/providers.ts
@@ -1,4 +1,5 @@
 export {
+	getGeneratedModelsForRuntimeProvider,
 	isProviderApiLine,
 	OLLAMA_DEFAULT_CONTEXT_WINDOW,
 	type ProviderApiLine,

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -391,15 +391,26 @@ describe("built-in provider metadata", () => {
 		const modelIds = Object.keys(chatGptModels);
 
 		expect(modelIds).toEqual(
-			expect.arrayContaining(["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"]),
+			expect.arrayContaining([
+				"gpt-5.5",
+				"gpt-5.3-codex-spark",
+				"gpt-5.6-terra",
+				"gpt-5.6-luna",
+				"gpt-5.6-sol",
+				"gpt-6-astra",
+			]),
 		);
 		expect(modelIds).not.toContain("gpt-5.5-pro");
 		expect(modelIds).not.toContain("gpt-5.1-codex-max");
 		expect(modelIds).not.toContain("gpt-5.2");
 		expect(modelIds).not.toContain("gpt-5.2-codex");
 		expect(modelIds).not.toContain("gpt-5.3-codex");
-		expect(modelIds).not.toContain("gpt-5.3-codex-spark");
+		// Retired for ChatGPT accounts on 2026-08-31
+		expect(modelIds).not.toContain("gpt-5.4");
+		expect(modelIds).not.toContain("gpt-5.4-mini");
 		expect(modelIds).not.toContain("gpt-5.4-nano");
+		// Bare alias of gpt-5.6-sol
+		expect(modelIds).not.toContain("gpt-5.6");
 		expect(modelIds).not.toContain("o3");
 		expect(chatGptModels["gpt-5.5"]).toEqual(
 			expect.objectContaining({
@@ -410,11 +421,12 @@ describe("built-in provider metadata", () => {
 				maxTokens: 128_000,
 			}),
 		);
-		expect(chatGptModels["gpt-5.4"]).toEqual(
+		expect(chatGptModels["gpt-5.6-terra"]).toEqual(
 			expect.objectContaining({
-				name: "GPT-5.4",
-				maxInputTokens: expect.any(Number),
-				contextWindow: expect.any(Number),
+				name: "GPT-5.6 Terra",
+				maxInputTokens: 272_000 * 0.95,
+				contextWindow: 400_000,
+				maxTokens: 128_000,
 			}),
 		);
 	});

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	BUILTIN_PROVIDER_MANIFESTS_BY_ID,
 	BUILTIN_SPECS,
+	getGeneratedModelsForRuntimeProvider,
 	resolveProviderApiLineBaseUrl,
 } from "./builtins";
 import { getModelsForProvider, getProvider } from "./model-registry";
@@ -429,6 +430,22 @@ describe("built-in provider metadata", () => {
 				maxTokens: 128_000,
 			}),
 		);
+	});
+
+	it("applies the ChatGPT subscription filter to the shared OpenAI catalog", () => {
+		const openAiModelIds = Object.keys(
+			getGeneratedModelsForRuntimeProvider("openai-native"),
+		);
+		const chatGptModelIds = Object.keys(
+			getGeneratedModelsForRuntimeProvider("openai-codex"),
+		);
+
+		expect(openAiModelIds).toEqual(
+			expect.arrayContaining(["gpt-4o", "gpt-5.5", "o3"]),
+		);
+		expect(chatGptModelIds).toContain("gpt-5.5");
+		expect(chatGptModelIds).not.toContain("gpt-4o");
+		expect(chatGptModelIds).not.toContain("o3");
 	});
 
 	it("routes native Z.AI providers through GLM thinking metadata", async () => {

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -39,13 +39,14 @@ import {
 	isClineNotSubscribedMessage,
 	isClineOrgIndividualInferenceSubscriptionMessage,
 } from "./errors";
-import { normalizeProviderId } from "./ids";
+import { BUILT_IN_PROVIDER, normalizeProviderId } from "./ids";
 import { toGatewayModelCapabilities } from "./model-capabilities";
 import {
 	BUILTIN_MODEL_OPERATION_CAPABILITIES,
 	BUILTIN_TRANSCRIPTION_TRANSPORTS,
 } from "./model-operations";
 import { filterOpenAICodexModels } from "./openai-codex-models";
+import { resolveProviderModelCatalogKeys } from "./provider-keys";
 import { GENERATED_PROVIDER_SPECS } from "./providers.generated";
 import {
 	ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
@@ -448,6 +449,26 @@ function buildClaudeCodeModels(): Record<string, ModelInfo> {
 
 function buildOpenAICodexModels(): Record<string, ModelInfo> {
 	return filterOpenAICodexModels(generatedModels("openai-native"));
+}
+
+/**
+ * Generated catalog models a runtime provider reads from, with that provider's
+ * catalog rules applied. Most runtime providers read their mapped catalog(s)
+ * as-is; the ChatGPT subscription provider shares the OpenAI catalog but only
+ * serves a filtered subset of it.
+ */
+export function getGeneratedModelsForRuntimeProvider(
+	providerId: string,
+): Record<string, ModelInfo> {
+	const models: Record<string, ModelInfo> = Object.assign(
+		{},
+		...resolveProviderModelCatalogKeys(providerId).map((catalogKey) =>
+			getGeneratedModelsForProvider(catalogKey),
+		),
+	);
+	return providerId === BUILT_IN_PROVIDER.OPENAI_CODEX
+		? filterOpenAICodexModels(models)
+		: models;
 }
 
 // Vercel-only model ids surfaced for the Cline provider while the OpenRouter

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -61,7 +61,7 @@ export const DEFAULT_INTERNAL_OCA_BASE_URL =
 export const DEFAULT_EXTERNAL_OCA_BASE_URL =
 	"https://code.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
 const CLINE_PASS_PROVIDER_ID = "cline-pass";
-const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.6-terra";
 const NATIVE_WEB_SEARCH_MODEL_TOOL_CAPABILITIES: readonly GatewayModelToolCapability[] =
 	[{ name: "web_search" }];
 const OPENAI_NATIVE_MODEL_TOOL_CAPABILITIES: readonly GatewayModelToolCapability[] =

--- a/sdk/packages/llms/src/providers/openai-codex-models.test.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.test.ts
@@ -26,18 +26,26 @@ function filterOne(
 describe("filterOpenAICodexModels", () => {
 	describe("model eligibility", () => {
 		it.each([
-			["gpt-5.4", true],
-			["gpt-5.5", true],
-			["gpt-5.5-codex", true],
-			["gpt-6.0", true],
-			["gpt-10.1", true],
-		])("allows %s (newer than 5.3)", (id, allowed) => {
-			expect(filterOne(id) !== undefined).toBe(allowed);
+			["gpt-5.5", "explicitly allowed"],
+			["gpt-5.3-codex-spark", "explicitly allowed"],
+			["gpt-5.5-codex", "newer than 5.4"],
+			["gpt-5.6-terra", "newer than 5.4"],
+			["gpt-5.10", "minor version compared numerically"],
+			["gpt-6-astra", "integer major version"],
+			["gpt-6.0", "newer major version"],
+			["gpt-10.1", "newer major version"],
+		])("allows %s (%s)", (id) => {
+			expect(filterOne(id)).toBeDefined();
 		});
 
 		it.each([
-			["gpt-5.3", "at the 5.3 cutoff"],
-			["gpt-5.1", "older than 5.3"],
+			["gpt-5.4", "retired for ChatGPT accounts"],
+			["gpt-5.4-mini", "retired for ChatGPT accounts"],
+			["gpt-5.6", "bare alias of the Sol variant"],
+			["gpt-5.5-pro", "explicitly disallowed"],
+			["gpt-5.3", "older than 5.4"],
+			["gpt-5.3-codex", "older than 5.4"],
+			["gpt-5.1", "older than 5.4"],
 			["gpt-4.1", "older major version"],
 			["gpt-5", "no minor version"],
 			["chatgpt-5.5", "id does not start with gpt-"],
@@ -62,10 +70,10 @@ describe("filterOpenAICodexModels", () => {
 
 	describe("context window adjustment", () => {
 		it.each([
-			"gpt-5.4",
-			"gpt-5.4-mini",
+			"gpt-5.5",
+			"gpt-5.6-terra",
 			"gpt-6.0",
-		])("scales %s maxInputTokens down to the effective Codex budget — the backend cap applies to every model, not just gpt-5.5", (id) => {
+		])("scales %s maxInputTokens down to the effective Codex budget", (id) => {
 			const maxInputTokens = 200_000;
 			const result = filterOne(id, { maxInputTokens });
 			expect(result?.maxInputTokens).toBe(
@@ -73,24 +81,10 @@ describe("filterOpenAICodexModels", () => {
 			);
 		});
 
-		it("leaves other limits untouched for non-5.5 models", () => {
-			const result = filterOne("gpt-6.0", {
-				contextWindow: 500_000,
-				maxTokens: 64_000,
-			});
-			expect(result?.contextWindow).toBe(500_000);
-			expect(result?.maxTokens).toBe(64_000);
-		});
-
-		it("preserves an undefined maxInputTokens instead of producing NaN", () => {
-			const result = filterOne("gpt-6.0", { maxInputTokens: undefined });
-			expect(result?.maxInputTokens).toBeUndefined();
-		});
-
-		it("overrides gpt-5.5 limits with the ChatGPT backend caps", () => {
-			const result = filterOne("gpt-5.5-codex", {
-				contextWindow: 1_000_000,
-				maxInputTokens: 900_000,
+		it("caps limits at the ChatGPT backend budget when the API catalog advertises more", () => {
+			const result = filterOne("gpt-5.6-terra", {
+				contextWindow: 1_050_000,
+				maxInputTokens: 922_000,
 				maxTokens: 900_000,
 			});
 			expect(result).toMatchObject({
@@ -98,6 +92,30 @@ describe("filterOpenAICodexModels", () => {
 				maxInputTokens: 272_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 				maxTokens: 128_000,
 			});
+		});
+
+		it("keeps smaller catalog limits untouched", () => {
+			const result = filterOne("gpt-5.3-codex-spark", {
+				contextWindow: 128_000,
+				maxInputTokens: 100_000,
+				maxTokens: 32_000,
+			});
+			expect(result).toMatchObject({
+				contextWindow: 128_000,
+				maxInputTokens: 100_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+				maxTokens: 32_000,
+			});
+		});
+
+		it("preserves undefined limits instead of producing NaN", () => {
+			const result = filterOne("gpt-6.0", {
+				contextWindow: undefined,
+				maxInputTokens: undefined,
+				maxTokens: undefined,
+			});
+			expect(result?.contextWindow).toBeUndefined();
+			expect(result?.maxInputTokens).toBeUndefined();
+			expect(result?.maxTokens).toBeUndefined();
 		});
 
 		it("does not mutate the input models", () => {
@@ -111,12 +129,16 @@ describe("filterOpenAICodexModels", () => {
 	it("keeps allowed models and drops disallowed ones from a mixed catalog", () => {
 		const models: Record<string, ModelInfo> = {
 			"gpt-5.5": makeModel("gpt-5.5"),
+			"gpt-5.4": makeModel("gpt-5.4"),
+			"gpt-5.6": makeModel("gpt-5.6"),
+			"gpt-5.6-sol": makeModel("gpt-5.6-sol"),
 			"gpt-6.0": makeModel("gpt-6.0"),
 			"gpt-5.1": makeModel("gpt-5.1"),
 			"o4-mini": makeModel("o4-mini", { family: "o4" }),
 		};
 		expect(Object.keys(filterOpenAICodexModels(models)).sort()).toEqual([
 			"gpt-5.5",
+			"gpt-5.6-sol",
 			"gpt-6.0",
 		]);
 	});

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -9,7 +9,31 @@ import type { ModelInfo } from "../catalog/types";
  */
 export const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 0.95;
 
-const GPT_VERSION_REGEX = /^gpt-(\d+\.\d+)/;
+/**
+ * Codex serves a 400K context / 272K input / 128K output budget regardless of
+ * what the OpenAI API catalog advertises for the same model (the API lists
+ * 1.05M for GPT-5.5+). Mirrors the Codex CLI so context tracking stays
+ * consistent across clients.
+ */
+const CODEX_CONTEXT_WINDOW = 400_000;
+const CODEX_MAX_INPUT_TOKENS = 272_000;
+const CODEX_MAX_OUTPUT_TOKENS = 128_000;
+
+/**
+ * Eligibility mirrors opencode's ChatGPT-plan rules for the shared OpenAI
+ * catalog: an explicit allow/deny list plus a "newer than GPT-5.4" version
+ * rule. GPT-5.4 and GPT-5.4 mini were retired for ChatGPT accounts on
+ * 2026-08-31 (replacements: GPT-5.6 Terra and GPT-5.6 Luna).
+ *
+ * REF: https://github.com/anomalyco/opencode/blob/v2/packages/core/src/plugin/provider/openai.ts
+ * REF: https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan
+ */
+const OPENAI_CODEX_ALLOWED_MODELS = new Set(["gpt-5.5", "gpt-5.3-codex-spark"]);
+// `gpt-5.6` is the API alias for the Sol variant; Codex only serves the named
+// GPT-5.6 variants.
+const OPENAI_CODEX_DISALLOWED_MODELS = new Set(["gpt-5.5-pro", "gpt-5.6"]);
+
+const GPT_VERSION_REGEX = /^gpt-(\d+)(?:\.(\d+))?/;
 
 function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	// O, pro, and nano variants are not supported
@@ -22,31 +46,29 @@ function isOpenAICodexAllowedModel(id: string, model: ModelInfo): boolean {
 	) {
 		return false;
 	}
-	// Must be newer than 5.3
+	if (OPENAI_CODEX_ALLOWED_MODELS.has(id)) return true;
+	if (OPENAI_CODEX_DISALLOWED_MODELS.has(id)) return false;
+	// Must be newer than 5.4; an omitted minor version is zero (e.g. gpt-6-astra)
 	const match = id.match(GPT_VERSION_REGEX);
-	return match ? Number.parseFloat(match[1]) > 5.3 : false;
+	if (!match) return false;
+	const major = Number(match[1]);
+	const minor = Number(match[2] ?? 0);
+	return major > 5 || (major === 5 && minor > 4);
 }
 
-/**
- * Applies the effective input budget to every allowed model. GPT-5.5
- * additionally gets hardcoded limits because the ChatGPT/Codex backend
- * enforces a 272K input / 128K output cap that is lower than what the
- * generated OpenAI API catalog reports.
- */
-function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
-	if (id.includes("gpt-5.5")) {
-		return {
-			...model,
-			contextWindow: 400_000,
-			maxInputTokens: 272_000 * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
-			maxTokens: 128_000,
-		};
-	}
+function toOpenAICodexModel(model: ModelInfo): ModelInfo {
 	return {
 		...model,
+		contextWindow: model.contextWindow
+			? Math.min(model.contextWindow, CODEX_CONTEXT_WINDOW)
+			: model.contextWindow,
 		maxInputTokens: model.maxInputTokens
-			? model.maxInputTokens * CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT
+			? Math.min(model.maxInputTokens, CODEX_MAX_INPUT_TOKENS) *
+				CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT
 			: model.maxInputTokens,
+		maxTokens: model.maxTokens
+			? Math.min(model.maxTokens, CODEX_MAX_OUTPUT_TOKENS)
+			: model.maxTokens,
 	};
 }
 
@@ -56,7 +78,7 @@ export function filterOpenAICodexModels(
 	const result: Record<string, ModelInfo> = {};
 	for (const [id, model] of Object.entries(models)) {
 		if (isOpenAICodexAllowedModel(id, model)) {
-			result[id] = toOpenAICodexModel(id, model);
+			result[id] = toOpenAICodexModel(model);
 		}
 	}
 	return result;

--- a/sdk/packages/llms/src/tests/live-providers.openai-codex.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.openai-codex.example.json
@@ -4,7 +4,7 @@
 		"openai-codex": {
 			"settings": {
 				"provider": "openai-codex",
-				"model": "gpt-5.4",
+				"model": "gpt-5.6-terra",
 				"headers": {
 					"originator": "cline-live-test",
 					"session_id": "llms-live-openai-codex",

--- a/sdk/packages/llms/src/tests/live-providers.openai-codex.reasoning.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.openai-codex.reasoning.example.json
@@ -4,7 +4,7 @@
 		"openai-codex-reasoning": {
 			"settings": {
 				"provider": "openai-codex",
-				"model": "gpt-5.4",
+				"model": "gpt-5.6-terra",
 				"headers": {
 					"originator": "cline-live-test",
 					"session_id": "llms-live-openai-codex-reasoning",


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-3232](https://linear.app/cline-bot/issue/CLINE-3232/codex-subscription-plan-shows-wrong-model-list)

### Description

Selecting the "OpenAI ChatGPT Subscription" (`openai-codex`) provider in the desktop app showed the full OpenAI API catalog in the model picker (`chatgpt-image-latest`, `gpt-4.1`, `gpt-4o`, `o3`, ...) instead of the Codex-only list. Two commits:

**1. Stop the picker from overwriting the Codex list (`@cline/core`)**

`toProviderConfig` builds `knownModels` from the generated catalog keys for the provider. `openai-codex` intentionally shares the `openai-native` catalog, but that raw catalog was never run through `filterOpenAICodexModels`. The desktop sidecar and the hub both call `getLocalProviderModels(provider, manager.getProviderConfig(provider))`, and the unfiltered `config.knownModels` wins in `mergeKnownModels`, overwriting the correct registry list. The same config feeds the runtime handler, so the Codex context caps were also dropped. Fix: apply `filterOpenAICodexModels` to the config-derived catalog for `openai-codex`.

**2. Align the Codex rules with opencode / OpenAI (`@cline/llms`)**

Our filter was originally a port of opencode's ChatGPT-plan rules and had drifted. Mirrors [opencode `v2` `plugin/provider/openai.ts`](https://github.com/anomalyco/opencode/blob/v2/packages/core/src/plugin/provider/openai.ts) as of today:

- Drop `gpt-5.4` and `gpt-5.4-mini`. OpenAI retired them for ChatGPT accounts in Codex on 2026-08-31 ([help article](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan), "What happens to GPT-5.4 and GPT-5.4 mini in Codex?"); opencode confirmed the backend now rejects them ([#48141](https://github.com/anomalyco/opencode/pull/48141)).
- Move the provider default from `gpt-5.4` to `gpt-5.6-terra`, OpenAI's stated replacement. A retired default would also be re-injected into the list as a fallback model.
- Compare GPT versions by major/minor so integer versions (`gpt-6-astra`) and multi-digit minors are not dropped by `parseFloat` (opencode [#47384](https://github.com/anomalyco/opencode/pull/47384), [#47385](https://github.com/anomalyco/opencode/pull/47385)).
- Explicit allow list `gpt-5.5`, `gpt-5.3-codex-spark`; explicit deny `gpt-5.5-pro` and the bare `gpt-5.6` alias of the Sol variant.
- Cap every Codex model at the 400K context / 272K input / 128K output backend budget instead of only `gpt-5.5`, so GPT-5.6+ no longer inherits the API's 1.05M limits (the 95% effective-input factor is kept).

Resulting list: `gpt-5.3-codex-spark, gpt-5.5, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra, gpt-6-astra`.

### Test Procedure

- New `toProviderConfig` test asserts the Codex config excludes the OpenAI API models and carries the Codex caps. Fails on `main`, passes here.
- Rewrote `openai-codex-models.test.ts` for the new rules (retired 5.4s, bare `gpt-5.6`, integer major versions, cap behaviour, smaller catalog limits preserved). Updated the registry and `resolveProviderConfig` tests accordingly.
- Reproduced the exact sidecar path (`getLocalProviderModels("openai-codex", toProviderConfig(settings))`) in a scratch script. Before: 33 models including the OpenAI API list from the screenshot. After: the 6 models above, default `gpt-5.6-terra`.
- `@cline/llms` full suite: 795 passed (1 pre-existing Bedrock failure unrelated to this change, also fails on `main`). `@cline/core` `services/llms`, `local-provider-service`, `provider-settings-manager`: 183 passed. `tsc` clean for `@cline/llms`; Biome clean on touched files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (sidecar `list_provider_models` path):

```
openai-codex picker models (33): chatgpt-image-latest, gpt-4.1, gpt-4.1-mini, gpt-4o, gpt-4o-2024-08-06, gpt-4o-2024-11-20, gpt-4o-mini, gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-pro, gpt-5.1, gpt-5.2, gpt-5.2-pro, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro, gpt-5.5, gpt-5.5-pro, gpt-5.6, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra, gpt-6-astra, gpt-image-1-mini, gpt-image-1.5, gpt-image-2, gpt-realtime-2.1, o3, o3-pro
```

After:

```
default model: gpt-5.6-terra
openai-codex picker models (6): gpt-5.3-codex-spark, gpt-5.5, gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra, gpt-6-astra
```

### Additional Notes

- `gpt-5.3-codex-spark` was deliberately removed from our list in #11342 based on the Codex app menu at the time. opencode keeps it allowed and verified it still works against the Codex endpoint with a ChatGPT credential on 2026-09-09, so it is back in. Easy to drop again if we prefer to follow the Codex app menu.
- Users with `openai-codex` settings still pinned to `gpt-5.4` / `gpt-5.4-mini` will get a backend error until they pick a new model; that is the same behaviour as the Codex CLI.
- The hub (`apps/cline-hub/src/server/providers.ts`) uses the same `getLocalProviderModels(provider, getProviderConfig(provider))` call, so the CLI picker benefits from the first commit too.