### PR TITLE
fix(llms): mark OpenCode provider as local-auth instead of oauth

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1234,17 +1234,19 @@ const BUILTIN_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "OpenCode",
 		description: "OpenCode SDK multi-provider runtime",
 		family: "opencode",
-		// local-auth: the provider spawns the local `opencode` server, which
-		// authenticates with whatever credentials `opencode auth login` stored
-		// on this machine. Cline has no OAuth flow for it, so tagging it
-		// "oauth" rendered a browser sign-in button that could not do anything.
+		// local-auth: the spawned `opencode` server authenticates from the
+		// credentials `opencode auth login` stores on this machine. Cline has
+		// no OAuth flow or API key for it.
 		capabilities: ["reasoning", "local-auth"],
 		defaultModelId: "openai/gpt-5.6-sol",
 		modelsProviderId: "opencode",
 		docsUrl: "https://opencode.ai/docs",
 		defaults: { baseUrl: "" },
 		configFields: [],
-		metadata: { localCliCommand: "opencode" },
+		metadata: {
+			// See `resolveProviderLocalCli`.
+			localCliCommand: "opencode",
+		},
 	},
 	{
 		id: "dify",

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1234,11 +1234,17 @@ const BUILTIN_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "OpenCode",
 		description: "OpenCode SDK multi-provider runtime",
 		family: "opencode",
-		capabilities: ["reasoning", "oauth"],
+		// local-auth: the provider spawns the local `opencode` server, which
+		// authenticates with whatever credentials `opencode auth login` stored
+		// on this machine. Cline has no OAuth flow for it, so tagging it
+		// "oauth" rendered a browser sign-in button that could not do anything.
+		capabilities: ["reasoning", "local-auth"],
 		defaultModelId: "openai/gpt-5.6-sol",
 		modelsProviderId: "opencode",
+		docsUrl: "https://opencode.ai/docs",
 		defaults: { baseUrl: "" },
 		configFields: [],
+		metadata: { localCliCommand: "opencode" },
 	},
 	{
 		id: "dify",

--- a/sdk/packages/llms/src/providers/local-cli.test.ts
+++ b/sdk/packages/llms/src/providers/local-cli.test.ts
@@ -16,6 +16,10 @@ describe("resolveProviderLocalCli", () => {
 			command: "claude",
 			docsUrl: "https://code.claude.com/docs/en/setup",
 		});
+		expect(resolveProviderLocalCli("opencode")).toEqual({
+			command: "opencode",
+			docsUrl: "https://opencode.ai/docs",
+		});
 	});
 
 	it("returns undefined for providers that name no local CLI", () => {


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-3236](https://linear.app/cline-bot/issue/CLINE-3236/fix-opencode-sign-in-button-and-oauth-labeling)

### Description

The `opencode` builtin declared the `oauth` capability, but Cline has no OAuth handler for it. The provider spawns the local `opencode` server, which authenticates from the credentials `opencode auth login` stores on the machine. Hosts route their connect UI off that capability, so the desktop app showed a "Sign in with browser" button that had nothing to call, and the CLI asked for an API key.

This is the same shape as Claude Code (#13407) and OpenAI Codex CLI: swap `oauth` for `local-auth`, and declare `metadata.localCliCommand: "opencode"` plus `docsUrl`. No host code changes; everything already keys off the capability:

- CLI: `resolveProviderSetupRoute` -> `local_cli`. The provider list reads "OpenCode (local CLI)", the setup screen probes `opencode --version`, and the settings entry is saved without a key.
- Desktop: `getProviderAuthKind` -> `local`. Settings shows the "Uses your local CLI sign-in" row with Connect / Disconnect.
- Core: `getProviderConfigFields("opencode")` -> `authMethod: "local"`, so readiness accepts a keyless entry. `resolveProviderLocalCli("opencode")` -> `{ command: "opencode", docsUrl }`.

### Test Procedure

Automated: `@cline/llms` `local-cli.test.ts` (new assertion) and `builtins.test.ts` pass; after `build:sdk`, `@cline/core` provider/auth tests (172) and `apps/cli` `local-cli.test.ts` + onboarding `model.test.ts` (16) pass; desktop `provider-connection.test.ts` + `provider-list-view.test.tsx` (19) pass. `tsc --noEmit` and biome clean.

Hands-on with the real CLI (`opencode-ai` 1.18.30, OpenRouter key read by OpenCode from the environment; Cline passes no key):
- CLI TUI (`bun run cli -i`, isolated `CLINE_DATA_DIR`): BYO -> "OpenCode (local CLI)" -> "OpenCode installed 1.18.30" -> model picker -> custom model id `openrouter/anthropic/claude-haiku-4.5` -> turn returns `opencode provider works`.
- CLI one-shot: `bun run cli -P opencode -m openrouter/anthropic/claude-haiku-4.5 "..."` returns `opencode provider works`.
- Desktop (headless `dev:sidecar` + `dev:web`): OpenCode panel shows the local CLI row; Connect flips the badge to Configured. OpenCode Go is unaffected (still API key).

Known follow-ups, outside this change:
- Desktop pre-flight `resolveCredentialError` still demands an API key for anything outside a hardcoded OAuth id set, so a desktop turn fails with "Missing API key" (same as Claude Code, CLINE-3238). #14007 fixes that generically off `local-auth`, which covers OpenCode with this PR.
- The OpenCode model list comes from the models.dev Zen record (bare ids like `claude-haiku-4.5`); the SDK provider needs `providerID/modelID`, so only custom ids work today (CLINE-3239). The CLI has the "Create custom model ID" escape hatch; the desktop's add-model flow fails with "baseUrl is required" for empty-base-URL builtins.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

CLI onboarding, OpenCode local CLI setup screen:

![CLI onboarding showing OpenCode installed 1.18.30 on the local CLI setup screen](https://cursor.com/artifacts/c/art-d617b7ea-01db-46f9-b288-be618b551f77)

Desktop settings, OpenCode provider before and after Connect:

![OpenCode provider panel showing the local CLI sign-in row with a Connect button](https://cursor.com/artifacts/c/art-e85d0ba1-5462-418b-8194-d52e54b4ba44)

![OpenCode provider panel showing Configured with a Disconnect button](https://cursor.com/artifacts/c/art-c73d3628-56e4-4458-9db6-65e6080d6203)