### PR TITLE
Use a URL to build requests

### DIFF
--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -90,6 +90,38 @@ function namesOf(data: ClineRecommendedModelsData) {
 }
 
 describe("fetchClineRecommendedModels", () => {
+	it("requests the same endpoint for host-only and endpoint-root bases", async () => {
+		for (const base of [BASE_URL, `${BASE_URL}/api/v1`]) {
+			let requested: string | undefined;
+			await fetchClineRecommendedModels({
+				baseUrl: base,
+				fetchImpl: (async (input: string) => {
+					requested = input;
+					return jsonResponse(ENDPOINT_PAYLOAD)(input);
+				}) as unknown as typeof fetch,
+				catalogLoader: async () => CATALOG,
+			});
+
+			expect(requested).toBe(
+				`${BASE_URL}/api/v1/ai/cline/recommended-models`,
+			);
+		}
+	});
+
+	it("falls back to plain concatenation when the base is not a parseable URL", async () => {
+		let requested: string | undefined;
+		await fetchClineRecommendedModels({
+			baseUrl: "not a url",
+			fetchImpl: (async (input: string) => {
+				requested = input;
+				return jsonResponse(ENDPOINT_PAYLOAD)(input);
+			}) as unknown as typeof fetch,
+			catalogLoader: async () => CATALOG,
+		});
+
+		expect(requested).toBe("not a url/api/v1/ai/cline/recommended-models");
+	});
+
 	it("resolves display names from the models catalog", async () => {
 		const data = await fetchClineRecommendedModels({
 			baseUrl: BASE_URL,

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -159,6 +159,18 @@ function getConfiguredApiBaseUrl(
 	}
 }
 
+const RECOMMENDED_MODELS_PATH = "/api/v1/ai/cline/recommended-models";
+
+function buildRecommendedModelsUrl(base: string): string {
+	try {
+		const url = new URL(base);
+		url.pathname = RECOMMENDED_MODELS_PATH;
+		return url.toString();
+	} catch {
+		return `${base}${RECOMMENDED_MODELS_PATH}`;
+	}
+}
+
 async function fetchWithTimeout(
 	fetchImpl: typeof fetch,
 	input: string,
@@ -282,13 +294,9 @@ export async function fetchClineRecommendedModels(
 	// promise resolves on a microtask, ahead of the zero-delay timer.
 	const deadline = Date.now() + timeoutMs;
 	try {
-		const base = getConfiguredApiBaseUrl(options);
+		const url = buildRecommendedModelsUrl(getConfiguredApiBaseUrl(options));
 		const fetchImpl = options.fetchImpl ?? fetch;
-		const resp = await fetchWithTimeout(
-			fetchImpl,
-			`${base}/api/v1/ai/cline/recommended-models`,
-			timeoutMs,
-		);
+		const resp = await fetchWithTimeout(fetchImpl, url, timeoutMs);
 		if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 		const json: unknown = await resp.json();
 		const data = normalizeResponse(json);


### PR DESCRIPTION
URLs should always be parseable, but it's a safeguard just in case. It's better to have an invalid value than to throw an unhandled error.

I'm opening this PR because I observed 401s in response to the endpoint `https://api.cline.bot/api/v1/api/v1/ai/cline/recommended-models` coming from the CLI.