### PR TITLE
fix(core): persist seeded sessions with their live idle status

### DIFF
--- a/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.test.ts
@@ -1232,9 +1232,12 @@ describe("LocalRuntimeHost", () => {
 		// Seeded history is durable immediately: if the resident session is
 		// lost before the first completed turn (hub restart/crash), the
 		// missing-session recovery rebuilds from the persisted file instead of
-		// silently wiping the conversation.
+		// silently wiping the conversation. The row must also carry the live
+		// "idle" status: the service defaults to "running", and a checkpoint
+		// restore that reuses this id resumes from the persisted manifest, so
+		// a stale "running" would surface as a turn that never existed.
 		expect(sessionService.createRootSessionWithArtifacts).toHaveBeenCalledWith(
-			expect.objectContaining({ sessionId }),
+			expect.objectContaining({ sessionId, status: "idle" }),
 		);
 		expect(sessionService.persistSessionMessages).toHaveBeenCalledWith(
 			sessionId,

--- a/sdk/packages/core/src/runtime/host/local-runtime-host.ts
+++ b/sdk/packages/core/src/runtime/host/local-runtime-host.ts
@@ -2162,6 +2162,11 @@ export class LocalRuntimeHost implements RuntimeHost {
 			sessionId: session.sessionId,
 			source: session.source,
 			pid: process.pid,
+			// Seeded sessions (forks, checkpoint restores) materialize at start
+			// while idle; the service otherwise defaults the row to "running",
+			// and a later restore that reuses the id resumes from that stale
+			// manifest status and reports a turn that never existed.
+			status: session.status,
 			interactive: session.interactive,
 			provider: session.config.providerId,
 			model: session.config.modelId,


### PR DESCRIPTION
### Related Issue

**Issue:** #14037

### Description

In the desktop app, a forked session got stuck on "Thinking..." after restoring a checkpoint and switching away from and back to the session.

Root cause: sessions seeded with history (forks, checkpoint restores) materialize their row and manifest eagerly at start via `ensureSessionPersisted`, but that call never passed the session's status, so `createRootSessionWithArtifacts` fell back to its `"running"` default while the live session was actually `"idle"`. A checkpoint restore reuses the session id and resumes from the persisted manifest, so the restored session came back with a stale `"running"` status. The webview's hydration then saw `running` plus a transcript ending on a user message and showed the working indicator indefinitely.

Fix: pass `status: session.status` when persisting the row. One-shot and prompted sessions are unaffected (they start as `running` already), and the first turn still transitions through `markTurnRunning`.

### Test Procedure

- Extended the existing `persists seeded history at session start` test in `local-runtime-host.test.ts` to assert the row is created with `status: "idle"`. Verified it fails without the fix and passes with it.
- Reproduced the issue end to end in the headless desktop app (sidecar + web UI in Chrome) following the exact steps from the issue: run a task with two turns in a git workspace, fork the session, restore the first checkpoint in the fork, switch to the original session, switch back. Before the fix the forked session showed a stuck "Thinking..." spinner and the composer read "Agent is working...". The persisted session row/manifest showed `status: running` with no prompt. After the fix, the same flow returns to the forked session in a normal idle state.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)