### PR TITLE
fix(desktop): keep voice input errors in chat instead of opening settings

### DIFF
--- a/apps/examples/desktop-app/webview/app/page.tsx
+++ b/apps/examples/desktop-app/webview/app/page.tsx
@@ -508,9 +508,6 @@ export default function Home() {
 												handleSettingsSectionChange("Models")
 											}
 											parentSession={activeParentSession}
-											onOpenVoiceInputSettings={() =>
-												handleSettingsSectionChange("Voice")
-											}
 											onThreadStarted={handleThreadStarted}
 										/>
 									</div>
@@ -574,7 +571,6 @@ function ChatThreadPane({
 	onOpenSetup,
 	onOpenModelSettings,
 	parentSession,
-	onOpenVoiceInputSettings,
 	onThreadStarted,
 }: {
 	threadId: string;
@@ -596,7 +592,6 @@ function ChatThreadPane({
 	onOpenSetup?: () => void;
 	onOpenModelSettings?: () => void;
 	parentSession?: { sessionId: string; title?: string };
-	onOpenVoiceInputSettings?: () => void;
 	onThreadStarted?: (threadId: string) => void;
 }) {
 	const {
@@ -1552,7 +1547,6 @@ function ChatThreadPane({
 			onModelChange={handleModelChange}
 			onModeToggle={handleModeToggle}
 			onPromptInputChange={handlePromptInputChange}
-			onOpenVoiceInputSettings={onOpenVoiceInputSettings}
 			onOpenModelSettings={onOpenModelSettings}
 			onReasoningChange={handleReasoningChange}
 			onSteerPromptInQueue={steerPromptInQueue}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.test.tsx
@@ -17,12 +17,14 @@ import {
 } from "./chat-input-bar";
 
 const {
+	toastMock,
 	loadProviderModelCatalogMock,
 	loadProviderModelsMock,
 	speechInputMockState,
 	startVercelStreamingTranscriptionMock,
 	subscribeToProviderModelsMock,
 } = vi.hoisted(() => ({
+	toastMock: vi.fn(),
 	loadProviderModelCatalogMock: vi.fn(),
 	loadProviderModelsMock: vi.fn(),
 	speechInputMockState: {
@@ -38,6 +40,7 @@ const {
 
 type MockSpeechInputProps = {
 	disabled?: boolean;
+	onError?: (error: unknown) => void;
 	onActiveChange?: (active: boolean) => void;
 	onClick?: (event: ReactMouseEvent<HTMLButtonElement>) => void;
 	onProcessingChange?: (processing: boolean) => void;
@@ -86,6 +89,8 @@ vi.mock("@/lib/vercel-streaming-transcription", () => ({
 	startVercelStreamingTranscription: startVercelStreamingTranscriptionMock,
 }));
 
+vi.mock("@/hooks/use-toast", () => ({ toast: toastMock }));
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -99,6 +104,7 @@ beforeEach(() => {
 		voiceInput: null,
 	});
 	loadProviderModelsMock.mockReset().mockResolvedValue([]);
+	toastMock.mockReset();
 	speechInputMockState.current = null;
 	startVercelStreamingTranscriptionMock.mockReset().mockResolvedValue({
 		done: new Promise<void>(() => {}),
@@ -642,6 +648,40 @@ describe("ChatInputBar", () => {
 		);
 	});
 
+	it.each([
+		[
+			new Error("Transcription connection closed"),
+			"Transcription connection closed",
+		],
+		[
+			new DOMException("Permission denied", "NotAllowedError"),
+			"Check the microphone permission for Cline and try again.",
+		],
+	])("shows speech failures in chat with a configured model: %s", async (error, description) => {
+		loadProviderModelCatalogMock.mockResolvedValue(
+			providerCatalog({
+				providerId: "openai-native",
+				providerName: "OpenAI",
+				modelId: "gpt-4o-mini-transcribe",
+				modelName: "GPT-4o mini Transcribe",
+				supportsStreaming: false,
+			}),
+		);
+		await renderVoiceComposer({ prompt: "Keep my draft" });
+		await act(async () => {
+			speechInputMockState.current?.onError?.(error);
+		});
+		expect(toastMock).toHaveBeenCalledWith({
+			variant: "destructive",
+			title: "Speech input failed",
+			description,
+		});
+		expect(container.querySelector("textarea")?.value).toBe("Keep my draft");
+		expect(
+			container.querySelector('[aria-label="Record speech"]'),
+		).not.toBeNull();
+	});
+
 	it("inserts a batch transcript only into its captured draft range", async () => {
 		loadProviderModelCatalogMock.mockResolvedValue(
 			providerCatalog({
@@ -833,7 +873,6 @@ describe("ChatInputBar", () => {
 
 	it("preserves an explicit High selection across capability and status updates", async () => {
 		const onReasoningChange = vi.fn();
-		const onOpenVoiceInputSettings = vi.fn();
 		const render = async (status: ChatSessionStatus) => {
 			await act(async () => {
 				root.render(
@@ -862,7 +901,6 @@ describe("ChatInputBar", () => {
 							}))}
 							onModeToggle={vi.fn()}
 							onModelChange={vi.fn()}
-							onOpenVoiceInputSettings={onOpenVoiceInputSettings}
 							onPromptInputChange={vi.fn()}
 							onProviderChange={vi.fn()}
 							onReasoningChange={onReasoningChange}

--- a/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
+++ b/apps/examples/desktop-app/webview/components/views/chat/chat-input-bar.tsx
@@ -320,7 +320,6 @@ type ChatInputBarProps = {
 		prompt: string,
 	) => Promise<void> | void;
 	onRemovePromptInQueue: (promptId: string) => Promise<void> | void;
-	onOpenVoiceInputSettings?: () => void;
 	onOpenModelSettings?: () => void;
 	summary: {
 		toolCalls: number;
@@ -359,7 +358,6 @@ function ChatInputBarImpl({
 	onSteerPromptInQueue,
 	onEditPromptInQueue,
 	onRemovePromptInQueue,
-	onOpenVoiceInputSettings,
 	onOpenModelSettings,
 	summary,
 }: ChatInputBarProps) {
@@ -819,38 +817,30 @@ function ChatInputBarImpl({
 		[transcriptionTarget],
 	);
 
-	const handleSpeechInputError = useCallback(
-		(error: unknown) => {
-			// Microphone failures surface as DOMExceptions (getUserMedia) or
-			// capture-layer events; provider failures (credentials, transcription
-			// setup) as plain Errors, and are fixed in Settings → Voice.
-			const isMicrophoneError =
-				error instanceof DOMException || error instanceof Event;
-			const message =
-				error instanceof Error
-					? error.message
-					: "Check microphone permission and audio provider settings.";
-			writeDesktopDebugLog({
-				scope: "voice-input",
-				level: "error",
-				message: "Speech input failed in the webview",
-				timestamp: new Date().toISOString(),
-				metadata: { failure: message },
-			});
-			if (!isMicrophoneError && onOpenVoiceInputSettings) {
-				onOpenVoiceInputSettings();
-				return;
-			}
-			toast({
-				variant: "destructive",
-				title: "Speech input failed",
-				description: isMicrophoneError
-					? "Check the microphone permission for Cline and try again."
-					: message,
-			});
-		},
-		[onOpenVoiceInputSettings],
-	);
+	const handleSpeechInputError = useCallback((error: unknown) => {
+		// Keep recording and provider failures in chat so the user can see
+		// the actual error and retry with their configured voice model.
+		const isMicrophoneError =
+			error instanceof DOMException || error instanceof Event;
+		const message =
+			error instanceof Error
+				? error.message
+				: "Check microphone permission and audio provider settings.";
+		writeDesktopDebugLog({
+			scope: "voice-input",
+			level: "error",
+			message: "Speech input failed in the webview",
+			timestamp: new Date().toISOString(),
+			metadata: { failure: message },
+		});
+		toast({
+			variant: "destructive",
+			title: "Speech input failed",
+			description: isMicrophoneError
+				? "Check the microphone permission for Cline and try again."
+				: message,
+		});
+	}, []);
 
 	const effortIndex = useMemo(
 		() => resolveEffortIndex(thinking, reasoningEffort),


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX (small bug fix; no linked issue)

### Description

**Issue:** Clicking the microphone can take the user to Settings → Voice even though a voice provider and transcription model are already selected. This interrupts the chat and hides why speech input failed.

**Root cause:** The composer’s speech-input error handler treated every error other than a browser `DOMException` or `Event` as a reason to open Voice settings. A connection or transcription failure therefore triggered the same redirect as an assumed configuration problem. The microphone is already gated on a configured transcription target, so this redirect did not indicate that the model selection was missing.

**Fix:** Show a “Speech input failed” toast in chat with the actual provider/recording error. Preserve microphone-permission guidance for browser errors, debug logging, the current draft, and the microphone control so users can retry. Remove the unused Voice-settings callback from the composer and its parent components.

### Test Procedure

- Composer regression suite: 40 tests passed (`bunx vitest run webview/components/views/chat/chat-input-bar.test.tsx --config vitest.config.ts`, from `apps/examples/desktop-app`).
- Desktop TypeScript check passed (`bunx tsc -p tsconfig.dev.json --noEmit`).
- UI build and formatting completed; `git diff --check` passed.
- Added regression coverage for a transcription connection error and a microphone permission error with a configured voice model. Both verify the toast, retained draft, and available microphone button.
- Manual follow-up: select a voice model, enter a draft, trigger a speech-input failure, and verify chat remains visible with the error toast. Actual microphone capture has not been manually tested.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

1. **Existing voice configuration:** Settings → Voice showing voice input enabled and the selected provider/model, establishing that configuration already exists.
2. **Before the fix:** After clicking the microphone and encountering a speech-input error, the app unexpectedly displays Settings → Voice with the model still selected. A short recording can show the transition from chat to settings.
3. **After the fix:** The same failure leaves chat visible with the draft intact, microphone button available, and a “Speech input failed” toast displaying the actual error.

<img width="907" height="290" alt="image" src="https://github.com/user-attachments/assets/1a01860a-a4f0-4778-a32d-e7d96f6eb2c4" />

<img width="877" height="255" alt="image" src="https://github.com/user-attachments/assets/cfd0e268-afdb-44ff-bcfe-ceba8f5b037a" />


### Additional Notes

This fixes the misleading navigation and hidden error. It does not resolve the underlying provider or recording failure; the error is now visible for diagnosis. Full-repository tests/lint and real microphone capture were not run.
