### PR TITLE
fix: restore plan-mode banner contrast when host omits --warning

### DIFF
--- a/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/CompletionOutputRow.test.tsx
@@ -167,6 +167,22 @@ describe("PlanCompletionOutputRow", () => {
 		expect(screen.getByRole("button", { name: "Copy plan response" })).toBeInTheDocument()
 	})
 
+	it("uses contrast-safe warning-foreground on the Plan label and copy button", () => {
+		render(<PlanCompletionOutputRow text="Here is the plan" />)
+
+		const label = screen.getByText("Plan")
+		expect(label).toHaveClass("text-warning-foreground")
+		expect(label).not.toHaveClass("text-warning/70")
+
+		const copyButton = screen.getByRole("button", { name: "Copy plan response" })
+		expect(copyButton).toHaveClass("text-warning-foreground")
+		expect(copyButton).not.toHaveClass("text-warning/70")
+
+		const banner = label.closest("div")?.parentElement
+		expect(banner).toHaveClass("bg-warning/10")
+		expect(banner).toHaveClass("border-warning/20")
+	})
+
 	it("copies the plan response text to the clipboard", async () => {
 		render(<PlanCompletionOutputRow text="Here is the plan" />)
 

--- a/apps/vscode/webview-ui/src/components/chat/PlanCompletionOutputRow.tsx
+++ b/apps/vscode/webview-ui/src/components/chat/PlanCompletionOutputRow.tsx
@@ -18,8 +18,8 @@ const PlanCompletionOutputRow = memo(({ text }: PlanCompletionOutputProps) => {
 	return (
 		<div className="rounded-sm border border-warning/20 overflow-visible bg-warning/10">
 			<div className="flex items-center justify-between gap-2 pl-2 pr-1 pt-1 -mb-1.5">
-				<span className="text-xs font-medium uppercase tracking-wider text-warning/70">Plan</span>
-				<CopyButton ariaLabel="Copy plan response" className="text-warning/70" textToCopy={text} />
+				<span className="text-xs font-medium uppercase tracking-wider text-warning-foreground">Plan</span>
+				<CopyButton ariaLabel="Copy plan response" className="text-warning-foreground" textToCopy={text} />
 			</div>
 			<div className="plan-completion-content p-2 w-full [&_hr]:opacity-20 [&_p:last-child]:mb-0">
 				<div className="wrap-anywhere [&_hr]:opacity-20">

--- a/apps/vscode/webview-ui/src/theme.css
+++ b/apps/vscode/webview-ui/src/theme.css
@@ -20,7 +20,7 @@
 	--color-text-block-background: var(--vscode-textCodeBlock-background);
 	--color-editor-group-border: var(--vscode-editorGroup-border);
 	--color-editor-widget-border: var(--vscode-editorWidget-border, #cccccc);
-	--color-editor-warning-foreground: var(--vscode-editorWarning-foreground);
+	--color-editor-warning-foreground: var(--vscode-editorWarning-foreground, var(--warning));
 	--color-sidebar-background: var(--vscode-sideBar-background);
 	--color-sidebar-foreground: var(--vscode-sideBar-foreground);
 	--color-input-foreground: var(--vscode-input-foreground);
@@ -71,7 +71,11 @@
 	--color-error-icon: var(--vscode-problemsErrorIcon-foreground, #c42b2b);
 	--color-description: var(--vscode-descriptionForeground);
 	--color-success: var(--vscode-charts-green);
-	--color-warning: var(--vscode-charts-yellow);
+	/* Prefer the host chart token when present (VS Code). Fall back to
+	   --warning so hosts that only inject --background/--foreground/--input
+	   (JetBrains webview) still get a contrast-safe accent. */
+	--color-warning: var(--vscode-charts-yellow, var(--warning));
+	--color-warning-foreground: var(--vscode-editorWarning-foreground, var(--warning));
 	--font-base:
 		var(--vscode-font-family), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
 		"Open Sans", "Helvetica Neue", sans-serif;
@@ -212,6 +216,8 @@
 	--border: oklch(0.922 0 0);
 	--input: oklch(0.922 0 0);
 	--ring: oklch(0.708 0 0);
+	/* Text-safe amber: JetBrains does not inject --warning onto <body>. */
+	--warning: #7e5100;
 	--chart-1: oklch(0.646 0.222 41.116);
 	--chart-2: oklch(0.6 0.118 184.704);
 	--chart-3: oklch(0.398 0.07 227.392);
@@ -246,6 +252,7 @@
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
 	--ring: oklch(0.556 0 0);
+	--warning: #cca700;
 	--chart-1: oklch(0.488 0.243 264.376);
 	--chart-2: oklch(0.696 0.17 162.48);
 	--chart-3: oklch(0.769 0.188 70.08);

--- a/apps/vscode/webview-ui/src/theme.css.test.ts
+++ b/apps/vscode/webview-ui/src/theme.css.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const themeCss = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "theme.css"), "utf8")
+
+function extractBlock(source: string, selector: string): string {
+	const needle = `${selector} {`
+	const start = source.indexOf(needle)
+	if (start === -1) {
+		throw new Error(`missing ${selector} block`)
+	}
+	const open = source.indexOf("{", start)
+	let depth = 0
+	for (let i = open; i < source.length; i++) {
+		const ch = source[i]
+		if (ch === "{") {
+			depth++
+		} else if (ch === "}") {
+			depth--
+			if (depth === 0) {
+				return source.slice(open + 1, i)
+			}
+		}
+	}
+	throw new Error(`unclosed ${selector} block`)
+}
+
+function cssVar(block: string, name: string): string {
+	const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+	const match = block.match(new RegExp(`${escaped}:\\s*([^;]+);`))
+	if (!match) {
+		throw new Error(`missing ${name}`)
+	}
+	return match[1].trim()
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+	const n = hex.replace("#", "")
+	return [Number.parseInt(n.slice(0, 2), 16), Number.parseInt(n.slice(2, 4), 16), Number.parseInt(n.slice(4, 6), 16)]
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+	const linear = [r, g, b].map((channel) => {
+		const srgb = channel / 255
+		return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+	})
+	return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+}
+
+function contrastRatio(foreground: string, background: string): number {
+	const a = relativeLuminance(hexToRgb(foreground))
+	const b = relativeLuminance(hexToRgb(background))
+	const [hi, lo] = a > b ? [a, b] : [b, a]
+	return (hi + 0.05) / (lo + 0.05)
+}
+
+function mixHex(foreground: string, background: string, amount: number): string {
+	const [fr, fg, fb] = hexToRgb(foreground)
+	const [br, bg, bb] = hexToRgb(background)
+	const mix = (from: number, to: number) => Math.round(from * amount + to * (1 - amount))
+	return `#${[mix(fr, br), mix(fg, bg), mix(fb, bb)].map((channel) => channel.toString(16).padStart(2, "0")).join("")}`
+}
+
+describe("webview warning theme tokens", () => {
+	it("falls back to --warning when the host does not inject VS Code warning colors", () => {
+		expect(themeCss).toContain("--color-warning: var(--vscode-charts-yellow, var(--warning));")
+		expect(themeCss).toContain("--color-warning-foreground: var(--vscode-editorWarning-foreground, var(--warning));")
+		expect(themeCss).toContain("--color-editor-warning-foreground: var(--vscode-editorWarning-foreground, var(--warning));")
+	})
+
+	it("defines per-scheme --warning that stays readable on light and dark banners", () => {
+		const lightWarning = cssVar(extractBlock(themeCss, ":root"), "--warning")
+		const darkWarning = cssVar(extractBlock(themeCss, ".dark"), "--warning")
+
+		expect(lightWarning).toMatch(/^#[0-9a-fA-F]{6}$/)
+		expect(darkWarning).toMatch(/^#[0-9a-fA-F]{6}$/)
+
+		// JetBrains light themes inject --background/--foreground/--input but
+		// not --warning. The :root fallback must contrast against white and
+		// against the 10% warning banner tint used by PlanCompletionOutputRow.
+		expect(contrastRatio(lightWarning, "#ffffff")).toBeGreaterThanOrEqual(4.5)
+		expect(contrastRatio(lightWarning, mixHex(lightWarning, "#ffffff", 0.1))).toBeGreaterThanOrEqual(4.5)
+
+		expect(contrastRatio(darkWarning, "#1e1e1e")).toBeGreaterThanOrEqual(4.5)
+		expect(contrastRatio(darkWarning, mixHex(darkWarning, "#1e1e1e", 0.1))).toBeGreaterThanOrEqual(4.5)
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** #14069

### Description

JetBrains hosts inject `--background`, `--foreground`, and `--input-*` onto the webview `<body>`, but they do not inject `--warning` or `--vscode-charts-yellow`. The plan-mode banner (`text-warning/70` on `bg-warning/10`) then resolves to a static bright yellow on a pale yellow tint, so the "Plan" label and copy icon disappear on light themes.

The JetBrains plugin itself is not in this repository. This PR hardens the **shared webview** that JetBrains ships:

- Define per-scheme `--warning` (`#7e5100` light / `#cca700` dark)
- Map `--color-warning` and `--color-warning-foreground` through `var(--vscode-charts-yellow, var(--warning))` / `var(--vscode-editorWarning-foreground, var(--warning))` so VS Code is unchanged when those tokens exist
- Use `text-warning-foreground` on the Plan label and copy button instead of `text-warning/70`

### Test Procedure

- `cd apps/vscode/webview-ui && bun run test -- src/theme.css.test.ts src/components/chat/CompletionOutputRow.test.tsx`
- Theme tests assert `--warning` exists on `:root` and `.dark`, the fallback chain is present, and both values meet WCAG 4.5:1 against white/dark backgrounds and the 10% banner tint
- Plan banner test asserts `text-warning-foreground` (not `text-warning/70`) on the label and copy button, while keeping `bg-warning/10`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`bun test`) and code is formatted and linted (`bun run format && bun run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CSS token / className change. Contrast of the light `--warning` fallback vs white is 6.85:1 (5.92:1 on the 10% banner tint).

### Additional Notes

Fixes #14069
