### PR TITLE
fix(core): strip regex lookaround patterns from MCP tool schemas

### DIFF
--- a/sdk/packages/core/src/extensions/mcp/tools.test.ts
+++ b/sdk/packages/core/src/extensions/mcp/tools.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { createMcpTools, stripLookaroundPatterns } from "./tools";
+import type { McpToolProvider } from "./types";
+
+// Emitted by Zod v4's z.email() (seen in resend-mcp); rejected by OpenAI with
+// "Invalid JSON schema: regex lookaround is not supported".
+const EMAIL_PATTERN =
+	"^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$";
+
+describe("stripLookaroundPatterns", () => {
+	it("drops lookaround patterns at any depth while keeping other keywords", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				email: {
+					type: "string",
+					format: "email",
+					pattern: EMAIL_PATTERN,
+					description: "Contact email address",
+				},
+				to: {
+					type: "array",
+					items: { type: "string", format: "email", pattern: EMAIL_PATTERN },
+				},
+				emails: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {
+							cc: { type: "array", items: { pattern: EMAIL_PATTERN } },
+						},
+					},
+				},
+				variant: {
+					anyOf: [{ type: "string", pattern: "(?<!x)y" }, { type: "null" }],
+				},
+			},
+			required: ["email"],
+		};
+
+		expect(stripLookaroundPatterns(schema)).toEqual({
+			type: "object",
+			properties: {
+				email: {
+					type: "string",
+					format: "email",
+					description: "Contact email address",
+				},
+				to: { type: "array", items: { type: "string", format: "email" } },
+				emails: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: { cc: { type: "array", items: {} } },
+					},
+				},
+				variant: { anyOf: [{ type: "string" }, { type: "null" }] },
+			},
+			required: ["email"],
+		});
+	});
+
+	it("keeps plain patterns and properties that happen to be named pattern", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				id: { type: "string", pattern: "^[a-z0-9-]+$" },
+				pattern: { type: "string", description: "glob to match" },
+			},
+		};
+
+		expect(stripLookaroundPatterns(schema)).toEqual(schema);
+	});
+});
+
+describe("createMcpTools", () => {
+	it("exposes MCP tool schemas without lookaround patterns", async () => {
+		const provider: McpToolProvider = {
+			listTools: async () => [
+				{
+					name: "create-contact",
+					inputSchema: {
+						type: "object",
+						properties: {
+							email: {
+								type: "string",
+								format: "email",
+								pattern: EMAIL_PATTERN,
+							},
+						},
+						required: ["email"],
+					},
+				},
+			],
+			callTool: async () => undefined,
+		};
+
+		const [tool] = await createMcpTools({ serverName: "resend", provider });
+		expect(tool?.inputSchema).toEqual({
+			type: "object",
+			properties: { email: { type: "string", format: "email" } },
+			required: ["email"],
+		});
+	});
+});

--- a/sdk/packages/core/src/extensions/mcp/tools.ts
+++ b/sdk/packages/core/src/extensions/mcp/tools.ts
@@ -13,6 +13,36 @@ function defaultMcpDescription(
 	return `Execute MCP tool "${tool.name}" from server "${serverName}".`;
 }
 
+const REGEX_LOOKAROUND = /\(\?<?[=!]/;
+
+/**
+ * OpenAI-backed models reject any request whose tool schemas contain a
+ * `pattern` using regex lookaround (e.g. Zod v4's `z.email()`), which blocks
+ * the whole conversation even when the tool is never called. `pattern` is only
+ * advisory to the model and the MCP server still validates arguments, so
+ * dropping just the offending patterns is lossless.
+ */
+export function stripLookaroundPatterns<T>(schema: T): T {
+	if (Array.isArray(schema)) {
+		return schema.map(stripLookaroundPatterns) as T;
+	}
+	if (!schema || typeof schema !== "object") {
+		return schema;
+	}
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (
+			key === "pattern" &&
+			typeof value === "string" &&
+			REGEX_LOOKAROUND.test(value)
+		) {
+			continue;
+		}
+		result[key] = stripLookaroundPatterns(value);
+	}
+	return result as T;
+}
+
 export async function createMcpTools(
 	options: CreateMcpToolsOptions,
 ): Promise<AgentTool[]> {
@@ -28,7 +58,7 @@ export async function createMcpTools(
 		return createTool({
 			name: agentToolName,
 			description: defaultMcpDescription(options.serverName, descriptor),
-			inputSchema: descriptor.inputSchema,
+			inputSchema: stripLookaroundPatterns(descriptor.inputSchema),
 			timeoutMs: options.timeoutMs,
 			retryable: options.retryable,
 			maxRetries: options.maxRetries,


### PR DESCRIPTION
### Related Issue

**Issue:** #14013

### Description

OpenAI-backed models (seen with `openai/gpt-6-astra` through the `cline` provider, on both the OpenAI and Azure routes) reject the whole request with `Invalid JSON schema: regex lookaround is not supported` if any tool schema contains a JSON Schema `pattern` that uses lookaround (`(?=`, `(?!`, `(?<=`, `(?<!`). Zod v4's `z.email()` emits exactly such a pattern, so any MCP server built on it (resend-mcp in the issue, also Figma and Backstage MCP servers) blocks every message in the session, even a plain `hi`, without the tool ever being called.

We were forwarding MCP `inputSchema` verbatim: `createMcpTools` -> `createTool` -> `jsonSchema()` in the AI SDK -> provider. The AI SDK does not sanitize tool schemas (`@ai-sdk/openai` maps `parameters: tool.inputSchema` as is), and the upstream fix (vercel/ai#20021) is unmerged and would only cover the direct OpenAI provider anyway, not the `cline` provider path where the model id is opaque to the client.

This adds a small recursive pass in `createMcpTools` that drops only `pattern` values containing lookaround. Everything else (`type`, `format`, `required`, plain patterns, properties that happen to be named `pattern`) is preserved. `pattern` is advisory to the model and the MCP server still validates arguments at execution time, so this is lossless for tool behavior. It is applied for all providers rather than scoped per provider because the `cline` provider cannot tell which vendor is downstream, and no provider enforces `pattern` on the model side.

For comparison, opencode's fix (anomalyco/opencode#32489) is a full Codex-style allowlist rewrite of the schema scoped to `@ai-sdk/openai` / `@ai-sdk/azure`; this PR intentionally does the minimum that fixes the reported failure.

### Test Procedure

Unit tests in `sdk/packages/core/src/extensions/mcp/tools.test.ts` cover the exact Resend `create-contact` / `send-email` / batch shapes from the issue (nested `items`, `anyOf`), plain patterns being kept, a property literally named `pattern` being kept, and the `createMcpTools` integration point. `bun -F @cline/core test:unit` for `src/extensions/mcp/` and `runtime-builder.test.ts` passes (119 tests), biome is clean, and `tsc` reports no new errors.

End to end against the real model: a dependency-free stdio MCP server exposing the Resend `create-contact` schema (with the lookaround email pattern) was registered in an isolated `--data-dir`, and the CLI was run with `-P cline -m openai/gpt-6-astra`.

Before (built from `main`'s `tools.ts`):

```
error: Failed to create stream: inference request failed: failed to generate stream from Vercel: failed to invoke model 'openai/gpt-6-astra' with streaming: request failed with status 400: {"error":{"message":"Invalid JSON schema: regex lookaround is not supported. Found at $.properties.email.pattern." ...
```

After (this branch): `hi` returns normally, and asking the model to call the tool works end to end:

```
[hook:tool_call] fake-resend__create-contact
[fake-resend__create-contact] {"email":"test@example.com","firstName":"Ada"}
[hook:tool_result] fake-resend__create-contact
   ⎿ {"content":[{"type":"text","text":"ok: {\"email\":\"test@example.com\",\"firstName\":\"Ada\"}"}]}
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (CLI/SDK change; terminal evidence above).

### Additional Notes

Out of scope here, but the issue also asks for better attribution of schema rejections (server/tool/path instead of the generic "check your model connection" hint). That is a separate, larger error-surface change.