### PR TITLE
feat(hub): hub daemon Langfuse trace coverage — daemon-distinct identity

### DIFF
--- a/sdk/packages/core/src/hub/daemon/telemetry.test.ts
+++ b/sdk/packages/core/src/hub/daemon/telemetry.test.ts
@@ -82,6 +82,20 @@ describe("createHubDaemonTelemetry", () => {
 		);
 	});
 
+	it("carries a daemon-distinct trace resource identity", () => {
+		mockGetProviderSettings.mockReturnValue(undefined);
+		createHubDaemonTelemetry();
+		// The daemon ships in the same binary as the CLI; without its own
+		// service name, daemon-emitted spans would be indistinguishable from
+		// CLI-local ones.
+		expect(mockCreateConfiguredTelemetryHandle).toHaveBeenCalledWith(
+			expect.objectContaining({
+				serviceName: "cline-hub-daemon",
+				serviceVersion: expect.any(String),
+			}),
+		);
+	});
+
 	it("stays anonymous when no cached account exists, then identifies once the user logs in", () => {
 		mockGetProviderSettings.mockReturnValue(undefined);
 		createHubDaemonTelemetry();

--- a/sdk/packages/core/src/hub/daemon/telemetry.ts
+++ b/sdk/packages/core/src/hub/daemon/telemetry.ts
@@ -32,6 +32,12 @@ export interface HubDaemonTelemetry {
  */
 export function createHubDaemonTelemetry(): HubDaemonTelemetry {
 	const config = createClineTelemetryServiceConfig({
+		// Spans carry only the OTel resource, not per-event metadata, so the
+		// daemon needs its own service identity: it ships in the same binary
+		// as the CLI, and without this its traces would be indistinguishable
+		// from CLI-local ones (`service.name: cline`).
+		serviceName: "cline-hub-daemon",
+		serviceVersion: CORE_BUILD_VERSION,
 		metadata: {
 			extension_version: CORE_BUILD_VERSION,
 			// "hub", not "cli": daemon-hosted sessions can be triggered by the

--- a/sdk/packages/shared/src/services/telemetry.ts
+++ b/sdk/packages/shared/src/services/telemetry.ts
@@ -463,6 +463,17 @@ export interface OpenTelemetryClientConfig {
 	tracesExporter?: string;
 
 	/**
+	 * OTel resource `service.name` (default "cline"). Distinguishes processes
+	 * that ship in the same binary — e.g. the CLI vs the detached hub daemon.
+	 */
+	serviceName?: string;
+
+	/**
+	 * OTel resource `service.version`.
+	 */
+	serviceVersion?: string;
+
+	/**
 	 * Protocol for OTLP exporters. SDK support is currently limited to "http/json".
 	 */
 	otlpProtocol?: string;


### PR DESCRIPTION
### Related

Stacked on #13974 (retarget when it merges). Completes the execution-host coverage for the Langfuse rollout: with this, every surface's cline-provider requests trace from whichever process runs `streamText()`.

| Surface | Execution | Trace owner | Covered by |
|---|---|---|---|
| VS Code | local | extension host | #13974 + #13982 |
| CLI (fallback/yolo/sandbox) | local | CLI process | #13974 + #13982 |
| CLI (normal, hub-routed) | hub | detached daemon | **this PR** |
| Desktop sidecar | hub | detached daemon | **this PR** (sidecar itself deliberately gets no tracer) |
| Hub dashboard/chat/scheduled | hub | detached daemon | **this PR** |

### What was already true (verified, no changes needed)

- **Activation reaches the daemon for free**: it is spawned detached from the same compiled binary as the CLI (`process.execPath`, embedded `/$bunfs/` entry), so #13982's inlined `OTEL_TRACES_EXPORTER` + `CLINE_TRACE_RECORD_CONTENT` apply to the daemon process. No separate daemon activation artifact exists or is needed.
- **Transport**: `createHubDaemonTelemetry()` → `createConfiguredTelemetryHandle` → core `OpenTelemetryProvider`, which builds and globally registers a `NodeTracerProvider` when `tracesExporter` is configured. The handle already flows into the hub server and the scheduled-run handlers.
- **Shutdown**: daemon dispose already flushes spans with a 5s hard deadline (a hung exporter can't hold the hub port).
- **Opt-out**: the daemon is a same-machine, same-user process, so the per-stream opt-out gate from #13974 (shared global settings file) reads the requesting user's own setting. Shared/cloud daemon topologies are tracked separately in ENG-2525 and gate nothing here.
- **No duplicate spans**: the one-export-path guard (in #13974) makes the direct `LANGFUSE_*` path decline whenever a host OTLP tracer is registered — a daemon with both configured relays once, through the collector. Deployment rule stands: don't set `LANGFUSE_*` on daemon hosts.
- **Identity/sampling metadata**: `AgentRuntime` already stamps distinctId, clientName/Version, clineCoreVersion, sessionId, conversationId onto every model request; the originating client's identity travels in the hub session start input (`localRuntime.extensionContext.client`), so daemon-emitted traces carry the originating surface.

### What this PR changes

Spans carry only the OTel **resource**, not per-event metadata — so daemon traces were indistinguishable from CLI-local ones (both `service.name: cline`, same binary). Now:

- `serviceName: "cline-hub-daemon"` + `serviceVersion` on the daemon's telemetry config (mirrors the existing `cline_type: "hub"` event-metadata distinction).
- New optional `serviceName`/`serviceVersion` fields on the shared `OpenTelemetryClientConfig` to plumb it (core's provider options already supported them).

### Test Procedure

```text
bunx vitest run src/hub/daemon/telemetry.test.ts   # 9/9 (1 new: daemon-distinct resource identity)
bun -F @cline/shared typecheck                      # clean
bun -F @cline/core typecheck                        # clean
```

Full core suite has 213 pre-existing environment failures on this machine (`No such built-in module: node:sqlite`) — identical on the base branch, unrelated to this diff.

**Manual acceptance (post-merge, with activation env):** start a real hub daemon, run `session.create` + `session.send_input` with the cline provider, verify one trace appears in Langfuse with `service.name=cline-hub-daemon` and the originating client in its runtime context; verify a Desktop-initiated session shows the desktop client identity while the trace is daemon-emitted.

### Type of Change

-   [x] ✨ New feature

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Relevant tests are passing and changed code is formatted and linted
-   [x] I have reviewed the contributor guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)