### PR TITLE
Fix compaction budgeting when a catalog-listed model ignores providers.json contextWindow

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -838,6 +838,40 @@ describe("AgentRuntime", () => {
 		});
 	});
 
+	it("passes full model metadata to prepareTurn for compaction budgeting", async () => {
+		const prepareTurn = vi.fn(() => undefined);
+		const model = new ScriptedModel([
+			() => [
+				{ type: "text-delta", text: "done" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({
+			model,
+			prepareTurn,
+			messageModelInfo: {
+				id: "qwen3.6:64k",
+				provider: "ollama",
+				contextWindow: 65536,
+				maxInputTokens: 65536,
+			},
+		});
+
+		const result = await runtime.run("Start");
+
+		expect(result.status).toBe("completed");
+		expect(prepareTurn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: {
+					id: "qwen3.6:64k",
+					provider: "ollama",
+					contextWindow: 65536,
+					maxInputTokens: 65536,
+				},
+			}),
+		);
+	});
+
 	it("lets prepareTurn project tool results after pending user input is added", async () => {
 		const consumePendingUserMessage = vi.fn(() => "latest steering");
 		const hugeToolOutput = "x".repeat(100_000);

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -1533,6 +1533,7 @@ export class AgentRuntime {
 			systemPrompt: request.systemPrompt,
 			tools: request.tools,
 			model: {
+				...this.config.messageModelInfo,
 				id: this.config.messageModelInfo?.id,
 				provider: this.config.messageModelInfo?.provider,
 			},

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.test.ts
@@ -135,6 +135,13 @@ describe("createAgentRuntimeConfig", () => {
 			providerId: "openai",
 			modelId: "gpt-4o",
 			providerConfig: { family: "gpt-4" },
+			knownModels: {
+				"gpt-4o": {
+					id: "gpt-4o",
+					contextWindow: 128000,
+					maxInputTokens: 128000,
+				},
+			},
 			thinking: true,
 			reasoningEffort: "high",
 			maxIterations: 7,
@@ -171,6 +178,8 @@ describe("createAgentRuntimeConfig", () => {
 			id: "gpt-4o",
 			provider: "openai",
 			family: "gpt-4",
+			contextWindow: 128000,
+			maxInputTokens: 128000,
 		});
 		expect(runtimeConfig.modelOptions).toEqual({
 			thinking: true,

--- a/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
+++ b/sdk/packages/core/src/runtime/config/agent-runtime-config-builder.ts
@@ -175,9 +175,11 @@ export function buildModelOptions(
 export function buildMessageModelInfo(
 	config: AgentConfig,
 ): AgentMessage["modelInfo"] {
+	const modelInfo = config.knownModels?.[config.modelId];
 	const family = (config.providerConfig as { family?: string } | undefined)
 		?.family;
 	return {
+		...modelInfo,
 		id: config.modelId,
 		provider: config.providerId,
 		family,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -31,8 +31,14 @@ import {
 	type AgentTool,
 	type AgentToolContext,
 	EMPTY_CONTENT_TEXT,
+	estimateRequestInputTokens,
 } from "@cline/shared";
 import { describe, expect, it, vi } from "vitest";
+import { createContextCompactionPrepareTurn } from "../../extensions/context/compaction";
+import {
+	COMPACTION_TRIGGER_RATIO,
+	CONTEXT_WINDOW_INPUT_RATIO,
+} from "../../extensions/context/compaction-shared";
 import { MESSAGE_BUILDER_LIMIT_ENV } from "../../session/services/message-builder";
 import {
 	SessionRuntime,
@@ -825,6 +831,53 @@ describe("SessionRuntime message preparation", () => {
 		expect(result).toEqual({
 			systemPrompt: "rewritten system prompt",
 		});
+	});
+
+	it("compacts at 81 percent of the providers.json context window when the catalog already lists the model", async () => {
+		const { compact, usableTokens, triggerTokens } =
+			await probeOllamaEightKCompaction({
+				"qwen3.6:64k": { id: "qwen3.6:64k", name: "qwen3.6:64k" },
+			});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(
+			compact.mock.calls[0]?.[0]?.budget.request.maxInputTokens,
+		).toBeCloseTo(usableTokens);
+		expect(
+			compact.mock.calls[0]?.[0]?.budget.request.triggerTokens,
+		).toBeCloseTo(triggerTokens);
+	});
+
+	it("compacts at 81 percent of the providers.json context window when the catalog omits the model", async () => {
+		const { compact, usableTokens, triggerTokens } =
+			await probeOllamaEightKCompaction({});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(
+			compact.mock.calls[0]?.[0]?.budget.request.maxInputTokens,
+		).toBeCloseTo(usableTokens);
+		expect(
+			compact.mock.calls[0]?.[0]?.budget.request.triggerTokens,
+		).toBeCloseTo(triggerTokens);
+	});
+
+	it("caps catalog maxInputTokens by the providers.json context window", async () => {
+		const { compact } = await probeOllamaEightKCompaction({
+			"qwen3.6:64k": {
+				id: "qwen3.6:64k",
+				name: "qwen3.6:64k",
+				maxInputTokens: 1_000_000,
+				contextWindow: 131_072,
+			},
+		});
+
+		expect(compact).toHaveBeenCalledTimes(1);
+		expect(compact.mock.calls[0]?.[0]?.budget.request.maxInputTokens).toBe(
+			8192,
+		);
+		expect(compact.mock.calls[0]?.[0]?.budget.request.triggerTokens).toBe(
+			8192 * 0.9,
+		);
 	});
 });
 
@@ -2108,6 +2161,100 @@ describe("SessionRuntime.subscribeEvents", () => {
 // ===========================================================================
 // P1 defect regression suites (#1, #2, #3) — added by impl-session-fixer.
 // ===========================================================================
+
+/**
+ * CLI Ollama: providers.json `contextWindow` becomes
+ * `providerConfig.maxInputTokens` and overlays ModelInfo.contextWindow.
+ * With no catalog maxInputTokens, usable input is 90% of that window and
+ * compact triggers at 90% of usable (81% of the window). The transcript is
+ * over that trigger and under 90% of the 128k fallback.
+ */
+async function probeOllamaEightKCompaction(
+	knownModels: Record<
+		string,
+		{
+			id: string;
+			name?: string;
+			maxInputTokens?: number;
+			contextWindow?: number;
+		}
+	>,
+) {
+	const contextWindow = 8192;
+	const usableTokens = contextWindow * CONTEXT_WINDOW_INPUT_RATIO;
+	const triggerTokens = usableTokens * COMPACTION_TRIGGER_RATIO;
+	const compact = vi.fn(
+		(_context: {
+			budget: { request: { maxInputTokens: number; triggerTokens: number } };
+		}) => ({
+			messages: [{ role: "user" as const, content: "compacted at 8k" }],
+		}),
+	);
+	const prepareTurn = createContextCompactionPrepareTurn({
+		providerId: "ollama",
+		modelId: "qwen3.6:64k",
+		compaction: { enabled: true, compact },
+	});
+	const { deps, configs } = makeRecordingRuntimeFactory();
+	const session = new SessionRuntime(
+		makeAgentConfig({
+			providerId: "ollama",
+			modelId: "qwen3.6:64k",
+			prepareTurn,
+			knownModels,
+			providerConfig: {
+				providerId: "ollama",
+				modelId: "qwen3.6:64k",
+				maxInputTokens: contextWindow,
+				knownModels,
+			},
+		}),
+		deps,
+	);
+	await session.run("go");
+	const runtimePrepareTurn = configs[0]?.prepareTurn;
+	if (!runtimePrepareTurn) {
+		throw new Error("Expected runtime prepareTurn");
+	}
+
+	const systemPrompt = "You are helpful.";
+	const filler = "x".repeat(25_000);
+	const requestInputTokens = estimateRequestInputTokens({
+		systemPrompt,
+		messages: [{ role: "user", content: filler }],
+		tools: [],
+	});
+	if (requestInputTokens <= triggerTokens) {
+		throw new Error(
+			`Fixture too small: ${requestInputTokens} tokens is not over the 8k trigger`,
+		);
+	}
+	if (requestInputTokens >= 128_000 * COMPACTION_TRIGGER_RATIO) {
+		throw new Error(
+			`Fixture too large: ${requestInputTokens} tokens would also trip the 128k fallback`,
+		);
+	}
+
+	await runtimePrepareTurn({
+		agentId: "agent-1",
+		conversationId: "conv-1",
+		parentAgentId: null,
+		iteration: 1,
+		messages: [
+			{
+				id: "m1",
+				role: "user",
+				content: [{ type: "text", text: filler }],
+				createdAt: 1,
+			},
+		],
+		systemPrompt,
+		tools: [],
+		model: {},
+	});
+
+	return { compact, usableTokens, triggerTokens };
+}
 
 /**
  * Build a runtime-factory that records the `AgentRuntimeConfig` it

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1490,12 +1490,5 @@ async function buildUserTurnContent(
 }
 
 function tryGetModelInfo(config: AgentConfig): ModelInfo | undefined {
-	if (config.knownModels?.[config.modelId]) {
-		return config.knownModels[config.modelId];
-	}
-	const resolvedKnownModels = resolveKnownModelsFromConfig(config);
-	if (resolvedKnownModels?.[config.modelId]) {
-		return resolvedKnownModels[config.modelId];
-	}
-	return undefined;
+	return resolveKnownModelsFromConfig(config)?.[config.modelId];
 }

--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -419,7 +419,7 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
-	it("projects providers.json contextWindow (maxInputTokens) onto the selected gateway model", async () => {
+	it("projects providers.json contextWindow onto the selected gateway model's contextWindow", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 
 		createAgentModelFromConfig(
@@ -438,6 +438,7 @@ describe("createAgentModelFromConfig", () => {
 							id: "llama3.1",
 							name: "llama3.1",
 							contextWindow: 131072,
+							maxInputTokens: 100000,
 						},
 					},
 				},
@@ -454,7 +455,7 @@ describe("createAgentModelFromConfig", () => {
 							expect.objectContaining({
 								id: "llama3.1",
 								contextWindow: 8192,
-								maxInputTokens: 8192,
+								maxInputTokens: 100000,
 							}),
 						],
 					}),

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -112,8 +112,9 @@ export function resolveKnownModelsFromConfig(
 	// surface them to the gateway so the resolved model definition carries
 	// the right limits (e.g. Ollama's num_ctx derives from the resolved
 	// model's context window):
-	//  - `maxInputTokens` is where `ProviderSettings.contextWindow` lands via
-	//    `toProviderConfig` (the providers.json path used by CLI/Core hosts).
+	//  - `providerConfig.maxInputTokens` is where `ProviderSettings.contextWindow`
+	//    lands via `toProviderConfig`. Overlay that onto ModelInfo.contextWindow
+	//    only; do not stamp it onto ModelInfo.maxInputTokens (catalog prompt budget).
 	//  - `modelInfo` is an explicit per-model override (the VS Code path);
 	//    it wins over the generic limit.
 	const configuredContextWindow = readPositiveInteger(pc?.maxInputTokens);
@@ -129,10 +130,7 @@ export function resolveKnownModelsFromConfig(
 		[config.modelId]: {
 			...knownModels?.[config.modelId],
 			...(configuredContextWindow !== undefined
-				? {
-						contextWindow: configuredContextWindow,
-						maxInputTokens: configuredContextWindow,
-					}
+				? { contextWindow: configuredContextWindow }
 				: {}),
 			...modelInfo,
 			id: config.modelId,


### PR DESCRIPTION
Fixes #13989

## Summary

Fixes auto-compaction failing to trigger even after overflow diagnostics report that the estimated prompt exceeds the configured context window.

Reproduced on native Ollama CLI 3.0.61. The affected logic lives in shared Core model-resolution code, not in an Ollama-specific handler.

## Root cause

Compaction decides whether to run from `context.model.info` inside `createContextCompactionPrepareTurn()`. On the CLI path, `SessionRuntime` fills that `model.info` from `tryGetModelInfo()`.

Before this change, `tryGetModelInfo()` returned the raw catalog entry from `config.knownModels[modelId]` whenever the model was already listed. It never called `resolveKnownModelsFromConfig()`, so the configured `providers.json.contextWindow` overlay was skipped.

That produced a split brain:

- Overflow diagnostics could log the configured window from provider settings.
- Compaction still budgeted against the catalog entry, often with a much larger `contextWindow` and therefore a much higher trigger threshold.
- Result: `estimatedInputTokens` looked over limit, but compaction never fired.

This only bites when the catalog already lists the model **and** the operator set `providers.json.contextWindow`. If the catalog omits the model, the old path already went through `resolveKnownModelsFromConfig()`.

## What this PR changes

### Commit 1 — Pass model context metadata to compaction

`AgentRuntime.prepareTurnForModelRequest()` now spreads `messageModelInfo` onto the `model` object it passes to `prepareTurn`. This is a separate hardening change for direct `AgentRuntime` callers.

The CLI compaction path goes through `SessionRuntime.createRuntimePrepareTurn()`, which supplies `model.info` from `tryGetModelInfo()`. Commit 2 is the fix for #13989.

### Commit 2 — Use providers.json contextWindow for compaction even when the catalog lists the model

- `tryGetModelInfo()` always resolves through `resolveKnownModelsFromConfig()`.
- `resolveKnownModelsFromConfig()` overlays configured `contextWindow` only. It no longer copies the configured window onto `maxInputTokens`.
- `buildMessageModelInfo()` includes catalog limits from `knownModels`.
- Regression tests cover catalog-present, catalog-absent, and catalog-with-inflated-`maxInputTokens` cases.

Effective compaction budget remains `min(catalog maxInputTokens, configured contextWindow)` via `resolveEffectiveMaxInputTokens()`.

## Scope

| Applies | Does not apply |
| --- | --- |
| CLI/Core hosts using `providers.json.contextWindow` | Providers or hosts that never set a configured window |
| Models already present in the catalog | Catalog-absent models (old path already worked) |
| Any provider sharing this Core resolution path | Proven end-to-end only on native Ollama in our report |

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run build:sdk`
- [x] `bun run test:unit --run src/runtime/config/agent-runtime-config-builder.test.ts src/runtime/orchestration/session-runtime-orchestrator.test.ts src/services/llms/handler-factory.test.ts` (3 files, 104 tests passed)