### PR TITLE
fix(llms): wire per-call Langfuse telemetry and isolate direct export

### DIFF
--- a/apps/vscode/src/services/telemetry/providers/opentelemetry/RUNBOOK.md
+++ b/apps/vscode/src/services/telemetry/providers/opentelemetry/RUNBOOK.md
@@ -68,3 +68,26 @@ remote disable/replacement. Remote fetch/apply timing is not an instant guarante
 - Test with an existing build/runtime tracer: remote changes must leave it alone.
 - Keep collector-side mitigation available for older clients and build-enabled
   releases. Remote configuration is not a substitute for that control.
+## AI SDK v7 integration and collector contract
+
+Each enabled SDK stream supplies its selected Langfuse integration through
+`telemetry.integrations`. Setting `isEnabled` without an integration does not
+produce AI SDK v7 spans. Relay integrations acquire the current host tracer per
+call, so replacing the remote-config provider also redirects subsequent streams.
+
+The integration emits the v7 semantic attributes, including
+`gen_ai.provider.name` and `gen_ai.request.model`, under the instrumentation scope
+`cline-provider-langfuse`. It does not emit the old `ai.model.provider` attribute.
+Before activation, update and validate the collector filter in cline/infra#547
+against these actual spans. A filter requiring `ai.model.provider` drops them all.
+Preserve child step/tool spans too: they share the dedicated instrumentation
+scope but may not carry the model-provider attribute. Do not enable the publish
+rollout until a real streamed response reaches the intended collector destination.
+
+Direct `LANGFUSE_*` credentials remain supported for `cline` and `cline-pass`
+when no host relay is registered. That path uses an isolated tracer provider and
+per-call integration; it neither registers a global AI SDK integration nor alters
+or shuts down another owner's tracer. When a relay is registered it takes
+precedence, including after an earlier direct request. Relay opt-out, sampling
+and content controls still apply, with no fallback to direct export when those
+controls disable a request.

--- a/bun.lock
+++ b/bun.lock
@@ -708,6 +708,7 @@
         "@langfuse/vercel-ai-sdk": "5.9.1",
         "@openrouter/ai-sdk-provider": "^3",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
         "@streamparser/json": "^0.0.21",
         "ai": "^7.0.58",

--- a/sdk/packages/llms/package.json
+++ b/sdk/packages/llms/package.json
@@ -69,6 +69,7 @@
 		"@langfuse/vercel-ai-sdk": "5.9.1",
 		"@openrouter/ai-sdk-provider": "^3",
 		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/context-async-hooks": "^2.6.1",
 		"@opentelemetry/sdk-trace-node": "^2.6.1",
 		"@streamparser/json": "^0.0.21",
 		"ai": "^7.0.58",

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -2263,13 +2263,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 							abortSignal: request.signal,
 							experimental_repairToolCall: repairMalformedToolCall as never,
 							telemetry: {
-								isEnabled: aiSdkTelemetry.isEnabled,
-								...(aiSdkTelemetry.recordInputs !== undefined
-									? { recordInputs: aiSdkTelemetry.recordInputs }
-									: {}),
-								...(aiSdkTelemetry.recordOutputs !== undefined
-									? { recordOutputs: aiSdkTelemetry.recordOutputs }
-									: {}),
+								...aiSdkTelemetry,
 								functionId: "cline-agent-turn",
 								includeRuntimeContext: {
 									distinctId: true,

--- a/sdk/packages/llms/src/services/langfuse-telemetry.integration.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.integration.test.ts
@@ -1,0 +1,240 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { markOtlpTraceRelayProvider } from "@cline/shared";
+import { context, trace } from "@opentelemetry/api";
+import {
+	InMemorySpanExporter,
+	NodeTracerProvider,
+	SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { streamText } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+	disposeLangfuseTelemetry,
+	resetLangfuseTelemetryForTests,
+	resolveAiSdkTelemetry,
+} from "./langfuse-telemetry";
+
+const { settingsPath, directExporters } = vi.hoisted(() => ({
+	settingsPath: { current: "" },
+	directExporters: [] as InMemorySpanExporter[],
+}));
+vi.mock("@cline/shared/storage", () => ({
+	resolveGlobalSettingsPath: () => settingsPath.current,
+}));
+// Keep the real AI SDK, Langfuse integration and OTel runtime. Replace only
+// the network exporter so credentialed direct-path tests cannot send data.
+vi.mock("@langfuse/otel", async () => {
+	const { InMemorySpanExporter, SimpleSpanProcessor } = await import(
+		"@opentelemetry/sdk-trace-node"
+	);
+	return {
+		LangfuseSpanProcessor: class extends SimpleSpanProcessor {
+			constructor() {
+				const exporter = new InMemorySpanExporter();
+				super(exporter);
+				directExporters.push(exporter);
+			}
+		},
+	};
+});
+let settingsDir: string;
+
+let provider: NodeTracerProvider;
+let exporter: InMemorySpanExporter;
+
+beforeEach(() => {
+	settingsDir = mkdtempSync(path.join(tmpdir(), "cline-relay-"));
+	settingsPath.current = path.join(settingsDir, "settings.json");
+	directExporters.length = 0;
+	vi.stubEnv("OTEL_SERVICE_NAME", "");
+	vi.stubEnv("LANGFUSE_BASE_URL", "");
+	vi.stubEnv("LANGFUSE_PUBLIC_KEY", "");
+	vi.stubEnv("LANGFUSE_SECRET_KEY", "");
+	vi.stubEnv("CLINE_TRACE_SAMPLE_PERCENT", "100");
+	vi.stubEnv("CLINE_TRACE_RECORD_CONTENT", "false");
+	trace.disable();
+	context.disable();
+	resetLangfuseTelemetryForTests();
+	exporter = new InMemorySpanExporter();
+	provider = new NodeTracerProvider({
+		spanProcessors: [new SimpleSpanProcessor(exporter)],
+	});
+	markOtlpTraceRelayProvider(provider);
+	provider.register();
+});
+
+afterEach(async () => {
+	await disposeLangfuseTelemetry();
+	rmSync(settingsDir, { recursive: true, force: true });
+	await provider.shutdown();
+	trace.disable();
+	context.disable();
+	resetLangfuseTelemetryForTests();
+	vi.unstubAllEnvs();
+});
+
+async function runStream(
+	telemetry = { isEnabled: true } as Awaited<
+		ReturnType<typeof resolveAiSdkTelemetry>
+	>,
+) {
+	const result = streamText({
+		model: new MockLanguageModelV4({
+			provider: "cline",
+			modelId: "test-model",
+			doStream: async () => ({
+				stream: new ReadableStream({
+					start(controller) {
+						controller.enqueue({ type: "stream-start", warnings: [] });
+						controller.enqueue({ type: "text-start", id: "text-1" });
+						controller.enqueue({
+							type: "text-delta",
+							id: "text-1",
+							delta: "private completion",
+						});
+						controller.enqueue({ type: "text-end", id: "text-1" });
+						controller.enqueue({
+							type: "finish",
+							finishReason: { unified: "stop", raw: "stop" },
+							usage: {
+								inputTokens: {
+									total: 1,
+									noCache: 1,
+									cacheRead: 0,
+									cacheWrite: 0,
+								},
+								outputTokens: { total: 1, text: 1, reasoning: 0 },
+							},
+						});
+						controller.close();
+					},
+				}),
+			}),
+		}),
+		prompt: "private prompt",
+		telemetry,
+	});
+	await result.consumeStream();
+	expect(await result.text).toBe("private completion");
+}
+
+it("exports AI SDK 7 stream spans through the host relay without Langfuse credentials", async () => {
+	const telemetry = await resolveAiSdkTelemetry("cline", "task-a");
+	expect(telemetry.isEnabled).toBe(true);
+	await runStream(telemetry);
+	await provider.forceFlush();
+	const spans = exporter.getFinishedSpans();
+	expect(spans.length).toBeGreaterThan(0);
+	expect(
+		spans.some((span) => span.attributes["gen_ai.provider.name"] === "cline"),
+	).toBe(true);
+	expect(
+		spans.every(
+			(span) => span.instrumentationScope.name === "cline-provider-langfuse",
+		),
+	).toBe(true);
+	const attributes = JSON.stringify(spans.map((span) => span.attributes));
+	expect(attributes).not.toContain("private prompt");
+	expect(attributes).not.toContain("private completion");
+});
+
+it("records prompt and completion only when the content flag is enabled", async () => {
+	vi.stubEnv("CLINE_TRACE_RECORD_CONTENT", "true");
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	const attributes = JSON.stringify(
+		exporter.getFinishedSpans().map((span) => span.attributes),
+	);
+	expect(attributes).toContain("private prompt");
+	expect(attributes).toContain("private completion");
+});
+
+it("stops emitting after a mid-session opt-out", async () => {
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	const initialCount = exporter.getFinishedSpans().length;
+	expect(initialCount).toBeGreaterThan(0);
+	writeFileSync(
+		settingsPath.current,
+		JSON.stringify({ telemetryOptOut: true }),
+	);
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans()).toHaveLength(initialCount);
+});
+
+it("emits no spans for an excluded provider or a sampled-out task", async () => {
+	await runStream(await resolveAiSdkTelemetry("openrouter", "task-a"));
+	vi.stubEnv("CLINE_TRACE_SAMPLE_PERCENT", "50");
+	await runStream(await resolveAiSdkTelemetry("cline", "task-c"));
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans()).toHaveLength(0);
+});
+
+it("reacquires the host tracer after provider replacement", async () => {
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans().length).toBeGreaterThan(0);
+	const oldExporter = exporter;
+	await provider.shutdown();
+	trace.disable();
+	exporter = new InMemorySpanExporter();
+	provider = new NodeTracerProvider({
+		spanProcessors: [new SimpleSpanProcessor(exporter)],
+	});
+	markOtlpTraceRelayProvider(provider);
+	provider.register();
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans().length).toBeGreaterThan(0);
+	expect(oldExporter.getFinishedSpans()).toHaveLength(0);
+});
+
+it("exports directly without claiming or shutting down a non-relay host tracer", async () => {
+	delete (provider as unknown as Record<string, unknown>)._clineOtlpTraceRelay;
+	vi.stubEnv("LANGFUSE_BASE_URL", "https://langfuse.example");
+	vi.stubEnv("LANGFUSE_PUBLIC_KEY", "public-key");
+	vi.stubEnv("LANGFUSE_SECRET_KEY", "secret-key");
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	expect(directExporters).toHaveLength(1);
+	expect(directExporters[0]?.getFinishedSpans().length).toBeGreaterThan(0);
+	expect(exporter.getFinishedSpans()).toHaveLength(0);
+	// A different AI SDK caller must not inherit our direct integration.
+	const directCount = directExporters[0]?.getFinishedSpans().length;
+	await runStream();
+	expect(directExporters[0]?.getFinishedSpans()).toHaveLength(directCount ?? 0);
+	await disposeLangfuseTelemetry();
+	trace.getTracer("host").startSpan("host still alive").end();
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual([
+		"host still alive",
+	]);
+});
+
+it("chooses only the host relay when direct credentials are also present", async () => {
+	vi.stubEnv("LANGFUSE_BASE_URL", "https://langfuse.example");
+	vi.stubEnv("LANGFUSE_PUBLIC_KEY", "public-key");
+	vi.stubEnv("LANGFUSE_SECRET_KEY", "secret-key");
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	await provider.forceFlush();
+	expect(exporter.getFinishedSpans().length).toBeGreaterThan(0);
+	expect(directExporters).toHaveLength(0);
+});
+
+it("keeps direct stream spans in one trace without a preinstalled host context manager", async () => {
+	trace.disable();
+	context.disable();
+	vi.stubEnv("LANGFUSE_BASE_URL", "https://langfuse.example");
+	vi.stubEnv("LANGFUSE_PUBLIC_KEY", "public-key");
+	vi.stubEnv("LANGFUSE_SECRET_KEY", "secret-key");
+	await runStream(await resolveAiSdkTelemetry("cline", "task-a"));
+	const spans = directExporters[0]?.getFinishedSpans() ?? [];
+	expect(spans.length).toBeGreaterThan(1);
+	expect(new Set(spans.map((span) => span.spanContext().traceId)).size).toBe(1);
+	expect(
+		trace.getTracer("unrelated").startSpan("unrelated").isRecording(),
+	).toBe(false);
+});

--- a/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.test.ts
@@ -1,256 +1,223 @@
-import { promises as fs } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { registerDisposableSpy, registerTelemetrySpy, telemetryStartSpy } =
-	vi.hoisted(() => ({
-		registerDisposableSpy: vi.fn(),
-		registerTelemetrySpy: vi.fn(),
-		telemetryStartSpy: vi.fn(),
-	}));
+const {
+	registerDisposableSpy,
+	spanProcessorConfigSpy,
+	integrationOptionsSpy,
+	telemetryStartSpy,
+	globalGetTracerSpy,
+	getDelegateSpy,
+	getTracerProviderSpy,
+	forceFlushSpy,
+	shutdownSpy,
+	setGlobalContextManagerSpy,
+	tracerProviderInstances,
+} = vi.hoisted(() => ({
+	registerDisposableSpy: vi.fn(),
+	spanProcessorConfigSpy: vi.fn(),
+	integrationOptionsSpy: vi.fn(),
+	telemetryStartSpy: vi.fn(),
+	globalGetTracerSpy: vi.fn(() => ({ name: "managed-global-tracer" })),
+	getDelegateSpy: vi.fn(),
+	getTracerProviderSpy: vi.fn(),
+	forceFlushSpy: vi.fn(),
+	shutdownSpy: vi.fn(),
+	setGlobalContextManagerSpy: vi.fn(() => true),
+	tracerProviderInstances: [] as Array<{
+		forceFlush: ReturnType<typeof vi.fn>;
+		shutdown: ReturnType<typeof vi.fn>;
+		getTracer: ReturnType<typeof vi.fn>;
+	}>,
+}));
 
-vi.mock("ai", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("ai")>();
-	return {
-		...actual,
-		registerTelemetry: (
-			...integrations: Parameters<typeof actual.registerTelemetry>
-		) => {
-			registerTelemetrySpy(...integrations);
-			actual.registerTelemetry(...integrations);
-		},
-	};
-});
+vi.mock("@cline/shared", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@cline/shared")>()),
+	registerDisposable: registerDisposableSpy,
+}));
+
+vi.mock("@langfuse/otel", () => ({
+	LangfuseSpanProcessor: class MockLangfuseSpanProcessor {
+		constructor(config: unknown) {
+			spanProcessorConfigSpy(config);
+		}
+	},
+}));
 
 vi.mock("@langfuse/vercel-ai-sdk", () => ({
 	LangfuseVercelAiSdkIntegration: class MockLangfuseVercelAiSdkIntegration {
 		onStart = telemetryStartSpy;
-	},
-}));
 
-const {
-	addSpanProcessorSpy,
-	forceFlushSpy,
-	shutdownSpy,
-	getDelegateSpy,
-	getTracerProviderSpy,
-	registeredGlobalProvider,
-} = vi.hoisted(() => ({
-	addSpanProcessorSpy: vi.fn(),
-	forceFlushSpy: vi.fn(async () => undefined),
-	shutdownSpy: vi.fn(async () => undefined),
-	getDelegateSpy: vi.fn(),
-	getTracerProviderSpy: vi.fn(),
-	registeredGlobalProvider: { current: undefined as unknown },
+		constructor(options: unknown) {
+			integrationOptionsSpy(options);
+		}
+	},
 }));
 
 class MockNodeTracerProvider {
-	// Mirrors OpenTelemetry's registerGlobal semantics: the first
-	// registration wins and later ones are silently ignored.
-	register = vi.fn(() => {
-		registeredGlobalProvider.current ??= this;
-	});
+	forceFlush = vi.fn(async () => undefined);
+	shutdown = vi.fn(async () => undefined);
+	getTracer = vi.fn(() => ({ name: "direct-langfuse-tracer" }));
+
+	constructor(_options: unknown) {
+		tracerProviderInstances.push(this);
+	}
 }
-
-vi.mock("@cline/shared", () => ({
-	registerDisposable: registerDisposableSpy,
-	isOtlpTraceRelayProvider: (provider: unknown) =>
-		!!provider &&
-		typeof provider === "object" &&
-		(provider as Record<string, unknown>)._clineOtlpTraceRelay === true,
-}));
-
-const { globalSettingsPathRef } = vi.hoisted(() => ({
-	globalSettingsPathRef: {
-		current: "/nonexistent/cline-global-settings.json",
-	},
-}));
-
-vi.mock("@cline/shared/storage", () => ({
-	resolveGlobalSettingsPath: () => globalSettingsPathRef.current,
-}));
-
-vi.mock("@langfuse/otel", () => ({
-	LangfuseSpanProcessor: class MockLangfuseSpanProcessor {},
-}));
-
-vi.mock("@opentelemetry/api", () => ({
-	trace: {
-		getTracerProvider: getTracerProviderSpy,
-	},
-}));
 
 vi.mock("@opentelemetry/sdk-trace-node", () => ({
 	NodeTracerProvider: MockNodeTracerProvider,
 }));
 
-import { generateText } from "ai";
-import { MockLanguageModelV4 } from "ai/test";
+vi.mock("@opentelemetry/api", () => ({
+	context: {
+		setGlobalContextManager: setGlobalContextManagerSpy,
+	},
+	trace: {
+		getTracer: globalGetTracerSpy,
+		getTracerProvider: getTracerProviderSpy,
+	},
+}));
+
+vi.mock("@opentelemetry/context-async-hooks", () => ({
+	AsyncLocalStorageContextManager: class MockContextManager {
+		enable() {
+			return this;
+		}
+		disable() {}
+	},
+}));
+
+const { globalSettingsPathRef } = vi.hoisted(() => ({
+	globalSettingsPathRef: { current: "/nonexistent/cline-global-settings.json" },
+}));
+vi.mock("@cline/shared/storage", () => ({
+	resolveGlobalSettingsPath: () => globalSettingsPathRef.current,
+}));
+
 import {
 	disposeLangfuseTelemetry,
-	ensureLangfuseTelemetry,
 	resetLangfuseTelemetryForTests,
 	resolveAiSdkTelemetry,
 } from "./langfuse-telemetry";
 
+const genericConfig = {
+	baseUrl: "https://langfuse.example",
+	publicKey: "public-key",
+	secretKey: "secret-key",
+};
+
 describe("langfuse telemetry", () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		resetLangfuseTelemetryForTests();
-		registerDisposableSpy.mockReset();
-		registerTelemetrySpy.mockReset();
-		telemetryStartSpy.mockReset();
-		addSpanProcessorSpy.mockReset();
-		forceFlushSpy.mockReset();
-		forceFlushSpy.mockResolvedValue(undefined);
-		shutdownSpy.mockReset();
-		shutdownSpy.mockResolvedValue(undefined);
-		getDelegateSpy.mockReset();
-		registeredGlobalProvider.current = undefined;
-		// Default global tracer state: a proxy whose delegate is inert until
-		// something registers — the state where the direct Langfuse path may
-		// register its own provider (no host OTLP exporter present).
-		getDelegateSpy.mockImplementation(
-			() =>
-				registeredGlobalProvider.current ?? { constructor: { name: "Inert" } },
-		);
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: getDelegateSpy,
-		});
-		process.env.LANGFUSE_BASE_URL = "https://langfuse.example";
-		process.env.LANGFUSE_PUBLIC_KEY = "public-key";
-		process.env.LANGFUSE_SECRET_KEY = "secret-key";
+		tracerProviderInstances.length = 0;
+		getDelegateSpy.mockReturnValue(undefined);
+		getTracerProviderSpy.mockReturnValue({ getDelegate: getDelegateSpy });
+		vi.stubEnv("LANGFUSE_BASE_URL", genericConfig.baseUrl);
+		vi.stubEnv("LANGFUSE_PUBLIC_KEY", genericConfig.publicKey);
+		vi.stubEnv("LANGFUSE_SECRET_KEY", genericConfig.secretKey);
+		vi.stubEnv("CLINE_TRACE_SAMPLE_PERCENT", "");
+		vi.stubEnv("CLINE_TRACE_RECORD_CONTENT", "");
+		vi.stubEnv("OTEL_SERVICE_NAME", "");
 	});
 
 	afterEach(() => {
-		delete process.env.LANGFUSE_BASE_URL;
-		delete process.env.LANGFUSE_PUBLIC_KEY;
-		delete process.env.LANGFUSE_SECRET_KEY;
-		delete process.env.CLINE_TRACE_SAMPLE_PERCENT;
-		delete process.env.CLINE_TRACE_RECORD_CONTENT;
+		vi.unstubAllEnvs();
 		globalSettingsPathRef.current = "/nonexistent/cline-global-settings.json";
 		resetLangfuseTelemetryForTests();
 	});
 
-	it("does not initialize telemetry for non-cline providers", async () => {
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
-
-		expect(registerDisposableSpy).not.toHaveBeenCalled();
-		expect(addSpanProcessorSpy).not.toHaveBeenCalled();
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
+	it("keeps third-party providers disabled before and after direct initialization", async () => {
+		await expect(resolveAiSdkTelemetry("openrouter")).resolves.toEqual({
+			isEnabled: false,
+		});
+		expect(spanProcessorConfigSpy).not.toHaveBeenCalled();
+		await expect(resolveAiSdkTelemetry("cline")).resolves.toEqual({
+			isEnabled: true,
+			integrations: expect.any(Object),
+		});
+		await expect(resolveAiSdkTelemetry("openrouter")).resolves.toEqual({
+			isEnabled: false,
+		});
+		expect(spanProcessorConfigSpy).toHaveBeenCalledOnce();
 	});
 
-	it("enables Cline backend providers and keeps other providers disabled", async () => {
-		await expect(ensureLangfuseTelemetry("cline-pass")).resolves.toBe(true);
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-		await expect(ensureLangfuseTelemetry("openrouter")).resolves.toBe(false);
-
-		expect(registerDisposableSpy).toHaveBeenCalledTimes(1);
-		expect(registeredGlobalProvider.current).toBeInstanceOf(
-			MockNodeTracerProvider,
-		);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledWith(expect.any(Object));
+	it("shares one isolated exporter between concurrent Cline backend requests", async () => {
+		const [first, second] = await Promise.all([
+			resolveAiSdkTelemetry("cline"),
+			resolveAiSdkTelemetry("cline-pass"),
+		]);
+		expect(first.integrations).toBeDefined();
+		expect(first.integrations).toBe(second.integrations);
+		expect(tracerProviderInstances).toHaveLength(1);
+		expect(spanProcessorConfigSpy).toHaveBeenCalledWith(genericConfig);
+		expect(registerDisposableSpy).toHaveBeenCalledOnce();
 	});
 
-	it("flushes before shutdown during disposal", async () => {
+	it("uses direct credentials even when a non-relay host owns an immutable tracer", async () => {
 		getDelegateSpy.mockReturnValue({
 			forceFlush: forceFlushSpy,
 			shutdown: shutdownSpy,
 		});
-
+		const decision = await resolveAiSdkTelemetry("cline");
+		expect(decision.isEnabled).toBe(true);
+		expect(integrationOptionsSpy).toHaveBeenCalledWith({
+			tracer: { name: "direct-langfuse-tracer" },
+		});
 		await disposeLangfuseTelemetry();
-
-		expect(forceFlushSpy).toHaveBeenCalledTimes(1);
-		expect(shutdownSpy).toHaveBeenCalledTimes(1);
-		expect(forceFlushSpy.mock.invocationCallOrder[0]).toBeLessThan(
-			shutdownSpy.mock.invocationCallOrder[0],
+		expect(forceFlushSpy).not.toHaveBeenCalled();
+		expect(shutdownSpy).not.toHaveBeenCalled();
+		expect(tracerProviderInstances[0]?.forceFlush).toHaveBeenCalledOnce();
+		expect(tracerProviderInstances[0]?.shutdown).toHaveBeenCalledOnce();
+		expect(
+			tracerProviderInstances[0]?.forceFlush.mock.invocationCallOrder[0],
+		).toBeLessThan(
+			tracerProviderInstances[0]?.shutdown.mock.invocationCallOrder[0] ?? 0,
 		);
 	});
 
-	it("declines direct export when the host's OTLP relay is registered directly (one export path)", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			addSpanProcessor: addSpanProcessorSpy,
+	it("never registers cleanup or touches the host when direct export is declined", async () => {
+		getDelegateSpy.mockReturnValue({
 			_clineOtlpTraceRelay: true,
+			forceFlush: forceFlushSpy,
+			shutdown: shutdownSpy,
 		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
-		expect(addSpanProcessorSpy).not.toHaveBeenCalled();
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
+		await resolveAiSdkTelemetry("cline");
+		await resolveAiSdkTelemetry("cline");
+		await disposeLangfuseTelemetry();
+		expect(registerDisposableSpy).not.toHaveBeenCalled();
+		expect(spanProcessorConfigSpy).not.toHaveBeenCalled();
+		expect(forceFlushSpy).not.toHaveBeenCalled();
+		expect(shutdownSpy).not.toHaveBeenCalled();
 	});
 
-	it("still attaches to a non-relay mutable tracer provider (base compatibility)", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			addSpanProcessor: addSpanProcessorSpy,
+	it("takes the relay path even after direct integration has been cached", async () => {
+		const direct = await resolveAiSdkTelemetry("cline");
+		getDelegateSpy.mockReturnValue({ _clineOtlpTraceRelay: true });
+		const relay = await resolveAiSdkTelemetry("cline");
+		expect(relay.integrations).not.toBe(direct.integrations);
+		expect(relay.recordInputs).toBe(false);
+		expect(integrationOptionsSpy).toHaveBeenLastCalledWith({
+			tracer: { name: "managed-global-tracer" },
 		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("registers its own provider when minification renames the proxy provider", async () => {
-		// Simulates the compiled release binary: the ProxyTracerProvider and
-		// its no-op delegate carry mangled constructor names, expose no
-		// addSpanProcessor, and only reflect a registration through
-		// getDelegate.
-		getTracerProviderSpy.mockReturnValue({
-			constructor: { name: "Zt" },
-			getDelegate: () =>
-				registeredGlobalProvider.current ?? { constructor: { name: "Qn" } },
+	it("does not initialize direct export with incomplete credentials", async () => {
+		vi.stubEnv("LANGFUSE_SECRET_KEY", "");
+		await expect(resolveAiSdkTelemetry("cline")).resolves.toEqual({
+			isEnabled: false,
 		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-		expect(registeredGlobalProvider.current).toBeInstanceOf(
-			MockNodeTracerProvider,
-		);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
+		expect(spanProcessorConfigSpy).not.toHaveBeenCalled();
 	});
 
-	it("declines direct export when the OTLP relay is registered through the proxy delegate", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({
-				addSpanProcessor: addSpanProcessorSpy,
-				_clineOtlpTraceRelay: true,
-			}),
-		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
-		expect(addSpanProcessorSpy).not.toHaveBeenCalled();
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
-	});
-
-	it("still attaches through the proxy delegate of a non-relay provider (base compatibility)", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({ addSpanProcessor: addSpanProcessorSpy }),
-		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-		expect(addSpanProcessorSpy).toHaveBeenCalledTimes(1);
-		expect(registerTelemetrySpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("disables telemetry when a foreign provider owns the slot and accepts no processors", async () => {
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({
-				forceFlush: forceFlushSpy,
-				shutdown: shutdownSpy,
-			}),
-		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
-	});
-
-	it("disables telemetry when the global slot rejects the registration", async () => {
-		// The delegate never reflects the attempted registration, matching an
-		// API whose global slot is stuck with an inert owner.
-		getTracerProviderSpy.mockReturnValue({
-			getDelegate: () => ({ constructor: { name: "SomethingInert" } }),
-		});
-
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(false);
-		expect(registerTelemetrySpy).not.toHaveBeenCalled();
+	it("recreates a direct runtime after disposal", async () => {
+		const first = await resolveAiSdkTelemetry("cline");
+		await disposeLangfuseTelemetry();
+		const second = await resolveAiSdkTelemetry("cline");
+		expect(second.integrations).not.toBe(first.integrations);
+		expect(tracerProviderInstances).toHaveLength(2);
 	});
 
 	describe("resolveAiSdkTelemetry (collector relay path)", () => {
@@ -274,7 +241,10 @@ describe("langfuse telemetry", () => {
 		it("keeps the direct Langfuse path unchanged: enabled with content recording untouched", async () => {
 			const decision = await resolveAiSdkTelemetry("cline", "task-a");
 
-			expect(decision).toEqual({ isEnabled: true });
+			expect(decision).toEqual({
+				isEnabled: true,
+				integrations: expect.any(Object),
+			});
 		});
 
 		it("defaults to full sampling when the host registered a tracer and no rate is set", async () => {
@@ -285,6 +255,7 @@ describe("langfuse telemetry", () => {
 
 			expect(decision).toEqual({
 				isEnabled: true,
+				integrations: expect.any(Object),
 				recordInputs: false,
 				recordOutputs: false,
 			});
@@ -317,6 +288,7 @@ describe("langfuse telemetry", () => {
 
 			expect(decision).toEqual({
 				isEnabled: true,
+				integrations: expect.any(Object),
 				recordInputs: false,
 				recordOutputs: false,
 			});
@@ -332,6 +304,7 @@ describe("langfuse telemetry", () => {
 
 			expect(decision).toEqual({
 				isEnabled: true,
+				integrations: expect.any(Object),
 				recordInputs: true,
 				recordOutputs: true,
 			});
@@ -443,7 +416,10 @@ describe("langfuse telemetry", () => {
 
 			const decision = await resolveAiSdkTelemetry("cline", "task-a");
 
-			expect(decision).toEqual({ isEnabled: true });
+			expect(decision).toEqual({
+				isEnabled: true,
+				integrations: expect.any(Object),
+			});
 		});
 
 		it("does not treat a console-only tracer as the relay", async () => {
@@ -469,6 +445,7 @@ describe("langfuse telemetry", () => {
 			const withRelay = await resolveAiSdkTelemetry("cline", "task-a");
 			expect(withRelay).toEqual({
 				isEnabled: true,
+				integrations: expect.any(Object),
 				recordInputs: false,
 				recordOutputs: false,
 			});
@@ -479,10 +456,11 @@ describe("langfuse telemetry", () => {
 				getDelegate: getDelegateSpy,
 			});
 			const withoutRelay = await resolveAiSdkTelemetry("cline", "task-a");
-			expect(withoutRelay).toEqual({ isEnabled: true });
-			expect(registeredGlobalProvider.current).toBeInstanceOf(
-				MockNodeTracerProvider,
-			);
+			expect(withoutRelay).toEqual({
+				isEnabled: true,
+				integrations: expect.any(Object),
+			});
+			expect(tracerProviderInstances).toHaveLength(1);
 		});
 
 		it("stays disabled when no recording tracer provider is registered", async () => {
@@ -496,32 +474,5 @@ describe("langfuse telemetry", () => {
 
 			expect(decision.isEnabled).toBe(false);
 		});
-	});
-
-	it("connects an AI SDK 7 call to the registered telemetry integration", async () => {
-		await expect(ensureLangfuseTelemetry("cline")).resolves.toBe(true);
-
-		await generateText({
-			model: new MockLanguageModelV4({
-				doGenerate: {
-					content: [{ type: "text", text: "hello" }],
-					finishReason: { unified: "stop", raw: "stop" },
-					usage: {
-						inputTokens: {
-							total: 1,
-							noCache: 1,
-							cacheRead: 0,
-							cacheWrite: 0,
-						},
-						outputTokens: { total: 1, text: 1, reasoning: 0 },
-					},
-					warnings: [],
-				},
-			}),
-			prompt: "say hello",
-			telemetry: { isEnabled: true },
-		});
-
-		expect(telemetryStartSpy).toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/llms/src/services/langfuse-telemetry.ts
+++ b/sdk/packages/llms/src/services/langfuse-telemetry.ts
@@ -1,12 +1,18 @@
-type MutableTracerProvider = {
-	addSpanProcessor?: (spanProcessor: unknown) => void;
-	getDelegate?: () => unknown;
-};
+import type { Tracer } from "@opentelemetry/api";
+import type { Telemetry } from "ai";
 
-type LangfuseTelemetryConfig = {
+type DirectLangfuseTelemetryConfig = {
 	baseUrl: string;
 	publicKey: string;
 	secretKey: string;
+};
+
+type DirectLangfuseTelemetryRuntime = {
+	integration: Telemetry;
+	tracerProvider: {
+		forceFlush(): Promise<void>;
+		shutdown(): Promise<void>;
+	};
 };
 
 export type LangfuseTraceAttributes = {
@@ -37,10 +43,26 @@ export async function withLangfuseTraceAttributes<T>(
 
 const LANGFUSE_DEBUG_ENV = "CLINE_DEBUG_LANGFUSE";
 
-let langfuseTelemetryReady: boolean | undefined;
-let langfuseTelemetryInitPromise:
-	| Promise<boolean | "relay-active">
-	| undefined;
+let directLangfuseRuntimes = new Map<
+	string,
+	Promise<DirectLangfuseTelemetryRuntime | undefined>
+>();
+let directLangfuseDisposableRegistration: Promise<void> | undefined;
+let langfuseContextManagerInitialization: Promise<void> | undefined;
+
+function readDirectLangfuseTelemetryConfig():
+	| DirectLangfuseTelemetryConfig
+	| undefined {
+	const baseUrl = process.env.LANGFUSE_BASE_URL?.trim();
+	const publicKey = process.env.LANGFUSE_PUBLIC_KEY?.trim();
+	const secretKey = process.env.LANGFUSE_SECRET_KEY?.trim();
+
+	if (!baseUrl || !publicKey || !secretKey) {
+		return undefined;
+	}
+
+	return { baseUrl, publicKey, secretKey };
+}
 
 function isClineProviderId(providerId: string): boolean {
 	return providerId === "cline" || providerId === "cline-pass";
@@ -48,6 +70,7 @@ function isClineProviderId(providerId: string): boolean {
 
 export type AiSdkTelemetryDecision = {
 	isEnabled: boolean;
+	integrations?: Telemetry;
 	recordInputs?: boolean;
 	recordOutputs?: boolean;
 };
@@ -55,24 +78,29 @@ export type AiSdkTelemetryDecision = {
 const TELEMETRY_DISABLED: AiSdkTelemetryDecision = { isEnabled: false };
 
 /**
- * Decide AI SDK telemetry for one stream. Two independent export paths:
- * - Direct Langfuse (env-configured credentials, hub/internal): unchanged
- *   behavior — full content, every request.
- * - Host OTLP tracer (collector relay): a host that registered a traces
- *   exporter gets every task (100%). CLINE_TRACE_SAMPLE_PERCENT reduces
- *   that, sampled per task by `samplingKey` so a task's requests trace
- *   together. Metadata-only unless CLINE_TRACE_RECORD_CONTENT is set.
+ * Select exactly one per-call integration. A host OTLP relay takes precedence
+ * over direct credentials, and its sampling, opt-out and content policy is
+ * checked on every stream. Direct exports own an isolated tracer provider.
  */
 export async function resolveAiSdkTelemetry(
 	providerId: string,
 	samplingKey?: string,
 ): Promise<AiSdkTelemetryDecision> {
-	if (await ensureLangfuseTelemetry(providerId)) {
-		return { isEnabled: true };
-	}
-
 	if (!isClineProviderId(providerId)) {
 		return TELEMETRY_DISABLED;
+	}
+
+	const relayTracer = await getHostOtlpTracer();
+	if (!relayTracer) {
+		const config = readDirectLangfuseTelemetryConfig();
+		if (!config) return TELEMETRY_DISABLED;
+		const integration = await ensureDirectLangfuseIntegration(
+			providerId,
+			config,
+		);
+		return integration
+			? { isEnabled: true, integrations: integration }
+			: TELEMETRY_DISABLED;
 	}
 
 	if (await isTelemetryOptedOutGlobally()) {
@@ -93,14 +121,18 @@ export async function resolveAiSdkTelemetry(
 			return TELEMETRY_DISABLED;
 		}
 	}
-	if (!(await hasHostOtlpTracer())) {
-		return TELEMETRY_DISABLED;
-	}
-
-	// Literal env access so bundlers can inline a build-time value.
+	const { LangfuseVercelAiSdkIntegration } = await import(
+		"@langfuse/vercel-ai-sdk"
+	);
+	// Resolve the host tracer per call so remote-config replacement cannot
+	// leave a cached integration attached to a shut-down provider.
+	const integration = new LangfuseVercelAiSdkIntegration({
+		tracer: relayTracer,
+	});
 	const recordContent = isEnvTruthy(process.env.CLINE_TRACE_RECORD_CONTENT);
 	return {
 		isEnabled: true,
+		integrations: integration,
 		recordInputs: recordContent,
 		recordOutputs: recordContent,
 	};
@@ -155,24 +187,19 @@ async function isTelemetryOptedOutGlobally(): Promise<boolean> {
  * by "some recording tracer exists". A console-only tracer must neither
  * enable the relay path nor suppress direct Langfuse export.
  */
-async function hasHostOtlpTracer(): Promise<boolean> {
-	try {
-		const [{ trace }, { isOtlpTraceRelayProvider }] = await Promise.all([
-			import("@opentelemetry/api"),
-			import("@cline/shared"),
-		]);
-		const tracerProvider = trace.getTracerProvider() as MutableTracerProvider;
-		return (
-			isOtlpTraceRelayProvider(tracerProvider) ||
-			isOtlpTraceRelayProvider(
-				typeof tracerProvider?.getDelegate === "function"
-					? tracerProvider.getDelegate()
-					: undefined,
-			)
-		);
-	} catch {
-		return false;
+async function getHostOtlpTracer(): Promise<Tracer | undefined> {
+	const [{ trace }, { isOtlpTraceRelayProvider }] = await Promise.all([
+		import("@opentelemetry/api"),
+		import("@cline/shared"),
+	]);
+	const provider = trace.getTracerProvider() as { getDelegate?: () => unknown };
+	if (
+		isOtlpTraceRelayProvider(provider) ||
+		isOtlpTraceRelayProvider(provider.getDelegate?.())
+	) {
+		return trace.getTracer("cline-provider-langfuse");
 	}
+	return undefined;
 }
 
 /** FNV-1a: stable across processes so a task samples identically on retries. */
@@ -185,264 +212,127 @@ function fnv1a32(value: string): number {
 	return hash;
 }
 
-function readLangfuseTelemetryConfig(): LangfuseTelemetryConfig | undefined {
-	const env = process?.env;
-	const baseUrl = env?.LANGFUSE_BASE_URL?.trim();
-	const publicKey = env?.LANGFUSE_PUBLIC_KEY?.trim();
-	const secretKey = env?.LANGFUSE_SECRET_KEY?.trim();
-
-	if (!baseUrl || !publicKey || !secretKey) {
-		return undefined;
-	}
-
-	return {
-		baseUrl,
-		publicKey,
-		secretKey,
-	};
-}
-
-export function hasLangfuseTelemetryConfig(): boolean {
-	return readLangfuseTelemetryConfig() !== undefined;
-}
-
-export async function ensureLangfuseTelemetry(
+async function ensureDirectLangfuseIntegration(
 	providerId: string,
-): Promise<boolean> {
-	if (!isClineProviderId(providerId)) {
-		return false;
+	config: DirectLangfuseTelemetryConfig,
+): Promise<Telemetry | undefined> {
+	const configKey = JSON.stringify(config);
+	let runtimePromise = directLangfuseRuntimes.get(configKey);
+	if (!runtimePromise) {
+		runtimePromise = registerDirectLangfuseDisposable().then(
+			async () => await initializeDirectLangfuseTelemetry(config),
+		);
+		directLangfuseRuntimes.set(configKey, runtimePromise);
 	}
 
-	if (!hasLangfuseTelemetryConfig()) {
-		return false;
+	const runtime = await runtimePromise;
+	if (!runtime && directLangfuseRuntimes.get(configKey) === runtimePromise) {
+		directLangfuseRuntimes.delete(configKey);
 	}
-
-	if (langfuseTelemetryReady !== undefined) {
-		debugLangfuse(`cached readiness=${String(langfuseTelemetryReady)}`);
-		return langfuseTelemetryReady;
-	}
-
-	if (!langfuseTelemetryInitPromise) {
-		langfuseTelemetryInitPromise = initializeLangfuseTelemetry();
-	}
-
-	const result = await langfuseTelemetryInitPromise;
-	if (result === "relay-active") {
-		// Not cached: the relay owning the tracer slot now may be disposed
-		// later, at which point the direct path should get to try again.
-		langfuseTelemetryInitPromise = undefined;
-		return false;
-	}
-	langfuseTelemetryReady = result;
-	debugLangfuse(`initialized readiness=${String(langfuseTelemetryReady)}`);
-	return langfuseTelemetryReady;
+	debugLangfuse(
+		`resolved direct integration=${String(Boolean(runtime))} provider=${providerId}`,
+	);
+	return runtime?.integration;
 }
 
-async function initializeLangfuseTelemetry(): Promise<boolean | "relay-active"> {
-	// Register for cleanup once, when initialization begins.
-	const { registerDisposable } = await import("@cline/shared");
-	registerDisposable(disposeLangfuseTelemetry);
-	const config = readLangfuseTelemetryConfig();
-	if (!config) {
-		return false;
+async function registerDirectLangfuseDisposable(): Promise<void> {
+	if (!directLangfuseDisposableRegistration) {
+		directLangfuseDisposableRegistration = import("@cline/shared").then(
+			({ registerDisposable }) => {
+				registerDisposable(disposeLangfuseTelemetry);
+			},
+		);
 	}
+	await directLangfuseDisposableRegistration;
+}
 
+async function ensureLangfuseContextManager(): Promise<void> {
+	if (!langfuseContextManagerInitialization) {
+		langfuseContextManagerInitialization = Promise.all([
+			import("@opentelemetry/api"),
+			import("@opentelemetry/context-async-hooks"),
+		]).then(([{ context }, { AsyncLocalStorageContextManager }]) => {
+			const contextManager = new AsyncLocalStorageContextManager().enable();
+			if (!context.setGlobalContextManager(contextManager)) {
+				// Another OpenTelemetry owner already installed a context manager.
+				contextManager.disable();
+			}
+		});
+	}
+	await langfuseContextManagerInitialization;
+}
+
+async function initializeDirectLangfuseTelemetry(
+	config: DirectLangfuseTelemetryConfig,
+): Promise<DirectLangfuseTelemetryRuntime | undefined> {
 	try {
-		// Give Langfuse and any other OTEL exporter a stable resource identity.
-		// Respect an explicitly configured service name from the host.
+		// Direct SDK consumers own this isolated exporter. It intentionally does
+		// not replace or modify the process's global tracer provider.
 		if (!process.env.OTEL_SERVICE_NAME?.trim()) {
 			process.env.OTEL_SERVICE_NAME = "cline-sdk";
 		}
+		await ensureLangfuseContextManager();
 		const [
 			{ LangfuseSpanProcessor },
 			{ LangfuseVercelAiSdkIntegration },
-			{ registerTelemetry },
-			{ trace },
 			{ NodeTracerProvider },
 		] = await Promise.all([
 			import("@langfuse/otel"),
 			import("@langfuse/vercel-ai-sdk"),
-			import("ai"),
-			import("@opentelemetry/api"),
 			import("@opentelemetry/sdk-trace-node"),
 		]);
 
-		// One export path per host: when the registered tracer provider is the
-		// OTLP collector relay (identified by its creator's marker, so a
-		// console-only tracer never trips this), attaching the direct Langfuse
-		// processor to it would ship every span twice — once direct, once
-		// through the collector — so the direct path declines. Non-relay
-		// providers keep the original cooperative behavior below. Class names
-		// are unreliable here (release binaries are minified), so all other
-		// provider detection is structural.
-		const { isOtlpTraceRelayProvider } = await import("@cline/shared");
-		const tracerProvider = trace.getTracerProvider() as MutableTracerProvider;
-		const existingDelegate =
-			typeof tracerProvider?.getDelegate === "function"
-				? tracerProvider.getDelegate()
-				: undefined;
-		if (
-			isOtlpTraceRelayProvider(tracerProvider) ||
-			isOtlpTraceRelayProvider(existingDelegate)
-		) {
-			debugLangfuse(
-				"OTLP relay tracer registered; declining direct Langfuse export (one export path per host)",
-			);
-			return "relay-active";
-		}
-
-		const spanProcessor = new LangfuseSpanProcessor({
-			baseUrl: config.baseUrl,
-			publicKey: config.publicKey,
-			secretKey: config.secretKey,
-		});
-		debugLangfuse(`creating span processor baseUrl=${config.baseUrl}`);
-
-		if (typeof tracerProvider?.addSpanProcessor === "function") {
-			tracerProvider.addSpanProcessor(spanProcessor);
-			const hasDelegate = hasActiveTracerDelegate(trace);
-			if (hasDelegate) {
-				registerTelemetry(new LangfuseVercelAiSdkIntegration());
-			}
-			debugLangfuse(
-				`attached processor to existing tracer provider delegateReady=${String(hasDelegate)}`,
-			);
-			return hasDelegate;
-		}
-
-		if (isRecordingTracerProvider(existingDelegate)) {
-			// A non-relay provider owns the global slot, so registering our own
-			// would be rejected. Attach to it when it accepts processors.
-			const delegate = existingDelegate as MutableTracerProvider;
-			if (typeof delegate.addSpanProcessor === "function") {
-				delegate.addSpanProcessor(spanProcessor);
-				registerTelemetry(new LangfuseVercelAiSdkIntegration());
-				debugLangfuse("attached processor to registered tracer delegate");
-				return true;
-			}
-			debugLangfuse(
-				"tracer provider slot already owned; disabling Langfuse export",
-			);
-			return false;
-		}
-
-		const nodeTracerProvider = new NodeTracerProvider({
+		const spanProcessor = new LangfuseSpanProcessor(config);
+		const tracerProvider = new NodeTracerProvider({
 			spanProcessors: [spanProcessor],
-		} as unknown as ConstructorParameters<typeof NodeTracerProvider>[0]);
-		nodeTracerProvider.register();
-		if (!isRegisteredGlobalTracerProvider(trace, nodeTracerProvider)) {
-			debugLangfuse(
-				"tracer provider registration was not accepted; disabling Langfuse export",
-			);
-			// Shut the orphaned provider down so its span processor does not
-			// keep buffering spans that can never be exported.
-			await nodeTracerProvider.shutdown?.();
-			return false;
-		}
-		registerTelemetry(new LangfuseVercelAiSdkIntegration());
-		debugLangfuse("registered NodeTracerProvider delegateReady=true");
-		return true;
+		});
+		const integration = new LangfuseVercelAiSdkIntegration({
+			tracer: tracerProvider.getTracer("cline-langfuse-direct"),
+		});
+		debugLangfuse(`created isolated direct exporter baseUrl=${config.baseUrl}`);
+
+		return { integration, tracerProvider };
 	} catch (error) {
 		debugLangfuse(
-			`initialization failed error=${error instanceof Error ? error.message : String(error)}`,
+			`direct initialization failed error=${error instanceof Error ? error.message : String(error)}`,
 		);
-		return false;
-	}
-}
-
-function hasActiveTracerDelegate(traceApi: {
-	getTracerProvider: () => unknown;
-}): boolean {
-	const tracerProvider = traceApi.getTracerProvider() as MutableTracerProvider;
-	if (typeof tracerProvider.getDelegate !== "function") {
-		// Some runtimes expose the registered tracer provider directly rather
-		// than through OpenTelemetry's ProxyTracerProvider. A direct provider
-		// has no delegate to inspect, but its addSpanProcessor API is sufficient
-		// evidence that it can receive and export spans.
-		return typeof tracerProvider.addSpanProcessor === "function";
-	}
-
-	return isRecordingTracerProvider(tracerProvider.getDelegate());
-}
-
-/**
- * Distinguishes a recording tracer provider from OpenTelemetry's no-op
- * fallback without relying on constructor names, which minified release
- * builds rename. Real SDK providers expose lifecycle methods the no-op
- * provider lacks.
- */
-function isRecordingTracerProvider(provider: unknown): boolean {
-	if (!provider || typeof provider !== "object") {
-		return false;
-	}
-	const candidate = provider as {
-		addSpanProcessor?: unknown;
-		forceFlush?: unknown;
-		shutdown?: unknown;
-	};
-	return (
-		typeof candidate.addSpanProcessor === "function" ||
-		typeof candidate.forceFlush === "function" ||
-		typeof candidate.shutdown === "function"
-	);
-}
-
-/**
- * Confirms the OpenTelemetry API accepted a provider registration. The API
- * silently keeps the previous owner when the global slot is taken, so the
- * only reliable signal is identity: the global provider (or its proxy
- * delegate) must be the exact instance that was just registered.
- */
-function isRegisteredGlobalTracerProvider(
-	traceApi: { getTracerProvider: () => unknown },
-	provider: unknown,
-): boolean {
-	const globalProvider = traceApi.getTracerProvider() as
-		| MutableTracerProvider
-		| null
-		| undefined;
-	if (globalProvider === provider) {
-		return true;
-	}
-	return (
-		typeof globalProvider?.getDelegate === "function" &&
-		globalProvider.getDelegate() === provider
-	);
-}
-
-async function flushLangfuseTelemetry(): Promise<void> {
-	try {
-		const { trace } = await import("@opentelemetry/api");
-		const tracerProvider = trace.getTracerProvider() as {
-			getDelegate?: () => {
-				forceFlush?: () => Promise<void>;
-			};
-		};
-		await tracerProvider.getDelegate?.()?.forceFlush?.();
-		debugLangfuse("forceFlush completed");
-	} catch (error) {
-		debugLangfuse(
-			`forceFlush failed error=${error instanceof Error ? error.message : String(error)}`,
-		);
+		return undefined;
 	}
 }
 
 export async function disposeLangfuseTelemetry(): Promise<void> {
-	try {
-		await flushLangfuseTelemetry();
-		const { trace } = await import("@opentelemetry/api");
-		const tracerProvider = trace.getTracerProvider() as {
-			getDelegate?: () => {
-				shutdown?: () => Promise<void>;
-			};
-		};
-		await tracerProvider.getDelegate?.()?.shutdown?.();
-		debugLangfuse("shutdown completed");
-	} catch (error) {
-		debugLangfuse(
-			`shutdown failed error=${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
+	const pendingRuntimes = [...directLangfuseRuntimes.values()];
+	directLangfuseRuntimes.clear();
+	directLangfuseDisposableRegistration = undefined;
+	const settledRuntimes = await Promise.allSettled(pendingRuntimes);
+	const runtimes = settledRuntimes.flatMap((result) =>
+		result.status === "fulfilled" && result.value ? [result.value] : [],
+	);
+
+	await Promise.all(
+		runtimes.map(async ({ tracerProvider }) => {
+			try {
+				await tracerProvider.forceFlush();
+				debugLangfuse("direct forceFlush completed");
+			} catch (error) {
+				debugLangfuse(
+					`direct forceFlush failed error=${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}),
+	);
+	await Promise.all(
+		runtimes.map(async ({ tracerProvider }) => {
+			try {
+				await tracerProvider.shutdown();
+				debugLangfuse("direct shutdown completed");
+			} catch (error) {
+				debugLangfuse(
+					`direct shutdown failed error=${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}),
+	);
 }
 
 export function debugLangfuse(message: string): void {
@@ -453,10 +343,7 @@ export function debugLangfuse(message: string): void {
 }
 
 function isLangfuseDebugEnabled(): boolean {
-	return isEnvTruthy(process.env[LANGFUSE_DEBUG_ENV]);
-}
-
-function isEnvTruthy(raw: string | undefined): boolean {
+	const raw = process.env[LANGFUSE_DEBUG_ENV];
 	if (!raw) {
 		return false;
 	}
@@ -464,7 +351,14 @@ function isEnvTruthy(raw: string | undefined): boolean {
 	return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
+function isEnvTruthy(raw: string | undefined): boolean {
+	if (!raw) return false;
+	const normalized = raw.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 export function resetLangfuseTelemetryForTests(): void {
-	langfuseTelemetryReady = undefined;
-	langfuseTelemetryInitPromise = undefined;
+	directLangfuseRuntimes = new Map();
+	directLangfuseDisposableRegistration = undefined;
+	langfuseContextManagerInitialization = undefined;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #13479

Stacked on #13974 (`alex/cline-provider-collector-traces`). Carries the necessary per-call integration and isolated exporter ownership from the superseded #13650. Retarget to `main` after #13974 merges.

### Description

With #13974, a credential-free AI SDK v7 stream resolves telemetry to enabled but emits zero spans: the relay never supplies an integration. A regression using the real AI SDK, Langfuse integration, and in-memory OpenTelemetry exporter reproduces this on the parent branch even though its 27 telemetry unit tests pass.

Pass the selected Langfuse integration through `telemetry.integrations` for every enabled stream. Relay calls acquire the current host tracer so provider replacement redirects subsequent requests. Direct `LANGFUSE_*` export uses an isolated tracer provider, and cleanup flushes and shuts down only SDK-owned exporters. This also prevents direct initialization from registering integrations globally or claiming a host's tracer slot.

Preserves #13974's Cline/ClinePass-only boundary, relay precedence over direct credentials, per-stream global opt-out, deterministic task sampling, and content-recording flag. A previously cached direct integration cannot bypass a subsequently registered relay's policy. Credentials continue to work for Cline providers when no host relay is active.

### Test Procedure

- `bun run build:sdk` — passed.
- `bun run typecheck` in `sdk/packages/llms` — passed.
- LLM telemetry unit tests: 23 passed; real-stream integration tests: 8 passed; AI SDK provider tests: 37 passed.
- Core host telemetry tests: 23 passed across `OpenTelemetryProvider.test.ts` and hub daemon `telemetry.test.ts`.
- Extension tracer lifecycle tests: 4 passed.
- Biome on changed TypeScript/package files and `git diff --check` — passed.
- The original real-stream regression failed on #13974 with zero exported spans and passes with this change. Coverage includes metadata-only output, explicit content capture, mid-session opt-out, excluded providers, deterministic sampling, tracer replacement, direct/relay coexistence, unrelated AI SDK calls, host ownership, and standalone async trace context.

The full extension unit runner did not pass locally: 669 passed / 48 failed, primarily missing generated proto modules, plus seven bundled-endpoint configuration assertions. `bun run protos` aborts because the installed protoc requires Rosetta on this Apple Silicon machine. Full extension validation remains for CI.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; SDK telemetry only.

### Additional Notes

**Collector coordination is required before #13982 activation.** Actual v7 spans contain `gen_ai.provider.name`, not `ai.model.provider`. At reviewed commit `202fe9d3`, cline/infra#547 filters out every span missing `ai.model.provider`, so it would drop these spans. Update the collector to the v7 contract and preserve step/tool children that may lack provider attributes; the dedicated `cline-provider-langfuse` instrumentation scope is present on all relay spans. The runbook documents this requirement. This PR does not add a legacy attribute shim or change rollout activation.

#13982 also does not set the tracing env values in the current combined stable `ext-vscode-ab-package.yml` workflow's next-bundle build. Review that coverage before treating the activation as applying to current stable releases. Its five isolated publication-gate regression tests passed during this review; no publishing workflow was dispatched.
