### PR TITLE
test(llms): isolate Bedrock fallback cases from catalog updates

### DIFF
--- a/sdk/packages/llms/src/providers/vendors/bedrock.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/bedrock.test.ts
@@ -305,11 +305,9 @@ describe("resolveBedrockModelId", () => {
 	});
 
 	it("preserves the raw id when no catalog variant confirms the geo profile", () => {
-		// Pattern-matched profile-only models without a catalog-confirmed
-		// geographic variant are never prefixed on assumption: AWS documents
-		// profile availability per model and geography, so an unconfirmed id
-		// (e.g. eu.amazon.nova-lite-v1:0 or us-gov.anthropic.claude-sonnet-5)
-		// may not exist.
+		// Keep catalog absence explicit: generated catalogs can gain variants
+		// without changing the resolver's fallback contract.
+		const hasCatalogModel = () => false;
 		const cases: Array<[string, string | undefined]> = [
 			["amazon.nova-lite-v1:0", "eu-central-1"],
 			["amazon.nova-pro-v1:0", "us-east-1"],
@@ -319,11 +317,14 @@ describe("resolveBedrockModelId", () => {
 			["anthropic.claude-newtier-6", "us-east-1"],
 		];
 		for (const [modelId, region] of cases) {
-			expect(resolveBedrockModelId(modelId, { region })).toBe(modelId);
+			expect(resolveBedrockModelId(modelId, { region, hasCatalogModel })).toBe(
+				modelId,
+			);
 			expect(
 				resolveBedrockModelId(modelId, {
 					region,
 					useCrossRegionInference: true,
+					hasCatalogModel,
 				}),
 			).toBe(modelId);
 		}
@@ -501,6 +502,7 @@ describe("resolveBedrockModelId", () => {
 		expect(
 			resolveBedrockModelId("anthropic.claude-sonnet-4-6", {
 				region: "ap-southeast-1",
+				hasCatalogModel,
 			}),
 		).toBe("anthropic.claude-sonnet-4-6");
 	});


### PR DESCRIPTION
### Related Issue

Repairs SDK CI after #14001: [the same failure on current main](https://github.com/cline/cline/actions/runs/34427387548).

### Description

Make the Bedrock fallback tests independent of generated catalog contents. The catalog now includes `eu.amazon.nova-lite-v1:0`, so the test's assumption that no regional variant exists is stale and fails on both Windows and Ubuntu.

Supply the existing catalog probe explicitly in the missing-variant cases, including the APAC fixture. The tests still exercise the real resolver; production behavior is unchanged.

### Test Procedure

From the repository root:

```sh
bun -F @cline/llms test
bun -F @cline/llms typecheck
bun run biome check sdk/packages/llms/src/providers/vendors/bedrock.test.ts
```

On Windows with Node 24.16.0 and Bun 1.3.14: 798 tests passed, 4 live-provider tests skipped; typecheck and Biome passed. The focused Bedrock suite reproduced the upstream assertion failure on the clean base before this change and passes all 26 tests after it.

### Type of Change

- [x] Bug fix

### Pre-flight Checklist

- [x] Changes are limited to one test-fixture fix.
- [x] LLM tests pass; the changed file is formatted and linted.
