### PR TITLE
security: raise js-yaml floor to 4.3.2 (CVE-2026-84375 — reachable via rule/skill frontmatter)

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -508,7 +508,7 @@
 		"ignore": "^7.0.3",
 		"image-size": "^2.0.2",
 		"isbinaryfile": "^5.0.2",
-		"js-yaml": "^4.1.1",
+		"js-yaml": "^4.3.2",
 		"jschardet": "^3.1.4",
 		"json5": "^2.2.3",
 		"jwt-decode": "^4.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -412,7 +412,7 @@
         "ignore": "^7.0.3",
         "image-size": "^2.0.2",
         "isbinaryfile": "^5.0.2",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.2",
         "jschardet": "^3.1.4",
         "json5": "^2.2.3",
         "jwt-decode": "^4.0.0",
@@ -818,7 +818,7 @@
     "axios": "1.18.0",
     "diff": "8.0.4",
     "fast-uri": ">=3.1.4",
-    "js-yaml": "^4.1.1",
+    "js-yaml": ">=4.3.2 <5",
     "mermaid": "11.16.1",
     "protobufjs": "7.6.5",
     "serialize-javascript": ">=7.0.3",
@@ -3789,7 +3789,7 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "jschardet": ["jschardet@3.1.4", "", {}, "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "@opentui/react": "0.4.3",
         "tar-fs": ">=3.1.1",
         "tar": "^7.5.2",
-        "js-yaml": "^4.1.1",
+        "js-yaml": ">=4.3.2 <5",
         "serialize-javascript": ">=7.0.3",
         "protobufjs": "7.6.5",
         "mermaid": "11.16.1",


### PR DESCRIPTION
## What

Bumps `js-yaml` 4.3.1 → **4.3.2** in the shipped VS Code extension.

- `apps/vscode/package.json`: `js-yaml ^4.1.1` → `^4.3.2`
- root `package.json` `overrides`: `js-yaml ^4.1.1` → `>=4.3.2 <5` (plain top-level key — version-scoped override keys are a no-op on bun 1.3.x)
- `bun.lock`: `js-yaml@4.3.1` entry **deleted**, resolved `js-yaml@4.3.2`. No other version change.

## Why

**CVE-2026-84375** (HIGH, fixed 4.3.2): `maxTotalMergeKeys` does not count empty mappings — a YAML document that repeatedly merges a large sequence of empty mappings consumes significant CPU. Also closes the Aikido duplicate AIKIDO-2026-641142.

Tiered **T1 — confirmed reachable**: `js-yaml` is a prod dependency of the extension (`apps/vscode/package.json:511`) and `yaml.load()` runs on frontmatter of rule / skill / agent-config markdown files read from the **open workspace** (`apps/vscode/src/core/context/instructions/user-instructions/frontmatter.ts:53`, `skills.ts:6`). A cloned repository can carry an attacker-authored `.clinerules/*.md`, so the payload reaches the parser without user interaction beyond opening the folder. `JSON_SCHEMA` does not help — merge-key handling is core loader logic.

## Quarantine (runbook §5b.2)

**Clean.** `js-yaml@4.3.2` published 2026-08-26T20:42Z (age 356 h at authoring) — clears the 72 h package quarantine.

## HIL review (assignee)

- [ ] Confirm the lock diff shows `js-yaml@4.3.1` removed and only `js-yaml@4.3.2` present (`grep -o 'js-yaml@[0-9.]*' bun.lock | sort -u`)
- [ ] `bun install --frozen-lockfile` succeeds
- [ ] Extension loads a `.clinerules/*.md` with frontmatter normally (frontmatter parsing unchanged in behaviour)
- [ ] **Mark Ready for review** — then SME review (jsimone, BarreiroT) begins

## Owner checklist

- [ ] CI green
- [ ] No behavioural change expected; `js-yaml` 4.3.2 is a patch release

---
Produced by the VMP Automation, 2026-09-10 run. Tracking: cline/compliance-automation#136.