### PR TITLE
fix: declare OpenCode as a local-auth provider instead of OAuth

### DIFF
--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -1234,11 +1234,19 @@ const BUILTIN_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
 		name: "OpenCode",
 		description: "OpenCode SDK multi-provider runtime",
 		family: "opencode",
-		capabilities: ["reasoning", "oauth"],
+		// local-auth: the SDK spawns `opencode serve`, which authenticates from
+		// the credentials the user configured in OpenCode itself (`opencode
+		// auth login`). There is no Cline-side OAuth flow, so hosts must not
+		// offer a browser sign-in button for this provider.
+		capabilities: ["reasoning", "local-auth"],
 		defaultModelId: "openai/gpt-5.6-sol",
 		modelsProviderId: "opencode",
+		docsUrl: "https://opencode.ai/docs",
 		defaults: { baseUrl: "" },
 		configFields: [],
+		metadata: {
+			localCliCommand: "opencode",
+		},
 	},
 	{
 		id: "dify",

--- a/sdk/packages/llms/src/providers/local-cli.test.ts
+++ b/sdk/packages/llms/src/providers/local-cli.test.ts
@@ -16,6 +16,10 @@ describe("resolveProviderLocalCli", () => {
 			command: "claude",
 			docsUrl: "https://code.claude.com/docs/en/setup",
 		});
+		expect(resolveProviderLocalCli("opencode")).toEqual({
+			command: "opencode",
+			docsUrl: "https://opencode.ai/docs",
+		});
 	});
 
 	it("returns undefined for providers that name no local CLI", () => {


### PR DESCRIPTION
## Problem

In the desktop app's provider settings, OpenCode rendered a "Sign in with browser" OAuth button, and clicking it did nothing useful. The provider is not OAuth: it runs through `ai-sdk-provider-opencode-sdk`, which spawns `opencode serve` and authenticates with whatever credentials the user already configured in OpenCode itself. Cline has no OAuth handler for it, so `run_provider_oauth_login` had nothing to run.

The root cause is the `opencode` builtin spec in `@cline/llms` carrying an `"oauth"` capability. The desktop app's `getProviderAuthKind` treats that capability as the primary signal for showing the browser sign-in UI. The same mislabel also made `isProviderSettingsUsable` fall through to the API-key path and refuse to mark OpenCode configured.

## Fix

Tag OpenCode as `local-auth` with `localCliCommand: "opencode"` and a `docsUrl`, the same way `claude-code` and `openai-codex-cli` are declared. No host code changes are needed:

- Desktop settings now render the "Uses your local CLI sign-in" panel with a working Connect button
- `getProviderConfigFields("opencode")` returns `authMethod: "local"`, so a Connect save counts as configured
- The CLI onboarding picker can probe `opencode --version` and point at the docs URL when it is missing

## Testing

- `bun -F @cline/llms test` (local-cli, builtins, model-capabilities) and `bun -F @cline/core test:unit -- src/services/providers` pass
- Added an `opencode` assertion to the existing `resolveProviderLocalCli` test
- Verified in the desktop app (headless dev mode): OpenCode now shows the local CLI panel, and Connect flips it to Configured with no error

Before clicking Connect:

![OpenCode provider settings showing the local CLI sign-in panel with a Connect button](https://cursor.com/artifacts/c/art-58bf8081-4c0e-461d-96b5-b4a49e7ab0e0)

After clicking Connect:

![OpenCode provider marked Configured with a Disconnect button](https://cursor.com/artifacts/c/art-389115ad-9cb9-4f36-ae28-bff2b6dfcc91)