### PR TITLE
fix(desktop): point local-auth credential failures at the provider CLI

### DIFF
--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ChatSessionConfig } from "@/lib/chat-schema";
-import { inferHydratedChatStatus, resolveCredentialError } from "./helpers";
+import {
+	inferHydratedChatStatus,
+	resolveCredentialError,
+	resolveCredentialFailureHint,
+} from "./helpers";
 
 function makeConfig(overrides: Partial<ChatSessionConfig>): ChatSessionConfig {
 	return {
@@ -66,6 +70,26 @@ describe("resolveCredentialError", () => {
 		expect(
 			resolveCredentialError(makeConfig({ provider: "Cline-Pass" })),
 		).toBeNull();
+	});
+});
+
+describe("resolveCredentialFailureHint", () => {
+	it("points local-auth providers at their own CLI", () => {
+		expect(resolveCredentialFailureHint("claude-code")).toBe(
+			"Sign in again with the `claude` CLI in a terminal, then try again.",
+		);
+		expect(resolveCredentialFailureHint("openai-codex-cli")).toMatch(
+			/`codex` CLI/,
+		);
+		expect(resolveCredentialFailureHint("opencode")).toMatch(/`opencode` CLI/);
+	});
+
+	it("points everything else at Settings → Models", () => {
+		for (const providerId of ["anthropic", "cline", "openai-codex", ""]) {
+			expect(resolveCredentialFailureHint(providerId)).toMatch(
+				/Settings → Models/,
+			);
+		}
 	});
 });
 

--- a/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
+++ b/apps/examples/desktop-app/webview/hooks/chat-session/helpers.ts
@@ -1,4 +1,7 @@
-import { getProviderCollectionSync } from "@cline/llms/browser";
+import {
+	getProviderCollectionSync,
+	resolveProviderLocalCli,
+} from "@cline/llms/browser";
 import {
 	createSessionId,
 	type GeneratedMedia,
@@ -185,6 +188,21 @@ export function resolveCredentialError(
 		return null;
 	}
 	return `Missing API key for provider "${config.provider}". Add credentials in Settings, or switch providers.`;
+}
+
+/**
+ * Where to send the user after a credential-looking turn failure. Local-auth
+ * providers (Claude Code, Codex CLI, OpenCode) borrow their login from a CLI
+ * on this machine, so Settings → Models has nothing to fix — e.g. Claude
+ * Code's "OAuth session expired and could not be refreshed" needs a fresh
+ * sign-in in the `claude` CLI itself.
+ */
+export function resolveCredentialFailureHint(providerId: string): string {
+	const cli = resolveProviderLocalCli(providerId);
+	if (cli) {
+		return `Sign in again with the \`${cli.command}\` CLI in a terminal, then try again.`;
+	}
+	return "Check your model connection in Settings → Models (or sign in with Cline), then try again.";
 }
 
 function mapHistoryStatusToChatStatus(

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.test.tsx
@@ -2955,6 +2955,63 @@ describe("useChatSession", () => {
 		expect(errorMessage?.content).not.toContain("Check your model connection");
 	});
 
+	it("points local-auth providers at their CLI for credential failures", async () => {
+		invokeMock.mockImplementation(
+			async (command: string, args?: Record<string, unknown>) => {
+				if (command === "get_process_context") {
+					return { cwd: "/workspace/cline", workspaceRoot: "/workspace/cline" };
+				}
+				if (command === "chat_session_command") {
+					const request = args?.request as
+						| { action?: string; config?: { sessionId?: string } }
+						| undefined;
+					if (request?.action === "start") {
+						return { sessionId: request.config?.sessionId };
+					}
+					if (request?.action === "send") {
+						return { ok: true };
+					}
+				}
+				return [];
+			},
+		);
+
+		await act(async () => {
+			current.setConfig((previous) => ({
+				...previous,
+				provider: "claude-code",
+				model: "sonnet",
+			}));
+		});
+		await act(async () => {
+			await current.sendPrompt("First prompt");
+		});
+		const chatEventHandler = handlerFor("chat_event");
+
+		await act(async () => {
+			chatEventHandler({
+				sessionId: current.sessionId,
+				stream: "chat_done",
+				chunk: JSON.stringify({
+					reason: "error",
+					text: "Failed to authenticate: OAuth session expired and could not be refreshed.",
+				}),
+				ts: Date.now(),
+				index: 1,
+			});
+		});
+		const errorMessage = current.messages.find(
+			(message) => message.role === "error",
+		);
+		// Claude Code's login lives in the `claude` CLI; Settings → Models has
+		// nothing that could fix an expired session there.
+		expect(errorMessage?.content).toContain("OAuth session expired");
+		expect(errorMessage?.content).toContain(
+			"Sign in again with the `claude` CLI",
+		);
+		expect(errorMessage?.content).not.toContain("Settings → Models");
+	});
+
 	it("drops stale failure bubbles from earlier turns on later hydration", async () => {
 		const history: Array<Record<string, unknown>> = [];
 		invokeMock.mockImplementation(

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -14,6 +14,7 @@ import {
 	mapSessionRecordStatus,
 	normalizeRuntimeConfig,
 	resolveCredentialError,
+	resolveCredentialFailureHint,
 } from "@/hooks/chat-session/helpers";
 import type {
 	AgentChunkEvent,
@@ -420,6 +421,7 @@ export function useChatSession() {
 	const rekeyedOptimisticIdByMessageIdRef = useRef<Record<string, string>>({});
 	const liveToolInputsRef = useRef<Record<string, unknown>>({});
 	const activeSessionIdRef = useRef<string | null>(null);
+	const providerIdRef = useRef(config.provider);
 	const activeAssistantMessageIdRef = useRef<string | null>(null);
 	const lastStreamIndexBySessionRef = useRef<Record<string, number>>({});
 	const lastStreamBootBySessionRef = useRef<Record<string, string>>({});
@@ -478,6 +480,9 @@ export function useChatSession() {
 	useEffect(() => {
 		messagesRef.current = messages;
 	}, [messages]);
+	useEffect(() => {
+		providerIdRef.current = config.provider;
+	}, [config.provider]);
 	useEffect(() => {
 		if (
 			persistedTokensIn === undefined ||
@@ -588,7 +593,7 @@ export function useChatSession() {
 			// credential problems and must not point users at Settings → Models.
 			const looksCredentialRelated =
 				!description ||
-				/unauthorized|401|403|forbidden|api key|credential|authentication|sign in|auth token|access token|invalid token|expired token|token expired/i.test(
+				/unauthorized|401|403|forbidden|api key|credential|authenticat|sign in|auth token|access token|invalid token|expired token|token expired|session expired/i.test(
 					description,
 				);
 			const content = [
@@ -596,7 +601,7 @@ export function useChatSession() {
 					? `The run failed: ${description}`
 					: "The run failed before a response was produced.",
 				looksCredentialRelated
-					? "Check your model connection in Settings → Models (or sign in with Cline), then try again."
+					? resolveCredentialFailureHint(providerIdRef.current)
 					: "",
 			]
 				.filter(Boolean)

--- a/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
+++ b/apps/examples/desktop-app/webview/hooks/use-chat-session.ts
@@ -593,7 +593,7 @@ export function useChatSession() {
 			// credential problems and must not point users at Settings → Models.
 			const looksCredentialRelated =
 				!description ||
-				/unauthorized|401|403|forbidden|api key|credential|authenticat|sign in|auth token|access token|invalid token|expired token|token expired|session expired/i.test(
+				/unauthorized|401|403|forbidden|api key|credential|authenticat|sign in|auth token|access token|invalid token|expired token|token expired|session expired|not logged in|\/login/i.test(
 					description,
 				);
 			const content = [


### PR DESCRIPTION
### Related Issue

**Issue:** [CLINE-3238](https://linear.app/cline-bot/issue/CLINE-3238/claude-code-shows-configured-but-fails-to-work)

### Description

Follow-up to #14007 for Renee's latest feedback on CLINE-3238. With Claude Code's login expired, the desktop showed `The run failed: Failed to authenticate: OAuth session expired and could not be refreshed.` with no guidance, and when a hint did fire for a local-auth provider it said "Check your model connection in Settings -> Models", where there is nothing to fix: the login lives in the `claude` CLI on the machine.

- `resolveCredentialFailureHint(providerId)` in `hooks/chat-session/helpers.ts` resolves the provider's local CLI from the catalog (`resolveProviderLocalCli`, the same `localCliCommand` metadata the CLI uses) and returns `Sign in again with the \`claude\` CLI in a terminal, then try again.` for Claude Code / Codex CLI / OpenCode; every other provider keeps the existing Settings -> Models hint.
- `appendTurnFailureMessage` in `use-chat-session.ts` uses it, reading the current provider through a ref so the callback's dependency list stays empty.
- The credential classifier now also matches `authenticate` (it only matched `authentication`), `session expired`, `not logged in` and `/login`, so Claude Code's two real messages (`Failed to authenticate: OAuth session expired...` and `Not logged in - Please run /login`) get a hint at all.

### Test Procedure

- Reproduced with the compiled desktop sidecar and the `claude` CLI signed out (auth token removed): the chat error now reads `The run failed: not logged in. Please run /login Sign in again with the \`claude\` CLI in a terminal, then try again.` Restored the login and confirmed Claude Code, Codex CLI and OpenCode turns still answer.
- Unit tests: `resolveCredentialFailureHint` covers the three local-auth ids and the Settings -> Models fallback (`helpers.test.ts`); `use-chat-session.test.tsx` adds a Claude Code turn failing with the exact "OAuth session expired" text and asserts the CLI hint appears and the Settings hint does not. Existing "no credential guidance for non-credential failures" test still passes.
- `vitest run webview/hooks/chat-session/helpers.test.ts webview/hooks/use-chat-session.test.tsx`: 72 passed; `bun run typecheck` (desktop) clean; biome clean.

What could break: API-key and OAuth providers are unaffected (no `localCliCommand`, so the fallback hint is unchanged). The wider regex only adds terms that are unambiguously about auth; "maximum context tokens" style failures are still excluded.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Claude Code with the CLI logged out:

![claude logged out: hint points at the CLI](https://cursor.com/artifacts/c/art-3967bfcd-39e7-444c-a75d-6af90264d81b)

### Additional Notes

Findings from the same audit that are intentionally not in this PR: (a) OpenCode picker ids are bare (`big-pickle`) but the OpenCode SDK needs `provider/model`, so picker turns fail with "Model returned empty response" in both hosts; (b) with `claude`/`codex` off PATH the SDK errors are internal ("Reinstall @anthropic-ai/claude-agent-sdk...", "session not found"); (c) the hub daemon only inherits the login-shell PATH when the sidecar spawned it; (d) custom "Add provider" providers fail with `Unknown or disabled provider` because the runtime gateway only registers builtins. Also, PR #14020 duplicates the already-merged #14018 and can be closed.