### PR TITLE
fix: separate Cline platform API URLs from inference settings

### DIFF
--- a/apps/cli/src/acp/organizations.ts
+++ b/apps/cli/src/acp/organizations.ts
@@ -35,10 +35,8 @@ let oauthTokenManager: RuntimeOAuthTokenManager | undefined;
 
 function createAccountService(input: ClineAccountInput): ClineAccountService {
 	const { providerSettingsManager } = input;
-	const settings = providerSettingsManager.getProviderSettings("cline");
 	return new ClineAccountService({
-		apiBaseUrl:
-			settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+		apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 		getAuthToken: async () => {
 			try {
 				oauthTokenManager ??= new RuntimeOAuthTokenManager({

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1218,13 +1218,12 @@ describe("runCli lightweight command dispatch", () => {
 			expect.anything(),
 			undefined,
 			expect.objectContaining({
-				clineApiBaseUrl: undefined,
 				clineProviderSettings: undefined,
 			}),
 		);
 	});
 
-	it("passes Cline provider settings as Cline account options", async () => {
+	it("passes Cline credentials without overriding the platform API URL", async () => {
 		const clineSettings = {
 			provider: "cline",
 			baseUrl: "https://api.example.test",
@@ -1248,9 +1247,11 @@ describe("runCli lightweight command dispatch", () => {
 			expect.anything(),
 			undefined,
 			expect.objectContaining({
-				clineApiBaseUrl: "https://api.example.test",
 				clineProviderSettings: clineSettings,
 			}),
+		);
+		expect(runtimeMocks.runInteractive.mock.calls[0]?.[3]).not.toHaveProperty(
+			"clineApiBaseUrl",
 		);
 	});
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1205,7 +1205,6 @@ export async function runCli(): Promise<void> {
 			}
 			await runInteractive(config, userInstructionService, resumeSessionId, {
 				initialPrompt: args.prompt,
-				clineApiBaseUrl: initialClineProviderSettings?.baseUrl,
 				clineProviderSettings: initialClineProviderSettings,
 				startupTarget,
 				initialNotice,

--- a/apps/cli/src/tui/cline-account.test.ts
+++ b/apps/cli/src/tui/cline-account.test.ts
@@ -105,6 +105,7 @@ describe("createClineAccountService", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 		coreMocks.getProviderSettings.mockReset();
 		coreMocks.saveProviderSettings.mockReset();
 		coreMocks.fetchMe.mockReset();
@@ -119,9 +120,15 @@ describe("createClineAccountService", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 	});
 
-	it("refreshes persisted Cline OAuth credentials before creating the account service", async () => {
+	it.each([
+		undefined,
+		"  https://override.test  ",
+		"   ",
+	])("routes OAuth refresh and account requests to the platform API with override %j", async (clineApiBaseUrl) => {
+		vi.stubEnv("CLINE_API_BASE_URL", "https://platform.test");
 		vi.spyOn(Date, "now").mockReturnValue(100_000);
 		mockFetchJson({
 			success: true,
@@ -141,6 +148,7 @@ describe("createClineAccountService", () => {
 		});
 		coreMocks.getProviderSettings.mockReturnValue({
 			provider: "cline",
+			baseUrl: "https://inference.test/api/v1",
 			auth: {
 				accessToken: "workos:old-access",
 				refreshToken: "refresh-token",
@@ -150,10 +158,18 @@ describe("createClineAccountService", () => {
 		});
 
 		const { createClineAccountService } = await import("./cline-account");
-		const service = await createClineAccountService({ config: makeConfig() });
+		const service = await createClineAccountService({
+			config: makeConfig(),
+			clineApiBaseUrl,
+		});
 
 		expect(service).toBeDefined();
-		expect(globalThis.fetch).toHaveBeenCalled();
+		const expectedBaseUrl = clineApiBaseUrl?.trim() || "https://platform.test";
+		expect(coreMocks.serviceOptions[0]?.apiBaseUrl).toBe(expectedBaseUrl);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			expect.stringContaining(expectedBaseUrl + "/"),
+			expect.anything(),
+		);
 		expect(coreMocks.saveProviderSettings).toHaveBeenCalledWith(
 			expect.objectContaining({
 				provider: "cline",
@@ -203,6 +219,7 @@ describe("loadClineAccountSnapshot", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 		coreMocks.getProviderSettings.mockReset();
 		coreMocks.saveProviderSettings.mockReset();
 		coreMocks.fetchMe.mockReset();
@@ -217,6 +234,7 @@ describe("loadClineAccountSnapshot", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 	});
 
 	it("identifies the loaded Cline account for telemetry and feature flags", async () => {
@@ -268,6 +286,7 @@ describe("loadIndividualSubscriptionPlans", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 		coreMocks.getProviderSettings.mockReset();
 		coreMocks.saveProviderSettings.mockReset();
 		coreMocks.fetchMe.mockReset();
@@ -282,6 +301,7 @@ describe("loadIndividualSubscriptionPlans", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 	});
 
 	it("loads individual subscription plans through the authorized account service", async () => {

--- a/apps/cli/src/tui/cline-account.ts
+++ b/apps/cli/src/tui/cline-account.ts
@@ -66,19 +66,10 @@ export function isClineAccountCreditsErrorMessage(message: string): boolean {
 	);
 }
 
-function resolveAccountApiBaseUrl(input: {
-	clineApiBaseUrl?: string;
-	clineProviderSettings?: ProviderSettings;
-}): string {
-	const settingsBaseUrl = input.clineProviderSettings?.baseUrl?.trim();
-	if (settingsBaseUrl) {
-		return settingsBaseUrl;
-	}
-	const configuredBaseUrl = input.clineApiBaseUrl?.trim();
-	if (configuredBaseUrl) {
-		return configuredBaseUrl;
-	}
-	return getClineEnvironmentConfig().apiBaseUrl;
+function resolveAccountApiBaseUrl(input: { clineApiBaseUrl?: string }): string {
+	return (
+		input.clineApiBaseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl
+	);
 }
 
 function resolveClineAccountAuthToken(input: {
@@ -143,7 +134,6 @@ export async function createClineAccountService(input: {
 		manager.getProviderSettings("cline") ?? input.clineProviderSettings;
 	const apiBaseUrl = resolveAccountApiBaseUrl({
 		clineApiBaseUrl: input.clineApiBaseUrl,
-		clineProviderSettings: settings,
 	});
 	const authToken = await resolveValidClineAccountAuthToken({
 		config: input.config,

--- a/apps/cli/src/tui/components/dialogs/provider-picker.tsx
+++ b/apps/cli/src/tui/components/dialogs/provider-picker.tsx
@@ -798,8 +798,7 @@ export function OAuthLoginContent(
 
 		const manager = new ProviderSettingsManager();
 		const existing = manager.getProviderSettings(providerId);
-		const apiBaseUrl =
-			existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+		const apiBaseUrl = getClineEnvironmentConfig().apiBaseUrl;
 
 		startClineDeviceAuth()
 			.then((result) => {

--- a/apps/cli/src/tui/views/onboarding/auth.test.ts
+++ b/apps/cli/src/tui/views/onboarding/auth.test.ts
@@ -38,7 +38,10 @@ const fakeTelemetry = { __id: "fake-telemetry" } as unknown as Parameters<
 
 function makeManager() {
 	return {
-		getProviderSettings: vi.fn(() => undefined),
+		getProviderSettings: vi.fn(() => ({
+			provider: "cline",
+			baseUrl: "https://inference.test/api/v1",
+		})),
 	} as unknown as Parameters<
 		typeof runOAuthAuthFlow
 	>[0]["providerSettingsManager"];
@@ -152,6 +155,7 @@ describe("onboarding auth telemetry forwarding", () => {
 		expect(hoisted.completeClineDeviceAuth).toHaveBeenCalledTimes(1);
 		const [opts] = hoisted.completeClineDeviceAuth.mock.calls[0];
 		expect(opts.telemetry).toBe(fakeTelemetry);
+		expect(opts.apiBaseUrl).toBe("https://api.example");
 		// We do NOT forward telemetry to startClineDeviceAuth — auth_started is
 		// emitted by completeClineDeviceAuth, so passing telemetry to the start
 		// helper would double-emit the event.

--- a/apps/cli/src/tui/views/onboarding/auth.ts
+++ b/apps/cli/src/tui/views/onboarding/auth.ts
@@ -90,8 +90,7 @@ export function runDeviceCodeAuthFlow(input: {
 	const existing = input.providerSettingsManager.getProviderSettings(
 		input.providerId,
 	);
-	const apiBaseUrl =
-		existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+	const apiBaseUrl = getClineEnvironmentConfig().apiBaseUrl;
 
 	// `startClineDeviceAuth` only requests the user/device code pair; the
 	// `auth_started` telemetry event is emitted by `completeClineDeviceAuth`

--- a/apps/cli/src/utils/enterprise.ts
+++ b/apps/cli/src/utils/enterprise.ts
@@ -45,8 +45,7 @@ async function loadCliRemoteConfigBundleUncached(): Promise<
 	}
 
 	const service = new ClineAccountService({
-		apiBaseUrl:
-			settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+		apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 		getAuthToken: async () => authToken,
 	});
 	const response = await service.fetchRemoteConfig().catch(() => null);

--- a/apps/cli/src/utils/free-model-cost.test.ts
+++ b/apps/cli/src/utils/free-model-cost.test.ts
@@ -32,7 +32,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline",
 				modelId: "deepseek/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(true);
 
@@ -58,7 +57,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline",
 				modelId: "cline-free/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(true);
 
@@ -66,7 +64,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline-pass",
 				modelId: "deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(false);
 	});
@@ -79,7 +76,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "openrouter",
 				modelId: "deepseek/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(false);
 		expect(fetchMock).not.toHaveBeenCalled();
@@ -102,7 +98,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline-pass",
 				modelId: "deepseek/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(true);
 
@@ -111,7 +106,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline-pass",
 				modelId: "cline-pass/glm-5.1",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(false);
 	});
@@ -133,7 +127,6 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline",
 				modelId: "acme/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(false);
 	});
@@ -156,14 +149,12 @@ describe("shouldZeroClineFreeModelCost", () => {
 			shouldZeroClineFreeModelCost({
 				providerId: "cline",
 				modelId: "deepseek/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(false);
 		await expect(
 			shouldZeroClineFreeModelCost({
 				providerId: "cline",
 				modelId: "deepseek/deepseek-v4-flash",
-				baseUrl: "https://cline.test/api/v1",
 			}),
 		).resolves.toBe(true);
 		expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/apps/cli/src/utils/free-model-cost.test.ts
+++ b/apps/cli/src/utils/free-model-cost.test.ts
@@ -10,10 +10,12 @@ import {
 afterEach(() => {
 	clearClineFreeModelCostCache();
 	vi.unstubAllGlobals();
+	vi.unstubAllEnvs();
 });
 
 describe("shouldZeroClineFreeModelCost", () => {
-	it("uses the Cline free model list", async () => {
+	it("uses the platform free model list independently of inference settings", async () => {
+		vi.stubEnv("CLINE_API_BASE_URL", "https://platform.test");
 		const fetchMock = vi.fn(
 			async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
 				return new Response(
@@ -35,7 +37,7 @@ describe("shouldZeroClineFreeModelCost", () => {
 		).resolves.toBe(true);
 
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
-			"https://cline.test/api/v1/ai/cline/recommended-models",
+			"https://platform.test/api/v1/ai/cline/recommended-models",
 		);
 	});
 

--- a/apps/cli/src/utils/free-model-cost.ts
+++ b/apps/cli/src/utils/free-model-cost.ts
@@ -66,7 +66,7 @@ function getClineFreeModelIds(baseUrl: string): Promise<readonly string[]> {
 }
 
 export async function shouldZeroClineFreeModelCost(
-	config: Pick<Config, "providerId" | "modelId" | "baseUrl">,
+	config: Pick<Config, "providerId" | "modelId">,
 ): Promise<boolean> {
 	// Free models are also selectable on ClinePass — they ride usage billing at $0
 	if (config.providerId !== "cline" && config.providerId !== "cline-pass")

--- a/apps/cli/src/utils/free-model-cost.ts
+++ b/apps/cli/src/utils/free-model-cost.ts
@@ -19,14 +19,6 @@ function modelIdsMatch(selectedModelId: string, freeModelId: string): boolean {
 	return selected === free;
 }
 
-function resolveClineRecommendedModelsUrl(baseUrl: string): string {
-	const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, "");
-	const apiBaseUrl = normalizedBaseUrl.endsWith("/api/v1")
-		? normalizedBaseUrl.slice(0, -"/api/v1".length)
-		: normalizedBaseUrl;
-	return `${apiBaseUrl}/api/v1/ai/cline/recommended-models`;
-}
-
 async function fetchClineFreeModelIds(
 	baseUrl: string,
 ): Promise<readonly string[] | undefined> {
@@ -36,9 +28,12 @@ async function fetchClineFreeModelIds(
 		CLINE_RECOMMENDED_MODELS_TIMEOUT_MS,
 	);
 	try {
-		const response = await fetch(resolveClineRecommendedModelsUrl(baseUrl), {
-			signal: controller.signal,
-		});
+		const response = await fetch(
+			`${baseUrl.trim().replace(/\/+$/, "")}/api/v1/ai/cline/recommended-models`,
+			{
+				signal: controller.signal,
+			},
+		);
 		if (!response.ok) return undefined;
 		const json = (await response.json()) as { free?: unknown };
 		return Array.isArray(json.free)
@@ -79,8 +74,7 @@ export async function shouldZeroClineFreeModelCost(
 	const modelId = normalizeModelId(config.modelId);
 	if (!modelId) return false;
 
-	const baseUrl =
-		config.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+	const baseUrl = getClineEnvironmentConfig().apiBaseUrl;
 	const freeModelIds = await getClineFreeModelIds(baseUrl);
 	return freeModelIds.some((freeModelId) =>
 		modelIdsMatch(modelId, freeModelId),

--- a/apps/cli/src/utils/free-model-cost.ts
+++ b/apps/cli/src/utils/free-model-cost.ts
@@ -28,8 +28,11 @@ async function fetchClineFreeModelIds(
 		CLINE_RECOMMENDED_MODELS_TIMEOUT_MS,
 	);
 	try {
+		const trimmedBaseUrl = baseUrl.trim();
+		let end = trimmedBaseUrl.length;
+		while (end > 0 && trimmedBaseUrl[end - 1] === "/") end--;
 		const response = await fetch(
-			`${baseUrl.trim().replace(/\/+$/, "")}/api/v1/ai/cline/recommended-models`,
+			`${trimmedBaseUrl.slice(0, end)}/api/v1/ai/cline/recommended-models`,
 			{
 				signal: controller.signal,
 			},

--- a/apps/cline-hub/src/server/desktop-commands.ts
+++ b/apps/cline-hub/src/server/desktop-commands.ts
@@ -179,8 +179,7 @@ export async function handleDesktopCommand(
 	}
 	if (command === "cline_account") {
 		const settings = providerSettingsManager.getProviderSettings("cline");
-		const apiBaseUrl =
-			settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+		const apiBaseUrl = getClineEnvironmentConfig().apiBaseUrl;
 		const authToken = await resolveHubClineAccountAuthToken({
 			settings,
 			apiBaseUrl,

--- a/apps/examples/desktop-app/sidecar/commands.ts
+++ b/apps/examples/desktop-app/sidecar/commands.ts
@@ -1883,10 +1883,8 @@ export async function handleCommand(
 			syncSignedOutAccountContext(ctx);
 			return CLINE_ACCOUNT_NOT_AUTHENTICATED_RESULT;
 		}
-		const settings = manager.getProviderSettings("cline");
 		const accountService = new ClineAccountService({
-			apiBaseUrl:
-				settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+			apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 			getAuthToken: async () => authToken,
 		});
 		const result = await executeClineAccountAction(
@@ -1907,10 +1905,9 @@ export async function handleCommand(
 		if (!authToken) {
 			return CLINE_ACCOUNT_NOT_AUTHENTICATED_RESULT;
 		}
-		const settings = manager.getProviderSettings("cline");
 		const environment = getClineEnvironmentConfig();
 		const requestOptions = {
-			apiBaseUrl: settings?.baseUrl?.trim() || environment.apiBaseUrl,
+			apiBaseUrl: environment.apiBaseUrl,
 			appBaseUrl: environment.appBaseUrl,
 			authToken,
 		};

--- a/apps/examples/desktop-app/sidecar/oauth-login.test.ts
+++ b/apps/examples/desktop-app/sidecar/oauth-login.test.ts
@@ -1,11 +1,24 @@
 import type { ProviderSettingsManager } from "@cline/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	cancelProviderOAuthLogin,
 	cancelProviderOAuthLoginsForOwner,
 	OAuthLoginCancelledError,
 	runCancellableProviderOAuthLogin,
 } from "./oauth-login";
+
+const deviceAuth = vi.hoisted(() => ({
+	start: vi.fn(),
+	complete: vi.fn(),
+	save: vi.fn(),
+}));
+vi.mock("@cline/core", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cline/core")>()),
+	startClineDeviceAuth: deviceAuth.start,
+	completeClineDeviceAuth: deviceAuth.complete,
+	saveLocalProviderOAuthCredentials: deviceAuth.save,
+	markLocalProviderEnabled: vi.fn(),
+}));
 
 type Credentials = { accessToken: string };
 
@@ -160,5 +173,44 @@ describe("runCancellableProviderOAuthLogin", () => {
 		resolveLogin({ accessToken: "late-token" });
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(save).not.toHaveBeenCalled();
+	});
+});
+
+describe("desktop Cline platform auth", () => {
+	afterEach(() => vi.unstubAllEnvs());
+	it.each([
+		"cline",
+		"cline-pass",
+	])("uses the platform root for %s device auth", async (providerId) => {
+		vi.stubEnv("CLINE_API_BASE_URL", "https://platform.test");
+		deviceAuth.start.mockResolvedValue({
+			deviceCode: "code",
+			userCode: "user-code",
+			verificationUri: "https://verify.test",
+			expiresInSeconds: 600,
+			pollIntervalSeconds: 5,
+		});
+		deviceAuth.complete.mockResolvedValue({
+			access: "token",
+			refresh: "refresh",
+			expires: 0,
+		});
+		deviceAuth.save.mockReturnValue({
+			provider: "cline",
+			auth: { accessToken: "token" },
+		});
+		const manager = {
+			getProviderSettings: () => ({
+				provider: "cline",
+				baseUrl: "https://inference.test/api/v1",
+			}),
+		} as unknown as ProviderSettingsManager;
+		await runCancellableProviderOAuthLogin(manager, providerId, vi.fn());
+		expect(deviceAuth.complete).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				apiBaseUrl: "https://platform.test",
+				provider: providerId,
+			}),
+		);
 	});
 });

--- a/apps/examples/desktop-app/sidecar/oauth-login.ts
+++ b/apps/examples/desktop-app/sidecar/oauth-login.ts
@@ -56,8 +56,7 @@ async function loginProviderForDesktop(
 		deviceCode: device.deviceCode,
 		expiresInSeconds: device.expiresInSeconds,
 		pollIntervalSeconds: device.pollIntervalSeconds,
-		apiBaseUrl:
-			existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+		apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 		provider: providerId,
 	});
 }

--- a/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
+++ b/apps/vscode/src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts
@@ -35,6 +35,10 @@ describe("refreshClineRecommendedModels", () => {
 		const result = await refreshClineRecommendedModels()
 
 		expect(sdkSpy).toHaveBeenCalledTimes(1)
+		expect(sdkSpy).toHaveBeenCalledWith({
+			apiBaseUrl: "https://api.cline-test.bot",
+			fetchImpl: expect.any(Function),
+		})
 		expect(result).toEqual(sdkResult)
 	})
 

--- a/apps/vscode/src/core/controller/models/refreshClineRecommendedModels.ts
+++ b/apps/vscode/src/core/controller/models/refreshClineRecommendedModels.ts
@@ -56,7 +56,7 @@ async function fetchAndCacheClineRecommendedModels(): Promise<ClineRecommendedMo
 	// extension's configured API base URL. On failure the SDK returns its own
 	// fallback list.
 	const result = await fetchClineRecommendedModels({
-		baseUrl: ClineEnv.config().apiBaseUrl,
+		apiBaseUrl: ClineEnv.config().apiBaseUrl,
 		fetchImpl: fetch,
 	})
 

--- a/apps/vscode/src/test/cline-core-vitest-stub.ts
+++ b/apps/vscode/src/test/cline-core-vitest-stub.ts
@@ -492,7 +492,7 @@ export const FALLBACK_CLINE_RECOMMENDED_MODELS: ClineRecommendedModelsData = {
 }
 
 export async function fetchClineRecommendedModels(_options?: {
-	baseUrl?: string
+	apiBaseUrl?: string
 	fetchImpl?: typeof fetch
 }): Promise<ClineRecommendedModelsData> {
 	return { recommended: [], free: [] }

--- a/sdk/packages/core/README.md
+++ b/sdk/packages/core/README.md
@@ -120,3 +120,14 @@ The package also exports storage and settings helpers such as:
 - Repo examples: [examples](https://github.com/cline/sdk/tree/main/examples), [apps/examples](https://github.com/cline/sdk/tree/main/apps/examples)
 - Workspace overview: [README.md](https://github.com/cline/cline/blob/main/README.md)
 - API and architecture references: [DOC.md](https://github.com/cline/cline/blob/main/DOC.md), [ARCHITECTURE.md](https://github.com/cline/cline/blob/main/ARCHITECTURE.md)
+
+## Cline platform API configuration
+
+Cline platform services use `getClineEnvironmentConfig().apiBaseUrl`, selected by
+`CLINE_ENVIRONMENT` / `CLINE_ENVIRONMENT_OVERRIDE` or overridden with
+`CLINE_API_BASE_URL`. Provider settings `baseUrl` configures the inference endpoint
+(e.g. `https://api.cline.bot/api/v1`) and does not configure platform services.
+
+`fetchClineRecommendedModels` and `getCachedClineRecommendedModels` accept an
+optional `apiBaseUrl` platform root (e.g. `https://api.cline.bot`) for hosts with
+separate environment configuration. These functions do not read provider settings.

--- a/sdk/packages/core/src/auth/provider-auth-registry.test.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	formatProviderOAuthApiKey,
 	getPersistedProviderApiKey,
@@ -10,12 +10,13 @@ import {
 	resolveProviderApiKeyFromSettings,
 } from "./provider-auth-registry";
 
-const { loginClineOAuth } = vi.hoisted(() => ({
+const { loginClineOAuth, getValidClineCredentials } = vi.hoisted(() => ({
 	loginClineOAuth: vi.fn(),
+	getValidClineCredentials: vi.fn(),
 }));
 
 vi.mock("./cline", () => ({
-	getValidClineCredentials: vi.fn(),
+	getValidClineCredentials,
 	loginClineOAuth,
 }));
 
@@ -283,5 +284,35 @@ describe("provider auth registry", () => {
 			accountId: "acct-stored",
 			metadata: { sessionStartedAtMs: 1_700_000_000_002 },
 		});
+	});
+});
+
+describe("Cline platform auth routing", () => {
+	afterEach(() => vi.unstubAllEnvs());
+	it.each([
+		"cline",
+		"cline-pass",
+	])("ignores %s inference settings for login and refresh", async (providerId) => {
+		vi.stubEnv("CLINE_API_BASE_URL", "https://platform.test");
+		const handler = getProviderAuthHandler(providerId);
+		if (!handler) throw new Error(`Missing auth handler: ${providerId}`);
+		const settings = {
+			provider: providerId,
+			baseUrl: "https://inference.test/api/v1",
+		};
+		await handler.login({
+			settings,
+			callbacks: { onAuth: vi.fn(), onPrompt: vi.fn() },
+		});
+		expect(loginClineOAuth).toHaveBeenLastCalledWith(
+			expect.objectContaining({ apiBaseUrl: "https://platform.test" }),
+		);
+		const credentials = { access: "access", refresh: "refresh", expires: 0 };
+		await handler.refresh({ settings, credentials, forceRefresh: true });
+		expect(getValidClineCredentials).toHaveBeenLastCalledWith(
+			credentials,
+			expect.objectContaining({ apiBaseUrl: "https://platform.test" }),
+			{ forceRefresh: true },
+		);
 	});
 });

--- a/sdk/packages/core/src/auth/provider-auth-registry.ts
+++ b/sdk/packages/core/src/auth/provider-auth-registry.ts
@@ -219,20 +219,18 @@ function createClineAuthHandler(input: {
 		storageProviderId: input.storageProviderId,
 		formatAccessToken: formatClineApiKey,
 		normalizeStoredAccessToken: stripClineApiKeyPrefix,
-		login: ({ settings, callbacks, telemetry }) =>
+		login: ({ callbacks, telemetry }) =>
 			loginClineOAuth({
-				apiBaseUrl:
-					settings?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+				apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 				useWorkOSDeviceAuth: true,
 				callbacks,
 				telemetry,
 			}),
-		refresh: ({ settings, credentials, forceRefresh, telemetry }) =>
+		refresh: ({ credentials, forceRefresh, telemetry }) =>
 			getValidClineCredentials(
 				credentials as ClineOAuthCredentials,
 				{
-					apiBaseUrl:
-						settings.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
+					apiBaseUrl: getClineEnvironmentConfig().apiBaseUrl,
 					telemetry,
 				},
 				{ forceRefresh },

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -95,6 +95,26 @@ function namesOf(data: ClineRecommendedModelsData) {
 }
 
 describe("fetchClineRecommendedModels", () => {
+	it.each([
+		[BASE_URL, BASE_URL],
+		[BASE_URL + "///", BASE_URL],
+		[BASE_URL + "/".repeat(100_000), BASE_URL],
+		[
+			BASE_URL + "/".repeat(100_000) + "path///",
+			BASE_URL + "/".repeat(100_000) + "path",
+		],
+	])("normalizes trailing slashes in case %#", async (apiBaseUrl, expectedBaseUrl) => {
+		const fetchImpl = vi.fn(jsonResponse(ENDPOINT_PAYLOAD));
+		await fetchClineRecommendedModels({
+			apiBaseUrl,
+			fetchImpl,
+			catalogLoader: async () => CATALOG,
+		});
+		expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+			expectedBaseUrl + "/api/v1/ai/cline/recommended-models",
+		);
+	});
+
 	it("resolves display names from the models catalog", async () => {
 		const data = await fetchClineRecommendedModels({
 			apiBaseUrl: BASE_URL,

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.test.ts
@@ -2,7 +2,8 @@ import {
 	GENERATED_CLINE_RECOMMENDED_MODELS,
 	getGeneratedProviderModels,
 } from "@cline/llms";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import {
 	applyClineFeaturedModels,
 	type ClineRecommendedModelsData,
@@ -96,7 +97,7 @@ function namesOf(data: ClineRecommendedModelsData) {
 describe("fetchClineRecommendedModels", () => {
 	it("resolves display names from the models catalog", async () => {
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
 			catalogLoader: async () => CATALOG,
 		});
@@ -120,7 +121,7 @@ describe("fetchClineRecommendedModels", () => {
 
 	it("degrades to endpoint names and id slugs when the catalog is unavailable", async () => {
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
 			catalogLoader: async () => {
 				throw new Error("models.dev unreachable");
@@ -136,7 +137,7 @@ describe("fetchClineRecommendedModels", () => {
 
 	it("does not wait for a hung catalog loader beyond the timeout", async () => {
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: jsonResponse(ENDPOINT_PAYLOAD),
 			timeoutMs: 25,
 			catalogLoader: () => new Promise(() => {}),
@@ -161,7 +162,7 @@ describe("fetchClineRecommendedModels", () => {
 
 		const startedAt = Date.now();
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: slowFeed,
 			timeoutMs,
 			catalogLoader: () => new Promise(() => {}),
@@ -187,7 +188,7 @@ describe("fetchClineRecommendedModels", () => {
 		};
 
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: slowFeed,
 			timeoutMs,
 			catalogLoader: async () => CATALOG,
@@ -198,7 +199,7 @@ describe("fetchClineRecommendedModels", () => {
 
 	it("returns the bundled fallback untouched when the endpoint fails", async () => {
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: async () => new Response("nope", { status: 500 }),
 			catalogLoader: async () => CATALOG,
 		});
@@ -365,7 +366,7 @@ describe("getCachedClineRecommendedModels", () => {
 			});
 		};
 		const options = {
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl,
 			catalogLoader: async () => CATALOG,
 		};
@@ -391,7 +392,7 @@ describe("getCachedClineRecommendedModels", () => {
 			return new Response("nope", { status: 500 });
 		};
 		const options = {
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl,
 			catalogLoader: async () => CATALOG,
 		};
@@ -419,7 +420,7 @@ describe("getCachedClineRecommendedModels", () => {
 			});
 		};
 		const stale = getCachedClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: staleFetch,
 			catalogLoader: async () => CATALOG,
 		});
@@ -439,7 +440,7 @@ describe("getCachedClineRecommendedModels", () => {
 			});
 		};
 		await getCachedClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: freshFetch,
 			catalogLoader: async () => CATALOG,
 		});
@@ -460,7 +461,7 @@ describe("peekClineRecommendedModels", () => {
 		resetClineRecommendedModelsCacheForTests();
 		let calls = 0;
 		await getCachedClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: async () => {
 				calls += 1;
 				return new Response(JSON.stringify(ENDPOINT_PAYLOAD), {
@@ -485,7 +486,7 @@ describe("generated offline featured models", () => {
 	it("preserves every generated tier and its authored order without loading a live catalog", async () => {
 		let catalogLoaded = false;
 		const data = await fetchClineRecommendedModels({
-			baseUrl: BASE_URL,
+			apiBaseUrl: BASE_URL,
 			fetchImpl: async () => {
 				throw new Error("offline");
 			},
@@ -550,5 +551,55 @@ describe("generated offline featured models", () => {
 				);
 			}
 		}
+	});
+});
+
+describe("recommendations platform API routing", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	it.each([
+		["production", "https://api.cline.bot"],
+		["staging", "https://core-api.staging.int.cline.bot"],
+		["local", "http://localhost:7777"],
+	])("uses the %s platform with a persisted inference URL", async (environment, apiBaseUrl) => {
+		vi.stubEnv("CLINE_ENVIRONMENT_OVERRIDE", environment);
+		vi.stubEnv("CLINE_API_BASE_URL", "");
+		const readSettings = vi
+			.spyOn(ProviderSettingsManager.prototype, "getProviderSettings")
+			.mockReturnValue({
+				provider: "cline",
+				baseUrl: "https://api.cline.bot/api/v1",
+			});
+		const fetchImpl = vi.fn(jsonResponse(ENDPOINT_PAYLOAD));
+		await fetchClineRecommendedModels({
+			fetchImpl,
+			catalogLoader: async () => CATALOG,
+		});
+		expect(fetchImpl).toHaveBeenCalledWith(
+			`${apiBaseUrl}/api/v1/ai/cline/recommended-models`,
+			expect.anything(),
+		);
+		expect(readSettings).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		undefined,
+		"  https://explicit.test/  ",
+	])("honors platform overrides (%s)", async (apiBaseUrl) => {
+		vi.stubEnv("CLINE_API_BASE_URL", "https://platform.test/");
+		const fetchImpl = vi.fn(jsonResponse(ENDPOINT_PAYLOAD));
+		await fetchClineRecommendedModels({
+			apiBaseUrl,
+			fetchImpl,
+			catalogLoader: async () => CATALOG,
+		});
+		const host = apiBaseUrl ? "https://explicit.test" : "https://platform.test";
+		expect(fetchImpl).toHaveBeenCalledWith(
+			`${host}/api/v1/ai/cline/recommended-models`,
+			expect.anything(),
+		);
 	});
 });

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -8,7 +8,6 @@ import {
 	type ProviderModel,
 	type ProviderModelFeaturedTier,
 } from "@cline/shared";
-import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import { getLiveModelsCatalog } from "./provider-defaults";
 import type { ModelInfo } from "./provider-settings";
 
@@ -29,12 +28,9 @@ export interface ClineRecommendedModelsData {
 type ModelsCatalog = Record<string, Record<string, ModelInfo>>;
 
 export interface FetchClineRecommendedModelsOptions {
-	baseUrl?: string;
+	/** Platform API root, separate from the provider inference baseUrl. */
+	apiBaseUrl?: string;
 	fetchImpl?: typeof fetch;
-	providerSettingsManager?: Pick<
-		ProviderSettingsManager,
-		"getProviderSettings"
-	>;
 	timeoutMs?: number;
 	/**
 	 * Loader for the live models catalog used to resolve display names.
@@ -110,23 +106,6 @@ function normalizeResponse(raw: unknown): ClineRecommendedModelsData | null {
 	}
 
 	return { recommended, free, clinePass };
-}
-
-function getConfiguredApiBaseUrl(
-	options: FetchClineRecommendedModelsOptions,
-): string {
-	const explicitBaseUrl = options.baseUrl?.trim();
-	if (explicitBaseUrl) return explicitBaseUrl;
-
-	const fallbackBaseUrl = getClineEnvironmentConfig().apiBaseUrl;
-	try {
-		const manager =
-			options.providerSettingsManager ?? new ProviderSettingsManager();
-		const settings = manager.getProviderSettings("cline");
-		return settings?.baseUrl?.trim() || fallbackBaseUrl;
-	} catch {
-		return fallbackBaseUrl;
-	}
 }
 
 async function fetchWithTimeout(
@@ -259,7 +238,9 @@ export async function fetchClineRecommendedModels(
 	// promise resolves on a microtask, ahead of the zero-delay timer.
 	const deadline = Date.now() + timeoutMs;
 	try {
-		const base = getConfiguredApiBaseUrl(options);
+		const base = (
+			options.apiBaseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl
+		).replace(/\/+$/, "");
 		const fetchImpl = options.fetchImpl ?? fetch;
 		const resp = await fetchWithTimeout(
 			fetchImpl,

--- a/sdk/packages/core/src/services/llms/cline-recommended-models.ts
+++ b/sdk/packages/core/src/services/llms/cline-recommended-models.ts
@@ -238,9 +238,11 @@ export async function fetchClineRecommendedModels(
 	// promise resolves on a microtask, ahead of the zero-delay timer.
 	const deadline = Date.now() + timeoutMs;
 	try {
-		const base = (
-			options.apiBaseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl
-		).replace(/\/+$/, "");
+		const apiBaseUrl =
+			options.apiBaseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
+		let end = apiBaseUrl.length;
+		while (end > 0 && apiBaseUrl[end - 1] === "/") end--;
+		const base = apiBaseUrl.slice(0, end);
 		const fetchImpl = options.fetchImpl ?? fetch;
 		const resp = await fetchWithTimeout(
 			fetchImpl,

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1895,7 +1895,7 @@ describe("listLocalProviders", () => {
 		);
 		const [recommendedId, freeId] = clineModelIds;
 		await getCachedClineRecommendedModels({
-			baseUrl: "https://api.example.test",
+			apiBaseUrl: "https://api.example.test",
 			fetchImpl: async () =>
 				new Response(
 					JSON.stringify({


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX — teammate report; no linked issue.

### Description

A saved Cline inference endpoint such as `https://api.cline.bot/api/v1` made the recommendations fetcher request `/api/v1/api/v1/ai/cline/recommended-models`, fail, and silently return the offline list. Recommendations now use the Cline environment's platform API root, independent of provider settings.

Rename the fetcher override to `apiBaseUrl`, remove its provider-settings dependency, and update all callers. Apply the same configuration boundary to core OAuth and CLI, hub, and desktop platform-service callers, including account/integration requests and the CLI free-model feed. Remove the CLI's inference-URL suffix-stripping workaround. Inference settings remain valid and require no migration; custom platform routing uses `CLINE_API_BASE_URL`.

### Test Procedure

- `bun run build:sdk` passed.
- Core recommendations, OAuth registry, OAuth protocol, and provider-service suites: 137 tests passed.
- CLI free-model cost, ACP organizations, and onboarding auth suites: 15 tests passed.
- Desktop OAuth suite: 7 tests passed; VS Code recommendations wrapper: 3 tests passed.
- Core, CLI, hub, and desktop type checks passed.
- Changed SDK/CLI/hub/desktop TypeScript files formatted and linted with Biome; no lint errors (existing informational diagnostics remain). VS Code staged-file Biome hook and gitleaks passed.

Regression coverage checks production/staging/local platform roots with a stored inference URL, explicit/environment platform overrides, trailing slashes, login/refresh and device-auth routing, CLI free-model routing, and VS Code option forwarding. No live account or inference requests were made.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; platform URL routing only.

### Additional Notes

The full monorepo test/lint commands were not run; focused validation is listed above. The experimental SDK option rename is intentional: `baseUrl` becomes `apiBaseUrl`, and `providerSettingsManager` is removed from `FetchClineRecommendedModelsOptions`. All repository callers are updated without compatibility shims.
