### PR TITLE
test(core): widen exit-grace shell test budget for slow Windows runners

### DIFF
--- a/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
+++ b/sdk/packages/core/src/extensions/tools/executors/bash.test.ts
@@ -1053,17 +1053,22 @@ describe("createShellExecutor with inherited stdio", () => {
 			? "C:\\Program Files\\Git\\bin\\bash.exe"
 			: "/bin/bash";
 	const hasBashShell = existsSync(bashShell);
+	// The command budget only has to stay under Vitest's testTimeout; the
+	// exit-grace path settles ~1s after the shell exits regardless. A cold
+	// Git Bash start on the 2-core Windows runner can take several seconds,
+	// so a tight budget times out before the grace timer ever fires.
+	const commandTimeoutMs = 15_000;
 
 	it.runIf(hasBashShell)(
 		"completes when a background child keeps the stdio pipes open after the shell exits",
 		async () => {
 			const executor = createShellExecutor({
 				shell: bashShell,
-				timeoutMs: 5_000,
+				timeoutMs: commandTimeoutMs,
 			});
-			// sleep outlives the 5s timeout, so without exit-grace completion
+			// sleep outlives the timeout, so without exit-grace completion
 			// this command times out instead of returning the echo output.
-			const output = await executor("sleep 8 & echo done", process.cwd(), ctx);
+			const output = await executor("sleep 30 & echo done", process.cwd(), ctx);
 			expect(output).toContain("done");
 			expect(output).toContain("background processes still running");
 		},
@@ -1074,11 +1079,11 @@ describe("createShellExecutor with inherited stdio", () => {
 		async () => {
 			const executor = createShellExecutor({
 				shell: bashShell,
-				timeoutMs: 5_000,
+				timeoutMs: commandTimeoutMs,
 			});
 			let error: unknown;
 			try {
-				await executor("sleep 8 & echo oops; exit 3", process.cwd(), ctx);
+				await executor("sleep 30 & echo oops; exit 3", process.cwd(), ctx);
 			} catch (caught) {
 				error = caught;
 			}


### PR DESCRIPTION
### Related Issue

Follow-up to the Windows `sdk-test` failure seen on #14018 ([failing run](https://github.com/cline/cline/actions/runs/34430603906)).

### Description

The two `createShellExecutor with inherited stdio` tests in `bash.test.ts` gave Git Bash a 5s command timeout. On the 2-core `windows-latest` runner a cold Git Bash start can take several seconds, so the command timeout fired before the 1s exit-grace timer ever ran:

```
FAIL src/extensions/tools/executors/bash.test.ts > createShellExecutor with inherited stdio > completes when a background child keeps the stdio pipes open after the shell exits
TimeoutError: Command timed out after 5000ms
```

The sibling test in the same block passed in ~1s on the same run, which points at cold-start cost rather than a real hang.

This raises the command budget to 15s (under the suite's 20s Vitest `testTimeout`, matching the existing note in `vitest.config.ts` that these budgets guard against hangs and are not timing assertions) and lengthens the background `sleep` so it still outlives the timeout. No production code changes.

### Test Procedure

From `sdk/packages/core`:

```sh
bun run test:unit -- src/extensions/tools/executors/bash.test.ts
```

34 passed, 12 skipped (Windows-only cases skipped on Linux).

To confirm the tests still guard the regression, I temporarily disabled the exit-grace path in `bash.ts` (multiplied `EXIT_STREAM_GRACE_MS` by 1000) and re-ran the two tests: both fail with `TimeoutError: Command timed out after 15000ms` in ~30s total, inside Vitest's budget. Restored `bash.ts` afterwards.

`bun run biome check` on the test file passes.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)