### PR TITLE
fix(vscode): time out undisplayed tool approvals

### DIFF
--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.test.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent } from "@cline/shared"
 import { describe, expect, it, vi } from "vitest"
 import { MessageTranslatorState, translateSessionEvent } from "./message-translator"
-import { SdkInteractionCoordinator } from "./sdk-interaction-coordinator"
+import { SdkInteractionCoordinator, TOOL_APPROVAL_TIMEOUT_MS } from "./sdk-interaction-coordinator"
 import { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { createTaskProxy } from "./task-proxy"
 import { DEFAULT_TOOL_APPROVAL_DENIAL_REASON, EDIT_TOOL_APPROVAL_DENIAL_REASON } from "./tool-approval-denial"
@@ -443,6 +443,47 @@ describe("SdkInteractionCoordinator", () => {
 		await expect(approvalPromise).resolves.toEqual({ approved: false, reason: "Task cancelled" })
 		expect(recordDeniedToolApproval).toHaveBeenCalledWith("tool-call", "read_files", "Task cancelled")
 		expect(coordinator.resolvePendingToolApproval(undefined, "yesButtonClicked")).toBe(false)
+	})
+
+	it("denies approval when posting it to the webview never settles", async () => {
+		vi.useFakeTimers()
+		try {
+			const task = createTaskProxy("session-123", vi.fn(), vi.fn())
+			const recordDeniedToolApproval = vi.fn()
+			const setTurnPhase = vi.fn()
+			const coordinator = new SdkInteractionCoordinator({
+				messages: new SdkMessageCoordinator({ getTask: () => task }),
+				getSessionId: () => "session-123",
+				postStateToWebview: vi.fn(() => new Promise<void>(() => {})),
+				recordDeniedToolApproval,
+				setTurnPhase,
+			})
+
+			const approvalPromise = coordinator.handleRequestToolApproval({
+				agentId: "agent",
+				conversationId: "conversation",
+				iteration: 1,
+				toolCallId: "tool-call",
+				toolName: "run_commands",
+				input: { command: "echo safe" },
+				policy: { autoApprove: false },
+			})
+
+			await vi.advanceTimersByTimeAsync(TOOL_APPROVAL_TIMEOUT_MS)
+
+			await expect(approvalPromise).resolves.toEqual({
+				approved: false,
+				reason: "Tool approval timed out after 5 minutes, so the tool was not executed.",
+			})
+			expect(recordDeniedToolApproval).toHaveBeenCalledWith(
+				"tool-call",
+				"run_commands",
+				"Tool approval timed out after 5 minutes, so the tool was not executed.",
+			)
+			expect(setTurnPhase).toHaveBeenLastCalledWith("streaming")
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 
 	it("awaits onToolApprovalAsk before emitting the approval ask", async () => {

--- a/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
+++ b/apps/vscode/src/sdk/sdk-interaction-coordinator.ts
@@ -7,6 +7,10 @@ import { buildToolApprovalAskMessage } from "./message-translator"
 import type { SdkMessageCoordinator } from "./sdk-message-coordinator"
 import { buildToolApprovalDenialReason } from "./tool-approval-denial"
 
+export const TOOL_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000
+const TOOL_APPROVAL_TIMEOUT_REASON = "Tool approval timed out after 5 minutes, so the tool was not executed."
+const TOOL_APPROVAL_DELIVERY_FAILED_REASON = "The tool approval request could not be displayed, so the tool was not executed."
+
 export interface ToolApprovalRequest {
 	agentId: string
 	conversationId: string
@@ -52,6 +56,7 @@ export interface SdkInteractionCoordinatorOptions {
 export class SdkInteractionCoordinator {
 	private pendingAskResolve: ((answer: string) => void) | undefined
 	private pendingToolApprovalResolve: ((result: { approved: boolean; reason?: string }) => void) | undefined
+	private pendingToolApprovalTimeout: ReturnType<typeof setTimeout> | undefined
 	private pendingToolApprovalMessage:
 		| {
 				toolCallId: string
@@ -118,16 +123,32 @@ export class SdkInteractionCoordinator {
 			payload: { sessionId: this.options.getSessionId(), status: "running" },
 		})
 		this.options.setTurnPhase?.("awaiting_approval", toolAskMessage.ts)
-		await this.options.postStateToWebview()
 
-		return new Promise<{ approved: boolean; reason?: string }>((resolve) => {
+		const approval = new Promise<{ approved: boolean; reason?: string }>((resolve) => {
 			this.pendingToolApprovalResolve = resolve
 			this.pendingToolApprovalMessage = {
 				toolCallId: request.toolCallId,
 				messageTs: toolAskMessage.ts,
 				toolName: request.toolName,
 			}
+			this.pendingToolApprovalTimeout = setTimeout(() => {
+				Logger.warn(`[SdkController] Tool approval timed out: tool=${request.toolName}`)
+				if (this.denyPendingToolApproval(TOOL_APPROVAL_TIMEOUT_REASON)) {
+					this.options.setTurnPhase?.("streaming")
+				}
+			}, TOOL_APPROVAL_TIMEOUT_MS)
 		})
+
+		void Promise.resolve()
+			.then(() => this.options.postStateToWebview())
+			.catch((error) => {
+				Logger.warn(`[SdkController] Failed to display tool approval: ${error}`)
+				if (this.denyPendingToolApproval(TOOL_APPROVAL_DELIVERY_FAILED_REASON)) {
+					this.options.setTurnPhase?.("streaming")
+				}
+			})
+
+		return approval
 	}
 
 	async handleAskQuestion(question: string, options: string[], _context: unknown): Promise<string> {
@@ -177,6 +198,7 @@ export class SdkInteractionCoordinator {
 
 		this.pendingToolApprovalResolve = undefined
 		this.pendingToolApprovalMessage = undefined
+		this.clearPendingToolApprovalTimeout()
 
 		const approved = responseType === "yesButtonClicked"
 		Logger.log(`[SdkController] Resolving pending tool approval: approved=${approved} (responseType=${responseType})`)
@@ -253,18 +275,34 @@ export class SdkInteractionCoordinator {
 		// use an empty answer so the lifecycle reason is not presented as user input.
 		resolveAsk?.("")
 
+		this.denyPendingToolApproval(reason)
+	}
+
+	private denyPendingToolApproval(reason: string): boolean {
+		const resolve = this.pendingToolApprovalResolve
+		if (!resolve) {
+			return false
+		}
+
 		const pendingMessage = this.pendingToolApprovalMessage
+		this.pendingToolApprovalResolve = undefined
 		this.pendingToolApprovalMessage = undefined
-		if (this.pendingToolApprovalResolve) {
-			// Record before resolving: the denial unblocks the core, which emits the
-			// tool's lifecycle events before the caller's abort lands. Unless the
-			// denial is already recorded, the translator renders those events as a
-			// second tool row next to the still-visible approval ask.
-			if (pendingMessage) {
-				this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, reason)
-			}
-			this.pendingToolApprovalResolve({ approved: false, reason })
-			this.pendingToolApprovalResolve = undefined
+		this.clearPendingToolApprovalTimeout()
+		// Record before resolving: the denial unblocks the core, which emits the
+		// tool's lifecycle events before the caller's abort lands. Unless the
+		// denial is already recorded, the translator renders those events as a
+		// second tool row next to the still-visible approval ask.
+		if (pendingMessage) {
+			this.options.recordDeniedToolApproval?.(pendingMessage.toolCallId, pendingMessage.toolName, reason)
+		}
+		resolve({ approved: false, reason })
+		return true
+	}
+
+	private clearPendingToolApprovalTimeout(): void {
+		if (this.pendingToolApprovalTimeout) {
+			clearTimeout(this.pendingToolApprovalTimeout)
+			this.pendingToolApprovalTimeout = undefined
 		}
 	}
 


### PR DESCRIPTION
### Related Issue

**Issue:** #14065

### Description

Prevents the SDK tool-approval flow from waiting indefinitely when the webview cannot display an approval request. Pending approvals now fail closed after five minutes, and a delivery failure also denies the tool instead of leaving the session blocked. Approve, reject, and lifecycle cleanup clear the timer.

Adds a regression test where `postStateToWebview` never settles.

### Test Procedure

- `bunx vitest run src/sdk/sdk-interaction-coordinator.test.ts --config vitest.config.ts` (17 passed)
- `bun run check-types` from `apps/vscode`
- `bunx biome check src/sdk/sdk-interaction-coordinator.ts src/sdk/sdk-interaction-coordinator.test.ts`
- `bun run test:unit` was also attempted; an unrelated concurrent `TaskComplete` hook fixture timed out, while rerunning that file passed 14/14.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is a coordinator lifecycle fix with a regression test.

### Additional Notes

This is intentionally limited to the SDK interaction coordinator. The legacy extension uses a separate `Task.ask` lifecycle.
