### PR TITLE
fix(automation): make event ingress atomic and retryable

### DIFF
--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -746,6 +746,14 @@ orchestrator used by core and hub layers.
    declare `automationEvents` and submit normalized events through
    `ctx.automation.ingestEvent(...)`; sandboxed plugins forward those events
    through the core plugin event bridge.
+   Acceptance is one synchronous SQLite write transaction: the event log,
+   matching runs, debounce changes, materialization pointers, and final
+   processing status commit together. A failure rolls all of them back and
+   propagates to the caller, which must redeliver the event to retry. Other
+   connections cannot observe or claim partial fan-out. Committed events remain
+   deduplicated by event ID, including a retry after a lost response. Failures
+   are logged outside the transaction, not persisted as deduplication tombstones.
+
 7. **Runner** (`cron/runner/cron-runner.ts`): polls `cron.db`, atomically claims
    queued runs, executes them via the existing `HubScheduleRuntimeHandlers`
    (`startSession` → `sendSession` → `stopSession` / `abortSession`),

--- a/sdk/packages/core/src/cron/events/cron-event-ingress.test.ts
+++ b/sdk/packages/core/src/cron/events/cron-event-ingress.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CronEventSpec } from "@cline/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SqliteCronStore } from "../store/sqlite-cron-store";
 import {
 	automationEventMatchesFilters,
@@ -71,6 +71,111 @@ describe("CronEventIngress", () => {
 			spec,
 		}).record;
 	}
+
+	function event(eventId = "evt_retry") {
+		return {
+			eventId,
+			eventType: "github.pull_request.opened",
+			source: "github",
+			occurredAt: new Date(nowMs).toISOString(),
+			dedupeKey: "pr:12",
+			attributes: { repository: "acme/api" },
+		};
+	}
+
+	it.each([
+		"first run",
+		"second run",
+		"processing status",
+	])("rolls back failed acceptance at %s and accepts redelivery once", (failurePoint) => {
+		const first = seedEventSpec({ id: "first" });
+		const second = seedEventSpec({ id: "second" });
+		const originalEnqueue = store.enqueueRun.bind(store);
+		let calls = 0;
+		const injected =
+			failurePoint === "processing status"
+				? vi.spyOn(store, "updateEventLogProcessing").mockImplementation(() => {
+						throw new Error("injected failure");
+					})
+				: vi.spyOn(store, "enqueueRun").mockImplementation((input) => {
+						calls++;
+						if (calls === (failurePoint === "first run" ? 1 : 2))
+							throw new Error("injected failure");
+						return originalEnqueue(input);
+					});
+		expect(() => ingress.ingestEvent(event())).toThrow("injected failure");
+		injected.mockRestore();
+		expect(store.getEventLog("evt_retry")).toBeUndefined();
+		expect(store.listRuns()).toHaveLength(0);
+		expect(store.getSpec(first.specId)?.lastMaterializedRunId).toBeUndefined();
+		expect(store.getSpec(second.specId)?.lastMaterializedRunId).toBeUndefined();
+
+		// Reopening proves retryability comes from persisted state, not this instance.
+		store.close();
+		store = new SqliteCronStore({ dbPath: join(dir, "cron.db") });
+		ingress = new CronEventIngress({ store, now: () => nowMs });
+		const retried = ingress.ingestEvent(event());
+		expect(retried.duplicate).toBe(false);
+		expect(retried.queuedRuns).toHaveLength(2);
+		expect(new Set(retried.queuedRuns.map((run) => run.specId))).toEqual(
+			new Set([first.specId, second.specId]),
+		);
+		expect(retried.event.processingStatus).toBe("queued");
+		expect(retried.event.queuedRunCount).toBe(2);
+		expect(ingress.ingestEvent(event()).duplicate).toBe(true);
+		expect(store.listRuns()).toHaveLength(2);
+	});
+
+	it("rolls back debounce changes when processing fails after materialization", () => {
+		seedEventSpec({ debounceSeconds: 30 });
+		const accepted = ingress.ingestEvent(event("evt_original"));
+		const originalRun = accepted.queuedRuns[0];
+		expect(originalRun).toBeDefined();
+		nowMs += 10000;
+		const injected = vi
+			.spyOn(store, "updateEventLogProcessing")
+			.mockImplementationOnce(() => {
+				throw new Error("status write failed");
+			});
+		expect(() => ingress.ingestEvent(event())).toThrow("status write failed");
+		injected.mockRestore();
+		expect(store.getEventLog("evt_retry")).toBeUndefined();
+		expect(store.listRuns()).toEqual([originalRun]);
+		const retried = ingress.ingestEvent(event());
+		expect(retried.queuedRuns[0]?.runId).toBe(originalRun?.runId);
+		expect(retried.queuedRuns[0]?.triggerEventId).toBe("evt_retry");
+		expect(retried.queuedRuns[0]?.scheduledFor).toBe(
+			"2026-04-23T10:00:40.000Z",
+		);
+		expect(store.listRuns()).toHaveLength(1);
+	});
+
+	it("does not expose partial acceptance to another connection", () => {
+		seedEventSpec({ id: "first" });
+		seedEventSpec({ id: "second" });
+		const peer = new SqliteCronStore({ dbPath: join(dir, "cron.db") });
+		const enqueue = store.enqueueRun.bind(store);
+		const observed = vi
+			.spyOn(store, "enqueueRun")
+			.mockImplementation((input) => {
+				const run = enqueue(input);
+				expect(peer.getEventLog("evt_retry")).toBeUndefined();
+				expect(peer.listRuns()).toHaveLength(0);
+				return run;
+			});
+		try {
+			ingress.ingestEvent(event());
+			expect(observed).toHaveBeenCalledTimes(2);
+			expect(peer.getEventLog("evt_retry")?.processingStatus).toBe("queued");
+			expect(peer.listRuns()).toHaveLength(2);
+			const peerIngress = new CronEventIngress({ store: peer });
+			expect(peerIngress.ingestEvent(event()).duplicate).toBe(true);
+			expect(peer.listRuns()).toHaveLength(2);
+		} finally {
+			observed.mockRestore();
+			peer.close();
+		}
+	});
 
 	it("persists a normalized event and queues matching event runs", () => {
 		const spec = seedEventSpec({

--- a/sdk/packages/core/src/cron/events/cron-event-ingress.ts
+++ b/sdk/packages/core/src/cron/events/cron-event-ingress.ts
@@ -9,8 +9,9 @@ import type {
 /**
  * Durable ingress for normalized automation events.
  *
- * This layer persists the incoming event before matching, then materializes
- * queued `cron_runs` for matching event specs. It deliberately does not
+ * This layer atomically persists the incoming event and materializes queued
+ * `cron_runs` for matching event specs. Failed acceptance rolls back so the
+ * same event can be redelivered without partial fan-out. It deliberately does not
  * execute agents; the normal runner claim loop owns execution.
  */
 
@@ -183,15 +184,40 @@ export class CronEventIngress {
 	public ingestEvent(event: AutomationEventEnvelope): CronEventIngressResult {
 		const receivedAt = new Date(this.nowFn()).toISOString();
 		const normalized = normalizeEvent(event, receivedAt);
+		try {
+			const result = this.store.eventTransaction(() =>
+				this.materializeEvent(normalized, receivedAt),
+			);
+			this.logger?.debug(
+				result.duplicate ? "cron.event.duplicate" : "cron.event.processed",
+				{
+					eventId: result.event.eventId,
+					eventType: result.event.eventType,
+					source: result.event.source,
+					status: result.event.processingStatus,
+					matchedSpecCount: result.event.matchedSpecCount,
+					queuedRunCount: result.event.queuedRunCount,
+				},
+			);
+			return result;
+		} catch (error) {
+			this.logger?.error?.("cron.event.failed", {
+				eventId: normalized.eventId,
+				eventType: normalized.eventType,
+				error,
+			});
+			throw error;
+		}
+	}
+
+	private materializeEvent(
+		normalized: AutomationEventEnvelope,
+		receivedAt: string,
+	): CronEventIngressResult {
 		const inserted = this.store.insertEventLog(normalized, {
 			receivedAtIso: receivedAt,
 		});
 		if (!inserted.created) {
-			this.logger?.debug("cron.event.duplicate", {
-				eventId: inserted.record.eventId,
-				eventType: inserted.record.eventType,
-				source: inserted.record.source,
-			});
 			return {
 				event: inserted.record,
 				duplicate: true,
@@ -206,85 +232,63 @@ export class CronEventIngress {
 			};
 		}
 
-		try {
-			const allCandidateSpecs = this.store.listEventSpecsForType(
-				normalized.eventType,
-			);
-			const suppressions: CronEventSuppression[] = [];
-			const matchedSpecs: CronSpecRecord[] = [];
-			const queuedRuns: CronRunRecord[] = [];
+		const allCandidateSpecs = this.store.listEventSpecsForType(
+			normalized.eventType,
+		);
+		const suppressions: CronEventSuppression[] = [];
+		const matchedSpecs: CronSpecRecord[] = [];
+		const queuedRuns: CronRunRecord[] = [];
 
-			for (const spec of allCandidateSpecs) {
-				if (!automationEventMatchesFilters(normalized, spec.filters)) {
-					suppressions.push({
-						specId: spec.specId,
-						externalId: spec.externalId,
-						reason: "filter_mismatch",
-						dedupeKey: normalized.dedupeKey,
-					});
-					continue;
-				}
-				matchedSpecs.push(spec);
-				const run = this.materializeForSpec(
-					spec,
-					normalized,
-					inserted.record.receivedAt,
-				);
-				if (run.run) {
-					queuedRuns.push(run.run);
-				} else {
-					suppressions.push({
-						specId: spec.specId,
-						externalId: spec.externalId,
-						reason: run.reason,
-						dedupeKey: normalized.dedupeKey,
-					});
-				}
+		for (const spec of allCandidateSpecs) {
+			if (!automationEventMatchesFilters(normalized, spec.filters)) {
+				suppressions.push({
+					specId: spec.specId,
+					externalId: spec.externalId,
+					reason: "filter_mismatch",
+					dedupeKey: normalized.dedupeKey,
+				});
+				continue;
 			}
-
-			const status =
-				matchedSpecs.length === 0
-					? "unmatched"
-					: queuedRuns.length > 0
-						? "queued"
-						: "suppressed";
-			this.store.updateEventLogProcessing(inserted.record.eventId, {
-				status,
-				matchedSpecCount: matchedSpecs.length,
-				queuedRunCount: queuedRuns.length,
-				suppressedCount: suppressions.filter(
-					(s) => s.reason !== "filter_mismatch",
-				).length,
-			});
-			const updated = this.store.getEventLog(inserted.record.eventId);
-			this.logger?.debug("cron.event.processed", {
-				eventId: inserted.record.eventId,
-				eventType: inserted.record.eventType,
-				status,
-				matchedSpecCount: matchedSpecs.length,
-				queuedRunCount: queuedRuns.length,
-			});
-			return {
-				event: updated ?? inserted.record,
-				duplicate: false,
-				matchedSpecs,
-				queuedRuns,
-				suppressions,
-			};
-		} catch (err) {
-			this.store.updateEventLogProcessing(inserted.record.eventId, {
-				status: "failed",
-				error: err instanceof Error ? err.message : String(err),
-			});
-			if (this.logger?.error) {
-				this.logger.error("cron.event.failed", {
-					eventId: inserted.record.eventId,
-					eventType: inserted.record.eventType,
-					error: err,
+			matchedSpecs.push(spec);
+			const run = this.materializeForSpec(
+				spec,
+				normalized,
+				inserted.record.receivedAt,
+			);
+			if (run.run) {
+				queuedRuns.push(run.run);
+			} else {
+				suppressions.push({
+					specId: spec.specId,
+					externalId: spec.externalId,
+					reason: run.reason,
+					dedupeKey: normalized.dedupeKey,
 				});
 			}
-			throw err;
 		}
+
+		const status =
+			matchedSpecs.length === 0
+				? "unmatched"
+				: queuedRuns.length > 0
+					? "queued"
+					: "suppressed";
+		this.store.updateEventLogProcessing(inserted.record.eventId, {
+			status,
+			matchedSpecCount: matchedSpecs.length,
+			queuedRunCount: queuedRuns.length,
+			suppressedCount: suppressions.filter(
+				(s) => s.reason !== "filter_mismatch",
+			).length,
+		});
+		const updated = this.store.getEventLog(inserted.record.eventId);
+		return {
+			event: updated ?? inserted.record,
+			duplicate: false,
+			matchedSpecs,
+			queuedRuns,
+			suppressions,
+		};
 	}
 
 	private materializeForSpec(

--- a/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
+++ b/sdk/packages/core/src/cron/store/sqlite-cron-store.ts
@@ -1294,6 +1294,19 @@ export class SqliteCronStore {
 		return count > 0 ? count : undefined;
 	}
 
+	/** Execute synchronous event acceptance and materialization as one atomic write. */
+	public eventTransaction<T>(work: () => T): T {
+		this.db.exec("BEGIN IMMEDIATE;");
+		try {
+			const result = work();
+			this.db.exec("COMMIT;");
+			return result;
+		} catch (error) {
+			this.db.exec("ROLLBACK;");
+			throw error;
+		}
+	}
+
 	public insertEventLog(
 		event: AutomationEventEnvelope,
 		options: { receivedAtIso?: string } = {},


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to the schedules audit associated with [CLINE-3224](https://linear.app/cline-bot/issue/CLINE-3224/fix-daily-schedule-running-multiple-times-each-morning). This fixes the separate event-triggered acceptance path; the daily scheduling fixes remain in #14004.

### Description

An event matching two automations could queue the first run, fail before queuing the second, and then reject redelivery as a duplicate. `ingestEvent()` persisted the event ID before matching and materialization; its failure handler left a `failed` event record that the duplicate check treated as fully processed. A process interruption in that window could similarly leave a `received` record and partial work.

This change makes acceptance one synchronous SQLite `BEGIN IMMEDIATE` transaction covering the event record, matching queued runs, debounce changes, materialization pointers, and final processing status. A failure rolls back the entire acceptance and propagates to the caller. The producer can redeliver the same event ID, and an already committed event still deduplicates normally, including when a response was lost. Other connections cannot see or claim partial work.

Processing logs are emitted after commit; failure logs are outside the transaction. Failed acceptance no longer leaves an event-log tombstone that suppresses retry. No agent execution occurs inside the transaction.

### Test Procedure

**Deterministic reproduction and expected behavior**

The new tests in `sdk/packages/core/src/cron/events/cron-event-ingress.test.ts` use temporary databases and injected store failures:

1. Seed two enabled event specs matching the same event type and attributes.
2. Ingest an event with a fixed event ID. Inject an exception before the first enqueue, on the second enqueue, or while writing the final processing status.
3. Before the fix, the event remains recorded as failed; later failure points also leave partial or complete queued runs. Redelivery is rejected as a duplicate.
4. With the fix, assert that neither the event record nor any new runs remain, and both specs' last-materialized pointers are unchanged.
5. Close/reopen the database, redeliver the identical event, and verify exactly one queued run per matching spec. Redeliver again and verify it is a duplicate with no extra runs.

Additional cases:

- Start with a queued debounced run, ingest a new event with the same dedupe key, then fail the final status write. Its original event reference, scheduled time, and run record must be restored. Retrying successfully updates that same run once.
- Observe acceptance through a second database connection after each enqueue. Neither the event nor partial runs should be visible before commit; afterward the complete result is visible and redelivery through the peer connection deduplicates.
- Existing matching/filtering, unmatched events, cooldown, dedupe-window, and debounce tests continue to pass.

**Validation**

- `bun run build:sdk` — SDK build.
- From `sdk`: `bun -F @cline/core test:unit src/cron src/ClineCore.test.ts src/hub/server/agenda-task-hub.test.ts` — 115 tests passed across event ingress, scheduling, ClineCore, and hub integration.
- From `sdk`: `bun -F @cline/core typecheck` — core and smoke typechecks.
- Biome checks on the changed TypeScript files and `git diff --check`.
- Verified the new regressions against the original ingress implementation, then restored the fix and rebuilt. The original implementation fails the five new cases.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

The targeted tests, build, typechecks, and formatting checks above were run. The full monorepo test/lint commands were not run.

### Screenshots

Not applicable; this changes backend event acceptance only.

### Additional Notes

- Based directly on `main` in `bee/fix-event-ingress-recovery`; does not include or depend on #14004.
- Retry requires producer redelivery after a failed/unacknowledged call; this does not introduce an automatic background retry worker or promise exactly-once external agent side effects.
- Historical partially processed records are not migrated or replayed. This prevents new partial acceptance rather than guessing which old external work is safe to repeat.
- Transaction callbacks are synchronous database work only; matching and materialization do not await provider/network calls.
