### PR TITLE
fix(vscode): preserve log severity and quiet successful empty hooks

### DIFF
--- a/apps/vscode/proto/host/env.proto
+++ b/apps/vscode/proto/host/env.proto
@@ -35,7 +35,7 @@ service EnvService {
   rpc shutdown(cline.EmptyRequest) returns (cline.Empty);
 
   // Logs a debug message to the host environment's log/output console.
-  rpc debugLog(cline.StringRequest) returns (cline.Empty);
+  rpc debugLog(DebugLogRequest) returns (cline.Empty);
 
   // Opens an external URL in the default browser.
   // In remote environments (VS Code Server, SSH, etc.), this routes the URL
@@ -72,4 +72,10 @@ message GetTelemetrySettingsResponse {
 message TelemetrySettingsEvent {
   Setting is_enabled = 1;
   optional string error_level = 2;
+}
+
+message DebugLogRequest {
+  // Keep field 2 for wire compatibility with the former cline.StringRequest.
+  string value = 2;
+  optional string level = 3;
 }

--- a/apps/vscode/src/common.ts
+++ b/apps/vscode/src/common.ts
@@ -33,8 +33,8 @@ import { arePathsEqual } from "./utils/path"
  */
 export async function initialize(storageContext: StorageContext): Promise<WebviewProvider> {
 	// Configure the shared Logging class to use HostProvider's output channels and debug logger
-	Logger.subscribe((msg: string) => HostProvider.get().logToChannel(msg)) // File system logging
-	Logger.subscribe((msg: string) => HostProvider.env.debugLog({ value: msg })) // Host debug logging
+	Logger.subscribe((level, msg) => HostProvider.get().logToChannel(`${new Date().toISOString()} ${level} ${msg}`)) // File system logging
+	Logger.subscribe((level, msg) => HostProvider.env.debugLog({ value: msg, level })) // Host debug logging
 
 	// Register the SDK early logger so diagnostic events from
 	// ProviderSettingsManager, RuntimeOAuthTokenManager, and Cline auth

--- a/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
+++ b/apps/vscode/src/core/hooks/__tests__/hook-factory.test.ts
@@ -4,9 +4,17 @@ import fs from "fs/promises"
 import path from "path"
 import sinon from "sinon"
 import { setDistinctId } from "@/services/logging/distinctId"
+import { Logger } from "@/shared/services/Logger"
 import { stubWorkspacePaths } from "../../../test/host-provider-test-utils"
 import { HookFactory, isPathWithin } from "../hook-factory"
-import { createHookTestEnv, HookTestEnv, stubHookDirs, withPlatform, writeHookScriptForPlatform } from "./test-utils"
+import {
+	createHookTestEnv,
+	createTestHook,
+	HookTestEnv,
+	stubHookDirs,
+	withPlatform,
+	writeHookScriptForPlatform,
+} from "./test-utils"
 
 describe("Hook System", () => {
 	let tempDir: string
@@ -265,6 +273,27 @@ console.log("not valid json")`
 			// Hook succeeded (exit 0) but couldn't parse JSON, so returns success without context
 			result.cancel.should.be.false()
 			;(result.contextModification === undefined || result.contextModification === "").should.be.true()
+		})
+
+		it("should log empty successful output at debug level", async () => {
+			await createTestHook(tempDir, "PreToolUse", {}, { exitWithoutOutput: true })
+			const debugStub = sandbox.stub(Logger, "debug")
+			const warnStub = sandbox.stub(Logger, "warn")
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PreToolUse")
+			const result = await runner.run({
+				taskId: "test-task",
+				preToolUse: {
+					toolName: "test_tool",
+					parameters: {},
+				},
+			})
+
+			result.cancel.should.be.false()
+			debugStub.calledOnce.should.be.true()
+			debugStub.firstCall.args[0].should.equal("[Hook PreToolUse] Completed successfully but no JSON response found")
+			warnStub.called.should.be.false()
 		})
 
 		it("should pass hook input via stdin", async () => {

--- a/apps/vscode/src/core/hooks/hook-factory.ts
+++ b/apps/vscode/src/core/hooks/hook-factory.ts
@@ -519,7 +519,12 @@ class StdioHookRunner<Name extends HookName> extends HookRunner<Name> {
 			// No valid JSON found
 			if (exitCode === 0) {
 				// Hook succeeded but didn't provide JSON - allow execution (no cancellation)
-				Logger.warn(`[Hook ${this.hookName}] Completed successfully but no JSON response found`)
+				const noJsonMessage = `[Hook ${this.hookName}] Completed successfully but no JSON response found`
+				if (stdout.trim()) {
+					Logger.warn(noJsonMessage)
+				} else {
+					Logger.debug(noJsonMessage)
+				}
 				const durationMs = performance.now() - startTime
 
 				// Capture success telemetry even without JSON

--- a/apps/vscode/src/hosts/vscode/hostbridge/env/debugLog.ts
+++ b/apps/vscode/src/hosts/vscode/hostbridge/env/debugLog.ts
@@ -1,11 +1,22 @@
-import { Empty, StringRequest } from "@shared/proto/cline/common"
+import { Empty } from "@shared/proto/cline/common"
 import * as vscode from "vscode"
+import { DebugLogRequest } from "@/shared/proto/index.host"
 
-const CLINE_OUTPUT_CHANNEL = vscode.window.createOutputChannel("Cline")
+const CLINE_OUTPUT_CHANNEL = vscode.window.createOutputChannel("Cline", { log: true })
+
+const LOG_METHOD_BY_LEVEL: Record<string, (message: string) => void> = {
+	ERROR: (message) => CLINE_OUTPUT_CHANNEL.error(message),
+	WARN: (message) => CLINE_OUTPUT_CHANNEL.warn(message),
+	LOG: (message) => CLINE_OUTPUT_CHANNEL.info(message),
+	INFO: (message) => CLINE_OUTPUT_CHANNEL.info(message),
+	DEBUG: (message) => CLINE_OUTPUT_CHANNEL.debug(message),
+	TRACE: (message) => CLINE_OUTPUT_CHANNEL.trace(message),
+}
 
 // Appends a log message to all Cline output channels.
-export async function debugLog(request: StringRequest): Promise<Empty> {
-	CLINE_OUTPUT_CHANNEL.appendLine(request.value)
+export async function debugLog(request: DebugLogRequest): Promise<Empty> {
+	const logMethod = LOG_METHOD_BY_LEVEL[request.level ?? "LOG"] ?? LOG_METHOD_BY_LEVEL.LOG
+	logMethod(request.value)
 	return Empty.create({})
 }
 

--- a/apps/vscode/src/shared/services/Logger.ts
+++ b/apps/vscode/src/shared/services/Logger.ts
@@ -4,12 +4,12 @@
 export class Logger {
 	private static isVerbose = process.env.IS_DEV === "true"
 
-	private static subscribers: Set<(msg: string) => void> = new Set()
+	private static subscribers: Set<(level: string, msg: string) => void> = new Set()
 
-	private static output(msg: string): void {
+	private static output(level: string, msg: string): void {
 		for (const subscriber of Logger.subscribers) {
 			try {
-				subscriber(msg)
+				subscriber(level, msg)
 			} catch {
 				// ignore errors from subscribers
 			}
@@ -19,7 +19,7 @@ export class Logger {
 	/**
 	 * Register a callback to receive log output messages.
 	 */
-	static subscribe(outputFn: (msg: string) => void) {
+	static subscribe(outputFn: (level: string, msg: string) => void) {
 		Logger.subscribers.add(outputFn)
 	}
 
@@ -54,8 +54,7 @@ export class Logger {
 				fullMessage += ` ${args.map((arg) => JSON.stringify(arg)).join(" ")}`
 			}
 			const errorSuffix = error?.message ? ` ${error.message}` : ""
-			const ts = new Date().toISOString()
-			Logger.output(`${ts} ${level} ${fullMessage}${errorSuffix}`.trimEnd())
+			Logger.output(level, `${fullMessage}${errorSuffix}`.trimEnd())
 		} catch {
 			// do nothing if Logger fails
 		}


### PR DESCRIPTION
### Related Issue

Closes #14075

### Description

- Route Cline logger severity through the host bridge to a VS Code `LogOutputChannel`.
- Preserve the existing timestamped plain-text/file log format while sending raw messages to the VS Code channel.
- Map Cline error, warning, info, debug, and trace levels to the corresponding VS Code methods. `LOG` intentionally maps to `info()`.
- Keep the `debugLog` request wire-compatible with the former `StringRequest.value` field.
- Log successful hooks with empty stdout at debug instead of warning.
- Preserve warnings for successful hooks that emit nonempty malformed output.
- Add regression coverage for the successful empty-hook case.

### Test Procedure

- `bun run protos` — passed; no tracked generated-file changes
- `bun run format:fix` — passed
- `bun run check-types` — passed
- `bun run lint` — passed
- `bun test src/core/hooks/__tests__/hook-factory.test.ts` — 29 passed, 0 failed
- `bun run test:unit` — 77 files, 1,100 passed, 0 failed
- Pre-commit gitleaks scan — passed

Manual Extension Development Host smoke test was not run because this workspace has no active display session.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single bug fix
- [x] Tests are passing and code is formatted and linted
- [x] I have reviewed the contributor guidelines

### Attribution

Agent: ChatGPT Codex  
LLM: GPT-5.6

The severity-routing behavior was adapted from prior Cline v4.0.12 work authored with Claude Sonnet 5; co-author attribution is retained in the relevant commit.