### PR TITLE
fix(core): identify shell editions and discourage redundant wrappers

### DIFF
--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -119,7 +119,41 @@ describe("createVscodeRunCommandsTool", () => {
 		// A profile change takes effect at the next description read (the
 		// model-request boundary), without a session rebuild.
 		mocks.getGlobalSettingsKey.mockReturnValue("powershell-7")
-		expect(tool.description).toContain("Commands run through PowerShell")
+		expect(tool.description).toContain("Microsoft PowerShell (pwsh.exe)")
+		expect(tool.description).toContain("another pwsh.exe -Command invocation")
+
+		mocks.getGlobalSettingsKey.mockReturnValue("powershell-legacy")
+		expect(tool.description).toContain("Windows PowerShell (powershell.exe)")
+		expect(tool.description).toContain("another powershell.exe -Command invocation")
+	})
+
+	it("keeps the prompted PowerShell edition until the next model request", async () => {
+		Object.defineProperty(process, "platform", { value: "win32" })
+		mocks.existsSync.mockReturnValue(true)
+		mocks.getGlobalSettingsKey.mockReturnValue("powershell-legacy")
+		const manager = createFakeTerminalManager(createFakeTerminalProcess({ lines: ["ok"] }))
+		const getOrCreateTerminal = vi.spyOn(manager, "getOrCreateTerminal")
+		const tool = createVscodeRunCommandsTool({ cwd: "C:\\workspace", getTerminalManager: () => manager })
+		const legacyDescription = tool.description
+		expect(legacyDescription).toContain("Windows PowerShell (powershell.exe)")
+
+		mocks.getGlobalSettingsKey.mockReturnValue("powershell-7")
+		await tool.execute(
+			{ commands: ["Write-Output 'ok'"] },
+			{ agentId: "agent-1", conversationId: "conversation-1", iteration: 1 },
+		)
+		expect(getOrCreateTerminal).toHaveBeenLastCalledWith("C:\\workspace", "powershell-legacy")
+
+		const nextDescription = tool.description
+		expect(nextDescription).toContain("Microsoft PowerShell (pwsh.exe)")
+		expect(nextDescription).not.toBe(legacyDescription)
+		expect(tool.description).toBe(nextDescription)
+		manager.runCommand = () => createFakeTerminalProcess({ lines: ["ok"] })
+		await tool.execute(
+			{ commands: ["Write-Output 'ok'"] },
+			{ agentId: "agent-1", conversationId: "conversation-1", iteration: 2 },
+		)
+		expect(getOrCreateTerminal).toHaveBeenLastCalledWith("C:\\workspace", "powershell-7")
 	})
 })
 

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -479,16 +479,52 @@ describe("default apply_patch tool", () => {
 });
 
 describe("run_commands tool description", () => {
-	it("names PowerShell with ';' sequencing for PowerShell shells", () => {
-		const description = buildRunCommandsDescription("powershell", true);
-		expect(description).toContain("Commands run through PowerShell");
+	it.each([
+		"powershell",
+		"powershell.exe",
+		"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\PowerShell.EXE",
+	])("names Windows PowerShell and its redundant wrapper for %s", (shell) => {
+		const description = buildRunCommandsDescription(shell, true);
+		expect(description).toContain("Windows PowerShell (powershell.exe)");
+		expect(description).toContain(
+			"do not wrap them in another powershell.exe -Command invocation",
+		);
+		expect(description).not.toContain("Microsoft PowerShell");
 		expect(description).toContain("use ';' to sequence commands");
 		expect(description).toContain("in Windows environment");
+	});
+
+	it.each([
+		"pwsh",
+		"pwsh.exe",
+		"C:\\Program Files\\PowerShell\\7\\PWSH.EXE",
+	])("names Microsoft PowerShell and its redundant wrapper for %s", (shell) => {
+		const description = buildRunCommandsDescription(shell, true);
+		expect(description).toContain("Microsoft PowerShell (pwsh.exe)");
+		expect(description).toContain(
+			"do not wrap them in another pwsh.exe -Command invocation",
+		);
+		expect(description).toContain("use ';' to sequence commands");
+		expect(description).toContain(
+			"Only start another shell when you intentionally need a different shell or a separate process.",
+		);
+		expect(description).not.toContain("Windows PowerShell");
+	});
+
+	it("describes pwsh on Unix without claiming a Windows host or a version", () => {
+		const description = buildRunCommandsDescription("/usr/bin/pwsh", false);
+		expect(description).toContain("Microsoft PowerShell (pwsh)");
+		expect(description).toContain("another pwsh -Command invocation");
+		expect(description).not.toContain("Windows");
+		expect(description).not.toMatch(/PowerShell \d/);
 	});
 
 	it("names cmd.exe with '&&' sequencing for cmd shells", () => {
 		const description = buildRunCommandsDescription("cmd", true);
 		expect(description).toContain("Commands run through cmd.exe");
+		expect(description).toContain(
+			"do not wrap them in another cmd.exe /c invocation",
+		);
 		expect(description).toContain("use '&&' to sequence commands");
 		expect(description).not.toContain("PowerShell");
 	});
@@ -501,11 +537,14 @@ describe("run_commands tool description", () => {
 	});
 
 	it("notes the Windows host for POSIX shells on Windows only", () => {
-		const onWindows = buildRunCommandsDescription("posix", true);
+		const onWindows = buildRunCommandsDescription(
+			"C:\\Program Files\\Git\\bin\\bash.exe",
+			true,
+		);
 		expect(onWindows).toContain("POSIX (bash-compatible) shell on Windows");
 		expect(onWindows).not.toContain("PowerShell");
 
-		const onUnix = buildRunCommandsDescription("posix", false);
+		const onUnix = buildRunCommandsDescription("/bin/bash", false);
 		expect(onUnix).not.toContain("Windows");
 		expect(onUnix).toContain("grep/head/tail");
 	});
@@ -533,7 +572,20 @@ describe("run_commands tool description", () => {
 		expect(tool.description).not.toContain("PowerShell");
 
 		shell = "powershell.exe";
-		expect(tool.description).toContain("Commands run through PowerShell");
+		const windowsPowerShellDescription = tool.description;
+		expect(windowsPowerShellDescription).toContain(
+			"Windows PowerShell (powershell.exe)",
+		);
+		expect(tool.description).toBe(windowsPowerShellDescription);
+
+		shell = "pwsh.exe";
+		const microsoftPowerShellDescription = tool.description;
+		expect(microsoftPowerShellDescription).toContain("Microsoft PowerShell");
+		expect(microsoftPowerShellDescription).not.toBe(
+			windowsPowerShellDescription,
+		);
+		shell = "C:\\Program Files\\PowerShell\\7\\PWSH.EXE";
+		expect(tool.description).toBe(microsoftPowerShellDescription);
 
 		// The property must survive the shallow copy the runtime performs when
 		// building AgentToolDefinitions for a model request.

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -9,9 +9,9 @@ import {
 	type AgentToolContext,
 	createTool,
 	getDefaultShell,
+	getPowerShellEdition,
 	getShellKind,
 	type ITelemetryService,
-	type ShellKind,
 	validateWithZod,
 	zodToJsonSchema,
 } from "@cline/shared";
@@ -421,22 +421,40 @@ const RUN_COMMANDS_SHARED_INSTRUCTIONS =
 
 /**
  * Build the run_commands tool description for the shell that will actually
- * execute the commands. The shell kind decides the syntax guidance (quoting,
- * sequencing, heredocs), and isWindows adds environment context for POSIX
- * shells running on a Windows host (e.g. Git Bash).
+ * execute the commands. Derive the edition and wrapper guidance from the
+ * same executable, without probing a version or adding volatile prompt text.
+ * isWindows describes the host, not the shell's edition.
  */
 export function buildRunCommandsDescription(
-	shellKind: ShellKind,
+	shell: string,
 	isWindows: boolean,
 ): string {
+	const shellKind = getShellKind(shell);
 	if (shellKind === "powershell" || shellKind === "cmd") {
-		const shellName = shellKind === "powershell" ? "PowerShell" : "cmd.exe";
+		const edition = getPowerShellEdition(shell);
+		const executable =
+			edition === "windows"
+				? "powershell.exe"
+				: edition === "core"
+					? isWindows
+						? "pwsh.exe"
+						: "pwsh"
+					: "cmd.exe";
+		const shellName =
+			edition === "windows"
+				? `Windows PowerShell (${executable})`
+				: edition === "core"
+					? `Microsoft PowerShell (${executable})`
+					: executable;
+		const wrapper = `${executable} ${shellKind === "powershell" ? "-Command" : "/c"}`;
 		const sequencingOperator = shellKind === "powershell" ? "';'" : "'&&'";
 		return (
-			"Run non-interactive shell commands from the root of the workspace in Windows environment. " +
+			`Run non-interactive shell commands from the root of the workspace${isWindows ? " in Windows environment" : ""}. ` +
 			RUN_COMMANDS_SHARED_INSTRUCTIONS +
 			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
 			`Commands run through ${shellName}; quote paths and arguments for ${shellName} and use ${sequencingOperator} to sequence commands. ` +
+			`Write commands directly; do not wrap them in another ${wrapper} invocation. ` +
+			"Only start another shell when you intentionally need a different shell or a separate process. " +
 			"Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."
 		);
 	}
@@ -490,8 +508,7 @@ export function createShellTool(
 		typeof configShell === "function"
 			? configShell
 			: () => configShell ?? getDefaultShell(process.platform);
-	const describe = () =>
-		buildRunCommandsDescription(getShellKind(resolveShell()), isWindows);
+	const describe = () => buildRunCommandsDescription(resolveShell(), isWindows);
 
 	const tool = createTool<unknown, ToolOperationResult[]>({
 		name: "run_commands",

--- a/sdk/packages/core/src/extensions/tools/index.test.ts
+++ b/sdk/packages/core/src/extensions/tools/index.test.ts
@@ -58,7 +58,14 @@ describe("createBuiltinTools shell configuration", () => {
 			name: "executor shell",
 			options: { executorOptions: { bash: { shell: "powershell.exe" } } },
 			expectedShell: "powershell.exe",
-			expectedDescription: "Commands run through PowerShell",
+			expectedDescription:
+				"Commands run through Windows PowerShell (powershell.exe)",
+		},
+		{
+			name: "Microsoft PowerShell executable",
+			options: { shell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+			expectedShell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+			expectedDescription: "Commands run through Microsoft PowerShell",
 		},
 		{
 			name: "top-level shell precedence",

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -269,6 +269,7 @@ export { decodeJwtPayload } from "./parse/jwt";
 export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export {
 	getDefaultShell,
+	getPowerShellEdition,
 	getShellArgs,
 	getShellInvocation,
 	getShellKind,

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -269,7 +269,6 @@ export { decodeJwtPayload } from "./parse/jwt";
 export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export {
 	getDefaultShell,
-	getPowerShellEdition,
 	getShellArgs,
 	getShellInvocation,
 	getShellKind,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -294,6 +294,7 @@ export { decodeJwtPayload } from "./parse/jwt";
 export { type OmitUndefinedValues, omitUndefinedValues } from "./parse/object";
 export {
 	getDefaultShell,
+	getPowerShellEdition,
 	getShellArgs,
 	getShellInvocation,
 	getShellKind,

--- a/sdk/packages/shared/src/parse/shell.ts
+++ b/sdk/packages/shared/src/parse/shell.ts
@@ -29,12 +29,7 @@ export type ShellKind = "powershell" | "cmd" | "wsl" | "posix";
 export function getShellKind(shell: string): ShellKind {
 	const shellName = normalizeShellName(shell);
 
-	if (
-		shellName === "powershell" ||
-		shellName === "powershell.exe" ||
-		shellName === "pwsh" ||
-		shellName === "pwsh.exe"
-	) {
+	if (getPowerShellEdition(shell) !== undefined) {
 		return "powershell";
 	}
 
@@ -186,12 +181,14 @@ function splitCompleteQuotedString(
 }
 
 /**
- * Classify a PowerShell executable path or name by edition, matching the
- * registry names: `powershell(.exe)` is Windows PowerShell 5.1 and
- * `pwsh(.exe)` is PowerShell 7+. Anything else is not a PowerShell
- * executable and returns undefined.
+ * Classify a PowerShell executable path or name by edition:
+ * `powershell(.exe)` is Windows PowerShell and `pwsh(.exe)` is Microsoft
+ * PowerShell. This identifies the edition, not the installed version.
+ * Anything else returns undefined.
  */
-function getPowerShellEdition(shell: string): "windows" | "core" | undefined {
+export function getPowerShellEdition(
+	shell: string,
+): "windows" | "core" | undefined {
 	const name = normalizeShellName(shell);
 	if (name === "powershell" || name === "powershell.exe") return "windows";
 	if (name === "pwsh" || name === "pwsh.exe") return "core";


### PR DESCRIPTION
### Related Issue

Follow-up to #13815 and #13284.

### Description

Distinguish Windows PowerShell (`powershell.exe`) from Microsoft PowerShell (`pwsh.exe`, or `pwsh` on Unix) in the `run_commands` description. Both were called simply "PowerShell", leaving the active edition unclear. Tell the model to write commands directly instead of adding a redundant matching `-Command` wrapper; give cmd.exe the equivalent `/c` guidance. Intentional launches of another shell or a separate process remain allowed.

Reuse the existing edition classifier and the shell snapshot already shared by prompting and execution. Equivalent executable paths produce identical descriptions; an edition change takes effect at the next model request. No version number is asserted: the selected executable identifies an edition, not a verified installed version. There are no new probes, settings or execution changes. The guidance also applies to VS Code foreground terminals, where #13815's unwrapping does not run.

### Test Procedure

From the repository root, with Windows PowerShell and pwsh on PATH:

```sh
bun run build:sdk
bun -F @cline/shared test:unit
bun -F @cline/core test:unit src/extensions/tools/definitions.test.ts src/extensions/tools/index.test.ts src/extensions/tools/executors/bash.powershell.test.ts src/extensions/tools/executors/bash.test.ts src/extensions/tools/executors/run-command-execution-controller.test.ts
bun -F @cline/shared typecheck
bun -F @cline/core typecheck
bun --cwd apps/vscode run test:vitest src/sdk/vscode-run-commands-tool.test.ts
bun --cwd apps/vscode run check-types
```

At `df18fe56b`, Windows validation with Node 24.16.0 and Bun 1.3.14 passed 661 tests (one Linux-only test skipped), SDK build, SDK/extension typechecks, Biome and a built-SDK Node smoke check. After removing the unused browser re-export, shared build/typecheck, 120 core/adapter tests and a built browser/Node export check passed. The new description tests failed against the original implementation.

### Type of Change

- [x] Bug fix

### Pre-flight Checklist

- [x] Changes are limited to shell guidance and its shared classifier.
- [x] Relevant tests pass; changed files are formatted and linted.
