### PR TITLE
fix(llms): correct OpenCode Go session headers and model API routing

### DIFF
--- a/sdk/packages/llms/src/catalog/README.md
+++ b/sdk/packages/llms/src/catalog/README.md
@@ -8,6 +8,22 @@ generation scripts.
 This file documents the intended meaning of the token-limit fields and the
 boundary between catalog metadata and runtime request policy.
 
+## Per-model API Protocols
+
+Models.dev's model-level `provider.npm` is retained as `metadata.apiProtocol`
+for OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and Gemini.
+Providers opt into these model routes with `metadata.routing.modelApiProtocol`
+when they serve those protocols under a shared base URL. The selected adapter
+also owns request options, serialization, and stream parsing. Native providers
+and local CLI providers retain their own transports.
+
+OpenCode Go opts in and sends `x-opencode-session` from request metadata's
+`sessionId`, plus a Cline User-Agent. Direct gateway callers should supply a
+stable `sessionId` per conversation; ClineCore supplies its session identity.
+Go's Qwen entries without an upstream adapter declaration use Anthropic
+Messages, matching [Go's endpoint documentation](https://opencode.ai/docs/go/#endpoints).
+An explicit upstream declaration takes precedence over that narrow fallback.
+
 ## Audio Modalities
 
 Audio-capable entries retain models.dev's directional modality metadata:

--- a/sdk/packages/llms/src/catalog/catalog-live.test.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.test.ts
@@ -14,6 +14,44 @@ import {
 } from "./catalog-live";
 
 describe("models-dev-catalog", () => {
+	it("preserves model adapters and narrowly fills missing Go Qwen declarations", () => {
+		const models = {
+			muse: { tool_call: true, provider: { npm: "@ai-sdk/openai" } },
+			minimax: { tool_call: true, provider: { npm: "@ai-sdk/anthropic" } },
+			google: { tool_call: true, provider: { npm: "@ai-sdk/google" } },
+			qwen: { tool_call: true, family: "qwen3.7-plus" },
+			explicitQwen: {
+				tool_call: true,
+				family: "qwen",
+				provider: { npm: "@ai-sdk/openai-compatible" },
+			},
+			unknownQwen: {
+				tool_call: true,
+				family: "qwen",
+				provider: { npm: "unknown-sdk" },
+			},
+			glm: { tool_call: true, family: "glm" },
+		};
+		const result = normalizeModelsDevProviderModels({
+			"opencode-go": { npm: "@ai-sdk/openai-compatible", models },
+			"other-gateway": { npm: "@ai-sdk/openai-compatible", models },
+		});
+		expect(result["opencode-go"].muse.metadata?.apiProtocol).toBe(
+			"openai-responses",
+		);
+		expect(result["opencode-go"].minimax.metadata?.apiProtocol).toBe(
+			"anthropic",
+		);
+		expect(result["opencode-go"].google.metadata?.apiProtocol).toBe("gemini");
+		expect(result["opencode-go"].qwen.metadata?.apiProtocol).toBe("anthropic");
+		expect(result["opencode-go"].explicitQwen.metadata?.apiProtocol).toBe(
+			"openai-chat",
+		);
+		expect(result["opencode-go"].unknownQwen.metadata).toBeUndefined();
+		expect(result["opencode-go"].glm.metadata).toBeUndefined();
+		expect(result["other-gateway"].qwen.metadata).toBeUndefined();
+	});
+
 	it("bundles zero prices for every Cline Pass model without a live refresh", () => {
 		const models = Object.values(getGeneratedModelsForProvider("cline-pass"));
 		expect(models.length).toBeGreaterThan(0);

--- a/sdk/packages/llms/src/catalog/catalog-live.ts
+++ b/sdk/packages/llms/src/catalog/catalog-live.ts
@@ -19,6 +19,7 @@ import {
 import type { ModelInfo, ModelModality } from "./types";
 
 export interface ModelsDevModel {
+	provider?: { npm?: string };
 	name?: string;
 	tool_call?: boolean;
 	reasoning?: boolean;
@@ -319,6 +320,9 @@ function toModelInfo(modelId: string, model: ModelsDevModel): ModelInfo {
 	const modalities = toModalities(model);
 	const operation = resolveCatalogModelOperation(model);
 	const operationModes = resolveCatalogModelOperationModes(modelId, model);
+	const apiProtocol = model.provider?.npm
+		? MODEL_API_PROTOCOLS[model.provider.npm]
+		: undefined;
 
 	return {
 		id: modelId,
@@ -342,8 +346,19 @@ function toModelInfo(modelId: string, model: ModelsDevModel): ModelInfo {
 		...(operation !== "language" ? { operation } : {}),
 		...(operationModes ? { operationModes } : {}),
 		...(modalities !== undefined ? { modalities } : {}),
+		...(apiProtocol ? { metadata: { apiProtocol } } : {}),
 	};
 }
+
+const MODEL_API_PROTOCOLS: Record<
+	string,
+	NonNullable<ModelInfo["metadata"]>["apiProtocol"]
+> = {
+	"@ai-sdk/openai": "openai-responses",
+	"@ai-sdk/openai-compatible": "openai-chat",
+	"@ai-sdk/anthropic": "anthropic",
+	"@ai-sdk/google": "gemini",
+};
 
 function isDeprecatedModel(model: ModelsDevModel): boolean {
 	return model.status === "deprecated";
@@ -364,6 +379,16 @@ export function normalizeModelsDevProviderModels(
 		const models: Record<string, ModelInfo> = {};
 		for (const [modelId, model] of Object.entries(source.models)) {
 			const rawInfo = toModelInfo(modelId, model);
+			// Go documents Qwen's Messages endpoint, but some models.dev Qwen
+			// entries still omit provider.npm. Explicit upstream declarations win.
+			// https://opencode.ai/docs/go/#endpoints
+			if (
+				targetProviderId === "opencode-go" &&
+				/^qwen(?:\d|$)/.test(model.family ?? "") &&
+				!model.provider?.npm
+			) {
+				rawInfo.metadata = { ...rawInfo.metadata, apiProtocol: "anthropic" };
+			}
 			const modalities = normalizeBuiltinModelOperationModalities({
 				providerId: targetProviderId,
 				modelId,

--- a/sdk/packages/llms/src/catalog/catalog.generated.ts
+++ b/sdk/packages/llms/src/catalog/catalog.generated.ts
@@ -14,7 +14,7 @@ export const GENERATED_PROVIDER_MODELS: {
   version: number
   providers: Record<string, Record<string, ModelInfo>>
 } = {
-  version: 1788996592014,
+  version: 1789081881778,
   providers: {
   "302ai": {
     "gpt-6-astra": {
@@ -117381,6 +117381,9 @@ export const GENERATED_PROVIDER_MODELS: {
         "output": [
           "text"
         ]
+      },
+      "metadata": {
+        "apiProtocol": "openai-responses"
       }
     },
     "hy4-preview": {
@@ -117486,7 +117489,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0.2
       },
       "releaseDate": "2026-08-26",
-      "family": "qwen"
+      "family": "qwen",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "deepseek-v4-flash-vision-exp": {
       "id": "deepseek-v4-flash-vision-exp",
@@ -117588,7 +117594,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0
       },
       "releaseDate": "2026-08-12",
-      "family": "grok"
+      "family": "grok",
+      "metadata": {
+        "apiProtocol": "openai-responses"
+      }
     },
     "muse-spark-1.2-contributor": {
       "id": "muse-spark-1.2-contributor",
@@ -117637,6 +117646,9 @@ export const GENERATED_PROVIDER_MODELS: {
         "output": [
           "text"
         ]
+      },
+      "metadata": {
+        "apiProtocol": "openai-responses"
       }
     },
     "qwen3.8-max": {
@@ -117678,7 +117690,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 2.5
       },
       "releaseDate": "2026-08-03",
-      "family": "qwen3.8-max"
+      "family": "qwen3.8-max",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "deepseek-v4-flash": {
       "id": "deepseek-v4-flash",
@@ -117777,7 +117792,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0.25
       },
       "releaseDate": "2026-07-09",
-      "family": "gpt-luna"
+      "family": "gpt-luna",
+      "metadata": {
+        "apiProtocol": "openai-responses"
+      }
     },
     "hy3": {
       "id": "hy3",
@@ -117921,7 +117939,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0.5
       },
       "releaseDate": "2026-06-02",
-      "family": "qwen3.7-plus"
+      "family": "qwen3.7-plus",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "minimax-m3": {
       "id": "minimax-m3",
@@ -117949,7 +117970,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0
       },
       "releaseDate": "2026-05-31",
-      "family": "minimax-m3"
+      "family": "minimax-m3",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "qwen3.7-max": {
       "id": "qwen3.7-max",
@@ -117979,7 +118003,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 3.125
       },
       "releaseDate": "2026-05-21",
-      "family": "qwen3.7-max"
+      "family": "qwen3.7-max",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "deepseek-v4-pro": {
       "id": "deepseek-v4-pro",
@@ -118145,7 +118172,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0.625
       },
       "releaseDate": "2026-04-02",
-      "family": "qwen3.6"
+      "family": "qwen3.6",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     },
     "minimax-m2.7": {
       "id": "minimax-m2.7",
@@ -118167,7 +118197,10 @@ export const GENERATED_PROVIDER_MODELS: {
         "cacheWrite": 0
       },
       "releaseDate": "2026-03-18",
-      "family": "minimax-m2.7"
+      "family": "minimax-m2.7",
+      "metadata": {
+        "apiProtocol": "anthropic"
+      }
     }
   },
   "openreason": {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -2034,9 +2034,14 @@ export function withEmptyResponseRetry(
 	});
 }
 
-function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
+function createAiSdkProvider(
+	defaultKind: ProviderModuleKind,
+): GatewayProviderFactory {
 	return async (config) => ({
 		async *stream(request, context) {
+			// Multi-protocol HTTP gateways declare model adapters in models.dev.
+			// Keep native and local CLI transports authoritative for their models.
+			const kind = resolveModelProviderKind(defaultKind, context);
 			const log = context.logger;
 			let stream: AiSdkStreamResult | undefined;
 			const capturedError: { current: CapturedStreamError | undefined } = {
@@ -2350,6 +2355,27 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 			}
 		},
 	});
+}
+
+function resolveModelProviderKind(
+	defaultKind: ProviderModuleKind,
+	context: GatewayProviderContext,
+): ProviderModuleKind {
+	if (
+		defaultKind !== "openai-compatible" ||
+		!context.provider.metadata?.routing?.modelApiProtocol
+	)
+		return defaultKind;
+	switch (context.model.metadata?.apiProtocol) {
+		case "openai-responses":
+			return "openai";
+		case "anthropic":
+			return "anthropic";
+		case "gemini":
+			return "google";
+		default:
+			return defaultKind;
+	}
 }
 
 export const createOpenAIProvider = createAiSdkProvider("openai");

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -583,6 +583,9 @@ function modelInfoToGateway(
 	if (typeof info.metadata?.reasoningDefaultOn === "boolean") {
 		metadata.reasoningDefaultOn = info.metadata.reasoningDefaultOn;
 	}
+	if (info.metadata?.apiProtocol) {
+		metadata.apiProtocol = info.metadata.apiProtocol;
+	}
 	return {
 		id: info.id,
 		name: info.name ?? info.id,
@@ -759,6 +762,19 @@ const clinePass = createClineLikeSpec({
  * be duplicated here.
  */
 const OPENAI_COMPATIBLE_SPEC_OVERRIDES: BuiltinSpecOverride[] = [
+	{
+		id: "opencode-go",
+		docsUrl: "https://opencode.ai/docs/go/",
+		defaults: { headers: { "User-Agent": "Cline/SDK" } },
+		metadata: {
+			routing: { modelApiProtocol: true },
+			stickySession: {
+				transport: "header",
+				field: "x-opencode-session",
+				metadataKey: "sessionId",
+			},
+		},
+	},
 	{
 		id: "openai-compatible",
 		name: "OpenAI Compatible",

--- a/sdk/packages/llms/src/providers/compat.test.ts
+++ b/sdk/packages/llms/src/providers/compat.test.ts
@@ -362,6 +362,34 @@ describe("createGatewayApiHandler.createMessage", () => {
 		openaiCompatibleSpy.mockClear();
 	});
 
+	it.each([
+		["openai-responses", "openai"],
+		["anthropic", "anthropic"],
+	])("retains live model protocol %s through the handler", async (apiProtocol, family) => {
+		streamTextSpy.mockReturnValue({
+			fullStream: (async function* () {
+				yield { type: "finish", finishReason: "stop" };
+			})(),
+		});
+		const handler = createGatewayApiHandler({
+			providerId: "opencode-go",
+			modelId: "new-live-model",
+			apiKey: "test-key",
+			knownModels: {
+				"new-live-model": { id: "new-live-model", metadata: { apiProtocol } },
+			},
+		});
+		for await (const _chunk of handler.createMessage("", [
+			{ role: "user", content: "Hello" },
+		])) {
+			// Exercise the live catalog -> handler -> gateway projection.
+		}
+		expect(streamTextSpy.mock.calls.at(-1)?.[0].model).toMatchObject({
+			modelId: "new-live-model",
+			family,
+		});
+	});
+
 	it("uses the default maxOutputTokens without expanding to catalog maxTokens", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: (async function* () {

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -70,6 +70,9 @@ function toGatewayModelDefinition(
 		capabilities: toGatewayModelCapabilities(model.capabilities),
 		reasoningOptions: model.reasoningOptions,
 		metadata: {
+			...(model.metadata?.apiProtocol
+				? { apiProtocol: model.metadata.apiProtocol }
+				: {}),
 			family: model.family,
 			pricing: model.pricing,
 			status: model.status,

--- a/sdk/packages/llms/src/providers/opencode-go.test.ts
+++ b/sdk/packages/llms/src/providers/opencode-go.test.ts
@@ -1,0 +1,268 @@
+import type { AgentModelEvent, AgentToolDefinition } from "@cline/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createGateway } from "./gateway";
+
+const tool: AgentToolDefinition = {
+	name: "read_files",
+	description: "Read files",
+	inputSchema: {
+		type: "object",
+		properties: { path: { type: "string" } },
+		required: ["path"],
+	},
+};
+
+function sse(events: Record<string, unknown>[]) {
+	return events
+		.map(
+			(event) =>
+				`event: ${event.type ?? "message"}\ndata: ${JSON.stringify(event)}\n\n`,
+		)
+		.join("");
+}
+
+const chatResponse = `${sse([
+	{
+		id: "chat-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "test",
+		choices: [{ index: 0, delta: { content: "OK" }, finish_reason: null }],
+	},
+	{
+		id: "chat-1",
+		object: "chat.completion.chunk",
+		created: 1,
+		model: "test",
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+	},
+])}data: [DONE]\n\n`;
+
+const responsesResponse = sse([
+	{
+		type: "response.created",
+		response: { id: "resp-1", created_at: 1, model: "test" },
+	},
+	{
+		type: "response.output_item.added",
+		output_index: 0,
+		item: { type: "message", id: "msg-1", role: "assistant", content: [] },
+	},
+	{
+		type: "response.output_text.delta",
+		item_id: "msg-1",
+		output_index: 0,
+		content_index: 0,
+		delta: "OK",
+	},
+	{
+		type: "response.output_item.done",
+		output_index: 0,
+		item: {
+			type: "message",
+			id: "msg-1",
+			role: "assistant",
+			content: [{ type: "output_text", text: "OK", annotations: [] }],
+		},
+	},
+	{
+		type: "response.completed",
+		response: {
+			id: "resp-1",
+			created_at: 1,
+			model: "test",
+			status: "completed",
+			incomplete_details: null,
+			usage: {
+				input_tokens: 10,
+				output_tokens: 1,
+				input_tokens_details: { cached_tokens: 0 },
+				output_tokens_details: { reasoning_tokens: 0 },
+			},
+		},
+	},
+]);
+
+const messagesResponse = sse([
+	{
+		type: "message_start",
+		message: {
+			id: "msg-1",
+			type: "message",
+			role: "assistant",
+			model: "test",
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 10, output_tokens: 0 },
+		},
+	},
+	{
+		type: "content_block_start",
+		index: 0,
+		content_block: { type: "text", text: "" },
+	},
+	{
+		type: "content_block_delta",
+		index: 0,
+		delta: { type: "text_delta", text: "OK" },
+	},
+	{ type: "content_block_stop", index: 0 },
+	{
+		type: "message_delta",
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: 1 },
+	},
+	{ type: "message_stop" },
+]);
+
+describe("OpenCode Go HTTP integration", () => {
+	it.each([
+		["openai-compatible", { apiProtocol: "openai-responses" }],
+		["opencode-go", {}],
+		["opencode-go", { apiProtocol: "unknown" }],
+	])("keeps chat routing without an opted-in known protocol (%s, %j)", async (providerId, metadata) => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+				new Response(chatResponse, {
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId,
+					apiKey: "test-key",
+					baseUrl: "https://gateway.example/v1",
+					models: [{ id: "test-model", name: "Test", metadata }],
+					fetch: fetchMock as unknown as typeof fetch,
+				},
+			],
+		});
+		for await (const _event of await gateway.stream({
+			providerId,
+			modelId: "test-model",
+			metadata: { sessionId: "test-session" },
+			messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+		})) {
+			/* Drain the real adapter stream. */
+		}
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+			"https://gateway.example/v1/chat/completions",
+		);
+	});
+
+	it("keeps a Go conversation header through Responses retries", async () => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
+				if (fetchMock.mock.calls.length === 1)
+					return new Response(
+						JSON.stringify({ error: { message: "temporarily unavailable" } }),
+						{ status: 503, headers: { "content-type": "application/json" } },
+					);
+				return new Response(responsesResponse, {
+					headers: { "content-type": "text/event-stream" },
+				});
+			},
+		);
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "opencode-go",
+					apiKey: "test-key",
+					fetch: fetchMock as unknown as typeof fetch,
+				},
+			],
+		});
+		const events: AgentModelEvent[] = [];
+		for await (const event of await gateway.stream({
+			providerId: "opencode-go",
+			modelId: "muse-spark-1.3-contributor",
+			metadata: { sessionId: "retry-session" },
+			messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+		}))
+			events.push(event);
+		expect(events).toContainEqual(
+			expect.objectContaining({ type: "text-delta", text: "OK" }),
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		for (const [, init] of fetchMock.mock.calls)
+			expect(new Headers(init?.headers).get("x-opencode-session")).toBe(
+				"retry-session",
+			);
+	});
+
+	it.each([
+		["glm-5.3", "chat/completions", chatResponse],
+		["kimi-k2.6", "chat/completions", chatResponse],
+		["muse-spark-1.3-contributor", "responses", responsesResponse],
+		["muse-spark-1.2-contributor", "responses", responsesResponse],
+		["minimax-m2.7", "messages", messagesResponse],
+		["qwen3.7-plus", "messages", messagesResponse],
+	])("routes %s with conversation headers, tools, and stream decoding", async (modelId, endpoint, response) => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+				new Response(response, {
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "opencode-go",
+					apiKey: "test-key",
+					fetch: fetchMock as unknown as typeof fetch,
+				},
+			],
+		});
+		for (const sessionId of [
+			"conversation-a",
+			"conversation-a",
+			"conversation-b",
+		]) {
+			const events: AgentModelEvent[] = [];
+			for await (const event of await gateway.stream({
+				providerId: "opencode-go",
+				modelId,
+				metadata: { sessionId },
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "Inspect the project" }],
+					},
+				],
+				tools: [tool],
+			}))
+				events.push(event);
+			expect(events).toContainEqual(
+				expect.objectContaining({ type: "text-delta", text: "OK" }),
+			);
+			expect(events).toContainEqual(
+				expect.objectContaining({ type: "finish", reason: "stop" }),
+			);
+			const [url, init] = fetchMock.mock.calls.at(-1) ?? [];
+			expect(String(url)).toBe(`https://opencode.ai/zen/go/v1/${endpoint}`);
+			const headers = new Headers(init?.headers);
+			expect(headers.get("x-opencode-session")).toBe(sessionId);
+			expect(headers.get("user-agent")).toContain("Cline/");
+			expect(
+				headers.get(endpoint === "messages" ? "x-api-key" : "authorization"),
+			).toBe(endpoint === "messages" ? "test-key" : "Bearer test-key");
+			const body = JSON.parse(String(init?.body));
+			expect(body.model).toBe(modelId);
+			expect(body.tools).toHaveLength(1);
+			if (endpoint === "responses") {
+				expect(body.input).toBeDefined();
+				expect(body.messages).toBeUndefined();
+				expect(body.tools[0].name).toBe("read_files");
+			} else if (endpoint === "messages") {
+				expect(body.tools[0].input_schema).toEqual(tool.inputSchema);
+			} else {
+				expect(body.tools[0].function.name).toBe("read_files");
+			}
+		}
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/sdk/packages/llms/src/providers/request-headers.test.ts
+++ b/sdk/packages/llms/src/providers/request-headers.test.ts
@@ -147,4 +147,29 @@ describe("resolveProviderRequestHeaders", () => {
 			}),
 		).toEqual({ "x-session": "session" });
 	});
+
+	it("identifies Go conversations and the client while preserving custom headers", () => {
+		for (const sessionId of ["conversation-a", "conversation-b"]) {
+			expect(
+				resolveProviderRequestHeaders({
+					providerId: "opencode-go",
+					sessionId,
+					defaultSource: "desktop",
+					coreVersion: "0.0.82",
+					client: { version: "1.2.3" },
+					headers: {
+						stored: { "x-stored": "kept", "x-opencode-session": "stale" },
+						config: { "x-config": "kept" },
+						session: { "x-session": "kept" },
+					},
+				}),
+			).toEqual({
+				"x-opencode-session": sessionId,
+				"User-Agent": "Cline/1.2.3",
+				"x-stored": "kept",
+				"x-config": "kept",
+				"x-session": "kept",
+			});
+		}
+	});
 });

--- a/sdk/packages/llms/src/providers/request-headers.ts
+++ b/sdk/packages/llms/src/providers/request-headers.ts
@@ -136,6 +136,12 @@ function buildOpenAICodexRequestHeaders(
 function resolveRequiredProviderHeaders(
 	input: ResolveProviderRequestHeadersInput,
 ): Record<string, string> | undefined {
+	if (input.providerId === "opencode-go") {
+		return {
+			"x-opencode-session": input.sessionId,
+			"User-Agent": `Cline/${trimNonEmpty(input.client?.version) ?? input.coreVersion}`,
+		};
+	}
 	return (
 		buildClineRequestHeaders(input) ?? buildOpenAICodexRequestHeaders(input)
 	);

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -98,6 +98,8 @@ export interface GatewayModelOperationCapability {
 }
 
 export interface GatewayProviderRouting {
+	/** Honor catalog model API protocols under this provider's shared base URL. */
+	modelApiProtocol?: boolean;
 	promptCache?: {
 		format: GatewayPromptCacheFormat;
 		routes: GatewayModelRoute[];

--- a/sdk/packages/shared/src/llms/model-info.ts
+++ b/sdk/packages/shared/src/llms/model-info.ts
@@ -66,6 +66,10 @@ export const ModelMetadataSchema = z
 	// Keep metadata open for catalog-defined facts while typing routing fields.
 	.object({
 		reasoningDefaultOn: z.boolean().optional(),
+		/** Per-model wire protocol for gateways that serve multiple API formats. */
+		apiProtocol: z
+			.enum(["openai-chat", "openai-responses", "anthropic", "gemini"])
+			.optional(),
 	})
 	.catchall(z.unknown());
 


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-2522 — OpenCode doesn't work](https://linear.app/cline-bot/issue/ENG-2522/opencode-doesnt-work)

### Description

OpenCode Go requests now carry a stable conversation ID and use the API protocol declared for the selected model. This addresses the reported `Request is missing x-opencode-session and cannot be routed efficiently` failure and the transport mismatch found while investigating Muse Spark's `Internal server error`.

**Root causes**

- Go requires `x-opencode-session` to stay stable within a conversation and a client-specific User-Agent. Cline's required-header handling covered Cline billing and Codex, but not Go; Go also had not opted into the gateway's existing sticky-session support.
- The Go provider defaults to OpenAI Chat Completions. Models.dev declares different adapters through model-level `provider.npm`, but catalog normalization discarded that field. Consequently, Muse Spark requests went to `/chat/completions` instead of `/responses`. MiniMax models likewise need the Messages adapter.
- Several Go Qwen catalog entries omit the adapter declaration even though Go documents an Anthropic Messages endpoint.

**Fixes**

- Add Go's session and client headers to shared session setup. Enable gateway sticky-session headers for direct gateway callers using `metadata.sessionId`; retries reuse the same identity. The builtin also supplies a Cline User-Agent.
- Preserve model adapter declarations as typed `metadata.apiProtocol` through catalog normalization and both builtin/live model projections. Refresh the bundled Go routing metadata and catalog version so the fix works before a live catalog refresh.
- Let HTTP gateways opt into per-model protocol routing under their shared base URL. Go opts in; other providers and local CLI transports retain their existing behavior. The selected adapter handles serialization, provider options, and stream parsing, rather than rewriting only the URL.
- Add a narrowly scoped Go Qwen fallback when upstream omits `provider.npm`. Explicit upstream declarations take precedence.

| Go model | API route |
| --- | --- |
| GLM, Kimi | `/chat/completions` |
| Muse Spark, GPT, Grok with OpenAI adapter declarations | `/responses` |
| MiniMax, Qwen | `/messages` |

References: [Go client requirements](https://opencode.ai/docs/go/#where-can-i-use-it), [Go endpoints](https://opencode.ai/docs/go/#endpoints), [models.dev catalog](https://models.dev/api.json).

### Test Procedure

- `bun run build:sdk` — all SDK packages built successfully.
- `bun run types` — workspace typechecks passed, including core smoke types.
- `bun -F @cline/llms test` — 821 passed, 4 skipped; subsequently added two live-model projection regressions and reran `src/providers/compat.test.ts` (22 passed).
- `bun -F @cline/shared test` — 415 passed, 4 skipped.
- Biome check on changed TypeScript sources/tests and `git diff --check` passed. The pre-commit secret scan passed.

The new HTTP integration tests use the real AI SDK adapters with mocked upstream SSE responses. They verify endpoints, authentication headers, conversation identity across repeated requests and separate sessions, tool schema serialization, streamed text/completion parsing, and a Responses retry. Negative cases cover unknown protocols and providers that have not opted into model routing. Catalog tests cover missing and explicit Qwen declarations; handler tests verify live model metadata survives conversion into gateway models.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change; the reported error screenshots are described above.

### Additional Notes

No authenticated live Go request was performed. The missing-header defect and protocol mismatch are confirmed against the source and official documentation; the teammate's particular Muse Spark server error has not been independently reproduced. After deployment, validate a real Go conversation with Muse Spark and a Chat Completions model, including a tool turn. Direct gateway consumers must provide a stable `metadata.sessionId` per conversation; ClineCore provides its session identity automatically.
