### PR TITLE
fix(core): refine PowerShell shell guidance

### DIFF
--- a/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
+++ b/apps/vscode/src/sdk/vscode-run-commands-tool.test.ts
@@ -119,11 +119,14 @@ describe("createVscodeRunCommandsTool", () => {
 		// A profile change takes effect at the next description read (the
 		// model-request boundary), without a session rebuild.
 		mocks.getGlobalSettingsKey.mockReturnValue("powershell-7")
-		expect(tool.description).toContain("Microsoft PowerShell (pwsh.exe)")
+		expect(tool.description).toContain("PowerShell (pwsh.exe)")
+		expect(tool.description).not.toMatch(/PowerShell (?:Core|\d)/)
+		expect(tool.description).toContain("quote paths and arguments for pwsh.exe")
 		expect(tool.description).toContain("another pwsh.exe -Command invocation")
 
 		mocks.getGlobalSettingsKey.mockReturnValue("powershell-legacy")
 		expect(tool.description).toContain("Windows PowerShell (powershell.exe)")
+		expect(tool.description).toContain("quote paths and arguments for powershell.exe")
 		expect(tool.description).toContain("another powershell.exe -Command invocation")
 	})
 
@@ -145,7 +148,7 @@ describe("createVscodeRunCommandsTool", () => {
 		expect(getOrCreateTerminal).toHaveBeenLastCalledWith("C:\\workspace", "powershell-legacy")
 
 		const nextDescription = tool.description
-		expect(nextDescription).toContain("Microsoft PowerShell (pwsh.exe)")
+		expect(nextDescription).toContain("PowerShell (pwsh.exe)")
 		expect(nextDescription).not.toBe(legacyDescription)
 		expect(tool.description).toBe(nextDescription)
 		manager.runCommand = () => createFakeTerminalProcess({ lines: ["ok"] })

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -487,9 +487,15 @@ describe("run_commands tool description", () => {
 		const description = buildRunCommandsDescription(shell, true);
 		expect(description).toContain("Windows PowerShell (powershell.exe)");
 		expect(description).toContain(
+			"quote paths and arguments for powershell.exe",
+		);
+		expect(description).not.toContain(
+			"quote paths and arguments for Windows PowerShell",
+		);
+		expect(description).toContain(
 			"do not wrap them in another powershell.exe -Command invocation",
 		);
-		expect(description).not.toContain("Microsoft PowerShell");
+		expect(description).not.toContain("PowerShell (pwsh.exe)");
 		expect(description).toContain("use ';' to sequence commands");
 		expect(description).toContain("in Windows environment");
 	});
@@ -498,9 +504,14 @@ describe("run_commands tool description", () => {
 		"pwsh",
 		"pwsh.exe",
 		"C:\\Program Files\\PowerShell\\7\\PWSH.EXE",
-	])("names Microsoft PowerShell and its redundant wrapper for %s", (shell) => {
+	])("names PowerShell and its redundant wrapper for %s", (shell) => {
 		const description = buildRunCommandsDescription(shell, true);
-		expect(description).toContain("Microsoft PowerShell (pwsh.exe)");
+		expect(description).toContain("PowerShell (pwsh.exe)");
+		expect(description).toContain("quote paths and arguments for pwsh.exe");
+		expect(description).not.toContain(
+			"quote paths and arguments for PowerShell",
+		);
+		expect(description).not.toMatch(/PowerShell (?:Core|\d)/);
 		expect(description).toContain(
 			"do not wrap them in another pwsh.exe -Command invocation",
 		);
@@ -511,12 +522,13 @@ describe("run_commands tool description", () => {
 		expect(description).not.toContain("Windows PowerShell");
 	});
 
-	it("describes pwsh on Unix without claiming a Windows host or a version", () => {
+	it("describes PowerShell on Unix without claiming a version or Windows host", () => {
 		const description = buildRunCommandsDescription("/usr/bin/pwsh", false);
-		expect(description).toContain("Microsoft PowerShell (pwsh)");
+		expect(description).toContain("PowerShell (pwsh)");
+		expect(description).toContain("quote paths and arguments for pwsh");
 		expect(description).toContain("another pwsh -Command invocation");
 		expect(description).not.toContain("Windows");
-		expect(description).not.toMatch(/PowerShell \d/);
+		expect(description).not.toMatch(/PowerShell (?:Core|\d)/);
 	});
 
 	it("names cmd.exe with '&&' sequencing for cmd shells", () => {
@@ -579,13 +591,12 @@ describe("run_commands tool description", () => {
 		expect(tool.description).toBe(windowsPowerShellDescription);
 
 		shell = "pwsh.exe";
-		const microsoftPowerShellDescription = tool.description;
-		expect(microsoftPowerShellDescription).toContain("Microsoft PowerShell");
-		expect(microsoftPowerShellDescription).not.toBe(
-			windowsPowerShellDescription,
-		);
+		const powerShellDescription = tool.description;
+		const pwshExecutable = process.platform === "win32" ? "pwsh.exe" : "pwsh";
+		expect(powerShellDescription).toContain(`PowerShell (${pwshExecutable})`);
+		expect(powerShellDescription).not.toBe(windowsPowerShellDescription);
 		shell = "C:\\Program Files\\PowerShell\\7\\PWSH.EXE";
-		expect(tool.description).toBe(microsoftPowerShellDescription);
+		expect(tool.description).toBe(powerShellDescription);
 
 		// The property must survive the shallow copy the runtime performs when
 		// building AgentToolDefinitions for a model request.

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -444,7 +444,7 @@ export function buildRunCommandsDescription(
 			edition === "windows"
 				? `Windows PowerShell (${executable})`
 				: edition === "core"
-					? `Microsoft PowerShell (${executable})`
+					? `PowerShell (${executable})`
 					: executable;
 		const wrapper = `${executable} ${shellKind === "powershell" ? "-Command" : "/c"}`;
 		const sequencingOperator = shellKind === "powershell" ? "';'" : "'&&'";
@@ -452,7 +452,7 @@ export function buildRunCommandsDescription(
 			`Run non-interactive shell commands from the root of the workspace${isWindows ? " in Windows environment" : ""}. ` +
 			RUN_COMMANDS_SHARED_INSTRUCTIONS +
 			`Output beyond ~${Math.round(MAX_COMMAND_OUTPUT_CHARS / 1000)}k characters is middle-truncated (start and end preserved); filter output when you need specific sections. ` +
-			`Commands run through ${shellName}; quote paths and arguments for ${shellName} and use ${sequencingOperator} to sequence commands. ` +
+			`Commands run through ${shellName}; quote paths and arguments for ${executable} and use ${sequencingOperator} to sequence commands. ` +
 			`Write commands directly; do not wrap them in another ${wrapper} invocation. ` +
 			"Only start another shell when you intentionally need a different shell or a separate process. " +
 			"Include multiple commands in the same call when they are independent and safe to run concurrently. When independent reads, searches, or edits are also needed, call those tools in the same response."

--- a/sdk/packages/core/src/extensions/tools/index.test.ts
+++ b/sdk/packages/core/src/extensions/tools/index.test.ts
@@ -15,6 +15,8 @@ const context: AgentToolContext = {
 	iteration: 1,
 };
 
+const pwshExecutable = process.platform === "win32" ? "pwsh.exe" : "pwsh";
+
 function createSuccessfulChildProcess(): ChildProcessWithoutNullStreams {
 	const child = Object.assign(new EventEmitter(), {
 		stdout: new EventEmitter(),
@@ -62,10 +64,10 @@ describe("createBuiltinTools shell configuration", () => {
 				"Commands run through Windows PowerShell (powershell.exe)",
 		},
 		{
-			name: "Microsoft PowerShell executable",
+			name: "pwsh executable",
 			options: { shell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
 			expectedShell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
-			expectedDescription: "Commands run through Microsoft PowerShell",
+			expectedDescription: `Commands run through PowerShell (${pwshExecutable})`,
 		},
 		{
 			name: "top-level shell precedence",


### PR DESCRIPTION
### Related Issue

**Issue:** Follow-up to #14025 and [review feedback](https://github.com/cline/cline/pull/14025#issuecomment-5627135579).

### Description

PR #14025 made the `run_commands` prompt distinguish PowerShell editions, but its `pwsh` label is unconventional and its quoting guidance repeats the full shell name.

Label `pwsh` as PowerShell and use the host-specific executable name in the quoting clause: `pwsh.exe` on Windows and `pwsh` on Unix. The executable distinguishes it from Windows PowerShell without claiming an installed major version or requiring a version probe. Shell selection and command execution remain unchanged.

### Test Procedure

From the repository root:

```sh
bun run build:sdk
bun -F @cline/core test:unit src/extensions/tools/definitions.test.ts src/extensions/tools/index.test.ts
bun -F @cline/core typecheck
bun biome check --diagnostic-level=error sdk/packages/core/src/extensions/tools/definitions.ts sdk/packages/core/src/extensions/tools/definitions.test.ts sdk/packages/core/src/extensions/tools/index.test.ts

cd apps/vscode
bun run test:vitest src/sdk/vscode-run-commands-tool.test.ts
bunx tsc --noEmit
bunx tsc --project tsconfig.vscode-compat.json --noEmit
bun biome check --config-path ./biome.jsonc --diagnostic-level=error src/sdk/vscode-run-commands-tool.test.ts

cd webview-ui
bunx tsc --noEmit
```

All checks passed on Windows with Bun 1.3.14. The focused core suite passed 73 tests; the VS Code suite passed 47 tests.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [x] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single wording improvement and its focused tests.
- [x] Relevant tests are passing; changed files are formatted and linted.
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md).