### PR TITLE
fix(core,desktop): make the regional API Line control the provider base URL

### DIFF
--- a/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
+++ b/apps/examples/desktop-app/webview/components/views/settings/provider-list-view.tsx
@@ -545,6 +545,19 @@ export function ProviderDetailContent({
 	const [localConfigValues, setLocalConfigValues] = useState<
 		Record<string, ProviderConfigFieldPrimitive>
 	>(() => getInitialConfigValues(provider));
+	// The effective base URL is resolved by the sidecar, so selecting a
+	// regional API line changes it without the field itself being edited.
+	// Adopt the new endpoint instead of leaving the previous region's URL in
+	// the draft, which would otherwise be committed back on the next blur.
+	const catalogBaseUrlRef = useRef(provider.baseUrl);
+	useEffect(() => {
+		if (provider.baseUrl === catalogBaseUrlRef.current) return;
+		catalogBaseUrlRef.current = provider.baseUrl;
+		setLocalConfigValues((current) => ({
+			...current,
+			baseUrl: provider.baseUrl ?? "",
+		}));
+	}, [provider.baseUrl]);
 	const [manualKeyExpanded, setManualKeyExpanded] = useState(false);
 	const [modelSearchState, setModelSearchState] = useState<{
 		providerId: string;

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -1648,14 +1648,13 @@ describe("regional API line routing", () => {
 		expect(qwen.baseUrl).toBe(QWEN_CHINA_BASE_URL);
 	});
 
-	it("switching api line drops a previously pinned regional base url", () => {
+	it("does not pin a regional endpoint as an explicit base url", () => {
 		saveLocalProviderSettings(manager, {
 			providerId: "qwen",
 			enabled: true,
 			apiKey: "key",
 			baseUrl: QWEN_CHINA_BASE_URL,
 		});
-
 		saveLocalProviderSettings(manager, {
 			providerId: "qwen",
 			apiLine: "international",
@@ -1668,39 +1667,58 @@ describe("regional API line routing", () => {
 		);
 	});
 
-	it("keeps a custom base url when the api line changes", () => {
+	// The settings UI commits the base URL input on blur, which can land
+	// after the api line save that triggered it.
+	it("api line survives a base url save arriving afterwards", () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+		});
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			apiLine: "international",
+		});
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			baseUrl: QWEN_CHINA_BASE_URL,
+		});
+
+		const settings = manager.getProviderSettings("qwen");
+		expect(settings?.apiLine).toBe("international");
+		expect(toProviderConfig(settings!).baseUrl).toBe(
+			QWEN_INTERNATIONAL_BASE_URL,
+		);
+	});
+
+	it("keeps a genuinely custom base url", () => {
 		saveLocalProviderSettings(manager, {
 			providerId: "qwen",
 			enabled: true,
 			apiKey: "key",
 			baseUrl: "https://proxy.example.invalid/v1",
 		});
-
 		saveLocalProviderSettings(manager, {
 			providerId: "qwen",
 			apiLine: "international",
 		});
 
-		expect(manager.getProviderSettings("qwen")?.baseUrl).toBe(
+		const settings = manager.getProviderSettings("qwen");
+		expect(settings?.baseUrl).toBe("https://proxy.example.invalid/v1");
+		expect(toProviderConfig(settings!).baseUrl).toBe(
 			"https://proxy.example.invalid/v1",
 		);
 	});
 
-	it("leaves the base url alone for saves that do not touch the api line", () => {
+	it("still stores the base url for providers without regional endpoints", () => {
 		saveLocalProviderSettings(manager, {
-			providerId: "qwen",
+			providerId: "ollama",
 			enabled: true,
-			apiKey: "key",
-			baseUrl: QWEN_CHINA_BASE_URL,
+			baseUrl: "https://ollama.com",
 		});
 
-		saveLocalProviderSettings(manager, {
-			providerId: "qwen",
-			apiKey: "rotated",
-		});
-
-		expect(manager.getProviderSettings("qwen")?.baseUrl).toBe(
-			QWEN_CHINA_BASE_URL,
+		expect(manager.getProviderSettings("ollama")?.baseUrl).toBe(
+			"https://ollama.com",
 		);
 	});
 });

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -13,6 +13,7 @@ import {
 	clearLiveModelsCatalogCache,
 	clearPrivateModelsCatalogCache,
 } from "../llms/provider-defaults";
+import { toProviderConfig } from "../llms/provider-settings";
 import { ProviderSettingsManager } from "../storage/provider-settings-manager";
 import {
 	parseModelsFile,
@@ -1595,6 +1596,112 @@ describe("saveLocalProviderSettings", () => {
 		});
 
 		expect(manager.getLastUsedProviderSettings()).toBeUndefined();
+	});
+});
+
+// ===========================================================================
+// regional API line routing
+// ===========================================================================
+
+const QWEN_CHINA_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+const QWEN_INTERNATIONAL_BASE_URL =
+	"https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+
+describe("regional API line routing", () => {
+	let manager: ProviderSettingsManager;
+	let cleanup: () => void;
+
+	beforeEach(() => {
+		({ manager, cleanup } = makeTempManager());
+	});
+
+	afterEach(() => cleanup());
+
+	async function listQwen() {
+		const { providers } = await listLocalProviders(manager);
+		const qwen = providers.find((provider) => provider.id === "qwen");
+		if (!qwen) throw new Error("qwen provider missing from catalog");
+		return qwen;
+	}
+
+	it("lists the api line endpoint instead of the provider default", async () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+			apiLine: "international",
+		});
+
+		const qwen = await listQwen();
+		expect(qwen.baseUrl).toBe(QWEN_INTERNATIONAL_BASE_URL);
+		expect(qwen.configValues?.baseUrl).toBe(QWEN_INTERNATIONAL_BASE_URL);
+	});
+
+	it("falls back to the provider default when no api line is set", async () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+		});
+
+		const qwen = await listQwen();
+		expect(qwen.baseUrl).toBe(QWEN_CHINA_BASE_URL);
+	});
+
+	it("switching api line drops a previously pinned regional base url", () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+			baseUrl: QWEN_CHINA_BASE_URL,
+		});
+
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			apiLine: "international",
+		});
+
+		const settings = manager.getProviderSettings("qwen");
+		expect(settings).not.toHaveProperty("baseUrl");
+		expect(toProviderConfig(settings!).baseUrl).toBe(
+			QWEN_INTERNATIONAL_BASE_URL,
+		);
+	});
+
+	it("keeps a custom base url when the api line changes", () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+			baseUrl: "https://proxy.example.invalid/v1",
+		});
+
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			apiLine: "international",
+		});
+
+		expect(manager.getProviderSettings("qwen")?.baseUrl).toBe(
+			"https://proxy.example.invalid/v1",
+		);
+	});
+
+	it("leaves the base url alone for saves that do not touch the api line", () => {
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			enabled: true,
+			apiKey: "key",
+			baseUrl: QWEN_CHINA_BASE_URL,
+		});
+
+		saveLocalProviderSettings(manager, {
+			providerId: "qwen",
+			apiKey: "rotated",
+		});
+
+		expect(manager.getProviderSettings("qwen")?.baseUrl).toBe(
+			QWEN_CHINA_BASE_URL,
+		);
 	});
 });
 

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -310,7 +310,56 @@ function toConfigPrimitive(
 	return undefined;
 }
 
+/**
+ * Mirror the base URL precedence `toProviderConfig` applies at request time:
+ * explicit base URL > regional API line endpoint > provider default. Listing
+ * has to resolve it the same way, otherwise the settings UI shows (and lets
+ * the user re-save) a different endpoint than the one requests actually use.
+ */
+function resolveEffectiveBaseUrl(
+	providerId: string,
+	settings: ProviderSettings | undefined,
+	info: { baseUrl?: string } | undefined,
+): string | undefined {
+	return (
+		settings?.baseUrl ??
+		LlmsModels.resolveProviderApiLineBaseUrl(providerId, settings?.apiLine) ??
+		info?.baseUrl
+	);
+}
+
+const PROVIDER_API_LINES = ["china", "international"] as const;
+
+function normalizeBaseUrlForCompare(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim().replace(/\/+$/, "");
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * True when the base URL is one Cline itself derives for the provider (its
+ * default endpoint or one of its regional API line endpoints), as opposed to
+ * a custom endpoint the user actually typed.
+ */
+function isDerivedProviderBaseUrl(
+	providerId: string,
+	baseUrl: unknown,
+): boolean {
+	const normalized = normalizeBaseUrlForCompare(baseUrl);
+	if (!normalized) return false;
+	const derived = [
+		LlmsModels.MODEL_COLLECTIONS_BY_PROVIDER_ID[providerId]?.provider?.baseUrl,
+		...PROVIDER_API_LINES.map((apiLine) =>
+			LlmsModels.resolveProviderApiLineBaseUrl(providerId, apiLine),
+		),
+	];
+	return derived.some(
+		(candidate) => normalizeBaseUrlForCompare(candidate) === normalized,
+	);
+}
+
 function resolveConfigValues(
+	providerId: string,
 	fields: readonly ProviderConfigField[] | undefined,
 	settings: ProviderSettings | undefined,
 	info: { baseUrl?: string } | undefined,
@@ -320,8 +369,8 @@ function resolveConfigValues(
 	const values: Record<string, ProviderConfigFieldPrimitive> = {};
 	for (const field of fields) {
 		const persistedValue = toConfigPrimitive(
-			field.path === "baseUrl" && settings?.baseUrl === undefined
-				? info?.baseUrl
+			field.path === "baseUrl"
+				? resolveEffectiveBaseUrl(providerId, settings, info)
 				: getPathValue(settings, field.path),
 		);
 		const value = persistedValue ?? field.defaultValue;
@@ -801,7 +850,7 @@ export async function listLocalProviders(
 						oauthAccessTokenPresent: persistedSettings
 							? hasOAuthAccessToken(persistedSettings)
 							: undefined,
-						baseUrl: persistedSettings?.baseUrl ?? info?.baseUrl,
+						baseUrl: resolveEffectiveBaseUrl(id, persistedSettings, info),
 						defaultModelId: info?.defaultModelId,
 						protocol: persistedSettings?.protocol ?? info?.protocol,
 						client: persistedSettings?.client ?? info?.client,
@@ -811,6 +860,7 @@ export async function listLocalProviders(
 							"The base endpoint to use for provider requests.",
 						configFields,
 						configValues: resolveConfigValues(
+							id,
 							configFields,
 							persistedSettings,
 							info,
@@ -1076,6 +1126,20 @@ export function saveLocalProviderSettings(
 		"capabilities",
 	] as const) {
 		if (Object.hasOwn(request, key)) next[key] = request[key];
+	}
+
+	// A regional API line only reaches the request when no explicit base URL
+	// shadows it. Settings UIs seed the base URL field with the endpoint they
+	// display, so saving any field pins that endpoint and the next line switch
+	// would silently keep routing to the old region. Drop a base URL that is
+	// merely one of the provider's own derived endpoints; a genuinely custom
+	// one still wins.
+	if (
+		Object.hasOwn(request, "apiLine") &&
+		LlmsModels.isProviderApiLine(next.apiLine) &&
+		isDerivedProviderBaseUrl(providerId, next.baseUrl)
+	) {
+		delete next.baseUrl;
 	}
 
 	// Merged object fields

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -337,25 +337,26 @@ function normalizeBaseUrlForCompare(value: unknown): string | undefined {
 }
 
 /**
- * True when the base URL is one Cline itself derives for the provider (its
- * default endpoint or one of its regional API line endpoints), as opposed to
- * a custom endpoint the user actually typed.
+ * True when the provider exposes regional API line endpoints and the base URL
+ * is one Cline itself derives for it (a regional endpoint or its default), as
+ * opposed to a custom endpoint the user actually typed. Scoped to regional
+ * providers so custom and OpenAI-compatible entries, whose base URL is the
+ * only way to reach them, keep storing it.
  */
-function isDerivedProviderBaseUrl(
+function isDerivedRegionalBaseUrl(
 	providerId: string,
 	baseUrl: unknown,
 ): boolean {
 	const normalized = normalizeBaseUrlForCompare(baseUrl);
 	if (!normalized) return false;
-	const derived = [
+	const regional = PROVIDER_API_LINES.map((apiLine) =>
+		LlmsModels.resolveProviderApiLineBaseUrl(providerId, apiLine),
+	).filter((url): url is string => Boolean(url));
+	if (regional.length === 0) return false;
+	return [
+		...regional,
 		LlmsModels.MODEL_COLLECTIONS_BY_PROVIDER_ID[providerId]?.provider?.baseUrl,
-		...PROVIDER_API_LINES.map((apiLine) =>
-			LlmsModels.resolveProviderApiLineBaseUrl(providerId, apiLine),
-		),
-	];
-	return derived.some(
-		(candidate) => normalizeBaseUrlForCompare(candidate) === normalized,
-	);
+	].some((candidate) => normalizeBaseUrlForCompare(candidate) === normalized);
 }
 
 function resolveConfigValues(
@@ -1129,16 +1130,13 @@ export function saveLocalProviderSettings(
 	}
 
 	// A regional API line only reaches the request when no explicit base URL
-	// shadows it. Settings UIs seed the base URL field with the endpoint they
-	// display, so saving any field pins that endpoint and the next line switch
-	// would silently keep routing to the old region. Drop a base URL that is
-	// merely one of the provider's own derived endpoints; a genuinely custom
-	// one still wins.
-	if (
-		Object.hasOwn(request, "apiLine") &&
-		LlmsModels.isProviderApiLine(next.apiLine) &&
-		isDerivedProviderBaseUrl(providerId, next.baseUrl)
-	) {
+	// shadows it (see `toProviderConfig`). Settings UIs seed the base URL input
+	// with whichever endpoint they currently display, so persisting that value
+	// would pin the old region and silently outrank every later line switch.
+	// Regional providers reach all of their endpoints through the line
+	// selector, so such a base URL carries no information worth storing —
+	// keep only one the user genuinely customized.
+	if (isDerivedRegionalBaseUrl(providerId, next.baseUrl)) {
 		delete next.baseUrl;
 	}
 


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — found while manually verifying every configured provider in the desktop app. Small bug fix, no prior discussion.

### Description

Selecting a regional **API Line** (Qwen's *International* vs *China* DashScope endpoint) in Settings → Models had no effect. Sends kept failing with the provider-side error `Incorrect API key provided`, which reads like a bad credential but is really a request going to the wrong region. The same key returns `HTTP 200` against `dashscope-intl.aliyuncs.com` and `HTTP 401` against `dashscope.aliyuncs.com`, so the credential was never the problem.

Three defects combine:

1. **The catalog reported the wrong endpoint.** `listLocalProviders` resolved the displayed base URL as `persistedSettings?.baseUrl ?? info?.baseUrl` — the provider's *static default* — ignoring `apiLine` entirely. After choosing *International*, Settings still displayed the China host, contradicting what requests would use.

2. **That wrong value then got pinned.** Settings seeds the Base URL input from the catalog and commits it on blur, so merely focusing and leaving the field persisted the China default as an *explicit* `baseUrl`. Since `toProviderConfig` gives an explicit base URL precedence over `apiLine`, the API Line selection was permanently shadowed with no way to recover from the UI. The blur commit can also land *after* the API Line save that caused it, so the outcome depended on which request finished last.

3. **The detail panel showed a stale value.** Its field drafts are seeded once, so even after the sidecar resolved a new endpoint the input kept showing the previous region's URL — and committed it back on the next blur.

### Changes

`sdk/packages/core/src/services/providers/local-provider-service.ts`:

- List the base URL with the **same precedence `toProviderConfig` applies at request time** (explicit base URL → regional API line endpoint → provider default) via a new `resolveEffectiveBaseUrl`. What Settings shows is now what requests use.
- Never persist a base URL that is one of a **regional** provider's own derived endpoints. The API Line selector already reaches all of them, so such a value carries no information, and dropping it makes the result independent of which save arrives last. A genuinely custom endpoint still wins, and providers without regional endpoints (Ollama, LM Studio, LiteLLM, custom OpenAI-compatible) keep storing their base URL as before.

`apps/examples/desktop-app/webview/.../provider-list-view.tsx`:

- Adopt the catalog's base URL when it changes, so the input reflects the selected line instead of committing a stale value back.

This is generic across every provider with regional endpoints (Qwen, Moonshot, Z.AI, MiniMax), not Qwen-specific.

### Test Procedure

**Automated.** Five regression tests added in `local-provider-service.test.ts`: listing the API line endpoint, falling back to the default when no line is set, not pinning a regional endpoint, the API line surviving a base URL save that arrives afterwards (the blur race), preserving a genuinely custom base URL, and still storing the base URL for providers without regional endpoints.

- `bun -F @cline/core test:unit -- local-provider-service` → **101 passed**.
- Reverting only the source file makes the blur-race test fail, confirming the tests bite.
- Full `bun -F @cline/core test:unit` has 13 failures in `session-history-search`, `hub/server/boundary`, `checkpoint-restore` and `workspace-manifest`. These are **pre-existing**: reverting `src/services/providers/` to `main` reproduces exactly the same 4 files / 13 tests. `workspace-manifest` is the cloud-VM git artifact documented in `AGENTS.md`.
- `bun biome check --diagnostic-level=error` clean; `bun run typecheck` clean for both `@cline/core` and the desktop app.

**What could break.** The risk is stripping a base URL someone actually needs. That is why the new rule is scoped to providers that declare `apiLineBaseUrls`; for everything else the save path is untouched, which the Ollama test covers. A custom endpoint on a regional provider is explicitly preserved and tested.

**Manual.** Verified end-to-end in the desktop app. Before the fix, Alibaba Qwen with a valid International-line key failed; after selecting **API Line = International** the Base URL field updates on its own and the same key returns a reply.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

Found while manually sending a turn through every provider that has a credential. Two other providers looked broken but are not code bugs, noted here for context:

- **Ollama** — the key is an Ollama Cloud key while the provider defaults to `http://localhost:11434`. Pointing Base URL at `https://ollama.com` and picking a model the account can use works. No change needed, though defaulting a cloud-only key to a local URL is a rough edge.
- **Doubao** — Cline only defines the CN Ark host (`ark.cn-beijing.volces.com`); there is no BytePlus international option, unlike Qwen/Moonshot/Z.AI/MiniMax which have `apiLineBaseUrls`. A BytePlus key therefore fails with `The API key doesn't exist` until the Base URL is edited by hand. Giving Doubao an API Line would make it consistent, but that is out of scope here.