### PR TITLE
feat(desktop): list Cline Pass with Cline and add a set-up row to the composer provider picker

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -1553,6 +1553,7 @@ function ChatThreadPane({
 			onModeToggle={handleModeToggle}
 			onPromptInputChange={handlePromptInputChange}
 			onOpenVoiceInputSettings={onOpenVoiceInputSettings}
+			onOpenModelSettings={onOpenModelSettings}
 			onReasoningChange={handleReasoningChange}
 			onSteerPromptInQueue={steerPromptInQueue}
 			onEditPromptInQueue={updatePromptInQueue}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -1538,6 +1538,85 @@ describe("ChatInputBar", () => {
 		expect(optionLabels[2]).toContain("Other Model");
 	});
 
+	it("opens model settings from the provider picker's set-up row", async () => {
+		loadProviderModelCatalogMock.mockResolvedValue({
+			providers: [],
+			enabledProviderIds: ["cline", "cline-pass"],
+			providerModels: {
+				cline: ["anthropic/claude-opus-5"],
+				"cline-pass": ["anthropic/claude-opus-5"],
+			},
+			providerModelDetails: {},
+			providerNames: { cline: "Cline", "cline-pass": "Cline Pass" },
+			providerReasoningModels: {},
+		});
+		const onOpenModelSettings = vi.fn();
+		const onProviderChange = vi.fn();
+
+		await act(async () => {
+			root.render(
+				<WorkspaceProvider value={workspaceValue}>
+					<ChatInputBar
+						attachments={[]}
+						gitBranch="main"
+						mode="act"
+						model="anthropic/claude-opus-5"
+						onAbort={vi.fn()}
+						onAttachFiles={vi.fn()}
+						onEditPromptInQueue={vi.fn()}
+						onListGitBranches={vi.fn(async () => ({
+							current: "main",
+							branches: ["main"],
+						}))}
+						onModeToggle={vi.fn()}
+						onModelChange={vi.fn()}
+						onOpenModelSettings={onOpenModelSettings}
+						onPromptInputChange={vi.fn()}
+						onProviderChange={onProviderChange}
+						onReasoningChange={vi.fn()}
+						onRemoveAttachment={vi.fn()}
+						onRemovePromptInQueue={vi.fn()}
+						onSend={vi.fn()}
+						onSteerPromptInQueue={vi.fn()}
+						onSwitchGitBranch={vi.fn(async () => true)}
+						promptDraft={{ version: 0, value: "" }}
+						promptsInQueue={[]}
+						provider="cline"
+						reasoningEffort="low"
+						status="idle"
+						summary={{ toolCalls: 0, tokensIn: 0, tokensOut: 0 }}
+						thinking={false}
+					/>
+				</WorkspaceProvider>,
+			);
+			await Promise.resolve();
+		});
+		const providerTrigger = container.querySelector<HTMLButtonElement>(
+			'[aria-label^="Provider:"]',
+		);
+		await vi.waitFor(() => {
+			expect(providerTrigger?.textContent).toContain("Cline");
+		});
+
+		await act(async () => providerTrigger?.click());
+		const panel = document.querySelector('[role="dialog"]');
+		const options = [...(panel?.querySelectorAll('[role="option"]') ?? [])];
+		// Both Cline entries list (one sign-in configures both); the set-up
+		// row trails the real providers.
+		expect(options.map((option) => option.textContent)).toEqual([
+			"Cline",
+			"Cline Pass",
+			"Set up another provider",
+		]);
+
+		await act(async () => (options[2] as HTMLButtonElement).click());
+		expect(onOpenModelSettings).toHaveBeenCalledTimes(1);
+		expect(onProviderChange).not.toHaveBeenCalled();
+		// The row is an action, not a selection: the trigger still shows Cline.
+		expect(providerTrigger?.textContent).toContain("Cline");
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+	});
+
 	describe("cline-pass picker offer", () => {
 		const renderComposer = async (props: {
 			model: string;

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -21,7 +21,6 @@ const {
 	loadProviderModelsMock,
 	speechInputMockState,
 	startVercelStreamingTranscriptionMock,
-	subscribeToProviderCatalogInvalidationMock,
 	subscribeToProviderModelsMock,
 } = vi.hoisted(() => ({
 	loadProviderModelCatalogMock: vi.fn(),
@@ -30,9 +29,6 @@ const {
 		current: null as MockSpeechInputProps | null,
 	},
 	startVercelStreamingTranscriptionMock: vi.fn(),
-	subscribeToProviderCatalogInvalidationMock: vi.fn<
-		(listener: () => void) => () => void
-	>(() => vi.fn()),
 	subscribeToProviderModelsMock: vi.fn<
 		(
 			listener: (providerId: string, models: ProviderModel[]) => void,
@@ -82,8 +78,6 @@ vi.mock("@/components/ai-elements/speech-input", async () => {
 vi.mock("@/lib/provider-model-catalog", () => ({
 	loadProviderModelCatalog: loadProviderModelCatalogMock,
 	loadProviderModels: loadProviderModelsMock,
-	subscribeToProviderCatalogInvalidation:
-		subscribeToProviderCatalogInvalidationMock,
 	subscribeToProviderModels: subscribeToProviderModelsMock,
 	VOICE_INPUT_SETTINGS_CHANGED_EVENT: "cline:test-voice-input-settings-changed",
 }));
@@ -99,7 +93,6 @@ beforeEach(() => {
 	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 	loadProviderModelCatalogMock.mockReset().mockResolvedValue({
 		providers: [],
-		configuredProviderIds: [],
 		enabledProviderIds: ["cline"],
 		providerModels: { cline: ["test-model"] },
 		providerReasoningModels: { cline: [] },
@@ -113,9 +106,6 @@ beforeEach(() => {
 		cancel: vi.fn(),
 	});
 	subscribeToProviderModelsMock.mockReset().mockReturnValue(vi.fn());
-	subscribeToProviderCatalogInvalidationMock
-		.mockReset()
-		.mockReturnValue(vi.fn());
 	HTMLElement.prototype.scrollIntoView = vi.fn();
 	HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
 	HTMLElement.prototype.setPointerCapture = vi.fn();
@@ -152,7 +142,6 @@ function providerCatalog(
 ) {
 	return {
 		providers: [],
-		configuredProviderIds: [],
 		enabledProviderIds: ["cline"],
 		providerModels: { cline: ["test-model"] },
 		providerReasoningModels: { cline: [] },
@@ -1024,7 +1013,6 @@ describe("ChatInputBar", () => {
 	it("selects High from the supported model thinking menu", async () => {
 		loadProviderModelCatalogMock.mockResolvedValue({
 			providers: [],
-			configuredProviderIds: [],
 			enabledProviderIds: ["cline"],
 			providerModels: { cline: ["test-model"] },
 			providerReasoningModels: { cline: ["test-model"] },
@@ -1353,7 +1341,6 @@ describe("ChatInputBar", () => {
 		);
 		loadProviderModelCatalogMock.mockResolvedValue({
 			providers: [],
-			configuredProviderIds: [],
 			enabledProviderIds: ["openrouter"],
 			providerModels: {
 				openrouter: ["old-session-model", "user-picked-model"],
@@ -1453,7 +1440,6 @@ describe("ChatInputBar", () => {
 	it("renders the cline model picker with recommended and free sections", async () => {
 		loadProviderModelCatalogMock.mockResolvedValue({
 			providers: [],
-			configuredProviderIds: [],
 			enabledProviderIds: ["cline"],
 			providerModels: {
 				cline: [
@@ -1552,91 +1538,6 @@ describe("ChatInputBar", () => {
 		expect(optionLabels[2]).toContain("Other Model");
 	});
 
-	it("marks configured providers in the picker and refreshes on catalog invalidation", async () => {
-		const catalog = {
-			providers: [],
-			configuredProviderIds: ["anthropic"],
-			enabledProviderIds: ["cline", "anthropic"],
-			providerModels: { cline: ["test-model"], anthropic: ["claude"] },
-			providerNames: { cline: "Cline", anthropic: "Anthropic" },
-			providerReasoningModels: {},
-		};
-		loadProviderModelCatalogMock.mockResolvedValue(catalog);
-		let invalidate!: () => void;
-		subscribeToProviderCatalogInvalidationMock.mockImplementation(
-			(listener) => {
-				invalidate = listener;
-				return vi.fn();
-			},
-		);
-
-		await act(async () => {
-			root.render(
-				<WorkspaceProvider value={workspaceValue}>
-					<ChatInputBar
-						attachments={[]}
-						gitBranch="main"
-						mode="act"
-						model="test-model"
-						onAbort={vi.fn()}
-						onAttachFiles={vi.fn()}
-						onEditPromptInQueue={vi.fn()}
-						onListGitBranches={vi.fn(async () => ({
-							current: "main",
-							branches: ["main"],
-						}))}
-						onModeToggle={vi.fn()}
-						onModelChange={vi.fn()}
-						onPromptInputChange={vi.fn()}
-						onProviderChange={vi.fn()}
-						onReasoningChange={vi.fn()}
-						onRemoveAttachment={vi.fn()}
-						onRemovePromptInQueue={vi.fn()}
-						onSend={vi.fn()}
-						onSteerPromptInQueue={vi.fn()}
-						onSwitchGitBranch={vi.fn(async () => true)}
-						promptDraft={{ version: 0, value: "" }}
-						promptsInQueue={[]}
-						provider="cline"
-						reasoningEffort="low"
-						status="idle"
-						summary={{ toolCalls: 0, tokensIn: 0, tokensOut: 0 }}
-						thinking={false}
-					/>
-				</WorkspaceProvider>,
-			);
-			await Promise.resolve();
-		});
-		const providerTrigger = container.querySelector<HTMLButtonElement>(
-			'[aria-label^="Provider:"]',
-		);
-		await vi.waitFor(() => {
-			expect(providerTrigger?.textContent).toContain("Cline");
-		});
-		// The trigger never carries the status; only list rows do.
-		expect(providerTrigger?.querySelector('[aria-label="Configured"]')).toBe(
-			null,
-		);
-		const configuredRows = () =>
-			[...document.querySelectorAll('[role="option"]')]
-				.filter((option) => option.querySelector('[aria-label="Configured"]'))
-				.map((option) => option.textContent);
-
-		await act(async () => providerTrigger?.click());
-		expect(configuredRows()).toEqual(["Anthropic"]);
-
-		// Credentials saved in settings invalidate the shared catalog; the open
-		// picker must reflect the new readiness without a remount.
-		loadProviderModelCatalogMock.mockResolvedValue({
-			...catalog,
-			configuredProviderIds: ["cline", "anthropic"],
-		});
-		await act(async () => invalidate());
-		await vi.waitFor(() => {
-			expect(configuredRows()).toEqual(["Cline", "Anthropic"]);
-		});
-	});
-
 	describe("cline-pass picker offer", () => {
 		const renderComposer = async (props: {
 			model: string;
@@ -1693,7 +1594,6 @@ describe("ChatInputBar", () => {
 			// picker hides while the subscribed tier is non-empty.
 			loadProviderModelCatalogMock.mockResolvedValue({
 				providers: [],
-				configuredProviderIds: [],
 				enabledProviderIds: ["cline", "cline-pass"],
 				providerModels: {
 					cline: ["test-model"],
@@ -1741,7 +1641,6 @@ describe("ChatInputBar", () => {
 		function mockBundledCatalog() {
 			loadProviderModelCatalogMock.mockResolvedValue({
 				providers: [],
-				configuredProviderIds: [],
 				enabledProviderIds: ["cline", "cline-pass"],
 				providerModels: {
 					cline: ["test-model"],

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -5,15 +5,7 @@ import {
 	formatDisplayUserInput,
 } from "@cline/shared/browser";
 import { AgentPromptQueue, SearchCombobox } from "@cline/ui";
-import {
-	ArrowUp,
-	Brain,
-	CircleCheck,
-	CircleStop,
-	Cpu,
-	Paperclip,
-	X,
-} from "lucide-react";
+import { ArrowUp, Brain, CircleStop, Cpu, Paperclip, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	SpeechInput,
@@ -54,7 +46,6 @@ import { normalizeProviderId } from "@/lib/provider-id";
 import {
 	loadProviderModelCatalog,
 	loadProviderModels,
-	subscribeToProviderCatalogInvalidation,
 	subscribeToProviderModels,
 	type TranscriptionModelTarget,
 	VOICE_INPUT_SETTINGS_CHANGED_EVENT,
@@ -1634,9 +1625,6 @@ const ModelSelector = memo(function ModelSelector({
 		"loading" | "catalog" | "fallback"
 	>("loading");
 	const [enabledProviderIds, setEnabledProviderIds] = useState<string[]>([]);
-	const [configuredProviderIds, setConfiguredProviderIds] = useState<string[]>(
-		[],
-	);
 	const [providerNames, setProviderNames] = useState<Record<string, string>>(
 		{},
 	);
@@ -1811,7 +1799,6 @@ const ModelSelector = memo(function ModelSelector({
 					...(payload.providerModelDetails ?? {}),
 				}));
 				setReasoningCapabilitySource("catalog");
-				setConfiguredProviderIds(payload.configuredProviderIds);
 				setEnabledProviderIds((current) => {
 					const nextProviderIds = new Set(payload.enabledProviderIds);
 					if (normalizedProvider) {
@@ -1890,26 +1877,6 @@ const ModelSelector = memo(function ModelSelector({
 				current.includes(normalizedId) ? current : [...current, normalizedId],
 			);
 		});
-	}, []);
-
-	// Credentials saved or removed in settings (or OAuth completing) invalidate
-	// the shared catalog; refetch so the readiness indicators don't go stale
-	// while the composer stays mounted.
-	useEffect(() => {
-		let cancelled = false;
-		const unsubscribe = subscribeToProviderCatalogInvalidation(() => {
-			loadProviderModelCatalog()
-				.then((payload) => {
-					if (!cancelled) {
-						setConfiguredProviderIds(payload.configuredProviderIds);
-					}
-				})
-				.catch(() => {});
-		});
-		return () => {
-			cancelled = true;
-			unsubscribe();
-		};
 	}, []);
 
 	// The remembered selection (what new sessions default to) is only written
@@ -2038,25 +2005,13 @@ const ModelSelector = memo(function ModelSelector({
 		},
 		[onModelChange, rememberSelection, resolvedProvider],
 	);
-	// Enabled providers can lack usable credentials (e.g. entries seeded by
-	// legacy migration), so mark the ones that are actually ready for a turn.
 	const providerOptions = useMemo(
 		() =>
 			providers.map((value) => ({
-				...(configuredProviderIds.includes(value)
-					? {
-							indicator: (
-								<CircleCheck
-									aria-label="Configured"
-									className="size-3 shrink-0 text-emerald-500"
-								/>
-							),
-						}
-					: {}),
 				label: providerNames[value]?.trim() || value,
 				value,
 			})),
-		[configuredProviderIds, providerNames, providers],
+		[providerNames, providers],
 	);
 	const selectedModelLabel =
 		visibleModelPicker.options.find((option) => option.value === resolvedModel)

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -5,7 +5,15 @@ import {
 	formatDisplayUserInput,
 } from "@cline/shared/browser";
 import { AgentPromptQueue, SearchCombobox } from "@cline/ui";
-import { ArrowUp, Brain, CircleStop, Cpu, Paperclip, X } from "lucide-react";
+import {
+	ArrowUp,
+	Brain,
+	CircleStop,
+	Cpu,
+	Paperclip,
+	Plus,
+	X,
+} from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	SpeechInput,
@@ -313,6 +321,7 @@ type ChatInputBarProps = {
 	) => Promise<void> | void;
 	onRemovePromptInQueue: (promptId: string) => Promise<void> | void;
 	onOpenVoiceInputSettings?: () => void;
+	onOpenModelSettings?: () => void;
 	summary: {
 		toolCalls: number;
 		tokensIn: number;
@@ -351,6 +360,7 @@ function ChatInputBarImpl({
 	onEditPromptInQueue,
 	onRemovePromptInQueue,
 	onOpenVoiceInputSettings,
+	onOpenModelSettings,
 	summary,
 }: ChatInputBarProps) {
 	const {
@@ -1523,6 +1533,7 @@ function ChatInputBarImpl({
 							onModelSupportsReasoningChange={
 								handleModelSupportsReasoningChange
 							}
+							onOpenModelSettings={onOpenModelSettings}
 							onProviderChange={onProviderChange}
 							provider={provider}
 						/>
@@ -1597,6 +1608,9 @@ export const ChatInputBar = memo(ChatInputBarImpl);
 
 // Memoized: the selectors load/hold the full provider-model catalog, so they
 // should not re-render for every keystroke in the composer textarea.
+/** Sentinel provider-picker row that opens Settings → Models instead of selecting. */
+const ADD_PROVIDER_OPTION_VALUE = "__add-provider__";
+
 const ModelSelector = memo(function ModelSelector({
 	provider,
 	model,
@@ -1605,6 +1619,7 @@ const ModelSelector = memo(function ModelSelector({
 	onModelChange,
 	onModelSupportsReasoningChange,
 	onModelSupportsImagesChange,
+	onOpenModelSettings,
 }: {
 	provider: string;
 	model: string;
@@ -1613,6 +1628,8 @@ const ModelSelector = memo(function ModelSelector({
 	onModelChange: (model: string) => void;
 	onModelSupportsReasoningChange: (supportsReasoning: boolean | null) => void;
 	onModelSupportsImagesChange: (supported: boolean | null) => void;
+	/** Opens Settings → Models; adds a "set up another provider" row when set. */
+	onOpenModelSettings?: () => void;
 }) {
 	const normalizedProvider = normalizeProviderId(provider);
 	const [providerModels, setProviderModels] = useState<
@@ -1968,6 +1985,11 @@ const ModelSelector = memo(function ModelSelector({
 
 	const handleProviderSelect = useCallback(
 		(value: string) => {
+			if (value === ADD_PROVIDER_OPTION_VALUE) {
+				setMobileOpen(false);
+				onOpenModelSettings?.();
+				return;
+			}
 			onProviderChange(value);
 			const rememberedModel = lastSelection.lastModelByProvider[value];
 			const providerModelIds = visibleProviderModels[value] ?? [];
@@ -1992,6 +2014,7 @@ const ModelSelector = memo(function ModelSelector({
 			lastSelection.lastModelByProvider,
 			model,
 			onModelChange,
+			onOpenModelSettings,
 			onProviderChange,
 			pickerDataForProvider,
 			rememberSelection,
@@ -2005,13 +2028,25 @@ const ModelSelector = memo(function ModelSelector({
 		},
 		[onModelChange, rememberSelection, resolvedProvider],
 	);
+	// The picker only lists providers with saved settings, so it is also the
+	// natural place to reach the rest of the catalog.
 	const providerOptions = useMemo(
-		() =>
-			providers.map((value) => ({
+		() => [
+			...providers.map((value) => ({
 				label: providerNames[value]?.trim() || value,
 				value,
 			})),
-		[providerNames, providers],
+			...(onOpenModelSettings
+				? [
+						{
+							icon: <Plus className="size-3 shrink-0 text-muted-foreground" />,
+							label: "Set up another provider",
+							value: ADD_PROVIDER_OPTION_VALUE,
+						},
+					]
+				: []),
+		],
+		[onOpenModelSettings, providerNames, providers],
 	);
 	const selectedModelLabel =
 		visibleModelPicker.options.find((option) => option.value === resolvedModel)

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.test.ts
@@ -285,35 +285,4 @@ describe("transcription model selection", () => {
 			}),
 		).toMatchObject({ supportsStreaming: true });
 	});
-
-	it("separates enabled providers from ones with usable credentials", () => {
-		const chatModel = {
-			id: "model",
-			name: "Model",
-			inputModalities: ["text"],
-			outputModalities: ["text"],
-		};
-		const base = { models: 1, color: "#000000", letter: "P" };
-		const catalog = buildProviderModelCatalog([
-			{
-				...base,
-				id: "anthropic",
-				name: "Anthropic",
-				enabled: true,
-				apiKey: "sk-123",
-				modelList: [chatModel],
-			},
-			{
-				...base,
-				id: "openai",
-				name: "OpenAI",
-				enabled: true,
-				configured: false,
-				modelList: [chatModel],
-			},
-		]);
-
-		expect(catalog.enabledProviderIds).toEqual(["anthropic", "openai"]);
-		expect(catalog.configuredProviderIds).toEqual(["anthropic"]);
-	});
 });

--- a/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
+++ b/apps/examples/desktop-app/webview/lib/provider-model-catalog.ts
@@ -2,7 +2,6 @@
 
 import { isChatCompatibleModel } from "@cline/shared/browser";
 import { desktopClient } from "@/lib/desktop-client";
-import { isProviderConnected } from "@/lib/provider-connection";
 import type {
 	Provider,
 	ProviderCatalogResponse,
@@ -14,8 +13,6 @@ import type {
 export type ProviderModelCatalog = {
 	providers: Provider[];
 	enabledProviderIds: string[];
-	/** Providers with usable credentials (see `isProviderConnected`). */
-	configuredProviderIds: string[];
 	providerModels: Record<string, string[]>;
 	/** Full chat-model entries per provider (display names, capabilities). */
 	providerModelDetails: Record<string, ProviderModel[]>;
@@ -111,9 +108,6 @@ export function buildProviderModelCatalog(
 				(provider) =>
 					provider.enabled && toModelIds(provider.modelList).length > 0,
 			)
-			.map((provider) => provider.id),
-		configuredProviderIds: providers
-			.filter(isProviderConnected)
 			.map((provider) => provider.id),
 		providerModels: Object.fromEntries(
 			providers.map((provider) => [

--- a/sdk/packages/core/src/services/providers/local-provider-service.test.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.test.ts
@@ -2015,6 +2015,47 @@ describe("listLocalProviders", () => {
 		});
 	});
 
+	it("enables ClinePass from a Cline sign-in that never wrote a ClinePass entry", async () => {
+		// Desktop onboarding signs in as "cline" only; the shared credentials
+		// make ClinePass usable, so it must surface as enabled without its own
+		// providers.json entry.
+		manager.saveProviderSettings(
+			{
+				provider: "cline",
+				auth: {
+					accessToken: "shared-token",
+					refreshToken: "shared-refresh",
+				},
+			},
+			{ setLastUsed: false, tokenSource: "oauth" },
+		);
+
+		const { providers } = await listLocalProviders(manager, {
+			isClinePassEnabled: true,
+		});
+		const clinePass = providers.find(
+			(provider) => provider.id === "cline-pass",
+		);
+
+		expect(manager.read().providers["cline-pass"]).toBeUndefined();
+		expect(clinePass).toMatchObject({
+			enabled: true,
+			configured: true,
+			oauthAccessTokenPresent: true,
+		});
+	});
+
+	it("keeps ClinePass disabled when Cline has no entry", async () => {
+		const { providers } = await listLocalProviders(manager, {
+			isClinePassEnabled: true,
+		});
+		const clinePass = providers.find(
+			(provider) => provider.id === "cline-pass",
+		);
+
+		expect(clinePass?.enabled).toBe(false);
+	});
+
 	it("exposes model count", async () => {
 		await addLocalProvider(manager, {
 			providerId: "count-provider",

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -765,6 +765,15 @@ export async function listLocalProviders(
 					featuredData,
 				);
 				const directSettings = state.providers[id]?.settings;
+				// Providers that store their credentials under another provider
+				// (ClinePass signs in as "cline") are enabled whenever that
+				// provider is: one Cline sign-in configures both, so both must
+				// show wherever `enabled` gates a picker.
+				const storageProviderId = getProviderAuthHandler(id)?.storageProviderId;
+				const sharedSettings =
+					storageProviderId && storageProviderId !== id
+						? state.providers[storageProviderId]?.settings
+						: undefined;
 				const persistedSettings = manager.getProviderSettings(id);
 				const name = info?.name ?? titleCaseFromId(id);
 				const capabilities = resolveProviderCapabilities(
@@ -781,7 +790,7 @@ export async function listLocalProviders(
 						models: modelList.length,
 						color: stableColor(id),
 						letter: createLetter(name),
-						enabled: Boolean(directSettings),
+						enabled: Boolean(directSettings ?? sharedSettings),
 						// Distinct from `enabled` (any persisted entry, which
 						// migrations and empty saves can create): true only when
 						// the saved settings hold real credentials or a usable

--- a/sdk/packages/ui/components/search-combobox.tsx
+++ b/sdk/packages/ui/components/search-combobox.tsx
@@ -15,8 +15,6 @@ export interface SearchComboboxOption {
 	badge?: string;
 	description?: string;
 	icon?: ReactNode;
-	/** Small status node after the label, shown in list rows but not the trigger. */
-	indicator?: ReactNode;
 	label: string;
 	/** Id of the section this option belongs to (see `sections`). */
 	section?: string;
@@ -262,7 +260,6 @@ export function SearchCombobox({
 								{option.badge}
 							</span>
 						) : null}
-						{option.indicator}
 					</span>
 					{option.description ? (
 						<small className="truncate text-[0.625rem] text-cline-ui-muted-foreground">

--- a/sdk/packages/ui/tests/search-combobox.test.tsx
+++ b/sdk/packages/ui/tests/search-combobox.test.tsx
@@ -174,7 +174,6 @@ describe("SearchCombobox", () => {
 		const sectionedOptions = [
 			{
 				badge: "NEW",
-				indicator: <span data-testid="indicator" />,
 				label: "Claude Opus 5",
 				section: "recommended",
 				value: "anthropic/claude-opus-5",
@@ -202,11 +201,8 @@ describe("SearchCombobox", () => {
 			),
 		);
 
-		const trigger = container.querySelector("button");
-		expect(trigger?.querySelector('[data-testid="indicator"]')).toBeNull();
-		await act(async () => trigger?.click());
+		await act(async () => container.querySelector("button")?.click());
 		const panel = container.querySelector('[role="dialog"]');
-		expect(panel?.querySelector('[data-testid="indicator"]')).not.toBeNull();
 		expect(panel?.textContent).toContain("Recommended");
 		expect(panel?.textContent).toContain("Free");
 		expect(panel?.textContent).toContain("No cost");


### PR DESCRIPTION
### Related Issue

Follow-up to #14021 (the configured-provider indicator), prompted by reviewing what a brand-new Cline Pass user actually sees in the composer.

### Description

Three related changes to the composer's provider picker, all driven by the same fact: **the picker only lists providers that have a saved `providers.json` entry.** That's `enabledProviderIds` in the webview, which the sidecar derives from `enabled = Boolean(directSettings)` in `listLocalProviders` — literally "does an entry exist for this id".

**1. Cline Pass now lists alongside Cline.** Desktop onboarding signs in with `provider: "cline"` and never writes a `cline-pass` entry. Cline Pass stores its credentials *under* `cline` (`storageProviderId: "cline"` in the auth registry), so the one sign-in genuinely configures both — `getProviderSettings("cline-pass")` already resolves the shared auth, and Settings already shows Cline Pass as Configured. But the composer keyed on entry-existence, so a fresh Cline Pass user saw exactly one row: Cline. `listLocalProviders` now marks a provider enabled whenever the provider it stores credentials under is enabled. This is symmetric by construction: a `cline-pass` sign-in writes the `cline` entry (that's where the token goes) and then `markLocalProviderEnabled("cline-pass")`, so Cline was already covered in that direction.

The CLI's provider picker inherits this — it treats `enabled` as `isConfigured` — so Cline Pass now reads as configured there too when Cline is. That matches reality.

**2. A "Set up another provider" row at the bottom of the picker.** Since the picker is by construction "what you've set up", it's the natural place to reach the rest of the catalog. The row is a sentinel option (`__add-provider__`) with a `Plus` icon; `handleProviderSelect` intercepts it and calls `onOpenModelSettings` — the same callback the welcome-state "connect a model" notice already uses to open Settings → Models — instead of selecting. It's an action, not a selection: `onProviderChange` is never called and the trigger keeps showing the current provider. It only renders when the callback is provided, so existing callers that don't pass it are unaffected. On the compact (<560px) layout it also closes the mobile menu, since the settings view overlays it.

I went with a sentinel option rather than adding a footer slot to `SearchCombobox` deliberately: it gets keyboard navigation, `Enter`, search-highlighting, and close-on-select for free, and doesn't need a new UI-package prop. The one quirk is that a search query filters it like any other row — which reads as reasonable.

**3. Reverts #14021's green "Configured" check on the picker rows.** For anyone who set their providers up in the app, every row satisfies `isProviderConnected` and gets the same check — decoration, not information. The two predicates only diverge on entries with no usable credentials (legacy VS Code migration seeding, empty saves, sign-outs that leave the entry behind). That *is* worth surfacing, but Settings already does it per provider and has the affordance to fix it; the composer doesn't. The `indicator` prop on `SearchCombobox` goes too — the picker was its only consumer. `isProviderConnected` itself stays; Settings, voice input, and the first-run notice still use it.

#### Gotchas found along the way

- `Boolean(directSettings)` is a weaker predicate than it looks: a `cline` entry persists after sign-out (the auth block is blanked, not the row), so a signed-out user still sees Cline — and now Cline Pass — in the picker. That's pre-existing behavior for Cline and the change keeps the pair consistent; the turn fails with the normal credential-failure hint.
- `resolveProviderSettings` merges the storage provider's `auth`/`apiKey`/`baseUrl` under the alias's `provider` id, which is why `configured` and `oauthAccessTokenPresent` were already `true` for Cline Pass while `enabled` was `false`. The fix only had to touch `enabled`.

### Test Procedure

- `sdk/packages/core` `local-provider-service.test.ts`: 97 pass, including two new cases — Cline Pass is `enabled: true, configured: true, oauthAccessTokenPresent: true` from a `cline`-only sign-in with **no** `cline-pass` entry on disk, and stays `enabled: false` when there's no `cline` entry either.
- Desktop webview `chat-input-bar.test.tsx` + `provider-model-catalog.test.ts`: 45 pass, including a new test that opens the picker, asserts the rows are exactly `["Cline", "Cline Pass", "Set up another provider"]`, clicks the last one, and checks `onOpenModelSettings` fired once, `onProviderChange` never did, the trigger still reads Cline, and the panel closed.
- `sdk/packages/ui` `search-combobox.test.tsx`: 7 pass after dropping the `indicator` prop.
- CLI `provider-picker.test.ts`, `onboarding/model.test.ts`, `cline-model-picker.test.ts`: 26 pass (these mock the catalog, so they mostly confirm nothing depends on the old shape).
- `bun -F @cline/core typecheck` clean; `bun -F @cline/code typecheck` clean. The webview isn't typechecked by the app's `typecheck` script, so I ran `tsc` on `webview/tsconfig.json` and grepped the changed files: the only hits are the pre-existing `vi.fn()` Mock-typing errors in the test helpers (same lines on `main`), none from this change.
- Biome lint + format clean on all changed files.

Not exercised: a real Tauri run. The webview + sidecar path is the same code the tests hit, but a smoke on a fresh profile (sign in with Cline → open the composer picker → see both rows + the set-up row → click it → land on Settings → Models) is worth a minute before this ships in a release.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No screenshots — built in a headless sandbox. The picker change is: two Cline rows instead of one, and a trailing `+ Set up another provider` row; no green checks.

### Additional Notes

- Intended for desktop 0.0.26; the release commit on `main` will pick up changelog bullets for this once it lands.
- The `enabled` semantic change is in `@cline/core`, so it also reaches the CLI (`isConfigured` in its provider picker) — that's the intended direction, noted here so it isn't a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qj6N74NgMeXSWn8qg7S4tw
