### PR TITLE
fix(desktop): use baseline Bun target for Windows x64 sidecar

### DIFF
--- a/apps/examples/desktop-app/package.json
+++ b/apps/examples/desktop-app/package.json
@@ -32,6 +32,7 @@
 		"pretest:settings-ui": "bun run build:ui",
 		"test:settings-ui": "vitest run webview/components/views/settings webview/components/ui/switch-integration.test.tsx --config vitest.config.ts",
 		"test:sidecar": "vitest run sidecar scripts/telemetry-define-args.test.ts --config vitest.config.ts",
+		"test:build-sidecar-target": "bun test scripts/build-sidecar-target.test.ts",
 		"clean": "rm -rf webview/.next webview/out node_modules dist && (cd src-tauri && rm -rf target node_modules dist)"
 	},
 	"dependencies": {

--- a/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-bin.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { resolveBunCompileTarget } from "./build-sidecar-target";
 import { telemetryDefineArgs } from "./telemetry-define-args";
 
 const resolveTargetTriple = async (): Promise<string> => {
@@ -16,21 +17,6 @@ const resolveTargetTriple = async (): Promise<string> => {
 		throw new Error("failed to resolve Rust host target triple");
 	}
 	return host;
-};
-
-// Bun cross-compiles --compile binaries, so a CI runner can produce the
-// sidecar for a different architecture than its own (e.g. the x86_64 macOS
-// bundle from an arm64 runner). Without an explicit --target, bun always
-// emits a host-arch binary even when Tauri is building for another triple.
-const resolveBunCompileTarget = (targetTriple: string): string | undefined => {
-	if (targetTriple.startsWith("aarch64-apple-darwin"))
-		return "bun-darwin-arm64";
-	if (targetTriple.startsWith("x86_64-apple-darwin")) return "bun-darwin-x64";
-	if (targetTriple.startsWith("x86_64-pc-windows")) return "bun-windows-x64";
-	if (targetTriple.startsWith("x86_64-unknown-linux")) return "bun-linux-x64";
-	if (targetTriple.startsWith("aarch64-unknown-linux"))
-		return "bun-linux-arm64";
-	return undefined;
 };
 
 const sidecarOutfile = (targetTriple: string): string => {

--- a/apps/examples/desktop-app/scripts/build-sidecar-target.test.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-target.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { resolveBunCompileTarget } from "./build-sidecar-target";
+
+describe("resolveBunCompileTarget", () => {
+	it("uses Bun's baseline build for Windows x64", () => {
+		expect(resolveBunCompileTarget("x86_64-pc-windows-msvc")).toBe(
+			"bun-windows-x64-baseline",
+		);
+	});
+
+	it.each([
+		["aarch64-apple-darwin", "bun-darwin-arm64"],
+		["x86_64-apple-darwin", "bun-darwin-x64"],
+		["x86_64-unknown-linux-gnu", "bun-linux-x64"],
+		["aarch64-unknown-linux-gnu", "bun-linux-arm64"],
+	])("keeps %s mapped to %s", (targetTriple, expectedTarget) => {
+		expect(resolveBunCompileTarget(targetTriple)).toBe(expectedTarget);
+	});
+
+	it("lets Bun use its host target for unknown Rust triples", () => {
+		expect(
+			resolveBunCompileTarget("riscv64gc-unknown-linux-gnu"),
+		).toBeUndefined();
+	});
+});

--- a/apps/examples/desktop-app/scripts/build-sidecar-target.ts
+++ b/apps/examples/desktop-app/scripts/build-sidecar-target.ts
@@ -1,0 +1,17 @@
+// Bun cross-compiles --compile binaries, so a CI runner can produce the
+// sidecar for a different architecture than its own (e.g. the x86_64 macOS
+// bundle from an arm64 runner). Without an explicit --target, bun always
+// emits a host-arch binary even when Tauri is building for another triple.
+export const resolveBunCompileTarget = (
+	targetTriple: string,
+): string | undefined => {
+	if (targetTriple.startsWith("aarch64-apple-darwin"))
+		return "bun-darwin-arm64";
+	if (targetTriple.startsWith("x86_64-apple-darwin")) return "bun-darwin-x64";
+	if (targetTriple.startsWith("x86_64-pc-windows"))
+		return "bun-windows-x64-baseline";
+	if (targetTriple.startsWith("x86_64-unknown-linux")) return "bun-linux-x64";
+	if (targetTriple.startsWith("aarch64-unknown-linux"))
+		return "bun-linux-arm64";
+	return undefined;
+};


### PR DESCRIPTION
### Related Issue

**Issue:** #14066

### Description

The Desktop app currently compiles its Windows x64 sidecar with Bun's standard x64 target. On older x64 CPUs that support SSE4.2 but not AVX, that binary can fail before the sidecar starts.

This changes only the Desktop sidecar target mapping to `bun-windows-x64-baseline`. The resolver is extracted into a small testable module, with coverage that preserves the existing Darwin and Linux mappings and the unknown-triple fallback. The Tauri sidecar filename contract is unchanged.

This is complementary to the open CLI baseline work in #12273 and #13167; it does not change or claim to fix the CLI packaging path.

### Test Procedure

- `bun run test:build-sidecar-target` — 6 passed
- `bun run build:sdk`
- `bun -F @cline/code typecheck`
- Biome check on the four touched files
- `git diff --check`
- `TARGET=x86_64-pc-windows-msvc bun run build:sidecar:bin` with Bun 1.3.13 — produced a PE32+ x86-64 executable and selected `bun-windows-x64-baseline-v1.3.13`

The generated binary was not run on a Windows pre-AVX machine.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Focused tests are passing and the changed files are formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a packaging change with no UI changes.

### Additional Notes

The baseline target keeps Bun's documented SSE4.2 floor; this PR does not claim support for CPUs below that requirement.
