### PR TITLE
fix(cli): resolve featured model aliases for reasoning options

### DIFF
--- a/apps/cli/src/tui/components/model-selector/cline-model-entries.ts
+++ b/apps/cli/src/tui/components/model-selector/cline-model-entries.ts
@@ -1,9 +1,33 @@
-import type {
-	ClineRecommendedModel,
-	ClineRecommendedModelsData,
+import {
+	type ClineRecommendedModel,
+	type ClineRecommendedModelsData,
+	Llms,
 } from "@cline/core";
 
 export type ClineModelPickerTier = "recommended" | "subscribed" | "free";
+
+export function findFeaturedModelOption<T extends { key: string }>(
+	models: readonly T[],
+	modelId: string,
+): T | undefined {
+	const exact = models.find((model) => model.key === modelId);
+	if (exact) return exact;
+
+	// Resolve capability metadata without changing the feed's routed model ID.
+	for (const rule of Llms.VERCEL_OPENROUTER_MODEL_ID_ALIAS_RULES) {
+		let alternateId: string | undefined;
+		if (modelId.startsWith(rule.aliasPrefix)) {
+			alternateId = `${rule.canonicalPrefix}${modelId.slice(rule.aliasPrefix.length)}`;
+		} else if (modelId.startsWith(rule.canonicalPrefix)) {
+			alternateId = `${rule.aliasPrefix}${modelId.slice(rule.canonicalPrefix.length)}`;
+		}
+		if (alternateId) {
+			const alternate = models.find((model) => model.key === alternateId);
+			if (alternate) return alternate;
+		}
+	}
+	return undefined;
+}
 
 export interface ClineModelPickerItem {
 	kind: "model";

--- a/apps/cli/src/tui/components/model-selector/cline-model-picker.test.ts
+++ b/apps/cli/src/tui/components/model-selector/cline-model-picker.test.ts
@@ -2,10 +2,46 @@ import { describe, expect, it } from "vitest";
 import {
 	buildFeaturedModelEntries,
 	CLINE_PASS_FREE_SECTION_DESCRIPTION,
+	findFeaturedModelOption,
 	freeTierDescriptionFor,
 } from "./cline-model-entries";
 
 const model = (id: string) => ({ id, name: id, description: "", tags: [] });
+
+describe("featured model reasoning metadata", () => {
+	it.each([
+		["z-ai/glm-5.3-flash", "zai/glm-5.3-flash"],
+		["zai/glm-5.3-flash", "z-ai/glm-5.3-flash"],
+	])("resolves %s against catalog key %s", (feedId, catalogId) => {
+		const option = { key: catalogId, supportsReasoning: true };
+		const entries = buildFeaturedModelEntries("cline", {
+			recommended: [],
+			free: [model(feedId)],
+			clinePass: [],
+		});
+		const entry = entries[0];
+		if (entry.kind !== "model") throw new Error("Expected a free model");
+		expect(findFeaturedModelOption([option], entry.model.id)).toBe(option);
+		expect(entry.model.id).toBe(feedId);
+	});
+
+	it("prefers exact metadata when both spellings exist", () => {
+		const exact = { key: "z-ai/glm-5.3-flash", supportsReasoning: false };
+		const alias = { key: "zai/glm-5.3-flash", supportsReasoning: true };
+		expect(findFeaturedModelOption([alias, exact], exact.key)).toBe(exact);
+	});
+
+	it("does not borrow capabilities from a different vendor or model variant", () => {
+		const options = [
+			{ key: "other/glm-5.3-flash", supportsReasoning: true },
+			{ key: "zai/glm-5.3-flash:free", supportsReasoning: true },
+		];
+		expect(
+			findFeaturedModelOption(options, "z-ai/glm-5.3-flash"),
+		).toBeUndefined();
+		expect(findFeaturedModelOption([], "unknown/model")).toBeUndefined();
+	});
+});
 
 describe("cline model picker entries", () => {
 	it("builds Recommended/Free sections for the cline provider", () => {

--- a/apps/cli/src/tui/hooks/use-model-selector.tsx
+++ b/apps/cli/src/tui/hooks/use-model-selector.tsx
@@ -29,6 +29,7 @@ import {
 	ProviderPickerContent,
 	UseExistingOrReconfigureContent,
 } from "../components/dialogs/provider-picker";
+import { findFeaturedModelOption } from "../components/model-selector/cline-model-entries";
 import { buildFeaturedModelEntries } from "../components/model-selector/cline-model-picker";
 import {
 	BROWSE_ALL_ACTION,
@@ -525,8 +526,9 @@ export function useModelSelector(opts: {
 					}
 
 					config.modelId = clineResult;
-					const selectedModel = modelOptions.find(
-						(m: ModelOption) => m.key === clineResult,
+					const selectedModel = findFeaturedModelOption(
+						modelOptions,
+						clineResult,
 					);
 					if (selectedModel?.supportsReasoning) {
 						const currentLevel: ThinkingLevel = config.reasoningEffort


### PR DESCRIPTION
### Related Issue

Addresses #13926.

### Description

The featured model picker returns IDs from the recommendation feed, while reasoning support is looked up in the provider's model options by exact ID. If the feed uses `z-ai/glm-5.3-flash` and the catalog uses `zai/glm-5.3-flash`, the lookup fails and the CLI skips the thinking-level dialog and clears reasoning settings.

Resolve featured model metadata using the existing model-ID alias rules after trying an exact match. Keep the selected feed ID unchanged for request routing and free-model identification. Do not match arbitrary vendor prefixes or different model variants.

### Test Procedure

- The two alias-direction regression cases failed with the original exact-match lookup and pass with alias resolution.
- Model picker, onboarding model, and free-model cost tests: 30 passed across 3 files.
- `bun run build:sdk`: passed.
- `bun -F @cline/cli build`: passed (includes hub webview build; nonfatal bundle-size warnings).
- `bun -F @cline/cli typecheck`: passed.
- Biome checks for all three changed files and `git diff --check`: passed.

Tests cover both alias directions, exact-match precedence, unchanged featured IDs, unknown models, unrelated vendor prefixes, and `:free` variant isolation.

### Type of Change

- [x] Bug fix

### Additional Notes

This patch addresses alias mismatches in the featured picker. It does not change supported reasoning-effort values or resolve missing metadata in a stale catalog. No live authenticated provider session or interactive TUI end-to-end test was run.
