### PR TITLE
fix(desktop): stop rendering a deleted queued prompt in the chat

### DIFF
--- a/apps/examples/desktop-app/sidecar/context.test.ts
+++ b/apps/examples/desktop-app/sidecar/context.test.ts
@@ -531,6 +531,65 @@ describe("Code sidecar runtime capabilities", () => {
 		).toHaveLength(2);
 	});
 
+	it("does not announce a queued prompt start when the head is deleted from the queue", async () => {
+		const { createSidecarContext, initializeSessionManager } = await import(
+			"./context"
+		);
+		let onEvent: ((event: unknown) => void) | undefined;
+		createCoreMock.mockResolvedValue({
+			runtimeAddress: "ws://127.0.0.1:25463/hub",
+			subscribe: vi.fn((handler: (event: unknown) => void) => {
+				onEvent = handler;
+				return () => {};
+			}),
+			dispose: vi.fn(),
+		});
+
+		const ctx = createSidecarContext("/workspace/project");
+		ctx.wsClients.add({ send: vi.fn() });
+		await initializeSessionManager(ctx);
+		ctx.liveSessions.set("session-1", {
+			config: {},
+			messages: [],
+			promptsInQueue: [
+				{ id: "prompt-1", prompt: "first", steer: false, attachmentCount: 0 },
+				{ id: "prompt-2", prompt: "second", steer: false, attachmentCount: 0 },
+			],
+			busy: true,
+			startedAt: Date.now(),
+			status: "running",
+		});
+
+		// Removing the head only produces a shrunken snapshot — no
+		// pending_prompt_submitted — so nothing must reach the transcript.
+		onEvent?.({
+			type: "pending_prompts",
+			payload: {
+				sessionId: "session-1",
+				prompts: [{ id: "prompt-2", prompt: "second", delivery: "queue" }],
+			},
+		});
+
+		const events = readEvents(ctx);
+		expect(
+			events.filter(
+				(message) =>
+					message.event.name === "chat_event" &&
+					(message.event.payload as { stream?: string }).stream ===
+						"chat_queued_prompt_start",
+			),
+		).toHaveLength(0);
+		expect(
+			events.find((message) => message.event.name === "prompts_in_queue_state")
+				?.event.payload,
+		).toEqual({
+			sessionId: "session-1",
+			items: [
+				{ id: "prompt-2", prompt: "second", steer: false, attachmentCount: 0 },
+			],
+		});
+	});
+
 	it("relays generated media for attach-only Hub sessions", async () => {
 		const { createSidecarContext, handleHubLiveEvent } = await import(
 			"./context"

--- a/apps/examples/desktop-app/sidecar/context.ts
+++ b/apps/examples/desktop-app/sidecar/context.ts
@@ -426,10 +426,8 @@ function handleAgentEvent(
 // CoreSessionEvent routing
 // ---------------------------------------------------------------------------
 
-// The runtime's queue drain emits a pending_prompts snapshot (head removed)
-// and a pending_prompt_submitted event for the same prompt back-to-back, and
-// both are translated here into chat_queued_prompt_start — dedupe by prompt
-// id or the UI renders the user message twice.
+// Dedupe by prompt id so a repeated pending_prompt_submitted for the same
+// prompt cannot render the user message twice.
 function emitQueuedPromptStart(
 	ctx: SidecarContext,
 	sessionId: string,
@@ -490,20 +488,10 @@ export function handleCoreSessionEvent(
 					session,
 					mapped.map((item) => item.id),
 				);
-				const previous = session.promptsInQueue;
+				// A shrinking snapshot is not evidence that the head started
+				// running: the user may have deleted it or the queue may have been
+				// discarded. Only pending_prompt_submitted announces a start.
 				session.promptsInQueue = mapped;
-				if (
-					previous.length > mapped.length &&
-					previous[0] &&
-					previous[0].id !== mapped[0]?.id
-				) {
-					emitQueuedPromptStart(ctx, sessionId, session, {
-						promptId: previous[0].id,
-						prompt: previous[0].prompt,
-						attachmentCount: previous[0].attachmentCount ?? 0,
-						userImages: previous[0].userImages,
-					});
-				}
 			}
 			sendPromptsInQueueSnapshot(ctx, sessionId);
 			break;


### PR DESCRIPTION
### Related Issue

**Issue:** #14038

### Description

Deleting the first queued prompt in the desktop app made it show up in the chat as a user message that never ran.

The sidecar's `pending_prompts` handler in `sidecar/context.ts` inferred that the head of the queue had started running whenever a snapshot arrived with fewer items and a different head, and emitted `chat_queued_prompt_start` for the old head (which is what renders the user bubble). Deleting the first queued prompt, or discarding the queue on abort, produces exactly that snapshot shape, so the removed prompt was announced as started.

The runtime already emits `pending_prompt_submitted` for every real start (`drain` and `consumeSteer` in `PendingPromptsController`), and the sidecar already translates that into `chat_queued_prompt_start`. This PR drops the snapshot-diff heuristic and relies on `pending_prompt_submitted` alone. The per-session id dedupe in `emitQueuedPromptStart` is kept.

### Test Procedure

Automated:
- Added a regression test in `sidecar/context.test.ts`: a `pending_prompts` snapshot with the head removed and no `pending_prompt_submitted` must not emit `chat_queued_prompt_start`, while `prompts_in_queue_state` still reflects the remaining queue. It fails on `main` (one start event emitted for the deleted prompt) and passes with the fix.
- The existing "announces a queued prompt start once when drain emits both queue events" test still passes, confirming real drains are still announced via `pending_prompt_submitted`.
- `bunx vitest run sidecar` (23 files, 291 tests passed), `tsc -p tsconfig.dev.json --noEmit`, and `biome check` on the touched files are clean.

Manual (desktop app running headless via `dev:sidecar` + `dev:web`, following the issue's repro steps):
1. Sent a task that runs `sleep 120` so the agent stays busy.
2. Submitted a second prompt while busy; it landed in the queue ("1 prompt queued").
3. Expanded the queue and clicked the trash icon.
4. The queue row disappeared and the deleted prompt never appeared in the transcript (also confirmed with browser find: 0 matches). The first task later completed normally.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Left: queued prompt expanded while the first task is running. Right: right after clicking Remove, the queue is empty and the deleted prompt is not in the transcript.

![Queue delete before and after](https://cursor.com/artifacts/c/art-2339d21b-21a0-44b4-b40d-2527dfe3538f)

### Additional Notes

The same heuristic also misfired when the queue was discarded via abort of a queue-initiated turn (`discardQueue` emits an empty snapshot), so that case is fixed by the same change.